### PR TITLE
Use "request-id" header if present for req.id

### DIFF
--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -49,7 +49,7 @@ Additionally, `genReqId` option can be used for generating the request id by you
 let i = 0
 const fastify = require('fastify')({
   logger: {
-    genReqId: function () { return i++ }
+    genReqId: function (req) { return i++ }
   }
 })
 ```

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -44,7 +44,8 @@ fastify.get('/', options, function (req, reply) {
 })
 ```
 
-Additionally, `genReqId` option can be used for generating the request id by yourself.
+By default fastify adds an id to every request for easier tracking. If the "request-id" header is present its value is used, otherwise a new incremental id is generated.
+Additionally, `genReqId` option can be used for generating the request id by yourself. It will received the incoming request as a parameter.
 ```js
 let i = 0
 const fastify = require('fastify')({

--- a/fastify.js
+++ b/fastify.js
@@ -147,7 +147,7 @@ function build (options) {
   return fastify
 
   function fastify (req, res) {
-    req.id = genReqId()
+    req.id = genReqId(req)
     req.log = res.log = logger.child({ reqId: req.id })
 
     req.log.info({ req }, 'incoming request')

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -32,8 +32,8 @@ function createLogger (opts, stream) {
 function reqIdGenFactory () {
   var maxInt = 2147483647
   var nextReqId = 0
-  return function genReqId () {
-    return (nextReqId = (nextReqId + 1) & maxInt)
+  return function genReqId (req) {
+    return req.headers['request-id'] || (nextReqId = (nextReqId + 1) & maxInt)
   }
 }
 

--- a/test/internals/logger.test.js
+++ b/test/internals/logger.test.js
@@ -45,6 +45,31 @@ test('The logger should add a unique id for every request', t => {
   }
 })
 
+test('The logger should reuse request id header for req.id', t => {
+  const fastify = Fastify()
+  fastify.get('/', (req, reply) => {
+    t.ok(req.req.id)
+    reply.send({ id: req.req.id })
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    fastify.inject({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port,
+      headers: {
+        'Request-Id': 'request-id-1'
+      }
+    }, res => {
+      const payload = JSON.parse(res.payload)
+      t.ok(payload.id === 'request-id-1', 'the request id from the header should be returned')
+      fastify.close()
+      t.end()
+    })
+  })
+})
+
 function Queue () {
   this.q = []
   this.running = false


### PR DESCRIPTION
If a "request-id" header is present in the request it is used for req.id instead of a newly generated one.
This allows for request flow tracking across multiple services.

See #343 