### PR TITLE
Typo fix "strems" to "streams"

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -98,7 +98,7 @@ If you want to know more please review [Routes#async-await](https://github.com/f
 
 <a name="send-streams"></a>
 #### Streams
-*send* can also handle strems out of the box, internally uses [pump](https://www.npmjs.com/package/pump) to avoid leaks of file descriptors. If you are sending a stream and you have not setted a `'Content-Type'` header, *send* will set it at `'application/octet-stream'`.
+*send* can also handle streams out of the box, internally uses [pump](https://www.npmjs.com/package/pump) to avoid leaks of file descriptors. If you are sending a stream and you have not setted a `'Content-Type'` header, *send* will set it at `'application/octet-stream'`.
 ```js
 fastify.get('/streams', function (request, reply) {
   const fs = require('fs')


### PR DESCRIPTION
Noticed this typo in another patch but didn't want to conflate two issues so opening a separate PR. Apologies for the overhead.