### PR TITLE
initial ts documentation

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -1,0 +1,116 @@
+<h1 align="center">Fastify</h1>
+
+## TypeScript
+Fastify is shipped with the a typings file so it should "just work" when your used in a TypeScript application.
+
+If you're using plugins be sure to read the sections below.
+
+Here's a TypeScript example app. It closely aligns with the JavaScript examples:
+
+```ts
+import * as fastify from 'fastify'
+import { Server, IncomingMessage, ServerResponse } from 'http'
+
+// Create a http server. We pass the relevant typings for our http version used.
+// By passing these get correctly typed access to the underlying http objects in routes.
+const server: fastify.FastifyInstance<Server, IncomingMessage, ServerResponse> = fastify({})
+
+const opts: fastify.RouteShorthandOptions = {
+  schema: {
+    response: {
+      200: {
+        type: 'object',
+        properties: {
+          pong: {
+            type: 'string'
+          }
+        }
+      }
+    }
+  }
+}
+
+server.get('/ping', opts, (req, reply) => {
+  console.log(reply.res) // this is the http.ServerResponse with correct typings!
+  reply.code(200).send({ pong: 'it worked!' })
+})
+```
+
+## Contributing
+TypeScript related changes can be considered to fall into one of two categories:
+
+* Core - The typings bundled with fastify
+* Plugins - Fastify ecosystem plugins
+
+Make sure to read our `CONTRIBUTING.md` file before getting started to make sure things go smoothly!
+
+## Core Types
+When updating core types you should make a PR to this repository. Ensure you:
+
+1. Update `examples/typescript-server.ts` to reflect the changes (if necessary)
+2. Update `test/types/index.ts` to validate changes work as expected
+
+## Plugin Types
+
+### Installation
+Typings for plugins are hosted in DefinitelyTyped. This means when using plugins you should install like so:
+
+```
+npm install fastify-url-data @types/fastify-url-data
+```
+
+After this you should be good to go. Some types might not be available yet, so don't be shy about contributing.
+
+### Authouring
+Typings for many plugins that extend the `FastifyRequest` and `FastifyReply` objects can be achieved as shown below.
+
+This code demonstrates adding types for `fastify-url-data` to your application.
+
+```ts
+// filename: custom-types.d.ts
+
+// Core typings and values
+import fastify = require('fastify');
+
+// Extra types that will be used for plugin typings
+import { UrlObject } from 'url';
+
+// Extend FastifyReply with the "fastify-url-data" plugin
+declare module 'fastify' {
+  interface FastifyRequest {
+    urlData (): UrlObject
+  }
+}
+
+declare function urlData (): void
+
+declare namespace urlData {}
+
+export = urlData;
+```
+
+Now you can use `fastify-url-data` like so:
+
+```ts
+import * as fastify from 'fastify'
+import * as urlData from 'fastify-url-data'
+
+/// <reference types="./custom-types.d.ts"/>
+
+const server = fastify();
+
+server.register(urlData)
+
+server.get('/data', (req, reply) => {
+  console.log(req.urlData().auth)
+  console.log(req.urlData().host)
+  console.log(req.urlData().port)
+  console.log(req.urlData().query)
+
+  reply.send({msg: 'ok'})
+})
+
+server.listen(3030)
+```
+
+Remember, if you author typings for a plugin you should publish them to DefinitelyTyped!

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -1,11 +1,12 @@
 <h1 align="center">Fastify</h1>
 
+<a id="typescript"></a>
 ## TypeScript
-Fastify is shipped with the a typings file so it should "just work" when your used in a TypeScript application.
+Fastify is shipped with the a typings file so it should "just work" when used in a TypeScript application.
 
