### PR TITLE
Route prefixing

### DIFF
--- a/benchmarks/express-route-prefix.js
+++ b/benchmarks/express-route-prefix.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const express = require('express')
+const app = express()
+
+const router = express.Router()
+
+router.get('/hello', (req, res) => {
+  res.send({ hello: 'world' })
+})
+
+app.use('/greet', router)
+
+app.listen(3000, function () {
+  console.log('Example app listening on port 3000!')
+})

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -20,6 +20,10 @@ fastify.register([
 })
 ```
 
+<a name="route-prefixing-option"></a>
+### Route Prefixing option
+If you pass an option with the key `prefix` with a `string` value, Fastify will use it to prefix all the routes inside the register, for more info check [here](https://github.com/fastify/fastify/blob/master/docs/Routes.md#route-prefixing).
+
 <a name="error-handling"></a>
 #### Error handling
 The error handling is done by [avvio](https://github.com/mcollina/avvio#error-handling).  

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -70,3 +70,39 @@ The above route declaration is more *Hapi*-like, but if you prefer an *Express/R
 `fastify.delete(path, [schema], handler)`  
 `fastify.options(path, [schema], handler)`  
 `fastify.patch(path, [schema], handler)`  
+
+<a name="route-prefixing"></a>
+### Route Prefixing
+Sometimes you need to maintain two or more different versions of the same api, a classic approach is to prefix all the routes with the api version number, `/v1/user` for example.  
+Fastify offers you a fast and smart way to create different version of the same api without changing all the route names by hand, *route prefixing*. Let's see how it works:
+
+```js
+// server.js
+const fastify = require('fastify')()
+
+fastify.register(require('./routes/v1/users'), { prefix: '/v1' })
+fastify.register(require('./routes/v2/users'), { prefix: '/v2' })
+
+fastify.listen(3000)
+```
+```js
+// routes/v1/users.js
+module.exports = function (fastify, opts, next) {
+  fastify.get('/user', handler_v1)
+  next()
+}
+```
+```js
+// routes/v2/users.js
+module.exports = function (fastify, opts, next) {
+  fastify.get('/user', handler_v2)
+  next()
+}
+```
+Fastify will not complain because your are using the same name for two different routes, because at compilation time it will handle the prefix automatically *(this also means that the performances will not be affected at all!)*.
+
+Now your clients will have access to the following routes:
+- `/v1/user`
+- `/v2/user`
+
+You can to this as many time as you want, it works also for nested `register` and routes parameter are supported as well.

--- a/examples/route-prefix.js
+++ b/examples/route-prefix.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const fastify = require('../fastify')()
+
+const schema = {
+  schema: {
+    response: {
+      '2xx': {
+        type: 'object',
+        properties: {
+          greet: { type: 'string' }
+        }
+      }
+    }
+  }
+}
+
+fastify.register(function (instance, opts, next) {
+  // the route will be '/english/hello'
+  instance.get('/hello', schema, (req, reply) => {
+    reply.send({ greet: 'hello' })
+  })
+  next()
+}, { prefix: '/english' })
+
+fastify.register(function (instance, opts, next) {
+  // the route will be '/italian/hello'
+  instance.get('/hello', schema, (req, reply) => {
+    reply.send({ greet: 'ciao' })
+  })
+  next()
+}, { prefix: '/italian' })
+
+fastify.listen(8000, function (err) {
+  if (err) {
+    throw err
+  }
+  console.log(`server listening on ${fastify.server.address().port}`)
+})

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "ajv": "^5.1.5",
-    "avvio": "^0.6.1",
+    "avvio": "^1.0.0",
     "fast-json-stringify": "^0.12.1",
     "fast-safe-stringify": "^1.2.0",
     "fastify-cli": "^0.6.1",

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -1,0 +1,97 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('..')
+
+test('Prefix options should add a prefix for all the routes inside a register / 1', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.get('/first', (req, reply) => {
+    reply.send({ route: '/first' })
+  })
+
+  fastify.register(function (fastify, opts, next) {
+    fastify.get('/first', (req, reply) => {
+      reply.send({ route: '/v1/first' })
+    })
+
+    fastify.register(function (fastify, opts, next) {
+      fastify.get('/first', (req, reply) => {
+        reply.send({ route: '/v1/v2/first' })
+      })
+      next()
+    }, { prefix: '/v2' }, next)
+  }, { prefix: '/v1' })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/first'
+  }, res => {
+    t.same(JSON.parse(res.payload), { route: '/first' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/v1/first'
+  }, res => {
+    t.same(JSON.parse(res.payload), { route: '/v1/first' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/v1/v2/first'
+  }, res => {
+    t.same(JSON.parse(res.payload), { route: '/v1/v2/first' })
+  })
+})
+
+test('Prefix options should add a prefix for all the routes inside a register / 2', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.register(function (fastify, opts, next) {
+    fastify.get('/first', (req, reply) => {
+      reply.send({ route: '/v1/first' })
+    })
+
+    fastify.get('/second', (req, reply) => {
+      reply.send({ route: '/v1/second' })
+    })
+    next()
+  }, { prefix: '/v1' })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/v1/first'
+  }, res => {
+    t.same(JSON.parse(res.payload), { route: '/v1/first' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/v1/second'
+  }, res => {
+    t.same(JSON.parse(res.payload), { route: '/v1/second' })
+  })
+})
+
+test('Prefix should support parameters as well', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  fastify.register(function (fastify, opts, next) {
+    fastify.get('/hello', (req, reply) => {
+      reply.send({ id: req.params.id })
+    })
+    next()
+  }, { prefix: '/v1/:id' })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/v1/param/hello'
+  }, res => {
+    t.same(JSON.parse(res.payload), { id: 'param' })
+  })
+})


### PR DESCRIPTION
With this PR we introduce a system that allows the user to prefix all the routes inside a `register`, this could be useful when you need to maintain two different versions of the same api for example.
Talking about examples:

```js
const fastify = require('fastify')()

fastify.register(require('./routes-v1'), { prefix: '/v1' })
fastify.register(require('./routes-v2'), { prefix: '/v2' })

fastify.listen(3000)
``` 
```js
// routes-v1.js
module.exports = function (fastify, opts, next) {
  fastify.get('/user', handler)
}
```
```js
// routes-v2.js
module.exports = function (fastify, opts, next) {
  fastify.get('/user', handler)
}
```
The clients will have access to the routes:
- `/v1/user`
- `/v2/user`

Feedbacks? :)

cc @lucamaraschi @davidmarkclements