### PR TITLE
Add response type shortcut method

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -29,6 +29,17 @@ If you not set a `'Content-Type'` header, Fastify assumes that you are using `'a
 
 *Note that if you are using a custom serializer that does not serialize to JSON, you must set a custom `'Content-Type'` header.*
 
+<a name="type"></a>
+### Type
+Sets the content type for the reponse.  
+This is a shortcut for `reply.header('Content-Type', 'the/type')`.
+
+Example:
+
+```
+reply.type('text/html')
+```
+
 <a name="serializer"></a>
 ### Serializer
 Fastify was born as a full JSON compatible server, so out of the box will serialize your payload that you put in the `.send()` function using the internal serializers, [fast-json-stringify](https://www.npmjs.com/package/fast-json-stringify) if you setted an output schema, otherwise [fast-safe-stringify](https://www.npmjs.com/package/fast-safe-stringify).

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -127,6 +127,11 @@ Reply.prototype.serializer = function (fn) {
   return this
 }
 
+Reply.prototype.type = function (type) {
+  this.res.setHeader('Content-Type', type)
+  return this
+}
+
 function wrapPumpCallback (reply) {
   return function pumpCallback (err) {
     if (err) {

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -51,6 +51,20 @@ test('Reply can set code and header of a response', t => {
   }
 })
 
+test('Reply can set the type of a response', t => {
+  t.plan(1)
+  try {
+    fastify.get('/auto-type', function (req, reply) {
+      reply.code(200)
+      reply.type('text/plain')
+      reply.send('hello world!')
+    })
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+})
+
 test('reply.serializer should set a custom serializer', t => {
   t.plan(2)
   const reply = new Reply(null, null, null)
@@ -109,6 +123,18 @@ fastify.listen(0, err => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
       t.deepEqual(JSON.parse(body), 'hello world!')
+    })
+  })
+
+  test('auto type shoud be text/plain', t => {
+    t.plan(3)
+    request({
+      method: 'GET',
+      uri: 'http://localhost:' + fastify.server.address().port + '/auto-type'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.headers['content-type'], 'text/plain')
+      t.deepEqual(body, 'hello world!')
     })
   })
 


### PR DESCRIPTION
This commit adds a `type` method to the `Reply` object. The `type`
method is a shortcut for `reply.header('Content-Type', 'the/type')`.