### PR TITLE
Remove request devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "ienoopen": "^1.0.0",
     "joi": "^11.3.4",
     "pre-commit": "^1.2.2",
-    "request": "^2.83.0",
     "serve-static": "^1.13.1",
     "snazzy": "^7.0.0",
     "split2": "^2.2.0",
@@ -101,7 +100,8 @@
     "light-my-request": "^1.0.0",
     "middie": "^2.1.1",
     "pino": "^4.7.2",
-    "pump": "^1.0.2"
+    "pump": "^1.0.2",
+    "simple-get": "^2.7.0"
   },
   "greenkeeper": {
     "ignore": [

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -2,7 +2,7 @@
 
 const t = require('tap')
 const test = t.test
-const request = require('request')
+const sget = require('simple-get').concat
 const Fastify = require('..')
 
 test('default 404', t => {
@@ -22,10 +22,11 @@ test('default 404', t => {
 
     test('unsupported method', t => {
       t.plan(2)
-      request({
+      sget({
         method: 'PUT',
-        uri: 'http://localhost:' + fastify.server.address().port,
-        json: {}
+        url: 'http://localhost:' + fastify.server.address().port,
+        body: {},
+        json: true
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
@@ -34,10 +35,11 @@ test('default 404', t => {
 
     test('unsupported route', t => {
       t.plan(2)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + fastify.server.address().port + '/notSupported',
-        json: {}
+        url: 'http://localhost:' + fastify.server.address().port + '/notSupported',
+        body: {},
+        json: true
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
@@ -67,10 +69,11 @@ test('customized 404', t => {
 
     test('unsupported method', t => {
       t.plan(3)
-      request({
+      sget({
         method: 'PUT',
-        uri: 'http://localhost:' + fastify.server.address().port,
-        json: {}
+        url: 'http://localhost:' + fastify.server.address().port,
+        body: {},
+        json: true
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
@@ -80,10 +83,11 @@ test('customized 404', t => {
 
     test('unsupported route', t => {
       t.plan(3)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + fastify.server.address().port + '/notSupported',
-        json: {}
+        url: 'http://localhost:' + fastify.server.address().port + '/notSupported',
+        body: {},
+        json: true
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
@@ -128,10 +132,11 @@ test('encapsulated 404', t => {
 
     test('root unsupported method', t => {
       t.plan(3)
-      request({
+      sget({
         method: 'PUT',
-        uri: 'http://localhost:' + fastify.server.address().port,
-        json: {}
+        url: 'http://localhost:' + fastify.server.address().port,
+        body: {},
+        json: true
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
@@ -141,10 +146,11 @@ test('encapsulated 404', t => {
 
     test('root insupported route', t => {
       t.plan(3)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + fastify.server.address().port + '/notSupported',
-        json: {}
+        url: 'http://localhost:' + fastify.server.address().port + '/notSupported',
+        body: {},
+        json: true
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
@@ -154,10 +160,11 @@ test('encapsulated 404', t => {
 
     test('unsupported method', t => {
       t.plan(3)
-      request({
+      sget({
         method: 'PUT',
-        uri: 'http://localhost:' + fastify.server.address().port + '/test',
-        json: {}
+        url: 'http://localhost:' + fastify.server.address().port + '/test',
+        body: {},
+        json: true
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
@@ -167,10 +174,11 @@ test('encapsulated 404', t => {
 
     test('unsupported route', t => {
       t.plan(3)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + fastify.server.address().port + '/test/notSupported',
-        json: {}
+        url: 'http://localhost:' + fastify.server.address().port + '/test/notSupported',
+        body: {},
+        json: true
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
@@ -180,10 +188,11 @@ test('encapsulated 404', t => {
 
     test('unsupported method bis', t => {
       t.plan(3)
-      request({
+      sget({
         method: 'PUT',
-        uri: 'http://localhost:' + fastify.server.address().port + '/test2',
-        json: {}
+        url: 'http://localhost:' + fastify.server.address().port + '/test2',
+        body: {},
+        json: true
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
@@ -193,10 +202,11 @@ test('encapsulated 404', t => {
 
     test('unsupported route bis', t => {
       t.plan(3)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + fastify.server.address().port + '/test2/notSupported',
-        json: {}
+        url: 'http://localhost:' + fastify.server.address().port + '/test2/notSupported',
+        body: {},
+        json: true
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
@@ -230,10 +240,11 @@ test('run hooks on default 404', t => {
   fastify.listen(0, err => {
     t.error(err)
 
-    request({
+    sget({
       method: 'PUT',
-      uri: 'http://localhost:' + fastify.server.address().port,
-      json: {}
+      url: 'http://localhost:' + fastify.server.address().port,
+      body: {},
+      json: true
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 404)
@@ -278,10 +289,11 @@ test('run hooks with encapsulated 404', t => {
   fastify.listen(0, err => {
     t.error(err)
 
-    request({
+    sget({
       method: 'PUT',
-      uri: 'http://localhost:' + fastify.server.address().port + '/test',
-      json: {}
+      url: 'http://localhost:' + fastify.server.address().port + '/test',
+      body: {},
+      json: true
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 404)
@@ -308,10 +320,11 @@ test('run middlewares on default 404', t => {
   fastify.listen(0, err => {
     t.error(err)
 
-    request({
+    sget({
       method: 'PUT',
-      uri: 'http://localhost:' + fastify.server.address().port,
-      json: {}
+      url: 'http://localhost:' + fastify.server.address().port,
+      body: {},
+      json: true
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 404)
@@ -347,10 +360,11 @@ test('run middlewares with encapsulated 404', t => {
   fastify.listen(0, err => {
     t.error(err)
 
-    request({
+    sget({
       method: 'PUT',
-      uri: 'http://localhost:' + fastify.server.address().port + '/test',
-      json: {}
+      url: 'http://localhost:' + fastify.server.address().port + '/test',
+      body: {},
+      json: true
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 404)

--- a/test/ajv-options.test.js
+++ b/test/ajv-options.test.js
@@ -2,7 +2,7 @@
 
 const t = require('tap')
 const test = t.test
-const request = require('request')
+const sget = require('simple-get').concat
 const Fastify = require('..')
 
 const schemaWithFilter = {
@@ -45,16 +45,14 @@ test('ajv - removeAdditional', t => {
 
     fastify.post('/', schemaWithFilter, function (req, reply) {
       t.deepEqual(req.body, { a: 1 })
-      reply.code(200).send()
+      reply.code(200).send({})
     })
 
-    request({
+    sget({
       method: 'POST',
-      uri: 'http://localhost:' + fastify.server.address().port,
-      body: '{"a": 1, "b": 2}',
-      headers: {
-        'Content-Type': 'application/json'
-      }
+      url: 'http://localhost:' + fastify.server.address().port,
+      body: { a: 1, b: 2 },
+      json: true
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -76,16 +74,14 @@ test('ajv - useDefaults', t => {
 
     fastify.post('/', schemaWithDefaults, function (req, reply) {
       t.deepEqual(req.body, { a: 100 })
-      reply.code(200).send()
+      reply.code(200).send({})
     })
 
-    request({
+    sget({
       method: 'POST',
-      uri: 'http://localhost:' + fastify.server.address().port,
-      body: '{}',
-      headers: {
-        'Content-Type': 'application/json'
-      }
+      url: 'http://localhost:' + fastify.server.address().port,
+      body: {},
+      json: true
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const request = require('request')
+const sget = require('simple-get').concat
 const Fastify = require('..')
 const fastify = Fastify()
 const sleep = require('then-sleep')
@@ -56,9 +56,9 @@ function asyncTest (t) {
 
     test('shorthand - request async await test', t => {
       t.plan(4)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + fastify.server.address().port
+        url: 'http://localhost:' + fastify.server.address().port
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
@@ -69,9 +69,9 @@ function asyncTest (t) {
 
     test('shorthand - request async test', t => {
       t.plan(4)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + fastify.server.address().port + '/no-await'
+        url: 'http://localhost:' + fastify.server.address().port + '/no-await'
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
@@ -95,9 +95,9 @@ function asyncTest (t) {
 
     server.listen(0, (err) => {
       t.error(err)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + server.server.address().port + '/'
+        url: 'http://localhost:' + server.server.address().port + '/'
       }, (err, res, body) => {
         t.error(err)
         t.deepEqual(payload, JSON.parse(body))
@@ -121,9 +121,9 @@ function asyncTest (t) {
 
     server.listen(0, (err) => {
       t.error(err)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + server.server.address().port + '/'
+        url: 'http://localhost:' + server.server.address().port + '/'
       }, (err, res, body) => {
         t.error(err)
         t.deepEqual(payload, JSON.parse(body))
@@ -175,9 +175,9 @@ function asyncTest (t) {
 
     server.listen(0, (err) => {
       t.error(err)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + server.server.address().port + '/'
+        url: 'http://localhost:' + server.server.address().port + '/'
       }, (err, res, body) => {
         t.error(err)
         t.deepEqual(payload, JSON.parse(body))
@@ -201,9 +201,9 @@ function asyncTest (t) {
 
     server.listen(0, (err) => {
       t.error(err)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + server.server.address().port + '/'
+        url: 'http://localhost:' + server.server.address().port + '/'
       }, (err, res, body) => {
         t.error(err)
         t.deepEqual(payload, JSON.parse(body))

--- a/test/custom-parser.test.js
+++ b/test/custom-parser.test.js
@@ -2,7 +2,7 @@
 
 const t = require('tap')
 const test = t.test
-const request = require('request')
+const sget = require('simple-get').concat
 const Fastify = require('..')
 const jsonParser = require('fast-json-body')
 
@@ -39,9 +39,9 @@ test('contentTypeParser should add a custom parser', t => {
     t.test('in POST', t => {
       t.plan(3)
 
-      request({
+      sget({
         method: 'POST',
-        uri: 'http://localhost:' + fastify.server.address().port,
+        url: 'http://localhost:' + fastify.server.address().port,
         body: '{"hello":"world"}',
         headers: {
           'Content-Type': 'application/jsoff'
@@ -49,16 +49,16 @@ test('contentTypeParser should add a custom parser', t => {
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
-        t.deepEqual(body, JSON.stringify({ hello: 'world' }))
+        t.deepEqual(body.toString(), JSON.stringify({ hello: 'world' }))
       })
     })
 
     t.test('in OPTIONS', t => {
       t.plan(3)
 
-      request({
+      sget({
         method: 'OPTIONS',
-        uri: 'http://localhost:' + fastify.server.address().port,
+        url: 'http://localhost:' + fastify.server.address().port,
         body: '{"hello":"world"}',
         headers: {
           'Content-Type': 'application/jsoff'
@@ -66,7 +66,7 @@ test('contentTypeParser should add a custom parser', t => {
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
-        t.deepEqual(body, JSON.stringify({ hello: 'world' }))
+        t.deepEqual(body.toString(), JSON.stringify({ hello: 'world' }))
       })
     })
   })
@@ -98,9 +98,9 @@ test('contentTypeParser should handle multiple custom parsers', t => {
     t.error(err)
     fastify.server.unref()
 
-    request({
+    sget({
       method: 'POST',
-      uri: 'http://localhost:' + fastify.server.address().port,
+      url: 'http://localhost:' + fastify.server.address().port,
       body: '{"hello":"world"}',
       headers: {
         'Content-Type': 'application/jsoff'
@@ -108,12 +108,12 @@ test('contentTypeParser should handle multiple custom parsers', t => {
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
-      t.deepEqual(body, JSON.stringify({ hello: 'world' }))
+      t.deepEqual(body.toString(), JSON.stringify({ hello: 'world' }))
     })
 
-    request({
+    sget({
       method: 'POST',
-      uri: 'http://localhost:' + fastify.server.address().port + '/hello',
+      url: 'http://localhost:' + fastify.server.address().port + '/hello',
       body: '{"hello":"world"}',
       headers: {
         'Content-Type': 'application/ffosj'
@@ -121,7 +121,7 @@ test('contentTypeParser should handle multiple custom parsers', t => {
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
-      t.deepEqual(body, JSON.stringify({ hello: 'world' }))
+      t.deepEqual(body.toString(), JSON.stringify({ hello: 'world' }))
     })
   })
 })
@@ -141,9 +141,9 @@ test('contentTypeParser should handle errors', t => {
   fastify.listen(0, err => {
     t.error(err)
 
-    request({
+    sget({
       method: 'POST',
-      uri: 'http://localhost:' + fastify.server.address().port,
+      url: 'http://localhost:' + fastify.server.address().port,
       body: '{"hello":"world"}',
       headers: {
         'Content-Type': 'application/jsoff'
@@ -203,9 +203,9 @@ test('contentTypeParser should support encapsulation, second try', t => {
   fastify.listen(0, err => {
     t.error(err)
 
-    request({
+    sget({
       method: 'POST',
-      uri: 'http://localhost:' + fastify.server.address().port,
+      url: 'http://localhost:' + fastify.server.address().port,
       body: '{"hello":"world"}',
       headers: {
         'Content-Type': 'application/jsoff'
@@ -213,7 +213,7 @@ test('contentTypeParser should support encapsulation, second try', t => {
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
-      t.deepEqual(body, JSON.stringify({ hello: 'world' }))
+      t.deepEqual(body.toString(), JSON.stringify({ hello: 'world' }))
       fastify.close()
     })
   })
@@ -237,9 +237,9 @@ test('contentTypeParser shouldn\'t support request with undefined "Content-Type"
   fastify.listen(0, err => {
     t.error(err)
 
-    request({
+    sget({
       method: 'POST',
-      uri: 'http://localhost:' + fastify.server.address().port,
+      url: 'http://localhost:' + fastify.server.address().port,
       body: 'unknown content type!',
       headers: {
         // 'Content-Type': undefined
@@ -307,9 +307,9 @@ test('catch all content type parser', t => {
   fastify.listen(0, err => {
     t.error(err)
 
-    request({
+    sget({
       method: 'POST',
-      uri: 'http://localhost:' + fastify.server.address().port,
+      url: 'http://localhost:' + fastify.server.address().port,
       body: 'hello',
       headers: {
         'Content-Type': 'application/jsoff'
@@ -317,11 +317,11 @@ test('catch all content type parser', t => {
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
-      t.deepEqual(body, '"hello"')
+      t.deepEqual(body.toString(), '"hello"')
 
-      request({
+      sget({
         method: 'POST',
-        uri: 'http://localhost:' + fastify.server.address().port,
+        url: 'http://localhost:' + fastify.server.address().port,
         body: 'hello',
         headers: {
           'Content-Type': 'very-weird-content-type'
@@ -329,7 +329,7 @@ test('catch all content type parser', t => {
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
-        t.deepEqual(body, '"hello"')
+        t.deepEqual(body.toString(), '"hello"')
         fastify.close()
       })
     })
@@ -362,9 +362,9 @@ test('catch all content type parser should not interfere with other conte type p
   fastify.listen(0, err => {
     t.error(err)
 
-    request({
+    sget({
       method: 'POST',
-      uri: 'http://localhost:' + fastify.server.address().port,
+      url: 'http://localhost:' + fastify.server.address().port,
       body: '{"hello":"world"}',
       headers: {
         'Content-Type': 'application/jsoff'
@@ -372,11 +372,11 @@ test('catch all content type parser should not interfere with other conte type p
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
-      t.deepEqual(body, JSON.stringify({ hello: 'world' }))
+      t.deepEqual(body.toString(), JSON.stringify({ hello: 'world' }))
 
-      request({
+      sget({
         method: 'POST',
-        uri: 'http://localhost:' + fastify.server.address().port,
+        url: 'http://localhost:' + fastify.server.address().port,
         body: 'hello',
         headers: {
           'Content-Type': 'very-weird-content-type'
@@ -384,7 +384,7 @@ test('catch all content type parser should not interfere with other conte type p
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
-        t.deepEqual(body, '"hello"')
+        t.deepEqual(body.toString(), '"hello"')
         fastify.close()
       })
     })

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -4,7 +4,7 @@ const t = require('tap')
 const test = t.test
 const Fastify = require('..')
 const fp = require('fastify-plugin')
-const request = require('request')
+const sget = require('simple-get').concat
 
 test('server methods should exist', t => {
   t.plan(2)
@@ -82,9 +82,9 @@ test('decorateReply inside register', t => {
     t.error(err)
     fastify.server.unref()
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/yes'
+      url: 'http://localhost:' + fastify.server.address().port + '/yes'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -92,9 +92,9 @@ test('decorateReply inside register', t => {
       t.deepEqual(JSON.parse(body), { hello: 'world' })
     })
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/no'
+      url: 'http://localhost:' + fastify.server.address().port + '/no'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -130,9 +130,9 @@ test('decorateReply as plugin (inside .after)', t => {
     t.error(err)
     fastify.server.unref()
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/yes'
+      url: 'http://localhost:' + fastify.server.address().port + '/yes'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -140,9 +140,9 @@ test('decorateReply as plugin (inside .after)', t => {
       t.deepEqual(JSON.parse(body), { hello: 'world' })
     })
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/no'
+      url: 'http://localhost:' + fastify.server.address().port + '/no'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -178,9 +178,9 @@ test('decorateReply as plugin (outside .after)', t => {
     t.error(err)
     fastify.server.unref()
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/yes'
+      url: 'http://localhost:' + fastify.server.address().port + '/yes'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -188,9 +188,9 @@ test('decorateReply as plugin (outside .after)', t => {
       t.deepEqual(JSON.parse(body), { hello: 'world' })
     })
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/no'
+      url: 'http://localhost:' + fastify.server.address().port + '/no'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -225,9 +225,9 @@ test('decorateRequest inside register', t => {
     t.error(err)
     fastify.server.unref()
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/yes'
+      url: 'http://localhost:' + fastify.server.address().port + '/yes'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -235,9 +235,9 @@ test('decorateRequest inside register', t => {
       t.deepEqual(JSON.parse(body), { hello: 'world' })
     })
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/no'
+      url: 'http://localhost:' + fastify.server.address().port + '/no'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -273,9 +273,9 @@ test('decorateRequest as plugin (inside .after)', t => {
     t.error(err)
     fastify.server.unref()
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/yes'
+      url: 'http://localhost:' + fastify.server.address().port + '/yes'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -283,9 +283,9 @@ test('decorateRequest as plugin (inside .after)', t => {
       t.deepEqual(JSON.parse(body), { hello: 'world' })
     })
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/no'
+      url: 'http://localhost:' + fastify.server.address().port + '/no'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -321,9 +321,9 @@ test('decorateRequest as plugin (outside .after)', t => {
     t.error(err)
     fastify.server.unref()
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/yes'
+      url: 'http://localhost:' + fastify.server.address().port + '/yes'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -331,9 +331,9 @@ test('decorateRequest as plugin (outside .after)', t => {
       t.deepEqual(JSON.parse(body), { hello: 'world' })
     })
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/no'
+      url: 'http://localhost:' + fastify.server.address().port + '/no'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)

--- a/test/delete.test.js
+++ b/test/delete.test.js
@@ -2,7 +2,7 @@
 
 const t = require('tap')
 const test = t.test
-const request = require('request')
+const sget = require('simple-get').concat
 const fastify = require('..')()
 
 const schema = {
@@ -128,9 +128,9 @@ fastify.listen(0, err => {
 
   test('shorthand - request delete', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'DELETE',
-      uri: 'http://localhost:' + fastify.server.address().port
+      url: 'http://localhost:' + fastify.server.address().port
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -141,9 +141,9 @@ fastify.listen(0, err => {
 
   test('shorthand - request delete params schema', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'DELETE',
-      uri: 'http://localhost:' + fastify.server.address().port + '/params/world/123'
+      url: 'http://localhost:' + fastify.server.address().port + '/params/world/123'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -154,9 +154,9 @@ fastify.listen(0, err => {
 
   test('shorthand - request delete params schema error', t => {
     t.plan(3)
-    request({
+    sget({
       method: 'DELETE',
-      uri: 'http://localhost:' + fastify.server.address().port + '/params/world/string'
+      url: 'http://localhost:' + fastify.server.address().port + '/params/world/string'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 400)
@@ -176,12 +176,12 @@ fastify.listen(0, err => {
 
   test('shorthand - request delete headers schema', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'DELETE',
       headers: {
         'x-test': 1
       },
-      uri: 'http://localhost:' + fastify.server.address().port + '/headers'
+      url: 'http://localhost:' + fastify.server.address().port + '/headers'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -192,12 +192,12 @@ fastify.listen(0, err => {
 
   test('shorthand - request delete headers schema error', t => {
     t.plan(3)
-    request({
+    sget({
       method: 'DELETE',
       headers: {
         'x-test': 'abc'
       },
-      uri: 'http://localhost:' + fastify.server.address().port + '/headers'
+      url: 'http://localhost:' + fastify.server.address().port + '/headers'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 400)
@@ -217,9 +217,9 @@ fastify.listen(0, err => {
 
   test('shorthand - request delete querystring schema', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'DELETE',
-      uri: 'http://localhost:' + fastify.server.address().port + '/query?hello=123'
+      url: 'http://localhost:' + fastify.server.address().port + '/query?hello=123'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -230,9 +230,9 @@ fastify.listen(0, err => {
 
   test('shorthand - request delete querystring schema error', t => {
     t.plan(3)
-    request({
+    sget({
       method: 'DELETE',
-      uri: 'http://localhost:' + fastify.server.address().port + '/query?hello=world'
+      url: 'http://localhost:' + fastify.server.address().port + '/query?hello=world'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 400)
@@ -252,9 +252,9 @@ fastify.listen(0, err => {
 
   test('shorthand - request delete missing schema', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'DELETE',
-      uri: 'http://localhost:' + fastify.server.address().port + '/missing'
+      url: 'http://localhost:' + fastify.server.address().port + '/missing'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -2,7 +2,7 @@
 
 const t = require('tap')
 const test = t.test
-const request = require('request')
+const sget = require('simple-get').concat
 const fastify = require('..')()
 const safeStringify = require('fast-safe-stringify')
 
@@ -215,9 +215,9 @@ fastify.listen(0, err => {
 
   test('shorthand - request get', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port
+      url: 'http://localhost:' + fastify.server.address().port
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -228,9 +228,9 @@ fastify.listen(0, err => {
 
   test('shorthand - request get params schema', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/params/world/123'
+      url: 'http://localhost:' + fastify.server.address().port + '/params/world/123'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -241,9 +241,9 @@ fastify.listen(0, err => {
 
   test('shorthand - request get params schema error', t => {
     t.plan(3)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/params/world/string'
+      url: 'http://localhost:' + fastify.server.address().port + '/params/world/string'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 400)
@@ -263,12 +263,12 @@ fastify.listen(0, err => {
 
   test('shorthand - request get headers schema', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'GET',
       headers: {
         'x-test': 1
       },
-      uri: 'http://localhost:' + fastify.server.address().port + '/headers'
+      url: 'http://localhost:' + fastify.server.address().port + '/headers'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -279,12 +279,12 @@ fastify.listen(0, err => {
 
   test('shorthand - request get headers schema error', t => {
     t.plan(3)
-    request({
+    sget({
       method: 'GET',
       headers: {
         'x-test': 'abc'
       },
-      uri: 'http://localhost:' + fastify.server.address().port + '/headers'
+      url: 'http://localhost:' + fastify.server.address().port + '/headers'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 400)
@@ -304,9 +304,9 @@ fastify.listen(0, err => {
 
   test('shorthand - request get querystring schema', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/query?hello=123'
+      url: 'http://localhost:' + fastify.server.address().port + '/query?hello=123'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -317,9 +317,9 @@ fastify.listen(0, err => {
 
   test('shorthand - request get querystring schema error', t => {
     t.plan(3)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/query?hello=world'
+      url: 'http://localhost:' + fastify.server.address().port + '/query?hello=world'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 400)
@@ -339,9 +339,9 @@ fastify.listen(0, err => {
 
   test('shorthand - request get missing schema', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/missing'
+      url: 'http://localhost:' + fastify.server.address().port + '/missing'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -352,9 +352,9 @@ fastify.listen(0, err => {
 
   test('shorthand - request get missing schema', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/wrong-object-for-schema'
+      url: 'http://localhost:' + fastify.server.address().port + '/wrong-object-for-schema'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -365,9 +365,9 @@ fastify.listen(0, err => {
 
   test('shorthand - custom serializer', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/custom-serializer'
+      url: 'http://localhost:' + fastify.server.address().port + '/custom-serializer'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -378,38 +378,38 @@ fastify.listen(0, err => {
 
   test('shorthand - empty response', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/empty'
+      url: 'http://localhost:' + fastify.server.address().port + '/empty'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
       t.strictEqual(response.headers['content-length'], '0')
-      t.deepEqual(body, '')
+      t.deepEqual(body.toString(), '')
     })
   })
 
   test('shorthand - send a falsy boolean', t => {
     t.plan(3)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/boolean'
+      url: 'http://localhost:' + fastify.server.address().port + '/boolean'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
-      t.deepEqual(body, 'false')
+      t.deepEqual(body.toString(), 'false')
     })
   })
 
   test('shorthand - send null value', t => {
     t.plan(3)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/null'
+      url: 'http://localhost:' + fastify.server.address().port + '/null'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
-      t.deepEqual(body, 'null')
+      t.deepEqual(body.toString(), 'null')
     })
   })
 })

--- a/test/head.test.js
+++ b/test/head.test.js
@@ -2,7 +2,7 @@
 
 const t = require('tap')
 const test = t.test
-const request = require('request')
+const sget = require('simple-get').concat
 const fastify = require('..')()
 
 const schema = {
@@ -98,9 +98,9 @@ fastify.listen(0, err => {
 
   test('shorthand - request head', t => {
     t.plan(2)
-    request({
+    sget({
       method: 'HEAD',
-      uri: 'http://localhost:' + fastify.server.address().port
+      url: 'http://localhost:' + fastify.server.address().port
     }, (err, response) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -109,9 +109,9 @@ fastify.listen(0, err => {
 
   test('shorthand - request head params schema', t => {
     t.plan(2)
-    request({
+    sget({
       method: 'HEAD',
-      uri: 'http://localhost:' + fastify.server.address().port + '/params/world/123'
+      url: 'http://localhost:' + fastify.server.address().port + '/params/world/123'
     }, (err, response) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -120,9 +120,9 @@ fastify.listen(0, err => {
 
   test('shorthand - request head params schema error', t => {
     t.plan(2)
-    request({
+    sget({
       method: 'HEAD',
-      uri: 'http://localhost:' + fastify.server.address().port + '/params/world/string'
+      url: 'http://localhost:' + fastify.server.address().port + '/params/world/string'
     }, (err, response) => {
       t.error(err)
       t.strictEqual(response.statusCode, 400)
@@ -131,9 +131,9 @@ fastify.listen(0, err => {
 
   test('shorthand - request head querystring schema', t => {
     t.plan(2)
-    request({
+    sget({
       method: 'HEAD',
-      uri: 'http://localhost:' + fastify.server.address().port + '/query?hello=123'
+      url: 'http://localhost:' + fastify.server.address().port + '/query?hello=123'
     }, (err, response) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -142,9 +142,9 @@ fastify.listen(0, err => {
 
   test('shorthand - request head querystring schema error', t => {
     t.plan(2)
-    request({
+    sget({
       method: 'HEAD',
-      uri: 'http://localhost:' + fastify.server.address().port + '/query?hello=world'
+      url: 'http://localhost:' + fastify.server.address().port + '/query?hello=world'
     }, (err, response) => {
       t.error(err)
       t.strictEqual(response.statusCode, 400)
@@ -153,9 +153,9 @@ fastify.listen(0, err => {
 
   test('shorthand - request head missing schema', t => {
     t.plan(2)
-    request({
+    sget({
       method: 'HEAD',
-      uri: 'http://localhost:' + fastify.server.address().port + '/missing'
+      url: 'http://localhost:' + fastify.server.address().port + '/missing'
     }, (err, response) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const request = require('request')
+const sget = require('simple-get').concat
 
 module.exports.payloadMethod = function (method, t) {
   const test = t.test
@@ -69,9 +69,9 @@ module.exports.payloadMethod = function (method, t) {
 
     test(`${upMethod} - correctly replies`, t => {
       t.plan(3)
-      request({
+      sget({
         method: upMethod,
-        uri: 'http://localhost:' + fastify.server.address().port,
+        url: 'http://localhost:' + fastify.server.address().port,
         body: {
           hello: 'world'
         },
@@ -85,9 +85,9 @@ module.exports.payloadMethod = function (method, t) {
 
     test(`${upMethod} - correctly replies if the content type has the charset`, t => {
       t.plan(3)
-      request({
+      sget({
         method: upMethod,
-        uri: 'http://localhost:' + fastify.server.address().port,
+        url: 'http://localhost:' + fastify.server.address().port,
         body: JSON.stringify({ hello: 'world' }),
         headers: {
           'content-type': 'application/json;charset=utf-8'
@@ -95,15 +95,15 @@ module.exports.payloadMethod = function (method, t) {
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
-        t.deepEqual(body, JSON.stringify({ hello: 'world' }))
+        t.deepEqual(body.toString(), JSON.stringify({ hello: 'world' }))
       })
     })
 
     test(`${upMethod} without schema - correctly replies`, t => {
       t.plan(3)
-      request({
+      sget({
         method: upMethod,
-        uri: 'http://localhost:' + fastify.server.address().port + '/missing',
+        url: 'http://localhost:' + fastify.server.address().port + '/missing',
         body: {
           hello: 'world'
         },
@@ -117,9 +117,9 @@ module.exports.payloadMethod = function (method, t) {
 
     test(`${upMethod} with body and querystring - correctly replies`, t => {
       t.plan(3)
-      request({
+      sget({
         method: upMethod,
-        uri: 'http://localhost:' + fastify.server.address().port + '/with-query?foo=hello',
+        url: 'http://localhost:' + fastify.server.address().port + '/with-query?foo=hello',
         body: {
           hello: 'world'
         },
@@ -133,9 +133,9 @@ module.exports.payloadMethod = function (method, t) {
 
     test(`${upMethod} returns 415 - incorrect media type if body is not json`, t => {
       t.plan(2)
-      request({
+      sget({
         method: upMethod,
-        uri: 'http://localhost:' + fastify.server.address().port + '/missing',
+        url: 'http://localhost:' + fastify.server.address().port + '/missing',
         body: 'hello world',
         timeout: 500
       }, (err, response, body) => {
@@ -151,9 +151,9 @@ module.exports.payloadMethod = function (method, t) {
     if (loMethod === 'options') {
       test(`OPTIONS returns 415 - should return 415 if Content-Type is not json`, t => {
         t.plan(2)
-        request({
+        sget({
           method: upMethod,
-          uri: 'http://localhost:' + fastify.server.address().port + '/missing',
+          url: 'http://localhost:' + fastify.server.address().port + '/missing',
           body: 'hello world',
           headers: {
             'Content-Type': 'text/plain'
@@ -168,9 +168,9 @@ module.exports.payloadMethod = function (method, t) {
 
     test(`${upMethod} returns 422 - Unprocessable Entity`, t => {
       t.plan(2)
-      request({
+      sget({
         method: upMethod,
-        uri: 'http://localhost:' + fastify.server.address().port,
+        url: 'http://localhost:' + fastify.server.address().port,
         body: 'hello world',
         headers: {
           'Content-Type': 'application/json'

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -2,7 +2,7 @@
 
 const t = require('tap')
 const test = t.test
-const request = require('request')
+const sget = require('simple-get').concat
 const Fastify = require('..')
 const fastify = require('..')()
 
@@ -69,9 +69,9 @@ fastify.listen(0, err => {
 
   test('hooks - success', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port
+      url: 'http://localhost:' + fastify.server.address().port
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -82,9 +82,9 @@ fastify.listen(0, err => {
 
   test('hooks - throw preHandler', t => {
     t.plan(2)
-    request({
+    sget({
       method: 'HEAD',
-      uri: 'http://localhost:' + fastify.server.address().port
+      url: 'http://localhost:' + fastify.server.address().port
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 500)
@@ -93,9 +93,9 @@ fastify.listen(0, err => {
 
   test('hooks - throw onRequest', t => {
     t.plan(2)
-    request({
+    sget({
       method: 'DELETE',
-      uri: 'http://localhost:' + fastify.server.address().port
+      url: 'http://localhost:' + fastify.server.address().port
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 500)
@@ -171,9 +171,9 @@ test('onRequest hook should support encapsulation / 3', t => {
     t.error(err)
     fastify.server.unref()
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/first'
+      url: 'http://localhost:' + fastify.server.address().port + '/first'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -181,9 +181,9 @@ test('onRequest hook should support encapsulation / 3', t => {
       t.deepEqual(JSON.parse(body), { hello: 'world' })
     })
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/second'
+      url: 'http://localhost:' + fastify.server.address().port + '/second'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -227,9 +227,9 @@ test('preHandler hook should support encapsulation / 5', t => {
     t.error(err)
     fastify.server.unref()
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/first'
+      url: 'http://localhost:' + fastify.server.address().port + '/first'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -237,9 +237,9 @@ test('preHandler hook should support encapsulation / 5', t => {
       t.deepEqual(JSON.parse(body), { hello: 'world' })
     })
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/second'
+      url: 'http://localhost:' + fastify.server.address().port + '/second'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -313,9 +313,9 @@ test('onResponse hook should support encapsulation / 3', t => {
     t.error(err)
     fastify.server.unref()
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/first'
+      url: 'http://localhost:' + fastify.server.address().port + '/first'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -323,9 +323,9 @@ test('onResponse hook should support encapsulation / 3', t => {
       t.deepEqual(JSON.parse(body), { hello: 'world' })
     })
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/second'
+      url: 'http://localhost:' + fastify.server.address().port + '/second'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)

--- a/test/https/https.test.js
+++ b/test/https/https.test.js
@@ -2,7 +2,7 @@
 
 const t = require('tap')
 const test = t.test
-const request = require('request')
+const sget = require('simple-get').concat
 const fs = require('fs')
 const path = require('path')
 const Fastify = require('../..')
@@ -37,9 +37,9 @@ fastify.listen(0, err => {
 
   test('https get request', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'GET',
-      uri: 'https://localhost:' + fastify.server.address().port,
+      url: 'https://localhost:' + fastify.server.address().port,
       rejectUnauthorized: false
     }, (err, response, body) => {
       t.error(err)

--- a/test/input-validation.js
+++ b/test/input-validation.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const request = require('request')
+const sget = require('simple-get').concat
 const Ajv = require('ajv')
 const Joi = require('joi')
 
@@ -114,18 +114,18 @@ module.exports.payloadMethod = function (method, t) {
     test(`${upMethod} - correctly replies`, t => {
       if (upMethod === 'HEAD') {
         t.plan(2)
-        request({
+        sget({
           method: upMethod,
-          uri: 'http://localhost:' + fastify.server.address().port
+          url: 'http://localhost:' + fastify.server.address().port
         }, (err, response) => {
           t.error(err)
           t.strictEqual(response.statusCode, 200)
         })
       } else {
         t.plan(3)
-        request({
+        sget({
           method: upMethod,
-          uri: 'http://localhost:' + fastify.server.address().port,
+          url: 'http://localhost:' + fastify.server.address().port,
           body: {
             hello: 42
           },
@@ -140,9 +140,9 @@ module.exports.payloadMethod = function (method, t) {
 
     test(`${upMethod} - 400 on bad parameters`, t => {
       t.plan(3)
-      request({
+      sget({
         method: upMethod,
-        uri: 'http://localhost:' + fastify.server.address().port,
+        url: 'http://localhost:' + fastify.server.address().port,
         body: {
           hello: 'world'
         },
@@ -166,9 +166,9 @@ module.exports.payloadMethod = function (method, t) {
 
     test(`${upMethod} - input-validation coerce`, t => {
       t.plan(3)
-      request({
+      sget({
         method: upMethod,
-        uri: 'http://localhost:' + fastify.server.address().port,
+        url: 'http://localhost:' + fastify.server.address().port,
         body: {
           hello: '42'
         },
@@ -182,9 +182,9 @@ module.exports.payloadMethod = function (method, t) {
 
     test(`${upMethod} - input-validation custom schema compiler`, t => {
       t.plan(3)
-      request({
+      sget({
         method: upMethod,
-        uri: 'http://localhost:' + fastify.server.address().port + '/custom',
+        url: 'http://localhost:' + fastify.server.address().port + '/custom',
         body: {
           hello: '42',
           world: 55
@@ -199,9 +199,9 @@ module.exports.payloadMethod = function (method, t) {
 
     test(`${upMethod} - input-validation joi schema compiler ok`, t => {
       t.plan(3)
-      request({
+      sget({
         method: upMethod,
-        uri: 'http://localhost:' + fastify.server.address().port + '/joi',
+        url: 'http://localhost:' + fastify.server.address().port + '/joi',
         body: {
           hello: '42'
         },
@@ -215,9 +215,9 @@ module.exports.payloadMethod = function (method, t) {
 
     test(`${upMethod} - input-validation joi schema compiler ko`, t => {
       t.plan(3)
-      request({
+      sget({
         method: upMethod,
-        uri: 'http://localhost:' + fastify.server.address().port + '/joi',
+        url: 'http://localhost:' + fastify.server.address().port + '/joi',
         body: {
           hello: 44
         },
@@ -235,9 +235,9 @@ module.exports.payloadMethod = function (method, t) {
 
     test(`${upMethod} - input-validation instance custom schema compiler encapsulated`, t => {
       t.plan(3)
-      request({
+      sget({
         method: upMethod,
-        uri: 'http://localhost:' + fastify.server.address().port + '/plugin',
+        url: 'http://localhost:' + fastify.server.address().port + '/plugin',
         body: { },
         json: true
       }, (err, response, body) => {
@@ -253,9 +253,9 @@ module.exports.payloadMethod = function (method, t) {
 
     test(`${upMethod} - input-validation custom schema compiler encapsulated`, t => {
       t.plan(3)
-      request({
+      sget({
         method: upMethod,
-        uri: 'http://localhost:' + fastify.server.address().port + '/plugin/custom',
+        url: 'http://localhost:' + fastify.server.address().port + '/plugin/custom',
         body: { },
         json: true
       }, (err, response, body) => {

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -2,7 +2,8 @@
 
 const t = require('tap')
 const test = t.test
-const request = require('request')
+const sget = require('simple-get').concat
+const http = require('http')
 
 const Reply = require('../../lib/reply')
 
@@ -84,34 +85,34 @@ test('within an instance', t => {
 
     test('custom serializer should be used', t => {
       t.plan(3)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + fastify.server.address().port + '/custom-serializer'
+        url: 'http://localhost:' + fastify.server.address().port + '/custom-serializer'
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.headers['content-type'], 'text/plain')
-        t.deepEqual(body, 'hello=world!')
+        t.deepEqual(body.toString(), 'hello=world!')
       })
     })
 
     test('status code and content-type should be correct', t => {
       t.plan(4)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + fastify.server.address().port
+        url: 'http://localhost:' + fastify.server.address().port
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
         t.strictEqual(response.headers['content-type'], 'text/plain')
-        t.deepEqual(body, 'hello world!')
+        t.deepEqual(body.toString(), 'hello world!')
       })
     })
 
     test('auto status code shoud be 200', t => {
       t.plan(3)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + fastify.server.address().port + '/auto-status-code'
+        url: 'http://localhost:' + fastify.server.address().port + '/auto-status-code'
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
@@ -121,63 +122,55 @@ test('within an instance', t => {
 
     test('auto type shoud be text/plain', t => {
       t.plan(3)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + fastify.server.address().port + '/auto-type'
+        url: 'http://localhost:' + fastify.server.address().port + '/auto-type'
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.headers['content-type'], 'text/plain')
-        t.deepEqual(body, 'hello world!')
+        t.deepEqual(body.toString(), 'hello world!')
       })
     })
 
     test('redirect to `/` - 1', t => {
-      t.plan(2)
-      request({
-        method: 'GET',
-        uri: 'http://localhost:' + fastify.server.address().port + '/redirect',
-        followRedirect: false
-      }, (err, response, body) => {
-        t.error(err)
+      t.plan(1)
+
+      http.get('http://localhost:' + fastify.server.address().port + '/redirect', function (response) {
         t.strictEqual(response.statusCode, 302)
       })
     })
 
     test('redirect to `/` - 2', t => {
-      t.plan(2)
-      request({
-        method: 'GET',
-        uri: 'http://localhost:' + fastify.server.address().port + '/redirect-code',
-        followRedirect: false
-      }, (err, response, body) => {
-        t.error(err)
+      t.plan(1)
+
+      http.get('http://localhost:' + fastify.server.address().port + '/redirect-code', function (response) {
         t.strictEqual(response.statusCode, 301)
       })
     })
 
     test('redirect to `/` - 3', t => {
       t.plan(4)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + fastify.server.address().port + '/redirect'
+        url: 'http://localhost:' + fastify.server.address().port + '/redirect'
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
         t.strictEqual(response.headers['content-type'], 'text/plain')
-        t.deepEqual(body, 'hello world!')
+        t.deepEqual(body.toString(), 'hello world!')
       })
     })
 
     test('redirect to `/` - 4', t => {
       t.plan(4)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + fastify.server.address().port + '/redirect-code'
+        url: 'http://localhost:' + fastify.server.address().port + '/redirect-code'
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
         t.strictEqual(response.headers['content-type'], 'text/plain')
-        t.deepEqual(body, 'hello world!')
+        t.deepEqual(body.toString(), 'hello world!')
       })
     })
 

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -2,7 +2,7 @@
 
 const t = require('tap')
 const test = t.test
-const request = require('request')
+const sget = require('simple-get').concat
 const fastify = require('..')
 const cors = require('cors')
 const helmet = require('helmet')
@@ -31,9 +31,9 @@ test('use a middleware', t => {
 
     t.tearDown(instance.server.close.bind(instance.server))
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + instance.server.address().port
+      url: 'http://localhost:' + instance.server.address().port
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -59,9 +59,9 @@ test('use cors', t => {
 
     t.tearDown(instance.server.close.bind(instance.server))
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + instance.server.address().port
+      url: 'http://localhost:' + instance.server.address().port
     }, (err, response, body) => {
       t.error(err)
       t.equal(response.headers['access-control-allow-origin'], '*')
@@ -85,9 +85,9 @@ test('use helmet', t => {
 
     t.tearDown(instance.server.close.bind(instance.server))
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + instance.server.address().port
+      url: 'http://localhost:' + instance.server.address().port
     }, (err, response, body) => {
       t.error(err)
       t.ok(response.headers['x-xss-protection'])
@@ -112,9 +112,9 @@ test('use helmet and cors', t => {
 
     t.tearDown(instance.server.close.bind(instance.server))
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + instance.server.address().port
+      url: 'http://localhost:' + instance.server.address().port
     }, (err, response, body) => {
       t.error(err)
       t.ok(response.headers['x-xss-protection'])
@@ -148,9 +148,9 @@ test('middlewares should support encapsulation / 1', t => {
     t.ok(instance._middlewares.length === 0)
     t.tearDown(instance.server.close.bind(instance.server))
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + instance.server.address().port
+      url: 'http://localhost:' + instance.server.address().port
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -195,18 +195,18 @@ test('middlewares should support encapsulation / 2', t => {
     t.error(err)
     t.tearDown(instance.server.close.bind(instance.server))
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + instance.server.address().port + '/global'
+      url: 'http://localhost:' + instance.server.address().port + '/global'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.deepEqual(JSON.parse(body), { hello: 'world' })
 
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + instance.server.address().port + '/local'
+        url: 'http://localhost:' + instance.server.address().port + '/local'
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
@@ -259,18 +259,18 @@ test('middlewares should support encapsulation / 3', t => {
     t.error(err)
     t.tearDown(instance.server.close.bind(instance.server))
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + instance.server.address().port + '/global'
+      url: 'http://localhost:' + instance.server.address().port + '/global'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.deepEqual(JSON.parse(body), { hello: 'world' })
 
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + instance.server.address().port + '/local'
+        url: 'http://localhost:' + instance.server.address().port + '/local'
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
@@ -342,27 +342,27 @@ test('middlewares should support encapsulation / 4', t => {
     t.error(err)
     t.tearDown(instance.server.close.bind(instance.server))
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + instance.server.address().port + '/global'
+      url: 'http://localhost:' + instance.server.address().port + '/global'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.deepEqual(JSON.parse(body), { hello: 'world' })
 
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + instance.server.address().port + '/firstLocal'
+        url: 'http://localhost:' + instance.server.address().port + '/firstLocal'
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
         t.strictEqual(response.headers['content-length'], '' + body.length)
         t.deepEqual(JSON.parse(body), { hello: 'world' })
 
-        request({
+        sget({
           method: 'GET',
-          uri: 'http://localhost:' + instance.server.address().port + '/secondLocal'
+          url: 'http://localhost:' + instance.server.address().port + '/secondLocal'
         }, (err, response, body) => {
           t.error(err)
           t.strictEqual(response.statusCode, 200)
@@ -405,18 +405,18 @@ test('middlewares should support encapsulation / 5', t => {
     t.error(err)
     t.tearDown(instance.server.close.bind(instance.server))
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + instance.server.address().port + '/global'
+      url: 'http://localhost:' + instance.server.address().port + '/global'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.deepEqual(JSON.parse(body), { hello: 'world' })
 
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + instance.server.address().port + '/local'
+        url: 'http://localhost:' + instance.server.address().port + '/local'
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 500)
@@ -461,18 +461,18 @@ test('middlewares should support encapsulation with prefix', t => {
     t.error(err)
     t.tearDown(instance.server.close.bind(instance.server))
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + instance.server.address().port + '/global'
+      url: 'http://localhost:' + instance.server.address().port + '/global'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.deepEqual(JSON.parse(body), { hello: 'world' })
 
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + instance.server.address().port + '/local'
+        url: 'http://localhost:' + instance.server.address().port + '/local'
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 500)
@@ -550,9 +550,9 @@ test('middlewares with prefix', t => {
 
     t.test('/', t => {
       t.plan(2)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + instance.server.address().port + '/',
+        url: 'http://localhost:' + instance.server.address().port + '/',
         json: true
       }, (err, response, body) => {
         t.error(err)
@@ -566,9 +566,9 @@ test('middlewares with prefix', t => {
 
     t.test('/prefix', t => {
       t.plan(2)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + instance.server.address().port + '/prefix',
+        url: 'http://localhost:' + instance.server.address().port + '/prefix',
         json: true
       }, (err, response, body) => {
         t.error(err)
@@ -584,9 +584,9 @@ test('middlewares with prefix', t => {
 
     t.test('/prefix/', t => {
       t.plan(2)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + instance.server.address().port + '/prefix/',
+        url: 'http://localhost:' + instance.server.address().port + '/prefix/',
         json: true
       }, (err, response, body) => {
         t.error(err)
@@ -602,9 +602,9 @@ test('middlewares with prefix', t => {
 
     t.test('/prefix/inner', t => {
       t.plan(2)
-      request({
+      sget({
         method: 'GET',
-        uri: 'http://localhost:' + instance.server.address().port + '/prefix/inner',
+        url: 'http://localhost:' + instance.server.address().port + '/prefix/inner',
         json: true
       }, (err, response, body) => {
         t.error(err)

--- a/test/output-validation.test.js
+++ b/test/output-validation.test.js
@@ -2,7 +2,7 @@
 
 const t = require('tap')
 const test = t.test
-const request = require('request')
+const sget = require('simple-get').concat
 const fastify = require('..')()
 
 const opts = {
@@ -96,9 +96,9 @@ fastify.listen(0, err => {
 
   test('shorthand - string get ok', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/string'
+      url: 'http://localhost:' + fastify.server.address().port + '/string'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -109,9 +109,9 @@ fastify.listen(0, err => {
 
   test('shorthand - number get ok', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/number'
+      url: 'http://localhost:' + fastify.server.address().port + '/number'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 201)
@@ -122,9 +122,9 @@ fastify.listen(0, err => {
 
   test('shorthand - wrong-object-for-schema', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/wrong-object-for-schema'
+      url: 'http://localhost:' + fastify.server.address().port + '/wrong-object-for-schema'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 201)
@@ -135,9 +135,9 @@ fastify.listen(0, err => {
 
   test('shorthand - empty', t => {
     t.plan(2)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/empty'
+      url: 'http://localhost:' + fastify.server.address().port + '/empty'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 204)
@@ -146,9 +146,9 @@ fastify.listen(0, err => {
 
   test('shorthand - 400', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/400'
+      url: 'http://localhost:' + fastify.server.address().port + '/400'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 400)

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -3,7 +3,7 @@
 const t = require('tap')
 const test = t.test
 const Fastify = require('..')
-const request = require('request')
+const sget = require('simple-get').concat
 const fp = require('fastify-plugin')
 
 test('require a plugin', t => {
@@ -49,9 +49,9 @@ test('fastify.register with fastify-plugin should not incapsulate his code', t =
     t.error(err)
     fastify.server.unref()
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port
+      url: 'http://localhost:' + fastify.server.address().port
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -104,9 +104,9 @@ test('fastify.register with fastify-plugin registers root level plugins', t => {
     t.error(err)
     fastify.server.unref()
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port
+      url: 'http://localhost:' + fastify.server.address().port
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -114,9 +114,9 @@ test('fastify.register with fastify-plugin registers root level plugins', t => {
       t.deepEqual(JSON.parse(body), { test: 'first' })
     })
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/test2'
+      url: 'http://localhost:' + fastify.server.address().port + '/test2'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -166,9 +166,9 @@ test('check dependencies - should not throw', t => {
     t.error(err)
     fastify.server.unref()
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port
+      url: 'http://localhost:' + fastify.server.address().port
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -217,9 +217,9 @@ test('check dependencies - should throw', t => {
     t.error(err)
     fastify.server.unref()
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port
+      url: 'http://localhost:' + fastify.server.address().port
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -267,9 +267,9 @@ test('plugin incapsulation', t => {
     t.error(err)
     fastify.server.unref()
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/first'
+      url: 'http://localhost:' + fastify.server.address().port + '/first'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -277,9 +277,9 @@ test('plugin incapsulation', t => {
       t.deepEqual(JSON.parse(body), { plugin: 'first' })
     })
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/second'
+      url: 'http://localhost:' + fastify.server.address().port + '/second'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -339,9 +339,9 @@ test('add hooks after route declaration', t => {
   fastify.listen(0, err => {
     t.error(err)
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port
+      url: 'http://localhost:' + fastify.server.address().port
     }, (err, response, body) => {
       t.error(err)
       t.deepEqual(JSON.parse(body), { hook1: true, hook2: true, hook3: true })
@@ -378,17 +378,17 @@ test('nested plugins', t => {
   fastify.listen(0, err => {
     t.error(err)
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/parent/child1'
+      url: 'http://localhost:' + fastify.server.address().port + '/parent/child1'
     }, (err, response, body) => {
       t.error(err)
       t.deepEqual(JSON.parse(body), 'I am child 1')
     })
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/parent/child2'
+      url: 'http://localhost:' + fastify.server.address().port + '/parent/child2'
     }, (err, response, body) => {
       t.error(err)
       t.deepEqual(JSON.parse(body), 'I am child 2')

--- a/test/promises.test.js
+++ b/test/promises.test.js
@@ -2,7 +2,7 @@
 
 const t = require('tap')
 const test = t.test
-const request = require('request')
+const sget = require('simple-get').concat
 const Bluebird = require('bluebird')
 const fastify = require('..')()
 
@@ -75,11 +75,11 @@ fastify.listen(0, err => {
   t.error(err)
   fastify.server.unref()
 
-  test('shorthand - request promise es6 get', t => {
+  test('shorthand - sget promise es6 get', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port
+      url: 'http://localhost:' + fastify.server.address().port
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -88,11 +88,11 @@ fastify.listen(0, err => {
     })
   })
 
-  test('shorthand - request return promise es6 get', t => {
+  test('shorthand - sget return promise es6 get', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/return'
+      url: 'http://localhost:' + fastify.server.address().port + '/return'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -101,33 +101,33 @@ fastify.listen(0, err => {
     })
   })
 
-  test('shorthand - request promise es6 get error', t => {
+  test('shorthand - sget promise es6 get error', t => {
     t.plan(2)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/error'
+      url: 'http://localhost:' + fastify.server.address().port + '/error'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 500)
     })
   })
 
-  test('shorthand - request promise es6 get return error', t => {
+  test('shorthand - sget promise es6 get return error', t => {
     t.plan(2)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/return-error'
+      url: 'http://localhost:' + fastify.server.address().port + '/return-error'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 500)
     })
   })
 
-  test('shorthand - request promise bluebird get', t => {
+  test('shorthand - sget promise bluebird get', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/bluebird'
+      url: 'http://localhost:' + fastify.server.address().port + '/bluebird'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -136,23 +136,23 @@ fastify.listen(0, err => {
     })
   })
 
-  test('shorthand - request promise bluebird get error', t => {
+  test('shorthand - sget promise bluebird get error', t => {
     t.plan(2)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/bluebird-error'
+      url: 'http://localhost:' + fastify.server.address().port + '/bluebird-error'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 500)
     })
   })
 
-  test('request promise double send', t => {
+  test('sget promise double send', t => {
     t.plan(3)
 
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/kaboom'
+      url: 'http://localhost:' + fastify.server.address().port + '/kaboom'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)

--- a/test/register.test.js
+++ b/test/register.test.js
@@ -2,7 +2,7 @@
 
 const t = require('tap')
 const test = t.test
-const request = require('request')
+const sget = require('simple-get').concat
 const fastify = require('..')()
 
 test('fastify.register', t => {
@@ -87,11 +87,11 @@ fastify.listen(0, err => {
 })
 
 function makeRequest (path) {
-  test('fastify.register - request get', t => {
+  test('fastify.register - sget get', t => {
     t.plan(4)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/' + path
+      url: 'http://localhost:' + fastify.server.address().port + '/' + path
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -2,7 +2,7 @@
 
 const t = require('tap')
 const test = t.test
-const request = require('request')
+const sget = require('simple-get').concat
 const fastify = require('..')()
 
 test('route - get', t => {
@@ -90,9 +90,9 @@ fastify.listen(0, function (err) {
 
   test('route - get', t => {
     t.plan(3)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port
+      url: 'http://localhost:' + fastify.server.address().port
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -102,9 +102,9 @@ fastify.listen(0, function (err) {
 
   test('route - missing schema', t => {
     t.plan(3)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/missing'
+      url: 'http://localhost:' + fastify.server.address().port + '/missing'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
@@ -114,18 +114,18 @@ fastify.listen(0, function (err) {
 
   test('route - multiple methods', t => {
     t.plan(6)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/multiple'
+      url: 'http://localhost:' + fastify.server.address().port + '/multiple'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
       t.deepEqual(JSON.parse(body), { hello: 'world' })
     })
 
-    request({
+    sget({
       method: 'DELETE',
-      uri: 'http://localhost:' + fastify.server.address().port + '/multiple'
+      url: 'http://localhost:' + fastify.server.address().port + '/multiple'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)

--- a/test/store-config.test.js
+++ b/test/store-config.test.js
@@ -2,7 +2,7 @@
 
 const t = require('tap')
 const test = t.test
-const request = require('request')
+const sget = require('simple-get').concat
 const fastify = require('..')()
 
 const schema = {
@@ -59,40 +59,40 @@ fastify.listen(0, err => {
 
   test('config - request get', t => {
     t.plan(3)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/get',
+      url: 'http://localhost:' + fastify.server.address().port + '/get',
       json: true
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
-      t.deepEquals(response.body, Object.assign({url: '/get'}, schema.config))
+      t.deepEquals(body, Object.assign({url: '/get'}, schema.config))
     })
   })
 
   test('config - request route', t => {
     t.plan(3)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/route',
+      url: 'http://localhost:' + fastify.server.address().port + '/route',
       json: true
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
-      t.deepEquals(response.body, Object.assign({url: '/route'}, schema.config))
+      t.deepEquals(body, Object.assign({url: '/route'}, schema.config))
     })
   })
 
   test('config - request no-config', t => {
     t.plan(3)
-    request({
+    sget({
       method: 'GET',
-      uri: 'http://localhost:' + fastify.server.address().port + '/no-config',
+      url: 'http://localhost:' + fastify.server.address().port + '/no-config',
       json: true
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
-      t.deepEquals(response.body, {url: '/no-config'})
+      t.deepEquals(body, {url: '/no-config'})
     })
   })
 })


### PR DESCRIPTION
Use [`simple-get`](https://www.npmjs.com/package/simple-get) instead.
Use `http` plain to test redirects in `test/internals/reply.test.js`

https://github.com/fastify/fastify/issues/268