### PR TITLE
chore: add documentation clarification for req and res in fastify middlewares.

### DIFF
--- a/docs/Middlewares.md
+++ b/docs/Middlewares.md
@@ -8,7 +8,7 @@ Fastify provides out of the box an asynchronous [middleware engine](https://gith
 
 Fastify middlewares don't support the full syntax `middleware(err, req, res, next)`, because error handling is done inside Fastify.
 
-Also, if you are using Middlewares that bundles different small middlewares, such as [*helmet*](https://helmetjs.github.io/), we recommend to use the single modules to get better performances.
+Also, if you are using a middleware that bundles different, smaller middlewares, such as [*helmet*](https://helmetjs.github.io/), we recommend to use the single modules to get better performances.
 
 ```js
 fastify.use(require('cors')())
@@ -29,14 +29,15 @@ const helmet = require('fastify-helmet')
 fastify.register(helmet)
 ```
 
-Also remember that middlewares can be encapsulated, this means that you can decide where your middlewares should run by using `register` as explained in the [plugins guide](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md).
+Remember that middlewares can be encapsulated, this means that you can decide where your middlewares should run by using `register` as explained in the [plugins guide](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md).
+
+Fastify middlewares also do not expose the `send` method or other methods specific to the Fastify [Reply]('./Reply.md' "Reply") instance. This is because Fastify wraps the incoming `req` and `res` NodeJS instances using the [Request](./Request.md "Request") and [Reply](./Reply.md "Reply") classes internally, but this is done after the middlewares phase. If you need to create a middleware you have to use the NodeJS `req` and `res` instances. Otherwise, you can use the `preHandler` hook that has the [Request](./Request.md "Request") and [Reply](./Reply.md "Reply") Fastify instances. For more information, see [Hooks](./Hooks.md "Hooks").
 
 <a name="restrict-usage"></a>
 #### Restrict middleware execution to a certain path(s)
 If you need to run a middleware only under certain path(s), just pass the path as first parameter to `use` and you are done!
 
 *Note that this does not support routes with parameters, (eg: `/user/:id/comments`) and wildcard is not supported in multiple paths.*
-
 
 ```js
 const serveStatic = require('serve-static')

--- a/docs/Middlewares.md
+++ b/docs/Middlewares.md
@@ -31,7 +31,7 @@ fastify.register(helmet)
 
 Remember that middlewares can be encapsulated, this means that you can decide where your middlewares should run by using `register` as explained in the [plugins guide](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md).
 
-Fastify middlewares also do not expose the `send` method or other methods specific to the Fastify [Reply]('./Reply.md' "Reply") instance. This is because Fastify wraps the incoming `req` and `res` NodeJS instances using the [Request](./Request.md "Request") and [Reply](./Reply.md "Reply") classes internally, but this is done after the middlewares phase. If you need to create a middleware you have to use the NodeJS `req` and `res` instances. Otherwise, you can use the `preHandler` hook that has the [Request](./Request.md "Request") and [Reply](./Reply.md "Reply") Fastify instances. For more information, see [Hooks](./Hooks.md "Hooks").
+Fastify middlewares also do not expose the `send` method or other methods specific to the Fastify [Reply]('./Reply.md' "Reply") instance. This is because Fastify wraps the incoming `req` and `res` Node instances using the [Request](./Request.md "Request") and [Reply](./Reply.md "Reply") objects internally, but this is done after the middlewares phase. If you need to create a middleware you have to use the Node `req` and `res` instances. Otherwise, you can use the `preHandler` hook that has the [Request](./Request.md "Request") and [Reply](./Reply.md "Reply") Fastify instances. For more information, see [Hooks](./Hooks.md "Hooks").
 
 <a name="restrict-usage"></a>
 #### Restrict middleware execution to a certain path(s)


### PR DESCRIPTION
This was discussed in https://github.com/fastify/fastify/issues/319. I think it is a valuable clarification for the documentation and likely would have saved me some time getting set up!

Thanks!