### PR TITLE
Log less request data

### DIFF
--- a/benchmarks/bare.js
+++ b/benchmarks/bare.js
@@ -1,0 +1,9 @@
+'use strict'
+
+var server = require('http').createServer(handle)
+
+server.listen(3000)
+
+function handle (req, res) {
+  res.end(JSON.stringify({ hello: 'world' }))
+}

--- a/examples/asyncawait.js
+++ b/examples/asyncawait.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const fastify = require('../fastify')()
+
+const schema = {
+  schema: {
+    response: {
+      200: {
+        type: 'object',
+        properties: {
+          hello: {
+            type: 'string'
+          }
+        }
+      }
+    }
+  }
+}
+
+function result () {
+  return Promise.resolve({ hello: 'world' })
+}
+
+fastify
+  .get('/await', schema, async function (req, reply) {
+    reply.header('Content-Type', 'application/json').code(200)
+    return result()
+  })
+  .get('/', schema, async function (req, reply) {
+    reply.header('Content-Type', 'application/json').code(200)
+    return { hello: 'world' }
+  })
+
+fastify.listen(3000, err => {
+  if (err) throw err
+  console.log(`server listening on ${fastify.server.address().port}`)
+})

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const fastify = require('../fastify')()
+
+const schema = {
+  schema: {
+    response: {
+      200: {
+        type: 'object',
+        properties: {
+          hello: {
+            type: 'string'
+          }
+        }
+      }
+    }
+  }
+}
+
+fastify
+  .get('/', schema, function (req, reply) {
+    reply
+      .send({ hello: 'world' })
+  })
+
+fastify.listen(3000, err => {
+  if (err) throw err
+  console.log(`server listening on ${fastify.server.address().port}`)
+})

--- a/fastify.js
+++ b/fastify.js
@@ -19,6 +19,7 @@ const isValidLogger = require('./lib/validation').isValidLogger
 const decorator = require('./lib/decorate')
 const ContentTypeParser = require('./lib/ContentTypeParser')
 const Hooks = require('./lib/hooks')
+const serializers = require('./lib/serializers')
 
 function build (options) {
   options = options || {}
@@ -28,10 +29,11 @@ function build (options) {
 
   var logger
   if (options.logger && isValidLogger(options.logger)) {
-    logger = pinoHttp({ logger: options.logger })
+    logger = pinoHttp({ logger: options.logger, serializers })
   } else {
     options.logger = options.logger || {}
     options.logger.level = options.logger.level || 'fatal'
+    options.logger.serializers = options.logger.serializers || serializers
     logger = pinoHttp(options.logger)
   }
 

--- a/lib/serializers.js
+++ b/lib/serializers.js
@@ -5,7 +5,6 @@ function asReqValue (req) {
     id: req.id,
     method: req.method,
     url: req.url,
-    headers: req.headers,
     remoteAddress: req.connection.remoteAddress,
     remotePort: req.connection.remotePort
   }

--- a/lib/serializers.js
+++ b/lib/serializers.js
@@ -1,0 +1,23 @@
+'use strict'
+
+function asReqValue (req) {
+  return {
+    id: req.id,
+    method: req.method,
+    url: req.url,
+    headers: req.headers,
+    remoteAddress: req.connection.remoteAddress,
+    remotePort: req.connection.remotePort
+  }
+}
+
+function asResValue (res) {
+  return {
+    statusCode: res.statusCode
+  }
+}
+
+module.exports = {
+  req: asReqValue,
+  res: asResValue
+}


### PR DESCRIPTION
The more request data we log, the slower we go. So, I removed the headers by default, as those might pose a) a security risk and b) slow to encode and send.

This adds some percentage points to the benchmarks.