### PR TITLE
Allow specify ajv options per route

### DIFF
--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -23,6 +23,7 @@ They need to be in
     schema allows us to have 10-20% more throughput.
 * `beforeHandler(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#before-handler) called just before the request handler, useful if you need to perform authentication at route level for example, it could also be and array of functions.
 * `handler(request, reply)`: the function that will handle this request.
+* `schemaCompiler(schema)`: the function that build the schema for the validations. See [here](https://github.com/fastify/fastify/blob/master/docs/Validation-And-Serialize.md#schema-compiler)
 
   `request` is defined in [Request](https://github.com/fastify/fastify/blob/master/docs/Request.md).
 

--- a/docs/Validation-And-Serialize.md
+++ b/docs/Validation-And-Serialize.md
@@ -39,6 +39,36 @@ Example:
 ```
 *Note that Ajv will try to [coerce](https://github.com/epoberezkin/ajv#coercing-data-types) the values to the types specified in your schema type keywords, both to pass the validation and to use the correctly typed data afterwards.*
 
+<a name="schema-compiler"></a>
+#### Schema Compiler
+
+The `schemaCompiler` is a function that returns a function that validates the body, url parameters and the query string.
+
+The default `schemaCompiler` returns a function that implements the `ajv` validation interface.
+`fastify` use it internally to speed the validation up.
+
+But maybe you want to change the validation library. Perhaps you like `Joi`.
+In this case you can use it to validate the url parameters, the body and the querystring!
+
+```js
+const Joi = require('joi')
+
+fastify.post('/the/url', {
+  schema: {
+    body: Joi.object().keys({
+      hello: Joi.string().required()
+    }).required()
+  },
+  schemaCompiler: function (schema) {
+    return schema.validate.bind(validate)
+  }
+})
+```
+
+In that case the function retuned by schemaCompiler returns an object like:
+* `error`: filled with an instance of `Error` or a string that describes the validation error
+* `value`: the coerced value that passes the validation
+
 <a name="serialize"></a>
 ### Serialize
 Usually you will send your data to the clients via JSON, and Fastify has a powerful tools to help you: [fast-json-stringify](https://www.npmjs.com/package/fast-json-stringify), which is used if you have provided an output schema in the route options. We encourage you to use an output schema, as it will increase your throughput by x1-4 depending on your payload, and it will prevent accidental disclosure of sensitive information.

--- a/fastify.js
+++ b/fastify.js
@@ -5,7 +5,11 @@ const avvio = require('avvio')
 const http = require('http')
 const https = require('https')
 const Middie = require('middie')
+<<<<<<< b72b390435328e31a88387a2dfe29143428d376a
 const runHooks = require('fastseries')()
+=======
+const fastseries = require('fastseries')
+>>>>>>> Define schemaCompiler interface
 var shot = null
 try { shot = require('shot') } catch (e) { }
 
@@ -15,6 +19,7 @@ const supportedMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTI
 const buildSchema = require('./lib/validation').build
 const handleRequest = require('./lib/handleRequest')
 const isValidLogger = require('./lib/validation').isValidLogger
+const schemaCompiler = require('./lib/validation').schemaCompiler
 const decorator = require('./lib/decorate')
 const ContentTypeParser = require('./lib/ContentTypeParser')
 const Hooks = require('./lib/hooks')
@@ -485,10 +490,6 @@ function build (options) {
   function defaultRoute (req, res, params) {
     const reply = new Reply(req, res, null)
     reply.code(404).send(new Error('Not found'))
-  }
-
-  function schemaCompiler (schema) {
-    return ajv.compile(schema)
   }
 }
 

--- a/fastify.js
+++ b/fastify.js
@@ -5,7 +5,13 @@ const avvio = require('avvio')
 const http = require('http')
 const https = require('https')
 const Middie = require('middie')
+<<<<<<< 0f6368788670d3b76fa3be5dc83f818e2349d095
 const runHooks = require('fastseries')()
+=======
+const fastseries = require('fastseries')
+const Ajv = require('ajv')
+const ajv = new Ajv({ coerceTypes: true })
+>>>>>>> Move out ajv. Extrapolate validatorMaker
 var shot = null
 try { shot = require('shot') } catch (e) { }
 
@@ -100,6 +106,8 @@ function build (options) {
   fastify.addContentTypeParser = addContentTypeParser
   fastify.hasContentTypeParser = hasContentTypeParser
   fastify._contentTypeParser = new ContentTypeParser()
+
+  fastify.validatorMaker = validatorMaker
 
   // plugin
   fastify.register = fastify.use
@@ -318,9 +326,14 @@ function build (options) {
       preHandler: self._hooks.preHandler,
       RoutePrefix: self._RoutePrefix,
       beforeHandler: options.beforeHandler,
+<<<<<<< 0f6368788670d3b76fa3be5dc83f818e2349d095
       onResponse: options.onResponse,
       config: options.config,
       middie: self._middie
+=======
+      validatorMaker: options.validatorMaker,
+      config: options.config
+>>>>>>> Move out ajv. Extrapolate validatorMaker
     })
   }
 
@@ -359,7 +372,7 @@ function build (options) {
         opts.middie || _fastify._middie
       )
 
-      buildSchema(store)
+      buildSchema(store, opts.validatorMaker || _fastify.validatorMaker)
 
       store.preHandler.push.apply(store.preHandler, (opts.preHandler || _fastify._hooks.preHandler))
       if (opts.beforeHandler) {
@@ -483,6 +496,10 @@ function build (options) {
   function defaultRoute (req, res, params) {
     const reply = new Reply(req, res, null)
     reply.code(404).send(new Error('Not found'))
+  }
+
+  function validatorMaker (schema) {
+    return ajv.compile(schema)
   }
 }
 

--- a/fastify.js
+++ b/fastify.js
@@ -5,13 +5,7 @@ const avvio = require('avvio')
 const http = require('http')
 const https = require('https')
 const Middie = require('middie')
-<<<<<<< 0f6368788670d3b76fa3be5dc83f818e2349d095
 const runHooks = require('fastseries')()
-=======
-const fastseries = require('fastseries')
-const Ajv = require('ajv')
-const ajv = new Ajv({ coerceTypes: true })
->>>>>>> Move out ajv. Extrapolate validatorMaker
 var shot = null
 try { shot = require('shot') } catch (e) { }
 
@@ -107,7 +101,7 @@ function build (options) {
   fastify.hasContentTypeParser = hasContentTypeParser
   fastify._contentTypeParser = new ContentTypeParser()
 
-  fastify.validatorMaker = validatorMaker
+  fastify.schemaCompiler = schemaCompiler
 
   // plugin
   fastify.register = fastify.use
@@ -326,14 +320,9 @@ function build (options) {
       preHandler: self._hooks.preHandler,
       RoutePrefix: self._RoutePrefix,
       beforeHandler: options.beforeHandler,
-<<<<<<< 0f6368788670d3b76fa3be5dc83f818e2349d095
       onResponse: options.onResponse,
       config: options.config,
       middie: self._middie
-=======
-      validatorMaker: options.validatorMaker,
-      config: options.config
->>>>>>> Move out ajv. Extrapolate validatorMaker
     })
   }
 
@@ -372,7 +361,7 @@ function build (options) {
         opts.middie || _fastify._middie
       )
 
-      buildSchema(store, opts.validatorMaker || _fastify.validatorMaker)
+      buildSchema(store, opts.schemaCompiler || _fastify.schemaCompiler)
 
       store.preHandler.push.apply(store.preHandler, (opts.preHandler || _fastify._hooks.preHandler))
       if (opts.beforeHandler) {
@@ -498,7 +487,7 @@ function build (options) {
     reply.code(404).send(new Error('Not found'))
   }
 
-  function validatorMaker (schema) {
+  function schemaCompiler (schema) {
     return ajv.compile(schema)
   }
 }

--- a/fastify.js
+++ b/fastify.js
@@ -127,6 +127,9 @@ function build (options) {
   // fake http injection (for testing purposes)
   fastify.inject = inject
 
+  // Use this for caching Ajv instances with different options
+  const ajvCache = {}
+
   return fastify
 
   function fastify (req, res) {
@@ -359,7 +362,7 @@ function build (options) {
         opts.middie || _fastify._middie
       )
 
-      buildSchema(store)
+      buildSchema(store, ajvCache)
 
       store.preHandler.push.apply(store.preHandler, (opts.preHandler || _fastify._hooks.preHandler))
       if (opts.beforeHandler) {

--- a/fastify.js
+++ b/fastify.js
@@ -127,9 +127,6 @@ function build (options) {
   // fake http injection (for testing purposes)
   fastify.inject = inject
 
-  // Use this for caching Ajv instances with different options
-  const ajvCache = {}
-
   return fastify
 
   function fastify (req, res) {
@@ -362,7 +359,7 @@ function build (options) {
         opts.middie || _fastify._middie
       )
 
-      buildSchema(store, ajvCache)
+      buildSchema(store)
 
       store.preHandler.push.apply(store.preHandler, (opts.preHandler || _fastify._hooks.preHandler))
       if (opts.beforeHandler) {

--- a/fastify.js
+++ b/fastify.js
@@ -5,11 +5,7 @@ const avvio = require('avvio')
 const http = require('http')
 const https = require('https')
 const Middie = require('middie')
-<<<<<<< b72b390435328e31a88387a2dfe29143428d376a
 const runHooks = require('fastseries')()
-=======
-const fastseries = require('fastseries')
->>>>>>> Define schemaCompiler interface
 var shot = null
 try { shot = require('shot') } catch (e) { }
 
@@ -327,7 +323,8 @@ function build (options) {
       beforeHandler: options.beforeHandler,
       onResponse: options.onResponse,
       config: options.config,
-      middie: self._middie
+      middie: self._middie,
+      schemaCompiler: options.schemaCompiler
     })
   }
 

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -81,7 +81,8 @@ function jsonBodyParsed (err, body, req, res, params, handle) {
 }
 
 function handler (store, params, req, res, body, query) {
-  var valid = validateSchema(store, params, body, query)
+  var request = new store.Request(params, req, body, query, req.log)
+  var valid = validateSchema(store, request)
   if (valid !== true) {
     setImmediate(wrapReplyEnd, req, res, 400, valid)
     return
@@ -90,7 +91,7 @@ function handler (store, params, req, res, body, query) {
   // preHandler hook
   setImmediate(
     runHooks,
-    new State(new store.Request(params, req, body, query, req.log), new store.Reply(req, res, store), store),
+    new State(request, new store.Reply(req, res, store), store),
     hookIterator,
     store.preHandler,
     preHandlerCallback
@@ -122,7 +123,11 @@ function preHandlerCallback (err, code) {
 
 function wrapReplyEnd (req, res, statusCode, payload) {
   const reply = new Reply(req, res, null)
-  reply.code(statusCode).send(new Error(payload || ''))
+  if (payload instanceof Error) {
+    reply.code(statusCode).send(payload)
+  } else {
+    reply.code(statusCode).send(new Error(payload || ''))
+  }
   return
 }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -101,9 +101,7 @@ function isValidLogger (logger) {
 function schemaCompiler (schema) {
   const validateFunction = ajv.compile(schema)
   return function (body) {
-    const isOk = validateFunction(body)
-    if (isOk) return
-    return inputSchemaError(validateFunction.errors)
+    return !validateFunction(body) && inputSchemaError(validateFunction.errors)
   }
 }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -54,15 +54,29 @@ function build (opts, compile) {
   }
 }
 
-function validate (handle, params, body, query) {
-  var paramsErrors = handle[paramsSchema] && handle[paramsSchema](params)
-  if (paramsErrors) return paramsErrors
+function validate (store, request) {
+  var ret
 
-  var bodyErrors = handle[bodySchema] && handle[bodySchema](body)
-  if (bodyErrors) return bodyErrors
+  ret = store[paramsSchema] && store[paramsSchema](request.params)
+  // ajv interface
+  if (ret === false) return inputSchemaError(store[paramsSchema].errors)
+  // Joi like interface
+  if (ret && ret.error instanceof Error) return ret.error
+  if (ret && ret.value) request.params = ret.value
 
-  var querystringErrors = handle[querystringSchema] && handle[querystringSchema](query)
-  if (querystringErrors) return querystringErrors
+  ret = store[bodySchema] && store[bodySchema](request.body)
+  // ajv interface
+  if (ret === false) return inputSchemaError(store[bodySchema].errors)
+  // Joi like interface
+  if (ret && ret.error instanceof Error) return ret.error
+  if (ret && ret.value) request.body = ret.value
+
+  ret = store[querystringSchema] && store[querystringSchema](request.query)
+  // ajv interface
+  if (ret === false) return inputSchemaError(store[bodySchema].errors)
+  // Joi like interface
+  if (ret && ret.error instanceof Error) return ret.error
+  if (ret && ret.value) request.query = ret.query
 
   return true
 }
@@ -99,10 +113,7 @@ function isValidLogger (logger) {
 }
 
 function schemaCompiler (schema) {
-  const validateFunction = ajv.compile(schema)
-  return function (body) {
-    return !validateFunction(body) && inputSchemaError(validateFunction.errors)
-  }
+  return ajv.compile(schema)
 }
 
 module.exports = { build, validate, serialize, isValidLogger, schemaCompiler }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -54,31 +54,19 @@ function build (opts, compile) {
   }
 }
 
+function validateParam (validatorFunction, request, paramName) {
+  var ret = validatorFunction && validatorFunction(request[paramName])
+  if (ret === false) return inputSchemaError(validatorFunction.errors)
+  if (ret && ret.error) return ret.error
+  if (ret && ret.value) request[paramName] = ret.value
+  return false
+}
+
 function validate (store, request) {
-  var ret
-
-  ret = store[paramsSchema] && store[paramsSchema](request.params)
-  // ajv interface
-  if (ret === false) return inputSchemaError(store[paramsSchema].errors)
-  // Joi like interface
-  if (ret && ret.error instanceof Error) return ret.error
-  if (ret && ret.value) request.params = ret.value
-
-  ret = store[bodySchema] && store[bodySchema](request.body)
-  // ajv interface
-  if (ret === false) return inputSchemaError(store[bodySchema].errors)
-  // Joi like interface
-  if (ret && ret.error instanceof Error) return ret.error
-  if (ret && ret.value) request.body = ret.value
-
-  ret = store[querystringSchema] && store[querystringSchema](request.query)
-  // ajv interface
-  if (ret === false) return inputSchemaError(store[bodySchema].errors)
-  // Joi like interface
-  if (ret && ret.error instanceof Error) return ret.error
-  if (ret && ret.value) request.query = ret.query
-
-  return true
+  return validateParam(store[paramsSchema], request, 'params') ||
+    validateParam(store[bodySchema], request, 'body') ||
+    validateParam(store[querystringSchema], request, 'query') ||
+    true
 }
 
 function serialize (handle, data, statusCode) {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -55,13 +55,13 @@ function build (opts, validatorMaker) {
 }
 
 function validate (handle, params, body, query) {
-  const paramsErrors = handle[paramsSchema] && handle[paramsSchema](params)
+  var paramsErrors = handle[paramsSchema] && handle[paramsSchema](params)
   if (paramsErrors) return paramsErrors
 
-  const bodyErrors = handle[bodySchema] && handle[bodySchema](body)
+  var bodyErrors = handle[bodySchema] && handle[bodySchema](body)
   if (bodyErrors) return bodyErrors
 
-  const querystringErrors = handle[querystringSchema] && handle[querystringSchema](query)
+  var querystringErrors = handle[querystringSchema] && handle[querystringSchema](query)
   if (querystringErrors) return querystringErrors
 
   return true

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,12 +1,8 @@
 'use strict'
 
 const fastJsonStringify = require('fast-json-stringify')
-<<<<<<< 0f6368788670d3b76fa3be5dc83f818e2349d095
 const Ajv = require('ajv')
 const ajv = new Ajv({ coerceTypes: true })
-=======
-const fastSafeStringify = require('fast-safe-stringify')
->>>>>>> Move out ajv. Extrapolate validatorMaker
 
 const bodySchema = Symbol('body-schema')
 const querystringSchema = Symbol('querystring-schema')
@@ -59,17 +55,15 @@ function build (opts, validatorMaker) {
 }
 
 function validate (handle, params, body, query) {
-  if (handle[paramsSchema] && !handle[paramsSchema](params)) {
-    return inputSchemaError(handle[paramsSchema].errors)
-  }
+  const paramsErrors = handle[paramsSchema] && handle[paramsSchema](params)
+  if (paramsErrors) return paramsErrors
 
-  if (handle[bodySchema] && !handle[bodySchema](body)) {
-    return inputSchemaError(handle[bodySchema].errors)
-  }
+  const bodyErrors = handle[bodySchema] && handle[bodySchema](body)
+  if (bodyErrors) return bodyErrors
 
-  if (handle[querystringSchema] && !handle[querystringSchema](query)) {
-    return inputSchemaError(handle[querystringSchema].errors)
-  }
+  const querystringErrors = handle[querystringSchema] && handle[querystringSchema](query)
+  if (querystringErrors) return querystringErrors
+
   return true
 }
 
@@ -104,5 +98,14 @@ function isValidLogger (logger) {
   return result
 }
 
-module.exports = { build, validate, serialize, isValidLogger }
+function schemaCompiler (schema) {
+  const validateFuncion = ajv.compile(schema)
+  return function (body) {
+    const isOk = validateFuncion(body)
+    if (isOk) return
+    return inputSchemaError(validateFuncion.errors)
+  }
+}
+
+module.exports = { build, validate, serialize, isValidLogger, schemaCompiler }
 module.exports.symbols = { bodySchema, querystringSchema, responseSchema, paramsSchema }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -99,11 +99,11 @@ function isValidLogger (logger) {
 }
 
 function schemaCompiler (schema) {
-  const validateFuncion = ajv.compile(schema)
+  const validateFunction = ajv.compile(schema)
   return function (body) {
-    const isOk = validateFuncion(body)
+    const isOk = validateFunction(body)
     if (isOk) return
-    return inputSchemaError(validateFuncion.errors)
+    return inputSchemaError(validateFunction.errors)
   }
 }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -24,7 +24,7 @@ function getResponseSchema (responseSchemaDefinition) {
   }, {})
 }
 
-function build (opts, validatorMaker) {
+function build (opts, compile) {
   if (!opts.schema) {
     return
   }
@@ -34,7 +34,7 @@ function build (opts, validatorMaker) {
   }
 
   if (opts.schema.body) {
-    opts[bodySchema] = validatorMaker(opts.schema.body)
+    opts[bodySchema] = compile(opts.schema.body)
   }
 
   if (opts.schema.querystring) {
@@ -46,11 +46,11 @@ function build (opts, validatorMaker) {
       }
     }
 
-    opts[querystringSchema] = validatorMaker(opts.schema.querystring)
+    opts[querystringSchema] = compile(opts.schema.querystring)
   }
 
   if (opts.schema.params) {
-    opts[paramsSchema] = validatorMaker(opts.schema.params)
+    opts[paramsSchema] = compile(opts.schema.params)
   }
 }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -2,7 +2,7 @@
 
 const fastJsonStringify = require('fast-json-stringify')
 const Ajv = require('ajv')
-const ajv = new Ajv({ coerceTypes: true })
+const defaultAjvOptions = { coerceTypes: true }
 
 const bodySchema = Symbol('body-schema')
 const querystringSchema = Symbol('querystring-schema')
@@ -24,9 +24,16 @@ function getResponseSchema (responseSchemaDefinition) {
   }, {})
 }
 
-function build (opts) {
+function build (opts, ajvCache) {
   if (!opts.schema) {
     return
+  }
+
+  const ajvOptions = opts.schema.ajvOptions || defaultAjvOptions
+  const ajvCacheKey = JSON.stringify(ajvOptions)
+  var ajv = ajvCache[ajvCacheKey]
+  if (!ajv) {
+    ajv = ajvCache[ajvCacheKey] = new Ajv(ajvOptions)
   }
 
   if (opts.schema.response) {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -2,7 +2,7 @@
 
 const fastJsonStringify = require('fast-json-stringify')
 const Ajv = require('ajv')
-const defaultAjvOptions = { coerceTypes: true }
+const ajv = new Ajv({ coerceTypes: true })
 
 const bodySchema = Symbol('body-schema')
 const querystringSchema = Symbol('querystring-schema')
@@ -24,16 +24,9 @@ function getResponseSchema (responseSchemaDefinition) {
   }, {})
 }
 
-function build (opts, ajvCache) {
+function build (opts) {
   if (!opts.schema) {
     return
-  }
-
-  const ajvOptions = opts.schema.ajvOptions || defaultAjvOptions
-  const ajvCacheKey = JSON.stringify(ajvOptions)
-  var ajv = ajvCache[ajvCacheKey]
-  if (!ajv) {
-    ajv = ajvCache[ajvCacheKey] = new Ajv(ajvOptions)
   }
 
   if (opts.schema.response) {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,8 +1,12 @@
 'use strict'
 
 const fastJsonStringify = require('fast-json-stringify')
+<<<<<<< 0f6368788670d3b76fa3be5dc83f818e2349d095
 const Ajv = require('ajv')
 const ajv = new Ajv({ coerceTypes: true })
+=======
+const fastSafeStringify = require('fast-safe-stringify')
+>>>>>>> Move out ajv. Extrapolate validatorMaker
 
 const bodySchema = Symbol('body-schema')
 const querystringSchema = Symbol('querystring-schema')
@@ -24,7 +28,7 @@ function getResponseSchema (responseSchemaDefinition) {
   }, {})
 }
 
-function build (opts) {
+function build (opts, validatorMaker) {
   if (!opts.schema) {
     return
   }
@@ -34,7 +38,7 @@ function build (opts) {
   }
 
   if (opts.schema.body) {
-    opts[bodySchema] = ajv.compile(opts.schema.body)
+    opts[bodySchema] = validatorMaker(opts.schema.body)
   }
 
   if (opts.schema.querystring) {
@@ -46,11 +50,11 @@ function build (opts) {
       }
     }
 
-    opts[querystringSchema] = ajv.compile(opts.schema.querystring)
+    opts[querystringSchema] = validatorMaker(opts.schema.querystring)
   }
 
   if (opts.schema.params) {
-    opts[paramsSchema] = ajv.compile(opts.schema.params)
+    opts[paramsSchema] = validatorMaker(opts.schema.params)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "hide-powered-by": "^1.0.0",
     "hsts": "^2.0.0",
     "ienoopen": "^1.0.0",
+    "joi": "^10.6.0",
     "pino": "^4.7.0",
     "pre-commit": "^1.2.2",
     "request": "^2.81.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "standard": "^10.0.2",
     "tap": "^10.7.0",
     "then-sleep": "^1.0.1",
+    "typescript": "^2.5.2",
     "x-xss-protection": "^1.0.0"
   },
   "dependencies": {

--- a/test/input-validation.js
+++ b/test/input-validation.js
@@ -35,7 +35,7 @@ module.exports.payloadMethod = function (method, t) {
         additionalProperties: false
       }
     },
-    validatorMaker: schema => ajv.compile(schema)
+    schemaCompiler: schema => ajv.compile(schema)
   }
 
   test(`${upMethod} can be created`, t => {
@@ -129,7 +129,7 @@ module.exports.payloadMethod = function (method, t) {
       })
     })
 
-    test(`${upMethod} - input-validation custom validator maker`, t => {
+    test(`${upMethod} - input-validation custom schema compiler`, t => {
       t.plan(3)
       request({
         method: upMethod,

--- a/test/input-validation.js
+++ b/test/input-validation.js
@@ -35,7 +35,14 @@ module.exports.payloadMethod = function (method, t) {
         additionalProperties: false
       }
     },
-    schemaCompiler: schema => ajv.compile(schema)
+    schemaCompiler: function (schema) {
+      const validateFuncion = ajv.compile(schema)
+      return function (body) {
+        const isOk = validateFuncion(body)
+        if (isOk) return
+        return 'Invalid body'
+      }
+    }
   }
 
   test(`${upMethod} can be created`, t => {

--- a/test/input-validation.js
+++ b/test/input-validation.js
@@ -21,42 +21,10 @@ module.exports.payloadMethod = function (method, t) {
     }
   }
 
-  const optsWithDefault = {
-    schema: {
-      body: {
-        type: 'object',
-        properties: {
-          hello: {
-            type: 'integer'
-          },
-          world: {
-            type: 'integer',
-            default: 8
-          }
-        }
-      },
-      ajvOptions: {
-        useDefaults: true
-      }
-    }
-  }
-
   test(`${upMethod} can be created`, t => {
     t.plan(1)
     try {
       fastify[loMethod]('/', opts, function (req, reply) {
-        reply.send(req.body)
-      })
-      t.pass()
-    } catch (e) {
-      t.fail()
-    }
-  })
-
-  test(`${upMethod} can be created with useDefaults: true`, t => {
-    t.plan(1)
-    try {
-      fastify[loMethod]('/useDefaults', optsWithDefault, function (req, reply) {
         reply.send(req.body)
       })
       t.pass()
@@ -138,22 +106,6 @@ module.exports.payloadMethod = function (method, t) {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
         t.deepEqual(body, { hello: 42 })
-      })
-    })
-
-    test(`${upMethod} - input-validation default`, t => {
-      t.plan(3)
-      request({
-        method: upMethod,
-        uri: 'http://localhost:' + fastify.server.address().port + '/useDefaults',
-        body: {
-          hello: 7
-        },
-        json: true
-      }, (err, response, body) => {
-        t.error(err)
-        t.strictEqual(response.statusCode, 200)
-        t.deepEqual(body, { hello: 7, world: 8 })
       })
     })
   })

--- a/test/input-validation.js
+++ b/test/input-validation.js
@@ -35,13 +35,8 @@ module.exports.payloadMethod = function (method, t) {
         additionalProperties: false
       }
     },
-    schemaCompiler: function (schema) {
-      const validateFuncion = ajv.compile(schema)
-      return function (body) {
-        const isOk = validateFuncion(body)
-        if (isOk) return
-        return 'Invalid body'
-      }
+    schemaCompiler: function gg (schema) {
+      return ajv.compile(schema)
     }
   }
 
@@ -66,7 +61,7 @@ module.exports.payloadMethod = function (method, t) {
           },
           schemaCompiler: function (schema) {
             return function (body) {
-              return 'Always fail!'
+              return { error: new Error('Always fail!') }
             }
           }
         }
@@ -172,7 +167,6 @@ module.exports.payloadMethod = function (method, t) {
         t.deepEqual(body, { hello: 42 })
       })
     })
-
     test(`${upMethod} - input-validation custom schema compiler encapsulated`, t => {
       t.plan(3)
       request({

--- a/test/input-validation.js
+++ b/test/input-validation.js
@@ -21,10 +21,42 @@ module.exports.payloadMethod = function (method, t) {
     }
   }
 
+  const optsWithDefault = {
+    schema: {
+      body: {
+        type: 'object',
+        properties: {
+          hello: {
+            type: 'integer'
+          },
+          world: {
+            type: 'integer',
+            default: 8
+          }
+        }
+      },
+      ajvOptions: {
+        useDefaults: true
+      }
+    }
+  }
+
   test(`${upMethod} can be created`, t => {
     t.plan(1)
     try {
       fastify[loMethod]('/', opts, function (req, reply) {
+        reply.send(req.body)
+      })
+      t.pass()
+    } catch (e) {
+      t.fail()
+    }
+  })
+
+  test(`${upMethod} can be created with useDefaults: true`, t => {
+    t.plan(1)
+    try {
+      fastify[loMethod]('/useDefaults', optsWithDefault, function (req, reply) {
         reply.send(req.body)
       })
       t.pass()
@@ -106,6 +138,22 @@ module.exports.payloadMethod = function (method, t) {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
         t.deepEqual(body, { hello: 42 })
+      })
+    })
+
+    test(`${upMethod} - input-validation default`, t => {
+      t.plan(3)
+      request({
+        method: upMethod,
+        uri: 'http://localhost:' + fastify.server.address().port + '/useDefaults',
+        body: {
+          hello: 7
+        },
+        json: true
+      }, (err, response, body) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 200)
+        t.deepEqual(body, { hello: 7, world: 8 })
       })
     })
   })

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -44,7 +44,7 @@ test('handler function - invalid schema', t => {
     Request: Request,
     hooks: new Hooks()
   }
-  buildSchema(handle, {})
+  buildSchema(handle)
   internals.handler(handle, null, { log: { error: () => {} } }, res, { hello: 'world' }, null)
 })
 
@@ -70,7 +70,7 @@ test('handler function - reply', t => {
     Request: Request,
     preHandler: new Hooks().preHandler
   }
-  buildSchema(handle, {})
+  buildSchema(handle)
   internals.handler(handle, null, { log: null }, res, null, null)
 })
 

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -9,6 +9,9 @@ const Reply = require('../../lib/reply')
 const buildSchema = require('../../lib/validation').build
 const Hooks = require('../../lib/hooks')
 
+const Ajv = require('ajv')
+const ajv = new Ajv({ coerceTypes: true })
+
 test('Request object', t => {
   t.plan(6)
   const req = new Request('params', 'req', 'body', 'query', 'log')
@@ -44,7 +47,7 @@ test('handler function - invalid schema', t => {
     Request: Request,
     hooks: new Hooks()
   }
-  buildSchema(handle)
+  buildSchema(handle, schema => ajv.compile(schema))
   internals.handler(handle, null, { log: { error: () => {} } }, res, { hello: 'world' }, null)
 })
 
@@ -70,7 +73,7 @@ test('handler function - reply', t => {
     Request: Request,
     preHandler: new Hooks().preHandler
   }
-  buildSchema(handle)
+  buildSchema(handle, schema => ajv.compile(schema))
   internals.handler(handle, null, { log: null }, res, null, null)
 })
 

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -44,7 +44,7 @@ test('handler function - invalid schema', t => {
     Request: Request,
     hooks: new Hooks()
   }
-  buildSchema(handle)
+  buildSchema(handle, {})
   internals.handler(handle, null, { log: { error: () => {} } }, res, { hello: 'world' }, null)
 })
 
@@ -70,7 +70,7 @@ test('handler function - reply', t => {
     Request: Request,
     preHandler: new Hooks().preHandler
   }
-  buildSchema(handle)
+  buildSchema(handle, {})
   internals.handler(handle, null, { log: null }, res, null, null)
 })
 

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -12,6 +12,15 @@ const Hooks = require('../../lib/hooks')
 const Ajv = require('ajv')
 const ajv = new Ajv({ coerceTypes: true })
 
+function schemaCompiler (schema) {
+  const validateFuncion = ajv.compile(schema)
+  return function (body) {
+    const isOk = validateFuncion(body)
+    if (isOk) return
+    return 'Invalid body'
+  }
+}
+
 test('Request object', t => {
   t.plan(6)
   const req = new Request('params', 'req', 'body', 'query', 'log')
@@ -47,7 +56,7 @@ test('handler function - invalid schema', t => {
     Request: Request,
     hooks: new Hooks()
   }
-  buildSchema(handle, schema => ajv.compile(schema))
+  buildSchema(handle, schemaCompiler)
   internals.handler(handle, null, { log: { error: () => {} } }, res, { hello: 'world' }, null)
 })
 
@@ -73,7 +82,7 @@ test('handler function - reply', t => {
     Request: Request,
     preHandler: new Hooks().preHandler
   }
-  buildSchema(handle, schema => ajv.compile(schema))
+  buildSchema(handle, schemaCompiler)
   internals.handler(handle, null, { log: null }, res, null, null)
 })
 

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -17,7 +17,7 @@ function schemaCompiler (schema) {
   return function (body) {
     const isOk = validateFuncion(body)
     if (isOk) return
-    return 'Invalid body'
+    return { error: new Error('Invalid body') }
   }
 }
 

--- a/test/internals/validation.test.js
+++ b/test/internals/validation.test.js
@@ -17,14 +17,14 @@ test('Symbols', t => {
 test('build schema - missing schema', t => {
   t.plan(1)
   const opts = {}
-  validation.build(opts)
+  validation.build(opts, {})
   t.is(typeof opts[symbols.responseSchema], 'undefined')
 })
 
 test('build schema - missing output schema', t => {
   t.plan(1)
   const opts = { schema: {} }
-  validation.build(opts)
+  validation.build(opts, {})
   t.is(typeof opts[symbols.responseSchema], 'undefined')
 })
 
@@ -48,7 +48,7 @@ test('build schema - output schema', t => {
       }
     }
   }
-  validation.build(opts)
+  validation.build(opts, {})
   t.is(typeof opts[symbols.responseSchema]['2xx'], 'function')
   t.is(typeof opts[symbols.responseSchema]['201'], 'function')
 })
@@ -65,7 +65,7 @@ test('build schema - payload schema', t => {
       }
     }
   }
-  validation.build(opts)
+  validation.build(opts, {})
   t.is(typeof opts[symbols.bodySchema], 'function')
 })
 
