### PR TITLE
Add fastify-cookie to ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,31 +89,31 @@ __Method:__: `autocannon -c 100 -d 5 -p 10 localhost:3000` * 2, taking the secon
 * <a href="https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md"><code><b>Plugins Guide</b></code></a>
 
 ## Ecosystem
-- [`point-of-view`](https://github.com/fastify/point-of-view)
-Templates rendering (*ejs, pug, handlebars, marko*) plugin support for Fastify.
-- [`fastify-mongodb`](https://github.com/fastify/fastify-mongodb)
-Fastify MongoDB connection plugin, with this you can share the same MongoDb connection pool in every part of your server.
-- [`fastify-redis`](https://github.com/fastify/fastify-redis)
-Fastify Redis connection plugin, with this you can share the same Redis connection in every part of your server.
-- [`fastify-swagger`](https://github.com/fastify/fastify-swagger)
-Swagger documentation generator for Fastify
-- [`fastify-multipart`](https://github.com/fastify/fastify-multipart)
-Multipart support for Fastify
-- [`fastify-formbody`](https://github.com/jsumners/fastify-formbody)
-Plugin to parse x-www-form-urlencoded bodies
-- [`fastify-bearer-auth`](https://github.com/jsumners/fastify-bearer-auth)
-Bearer auth plugin for Fastify
-- [`fastify-pigeon`](https://github.com/fastify/fastify-pigeon) [Bankai](https://github.com/yoshuawuyts/bankai) assets compiler for Fastify
-- [`fastify-react`](https://github.com/fastify/fastify-react) React server side rendering support for Fastify with [Next](https://github.com/zeit/next.js/)
-- [`fastify-jwt`](https://github.com/fastify/fastify-jwt) JWT utils for Fastify, internally uses [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken)
-- [`fastify-websocket`](https://github.com/fastify/fastify-websocket) WebSocket support for Fastify. Built upon [websocket-stream](https://github.com/maxogden/websocket-stream)
-- [`fastify-helmet`](https://github.com/fastify/fastify-helmet) Important security headers for Fastify
-- [`fastify-auth`](https://github.com/fastify/fastify-auth) Run multiple auth functions in Fastify
-- [`fastify-leveldb`](https://github.com/fastify/fastify-leveldb) Plugin to share a common LevelDB connection across Fastify.
-- [`fastify-apollo`](https://github.com/coopnd/fastify-apollo) Run an [Apollo Server](https://github.com/apollographql/apollo-server) with Fastify.
 - [`fastify-accepts`](https://github.com/fastify/fastify-accepts) to have [accepts](https://www.npmjs.com/package/accepts) in your request object.
 - [`fastify-accepts-serializer`](https://github.com/fastify/fastify-accepts-serializer) to serialize to output according to `Accept` header
-- [`fastify-sse`](https://github.com/lolo32/fastify-sse) to provide Server-Sent Events with `reply.sse( … )` to Fastify 
+- [`fastify-apollo`](https://github.com/coopnd/fastify-apollo) Run an [Apollo Server](https://github.com/apollographql/apollo-server) with Fastify.
+- [`fastify-auth`](https://github.com/fastify/fastify-auth) Run multiple auth functions in Fastify
+- [`fastify-bearer-auth`](https://github.com/fastify/fastify-bearer-auth)
+Bearer auth plugin for Fastify
+- [`fastify-formbody`](https://github.com/fastify/fastify-formbody)
+Plugin to parse x-www-form-urlencoded bodies
+- [`fastify-helmet`](https://github.com/fastify/fastify-helmet) Important security headers for Fastify
+-- [`fastify-jwt`](https://github.com/fastify/fastify-jwt) JWT utils for Fastify, internally uses [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken)
+- [`fastify-leveldb`](https://github.com/fastify/fastify-leveldb) Plugin to share a common LevelDB connection across Fastify.
+- [`fastify-mongodb`](https://github.com/fastify/fastify-mongodb)
+Fastify MongoDB connection plugin, with this you can share the same MongoDb connection pool in every part of your server.
+- [`fastify-multipart`](https://github.com/fastify/fastify-multipart)
+Multipart support for Fastify
+- [`fastify-pigeon`](https://github.com/fastify/fastify-pigeon) [Bankai](https://github.com/yoshuawuyts/bankai) assets compiler for Fastify
+- [`fastify-react`](https://github.com/fastify/fastify-react) React server side rendering support for Fastify with [Next](https://github.com/zeit/next.js/)
+- [`fastify-redis`](https://github.com/fastify/fastify-redis)
+Fastify Redis connection plugin, with this you can share the same Redis connection in every part of your server.
+- [`fastify-sse`](https://github.com/lolo32/fastify-sse) to provide Server-Sent Events with `reply.sse( … )` to Fastify
+- [`fastify-swagger`](https://github.com/fastify/fastify-swagger)
+Swagger documentation generator for Fastify
+- [`fastify-websocket`](https://github.com/fastify/fastify-websocket) WebSocket support for Fastify. Built upon [websocket-stream](https://github.com/maxogden/websocket-stream)
+- [`point-of-view`](https://github.com/fastify/point-of-view)
+Templates rendering (*ejs, pug, handlebars, marko*) plugin support for Fastify.
 - *More coming soon*
 
 ## Team

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ __Method:__: `autocannon -c 100 -d 5 -p 10 localhost:3000` * 2, taking the secon
 - [`fastify-auth`](https://github.com/fastify/fastify-auth) Run multiple auth functions in Fastify
 - [`fastify-bearer-auth`](https://github.com/fastify/fastify-bearer-auth)
 Bearer auth plugin for Fastify
+- [`fastify-cookie`](https://github.com/fastify/fastify-cookie) Parse and set cookie headers
 - [`fastify-formbody`](https://github.com/fastify/fastify-formbody)
 Plugin to parse x-www-form-urlencoded bodies
 - [`fastify-helmet`](https://github.com/fastify/fastify-helmet) Important security headers for Fastify


### PR DESCRIPTION
This PR adds the `fastify-cookie` plugin to the Ecosystem section in the Readme. It also alphabetizes the Ecosystem section. I thought about creating a new "ecosystem.md" document and sectioning it like https://hapijs.com/plugins, but I wasn't sure about the classification of most plugins. I think this simple list is going to get unwieldy rather quickly, though.