### PR TITLE
coverage content-length to string

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -193,7 +193,7 @@ test('GET `/` route', t => {
     url: '/'
   }, res => {
     t.strictEqual(res.statusCode, 200)
-    t.strictEqual(res.headers['content-length'], res.payload.length)
+    t.strictEqual(res.headers['content-length'], '' + res.payload.length)
     t.deepEqual(JSON.parse(res.payload), { hello: 'world' })
     // even if the server is not running (inject does not run the server)
     // at the end of your tests is highly recommended call `.close()`,

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -166,7 +166,7 @@ function onSendEnd (reply, payload) {
   }
 
   if (!reply.res.getHeader('Content-Length')) {
-    reply.res.setHeader('Content-Length', Buffer.byteLength(payload).toString())
+    reply.res.setHeader('Content-Length', '' + Buffer.byteLength(payload))
   }
   reply.sent = true
   reply.res.end(payload)

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -166,7 +166,7 @@ function onSendEnd (reply, payload) {
   }
 
   if (!reply.res.getHeader('Content-Length')) {
-    reply.res.setHeader('Content-Length', Buffer.byteLength(payload))
+    reply.res.setHeader('Content-Length', Buffer.byteLength(payload).toString())
   }
   reply.sent = true
   reply.res.end(payload)

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -455,7 +455,7 @@ test('verify payload', t => {
   }, res => {
     t.deepEqual(modifiedPayload, JSON.parse(res.payload))
     t.strictEqual(res.statusCode, 200)
-    t.strictEqual(res.headers['content-length'], 20)
+    t.strictEqual(res.headers['content-length'], '20')
   })
 })
 

--- a/test/inject.test.js
+++ b/test/inject.test.js
@@ -32,7 +32,7 @@ test('should wait for the ready event', t => {
   }, res => {
     t.deepEqual(payload, JSON.parse(res.payload))
     t.strictEqual(res.statusCode, 200)
-    t.strictEqual(res.headers['content-length'], 17)
+    t.strictEqual(res.headers['content-length'], '17')
   })
 })
 
@@ -51,7 +51,7 @@ test('inject get request', t => {
   }, res => {
     t.deepEqual(payload, JSON.parse(res.payload))
     t.strictEqual(res.statusCode, 200)
-    t.strictEqual(res.headers['content-length'], 17)
+    t.strictEqual(res.headers['content-length'], '17')
   })
 })
 
@@ -70,7 +70,7 @@ test('inject get request - code check', t => {
   }, res => {
     t.deepEqual(payload, JSON.parse(res.payload))
     t.strictEqual(res.statusCode, 201)
-    t.strictEqual(res.headers['content-length'], 17)
+    t.strictEqual(res.headers['content-length'], '17')
   })
 })
 
@@ -88,7 +88,7 @@ test('inject get request - headers check', t => {
   }, res => {
     t.strictEqual('', res.payload)
     t.strictEqual(res.headers['content-type'], 'text/plain')
-    t.strictEqual(res.headers['content-length'], 0)
+    t.strictEqual(res.headers['content-length'], '0')
   })
 })
 
@@ -106,7 +106,7 @@ test('inject get request - querystring', t => {
   }, res => {
     t.deepEqual({ hello: 'world' }, JSON.parse(res.payload))
     t.strictEqual(res.statusCode, 200)
-    t.strictEqual(res.headers['content-length'], 17)
+    t.strictEqual(res.headers['content-length'], '17')
   })
 })
 
@@ -124,7 +124,7 @@ test('inject get request - params', t => {
   }, res => {
     t.deepEqual({ hello: 'world' }, JSON.parse(res.payload))
     t.strictEqual(res.statusCode, 200)
-    t.strictEqual(res.headers['content-length'], 17)
+    t.strictEqual(res.headers['content-length'], '17')
   })
 })
 
@@ -142,7 +142,7 @@ test('inject get request - wildcard', t => {
   }, res => {
     t.deepEqual({ '*': 'wildcard' }, JSON.parse(res.payload))
     t.strictEqual(res.statusCode, 200)
-    t.strictEqual(res.headers['content-length'], 16)
+    t.strictEqual(res.headers['content-length'], '16')
   })
 })
 
@@ -161,7 +161,7 @@ test('inject get request - headers', t => {
   }, res => {
     t.strictEqual('world', JSON.parse(res.payload).hello)
     t.strictEqual(res.statusCode, 200)
-    t.strictEqual(res.headers['content-length'], 69)
+    t.strictEqual(res.headers['content-length'], '69')
   })
 })
 
@@ -181,7 +181,7 @@ test('inject post request', t => {
   }, res => {
     t.deepEqual(payload, JSON.parse(res.payload))
     t.strictEqual(res.statusCode, 200)
-    t.strictEqual(res.headers['content-length'], 17)
+    t.strictEqual(res.headers['content-length'], '17')
   })
 })
 
@@ -201,7 +201,7 @@ test('inject post request - send stream', t => {
   }, res => {
     t.deepEqual('{"hello":"world"}', res.payload)
     t.strictEqual(res.statusCode, 200)
-    t.strictEqual(res.headers['content-length'], 17)
+    t.strictEqual(res.headers['content-length'], '17')
   })
 })
 


### PR DESCRIPTION
this pr show the problem in #465
> the typeof res.headers['content-length'] is not string, it is actually a number.

I have debug in `light-my-request` for a long time, at lastest I found it in `fastify/lib/reply.js`.