@@ -81,7 +81,7 @@ test('build schema - querystring schema', t => {
       }
     }
   }
-  validation.build(opts)
+  validation.build(opts, {})
   t.type(opts[symbols.querystringSchema].schema.type, 'string')
   t.is(typeof opts[symbols.querystringSchema], 'function')
 })
@@ -95,7 +95,7 @@ test('build schema - querystring schema abbreviated', t => {
       }
     }
   }
-  validation.build(opts)
+  validation.build(opts, {})
   t.type(opts[symbols.querystringSchema].schema.type, 'string')
   t.is(typeof opts[symbols.querystringSchema], 'function')
 })
@@ -112,6 +112,6 @@ test('build schema - params schema', t => {
       }
     }
   }
-  validation.build(opts)
+  validation.build(opts, {})
   t.is(typeof opts[symbols.paramsSchema], 'function')
 })

--- a/test/internals/validation.test.js
+++ b/test/internals/validation.test.js
@@ -3,6 +3,9 @@
 const t = require('tap')
 const test = t.test
 
+const Ajv = require('ajv')
+const ajv = new Ajv({ coerceTypes: true })
+
 const validation = require('../../lib/validation')
 const symbols = require('../../lib/validation').symbols
 
@@ -48,7 +51,7 @@ test('build schema - output schema', t => {
       }
     }
   }
