### PR TITLE
Fixes #188

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -90,7 +90,7 @@ fastify.listen(8000, function (err) {
 /* route.js */
 
 module.exports = function (fastify, options, next) {
-  fastify.get('/', schema, function (req, reply) {
+  fastify.get('/', function (req, reply) {
     reply.send({ hello: 'world' })
   })
   next()


### PR DESCRIPTION
Since that part of the doc shows how to use `register` and the `schema` option has already been explained few lines above, there is no need to add it here because it is not the focus of the section.