### PR TITLE
Fix extra dash in ecosystem list (thanks Atom)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Bearer auth plugin for Fastify
 - [`fastify-formbody`](https://github.com/fastify/fastify-formbody)
 Plugin to parse x-www-form-urlencoded bodies
 - [`fastify-helmet`](https://github.com/fastify/fastify-helmet) Important security headers for Fastify
--- [`fastify-jwt`](https://github.com/fastify/fastify-jwt) JWT utils for Fastify, internally uses [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken)
+- [`fastify-jwt`](https://github.com/fastify/fastify-jwt) JWT utils for Fastify, internally uses [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken)
 - [`fastify-leveldb`](https://github.com/fastify/fastify-leveldb) Plugin to share a common LevelDB connection across Fastify.
 - [`fastify-mongodb`](https://github.com/fastify/fastify-mongodb)
 Fastify MongoDB connection plugin, with this you can share the same MongoDb connection pool in every part of your server.


### PR DESCRIPTION
Atom was very helpful in my last PR and added an extra `-` while re-organizing the ecosystem list. This PR fixes Atom's helpfulness that I overlooked.