-  validation.build(opts)
+  validation.build(opts, schema => ajv.compile(schema))
   t.is(typeof opts[symbols.responseSchema]['2xx'], 'function')
   t.is(typeof opts[symbols.responseSchema]['201'], 'function')
 })
@@ -65,7 +68,7 @@ test('build schema - payload schema', t => {
       }
     }
   }
-  validation.build(opts)
+  validation.build(opts, schema => ajv.compile(schema))
   t.is(typeof opts[symbols.bodySchema], 'function')
 })
 
@@ -81,7 +84,7 @@ test('build schema - querystring schema', t => {
       }
     }
   }
-  validation.build(opts)
+  validation.build(opts, schema => ajv.compile(schema))
   t.type(opts[symbols.querystringSchema].schema.type, 'string')
   t.is(typeof opts[symbols.querystringSchema], 'function')
 })
@@ -95,7 +98,7 @@ test('build schema - querystring schema abbreviated', t => {
       }
     }
   }
-  validation.build(opts)
+  validation.build(opts, schema => ajv.compile(schema))
   t.type(opts[symbols.querystringSchema].schema.type, 'string')
   t.is(typeof opts[symbols.querystringSchema], 'function')
 })
@@ -112,6 +115,6 @@ test('build schema - params schema', t => {
       }
     }
   }
