### PR TITLE
Allow custom object storing to Store instance for future use

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -274,7 +274,7 @@ function build (options) {
       preHandler: self._hooks.preHandler,
       RoutePrefix: self._RoutePrefix,
       beforeHandler: options.beforeHandler,
-      custom: options.custom
+      config: options.config
     })
   }
 
@@ -304,7 +304,7 @@ function build (options) {
         opts.Request || _fastify._Request,
         opts.contentTypeParser || _fastify._contentTypeParser,
         [],
-        opts.custom
+        opts.config
       )
 
       buildSchema(store)
@@ -335,14 +335,14 @@ function build (options) {
     return _fastify
   }
 
-  function Store (schema, handler, Reply, Request, contentTypeParser, preHandler, custom) {
+  function Store (schema, handler, Reply, Request, contentTypeParser, preHandler, config) {
     this.schema = schema
     this.handler = handler
     this.Reply = Reply
     this.Request = Request
     this.contentTypeParser = contentTypeParser
     this.preHandler = preHandler
-    this.custom = custom
+    this.config = config
   }
 
   function iterator () {

--- a/fastify.js
+++ b/fastify.js
@@ -297,6 +297,9 @@ function build (options) {
       const prefix = _fastify._RoutePrefix.prefix
       const url = prefix + (path === '/' && prefix.length > 0 ? '' : path)
 
+      const config = opts.config || {}
+      config.url = url
+
       const store = new Store(
         opts.schema,
         opts.handler,
@@ -304,7 +307,7 @@ function build (options) {
         opts.Request || _fastify._Request,
         opts.contentTypeParser || _fastify._contentTypeParser,
         [],
-        opts.config
+        config
       )
 
       buildSchema(store)

--- a/fastify.js
+++ b/fastify.js
@@ -273,7 +273,8 @@ function build (options) {
       contentTypeParser: self._contentTypeParser,
       preHandler: self._hooks.preHandler,
       RoutePrefix: self._RoutePrefix,
-      beforeHandler: options.beforeHandler
+      beforeHandler: options.beforeHandler,
+      custom: options.custom
     })
   }
 
@@ -302,7 +303,8 @@ function build (options) {
         opts.Reply || _fastify._Reply,
         opts.Request || _fastify._Request,
         opts.contentTypeParser || _fastify._contentTypeParser,
-        []
+        [],
+        opts.custom
       )
 
       buildSchema(store)
@@ -333,13 +335,14 @@ function build (options) {
     return _fastify
   }
 
-  function Store (schema, handler, Reply, Request, contentTypeParser, preHandler) {
+  function Store (schema, handler, Reply, Request, contentTypeParser, preHandler, custom) {
     this.schema = schema
     this.handler = handler
     this.Reply = Reply
     this.Request = Request
     this.contentTypeParser = contentTypeParser
     this.preHandler = preHandler
+    this.custom = custom
   }
 
   function iterator () {

--- a/test/store-config.test.js
+++ b/test/store-config.test.js
@@ -20,7 +20,10 @@ function handler (req, reply) {
 test('config - get', t => {
   t.plan(1)
 
-  fastify.get('/get', schema, handler)
+  fastify.get('/get', {
+    schema: schema.schema,
+    config: Object.assign({}, schema.config)
+  }, handler)
 
   t.pass()
 })
@@ -33,7 +36,19 @@ test('config - route', t => {
     url: '/route',
     schema: schema.schema,
     handler: handler,
-    config: schema.config
+    config: Object.assign({}, schema.config)
+  })
+  t.pass()
+})
+
+test('config - no config', t => {
+  t.plan(1)
+
+  fastify.route({
+    method: 'GET',
+    url: '/no-config',
+    schema: schema.schema,
+    handler: handler
   })
   t.pass()
 })
@@ -51,7 +66,7 @@ fastify.listen(0, err => {
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
-      t.deepEquals(response.body, schema.config)
+      t.deepEquals(response.body, Object.assign({url: '/get'}, schema.config))
     })
   })
 
@@ -64,7 +79,20 @@ fastify.listen(0, err => {
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
-      t.deepEquals(body, schema.config)
+      t.deepEquals(response.body, Object.assign({url: '/route'}, schema.config))
+    })
+  })
+
+  test('config - request no-config', t => {
+    t.plan(3)
+    request({
+      method: 'GET',
+      uri: 'http://localhost:' + fastify.server.address().port + '/no-config',
+      json: true
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.deepEquals(response.body, {url: '/no-config'})
     })
   })
 })

