### PR TITLE
TS Typings: add socketPath as an option to the listen method

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -5,8 +5,6 @@
 import * as http from 'http';
 import * as pino from 'pino';
 
-type socketPath = string;
-
 declare function fastify(opts?: fastify.ServerOptions): fastify.FastifyInstance;
 
 declare namespace fastify {
@@ -217,21 +215,24 @@ declare namespace fastify {
      * internally waits for the .ready() event. The callback is the same as the
      * Node core.
      */
-    listen(port: number | socketPath, hostname: string, backlog: number, callback?: (err: Error) => void): http.Server
+    listen(port: number, hostname: string, backlog: number, callback?: (err: Error) => void): http.Server
+    listen(path: string, hostname: string, backlog: number, callback?: (err: Error) => void): http.Server
 
     /**
      * Starts the server on the given port after all the plugins are loaded,
      * internally waits for the .ready() event. The callback is the same as the
      * Node core.
      */
-    listen(port: number | socketPath, hostname: string, callback?: (err: Error) => void): http.Server
+    listen(port: number, hostname: string, callback?: (err: Error) => void): http.Server
+    listen(path: string, hostname: string, callback?: (err: Error) => void): http.Server
 
     /**
      * Starts the server on the given port after all the plugins are loaded,
      * internally waits for the .ready() event. The callback is the same as the
      * Node core.
      */
-    listen(port: number | socketPath, callback?: (err: Error) => void): http.Server
+    listen(port: number, callback?: (err: Error) => void): http.Server
+    listen(path: string, callback?: (err: Error) => void): http.Server
 
     /**
      * Registers a listener function that is invoked when all the plugins have

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -215,16 +215,7 @@ declare namespace fastify {
      * internally waits for the .ready() event. The callback is the same as the
      * Node core.
      */
-    listen(port: number, hostname: string, backlog: number, callback?: (err: Error) => void): http.Server
-    listen(path: string, hostname: string, backlog: number, callback?: (err: Error) => void): http.Server
-
-    /**
-     * Starts the server on the given port after all the plugins are loaded,
-     * internally waits for the .ready() event. The callback is the same as the
-     * Node core.
-     */
     listen(port: number, hostname: string, callback?: (err: Error) => void): http.Server
-    listen(path: string, hostname: string, callback?: (err: Error) => void): http.Server
 
     /**
      * Starts the server on the given port after all the plugins are loaded,

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -5,6 +5,8 @@
 import * as http from 'http';
 import * as pino from 'pino';
 
+type socketPath = string;
+
 declare function fastify(opts?: fastify.ServerOptions): fastify.FastifyInstance;
 
 declare namespace fastify {
@@ -215,21 +217,21 @@ declare namespace fastify {
      * internally waits for the .ready() event. The callback is the same as the
      * Node core.
      */
-    listen(port: number, hostname: string, backlog: number, callback?: (err: Error) => void): http.Server
+    listen(port: number | socketPath, hostname: string, backlog: number, callback?: (err: Error) => void): http.Server
 
     /**
      * Starts the server on the given port after all the plugins are loaded,
      * internally waits for the .ready() event. The callback is the same as the
      * Node core.
      */
-    listen(port: number, hostname: string, callback?: (err: Error) => void): http.Server
+    listen(port: number | socketPath, hostname: string, callback?: (err: Error) => void): http.Server
 
     /**
      * Starts the server on the given port after all the plugins are loaded,
      * internally waits for the .ready() event. The callback is the same as the
      * Node core.
      */
-    listen(port: number, callback?: (err: Error) => void): http.Server
+    listen(port: number | socketPath, callback?: (err: Error) => void): http.Server
 
     /**
      * Registers a listener function that is invoked when all the plugins have


### PR DESCRIPTION
This is supported in the library (https://github.com/fastify/fastify/pull/259) but typings were never updated