### PR TITLE
Updated readme, Fixes broken plugin listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,8 @@ they perform very closely on this benchmarks.
 - [`fastify-accepts-serializer`](https://github.com/fastify/fastify-accepts-serializer) to serialize to output according to `Accept` header
 - [`fastify-apollo`](https://github.com/coopnd/fastify-apollo) Run an [Apollo Server](https://github.com/apollographql/apollo-server) with Fastify. (GraphQL)
 - [`fastify-auth`](https://github.com/fastify/fastify-auth) Run multiple auth functions in Fastify
-- [`fastify-bearer-auth`](https://github.com/fastify/fastify-bearer-auth)
 - [`fastify-bankai`](https://github.com/fastify/fastify-bankai) [Bankai](https://github.com/yoshuawuyts/bankai) assets compiler for Fastify
-Bearer auth plugin for Fastify
+- [`fastify-bearer-auth`](https://github.com/fastify/fastify-bearer-auth) Bearer auth plugin for Fastify
 - [`fastify-cookie`](https://github.com/fastify/fastify-cookie) Parse and set cookie headers
 - [`fastify-env`](https://github.com/fastify/fastify-env) Load and check configuration
 - [`fastify-formbody`](https://github.com/fastify/fastify-formbody) Plugin to parse x-www-form-urlencoded bodies


### PR DESCRIPTION
This is the cause for the broken build of the website (ref https://github.com/fastify/website/issues/31).

The issue on the website has [a dedicated fix](https://github.com/fastify/website/pull/32) that makes the ecosystem parser slightly more flexible.

At the same time, I think the README here is broken and this PR addresses it.