### PR TITLE
Allow specifying address for listening

### DIFF
--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -25,6 +25,14 @@ fastify.listen(3000, err => {
 })
 ```
 
+Specifying an address is also supported:
+
+```js
+fastify.listen(3000, '127.0.0.1', err => {
+  if (err) throw err
+})
+```
+
 <a name="route"></a>
 #### route
 Method to add routes to the server, it also have shorthands functions, check [here](https://github.com/fastify/fastify/blob/master/docs/Routes.md).

--- a/fastify.js
+++ b/fastify.js
@@ -153,10 +153,16 @@ function build (options) {
     router(stripUrl(this.req.url), this.req, this.res, this.req.method)
   }
 
-  function listen (port, cb) {
+  function listen (port, address, cb) {
+    const hasAddress = arguments.length === 3
+    const _cb = (hasAddress) ? cb : address
     fastify.ready(function (err) {
-      if (err) return cb(err)
-      server.listen(port, cb)
+      if (err) return _cb(err)
+      if (hasAddress) {
+        server.listen(port, address, _cb)
+      } else {
+        server.listen(port, _cb)
+      }
     })
   }
 

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const test = require('tap').test
+const fastify = require('..')()
+
+test('listen accepts a port and a callback', t => {
+  t.plan(2)
+  fastify.listen(0, (err) => {
+    fastify.server.unref()
+    t.error(err)
+    t.pass()
+  })
+})
+
+test('listen accepts a port, address, and callback', t => {
+  t.plan(2)
+  fastify.listen(0, '127.0.0.1', (err) => {
+    fastify.server.unref()
+    t.error(err)
+    t.pass()
+  })
+})


### PR DESCRIPTION
The current listen method does not allow the user to specify the address they would like the server to listen on. This PR fixes that problem.