### PR TITLE
Add path to Request object

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -18,7 +18,7 @@ function Request (params, req, body, query, headers, log) {
   this.query = query
   this.headers = headers
   this.log = log
-  this.path = req ? sanitizeUrl(req.url) : ''
+  this.path = req ? sanitizeUrl(req.url) : undefined
 }
 
 function buildRequest (R) {
@@ -29,7 +29,7 @@ function buildRequest (R) {
     this.query = query
     this.headers = headers
     this.log = log
-    this.path = req ? sanitizeUrl(req.url) : ''
+    this.path = req ? sanitizeUrl(req.url) : undefined
   }
   _Request.prototype = new R()
   return _Request

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,5 +1,16 @@
 'use strict'
 
+// Copied from https://github.com/delvedor/find-my-way/blob/master/index.js#L378
+function sanitizeUrl (url) {
+  for (var i = 0, len = url.length; i < len; i++) {
+    var charCode = url.charCodeAt(i)
+    if (charCode === 63 || charCode === 35) {
+      return url.slice(0, i)
+    }
+  }
+  return url
+}
+
 function Request (params, req, body, query, headers, log) {
   this.params = params
   this.req = req
@@ -7,6 +18,7 @@ function Request (params, req, body, query, headers, log) {
   this.query = query
   this.headers = headers
   this.log = log
+  this.path = req ? sanitizeUrl(req.url) : ''
 }
 
 function buildRequest (R) {
@@ -17,6 +29,7 @@ function buildRequest (R) {
     this.query = query
     this.headers = headers
     this.log = log
+    this.path = req ? sanitizeUrl(req.url) : ''
   }
   _Request.prototype = new R()
   return _Request

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -22,20 +22,23 @@ function schemaCompiler (schema) {
 }
 
 test('Request object', t => {
-  t.plan(7)
-  const req = new Request('params', 'req', 'body', 'query', 'headers', 'log')
+  t.plan(8)
+  const req_ = { url: '/path' }
+  const req = new Request('params', req_, 'body', 'query', 'headers', 'log')
   t.type(req, Request)
   t.equal(req.params, 'params')
-  t.deepEqual(req.req, 'req')
+  t.deepEqual(req.req, req_)
   t.equal(req.body, 'body')
   t.equal(req.query, 'query')
   t.equal(req.headers, 'headers')
   t.equal(req.log, 'log')
+  t.equal(req.path, '/path')
 })
 
 test('handler function - invalid schema', t => {
   t.plan(2)
-  const res = {}
+  const req = { url: '/path', log: { error: () => {} } }
+  const res = { }
   res.end = () => {
     t.equal(res.statusCode, 400)
     t.pass()
@@ -61,11 +64,12 @@ test('handler function - invalid schema', t => {
     hooks: new Hooks()
   }
   buildSchema(handle, schemaCompiler)
-  internals.handler(handle, null, { log: { error: () => {} } }, res, { hello: 'world' }, null)
+  internals.handler(handle, null, req, res, { hello: 'world' }, null)
 })
 
 test('handler function - reply', t => {
   t.plan(3)
+  const req = { url: '/path', log: null }
   const res = {}
   res.end = () => {
     t.equal(res.statusCode, 204)
@@ -88,7 +92,36 @@ test('handler function - reply', t => {
     preHandler: new Hooks().preHandler
   }
   buildSchema(handle, schemaCompiler)
-  internals.handler(handle, null, { log: null }, res, null, null)
+  internals.handler(handle, null, req, res, null, null)
+})
+
+test('handler function - req.path without querystring', t => {
+  t.plan(4)
+  const req = { url: '/path?foo=bar', log: null }
+  const res = {}
+  res.end = () => {
+    t.equal(res.statusCode, 204)
+    t.pass()
+  }
+  res.getHeader = (key) => {
+    return false
+  }
+  res.setHeader = (key, value) => {
+    return
+  }
+  const handle = {
+    handler: (req, reply) => {
+      t.is(typeof req.path, 'string')
+      t.equal(req.path, '/path')
+      reply.code(204)
+      reply.send(undefined)
+    },
+    Reply: Reply,
+    Request: Request,
+    preHandler: new Hooks().preHandler
+  }
+  buildSchema(handle, schemaCompiler)
+  internals.handler(handle, null, req, res, null, null)
 })
 
 test('jsonBody and jsonBodyParsed should be functions', t => {


### PR DESCRIPTION
Fix https://github.com/fastify/fastify/issues/387

I'm not convinced:
- `sanitizeUrl` is already done in [`find-my-way`](https://github.com/delvedor/find-my-way/blob/master/index.js#L378)
- Because of encapsulation, `undefined` is used as default.

Suggestions?