### PR TITLE
Preload beforeHandler

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -47,7 +47,7 @@ Talking about scope, the hooks works in a slightly different way from the Reques
 
 <a name="before-handler"></a>
 ### beforeHandler
-Despite the name, `beforeHandler` is not a standard hook like `preHandler`, but is a function that your register right in the route option that will be executed only in the specified route. Can be useful if you need to handle the authentication at route level instead of at hook level (`preHandler` for example.)  
+Despite the name, `beforeHandler` is not a standard hook like `preHandler`, but is a function that your register right in the route option that will be executed only in the specified route. Can be useful if you need to handle the authentication at route level instead of at hook level (`preHandler` for example.), it could also be an array of functions.  
 **`beforeHandler` is executed always after the `preHandler` hook.**
 
 ```js
@@ -64,6 +64,25 @@ fastify.route({
     // your code
     done()
   },
+  handler: function (request, reply) {
+    reply.send({ hello: 'world' })
+  }
+})
+
+fastify.route({
+  method: 'GET',
+  url: '/',
+  schema: { ... },
+  beforeHandler: [
+    function first (request, reply, done) {
+      // your code
+      done()
+    },
+    function second (request, reply, done) {
+      // your code
+      done()
+    }
+  ],
   handler: function (request, reply) {
     reply.send({ hello: 'world' })
   }

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -8,6 +8,7 @@ Reply is a core Fastify object that exposes the following functions:
 - `.header(name, value)` - Sets the headers.
 - `.serializer(function)` - Sets a custom serializer for the payload.
 - `.send(payload)` - Sends the payload to the user, could be a plain text, JSON, stream, or an Error object.
+- `.sent` - A boolean value that you can use if you need to know it `send` has already been called.
 
 ```js
 fastify.get('/', options, function (request, reply) {

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -21,7 +21,7 @@ They need to be in
   * `params`: validates the params.
   * `response`: filter and generate a schema for the response, setting a
     schema allows us to have 10-20% more throughput.
-* `beforeHandler(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#before-handler) called just before the request handler, useful if you need to perform authentication at route level for example.
+* `beforeHandler(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#before-handler) called just before the request handler, useful if you need to perform authentication at route level for example, it could also be and array of functions.
 * `handler(request, reply)`: the function that will handle this request.
 
   `request` is defined in [Request](https://github.com/fastify/fastify/blob/master/docs/Request.md).

--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -44,23 +44,25 @@ The route properties are the same the developer has declared [here](https://gith
 ```js
 fastify.get('/route', opts, handler)
 
-for (var route of fastify) {
-  console.log(route)
-  /* will output:
-  {
-    '/route': {
-      get: {
-        method: String,
-        ulr: String,
-        schema: Object,
-        handler: Function,
-        Request: Function,
-        Reply: Function
+fastify.ready(() =>
+  for (var route of fastify) {
+    console.log(route)
+    /* will output:
+    {
+      '/route': {
+        get: {
+          method: String,
+          ulr: String,
+          schema: Object,
+          handler: Function,
+          Request: Function,
+          Reply: Function
+        }
       }
     }
+    */
   }
-  */
-}
+})
 ```
 
 <a name="close"></a>

--- a/fastify.js
+++ b/fastify.js
@@ -298,7 +298,7 @@ function build (options) {
       throw new Error(`Missing handler function for ${opts.method}:${opts.url} route.`)
     }
 
-    this.ready((notHandledErr, done) => {
+    this.after((notHandledErr, done) => {
       const prefix = (opts.RoutePrefix || this._RoutePrefix).prefix
       const url = prefix + (opts.url || opts.path)
 

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -114,27 +114,9 @@ function preHandlerCallback (err, code) {
     return
   }
 
-  if (this.store.beforeHandler) {
-    setImmediate(this.store.beforeHandler, this.request, this.reply, done(this))
-    return
-  }
-
   var result = this.store.handler(this.request, this.reply)
   if (result && typeof result.then === 'function') {
     this.reply.send(result)
-  }
-}
-
-function done (that) {
-  return function _done (err) {
-    if (err) {
-      that.reply.send(err)
-      return
-    }
-    var result = that.store.handler(that.request, that.reply)
-    if (result && typeof result.then === 'function') {
-      that.reply.send(result)
-    }
   }
 }
 

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -14,31 +14,33 @@ test('fastify can be iterated to get all the routes', t => {
 
   t.is(typeof fastify[Symbol.iterator], 'function')
 
-  for (let route of fastify) {
-    t.ok(route['/'] || route['/test'])
+  fastify.ready(() => {
+    for (let route of fastify) {
+      t.ok(route['/'] || route['/test'])
 
-    if (route['/']) {
-      t.ok(route['/'].get)
-      t.ok(route['/'].post)
+      if (route['/']) {
+        t.ok(route['/'].get)
+        t.ok(route['/'].post)
+      }
+
+      if (route['/test']) {
+        t.ok(route['/test'].get)
+      }
     }
 
-    if (route['/test']) {
-      t.ok(route['/test'].get)
-    }
-  }
+    // double check, because we do not want
+    // to exhaust things
+    for (let route of fastify) {
+      t.ok(route['/'] || route['/test'])
 
-  // double check, because we do not want
-  // to exhaust things
-  for (let route of fastify) {
-    t.ok(route['/'] || route['/test'])
+      if (route['/']) {
+        t.ok(route['/'].get)
+        t.ok(route['/'].post)
+      }
 
-    if (route['/']) {
-      t.ok(route['/'].get)
-      t.ok(route['/'].post)
+      if (route['/test']) {
+        t.ok(route['/test'].get)
+      }
     }
-
-    if (route['/test']) {
-      t.ok(route['/test'].get)
-    }
-  }
+  })
 })

--- a/test/throw.test.js
+++ b/test/throw.test.js
@@ -15,15 +15,13 @@ test('Fastify should throw on wrong options', t => {
 })
 
 test('Fastify should throw on multiple assignment to the same route', t => {
-  t.plan(2)
-  try {
-    fastify.get('/', () => {})
-    fastify.get('/', () => {})
-    t.fail()
-  } catch (e) {
-    t.is(e.message, 'GET already set for /')
-    t.pass()
-  }
+  t.plan(1)
+  fastify.get('/', () => {})
+  fastify.get('/', () => {})
+
+  fastify.ready(err => {
+    t.is(err.message, 'GET already set for /')
+  })
 })
 
 test('Should throw on unsupported method', t => {


### PR DESCRIPTION
**The problem(s)**
- we can't push the `beforeHandler` function into the `preHandler` hooks, otherwise that change will be reflected for all routes
- we also can't push the `beforeHandler` inside `preHandler` at runtime because it's expensive.
- we can't accept an array of beforeHandlers

**Actual solution**
- we accept only one beforeHandler that creates a closure if executed https://github.com/fastify/fastify/pull/115

**Proposal**
- Wrap the route creation inside an [`after`](https://github.com/mcollina/avvio#after), in this way we can be sure that all the hooks will be registered before store them inside the `Store` object.
- During the route creation we duplicate the preHandler array and remove every reference, in this way we can push inside it without compromising the hooks for the others routes, as result we are faster during the execution and we can also accept arrays.

**Significant changes for the users**
- If a user declare two times the same route, it will get the error in the next `after/ready` function (or `listen`).
- if a user want to use the route iterator, he/she must do it inside a `ready` block.

**Performances**
- Obviously this change improves the performances since it removes the `beforeHandler` check and closure.

**Why all this work?**
To accept an array of functions, enabling stuff like https://github.com/fastify/fastify-auth/pull/2.

Feedbacks?