### PR TITLE
Expose the default json serializer

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -8,7 +8,7 @@ Reply is a core Fastify object that exposes the following functions:
 - `.header(name, value)` - Sets the headers.
 - `.type(value)` - Sets the header `Content-Type`.
 - `.redirect([code,] url)` - Redirect to the specified url, the status code is optional (default to `302`).
-- `.serialize(reply, payload)` - Passes the specified reply and payload to the default json serializer and returns the serialized payload.
+- `.serialize(payload)` - Serializes the specified payload using the default json serializer and returns the serialized payload.
 - `.serializer(function)` - Sets a custom serializer for the payload.
 - `.send(payload)` - Sends the payload to the user, could be a plain text, JSON, stream, or an Error object.
 - `.sent` - A boolean value that you can use if you need to know it `send` has already been called.

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -8,6 +8,7 @@ Reply is a core Fastify object that exposes the following functions:
 - `.header(name, value)` - Sets the headers.
 - `.type(value)` - Sets the header `Content-Type`.
 - `.redirect([code,] url)` - Redirect to the specified url, the status code is optional (default to `302`).
+- `.serialize` - The default json serializer.
 - `.serializer(function)` - Sets a custom serializer for the payload.
 - `.send(payload)` - Sends the payload to the user, could be a plain text, JSON, stream, or an Error object.
 - `.sent` - A boolean value that you can use if you need to know it `send` has already been called.

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -8,7 +8,7 @@ Reply is a core Fastify object that exposes the following functions:
 - `.header(name, value)` - Sets the headers.
 - `.type(value)` - Sets the header `Content-Type`.
 - `.redirect([code,] url)` - Redirect to the specified url, the status code is optional (default to `302`).
-- `.serialize(reply, payload)` - The default json serializer.
+- `.serialize(reply, payload)` - Passes the specified reply and payload to the default json serializer and returns the serialized payload.
 - `.serializer(function)` - Sets a custom serializer for the payload.
 - `.send(payload)` - Sends the payload to the user, could be a plain text, JSON, stream, or an Error object.
 - `.sent` - A boolean value that you can use if you need to know it `send` has already been called.

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -8,7 +8,7 @@ Reply is a core Fastify object that exposes the following functions:
 - `.header(name, value)` - Sets the headers.
 - `.type(value)` - Sets the header `Content-Type`.
 - `.redirect([code,] url)` - Redirect to the specified url, the status code is optional (default to `302`).
-- `.serialize` - The default json serializer.
+- `.serialize(reply, payload)` - The default json serializer.
 - `.serializer(function)` - Sets a custom serializer for the payload.
 - `.send(payload)` - Sends the payload to the user, could be a plain text, JSON, stream, or an Error object.
 - `.sent` - A boolean value that you can use if you need to know it `send` has already been called.

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -51,6 +51,7 @@ declare namespace fastify {
     header: (name: string, value: any) => FastifyReply<HttpResponse>
     type: (contentType: string) => FastifyReply<HttpResponse>
     redirect: (statusCode: number, url: string) => FastifyReply<HttpResponse>
+    serialize: (reply: FastifyReply<HttpResponse>, payload: any) => string
     serializer: (fn: Function) => FastifyReply<HttpResponse>
     send: (payload?: string|Array<any>|Object|Error|Promise<any>|NodeJS.ReadableStream) => FastifyReply<HttpResponse>
     sent: boolean

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -51,7 +51,7 @@ declare namespace fastify {
     header: (name: string, value: any) => FastifyReply<HttpResponse>
     type: (contentType: string) => FastifyReply<HttpResponse>
     redirect: (statusCode: number, url: string) => FastifyReply<HttpResponse>
-    serialize: (reply: FastifyReply<HttpResponse>, payload: any) => string
+    serialize: (payload: any) => string
     serializer: (fn: Function) => FastifyReply<HttpResponse>
     send: (payload?: string|Array<any>|Object|Error|Promise<any>|NodeJS.ReadableStream) => FastifyReply<HttpResponse>
     sent: boolean

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -97,8 +97,8 @@ Reply.prototype.code = function (code) {
   return this
 }
 
-Reply.prototype.serialize = function (reply, payload) {
-  return serialize(reply.context, payload, reply.res.statusCode)
+Reply.prototype.serialize = function (payload) {
+  return serialize(this.context, payload, this.res.statusCode)
 }
 
 Reply.prototype.serializer = function (fn) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -97,6 +97,8 @@ Reply.prototype.code = function (code) {
   return this
 }
 
+Reply.prototype.serialize = serialize
+
 Reply.prototype.serializer = function (fn) {
   this._serializer = fn
   return this

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -97,7 +97,9 @@ Reply.prototype.code = function (code) {
   return this
 }
 
-Reply.prototype.serialize = serialize
+Reply.prototype.serialize = function (reply, payload) {
+  return serialize(reply.context, payload, reply.res.statusCode)
+}
 
 Reply.prototype.serializer = function (fn) {
   this._serializer = fn

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -8,7 +8,7 @@ const http = require('http')
 const Reply = require('../../lib/reply')
 
 test('Once called, Reply should return an object with methods', t => {
-  t.plan(7)
+  t.plan(8)
   const request = { req: 'req' }
   const response = { res: 'res' }
   function handle () {}
@@ -17,6 +17,7 @@ test('Once called, Reply should return an object with methods', t => {
   t.is(typeof reply.send, 'function')
   t.is(typeof reply.code, 'function')
   t.is(typeof reply.header, 'function')
+  t.is(typeof reply.serialize, 'function')
   t.strictEqual(reply._req, request)
   t.strictEqual(reply.res, response)
   t.strictEqual(reply.context, handle)

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -186,7 +186,7 @@ test('use reply.serialize in onSend hook', t => {
   const fastify = require('../..')()
   fastify.addHook('onSend', (request, reply, payload, next) => {
     function _serialize () {
-      const _payload = reply.serialize(reply, payload)
+      const _payload = reply.serialize(payload)
       return zlib.gzipSync(_payload)
     }
     reply.serializer(_serialize)

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -186,7 +186,7 @@ test('use reply.serialize in onSend hook', t => {
   const fastify = require('../..')()
   fastify.addHook('onSend', (request, reply, payload, next) => {
     function _serialize () {
-      const _payload = reply.serialize(reply.context, payload, reply.res.statusCode)
+      const _payload = reply.serialize(reply, payload)
       return zlib.gzipSync(_payload)
     }
     reply.serializer(_serialize)


### PR DESCRIPTION
I just had the situation where I needed to access the default json serializer. This PR exposes the `serialize` function at the reply.