### PR TITLE
Allow payload modifications

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -154,6 +154,10 @@ function wrapOnSendEnd (err, results) {
     return
   }
 
+  if (results.length > 1 && results[1]) {
+    this.reply._req.log.warn(new Error('Payload already overriden'))
+  }
+
   if (results[0]) {
     this.overriden = true
     this.payload = null

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -17,6 +17,7 @@ function Reply (req, res, context, request) {
   this.sent = false
   this._serializer = null
   this._errored = false
+  this.overriden = false
   this.request = request
 }
 
@@ -147,11 +148,20 @@ function handleReplyEnd (reply, payload) {
   )
 }
 
-function wrapOnSendEnd (err) {
+function wrapOnSendEnd (err, results) {
   if (err) {
     handleError(this.reply, err, onSendEnd)
     return
   }
+
+  if (results[0]) {
+    this.overriden = true
+    this.payload = null
+    // the first value in the onSend hook pipeline is taken
+    onSendEnd(this.reply, results[0])
+    return
+  }
+
   onSendEnd(this.reply, this.payload)
 }
 
@@ -217,7 +227,7 @@ function State (that, payload) {
 function hookIterator (fn, cb) {
   var ret = fn(this.request, this.reply, this.payload, cb)
   if (ret && typeof ret.then === 'function') {
-    ret.then(cb).catch(cb)
+    ret.then(payload => cb(null, payload)).catch(cb)
   }
 }
 


### PR DESCRIPTION
Supports the syntax in https://github.com/fastify/fastify/issues/400#issuecomment-340389561 with minimal core modification.

``` js
fastify.addHook('onSend', (request, reply, payload, next) => {
  next(null, { foo: 'bar' })
})
```

Or with async/await

```js
fastify.addHook('onSend', async (request, reply, payload) => {
  return { foo: 'bar' }
})
```

- The first value which is passed to the handler or returned is taken as new payload, this is equal to reply `sent` semantic.
- Tests are served later
- An error is logged when the payload was overridden multiple times