### PR TITLE
Renamed store in context

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -218,40 +218,40 @@ function build (options) {
     }
   }
 
-  function startHooks (req, res, params, store) {
-    res._context = store
+  function startHooks (req, res, params, context) {
+    res._context = context
     runHooks(
-      new State(req, res, params, store),
+      new State(req, res, params, context),
       hookIterator,
-      store.onRequest,
+      context.onRequest,
       middlewareCallback
     )
   }
 
   function middlewareCallback (err) {
     if (err) {
-      const reply = new Reply(this.req, this.res, this.store)
+      const reply = new Reply(this.req, this.res, this.context)
       reply.send(err)
       return
     }
-    this.store._middie.run(this.req, this.res, this)
+    this.context._middie.run(this.req, this.res, this)
   }
 
   function onRunMiddlewares (err, req, res, ctx) {
     if (err) {
-      const reply = new Reply(req, res, ctx.store)
+      const reply = new Reply(req, res, ctx.context)
       reply.send(err)
       return
     }
 
-    handleRequest(req, res, ctx.params, ctx.store)
+    handleRequest(req, res, ctx.params, ctx.context)
   }
 
-  function State (req, res, params, store) {
+  function State (req, res, params, context) {
     this.req = req
     this.res = res
     this.params = params
-    this.store = store
+    this.context = context
   }
 
   function hookIterator (fn, cb) {
@@ -277,7 +277,7 @@ function build (options) {
     instance._middie = Middie(onRunMiddlewares)
 
     if (opts.prefix) {
-      instance._404Store = null
+      instance._404Context = null
     }
 
     for (var i = 0; i < middlewares.length; i++) {
@@ -393,7 +393,7 @@ function build (options) {
       const config = opts.config || {}
       config.url = url
 
-      const store = new Store(
+      const context = new Context(
         opts.schema,
         opts.handler,
         opts.Reply || _fastify._Reply,
@@ -408,12 +408,12 @@ function build (options) {
         opts.middie || _fastify._middie
       )
 
-      buildSchema(store, opts.schemaCompiler || _fastify._schemaCompiler)
+      buildSchema(context, opts.schemaCompiler || _fastify._schemaCompiler)
 
-      store.preHandler.push.apply(store.preHandler, (opts.preHandler || _fastify._hooks.preHandler))
+      context.preHandler.push.apply(context.preHandler, (opts.preHandler || _fastify._hooks.preHandler))
       if (opts.beforeHandler) {
         opts.beforeHandler = Array.isArray(opts.beforeHandler) ? opts.beforeHandler : [opts.beforeHandler]
-        store.preHandler.push.apply(store.preHandler, opts.beforeHandler)
+        context.preHandler.push.apply(context.preHandler, opts.beforeHandler)
       }
 
       if (map.has(url)) {
@@ -423,23 +423,23 @@ function build (options) {
 
         if (Array.isArray(opts.method)) {
           for (i = 0; i < opts.method.length; i++) {
-            map.get(url)[opts.method[i]] = store
+            map.get(url)[opts.method[i]] = context
           }
         } else {
-          map.get(url)[opts.method] = store
+          map.get(url)[opts.method] = context
         }
-        router.on(opts.method, url, startHooks, store)
+        router.on(opts.method, url, startHooks, context)
       } else {
         const node = {}
         if (Array.isArray(opts.method)) {
           for (i = 0; i < opts.method.length; i++) {
-            node[opts.method[i]] = store
+            node[opts.method[i]] = context
           }
         } else {
-          node[opts.method] = store
+          node[opts.method] = context
         }
         map.set(url, node)
-        router.on(opts.method, url, startHooks, store)
+        router.on(opts.method, url, startHooks, context)
       }
       done(notHandledErr)
     })
@@ -448,7 +448,7 @@ function build (options) {
     return _fastify
   }
 
-  function Store (schema, handler, Reply, Request, contentTypeParser, onRequest, preHandler, onResponse, onSend, config, errorHandler, middie) {
+  function Context (schema, handler, Reply, Request, contentTypeParser, onRequest, preHandler, onResponse, onSend, config, errorHandler, middie) {
     this.schema = schema
     this.handler = handler
     this.Reply = Reply
@@ -586,8 +586,8 @@ function build (options) {
     opts = opts || {}
     handler = handler || basic404
 
-    if (!this._404Store) {
-      const store = new Store(
+    if (!this._404Context) {
+      const context = new Context(
         opts.schema,
         handler,
         this._Reply,
@@ -602,17 +602,17 @@ function build (options) {
         this._middie
       )
 
-      this._404Store = store
+      this._404Context = context
 
       var prefix = this._RoutePrefix.prefix
       var star = '/*'
 
-      fourOhFour.all(prefix + star, startHooks, store)
-      fourOhFour.all(prefix || '/', startHooks, store)
+      fourOhFour.all(prefix + star, startHooks, context)
+      fourOhFour.all(prefix || '/', startHooks, context)
     } else {
-      this._404Store.handler = handler
-      this._404Store.contentTypeParser = opts.contentTypeParser || this._contentTypeParser
-      this._404Store.config = opts.config || {}
+      this._404Context.handler = handler
+      this._404Context.contentTypeParser = opts.contentTypeParser || this._contentTypeParser
+      this._404Context.config = opts.config || {}
     }
   }
 

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -6,25 +6,25 @@ const runHooks = require('fastseries')()
 const validation = require('./validation')
 const validateSchema = validation.validate
 
-function handleRequest (req, res, params, store) {
+function handleRequest (req, res, params, context) {
   var method = req.method
 
   if (method === 'GET' || method === 'DELETE' || method === 'HEAD') {
-    return handler(store, params, req, res, null, urlUtil.parse(req.url, true).query)
+    return handler(context, params, req, res, null, urlUtil.parse(req.url, true).query)
   }
 
   if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
     // application/json content type
     if (req.headers['content-type'] && req.headers['content-type'].indexOf('application/json') > -1) {
-      return jsonBody(req, res, params, store)
+      return jsonBody(req, res, params, context)
     }
 
     // custom parser for a given content type
-    if (store.contentTypeParser.fastHasHeader(req.headers['content-type'])) {
-      return store.contentTypeParser.run(req.headers['content-type'], handler, store, params, req, res, urlUtil.parse(req.url, true).query)
+    if (context.contentTypeParser.fastHasHeader(req.headers['content-type'])) {
+      return context.contentTypeParser.run(req.headers['content-type'], handler, context, params, req, res, urlUtil.parse(req.url, true).query)
     }
 
-    setImmediate(wrapReplyEnd, store, req, res, 415)
+    setImmediate(wrapReplyEnd, context, req, res, 415)
     return
   }
 
@@ -32,19 +32,19 @@ function handleRequest (req, res, params, store) {
     if (req.headers['content-type']) {
       // application/json content type
       if (req.headers['content-type'].indexOf('application/json') > -1) {
-        return jsonBody(req, res, params, store)
+        return jsonBody(req, res, params, context)
       // custom parser for a given content type
-      } else if (store.contentTypeParser.fastHasHeader(req.headers['content-type'])) {
-        return store.contentTypeParser.run(req.headers['content-type'], handler, store, params, req, res, urlUtil.parse(req.url, true).query)
+      } else if (context.contentTypeParser.fastHasHeader(req.headers['content-type'])) {
+        return context.contentTypeParser.run(req.headers['content-type'], handler, context, params, req, res, urlUtil.parse(req.url, true).query)
       }
 
-      setImmediate(wrapReplyEnd, store, req, res, 415)
+      setImmediate(wrapReplyEnd, context, req, res, 415)
       return
     }
-    return handler(store, params, req, res, null, urlUtil.parse(req.url, true).query)
+    return handler(context, params, req, res, null, urlUtil.parse(req.url, true).query)
   }
 
-  setImmediate(wrapReplyEnd, store, req, res, 405)
+  setImmediate(wrapReplyEnd, context, req, res, 405)
   return
 }
 
@@ -100,7 +100,7 @@ function handler (context, params, req, res, body, query, headers) {
 function State (request, reply, context) {
   this.request = request
   this.reply = reply
-  this.store = context
+  this.context = context
 }
 
 function hookIterator (fn, cb) {
@@ -117,7 +117,7 @@ function preHandlerCallback (err, code) {
     return
   }
 
-  var result = this.store.handler(this.request, this.reply)
+  var result = this.context.handler(this.request, this.reply)
   if (result && typeof result.then === 'function') {
     result.then((payload) => {
       // this is for async functions that

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -10,9 +10,9 @@ const flatstr = require('flatstr')
 const fastseries = require('fastseries')
 const runHooks = fastseries()
 
-function Reply (req, res, store, request) {
+function Reply (req, res, context, request) {
   this.res = res
-  this.store = store
+  this.context = context
   this._req = req
   this.sent = false
   this._serializer = null
@@ -135,14 +135,14 @@ function wrapPumpCallback (reply) {
 }
 
 function handleReplyEnd (reply, payload) {
-  if (reply.store.onSend.length === 0) {
+  if (reply.context.onSend.length === 0) {
     return onSendEnd(reply, payload)
   }
   setImmediate(
     runHooks,
     new State(reply, payload),
     hookIterator,
-    reply.store.onSend,
+    reply.context.onSend,
     wrapOnSendEnd
   )
 }
@@ -159,7 +159,7 @@ function onSendEnd (reply, payload) {
   if (!reply.res.getHeader('Content-Type') || reply.res.getHeader('Content-Type') === 'application/json') {
     reply.res.setHeader('Content-Type', 'application/json')
     // Here we are assuming that the custom serializer is a json serializer
-    payload = reply._serializer ? reply._serializer(payload) : serialize(reply.store, payload, reply.res.statusCode)
+    payload = reply._serializer ? reply._serializer(payload) : serialize(reply.context, payload, reply.res.statusCode)
     flatstr(payload)
   } else if (reply._serializer) { // All the code below must have a 'content-type' setted
     payload = reply._serializer(payload)
@@ -190,7 +190,7 @@ function handleError (reply, err, cb) {
 
   reply._req.log.error({ res: reply.res, err }, err.message)
 
-  var errorHandler = reply.store.errorHandler
+  var errorHandler = reply.context.errorHandler
 
   if (errorHandler && !reply._errored) {
     reply.sent = false
@@ -222,9 +222,9 @@ function hookIterator (fn, cb) {
 }
 
 function buildReply (R) {
-  function _Reply (req, res, store, request) {
+  function _Reply (req, res, context, request) {
     this.res = res
-    this.store = store
+    this.context = context
     this._req = req
     this.sent = false
     this._serializer = null

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -69,11 +69,11 @@ function validateParam (validatorFunction, request, paramName) {
   return false
 }
 
-function validate (store, request) {
-  return validateParam(store[paramsSchema], request, 'params') ||
-    validateParam(store[bodySchema], request, 'body') ||
-    validateParam(store[querystringSchema], request, 'query') ||
-    validateParam(store[headersSchema], request, 'headers') ||
+function validate (context, request) {
+  return validateParam(context[paramsSchema], request, 'params') ||
+    validateParam(context[bodySchema], request, 'body') ||
+    validateParam(context[querystringSchema], request, 'query') ||
+    validateParam(context[headersSchema], request, 'headers') ||
     true
 }
 

--- a/test/context-config.test.js
+++ b/test/context-config.test.js
@@ -14,7 +14,7 @@ const schema = {
 }
 
 function handler (req, reply) {
-  reply.serializer(JSON.stringify).send(reply.store.config)
+  reply.serializer(JSON.stringify).send(reply.context.config)
 }
 
 test('config - get', t => {

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -19,7 +19,7 @@ test('Once called, Reply should return an object with methods', t => {
   t.is(typeof reply.header, 'function')
   t.strictEqual(reply._req, request)
   t.strictEqual(reply.res, response)
-  t.strictEqual(reply.store, handle)
+  t.strictEqual(reply.context, handle)
 })
 
 test('reply.send throw with circular JSON', t => {


### PR DESCRIPTION
The name `store` arrives from `find-my-way`, but here we are using it as Context object.
I think use this name is cleaner and clearer for the reader.

This could cause some regression if a plugin uses the `reply.store` property.