### PR TITLE
Add `path` alias for `url` in route options

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -8,8 +8,8 @@ fastify.route(options)
 ```
 * `method`: currently it supports `'DELETE'`, `'GET'`, `'HEAD'`, `'PATCH'`, `'POST'`, `'PUT'` and `'OPTIONS'`.
 
-* `url`: the path of the url to match this route.
-* `schema`: an object containing the schemas for the request and response.  
+* `url`: the path of the url to match this route (alias: `path`).
+* `schema`: an object containing the schemas for the request and response.
 They need to be in
   [JSON Schema](http://json-schema.org/) format, check [here](https://github.com/fastify/fastify/blob/master/docs/Validation-And-Serialize.md) for more info.
 
@@ -60,11 +60,11 @@ fastify.route({
 
 <a name="shorthand-declaration"></a>
 ### Shorthand declaration
-The above route declaration is more *Hapi*-like, but if you prefer an *Express/Restify* approach, we support it as well:  
-`fastify.get(path, [schema], handler)`  
-`fastify.head(path, [schema], handler)`  
-`fastify.post(path, [schema], handler)`  
-`fastify.put(path, [schema], handler)`  
-`fastify.delete(path, [schema], handler)`  
-`fastify.options(path, [schema], handler)`  
-`fastify.patch(path, [schema], handler)`  
+The above route declaration is more *Hapi*-like, but if you prefer an *Express/Restify* approach, we support it as well:
+`fastify.get(path, [schema], handler)`
+`fastify.head(path, [schema], handler)`
+`fastify.post(path, [schema], handler)`
+`fastify.put(path, [schema], handler)`
+`fastify.delete(path, [schema], handler)`
+`fastify.options(path, [schema], handler)`
+`fastify.patch(path, [schema], handler)`

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -61,10 +61,10 @@ fastify.route({
 <a name="shorthand-declaration"></a>
 ### Shorthand declaration
 The above route declaration is more *Hapi*-like, but if you prefer an *Express/Restify* approach, we support it as well:
-`fastify.get(path, [schema], handler)`
-`fastify.head(path, [schema], handler)`
-`fastify.post(path, [schema], handler)`
-`fastify.put(path, [schema], handler)`
-`fastify.delete(path, [schema], handler)`
-`fastify.options(path, [schema], handler)`
-`fastify.patch(path, [schema], handler)`
+`fastify.get(path, [schema], handler)`  
+`fastify.head(path, [schema], handler)`  
+`fastify.post(path, [schema], handler)`  
+`fastify.put(path, [schema], handler)`  
+`fastify.delete(path, [schema], handler)`  
+`fastify.options(path, [schema], handler)`  
+`fastify.patch(path, [schema], handler)`  

--- a/fastify.js
+++ b/fastify.js
@@ -251,16 +251,17 @@ function build (options) {
     opts.contentTypeParser = opts.contentTypeParser || this._contentTypeParser
     opts.hooks = opts.hooks || this._hooks
 
-    if (map.has(opts.url)) {
-      if (map.get(opts.url)[opts.method]) {
+    const url = opts.url || opts.path
+    if (map.has(url)) {
+      if (map.get(url)[opts.method]) {
         throw new Error(`${opts.method} already set for ${opts.url}`)
       }
 
-      map.get(opts.url)[opts.method] = opts
+      map.get(url)[opts.method] = opts
     } else {
-      const node = buildNode(opts.url, router)
+      const node = buildNode(url, router)
       node[opts.method] = opts
-      map.set(opts.url, node)
+      map.set(url, node)
     }
 
     // chainable api

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -75,3 +75,30 @@ fastify.listen(0, function (err) {
     })
   })
 })
+
+test('path can be specified in place of uri', t => {
+  t.plan(3)
+
+  fastify.listen(0, function (err) {
+    if (err) t.error(err)
+    fastify.server.unref()
+
+    fastify.route({
+      method: 'GET',
+      path: '/path',
+      handler: function (req, reply) {
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    const reqOpts = {
+      method: 'GET',
+      uri: 'http://localhost:' + fastify.server.address().port + '/path'
+    }
+    request(reqOpts, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.deepEqual(JSON.parse(body), { hello: 'world' })
+    })
+  })
+})


### PR DESCRIPTION
The `url` option in the `route` options is really specifying the `path`. This PR adds `path` as an alias for the current `url` name.