### PR TITLE
update documentation

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -193,7 +193,7 @@ test('GET `/` route', t => {
     url: '/'
   }, res => {
     t.strictEqual(res.statusCode, 200)
-    t.strictEqual(res.headers['content-length'], '' + body.length)
+    t.strictEqual(res.headers['content-length'], res.payload.length)
     t.deepEqual(JSON.parse(res.payload), { hello: 'world' })
     // even if the server is not running (inject does not run the server)
     // at the end of your tests is highly recommended call `.close()`,


### PR DESCRIPTION
#461 
when I use `fastify.inject()` test api, I found two problems:
1. there is no `body` param in callback.
2. the typeof `res.headers['content-length']` is not string, it is actually a number. 
