### PR TITLE
feat(reply): add cors support to schema

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -96,6 +96,7 @@ function build (options) {
       handler = schema
       schema = {}
     }
+
     return route({ method, url, schema, handler })
   }
 
@@ -108,6 +109,8 @@ function build (options) {
     if (!opts.handler) {
       throw new Error(`Missing handler function for ${opts.method}:${opts.url} route.`)
     }
+
+    opts.schema.cors = typeof options.cors === 'undefined' ? true : options.cors
 
     buildSchema(opts)
 

--- a/lib/tier-node.js
+++ b/lib/tier-node.js
@@ -119,9 +119,24 @@ Reply.prototype.send = function (payload) {
     throw new Error('Reply already sent')
   }
 
-  if (this.handle.schema && this.handle.schema.out && this.handle.schema.out.cors) {
-    this.res.setHeader('Access-Control-Allow-Origin', '*');
-    this.res.setHeader('Access-Control-Allow-Headers', 'Origin,X-Requested-With,Content-Type,Accept');
+  // If user enabled cors globally and did not disable it on this route
+  if (this.handle.schema && (this.handle.schema.cors || (this.handle.schema.out && this.handle.schema.out.cors))) {
+    // if cors not disabled for this route
+    if (this.handle.schema.out && this.handle.schema.out.cors !== false) {
+      const cors = this.handle.schema.cors || this.handle.schema.out.cors
+
+      const headers = {
+        'Access-Control-Allow-Origin': cors.origin || '*',
+        'Access-Control-Allow-Methods': cors.methods || 'POST,GET,PUT,DELETE,OPTIONS,XMODIFY',
+        'Access-Control-Allow-Credentials': cors.credentials || 'true',
+        'Access-Control-Max-Age': cors.age || '86400',
+        'Access-Control-Allow-Headers': cors.headers || 'X-Requested-With,X-HTTP-Method-Override,Content-Type,Accept'
+      }
+
+      for (let header in headers) {
+        this.res.setHeader(header, headers[header])
+      }
+    }
   }
 
   if (payload instanceof Error) {

--- a/lib/tier-node.js
+++ b/lib/tier-node.js
@@ -119,6 +119,11 @@ Reply.prototype.send = function (payload) {
     throw new Error('Reply already sent')
   }
 
+  if (this.handle.schema && this.handle.schema.out && this.handle.schema.out.cors) {
+    this.res.setHeader('Access-Control-Allow-Origin', '*');
+    this.res.setHeader('Access-Control-Allow-Headers', 'Origin,X-Requested-With,Content-Type,Accept');
+  }
+
   if (payload instanceof Error) {
     if (!this.res.statusCode || this.res.statusCode < 500) {
       this.res.statusCode = 500


### PR DESCRIPTION
With the prevalence of single page/front end apps, enabling CORs requests is a common need. Fastify already supports CORs by allowing the user to add the following headers during a reply:

```js
reply.header('Access-Control-Allow-Origin', '*');
reply.header('Access-Control-Allow-Headers', 'Origin,X-Requested-With,Content-Type,Accept');
````
These headers would need to be set in every route handler. So, while possible, it's not great.

This PR would instead allow the user to specify CORs support in the `out` schema like so:

```js
"out": {
  "cors": true,
  "type": "object",
  "properties": {
   }
}
```
And have the headers added automagically.