### PR TITLE
Add missing return type

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -248,7 +248,7 @@ declare namespace fastify {
      * Hook that is fired before a request is processed, but after the "onRequest"
      * hook
      */
-    addHook(name: 'preHandler', hook: FastifyMiddleware)
+    addHook(name: 'preHandler', hook: FastifyMiddleware): FastifyInstance
 
     /**
      * Hook that is called when a response is about to be sent to a client


### PR DESCRIPTION
In TypeScript, when the compiler option of `noImplicitAny` is enabled, the following error occurs.

So I added a return type.

```
251     addHook(name: 'preHandler', hook: FastifyMiddleware)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/fastify/fastify.d.ts(251,5): error TS7010: 'addHook', which lacks return-type annotation, implicitly has an 'any' return type.
```