### PR TITLE
No logger by default

### DIFF
--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -1,12 +1,32 @@
 <h1 align="center">Fastify</h1>
 
 ## Logging
-Since Fastify is really focused on performances, we choose the best logger to achieve the goal. **[Pino](https://github.com/pinojs/pino)**!
 
-By default Fastify uses [pino](https://github.com/pinojs/pino) as the logger, with the log level set to `'fatal'`.
+Logging is disabled by default, and you can enable it by passing
+`{ logger: true }` or `{ logger: { level: 'info' } }` when you create
+the fastify instance. Note that if the logger is disabled, it is impossible to
+enable it at runtime. We use
+[abstract-logging](https://www.npmjs.com/package/abstract-logging) for
+this purpose.
+
+Since Fastify is really focused on performances, it uses [pino](https://github.com/pinojs/pino) as its logger, with the default log level when enabled set to `'info'`.
+
+Enabling the logger is extremely easy:
+
+```js
+const fastify = require('fastify')({
+  logger: true
+})
+
+fastify.get('/', options, function (req, reply) {
+  req.log.info('Some info about the current request')
+  reply.send({ hello: 'world' })
+})
+```
 
 If you want to pass some options to the logger, just pass the logger option to Fastify.
 You can find all the options in the [Pino documentation](https://github.com/pinojs/pino/blob/master/docs/API.md#pinooptions-stream). If you want to pass a custom stream to the Pino instance, just add the stream field to the logger object.
+
 ```js
 const split = require('split2')
 const stream = split(JSON.parse)

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -9,7 +9,7 @@ enable it at runtime. We use
 [abstract-logging](https://www.npmjs.com/package/abstract-logging) for
 this purpose.
 
-Since Fastify is really focused on performances, it uses [pino](https://github.com/pinojs/pino) as its logger, with the default log level when enabled set to `'info'`.
+Since Fastify is really focused on performances, it uses [pino](https://github.com/pinojs/pino) as its logger, with the default log level, when enabled, set to `'info'`.
 
 Enabling the logger is extremely easy:
 

--- a/examples/example.js
+++ b/examples/example.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const fastify = require('../fastify')({ logger: false })
+const fastify = require('../fastify')()
 
 const opts = {
   schema: {

--- a/fastify.js
+++ b/fastify.js
@@ -35,8 +35,8 @@ function build (options) {
     logger = Object.create(abstractLogging)
     logger.child = () => logger
   } else {
-    options.logger = options.logger || {}
-    options.logger.level = options.logger.level || 'fatal'
+    options.logger = typeof options.logger === 'object' ? options.logger : {}
+    options.logger.level = options.logger.level || 'info'
     options.logger.serializers = options.logger.serializers || loggerUtils.serializers
     logger = loggerUtils.createLogger(options.logger)
   }

--- a/fastify.js
+++ b/fastify.js
@@ -31,8 +31,8 @@ function build (options) {
   var logger
   if (isValidLogger(options.logger)) {
     logger = loggerUtils.createLogger({ logger: options.logger, serializers: loggerUtils.serializers })
-  } else if (options.logger === false) {
-    logger = abstractLogging
+  } else if (!options.logger) {
+    logger = Object.create(abstractLogging)
     logger.child = () => logger
   } else {
     options.logger = options.logger || {}

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "hide-powered-by": "^1.0.0",
     "hsts": "^2.0.0",
     "ienoopen": "^1.0.0",
-    "joi": "^11.3.3",
+    "joi": "^11.3.4",
     "pre-commit": "^1.2.2",
     "request": "^2.83.0",
     "serve-static": "^1.13.1",
@@ -88,7 +88,7 @@
     "x-xss-protection": "^1.0.0"
   },
   "dependencies": {
-    "@types/node": "^8.0.33",
+    "@types/node": "^8.0.34",
     "@types/pino": "~4.7.0",
     "abstract-logging": "^1.0.0",
     "ajv": "^5.2.3",
@@ -96,10 +96,10 @@
     "fast-json-stringify": "^0.14.0",
     "fastify-cli": "^0.8.0",
     "fastseries": "^1.7.2",
-    "find-my-way": "^1.6.2",
+    "find-my-way": "^1.7.0",
     "flatstr": "^1.0.5",
     "light-my-request": "^1.0.0",
-    "middie": "^2.1.0",
+    "middie": "^2.1.1",
     "pino": "^4.7.2",
     "pump": "^1.0.2"
   }


### PR DESCRIPTION
This removed the logger by default using https://www.npmjs.com/package/abstract-logging, but it turns it on if `{ logger: true }` or `{ logger: { } }` is passed.