### PR TITLE
Listen timeout when used with Promise.resolve()

### DIFF
--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -28,7 +28,7 @@ test('listen after Promise.resolve()', t => {
   Promise.resolve()
     .then(() => {
       f.listen(0, (err) => {
-        fastify.server.unref()
+        f.server.unref()
         t.error(err)
         t.pass()
       })

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -1,7 +1,8 @@
 'use strict'
 
 const test = require('tap').test
-const fastify = require('..')()
+const Fastify = require('..')
+const fastify = Fastify()
 
 test('listen accepts a port and a callback', t => {
   t.plan(2)
@@ -19,4 +20,17 @@ test('listen accepts a port, address, and callback', t => {
     t.error(err)
     t.pass()
   })
+})
+
+test('listen after Promise.resolve()', t => {
+  t.plan(2)
+  const f = Fastify()
+  Promise.resolve()
+    .then(() => {
+      f.listen(0, (err) => {
+        fastify.server.unref()
+        t.error(err)
+        t.pass()
+      })
+    })
 })


### PR DESCRIPTION
This PR adds a test to show the problem opened by https://github.com/fastify/fastify/issues/165 but not exampled.

travis should fail