### PR TITLE
undefined content type bug

### DIFF
--- a/lib/ContentTypeParser.js
+++ b/lib/ContentTypeParser.js
@@ -18,6 +18,8 @@ ContentTypeParser.prototype.hasParser = function (contentType) {
 }
 
 ContentTypeParser.prototype.fastHasHeader = function (contentType) {
+  if (!contentType) return false
+
   for (var i = 0; i < this.parserList.length; i++) {
     if (contentType.indexOf(this.parserList[i]) > -1) return true
   }

--- a/test/custom-parser.test.js
+++ b/test/custom-parser.test.js
@@ -192,3 +192,36 @@ test('contentTypeParser should support encapsulation, second try', t => {
     })
   })
 })
+
+test('contentTypeParser shouldn\'t support request with undefined "Content-Type"', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.post('/', (req, reply) => {
+    reply.send(req.body)
+  })
+
+  fastify.addContentTypeParser('application/jsoff', function (req, done) {
+    jsonParser(req, function (err, body) {
+      if (err) return done(err)
+      done(body)
+    })
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    request({
+      method: 'POST',
+      uri: 'http://localhost:' + fastify.server.address().port,
+      body: 'unknown content type!',
+      headers: {
+        // 'Content-Type': undefined
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 415)
+      fastify.close()
+    })
+  })
+})


### PR DESCRIPTION
If the request headers don't contain the `Content-Type` field and a custom ContentTypeParser is registered, this bug occurs.

`contentType.indexOf` throws and error because `contentType` is undefined.

Maybe the correct way is checking the variable `typeof`.

Let me know