### PR TITLE
Do not use symbols to track the context and startTime

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -8,8 +8,6 @@
 
 const pino = require('pino')
 
-const startTime = Symbol('startTime')
-
 function createLogger (opts, stream) {
   stream = stream || opts.stream
   delete opts.stream
@@ -72,7 +70,7 @@ function now () {
 }
 
 function onResponseCallback (err, res) {
-  var responseTime = now() - res[startTime]
+  var responseTime = now() - res._startTime
 
   if (err) {
     res.log.error({
@@ -92,7 +90,6 @@ function onResponseCallback (err, res) {
 module.exports = {
   createLogger,
   reqIdGenFactory,
-  startTime,
   serializers,
   now,
   OnResponseState,


### PR DESCRIPTION
It seems using symbols is preventing some type-based optimizations
to happen. Switching back to properties increases the throughput
by 10%.