### PR TITLE
err.status alias to err.statusCode

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -95,7 +95,7 @@ fastify.get('/async-await', options, async function (request, reply) {
 })
 ```
 
-Rejected promises default to a `500` HTTP status code. Reject the promise, or `throw` in an `async function`, with an object that has `statusCode` and `message` properties to modify the reply.
+Rejected promises default to a `500` HTTP status code. Reject the promise, or `throw` in an `async function`, with an object that has `statusCode` (or `status`) and `message` properties to modify the reply.
 
 ```js
 fastify.get('/teapot', async function (request, reply) => {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -182,8 +182,10 @@ function wrapReplySend (reply, payload) {
 
 function handleError (reply, err, cb) {
   if (!reply.res.statusCode || reply.res.statusCode < 400) {
-    reply.res.statusCode = (err.statusCode && err.statusCode >= 400)
-      ? err.statusCode : 500
+    reply.res.statusCode =
+        ('status' in err && err.status >= 400) ? err.status
+      : ('statusCode' in err && err.statusCode >= 400) ? err.statusCode
+      : 500
   }
 
   reply._req.log.error({ res: reply.res, err }, err.message)

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -343,3 +343,29 @@ test('Error status code below 400 defaults to 500', t => {
     )
   })
 })
+
+test('Error.status property support', t => {
+  t.plan(2)
+  const fastify = Fastify()
+  const err = new Error('winter is coming')
+  err.status = 418
+
+  fastify.get('/', () => {
+    return Promise.reject(err)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, res => {
+    t.strictEqual(res.statusCode, 418)
+    t.deepEqual(
+      {
+        error: statusCodes['418'],
+        message: err.message,
+        statusCode: 418
+      },
+      JSON.parse(res.payload)
+    )
+  })
+})


### PR DESCRIPTION
Compatibility fix for middleware using `err.status` instead of `err.statusCode`.

Example of middleware error using only `status`: https://github.com/MichielDeMey/express-jwt-permissions/blob/master/error.js#L10

Example of aliased `status` and `statusCode`: https://github.com/jshttp/http-errors/blob/master/index.js#L57

I'm not sure if there is a standard/convention for this property. Based on my limited experience it appears both are used in the wild.