-If you're using plugins be sure to read the sections below.
+Plugins may or may not include typings. See [Plugin Types](#plugin-types) for more information.
 
-Here's a TypeScript example app. It closely aligns with the JavaScript examples:
+This example TypeScript app closely aligns with the JavaScript examples:
 
 ```ts
 import * as fastify from 'fastify'
@@ -37,6 +38,7 @@ server.get('/ping', opts, (req, reply) => {
 })
 ```
 
+<a id="contributing"></a>
 ## Contributing
 TypeScript related changes can be considered to fall into one of two categories:
 
@@ -45,12 +47,14 @@ TypeScript related changes can be considered to fall into one of two categories:
 
 Make sure to read our `CONTRIBUTING.md` file before getting started to make sure things go smoothly!
 
+<a id="core-types"></a>
 ### Core Types
 When updating core types you should make a PR to this repository. Ensure you:
 
 1. Update `examples/typescript-server.ts` to reflect the changes (if necessary)
 2. Update `test/types/index.ts` to validate changes work as expected
 
+<a id="plugin-types"></a>
 ### Plugin Types
 
 Typings for plugins are hosted in DefinitelyTyped. This means when using plugins you should install like so:
@@ -61,6 +65,7 @@ npm install fastify-url-data @types/fastify-url-data
 
 After this you should be good to go. Some types might not be available yet, so don't be shy about contributing.
 
+<a id="authoring-plugin-types"></a>
 ### Authouring Plugin Types
 Typings for many plugins that extend the `FastifyRequest` and `FastifyReply` objects can be achieved as shown below.
 

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -12,7 +12,8 @@ import * as fastify from 'fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
 
 // Create a http server. We pass the relevant typings for our http version used.
-// By passing these get correctly typed access to the underlying http objects in routes.
+// By passing types we get correctly typed access to the underlying http objects in routes.
+// If using http we'd pass <http2.Http2Server, http2.Http2ServerRequest, http2.Http2ServerResponse>
 const server: fastify.FastifyInstance<Server, IncomingMessage, ServerResponse> = fastify({})
 
 const opts: fastify.RouteShorthandOptions = {
@@ -44,15 +45,14 @@ TypeScript related changes can be considered to fall into one of two categories:
 
 Make sure to read our `CONTRIBUTING.md` file before getting started to make sure things go smoothly!
 
-## Core Types
+### Core Types
 When updating core types you should make a PR to this repository. Ensure you:
 
 1. Update `examples/typescript-server.ts` to reflect the changes (if necessary)
 2. Update `test/types/index.ts` to validate changes work as expected
 
-## Plugin Types
+### Plugin Types
 
-### Installation
 Typings for plugins are hosted in DefinitelyTyped. This means when using plugins you should install like so:
 
 ```
@@ -61,7 +61,7 @@ npm install fastify-url-data @types/fastify-url-data
 
 After this you should be good to go. Some types might not be available yet, so don't be shy about contributing.
 
-### Authouring
+### Authouring Plugin Types
 Typings for many plugins that extend the `FastifyRequest` and `FastifyReply` objects can be achieved as shown below.
 
 This code demonstrates adding types for `fastify-url-data` to your application.

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -38,6 +38,31 @@ server.get('/ping', opts, (req, reply) => {
 })
 ```
 
+<a id="http-prototypes"></a>
+## HTTP Prototypes
+By default, fastify will determine which version of http is being used based on the options you pass to it. If for any
+reason you need to override this you can do so as shown below:
+
+```ts
+interface CustomIncomingMessage extends http.IncomingMessage {
+  getClientDeviceType: () => string
+}
+
+// Passing overrides for the http prototypes to fastify
+const server: fastify.FastifyInstance<http.Server, CustomIncomingMessage, http.ServerResponse> = fastify()
+
+server.get('/ping', (req, reply) => {
+  // Access our custom method on the http prototype
+  const clientDeviceType = req.req.getClientDeviceType()
+
+  reply.send({ clientDeviceType: `you called this endpoint from a ${clientDeviceType}` })
+})
+```
+
+In this example we pass a modified `http.IncomingMessage` interface since it has been extended elsewhere in our
+application.
+
+
 <a id="contributing"></a>
 ## Contributing
 TypeScript related changes can be considered to fall into one of two categories:


### PR DESCRIPTION
This should serve as a start for TypeScript documentation. We could link to it in a PR/Issue template?