### PR TITLE
Fix 204 async. Add test

### DIFF
--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -120,7 +120,7 @@ function preHandlerCallback (err, code) {
     result.then((payload) => {
       // this is for async functions that
       // are using reply.send directly
-      if (payload !== undefined) {
+      if (payload !== undefined || this.reply.res.statusCode === 204) {
         this.reply.send(payload)
       }
     }).catch((err) => {

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -236,6 +236,23 @@ function asyncTest (t) {
       t.deepEqual(payload, { hello: 'world' })
     })
   })
+
+  test('support 204', t => {
+    t.plan(1)
+
+    const fastify = Fastify()
+
+    fastify.get('/', async (req, reply) => {
+      reply.code(204)
+    })
+
+    fastify.inject({
+      method: 'GET',
+      url: '/'
+    }, res => {
+      t.equal(res.statusCode, 204)
+    })
+  })
 }
 
 module.exports = asyncTest


### PR DESCRIPTION
A route like this goes to timeout:
```js
fastify.get('/', async (req, reply) => {
  await someKindOfAwesomeThing()
  reply.code(204)
})
```