### PR TITLE
Before handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,11 @@ Swagger documentation generator for Fastify
 Multipart support for Fastify
 - [`fastify-bearer-auth`](https://github.com/jsumners/fastify-bearer-auth)
 Bearer auth plugin for Fastify
-- [`fastify-pigeon`](https://github.com/fastify/fastify-pigeon) Bankai assets compiler for Fastify
-- [`fastify-react`](https://github.com/fastify/fastify-react) React server side rendering support for Fastify with Next
+- [`fastify-pigeon`](https://github.com/fastify/fastify-pigeon) [Bankai](https://github.com/yoshuawuyts/bankai) assets compiler for Fastify
+- [`fastify-react`](https://github.com/fastify/fastify-react) React server side rendering support for Fastify with [Next](https://github.com/zeit/next.js/)
+- [`fastify-jwt`](https://github.com/fastify/fastify-jwt) JWT utils for Fastify, internally uses [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken)
+- [`fastify-websocket`](https://github.com/fastify/fastify-websocket) WebSocket support for Fastify. Built upon [websocket-stream](https://github.com/maxogden/websocket-stream)
+- [`fastify-helmet`](https://github.com/fastify/fastify-helmet) Important security headers for Fastify
 - *More coming soon*
 
 ## Team

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -44,3 +44,28 @@ fastify.addHook('onClose', (instance, done) => {
 <a name="scope"></a>
 ### Scope
 Talking about scope, the hooks works in a slightly different way from the Request/Reply encapsulation model. For instance, `onRequest`, `preRouting` and `onClose` are never encapsulated, not matter where you are declaring them, while the `preHandler` hook is always encapsulated if you declare it inside a `register`.
+
+<a name="before-handler"></a>
+### beforeHandler
+Despite the name, `beforeHandler` is not a standard hook like `preHandler`, but is a function that your register right in the route option that will be executed only in the specified route. Can be useful if you need to handle the authentication at route level instead of at hook level (`preHandler` for example.)  
+**`beforeHandler` is executed always after the `preHandler` hook.**
+
+```js
+fastify.addHook('preHandler', (request, reply, done) => {
+  // your code
+  done()
+})
+
+fastify.route({
+  method: 'GET',
+  url: '/',
+  schema: { ... },
+  beforeHandler: function (request, reply, done) {
+    // your code
+    done()
+  },
+  handler: function (request, reply) {
+    reply.send({ hello: 'world' })
+  }
+})
+```

--- a/docs/Lifecycle.md
+++ b/docs/Lifecycle.md
@@ -10,11 +10,11 @@ Incoming Request
         │
         └─▶ onRequest Hook
               │
-        500 ◀─┴─▶ run Middlewares
+    4**/5** ◀─┴─▶ run Middlewares
                     │
-              500 ◀─┴─▶ preRouting Hook
+          4**/5** ◀─┴─▶ preRouting Hook
                           │
-                    500 ◀─┴─▶ Routing
+                4**/5** ◀─┴─▶ Routing
                                 │
                           404 ◀─┴─▶ Parsing
                                       │
@@ -22,9 +22,11 @@ Incoming Request
                                             │
                                       400 ◀─┴─▶ preHandler Hook
                                                   │
-                                            500 ◀─┴─▶ User Handler
+                                        4**/5** ◀─┴─▶ beforeHandler
                                                         │
-                                                        └─▶ Reply
+                                              4**/5** ◀─┴─▶ User Handler
                                                               │
-                                                              └─▶ Outgoing Response
+                                                              └─▶ Reply
+                                                                    │
+                                                                    └─▶ Outgoing Response
 ```

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -21,7 +21,7 @@ fastify.register([
 ```
 
 <a name="route-prefixing-option"></a>
-### Route Prefixing option
+#### Route Prefixing option
 If you pass an option with the key `prefix` with a `string` value, Fastify will use it to prefix all the routes inside the register, for more info check [here](https://github.com/fastify/fastify/blob/master/docs/Routes.md#route-prefixing).
 
 <a name="error-handling"></a>

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -21,6 +21,7 @@ They need to be in
   * `params`: validates the params.
   * `response`: filter and generate a schema for the response, setting a
     schema allows us to have 10-20% more throughput.
+* `beforeHandler(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#before-handler) called just before the request handler, useful if you need to perform authentication at route level for example.
 * `handler(request, reply)`: the function that will handle this request.
 
   `request` is defined in [Request](https://github.com/fastify/fastify/blob/master/docs/Request.md).
@@ -47,6 +48,21 @@ fastify.route({
         }
       }
     }
+  },
+  handler: function (request, reply) {
+    reply.send({ hello: 'world' })
+  }
+})
+```
+
+```js
+fastify.route({
+  method: 'GET',
+  url: '/',
+  schema: { ... },
+  beforeHandler: function (request, reply, done) {
+    // your authentication logic
+    done()
   },
   handler: function (request, reply) {
     reply.send({ hello: 'world' })

--- a/fastify.js
+++ b/fastify.js
@@ -280,8 +280,9 @@ function build (options) {
       Reply: self._Reply,
       Request: self._Request,
       contentTypeParser: self._contentTypeParser,
-      hooks: self._hooks,
-      RoutePrefix: self._RoutePrefix
+      preHandler: self._hooks.preHandler,
+      RoutePrefix: self._RoutePrefix,
+      beforeHandler: options.beforeHandler
     })
   }
 
@@ -300,7 +301,7 @@ function build (options) {
     opts.Reply = opts.Reply || this._Reply
     opts.Request = opts.Request || this._Request
     opts.contentTypeParser = opts.contentTypeParser || this._contentTypeParser
-    opts.hooks = opts.hooks || this._hooks
+    opts.preHandler = opts.preHandler || this._hooks.preHandler
     opts.RoutePrefix = opts.RoutePrefix || this._RoutePrefix
 
     const prefix = opts.RoutePrefix.prefix

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -92,7 +92,7 @@ function handler (store, params, req, res, body, query) {
     runHooks,
     new State(new store.Request(params, req, body, query, req.log), new store.Reply(req, res, store), store),
     hookIterator,
-    store.hooks.preHandler,
+    store.preHandler,
     preHandlerCallback
   )
 }
@@ -114,9 +114,27 @@ function preHandlerCallback (err, code) {
     return
   }
 
+  if (this.store.beforeHandler) {
+    setImmediate(this.store.beforeHandler, this.request, this.reply, done(this))
+    return
+  }
+
   var result = this.store.handler(this.request, this.reply)
   if (result && typeof result.then === 'function') {
     this.reply.send(result)
+  }
+}
+
+function done (that) {
+  return function _done (err) {
+    if (err) {
+      that.reply.send(err)
+      return
+    }
+    var result = that.store.handler(that.request, that.reply)
+    if (result && typeof result.then === 'function') {
+      that.reply.send(result)
+    }
   }
 }
 

--- a/test/beforeHandler.test.js
+++ b/test/beforeHandler.test.js
@@ -1,0 +1,147 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('..')
+
+test('beforeHandler', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  fastify.post('/', {
+    beforeHandler: (req, reply, done) => {
+      req.body.beforeHandler = true
+      done()
+    }
+  }, (req, reply) => {
+    reply.send(req.body)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: { hello: 'world' }
+  }, res => {
+    var payload = JSON.parse(res.payload)
+    t.deepEqual(payload, { beforeHandler: true, hello: 'world' })
+  })
+})
+
+test('beforeHandler should be called after preHandler hook', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  fastify.addHook('preHandler', (req, reply, next) => {
+    req.body.check = 'a'
+    next()
+  })
+
+  fastify.post('/', {
+    beforeHandler: (req, reply, done) => {
+      req.body.check += 'b'
+      done()
+    }
+  }, (req, reply) => {
+    reply.send(req.body)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: { hello: 'world' }
+  }, res => {
+    var payload = JSON.parse(res.payload)
+    t.deepEqual(payload, { check: 'ab', hello: 'world' })
+  })
+})
+
+test('beforeHandler should be unique per route', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.post('/', {
+    beforeHandler: (req, reply, done) => {
+      req.body.hello = 'earth'
+      done()
+    }
+  }, (req, reply) => {
+    reply.send(req.body)
+  })
+
+  fastify.post('/no', (req, reply) => {
+    reply.send(req.body)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: { hello: 'world' }
+  }, res => {
+    var payload = JSON.parse(res.payload)
+    t.deepEqual(payload, { hello: 'earth' })
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/no',
+    payload: { hello: 'world' }
+  }, res => {
+    var payload = JSON.parse(res.payload)
+    t.deepEqual(payload, { hello: 'world' })
+  })
+})
+
+test('beforeHandler should handle errors', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.post('/', {
+    beforeHandler: (req, reply, done) => {
+      done(new Error('kaboom'))
+    }
+  }, (req, reply) => {
+    reply.send(req.body)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: { hello: 'world' }
+  }, res => {
+    var payload = JSON.parse(res.payload)
+    t.equal(res.statusCode, 500)
+    t.deepEqual(payload, {
+      message: 'kaboom',
+      error: 'Internal Server Error',
+      statusCode: 500
+    })
+  })
+})
+
+test('beforeHandler should handle errors with custom status code', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.post('/', {
+    beforeHandler: (req, reply, done) => {
+      reply.code(401)
+      done(new Error('go away'))
+    }
+  }, (req, reply) => {
+    reply.send(req.body)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: { hello: 'world' }
+  }, res => {
+    var payload = JSON.parse(res.payload)
+    t.equal(res.statusCode, 401)
+    t.deepEqual(payload, {
+      message: 'go away',
+      error: 'Unauthorized',
+      statusCode: 401
+    })
+  })
+})

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -65,7 +65,7 @@ test('handler function - reply', t => {
     },
     Reply: Reply,
     Request: Request,
-    hooks: new Hooks()
+    preHandler: new Hooks().preHandler
   }
   buildSchema(handle)
   internals.handler(handle, null, { log: null }, res, null, null)


### PR DESCRIPTION
Sometimes the *preHandler* hook is not easy to use when you need to call a specific function before the final handler, the user must work with `register` to create the correct encapsulation and the code could be hard to read.

Usage:
```js
fastify.get('/', {
  beforeHandler: (req, reply, done) => {
    // ...
    done()
  }
}, (req, reply) => {
  reply.send({ hello: 'world' ])
})
``` 

As you can see from the code I'm using a closure to handle this, because I can't push at runtime the *beforeHandler* inside the *preHanlder* array otherwise I will change the *preHanlder* array forever causing tons of issues. `concat` won't work if *preHandler* is empty.
Have you got some better solution?

*Performances*:
There is almost no difference between use or not the *beforeHandler*, this change does not introduce a sensible loss of throughput, around 200-400 req/sec less.