### PR TITLE
Avoid serializing all the request for every log line

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -140,7 +140,9 @@ function build (options) {
 
   function fastify (req, res) {
     req.id = genReqId()
-    req.log = res.log = logger.child({ req: req })
+    req.log = res.log = logger.child({ reqId: req.id })
+
+    req.log.info({ req }, 'incoming request')
 
     res._startTime = now()
     res._context = null

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -133,7 +133,7 @@ function asyncTest (t) {
   })
 
   test('server logs an error if reply.send is called and a value is returned via async/await', t => {
-    const lines = ['Reply already sent', 'request completed']
+    const lines = ['incoming request', 'Reply already sent', 'request completed']
     t.plan(lines.length + 1)
 
     const splitStream = split(JSON.parse)

--- a/test/internals/logger.test.js
+++ b/test/internals/logger.test.js
@@ -5,13 +5,6 @@ const test = t.test
 const Fastify = require('../..')
 const loggerUtils = require('../../lib/logger')
 
-test('gen id factory', t => {
-  t.plan(2)
-  const genReqId = loggerUtils.reqIdGenFactory()
-  t.is(typeof genReqId, 'function')
-  t.is(typeof genReqId({}), 'number')
-})
-
 test('time resolution', t => {
   t.plan(2)
   t.is(typeof loggerUtils.now, 'function')


### PR DESCRIPTION
This increase the throughput by 5-10% even if logging is disabled.
This happens because `logger.child({ req })` is our current bottleneck, because `req` is a big object and we `logger.child()`  serializes it to JSON as soon as it see it.

This change would add all the request details only on the `'incoming request'` log line.