-  validation.build(opts)
+  validation.build(opts, schema => ajv.compile(schema))
   t.is(typeof opts[symbols.paramsSchema], 'function')
 })

--- a/test/internals/validation.test.js
+++ b/test/internals/validation.test.js
@@ -17,14 +17,14 @@ test('Symbols', t => {
 test('build schema - missing schema', t => {
   t.plan(1)
   const opts = {}
-  validation.build(opts, {})
+  validation.build(opts)
   t.is(typeof opts[symbols.responseSchema], 'undefined')
 })
 
 test('build schema - missing output schema', t => {
   t.plan(1)
   const opts = { schema: {} }
-  validation.build(opts, {})
+  validation.build(opts)
   t.is(typeof opts[symbols.responseSchema], 'undefined')
 })
 
@@ -48,7 +48,7 @@ test('build schema - output schema', t => {
       }
     }
   }
-  validation.build(opts, {})
+  validation.build(opts)
   t.is(typeof opts[symbols.responseSchema]['2xx'], 'function')
   t.is(typeof opts[symbols.responseSchema]['201'], 'function')
 })
@@ -65,7 +65,7 @@ test('build schema - payload schema', t => {
       }
     }
   }
-  validation.build(opts, {})
+  validation.build(opts)
   t.is(typeof opts[symbols.bodySchema], 'function')
 })
 
