### PR TITLE
Modify the payload in the onSend hook

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -21,7 +21,7 @@ fastify.addHook('preHandler', (request, reply, next) => {
   next()
 })
 
-fastify.addHook('onSend', (request, reply, payload, next) => {
+fastify.addHook('onSend', (request, reply, ctx, next) => {
   // some code
   next()
 })
@@ -53,7 +53,7 @@ fastify.addHook('preHandler', async (request, reply) => {
   return
 })
 
-fastify.addHook('onSend', async (request, reply, payload) => {
+fastify.addHook('onSend', async (request, reply, ctx) => {
   // some code
   await asyncMethod()
   // error occurred
@@ -104,17 +104,16 @@ fastify.addHook('preHandler', (request, reply, next) => {
 
 Note that in the `'preHandler'` and `'onSend'` hook the request and reply objects are different from `'onRequest'`, because the two arguments are [`request`](https://github.com/fastify/fastify/blob/master/docs/Request.md) and [`reply`](https://github.com/fastify/fastify/blob/master/docs/Reply.md) core Fastify objects.
 
-If you are using the `onSend` hook you can update the payload, but not overwrite it, for example:
+If you are using the `onSend` hook you can update or overwrite the payload:
+The next hook in the order of execution will get the updated/overwritten payload.
 ```js
-// this is valid
-fastify.addHook('onSend', (request, reply, payload, next) => {
-  payload.hello = 'world'
+fastify.addHook('onSend', (request, reply, ctx, next) => {
+  ctx.payload = { winter: 'is coming' }
   next()
 })
 
-// this is not valid
-fastify.addHook('onSend', (request, reply, payload, next) => {
-  payload = { hello: 'world' }
+fastify.addHook('onSend', (request, reply, ctx, next) => {
+  ctx.payload.winter = 'has come'
   next()
 })
 ```

--- a/examples/hooks.js
+++ b/examples/hooks.js
@@ -26,7 +26,7 @@ fastify
     console.log('preHandler')
     next()
   })
-  .addHook('onSend', function (request, reply, payload, next) {
+  .addHook('onSend', function (request, reply, ctx, next) {
     console.log('onSend')
     next()
   })

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -215,7 +215,7 @@ function State (that, payload) {
 }
 
 function hookIterator (fn, cb) {
-  var ret = fn(this.request, this.reply, this.payload, cb)
+  var ret = fn(this.request, this.reply, this, cb)
   if (ret && typeof ret.then === 'function') {
     ret.then(cb).catch(cb)
   }

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -381,7 +381,7 @@ test('hooks check 404', t => {
     reply.send({ hello: 'world' })
   })
 
-  fastify.addHook('onSend', (req, reply, payload, next) => {
+  fastify.addHook('onSend', (req, reply, ctx, next) => {
     t.deepEqual(req.query, { foo: 'asd' })
     t.ok('called', 'onSend')
     next()

--- a/test/500s.test.js
+++ b/test/500s.test.js
@@ -107,7 +107,7 @@ test('custom 500 with hooks', t => {
     reply.type('text/plain').send('an error happened: ' + err.message)
   })
 
-  fastify.addHook('onSend', (req, res, payload, next) => {
+  fastify.addHook('onSend', (req, res, ctx, next) => {
     t.ok('called', 'onSend')
     next()
   })

--- a/test/hooks-async.js
+++ b/test/hooks-async.js
@@ -28,7 +28,7 @@ function asyncHookTest (t) {
       }
     })
 
-    fastify.addHook('onSend', async function (request, reply, payload, next) {
+    fastify.addHook('onSend', async function (request, reply, ctx, next) {
       await sleep(1)
       t.ok('onSend called')
       next()

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -46,7 +46,7 @@ test('hooks', t => {
     next()
   })
 
-  fastify.addHook('onSend', function (req, reply, thePayload, next) {
+  fastify.addHook('onSend', function (req, reply, ctx, next) {
     t.ok('onSend called')
     next()
   })
@@ -373,7 +373,7 @@ test('onSend hook should support encapsulation / 2', t => {
   const fastify = Fastify()
   fastify.decorate('hello', 'world')
 
-  fastify.addHook('onSend', function (request, reply, thePayload, next) {
+  fastify.addHook('onSend', function (request, reply, ctx, next) {
     t.ok(this.hello)
     t.ok('onSend called')
     next()
@@ -385,7 +385,7 @@ test('onSend hook should support encapsulation / 2', t => {
 
   fastify.register((instance, opts, next) => {
     instance.decorate('hello2', 'world')
-    instance.addHook('onSend', function (request, reply, thePayload, next) {
+    instance.addHook('onSend', function (request, reply, ctx, next) {
       t.ok(this.hello)
       t.ok(this.hello2)
       t.ok('onSend called')
@@ -425,23 +425,23 @@ test('onSend hook should support encapsulation / 2', t => {
   })
 })
 
-test('verify payload', t => {
+test('modify payload', t => {
   t.plan(7)
   const fastify = Fastify()
   const payload = { hello: 'world' }
-  const modifiedPayload = { hello: 'modified' }
+  const modifiedPayload = { winter: 'is coming' }
 
-  fastify.addHook('onSend', function (request, reply, thePayload, next) {
+  fastify.addHook('onSend', function (request, reply, ctx, next) {
     t.ok('onSend called')
-    t.deepEqual(thePayload, payload)
+    t.deepEqual(ctx.payload, payload)
     // onSend allows only to modify Object keys and not the full object's reference
-    thePayload.hello = 'modified'
+    ctx.payload = modifiedPayload
     next()
   })
 
-  fastify.addHook('onSend', function (request, reply, thePayload, next) {
+  fastify.addHook('onSend', function (request, reply, ctx, next) {
     t.ok('onSend called')
-    t.deepEqual(thePayload, modifiedPayload)
+    t.deepEqual(ctx.payload, modifiedPayload)
     next()
   })
 
@@ -455,7 +455,7 @@ test('verify payload', t => {
   }, res => {
     t.deepEqual(modifiedPayload, JSON.parse(res.payload))
     t.strictEqual(res.statusCode, 200)
-    t.strictEqual(res.headers['content-length'], 20)
+    t.strictEqual(res.headers['content-length'], 22)
   })
 })
 


### PR DESCRIPTION
This is a way to solve our problem without the need to write a overcomplicated internal logic.

In my opinion this is just another case where a single `ctx` object is better than have `request`, `reply`. No need of duplicated data and becomes super easy access everything we need without changing core every time.

Related: https://github.com/fastify/fastify/issues/169 https://github.com/fastify/fastify/pull/330 https://github.com/fastify/fastify/pull/427

Thoughts?