### PR TITLE
Updated benchmarks to Fastify 0.27.0 and Node 8.4.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,17 @@ __Method:__: `autocannon -c 100 -d 5 -p 10 localhost:3000` * 2, taking the secon
 
 | Framework          | Version                    | Router?      |  Requests/sec |
 | :----------------- | :------------------------- | :----------: | ------------: |
-| hapi               | 16.5.0                     | &#10003;     | 3,194         |
-| Express            | 4.15.3                     | &#10003;     | 9,418         |
-| Restify            | 5.0.1                      | &#10003;     | 12,014        |
-| take-five          | 1.3.4                      | &#10003;     | 18,658        |
-| Koa (`koa-router`) | 2.3.0 (`koa-router@7.2.1`) | &#10003;     | 19,650        |
-| Koa                | 2.3.0                      | &#10007;     | 21,349        |
-| **Fastify**        | **0.25.2**                 | **&#10003;** | **23,301**    |
+| hapi               | 16.5.2                     | &#10003;     | 4,226         |
+| Restify            | 5.2.0                      | &#10003;     | 16,395        |
+| Express            | 4.15.4                     | &#10003;     | 18,740        |
+| Koa (`koa-router`) | 2.3.0 (`koa-router@7.2.1`) | &#10003;     | 21,361        |
+| take-five          | 1.3.4                      | &#10003;     | 25,838        |
+| Koa                | 2.3.0                      | &#10007;     | 26,228        |
+| **Fastify**        | **0.27.0**                 | **&#10003;** | **29,340**    |
 | -                  |                            |              |               |
-| `http.Server`      | 8.2.1                      | &#10007;     | 33,435        |
+| `http.Server`      | 8.4.0                      | &#10007;     | 37,846        |
+
+Benchmarks taken using https://github.com/fastify/benchmarks.
 
 ## Documentation
 * <a href="https://github.com/fastify/fastify/blob/master/docs/Getting-Started.md"><code><b>Getting Started</b></code></a>


### PR DESCRIPTION
@cagataycali @dougwilson  thanks for helping out. Between turbofan and the changes you made the results looks very different now.