### PR TITLE
Force 'content-type' in reply error

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -59,6 +59,7 @@ Reply.prototype.send = function (payload) {
     }
 
     this._req.log.error(payload)
+    this.res.setHeader('Content-Type', 'application/json')
     setImmediate(
       wrapReplyEnd,
       this,

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -27,6 +27,9 @@ test('handler function - invalid schema', t => {
     t.equal(res.statusCode, 400)
     t.pass()
   }
+  res.setHeader = (key, value) => {
+    return
+  }
   const handle = {
     schema: {
       body: {

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -14,7 +14,7 @@ codes.forEach(code => {
 
 function helper (code) {
   test('Reply error handling - code: ' + code, t => {
-    t.plan(2)
+    t.plan(3)
     const fastify = Fastify()
     const err = new Error('winter is coming')
 
@@ -29,6 +29,7 @@ function helper (code) {
       url: '/'
     }, res => {
       t.strictEqual(res.statusCode, Number(code))
+      t.equal(res.headers['content-type'], 'application/json')
       t.deepEqual(
         {
           error: statusCodes[code],


### PR DESCRIPTION
If we return an error generated from `Reply` the `content-type` is not `application/json`, this pr fixes that.