@@ -81,7 +81,7 @@ test('build schema - querystring schema', t => {
       }
     }
   }
-  validation.build(opts, {})
+  validation.build(opts)
   t.type(opts[symbols.querystringSchema].schema.type, 'string')
   t.is(typeof opts[symbols.querystringSchema], 'function')
 })
@@ -95,7 +95,7 @@ test('build schema - querystring schema abbreviated', t => {
       }
     }
   }
-  validation.build(opts, {})
+  validation.build(opts)
   t.type(opts[symbols.querystringSchema].schema.type, 'string')
   t.is(typeof opts[symbols.querystringSchema], 'function')
 })
@@ -112,6 +112,6 @@ test('build schema - params schema', t => {
       }
     }
   }
-  validation.build(opts, {})
+  validation.build(opts)
   t.is(typeof opts[symbols.paramsSchema], 'function')
 })

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -1,5 +1,5 @@
 'use strict'
 
 const t = require('tap')
-require('./helper').payloadMethod('options', t)
+// require('./helper').payloadMethod('options', t)
 require('./input-validation').payloadMethod('options', t)

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -1,5 +1,5 @@
 'use strict'
 
 const t = require('tap')
-// require('./helper').payloadMethod('options', t)
+require('./helper').payloadMethod('options', t)
 require('./input-validation').payloadMethod('options', t)


### PR DESCRIPTION
`ajv` constructor has some parameter.

This PR allows to set those parameter per route.

A instance object is used for caching the `ajv` object. It's made in evil way.
The caching can be important to avoid a lot of `ajv` objects.

Maybe the `defaultAjvOptions` can be merged with the specified options.