### PR TITLE
Fix scope in documentation examples

### DIFF
--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -36,19 +36,23 @@ Decorators are not *overwritable*, if you try to declare a decorator already dec
 As the name suggest, this api is needed if you want to add new methods to the `Reply` core object.  
 Just call the `decorateReply` api and pass the name of the new property and its value.
 ```js
-fastify.decorateReply('utility', () => {
+fastify.decorateReply('utility', function () {
   // something very useful
 })
+
+Note: using an arrow function will break the binding of `this` to the Fastify `reply` instance.
 ```
 
-<a name="decorate-request"></a>
-**decorateRequest**  
+<a name="decorate-request"></a>  
+**decorateRequest**
 As above, this api is needed if you want to add new methods to the `Request` core object.  
 Just call the `decorateRequest` api and pass the name of the new property and its value.
 ```js
-fastify.decorateRequest('utility', () => {
+fastify.decorateRequest('utility', function () {
   // something very useful
 })
+
+Note: using an arrow function will break the binding of `this` to the Fastify `request` instance.
 ```
 
 <a name="extend-server-error"></a>

--- a/docs/Plugins-Guide.md
+++ b/docs/Plugins-Guide.md
@@ -128,7 +128,7 @@ fastify.get('/html', (req, reply) => {
 ```
 It works, but it can be way better!
 ```js
-fastify.decorateReply('html', payload => {
+fastify.decorateReply('html', function (payload) {
   this.type('text/html') // this is the 'Reply' object
   this.send(generateHtml(payload))
 })
@@ -155,7 +155,7 @@ fastify.get('/happiness', (req, reply) => {
 ```
 Again, it works, but it can be way better!
 ```js
-fastify.decorateRequest('setHeader', header => {
+fastify.decorateRequest('setHeader', function (header) {
   this.isHappy = this.req.headers[header]
 })
 


### PR DESCRIPTION
The documentation is using arrow functions to in the examples for `decorateReply` and `decorateRequest`. The documentation also states that `this` is bound to the respective Fastify objects (request/reply) within the decorator functions. That is not true when using arrow functions. Therefore, this PR corrects the examples where it is relevant that `this` is bound correctly.