### PR TITLE
Pass request to the onsend hook on 422 and 415 errors

### DIFF
--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -24,7 +24,7 @@ function handleRequest (req, res, params, context) {
       return context.contentTypeParser.run(req.headers['content-type'], handler, context, params, req, res, urlUtil.parse(req.url, true).query)
     }
 
-    setImmediate(wrapReplyEnd, context, req, res, 415)
+    setImmediate(wrapReplyEnd, context, req, res, 415, params, null, urlUtil.parse(req.url, true).query, null)
     return
   }
 
@@ -38,13 +38,13 @@ function handleRequest (req, res, params, context) {
         return context.contentTypeParser.run(req.headers['content-type'], handler, context, params, req, res, urlUtil.parse(req.url, true).query)
       }
 
-      setImmediate(wrapReplyEnd, context, req, res, 415, params, null, urlUtil.parse(req.url, true).query)
+      setImmediate(wrapReplyEnd, context, req, res, 415, params, null, urlUtil.parse(req.url, true).query, null)
       return
     }
     return handler(context, params, req, res, null, urlUtil.parse(req.url, true).query)
   }
 
-  setImmediate(wrapReplyEnd, context, req, res, 405, params, null, urlUtil.parse(req.url, true).query)
+  setImmediate(wrapReplyEnd, context, req, res, 405, params, null, urlUtil.parse(req.url, true).query, null)
   return
 }
 
@@ -72,9 +72,9 @@ function jsonBody (req, res, params, context) {
 }
 
 function jsonBodyParsed (err, body, req, res, params, context) {
-  const query = urlUtil.parse(req.url, true).query
+  var query = urlUtil.parse(req.url, true).query
   if (err) {
-    setImmediate(wrapReplyEnd, context, req, res, 422, params, body, query)
+    setImmediate(wrapReplyEnd, context, req, res, 422, params, body, query, null)
     return
   }
   handler(context, params, req, res, body, query)

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -38,13 +38,13 @@ function handleRequest (req, res, params, context) {
         return context.contentTypeParser.run(req.headers['content-type'], handler, context, params, req, res, urlUtil.parse(req.url, true).query)
       }
 
-      setImmediate(wrapReplyEnd, context, req, res, 415)
+      setImmediate(wrapReplyEnd, context, req, res, 415, params, null, urlUtil.parse(req.url, true).query)
       return
     }
     return handler(context, params, req, res, null, urlUtil.parse(req.url, true).query)
   }
 
-  setImmediate(wrapReplyEnd, context, req, res, 405)
+  setImmediate(wrapReplyEnd, context, req, res, 405, params, null, urlUtil.parse(req.url, true).query)
   return
 }
 
@@ -72,18 +72,19 @@ function jsonBody (req, res, params, context) {
 }
 
 function jsonBodyParsed (err, body, req, res, params, context) {
+  const query = urlUtil.parse(req.url, true).query
   if (err) {
-    setImmediate(wrapReplyEnd, context, req, res, 422)
+    setImmediate(wrapReplyEnd, context, req, res, 422, params, body, query)
     return
   }
-  handler(context, params, req, res, body, urlUtil.parse(req.url, true).query)
+  handler(context, params, req, res, body, query)
 }
 
 function handler (context, params, req, res, body, query, headers) {
   var request = new context.Request(params, req, body, query, req.headers, req.log)
   var valid = validateSchema(context, request)
   if (valid !== true) {
-    setImmediate(wrapReplyEnd, context, req, res, 400, valid)
+    setImmediate(wrapReplyEnd, context, req, res, 400, params, body, query, valid)
     return
   }
 
@@ -131,8 +132,9 @@ function preHandlerCallback (err, code) {
   }
 }
 
