### PR TITLE
Test route handler rejection with non-Error

### DIFF
--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -6,6 +6,8 @@ const runHooks = require('fastseries')()
 const validation = require('./validation')
 const validateSchema = validation.validate
 
+const isError = Symbol.for('is-error')
+
 function handleRequest (req, res, params, context) {
   var method = req.method
 
@@ -126,6 +128,7 @@ function preHandlerCallback (err, code) {
         this.reply.send(payload)
       }
     }).catch((err) => {
+      this.reply[isError] = true
       this.reply.send(err)
     })
   }

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -5,8 +5,7 @@ const urlUtil = require('url')
 const runHooks = require('fastseries')()
 const validation = require('./validation')
 const validateSchema = validation.validate
-
-const isError = Symbol.for('is-error')
+const isError = require('./reply').isError
 
 function handleRequest (req, res, params, context) {
   var method = req.method

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -10,7 +10,7 @@ const flatstr = require('flatstr')
 const fastseries = require('fastseries')
 const runHooks = fastseries()
 
-const isError = Symbol.for('is-error')
+const isError = Symbol('is-error')
 
 function Reply (req, res, context, request) {
   this.res = res
@@ -175,22 +175,15 @@ function onSendEnd (reply, payload) {
 }
 
 function handleError (reply, err, cb) {
-  var message
-
   if (!reply.res.statusCode || reply.res.statusCode < 400) {
-    if (err === null || err === undefined) {
-      message = ''
-      reply.res.statusCode = 500
-    } else {
-      message = err.message || ''
-      reply.res.statusCode =
-          (err.status >= 400) ? err.status
-        : (err.statusCode >= 400) ? err.statusCode
-        : 500
-    }
+    reply.res.statusCode =
+        (err === null || err === undefined) ? 500
+      : (err.status >= 400) ? err.status
+      : (err.statusCode >= 400) ? err.statusCode
+      : 500
   }
 
-  reply._req.log.error({ res: reply.res, err }, message)
+  reply._req.log.error({ res: reply.res, err }, err && err.message)
 
   var errorHandler = reply.context.errorHandler
 
@@ -205,7 +198,7 @@ function handleError (reply, err, cb) {
 
   cb(reply, Object.assign({
     error: statusCodes[reply.res.statusCode + ''],
-    message: message,
+    message: (err || undefined) && err.message,
     statusCode: reply.res.statusCode
   }, reply._extendServerError && reply._extendServerError(err)))
 }
@@ -238,3 +231,4 @@ function buildReply (R) {
 
 module.exports = Reply
 module.exports.buildReply = buildReply
+module.exports.isError = isError

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -200,7 +200,7 @@ function handleError (reply, err, cb) {
 
   cb(reply, Object.assign({
     error: statusCodes[reply.res.statusCode + ''],
-    message: (err || undefined) && err.message,
+    message: (err || '') && err.message,
     statusCode: reply.res.statusCode
   }, reply._extendServerError && reply._extendServerError(err)))
 }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -10,6 +10,8 @@ const flatstr = require('flatstr')
 const fastseries = require('fastseries')
 const runHooks = fastseries()
 
+const isError = Symbol.for('is-error')
+
 function Reply (req, res, context, request) {
   this.res = res
   this.context = context
@@ -35,7 +37,7 @@ Reply.prototype.send = function (payload) {
 
   this.sent = true
 
-  if (payload === undefined) {
+  if (payload === undefined && this[isError] !== true) {
     this.res.setHeader('Content-Length', '0')
     if (!this.res.getHeader('Content-Type')) {
       this.res.setHeader('Content-Type', 'text/plain')
@@ -59,7 +61,7 @@ Reply.prototype.send = function (payload) {
     return
   }
 
-  if (payload instanceof Error) {
+  if (payload instanceof Error || this[isError] === true) {
     handleError(this, payload, wrapHandleReplyEnd)
     return
   }
@@ -173,14 +175,22 @@ function onSendEnd (reply, payload) {
 }
 
 function handleError (reply, err, cb) {
+  var message
+
   if (!reply.res.statusCode || reply.res.statusCode < 400) {
-    reply.res.statusCode =
-        ('status' in err && err.status >= 400) ? err.status
-      : ('statusCode' in err && err.statusCode >= 400) ? err.statusCode
-      : 500
+    if (err === null || err === undefined) {
+      message = ''
+      reply.res.statusCode = 500
+    } else {
+      message = err.message || ''
+      reply.res.statusCode =
+          (err.status >= 400) ? err.status
+        : (err.statusCode >= 400) ? err.statusCode
+        : 500
+    }
   }
 
-  reply._req.log.error({ res: reply.res, err }, err.message)
+  reply._req.log.error({ res: reply.res, err }, message)
 
   var errorHandler = reply.context.errorHandler
 
@@ -195,7 +205,7 @@ function handleError (reply, err, cb) {
 
   cb(reply, Object.assign({
     error: statusCodes[reply.res.statusCode + ''],
-    message: err.message,
+    message: message,
     statusCode: reply.res.statusCode
   }, reply._extendServerError && reply._extendServerError(err)))
 }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -37,7 +37,9 @@ Reply.prototype.send = function (payload) {
 
   this.sent = true
 
-  if (payload === undefined && this[isError] !== true) {
+  var _isError = this[isError]
+
+  if (payload === undefined && _isError !== true) {
     this.res.setHeader('Content-Length', '0')
     if (!this.res.getHeader('Content-Type')) {
       this.res.setHeader('Content-Type', 'text/plain')
@@ -61,7 +63,7 @@ Reply.prototype.send = function (payload) {
     return
   }
 
-  if (payload instanceof Error || this[isError] === true) {
+  if (payload instanceof Error || _isError === true) {
     handleError(this, payload, wrapHandleReplyEnd)
     return
   }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -15,6 +15,7 @@ const isError = Symbol('is-error')
 function Reply (req, res, context, request) {
   this.res = res
   this.context = context
+  this[isError] = false
   this._req = req
   this.sent = false
   this._serializer = null
@@ -222,6 +223,7 @@ function buildReply (R) {
   function _Reply (req, res, context, request) {
     this.res = res
     this.context = context
+    this[isError] = false
     this._req = req
     this.sent = false
     this._serializer = null

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -9,7 +9,7 @@ const zlib = require('zlib')
 const Reply = require('../../lib/reply')
 
 test('Once called, Reply should return an object with methods', t => {
-  t.plan(8)
+  t.plan(9)
   const request = { req: 'req' }
   const response = { res: 'res' }
   function handle () {}

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -15,6 +15,7 @@ test('Once called, Reply should return an object with methods', t => {
   function handle () {}
   const reply = new Reply(request, response, handle)
   t.is(typeof reply, 'object')
+  t.is(typeof reply[Reply.isError], 'boolean')
   t.is(typeof reply.send, 'function')
   t.is(typeof reply.code, 'function')
   t.is(typeof reply.header, 'function')

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -401,6 +401,7 @@ test('Support rejection with values that are not Error instances', t => {
           JSON.parse(res.payload),
           {
             error: statusCodes['500'],
+            message: '',
             statusCode: 500
           }
         )

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -377,23 +377,17 @@ test('Support rejection with values that are not Error instances', t => {
     undefined,
     123,
     'abc',
+    new RegExp(),
+    new Date(),
+    new Uint8Array()
   ]
   for (const nonErr of objs) {
     t.test('Type: ' + typeof nonErr, t => {
-      t.plan(2)
       const fastify = Fastify()
-  
+
       fastify.get('/', () => {
         return Promise.reject(nonErr)
       })
-
-      // TODO(sebdeckers) Find out how to do parallel async tests in tap.
-      // t.test('error handler', t => {
-      //   t.plan(1)
-      //   fastify.setErrorHandler((err, reply) => {
-      //     t.strictEqual(err, nonErr)
-      //   })
-      // })
 
       fastify.inject({
         method: 'GET',
@@ -404,11 +398,14 @@ test('Support rejection with values that are not Error instances', t => {
           JSON.parse(res.payload),
           {
             error: statusCodes['500'],
-            // TODO(sebdeckers) What is the expected message for each type?
-            message: '',
             statusCode: 500
           }
         )
+      })
+
+      fastify.setErrorHandler((err, reply) => {
+        t.strictEqual(err, nonErr)
+        t.end()
       })
     })
   }

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -371,18 +371,46 @@ test('Error.status property support', t => {
 })
 
 test('Support rejection with values that are not Error instances', t => {
-  t.plan(1)
-  const fastify = Fastify()
-  const nonErr = {}
+  const objs = [
+    {},
+    null,
+    undefined,
+    123,
+    'abc',
+  ]
+  for (const nonErr of objs) {
+    t.test('Type: ' + typeof nonErr, t => {
+      t.plan(2)
+      const fastify = Fastify()
+  
+      fastify.get('/', () => {
+        return Promise.reject(nonErr)
+      })
 
-  fastify.get('/', () => {
-    return Promise.reject(nonErr)
-  })
+      // TODO(sebdeckers) Find out how to do parallel async tests in tap.
+      // t.test('error handler', t => {
+      //   t.plan(1)
+      //   fastify.setErrorHandler((err, reply) => {
+      //     t.strictEqual(err, nonErr)
+      //   })
+      // })
 
-  fastify.inject({
-    method: 'GET',
-    url: '/'
-  }, res => {
-    t.strictEqual(res.statusCode, 500)
-  })
+      fastify.inject({
+        method: 'GET',
+        url: '/'
+      }, res => {
+        t.strictEqual(res.statusCode, 500)
+        t.deepEqual(
+          JSON.parse(res.payload),
+          {
+            error: statusCodes['500'],
+            // TODO(sebdeckers) What is the expected message for each type?
+            message: '',
+            statusCode: 500
+          }
+        )
+      })
+    })
+  }
+  t.end()
 })

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -369,3 +369,20 @@ test('Error.status property support', t => {
     )
   })
 })
+
+test('Support rejection with values that are not Error instances', t => {
+  t.plan(1)
+  const fastify = Fastify()
+  const nonErr = {}
+
+  fastify.get('/', () => {
+    return Promise.reject(nonErr)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, res => {
+    t.strictEqual(res.statusCode, 500)
+  })
+})

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -372,6 +372,9 @@ test('Error.status property support', t => {
 
 test('Support rejection with values that are not Error instances', t => {
   const objs = [
+    0,
+    '',
+    [],
     {},
     null,
     undefined,

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -384,12 +384,18 @@ test('Support rejection with values that are not Error instances', t => {
     new Date(),
     new Uint8Array()
   ]
+  t.plan(objs.length)
   for (const nonErr of objs) {
     t.test('Type: ' + typeof nonErr, t => {
       const fastify = Fastify()
 
       fastify.get('/', () => {
         return Promise.reject(nonErr)
+      })
+
+      fastify.setErrorHandler((err, reply) => {
+        t.strictEqual(err, nonErr)
+        t.end()
       })
 
       fastify.inject({
@@ -406,12 +412,6 @@ test('Support rejection with values that are not Error instances', t => {
           }
         )
       })
-
-      fastify.setErrorHandler((err, reply) => {
-        t.strictEqual(err, nonErr)
-        t.end()
-      })
     })
   }
-  t.end()
 })


### PR DESCRIPTION
I noticed that Fastify does type checking ([`err instanceof Error`](https://github.com/fastify/fastify/blob/431713bd877701d0f584df5ec11f3bc1b7f43656/lib/reply.js#L62)) when a promise is rejected (async function throws). This is problematic when the thing thrown does not actually inherit from Error.

It's not entirely clear to me how to address this.

- Expose a `Reply.prototype.error()` method
- Add a parameter or option to `Reply.prototype.send()` to mark the payload as error
- Replace the non-Error `err` with a `new Error()` instance (losing the original object)
- Set a private (Symbol) property to mark the payload as an error.

Suggestions?