### PR TITLE
Define hooks before routes synchronously even in a async context

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/node": "~8.0.27",
     "@types/pino": "~4.7.0",
     "ajv": "^5.2.2",
-    "avvio": "^2.1.1",
+    "avvio": "^2.2.0",
     "fast-json-stringify": "^0.13.0",
     "fastify-cli": "^0.6.1",
     "fastseries": "^1.7.2",


### PR DESCRIPTION
Bumped avvio to 2.2.0 and added a regression test for https://github.com/fastify/fastify-mongodb/issues/8