### PR TITLE
Better boom library support

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -115,6 +115,7 @@ Reply.prototype.headers = function (headers) {
   for (var i = 0; i < keys.length; i++) {
     this.header(keys[i], headers[keys[i]])
   }
+  return this
 }
 
 Reply.prototype.code = function (code) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -43,10 +43,15 @@ Reply.prototype.send = function (payload) {
   if (payload && payload.isBoom) {
     this._req.log.error(payload)
     this.res.statusCode = payload.output.statusCode
+
+    for (var k in payload.output.headers) {
+      this.header(k, payload.output.headers[k])
+    }
+
     setImmediate(
       wrapReplyEnd,
       this,
-      safeStringify(payload)
+      safeStringify(payload.output.payload)
     )
     return
   }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -44,9 +44,7 @@ Reply.prototype.send = function (payload) {
     this._req.log.error(payload)
     this.res.statusCode = payload.output.statusCode
 
-    for (var k in payload.output.headers) {
-      this.header(k, payload.output.headers[k])
-    }
+    this.headers(payload.output.headers)
 
     setImmediate(
       wrapReplyEnd,
@@ -110,6 +108,13 @@ Reply.prototype.send = function (payload) {
 Reply.prototype.header = function (key, value) {
   this.res.setHeader(key, value)
   return this
+}
+
+Reply.prototype.headers = function (headers) {
+  var keys = Object.keys(headers)
+  for (var i = 0; i < keys.length; i++) {
+    this.header(keys[i], headers[keys[i]])
+  }
 }
 
 Reply.prototype.code = function (code) {

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -2,7 +2,7 @@
 
 const t = require('tap')
 const test = t.test
-const safeStringify = require('fast-safe-stringify')
+// const safeStringify = require('fast-safe-stringify')
 const Fastify = require('..')
 const statusCodes = require('../lib/status-codes.json')
 const boom = require('boom')
@@ -151,24 +151,71 @@ test('onRequest hook error handling with code inside done', t => {
 })
 
 test('support for boom', t => {
-  t.plan(2)
+  t.plan(7)
   const fastify = Fastify()
-  const boomObject = boom.create(500, 'winter is coming', { hello: 'world' })
 
-  fastify.get('/', (req, reply) => {
-    reply.send(boomObject)
+  fastify.get('/500', (req, reply) => {
+    reply.send(boom.create(500, 'winter is coming', { hello: 'world' }))
+  })
+
+  fastify.get('/400', (req, reply) => {
+    reply.send(boom.create(400, 'winter is coming', { hello: 'world' }))
+  })
+
+  fastify.get('/401', (req, reply) => {
+    reply.send(boom.unauthorized('invalid password', 'sample'))
   })
 
   fastify.inject({
     method: 'GET',
-    url: '/'
+    url: '/500'
   }, res => {
     t.strictEqual(res.statusCode, 500)
     t.deepEqual(
       // we are doing this because Boom creates also a stack that is stripped during the stringify phase
-      JSON.parse(safeStringify(boomObject)),
-      JSON.parse(res.payload)
+      JSON.parse(res.payload),
+      {
+        statusCode: 500,
+        error: 'Internal Server Error',
+        message: 'An internal server error occurred'
+      }
     )
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/400'
+  }, res => {
+    t.strictEqual(res.statusCode, 400)
+    t.deepEqual(
+      // we are doing this because Boom creates also a stack that is stripped during the stringify phase
+      JSON.parse(res.payload),
+      {
+        statusCode: 400,
+        error: 'Bad Request',
+        message: 'winter is coming'
+      }
+    )
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/401'
+  }, res => {
+    t.strictEqual(res.statusCode, 401)
+    t.deepEqual(
+      // we are doing this because Boom creates also a stack that is stripped during the stringify phase
+      JSON.parse(res.payload),
+      {
+        statusCode: 401,
+        error: 'Unauthorized',
+        message: 'invalid password',
+        attributes: {
+          error: 'invalid password'
+        }
+      }
+    )
+    t.deepEqual(res.headers['www-authenticate'], 'sample error="invalid password"')
   })
 })
 

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -2,7 +2,6 @@
 
 const t = require('tap')
 const test = t.test
-// const safeStringify = require('fast-safe-stringify')
 const Fastify = require('..')
 const statusCodes = require('../lib/status-codes.json')
 const boom = require('boom')
@@ -151,7 +150,7 @@ test('onRequest hook error handling with code inside done', t => {
 })
 
 test('support for boom', t => {
-  t.plan(7)
+  t.plan(3)
   const fastify = Fastify()
 
   fastify.get('/500', (req, reply) => {
@@ -166,56 +165,68 @@ test('support for boom', t => {
     reply.send(boom.unauthorized('invalid password', 'sample'))
   })
 
-  fastify.inject({
-    method: 'GET',
-    url: '/500'
-  }, res => {
-    t.strictEqual(res.statusCode, 500)
-    t.deepEqual(
-      // we are doing this because Boom creates also a stack that is stripped during the stringify phase
-      JSON.parse(res.payload),
-      {
-        statusCode: 500,
-        error: 'Internal Server Error',
-        message: 'An internal server error occurred'
-      }
-    )
-  })
+  t.test('500', t => {
+    t.plan(2)
 
-  fastify.inject({
-    method: 'GET',
-    url: '/400'
-  }, res => {
-    t.strictEqual(res.statusCode, 400)
-    t.deepEqual(
-      // we are doing this because Boom creates also a stack that is stripped during the stringify phase
-      JSON.parse(res.payload),
-      {
-        statusCode: 400,
-        error: 'Bad Request',
-        message: 'winter is coming'
-      }
-    )
-  })
-
-  fastify.inject({
-    method: 'GET',
-    url: '/401'
-  }, res => {
-    t.strictEqual(res.statusCode, 401)
-    t.deepEqual(
-      // we are doing this because Boom creates also a stack that is stripped during the stringify phase
-      JSON.parse(res.payload),
-      {
-        statusCode: 401,
-        error: 'Unauthorized',
-        message: 'invalid password',
-        attributes: {
-          error: 'invalid password'
+    fastify.inject({
+      method: 'GET',
+      url: '/500'
+    }, res => {
+      t.strictEqual(res.statusCode, 500)
+      t.deepEqual(
+        // we are doing this because Boom creates also a stack that is stripped during the stringify phase
+        JSON.parse(res.payload),
+        {
+          statusCode: 500,
+          error: 'Internal Server Error',
+          message: 'An internal server error occurred'
         }
-      }
-    )
-    t.deepEqual(res.headers['www-authenticate'], 'sample error="invalid password"')
+      )
+    })
+  })
+
+  t.test('400', t => {
+    t.plan(2)
+
+    fastify.inject({
+      method: 'GET',
+      url: '/400'
+    }, res => {
+      t.strictEqual(res.statusCode, 400)
+      t.deepEqual(
+        // we are doing this because Boom creates also a stack that is stripped during the stringify phase
+        JSON.parse(res.payload),
+        {
+          statusCode: 400,
+          error: 'Bad Request',
+          message: 'winter is coming'
+        }
+      )
+    })
+  })
+
+  t.test('401', t => {
+    t.plan(3)
+
+    fastify.inject({
+      method: 'GET',
+      url: '/401'
+    }, res => {
+      t.strictEqual(res.statusCode, 401)
+      t.deepEqual(
+        // we are doing this because Boom creates also a stack that is stripped during the stringify phase
+        JSON.parse(res.payload),
+        {
+          statusCode: 401,
+          error: 'Unauthorized',
+          message: 'invalid password',
+          attributes: {
+            error: 'invalid password'
+          }
+        }
+      )
+      t.deepEqual(res.headers['www-authenticate'], 'sample error="invalid password"')
+    })
   })
 })
 


### PR DESCRIPTION
The 0.19.0 version adds the boom library support. It's amazing!

I've noticed the output is very strange:
```
{
 	"data": {
 		"hello": "world"
 	},
 	"isBoom": true,
 	"isServer": true,
 	"output": {
 		"statusCode": 500,
 		"payload": {
 			"statusCode": 500,
 			"error": "Internal Server Error",
 			"message": "An internal server error occurred"
 		},
 		"headers": {}
 	}
 }
```

Maybe the http body could contain only the `output.payload` property.

I've also added the headers