### PR TITLE
Fixed register TypeScript definition

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -79,7 +79,7 @@ declare namespace fastify {
   interface RouteOptions extends RouteShorthandOptions {
     method: HTTPMethod|HTTPMethod[],
     url: string,
-    handler?: RequestHandler
+    handler: RequestHandler
   }
 
   /**

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -9,14 +9,14 @@ declare function fastify(opts?: fastify.ServerOptions): fastify.FastifyInstance;
 
 declare namespace fastify {
 
-  type Plugin = (instance: FastifyInstance, opts: Object, callback?: (err?: Error) => void) => void
+  type Plugin<T> = (instance: FastifyInstance, opts: T, callback?: (err?: Error) => void) => void
 
   type Middleware = (req: http.IncomingMessage, res: http.OutgoingMessage, callback?: (err?: Error) => void) => void
 
   type HTTPMethod = 'DELETE' | 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'OPTIONS';
-  
+
   type FastifyMiddleware = (req: FastifyRequest, reply: FastifyReply, done: (err?: Error) => void) => void
-  
+
   type RequestHandler = (req: FastifyRequest, res: FastifyReply) => void
 
   /**
@@ -46,7 +46,7 @@ declare namespace fastify {
     type: (contentType: string) => FastifyReply
     redirect: (statusCode: number, url: string) => FastifyReply
     serializer: (fn: Function) => FastifyReply
-    send: (payload?: string|Array<any>|Object|Error|Promise<any>|ReadableStream) => FastifyReply 
+    send: (payload?: string|Array<any>|Object|Error|Promise<any>|ReadableStream) => FastifyReply
     sent: boolean
   }
 
@@ -81,7 +81,15 @@ declare namespace fastify {
     url: string,
     handler?: RequestHandler
   }
-  
+
+  /**
+   * Register options
+   */
+  interface RegisterOptions extends RouteShorthandOptions {
+    [key: string]: any,
+    prefix?: string,
+  }
+
   /**
    * Represents the fastify instance created by the factory function the module exports.
    */
@@ -208,7 +216,7 @@ declare namespace fastify {
     /**
      * Registers a plugin or array of plugins on the server
      */
-    register(plugin: Plugin|Array<Plugin>, opts?: RouteOptions, callback?: (err: Error) => void): FastifyInstance
+    register<T extends RegisterOptions>(plugin: Plugin<T>|Array<Plugin<T>>, opts?: T, callback?: (err: Error) => void): FastifyInstance
 
     /**
      * Decorate this fastify instance with new properties. Throws an execption if
@@ -233,7 +241,7 @@ declare namespace fastify {
      * like added to the error
      */
     extendServerError(extendFn: () => Object): FastifyInstance
-    
+
     /**
      * Determines if the given named decorator is available
      */

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -109,12 +109,16 @@ server
   })
   .route({
     method: ['GET', 'POST', 'PUT'],
-    url: '/route'
+    url: '/multi-route',
+    handler: function (req, reply) {
+      reply.send({ hello: 'world' })
+    }
   })
   .register(function (instance, options, done) {
     instance.get('/route', opts, function (req, reply) {
       reply.send({ hello: 'world' })
     })
+    done()
   },
   {prefix: 'v1', hello: 'world'},
   function (err) {
@@ -125,11 +129,13 @@ server
       instance.get('/first', opts, function (req, reply) {
         reply.send({ hello: 'world' })
       })
+      done()
     },
     function (instance, options, done) {
       instance.get('/second', opts, function (req, reply) {
         reply.send({ hello: 'world' })
       })
+      done()
     }
   ],
   {prefix: 'v1', hello: 'world'},

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -12,7 +12,7 @@ const server: fastify.FastifyInstance = fastify()
 server.use(cors())
 
 // Custom middleware
-server.use('/', (req, res, next) => {  
+server.use('/', (req, res, next) => {
   console.log(`${req.method} ${req.url}`);
 })
 
@@ -111,6 +111,32 @@ server
     method: ['GET', 'POST', 'PUT'],
     url: '/route'
   })
+  .register(function (instance, options, done) {
+    instance.get('/route', opts, function (req, reply) {
+      reply.send({ hello: 'world' })
+    })
+  },
+  {prefix: 'v1', hello: 'world'},
+  function (err) {
+    if (err) throw err
+  })
+  .register([
+    function (instance, options, done) {
+      instance.get('/first', opts, function (req, reply) {
+        reply.send({ hello: 'world' })
+      })
+    },
+    function (instance, options, done) {
+      instance.get('/second', opts, function (req, reply) {
+        reply.send({ hello: 'world' })
+      })
+    }
+  ],
+  {prefix: 'v1', hello: 'world'},
+  function (err) {
+    if (err) throw err
+  })
+
 
 
 // Using decorate requires casting so the compiler knows about new properties


### PR DESCRIPTION
Hi!

At the moment the TypeScript definition would fail on the `register` method because the type of the `options` parameter is defined as `RouteOptions` which is incorrect as in the `RouteOptions` type, you have to provide `url` and `method` and as the [documentation states](https://github.com/fastify/fastify/blob/master/docs/Getting-Started.md#register) you can pass pretty much what you want in the option object, as well as a [`prefix` parameter](https://github.com/fastify/fastify/blob/master/docs/Routes.md#route-prefixing) which is not even allowed in `RouteOptions`.

This PR fixes it and adds a type parameter to the `Plugin` type so that the options you pass to the `register` function are set to the plugin function as well.

Also, the test file wasn't testing the `register` function at all so I added 2 tests, one with one plugin and one with an array of two plugins.

Let me know what you think!