### PR TITLE
Move arrow function notes

### DIFF
--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -39,9 +39,9 @@ Just call the `decorateReply` api and pass the name of the new property and its 
 fastify.decorateReply('utility', function () {
   // something very useful
 })
+```
 
 Note: using an arrow function will break the binding of `this` to the Fastify `reply` instance.
-```
 
 <a name="decorate-request"></a>  
 **decorateRequest**
@@ -51,9 +51,9 @@ Just call the `decorateRequest` api and pass the name of the new property and it
 fastify.decorateRequest('utility', function () {
   // something very useful
 })
+```
 
 Note: using an arrow function will break the binding of `this` to the Fastify `request` instance.
-```
 
 <a name="extend-server-error"></a>
 **extendServerError**  


### PR DESCRIPTION
The previous fix for the scope in the decorators examples mistankenly
had the cautionary note within the examples themselves. This commit
moves them below the examples as they should have been from the start.