### PR TITLE
Fast json body

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Fastify Redis connection plugin, with this you can share the same Redis connecti
 Swagger documentation generator for Fastify
 - [`fastify-multipart`](https://github.com/fastify/fastify-multipart)  
 Multipart support for Fastify
+- [`fastify-bearer-auth`](https://github.com/jsumners/fastify-bearer-auth)  
+Bearer auth plugin for Fastify
 - *More coming soon*
 
 ## Team

--- a/lib/tier-node.js
+++ b/lib/tier-node.js
@@ -3,7 +3,6 @@
 
 const urlUtil = require('url')
 const runHooks = require('fastseries')()
-const jsonParser = require('body/json')
 const validation = require('./validation')
 const validateSchema = validation.validate
 
@@ -33,7 +32,7 @@ function routerHandler (node) {
       if (req.headers['content-type']) {
         // application/json content type
         if (req.headers['content-type'].indexOf('application/json') > -1) {
-          return jsonParser(req, bodyParsed(handle, params, req, res))
+          return jsonBody(req, res, params, handle)
         // custom parser for a given content type
         } else if (handle.contentTypeParser.fastHasHeader(req.headers['content-type'])) {
           return handle.contentTypeParser.run(req.headers['content-type'], handler, handle, params, req, res, urlUtil.parse(req.url, true).query)
@@ -49,7 +48,7 @@ function routerHandler (node) {
     if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
       // application/json content type
       if (req.headers['content-type'] && req.headers['content-type'].indexOf('application/json') > -1) {
-        return jsonParser(req, bodyParsed(handle, params, req, res))
+        return jsonBody(req, res, params, handle)
       // custom parser fir a given content type
       } else if (handle.contentTypeParser.fastHasHeader(req.headers['content-type'])) {
         return handle.contentTypeParser.run(req.headers['content-type'], handler, handle, params, req, res, urlUtil.parse(req.url, true).query)
@@ -66,17 +65,36 @@ function routerHandler (node) {
   }
 }
 
-function bodyParsed (handle, params, req, res) {
-  function parsed (err, body) {
-    if (err) {
-      res.statusCode = 422
-      setImmediate(wrapResEnd, res)
-      return
-    }
-    handler(handle, params, req, res, body, urlUtil.parse(req.url, true).query)
+function jsonBody (req, res, params, handle) {
+  var body = ''
+  req.on('error', onError)
+  req.on('data', onData)
+  req.on('end', onEnd)
+  function onError (err) {
+    jsonBodyParsed(err, null)
   }
+  function onData (chunk) {
+    body += chunk
+  }
+  function onEnd () {
+    setImmediate(parse, body)
+  }
+  function parse (json) {
+    try {
+      jsonBodyParsed(null, JSON.parse(body), req, res, params, handle)
+    } catch (err) {
+      jsonBodyParsed(err, null, req, res, params, handle)
+    }
+  }
+}
 
-  return parsed
+function jsonBodyParsed (err, body, req, res, params, handle) {
+  if (err) {
+    res.statusCode = 422
+    setImmediate(wrapResEnd, res)
+    return
+  }
+  handler(handle, params, req, res, body, urlUtil.parse(req.url, true).query)
 }
 
 function handler (handle, params, req, res, body, query) {
@@ -124,4 +142,4 @@ function wrapResEnd (res, payload) {
 }
 
 module.exports = build
-module.exports[Symbol.for('internals')] = { bodyParsed, routerHandler, handler }
+module.exports[Symbol.for('internals')] = { jsonBody, jsonBodyParsed, routerHandler, handler }

--- a/lib/tier-node.js
+++ b/lib/tier-node.js
@@ -71,7 +71,7 @@ function jsonBody (req, res, params, handle) {
   req.on('data', onData)
   req.on('end', onEnd)
   function onError (err) {
-    jsonBodyParsed(err, null)
+    jsonBodyParsed(err, null, req, res, params, handle)
   }
   function onData (chunk) {
     body += chunk

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
   "dependencies": {
     "ajv": "^4.11.5",
     "avvio": "^0.6.1",
-    "body": "^5.1.0",
     "fast-json-stringify": "^0.10.4",
     "fast-safe-stringify": "^1.1.13",
     "fastseries": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "coveralls": "^2.12.0",
     "dns-prefetch-control": "^0.1.0",
     "express": "^4.15.2",
+    "fast-json-body": "^1.1.0",
     "fastify-plugin": "^0.1.0",
     "frameguard": "^3.0.0",
     "hapi": "^16.1.0",

--- a/test/custom-parser.test.js
+++ b/test/custom-parser.test.js
@@ -4,7 +4,7 @@ const t = require('tap')
 const test = t.test
 const request = require('request')
 const Fastify = require('..')
-const jsonParser = require('body/json')
+const jsonParser = require('fast-json-body')
 
 test('contentTypeParser method should exist', t => {
   t.plan(1)

--- a/test/internals/tier-node.test.js
+++ b/test/internals/tier-node.test.js
@@ -21,12 +21,6 @@ test('Request object', t => {
   t.equal(req.log, 'log')
 })
 
-test('bodyParsed function', t => {
-  t.plan(1)
-  const parsed = internals.bodyParsed(null, null, null, null)
-  t.is(typeof parsed, 'function')
-})
-
 test('handler function - invalid schema', t => {
   t.plan(2)
   const res = {}


### PR DESCRIPTION
*tl;dr*
3k req/sec more when body parsing 🎉 
___
I was doing some experiment with [fast-json-body](https://github.com/delvedor/fast-json-body) and I got way better performances than [body](https://www.npmjs.com/package/body), around ~100% more throughput.

So I tried to replace our actual json body parser, `body`, with `fast-json-body` but I got just 1k more request. As it is easy to imagine, the problem is the closure we are creating during the body parsing. So I used the same code of `fast-json-body` for parse the body, but I've update it in a way that we don't need a callback, the result was 3k req/sec more!