### PR TITLE
Accept full options object in shorthand routes

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -31,19 +31,21 @@ Fastify is designed to be very performant, if you want to make it even faster, y
 ```js
 const fastify = require('fastify')()
 
-const schema = {
-  response: {
-    200: {
-      type: 'object',
-      properties: {
-        hello: { type: 'string' }
+const opts = {
+  schema: {
+    response: {
+      200: {
+        type: 'object',
+        properties: {
+          hello: { type: 'string' }
+        }
       }
     }
   }
 }
 
 // Declare a route with an output schema
-fastify.get('/', schema, function (request, reply) {
+fastify.get('/', opts, function (request, reply) {
   reply.send({ hello: 'world' })
 })
 

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -18,7 +18,7 @@ const fastify = require('fastify')({
   }
 })
 
-fastify.get('/', schema, function (req, reply) {
+fastify.get('/', options, function (req, reply) {
   req.log.info('Some info about the current request')
   reply.send({ hello: 'world' })
 })

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -10,7 +10,7 @@ Reply is a core Fastify object that exposes the following functions:
 - `.send(payload)` - Sends the payload to the user, could be a plain text, JSON, stream, or an Error object.
 
 ```js
-fastify.get('/', schema, function (request, reply) {
+fastify.get('/', options, function (request, reply) {
   // You code
   reply
     .code(200)
@@ -50,7 +50,7 @@ reply
 #### Objects
 As writed above, if you are sending JSON objects, *send* will serialize the object with [fast-json-stringify](https://www.npmjs.com/package/fast-json-stringify) if you setted an output schema, otherwise [fast-safe-stringify](https://www.npmjs.com/package/fast-safe-stringify).
 ```js
-fastify.get('/json', schema, function (request, reply) {
+fastify.get('/json', options, function (request, reply) {
   reply.send({ hello: 'world' })
 })
 ```
@@ -59,7 +59,7 @@ fastify.get('/json', schema, function (request, reply) {
 #### Promises
 *send* handle natively the *promises* and supports out of the box *async-await*.
 ```js
-fastify.get('/promises', schema, function (request, reply) {
+fastify.get('/promises', options, function (request, reply) {
   const promise = new Promise(...)
   reply
     .code(200)
@@ -67,7 +67,7 @@ fastify.get('/promises', schema, function (request, reply) {
     .send(promise)
 })
 
-fastify.get('/async-await', schema, async function (request, reply) {
+fastify.get('/async-await', options, async function (request, reply) {
   var res = await new Promise(function (resolve) {
     setTimeout(resolve, 200, { hello: 'world' })
   })

--- a/docs/Request.md
+++ b/docs/Request.md
@@ -10,7 +10,7 @@ Request is a core Fastify object containing the following fields:
 - `log` - the logger instance of the incoming request
 
 ```js
-fastify.post('/:params', schema, function (request, reply) {
+fastify.post('/:params', options, function (request, reply) {
   console.log(request.body)
   console.log(request.query)
   console.log(request.params)

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -36,20 +36,14 @@ fastify.route({
   url: '/',
   schema: {
     querystring: {
-      name: {
-        type: 'string'
-      },
-      excitement: {
-        type: 'integer'
-      }
+      name: { type: 'string' },
+      excitement: { type: 'integer' }
     },
     response: {
       200: {
         type: 'object',
         properties: {
-          hello: {
-            type: 'string'
-          }
+          hello: { type: 'string' }
         }
       }
     }
@@ -62,14 +56,33 @@ fastify.route({
 
 <a name="shorthand-declaration"></a>
 ### Shorthand declaration
-The above route declaration is more *Hapi*-like, but if you prefer an *Express/Restify* approach, we support it as well:
-`fastify.get(path, [schema], handler)`  
-`fastify.head(path, [schema], handler)`  
-`fastify.post(path, [schema], handler)`  
-`fastify.put(path, [schema], handler)`  
-`fastify.delete(path, [schema], handler)`  
-`fastify.options(path, [schema], handler)`  
-`fastify.patch(path, [schema], handler)`  
+The above route declaration is more *Hapi*-like, but if you prefer an *Express/Restify* approach, we support it as well:  
+`fastify.get(path, [options], handler)`  
+`fastify.head(path, [options], handler)`  
+`fastify.post(path, [options], handler)`  
+`fastify.put(path, [options], handler)`  
+`fastify.delete(path, [options], handler)`  
+`fastify.options(path, [options], handler)`  
+`fastify.patch(path, [options], handler)`  
+
+Example:
+```js
+const opts = {
+  schema: {
+    response: {
+      200: {
+        type: 'object',
+        properties: {
+          hello: { type: 'string' }
+        }
+      }
+    }
+  }
+}
+fastify.get('/', opts, (req, reply) => {
+  reply.send({ hello: 'world' })
+})
+```
 
 <a name="route-prefixing"></a>
 ### Route Prefixing

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -15,19 +15,21 @@ The modules you'll need:
 const minimist = require('minimist')
 const fastify = require('fastify')()
 
-const schema = {
-  response: {
-    200: {
-      type: 'object',
-      properties: {
-        hello: { type: 'string' }
+const options = {
+  schema: {
+    response: {
+      200: {
+        type: 'object',
+        properties: {
+          hello: { type: 'string' }
+        }
       }
     }
   }
 }
 
 function start (opts, callback) {
-  fastify.get('/', schema, function (request, reply) {
+  fastify.get('/', options, function (request, reply) {
     reply.send({ hello: 'world' })
   })
 
@@ -109,18 +111,20 @@ Example:
 const minimist = require('minimist')
 const fastify = require('fastify')()
 
-const schema = {
-  response: {
-    200: {
-      type: 'object',
-      properties: {
-        hello: { type: 'string' }
+const options = {
+  schema: {
+    response: {
+      200: {
+        type: 'object',
+        properties: {
+          hello: { type: 'string' }
+        }
       }
     }
   }
 }
 
-fastify.get('/', schema, function (request, reply) {
+fastify.get('/', options, function (request, reply) {
   reply.send({ hello: 'world' })
 })
 

--- a/examples/example.js
+++ b/examples/example.js
@@ -2,13 +2,15 @@
 
 const fastify = require('../fastify')()
 
-const schema = {
-  response: {
-    200: {
-      type: 'object',
-      properties: {
-        hello: {
-          type: 'string'
+const opts = {
+  schema: {
+    response: {
+      200: {
+        type: 'object',
+        properties: {
+          hello: {
+            type: 'string'
+          }
         }
       }
     }
@@ -16,17 +18,17 @@ const schema = {
 }
 
 fastify
-  .get('/', schema, function (req, reply) {
+  .get('/', opts, function (req, reply) {
     reply.header('Content-Type', 'application/json').code(200)
     reply.send({ hello: 'world' })
   })
-  .get('/promise', schema, function (req, reply) {
+  .get('/promise', opts, function (req, reply) {
     const promise = new Promise(function (resolve, reject) {
       resolve({ hello: 'world' })
     })
     reply.header('content-type', 'application/json').code(200).send(promise)
   })
-  .get('/return-promise', schema, function (req, reply) {
+  .get('/return-promise', opts, function (req, reply) {
     const promise = new Promise(function (resolve, reject) {
       resolve({ hello: 'world' })
     })
@@ -37,16 +39,16 @@ fastify
     const stream = fs.createReadStream(process.cwd() + '/examples/plugin.js', 'utf8')
     reply.code(200).send(stream)
   })
-  .post('/', schema, function (req, reply) {
+  .post('/', opts, function (req, reply) {
     reply.send({ hello: 'world' })
   })
   .head('/', {}, function (req, reply) {
     reply.send()
   })
-  .delete('/', schema, function (req, reply) {
+  .delete('/', opts, function (req, reply) {
     reply.send({ hello: 'world' })
   })
-  .patch('/', schema, function (req, reply) {
+  .patch('/', opts, function (req, reply) {
     reply.send({ hello: 'world' })
   })
 

--- a/examples/hooks.js
+++ b/examples/hooks.js
@@ -13,6 +13,10 @@ const opts = {
           }
         }
       }
+    },
+    beforeHandler: (req, reply, done) => {
+      console.log('before handler')
+      done()
     }
   }
 }
@@ -31,7 +35,7 @@ fastify
     next()
   })
 
-fastify.get('/', opts.schema, function (req, reply) {
+fastify.get('/', opts, function (req, reply) {
   reply.send({ hello: 'world' })
 })
 

--- a/examples/hooks.js
+++ b/examples/hooks.js
@@ -13,10 +13,6 @@ const opts = {
           }
         }
       }
-    },
-    beforeHandler: (req, reply, done) => {
-      console.log('before handler')
-      done()
     }
   }
 }

--- a/examples/https.js
+++ b/examples/https.js
@@ -8,13 +8,15 @@ const fastify = require('../fastify')({
   }
 })
 
-const schema = {
-  response: {
-    '2xx': {
-      type: 'object',
-      properties: {
-        hello: {
-          type: 'string'
+const opts = {
+  schema: {
+    response: {
+      '2xx': {
+        type: 'object',
+        properties: {
+          hello: {
+            type: 'string'
+          }
         }
       }
     }
@@ -22,7 +24,7 @@ const schema = {
 }
 
 fastify
-  .get('/', schema, function (req, reply) {
+  .get('/', opts, function (req, reply) {
     reply.header('Content-Type', 'application/json').code(200)
     reply.send({ hello: 'world' })
   })

--- a/examples/middleware.js
+++ b/examples/middleware.js
@@ -10,13 +10,15 @@ fastify.use(require('hsts')())
 fastify.use(require('ienoopen')())
 fastify.use(require('x-xss-protection')())
 
-const schema = {
-  response: {
-    '2xx': {
-      type: 'object',
-      properties: {
-        hello: {
-          type: 'string'
+const opts = {
+  schema: {
+    response: {
+      '2xx': {
+        type: 'object',
+        properties: {
+          hello: {
+            type: 'string'
+          }
         }
       }
     }
@@ -24,7 +26,7 @@ const schema = {
 }
 
 fastify
-  .get('/', schema, function (req, reply) {
+  .get('/', opts, function (req, reply) {
     reply.header('Content-Type', 'application/json').code(200)
     reply.send({ hello: 'world' })
   })

--- a/examples/plugin.js
+++ b/examples/plugin.js
@@ -2,10 +2,10 @@
 
 module.exports = function (fastify, opts, next) {
   fastify
-    .get('/', opts.schema, function (req, reply) {
+    .get('/', opts, function (req, reply) {
       reply.send({ hello: 'world' })
     })
-    .post('/', opts.schema, function (req, reply) {
+    .post('/', opts, function (req, reply) {
       reply.send({ hello: 'world' })
     })
   next()

--- a/examples/route-prefix.js
+++ b/examples/route-prefix.js
@@ -2,7 +2,7 @@
 
 const fastify = require('../fastify')()
 
-const schema = {
+const opts = {
   schema: {
     response: {
       '2xx': {
@@ -15,17 +15,17 @@ const schema = {
   }
 }
 
-fastify.register(function (instance, opts, next) {
+fastify.register(function (instance, options, next) {
   // the route will be '/english/hello'
-  instance.get('/hello', schema, (req, reply) => {
+  instance.get('/hello', opts, (req, reply) => {
     reply.send({ greet: 'hello' })
   })
   next()
 }, { prefix: '/english' })
 
-fastify.register(function (instance, opts, next) {
+fastify.register(function (instance, options, next) {
   // the route will be '/italian/hello'
-  instance.get('/hello', schema, (req, reply) => {
+  instance.get('/hello', opts, (req, reply) => {
     reply.send({ greet: 'ciao' })
   })
   next()

--- a/fastify.js
+++ b/fastify.js
@@ -276,7 +276,6 @@ function build (options) {
       url,
       handler,
       schema: options.schema || {},
-      beforeHandler: options.beforeHandler,
       Reply: self._Reply,
       Request: self._Request,
       contentTypeParser: self._contentTypeParser,

--- a/fastify.js
+++ b/fastify.js
@@ -238,44 +238,45 @@ function build (options) {
   }
 
   // Shorthand methods
-  function _delete (url, schema, handler) {
-    return _route(this, 'DELETE', url, schema, handler)
+  function _delete (url, opts, handler) {
+    return _route(this, 'DELETE', url, opts, handler)
   }
 
-  function _get (url, schema, handler) {
-    return _route(this, 'GET', url, schema, handler)
+  function _get (url, opts, handler) {
+    return _route(this, 'GET', url, opts, handler)
   }
 
-  function _head (url, schema, handler) {
-    return _route(this, 'HEAD', url, schema, handler)
+  function _head (url, opts, handler) {
+    return _route(this, 'HEAD', url, opts, handler)
   }
 
-  function _patch (url, schema, handler) {
-    return _route(this, 'PATCH', url, schema, handler)
+  function _patch (url, opts, handler) {
+    return _route(this, 'PATCH', url, opts, handler)
   }
 
-  function _post (url, schema, handler) {
-    return _route(this, 'POST', url, schema, handler)
+  function _post (url, opts, handler) {
+    return _route(this, 'POST', url, opts, handler)
   }
 
-  function _put (url, schema, handler) {
-    return _route(this, 'PUT', url, schema, handler)
+  function _put (url, opts, handler) {
+    return _route(this, 'PUT', url, opts, handler)
   }
 
-  function _options (url, schema, handler) {
-    return _route(this, 'OPTIONS', url, schema, handler)
+  function _options (url, opts, handler) {
+    return _route(this, 'OPTIONS', url, opts, handler)
   }
 
-  function _route (self, method, url, schema, handler) {
-    if (!handler && typeof schema === 'function') {
-      handler = schema
-      schema = {}
+  function _route (self, method, url, options, handler) {
+    if (!handler && typeof options === 'function') {
+      handler = options
+      options = {}
     }
     return route({
       method,
       url,
-      schema,
       handler,
+      schema: options.schema || {},
+      beforeHandler: options.beforeHandler,
       Reply: self._Reply,
       Request: self._Request,
       contentTypeParser: self._contentTypeParser,

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -97,10 +97,10 @@ function handler (store, params, req, res, body, query) {
   )
 }
 
-function State (request, reply, handle) {
+function State (request, reply, store) {
   this.request = request
   this.reply = reply
-  this.handle = handle
+  this.store = store
 }
 
 function hookIterator (fn, cb) {
@@ -113,7 +113,8 @@ function preHandlerCallback (err, code) {
     this.reply.send(err)
     return
   }
-  var result = this.handle.handler(this.request, this.reply)
+
+  var result = this.store.handler(this.request, this.reply)
   if (result && typeof result.then === 'function') {
     this.reply.send(result)
   }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -10,9 +10,9 @@ const serialize = validation.serialize
 const statusCodes = require('http').STATUS_CODES
 const stringify = JSON.stringify
 
-function Reply (req, res, handle) {
+function Reply (req, res, store) {
   this.res = res
-  this.handle = handle
+  this.store = store
   this._req = req
   this.sent = false
   this._serializer = null
@@ -86,7 +86,7 @@ Reply.prototype.send = function (payload) {
     this.res.setHeader('Content-Type', 'application/json')
 
     // Here we are assuming that the custom serializer is a json serializer
-    const str = this._serializer ? this._serializer(payload) : serialize(this.handle, payload, this.res.statusCode)
+    const str = this._serializer ? this._serializer(payload) : serialize(this.store, payload, this.res.statusCode)
     if (!this.res.getHeader('Content-Length')) {
       this.res.setHeader('Content-Length', Buffer.byteLength(str))
     }
@@ -148,9 +148,9 @@ function wrapReplySend (reply, payload) {
 }
 
 function buildReply (R) {
-  function _Reply (req, res, handle) {
+  function _Reply (req, res, store) {
     this.res = res
-    this.handle = handle
+    this.store = store
     this._req = req
     this.sent = false
     this._serializer = null

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -5,20 +5,22 @@ const test = t.test
 const request = require('request')
 const fastify = require('..')()
 
-const schema = {
-  response: {
-    '2xx': {
-      type: 'object',
-      properties: {
-        hello: {
-          type: 'string'
+const opts = {
+  schema: {
+    response: {
+      '2xx': {
+        type: 'object',
+        properties: {
+          hello: {
+            type: 'string'
+          }
         }
       }
     }
   }
 }
 
-fastify.get('/', schema, function (req, reply) {
+fastify.get('/', opts, function (req, reply) {
   reply.send({ hello: 'world' })
 })
 

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -4,13 +4,15 @@ const request = require('request')
 const fastify = require('..')()
 const sleep = require('then-sleep')
 
-const schema = {
-  response: {
-    '2xx': {
-      type: 'object',
-      properties: {
-        hello: {
-          type: 'string'
+const opts = {
+  schema: {
+    response: {
+      '2xx': {
+        type: 'object',
+        properties: {
+          hello: {
+            type: 'string'
+          }
         }
       }
     }
@@ -23,7 +25,7 @@ function asyncTest (t) {
   test('shorthand - async await get', t => {
     t.plan(1)
     try {
-      fastify.get('/', schema, async function awaitMyFunc (req, reply) {
+      fastify.get('/', opts, async function awaitMyFunc (req, reply) {
         await sleep(200)
         return { hello: 'world' }
       })
@@ -36,7 +38,7 @@ function asyncTest (t) {
   test('shorthand - async await get', t => {
     t.plan(1)
     try {
-      fastify.get('/no-await', schema, async function (req, reply) {
+      fastify.get('/no-await', opts, async function (req, reply) {
         return { hello: 'world' }
       })
       t.pass()

--- a/test/chainable.test.js
+++ b/test/chainable.test.js
@@ -5,13 +5,15 @@ const test = t.test
 const fastify = require('..')()
 
 const noop = () => {}
-const schema = {
-  response: {
-    '2xx': {
-      type: 'object',
-      properties: {
-        hello: {
-          type: 'string'
+const opts = {
+  schema: {
+    response: {
+      '2xx': {
+        type: 'object',
+        properties: {
+          hello: {
+            type: 'string'
+          }
         }
       }
     }
@@ -20,12 +22,12 @@ const schema = {
 
 test('chainable - get', t => {
   t.plan(1)
-  t.type(fastify.get('/', schema, noop), fastify)
+  t.type(fastify.get('/', opts, noop), fastify)
 })
 
 test('chainable - post', t => {
   t.plan(1)
-  t.type(fastify.post('/', schema, noop), fastify)
+  t.type(fastify.post('/', opts, noop), fastify)
 })
 
 test('chainable - route', t => {
@@ -33,7 +35,7 @@ test('chainable - route', t => {
   t.type(fastify.route({
     method: 'GET',
     url: '/other',
-    schema: schema,
+    schema: opts.schema,
     handler: noop
   }), fastify)
 })

--- a/test/delete.test.js
+++ b/test/delete.test.js
@@ -6,12 +6,14 @@ const request = require('request')
 const fastify = require('..')()
 
 const schema = {
-  response: {
-    '2xx': {
-      type: 'object',
-      properties: {
-        hello: {
-          type: 'string'
+  schema: {
+    response: {
+      '2xx': {
+        type: 'object',
+        properties: {
+          hello: {
+            type: 'string'
+          }
         }
       }
     }
@@ -19,25 +21,29 @@ const schema = {
 }
 
 const querySchema = {
-  querystring: {
-    type: 'object',
-    properties: {
-      hello: {
-        type: 'integer'
+  schema: {
+    querystring: {
+      type: 'object',
+      properties: {
+        hello: {
+          type: 'integer'
+        }
       }
     }
   }
 }
 
 const paramsSchema = {
-  params: {
-    type: 'object',
-    properties: {
-      foo: {
-        type: 'string'
-      },
-      test: {
-        type: 'integer'
+  schema: {
+    params: {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'string'
+        },
+        test: {
+          type: 'integer'
+        }
       }
     }
   }

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -7,12 +7,14 @@ const fastify = require('..')()
 const safeStringify = require('fast-safe-stringify')
 
 const schema = {
-  response: {
-    '2xx': {
-      type: 'object',
-      properties: {
-        hello: {
-          type: 'string'
+  schema: {
+    response: {
+      '2xx': {
+        type: 'object',
+        properties: {
+          hello: {
+            type: 'string'
+          }
         }
       }
     }
@@ -20,12 +22,14 @@ const schema = {
 }
 
 const numberSchema = {
-  response: {
-    '2xx': {
-      type: 'object',
-      properties: {
-        hello: {
-          type: 'number'
+  schema: {
+    response: {
+      '2xx': {
+        type: 'object',
+        properties: {
+          hello: {
+            type: 'number'
+          }
         }
       }
     }
@@ -33,25 +37,29 @@ const numberSchema = {
 }
 
 const querySchema = {
-  querystring: {
-    type: 'object',
-    properties: {
-      hello: {
-        type: 'integer'
+  schema: {
+    querystring: {
+      type: 'object',
+      properties: {
+        hello: {
+          type: 'integer'
+        }
       }
     }
   }
 }
 
 const paramsSchema = {
-  params: {
-    type: 'object',
-    properties: {
-      foo: {
-        type: 'string'
-      },
-      test: {
-        type: 'integer'
+  schema: {
+    params: {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'string'
+        },
+        test: {
+          type: 'integer'
+        }
       }
     }
   }

--- a/test/head.test.js
+++ b/test/head.test.js
@@ -6,33 +6,39 @@ const request = require('request')
 const fastify = require('..')()
 
 const schema = {
-  response: {
-    '2xx': {
-      type: 'null'
+  schema: {
+    response: {
+      '2xx': {
+        type: 'null'
+      }
     }
   }
 }
 
 const querySchema = {
-  querystring: {
-    type: 'object',
-    properties: {
-      hello: {
-        type: 'integer'
+  schema: {
+    querystring: {
+      type: 'object',
+      properties: {
+        hello: {
+          type: 'integer'
+        }
       }
     }
   }
 }
 
 const paramsSchema = {
-  params: {
-    type: 'object',
-    properties: {
-      foo: {
-        type: 'string'
-      },
-      test: {
-        type: 'integer'
+  schema: {
+    params: {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'string'
+        },
+        test: {
+          type: 'integer'
+        }
       }
     }
   }

--- a/test/helper.js
+++ b/test/helper.js
@@ -9,12 +9,14 @@ module.exports.payloadMethod = function (method, t) {
   const loMethod = method.toLowerCase()
 
   const schema = {
-    response: {
-      '2xx': {
-        type: 'object',
-        properties: {
-          hello: {
-            type: 'string'
+    schema: {
+      response: {
+        '2xx': {
+          type: 'object',
+          properties: {
+            hello: {
+              type: 'string'
+            }
           }
         }
       }

--- a/test/input-validation.js
+++ b/test/input-validation.js
@@ -8,12 +8,14 @@ module.exports.payloadMethod = function (method, t) {
   const upMethod = method.toUpperCase()
   const loMethod = method.toLowerCase()
 
-  const schema = {
-    body: {
-      type: 'object',
-      properties: {
-        hello: {
-          type: 'integer'
+  const opts = {
+    schema: {
+      body: {
+        type: 'object',
+        properties: {
+          hello: {
+            type: 'integer'
+          }
         }
       }
     }
@@ -22,7 +24,7 @@ module.exports.payloadMethod = function (method, t) {
   test(`${upMethod} can be created`, t => {
     t.plan(1)
     try {
-      fastify[loMethod]('/', schema, function (req, reply) {
+      fastify[loMethod]('/', opts, function (req, reply) {
         reply.send(req.body)
       })
       t.pass()

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -24,7 +24,7 @@ test('Once called, Reply should return an object with methods', t => {
   t.is(typeof reply.header, 'function')
   t.strictEqual(reply._req, request)
   t.strictEqual(reply.res, response)
-  t.strictEqual(reply.handle, handle)
+  t.strictEqual(reply.store, handle)
 })
 
 test('reply.header, reply.code and reply-serializer should return an instance of Reply', t => {

--- a/test/output-validation.test.js
+++ b/test/output-validation.test.js
@@ -5,21 +5,23 @@ const test = t.test
 const request = require('request')
 const fastify = require('..')()
 
-const schema = {
-  response: {
-    200: {
-      type: 'object',
-      properties: {
-        hello: {
-          type: 'string'
+const opts = {
+  schema: {
+    response: {
+      200: {
+        type: 'object',
+        properties: {
+          hello: {
+            type: 'string'
+          }
         }
-      }
-    },
-    '2xx': {
-      type: 'object',
-      properties: {
-        hello: {
-          type: 'number'
+      },
+      '2xx': {
+        type: 'object',
+        properties: {
+          hello: {
+            type: 'number'
+          }
         }
       }
     }
@@ -29,7 +31,7 @@ const schema = {
 test('shorthand - output string', t => {
   t.plan(1)
   try {
-    fastify.get('/string', schema, function (req, reply) {
+    fastify.get('/string', opts, function (req, reply) {
       reply.code(200).send({ hello: 'world' })
     })
     t.pass()
@@ -41,7 +43,7 @@ test('shorthand - output string', t => {
 test('shorthand - output number', t => {
   t.plan(1)
   try {
-    fastify.get('/number', schema, function (req, reply) {
+    fastify.get('/number', opts, function (req, reply) {
       reply.code(201).send({ hello: 55 })
     })
     t.pass()
@@ -53,7 +55,7 @@ test('shorthand - output number', t => {
 test('wrong object for schema - output', t => {
   t.plan(1)
   try {
-    fastify.get('/wrong-object-for-schema', schema, function (req, reply) {
+    fastify.get('/wrong-object-for-schema', opts, function (req, reply) {
       // will send { hello: null }
       reply.code(201).send({ hello: 'world' })
     })
@@ -67,7 +69,7 @@ test('empty response', t => {
   t.plan(1)
   try {
     // no checks
-    fastify.get('/empty', schema, function (req, reply) {
+    fastify.get('/empty', opts, function (req, reply) {
       reply.code(204).send()
     })
     t.pass()

--- a/test/promises.test.js
+++ b/test/promises.test.js
@@ -6,13 +6,15 @@ const request = require('request')
 const Bluebird = require('bluebird')
 const fastify = require('..')()
 
-const schema = {
-  response: {
-    '2xx': {
-      type: 'object',
-      properties: {
-        hello: {
-          type: 'string'
+const opts = {
+  schema: {
+    response: {
+      '2xx': {
+        type: 'object',
+        properties: {
+          hello: {
+            type: 'string'
+          }
         }
       }
     }
@@ -22,7 +24,7 @@ const schema = {
 test('shorthand - promise es6 get', t => {
   t.plan(1)
   try {
-    fastify.get('/', schema, function (req, reply) {
+    fastify.get('/', opts, function (req, reply) {
       const promise = new Promise((resolve, reject) => {
         resolve({ hello: 'world' })
       })
@@ -37,7 +39,7 @@ test('shorthand - promise es6 get', t => {
 test('shorthand - return promise es6 get', t => {
   t.plan(1)
   try {
-    fastify.get('/return', schema, function (req, reply) {
+    fastify.get('/return', opts, function (req, reply) {
       const promise = new Promise((resolve, reject) => {
         resolve({ hello: 'world' })
       })
@@ -52,7 +54,7 @@ test('shorthand - return promise es6 get', t => {
 test('shorthand - promise es6 get error', t => {
   t.plan(1)
   try {
-    fastify.get('/error', schema, function (req, reply) {
+    fastify.get('/error', opts, function (req, reply) {
       const promise = new Promise((resolve, reject) => {
         reject(new Error('some error'))
       })
@@ -67,7 +69,7 @@ test('shorthand - promise es6 get error', t => {
 test('shorthand - promise bluebird get', t => {
   t.plan(1)
   try {
-    fastify.get('/bluebird', schema, function (req, reply) {
+    fastify.get('/bluebird', opts, function (req, reply) {
       const promise = new Bluebird((resolve, reject) => {
         resolve({ hello: 'world' })
       })
@@ -82,7 +84,7 @@ test('shorthand - promise bluebird get', t => {
 test('shorthand - promise bluebird get error', t => {
   t.plan(1)
   try {
-    fastify.get('/bluebird-error', schema, function (req, reply) {
+    fastify.get('/bluebird-error', opts, function (req, reply) {
       const promise = new Bluebird((resolve, reject) => {
         reject(new Error('some error'))
       })


### PR DESCRIPTION
In the [full route declaration](https://github.com/fastify/fastify/blob/master/docs/Routes.md#full-declaration) the user can pass any option, while in the [shorthand declaration](https://github.com/fastify/fastify/blob/master/docs/Routes.md#shorthand-declaration) can pass just the schema. With this pr we conform the behaviour of these apis.