-function wrapReplyEnd (context, req, res, statusCode, payload) {
-  const reply = new context.Reply(req, res, context)
+function wrapReplyEnd (context, req, res, statusCode, params, body, query, payload) {
+  const request = new context.Request(params, req, body, query, req.headers, req.log)
+  const reply = new context.Reply(req, res, context, request)
   if (payload instanceof Error) {
     reply.code(statusCode).send(payload)
   } else {

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -8,6 +8,7 @@ const Request = require('../../lib/request')
 const Reply = require('../../lib/reply')
 const buildSchema = require('../../lib/validation').build
 const Hooks = require('../../lib/hooks')
+const sget = require('simple-get').concat
 
 const Ajv = require('ajv')
 const ajv = new Ajv({ coerceTypes: true })
@@ -112,4 +113,91 @@ test('jsonBody error handler', t => {
   } catch (e) {
     t.pass('jsonBody error')
   }
+})
+
+test('request should be defined in onSend Hook on post request with content type application/json', t => {
+  t.plan(3)
+  const fastify = require('../..')()
+
+  fastify.addHook('onSend', (request, reply, payload, done) => {
+    if (!request) {
+      reply.code(500)
+    }
+    done()
+  })
+  fastify.post('/', (request, reply) => {
+    reply.send(200)
+  })
+  fastify.listen(0, err => {
+    fastify.server.unref()
+    t.error(err)
+    sget({
+      method: 'POST',
+      url: 'http://localhost:' + fastify.server.address().port,
+      headers: {
+        'content-type': 'application/json'
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 422)
+    })
+  })
+})
+
+test('request should be defined in onSend Hook on post request with content type application/x-www-form-urlencoded', t => {
+  t.plan(3)
+  const fastify = require('../..')()
+
+  fastify.addHook('onSend', (request, reply, payload, done) => {
+    if (!request) {
+      reply.code(500)
+    }
+    done()
+  })
+  fastify.post('/', (request, reply) => {
+    reply.send(200)
+  })
+  fastify.listen(0, err => {
+    fastify.server.unref()
+    t.error(err)
+    sget({
+      method: 'POST',
+      url: 'http://localhost:' + fastify.server.address().port,
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded'
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 415)
+    })
+  })
+})
+
+test('request should be defined in onSend Hook on options request with content type application/x-www-form-urlencoded', t => {
+  t.plan(3)
+  const fastify = require('../..')()
+
+  fastify.addHook('onSend', (request, reply, payload, done) => {
+    if (!request) {
+      reply.code(500)
+    }
+    done()
+  })
+  fastify.options('/', (request, reply) => {
+    reply.send(200)
+  })
+  fastify.listen(0, err => {
+    fastify.server.unref()
+    t.error(err)
+    sget({
+      method: 'OPTIONS',
+      url: 'http://localhost:' + fastify.server.address().port,
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded'
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 415)
+    })
+  })
 })

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -116,13 +116,14 @@ test('jsonBody error handler', t => {
 })
 
 test('request should be defined in onSend Hook on post request with content type application/json', t => {
-  t.plan(3)
+  t.plan(7)
   const fastify = require('../..')()
 
   fastify.addHook('onSend', (request, reply, payload, done) => {
-    if (!request || !request.req || !request.params || !request.query) {
-      reply.code(500)
-    }
+    t.ok(request)
+    t.ok(request.req)
+    t.ok(request.params)
+    t.ok(request.query)
     done()
   })
   fastify.post('/', (request, reply) => {
@@ -139,19 +140,21 @@ test('request should be defined in onSend Hook on post request with content type
       }
     }, (err, response, body) => {
       t.error(err)
+      // a 422 error is expected because of no body
       t.strictEqual(response.statusCode, 422)
     })
   })
 })
 
 test('request should be defined in onSend Hook on post request with content type application/x-www-form-urlencoded', t => {
-  t.plan(3)
+  t.plan(7)
   const fastify = require('../..')()
 
   fastify.addHook('onSend', (request, reply, payload, done) => {
-    if (!request || !request.req || !request.params || !request.query) {
-      reply.code(500)
-    }
+    t.ok(request)
+    t.ok(request.req)
+    t.ok(request.params)
+    t.ok(request.query)
     done()
   })
   fastify.post('/', (request, reply) => {
@@ -168,19 +171,21 @@ test('request should be defined in onSend Hook on post request with content type
       }
     }, (err, response, body) => {
       t.error(err)
+      // a 415 error is expected because of missing content type parser
       t.strictEqual(response.statusCode, 415)
     })
   })
 })
 
 test('request should be defined in onSend Hook on options request with content type application/x-www-form-urlencoded', t => {
-  t.plan(3)
+  t.plan(7)
   const fastify = require('../..')()
 
   fastify.addHook('onSend', (request, reply, payload, done) => {
-    if (!request || !request.req || !request.params || !request.query) {
-      reply.code(500)
-    }
+    t.ok(request)
+    t.ok(request.req)
+    t.ok(request.params)
+    t.ok(request.query)
     done()
   })
   fastify.options('/', (request, reply) => {
@@ -197,6 +202,7 @@ test('request should be defined in onSend Hook on options request with content t
       }
     }, (err, response, body) => {
       t.error(err)
+      // a 415 error is expected because of missing content type parser
       t.strictEqual(response.statusCode, 415)
     })
   })

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -120,7 +120,7 @@ test('request should be defined in onSend Hook on post request with content type
   const fastify = require('../..')()
 
   fastify.addHook('onSend', (request, reply, payload, done) => {
-    if (!request) {
+    if (!request || !request.req || !request.params || !request.query) {
       reply.code(500)
     }
     done()
@@ -149,7 +149,7 @@ test('request should be defined in onSend Hook on post request with content type
   const fastify = require('../..')()
 
   fastify.addHook('onSend', (request, reply, payload, done) => {
-    if (!request) {
+    if (!request || !request.req || !request.params || !request.query) {
       reply.code(500)
     }
     done()
@@ -178,7 +178,7 @@ test('request should be defined in onSend Hook on options request with content t
   const fastify = require('../..')()
 
   fastify.addHook('onSend', (request, reply, payload, done) => {
-    if (!request) {
+    if (!request || !request.req || !request.params || !request.query) {
       reply.code(500)
     }
     done()


### PR DESCRIPTION
This PR ensures that a `request` object is passed to the `onSend` hook on 422 Unprocessable Entity and 415 Unsupported Media Type errors.

Fixes [#445](https://github.com/fastify/fastify/issues/445).