### PR TITLE
Upgrade deprecated koa middleware signature

### DIFF
--- a/benchmarks/koa.js
+++ b/benchmarks/koa.js
@@ -3,8 +3,8 @@
 var Koa = require('koa')
 var app = new Koa()
 
-app.use(function * () {
-  this.body = JSON.stringify({ hello: 'world' })
+app.use(async (ctx) => {
+  ctx.body = JSON.stringify({ hello: 'world' })
 })
 
 app.listen(3000)


### PR DESCRIPTION
Generators have been deprecated for a while in `koa`. This PR switches the middleware to use `async/await` which improves koa's benchmark score about `~20%` on my machine.