### PR TITLE
Converted conventional function declarations in examples folder to arrow functions

### DIFF
--- a/examples/asyncawait.js
+++ b/examples/asyncawait.js
@@ -17,16 +17,14 @@ const schema = {
   }
 }
 
-function result () {
-  return Promise.resolve({ hello: 'world' })
-}
+const result = async () => ({ hello: 'world' })
 
 fastify
-  .get('/await', schema, async function (req, reply) {
+  .get('/await', schema, async (req, reply) => {
     reply.header('Content-Type', 'application/json').code(200)
     return result()
   })
-  .get('/', schema, async function (req, reply) {
+  .get('/', schema, async (req, reply) => {
     reply.header('Content-Type', 'application/json').code(200)
     return { hello: 'world' }
   })

--- a/examples/example.js
+++ b/examples/example.js
@@ -18,37 +18,37 @@ const opts = {
 }
 
 fastify
-  .get('/', opts, function (req, reply) {
+  .get('/', opts, (req, reply) => {
     reply.header('Content-Type', 'application/json').code(200)
     reply.send({ hello: 'world' })
   })
-  .get('/promise', opts, function (req, reply) {
-    const promise = new Promise(function (resolve, reject) {
+  .get('/promise', opts, (req, reply) => {
+    const promise = new Promise((resolve, reject) => {
       resolve({ hello: 'world' })
     })
     reply.header('content-type', 'application/json').code(200).send(promise)
   })
-  .get('/return-promise', opts, function (req, reply) {
-    const promise = new Promise(function (resolve, reject) {
+  .get('/return-promise', opts, (req, reply) => {
+    const promise = new Promise((resolve, reject) => {
       resolve({ hello: 'world' })
     })
     return promise
   })
-  .get('/stream', function (req, reply) {
+  .get('/stream', (req, reply) => {
     const fs = require('fs')
     const stream = fs.createReadStream(process.cwd() + '/examples/plugin.js', 'utf8')
     reply.code(200).send(stream)
   })
-  .post('/', opts, function (req, reply) {
+  .post('/', opts, (req, reply) => {
     reply.send({ hello: 'world' })
   })
-  .head('/', {}, function (req, reply) {
+  .head('/', {}, (req, reply) => {
     reply.send()
   })
-  .delete('/', opts, function (req, reply) {
+  .delete('/', opts, (req, reply) => {
     reply.send({ hello: 'world' })
   })
-  .patch('/', opts, function (req, reply) {
+  .patch('/', opts, (req, reply) => {
     reply.send({ hello: 'world' })
   })
 

--- a/examples/hooks.js
+++ b/examples/hooks.js
@@ -18,30 +18,28 @@ const opts = {
 }
 
 fastify
-  .addHook('onRequest', function (req, res, next) {
+  .addHook('onRequest', (req, res, next) => {
     console.log('onRequest')
     next()
   })
-  .addHook('preHandler', function (request, reply, next) {
+  .addHook('preHandler', (request, reply, next) => {
     console.log('preHandler')
     next()
   })
-  .addHook('onSend', function (request, reply, payload, next) {
+  .addHook('onSend', (request, reply, payload, next) => {
     console.log('onSend')
     next()
   })
-  .addHook('onResponse', function (res, next) {
+  .addHook('onResponse', (res, next) => {
     console.log('onResponse')
     next()
   })
 
-fastify.get('/', opts, function (req, reply) {
+fastify.get('/', opts, (req, reply) => {
   reply.send({ hello: 'world' })
 })
 
-fastify.listen(3000, function (err) {
-  if (err) {
-    throw err
-  }
+fastify.listen(3000, err => {
+  if (err) throw err
   console.log(`server listening on ${fastify.server.address().port}`)
 })

--- a/examples/http2.js
+++ b/examples/http2.js
@@ -26,7 +26,7 @@ const opts = {
 }
 
 fastify
-  .get('/', opts, function (req, reply) {
+  .get('/', opts, (req, reply) => {
     reply.header('Content-Type', 'application/json').code(200)
     reply.send({ hello: 'world' })
   })

--- a/examples/https.js
+++ b/examples/https.js
@@ -25,7 +25,7 @@ const opts = {
 }
 
 fastify
-  .get('/', opts, function (req, reply) {
+  .get('/', opts, (req, reply) => {
     reply.header('Content-Type', 'application/json').code(200)
     reply.send({ hello: 'world' })
   })

--- a/examples/middleware.js
+++ b/examples/middleware.js
@@ -26,7 +26,7 @@ const opts = {
 }
 
 fastify
-  .get('/', opts, function (req, reply) {
+  .get('/', opts, (req, reply) => {
     reply.header('Content-Type', 'application/json').code(200)
     reply.send({ hello: 'world' })
   })

--- a/examples/plugin.js
+++ b/examples/plugin.js
@@ -1,11 +1,11 @@
 'use strict'
 
-module.exports = function (fastify, opts, next) {
+module.exports = (fastify, opts, next) => {
   fastify
-    .get('/', opts, function (req, reply) {
+    .get('/', opts, (req, reply) => {
       reply.send({ hello: 'world' })
     })
-    .post('/', opts, function (req, reply) {
+    .post('/', opts, (req, reply) => {
       reply.send({ hello: 'world' })
     })
   next()

--- a/examples/route-prefix.js
+++ b/examples/route-prefix.js
@@ -15,7 +15,7 @@ const opts = {
   }
 }
 
-fastify.register(function (instance, options, next) {
+fastify.register((instance, options, next) => {
   // the route will be '/english/hello'
   instance.get('/hello', opts, (req, reply) => {
     reply.send({ greet: 'hello' })
@@ -23,7 +23,7 @@ fastify.register(function (instance, options, next) {
   next()
 }, { prefix: '/english' })
 
-fastify.register(function (instance, options, next) {
+fastify.register((instance, options, next) => {
   // the route will be '/italian/hello'
   instance.get('/hello', opts, (req, reply) => {
     reply.send({ greet: 'ciao' })
@@ -31,9 +31,7 @@ fastify.register(function (instance, options, next) {
   next()
 }, { prefix: '/italian' })
 
-fastify.listen(8000, function (err) {
-  if (err) {
-    throw err
-  }
+fastify.listen(8000, err => {
+  if (err) throw err
   console.log(`server listening on ${fastify.server.address().port}`)
 })

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -18,7 +18,7 @@ const schema = {
 }
 
 fastify
-  .get('/', schema, function (req, reply) {
+  .get('/', schema, (req, reply) => {
     reply
       .send({ hello: 'world' })
   })

--- a/examples/typescript-server.ts
+++ b/examples/typescript-server.ts
@@ -33,13 +33,13 @@ const opts = {
   }
 }
 
-function getHelloHandler (req: fastify.FastifyRequest<http.IncomingMessage>,
-    reply: fastify.FastifyReply<http.ServerResponse>) {
+const getHelloHandler = (req: fastify.FastifyRequest<http.IncomingMessage>,
+    reply: fastify.FastifyReply<http.ServerResponse>) => {
   reply.header('Content-Type', 'application/json').code(200)
   reply.send({ hello: 'world' })
 }
 
-function getStreamHandler (req, reply) {
+const getStreamHandler = (req, reply) => {
   const stream = createReadStream(process.cwd() + '/examples/plugin.js', 'utf8')
   reply.code(200).send(stream)
 }

--- a/examples/use-plugin.js
+++ b/examples/use-plugin.js
@@ -14,13 +14,11 @@ const opts = {
     }
   }
 }
-fastify.register(require('./plugin'), opts, function (err) {
+fastify.register(require('./plugin'), opts, err => {
   if (err) throw err
 })
 
-fastify.listen(3000, function (err) {
-  if (err) {
-    throw err
-  }
+fastify.listen(3000, err => {
+  if (err) throw err
   console.log(`server listening on ${fastify.server.address().port}`)
 })


### PR DESCRIPTION
Arrow functions are (mostly) just "syntactic sugar" for conventional function declarations ([StackOverflow discussion](https://stackoverflow.com/a/44031830/8930221))

Arrow functions were being used in some examples. This commit changes all conventional function declarations which do not use `this` to arrow functions