### PR TITLE
feat(schema): add abbreviated querystring schema support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ npm install fastify --save
 const fastify = require('fastify')()
 
 const schema = {
+  querystring: {
+    name: {
+      type: 'string'
+    },
+    excitement: {
+      type: 'integer'
+    }
+  },
   out: {
     type: 'object',
     properties: {
@@ -45,7 +53,13 @@ const schema = {
 
 fastify
   .get('/', schema, function (req, reply) {
-    reply.send({ hello: 'world' })
+    let response = 'world'
+
+    if (req.query.name) response = req.query.name
+
+    while(req.query.excitement--) response += '!'
+
+    reply.send({ hello: response })
   })
   .get('/no-schema', function (req, reply) {
     reply.send({ hello: 'world' })

--- a/README.md
+++ b/README.md
@@ -33,14 +33,6 @@ npm install fastify --save
 const fastify = require('fastify')()
 
 const schema = {
-  querystring: {
-    name: {
-      type: 'string'
-    },
-    excitement: {
-      type: 'integer'
-    }
-  },
   out: {
     type: 'object',
     properties: {
@@ -53,13 +45,7 @@ const schema = {
 
 fastify
   .get('/', schema, function (req, reply) {
-    let response = 'world'
-
-    if (req.query.name) response = req.query.name
-
-    while(req.query.excitement--) response += '!'
-
-    reply.send({ hello: response })
+    reply.send({ hello: 'world' })
   })
   .get('/no-schema', function (req, reply) {
     reply.send({ hello: 'world' })
@@ -166,7 +152,9 @@ Options:
 
   * `payload`: validates the body of the request if it is a POST or a
     PUT. It uses [ajv][ajv].
-  * `querystring`: validates the querystring. It uses [ajv][ajv].
+  * `querystring`: validates the querystring. It uses [ajv][ajv]. This can be a complete JSON
+  Schema object, with the property `type` of `object` and `properties` object of parameters, or
+  simply the values of what would be contained in the `properties` object as shown below.
   * `params`: validates the params. It uses [ajv][ajv].
   * `out`: filter and generate a schema for the response, setting a
     schema allows us to have 10-20% more throughput. It uses
@@ -181,6 +169,14 @@ fastify.route({
   method: 'GET',
   url: '/',
   schema: {
+    querystring: {
+      name: {
+        type: 'string'
+      },
+      excitement: {
+        type: 'integer'
+      }
+    },
     out: {
       type: 'object',
       properties: {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -30,6 +30,14 @@ function build (opts) {
   }
 
   if (opts.schema.querystring) {
+    // querystring will always be an object, allow schema def to skip this
+    if (!opts.schema.querystring.type || !opts.schema.querystring.properties) {
+      opts.schema.querystring = {
+        type: 'object',
+        properties: opts.schema.querystring
+      }
+    }
+
     opts[querystringSchema] = ajv.compile(opts.schema.querystring)
   }
 

--- a/test/internals/validation.test.js
+++ b/test/internals/validation.test.js
@@ -61,7 +61,7 @@ test('build schema - payload schema', t => {
 })
 
 test('build schema - querystring schema', t => {
-  t.plan(1)
+  t.plan(2)
   const opts = {
     schema: {
       querystring: {
@@ -73,6 +73,21 @@ test('build schema - querystring schema', t => {
     }
   }
   validation.build(opts)
+  t.type(opts[symbols.querystringSchema].schema.type, 'string')
+  t.is(typeof opts[symbols.querystringSchema], 'function')
+})
+
+test('build schema - querystring schema abbreviated', t => {
+  t.plan(2)
+  const opts = {
+    schema: {
+      querystring: {
+        hello: { type: 'string' }
+      }
+    }
+  }
+  validation.build(opts)
+  t.type(opts[symbols.querystringSchema].schema.type, 'string')
   t.is(typeof opts[symbols.querystringSchema], 'function')
 })
 


### PR DESCRIPTION
For your consideration

+ Adds support for omitting some of the meta data around the `querystring` schema definition, as it will always be an object
+ Adds tests for verifying the meta-data is correctly set as a `type` of `object` for both full schema and abbreviated
+ Adds docs to the README showing usage