### PR TITLE
Add fastify-accepts-serializer to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Bearer auth plugin for Fastify
 - [`fastify-leveldb`](https://github.com/fastify/fastify-leveldb) Plugin to share a common LevelDB connection across Fastify.
 - [`fastify-apollo`](https://github.com/coopnd/fastify-apollo) Run an [Apollo Server](https://github.com/apollographql/apollo-server) with Fastify.
 - [`fastify-accepts`](https://github.com/fastify/fastify-accepts) to have [accepts](https://www.npmjs.com/package/accepts) in your request object.
-- [`fastify-accepts-serializer`](https://github.com/allevo/fastify-accepts-serializer) to serialize to output according to `Accept` header
+- [`fastify-accepts-serializer`](https://github.com/fastify/fastify-accepts-serializer) to serialize to output according to `Accept` header
 - *More coming soon*
 
 ## Team

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Bearer auth plugin for Fastify
 - [`fastify-leveldb`](https://github.com/fastify/fastify-leveldb) Plugin to share a common LevelDB connection across Fastify.
 - [`fastify-apollo`](https://github.com/coopnd/fastify-apollo) Run an [Apollo Server](https://github.com/apollographql/apollo-server) with Fastify.
 - [`fastify-accepts`](https://github.com/fastify/fastify-accepts) to have [accepts](https://www.npmjs.com/package/accepts) in your request object.
+- [`fastify-accepts-serializer`](https://github.com/allevo/fastify-accepts-serializer) to serialize to output according to `Accept header`
 - *More coming soon*
 
 ## Team

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Bearer auth plugin for Fastify
 - [`fastify-leveldb`](https://github.com/fastify/fastify-leveldb) Plugin to share a common LevelDB connection across Fastify.
 - [`fastify-apollo`](https://github.com/coopnd/fastify-apollo) Run an [Apollo Server](https://github.com/apollographql/apollo-server) with Fastify.
 - [`fastify-accepts`](https://github.com/fastify/fastify-accepts) to have [accepts](https://www.npmjs.com/package/accepts) in your request object.
-- [`fastify-accepts-serializer`](https://github.com/allevo/fastify-accepts-serializer) to serialize to output according to `Accept header`
+- [`fastify-accepts-serializer`](https://github.com/allevo/fastify-accepts-serializer) to serialize to output according to `Accept` header
 - *More coming soon*
 
 ## Team


### PR DESCRIPTION
I've written this in my repo but I'd like to have the fastify community contribution.
So, I'm glad if I can move "https://github.com/allevo/fastify-accepts-serializer" under fastify organization.

If no, please merge the PR.

I'll publish the package after the PR or the project movement.