### PR TITLE
Updated async await test for node v8

### DIFF
--- a/test/async-await.js
+++ b/test/async-await.js
@@ -78,7 +78,3 @@ function asyncTest (t) {
 }
 
 module.exports = asyncTest
-
-if (require.main === module) {
-  asyncTest(require('tap'))
-}

--- a/test/async-await.test.js
+++ b/test/async-await.test.js
@@ -1,14 +1,10 @@
 'use strict'
 
-const path = require('path')
-const childProcess = require('child_process')
 const tap = require('tap')
 
-if (Number(process.versions.node[0]) === 7) {
-  childProcess.fork(path.join(__dirname, 'async-await'), [], {
-    execArgv: ['--harmony-async-await']
-  })
+if (Number(process.versions.node[0]) >= 8) {
+  require('./async-await')(tap)
 } else {
-  tap.pass('Skip because Node version < 7')
+  tap.pass('Skip because Node version < 8')
   tap.end()
 }


### PR DESCRIPTION
Since node v8 is out we can remove the *async/await* test for node v7.