--- a/test/store-config.test.js
+++ b/test/store-config.test.js
@@ -7,17 +7,17 @@ const fastify = require('..')()
 
 const schema = {
   schema: { },
-  custom: {
+  config: {
     value1: 'foo',
     value2: true
   }
 }
 
 function handler (req, reply) {
-  reply.serializer(JSON.stringify).send(reply.store.custom)
+  reply.serializer(JSON.stringify).send(reply.store.config)
 }
 
-test('custom - get', t => {
+test('config - get', t => {
   t.plan(1)
 
   fastify.get('/get', schema, handler)
@@ -25,7 +25,7 @@ test('custom - get', t => {
   t.pass()
 })
 
-test('custom - route', t => {
+test('config - route', t => {
   t.plan(1)
 
   fastify.route({
@@ -33,7 +33,7 @@ test('custom - route', t => {
     url: '/route',
     schema: schema.schema,
     handler: handler,
-    custom: schema.custom
+    config: schema.config
   })
   t.pass()
 })
@@ -42,7 +42,7 @@ fastify.listen(0, err => {
   t.error(err)
   fastify.server.unref()
 
-  test('custom - request get', t => {
+  test('config - request get', t => {
     t.plan(3)
     request({
       method: 'GET',
@@ -51,11 +51,11 @@ fastify.listen(0, err => {
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
-      t.deepEquals(response.body, schema.custom)
+      t.deepEquals(response.body, schema.config)
     })
   })
 
-  test('custom - request route', t => {
+  test('config - request route', t => {
     t.plan(3)
     request({
       method: 'GET',
@@ -64,7 +64,7 @@ fastify.listen(0, err => {
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
-      t.deepEquals(body, schema.custom)
+      t.deepEquals(body, schema.config)
     })
   })
 })

--- a/test/store-custom.test.js
+++ b/test/store-custom.test.js
@@ -1,0 +1,70 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const request = require('request')
+const fastify = require('..')()
+
+const schema = {
+  schema: { },
+  custom: {
+    value1: 'foo',
+    value2: true
+  }
+}
+
+function handler (req, reply) {
+  reply.serializer(JSON.stringify).send(reply.store.custom)
+}
+
+test('custom - get', t => {
+  t.plan(1)
+
+  fastify.get('/get', schema, handler)
+
+  t.pass()
+})
+
+test('custom - route', t => {
+  t.plan(1)
+
+  fastify.route({
+    method: 'GET',
+    url: '/route',
+    schema: schema.schema,
+    handler: handler,
+    custom: schema.custom
+  })
+  t.pass()
+})
+
+fastify.listen(0, err => {
+  t.error(err)
+  fastify.server.unref()
+
+  test('custom - request get', t => {
+    t.plan(3)
+    request({
+      method: 'GET',
+      uri: 'http://localhost:' + fastify.server.address().port + '/get',
+      json: true
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.deepEquals(response.body, schema.custom)
+    })
+  })
+
+  test('custom - request route', t => {
+    t.plan(3)
+    request({
+      method: 'GET',
+      uri: 'http://localhost:' + fastify.server.address().port + '/route',
+      json: true
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.deepEquals(body, schema.custom)
+    })
+  })
+})


### PR DESCRIPTION
In some circumstances, plugins should read some properties from route definition.
This PR allows that.