### PR TITLE
reject promise with statusCode and message

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -94,6 +94,18 @@ fastify.get('/async-await', options, async function (request, reply) {
   return res
 })
 ```
+
+Rejected promises default to a `500` HTTP status code. Reject the promise, or `throw` in an `async function`, with an object that has `statusCode` and `message` properties to modify the reply.
+
+```js
+fastify.get('/teapot', async function (request, reply) => {
+  const err = new Error()
+  err.statusCode = 418
+  err.message = 'short and stout'
+  throw err
+})
+```
+
 If you want to know more please review [Routes#async-await](https://github.com/fastify/fastify/blob/master/docs/Routes.md#async-await)!
 
 <a name="send-streams"></a>

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -175,7 +175,8 @@ function wrapReplySend (reply, payload) {
 
 function handleError (reply, err) {
   if (!reply.res.statusCode || reply.res.statusCode < 400) {
-    reply.res.statusCode = 500
+    reply.res.statusCode = (err.statusCode && err.statusCode >= 400)
+      ? err.statusCode : 500
   }
 
   reply._req.log.error({ res: reply.res, err }, err.message)

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -291,3 +291,29 @@ if (Number(process.versions.node[0]) >= 6) {
     })
   })
 }
+
+test('Error instance sets HTTP status code', t => {
+  t.plan(2)
+  const fastify = Fastify()
+  const err = new Error('winter is coming')
+  err.statusCode = 418
+
+  fastify.get('/', () => {
+    return Promise.reject(err)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, res => {
+    t.strictEqual(res.statusCode, 418)
+    t.deepEqual(
+      {
+        error: statusCodes['418'],
+        message: err.message,
+        statusCode: 418
+      },
+      JSON.parse(res.payload)
+    )
+  })
+})

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -317,3 +317,29 @@ test('Error instance sets HTTP status code', t => {
     )
   })
 })
+
+test('Error status code below 400 defaults to 500', t => {
+  t.plan(2)
+  const fastify = Fastify()
+  const err = new Error('winter is coming')
+  err.statusCode = 399
+
+  fastify.get('/', () => {
+    return Promise.reject(err)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, res => {
+    t.strictEqual(res.statusCode, 500)
+    t.deepEqual(
+      {
+        error: statusCodes['500'],
+        message: err.message,
+        statusCode: 500
+      },
+      JSON.parse(res.payload)
+    )
+  })
+})


### PR DESCRIPTION
Fix for #401 

This can make it easier to handle errors using `async`/`await` and generate meaningful HTTP status codes/messages.