### PR TITLE
WIP: pipe implementation

### DIFF
--- a/lib/ContentTypeParser.js
+++ b/lib/ContentTypeParser.js
@@ -43,16 +43,16 @@ ContentTypeParser.prototype.getHandler = function (contentType) {
   }
 }
 
-ContentTypeParser.prototype.run = function (contentType, handler, context, params, req, res, query) {
-  this.getHandler(contentType)(req, done)
-
+ContentTypeParser.prototype.run = function (contentType, requestContext, callback) {
   function done (body) {
     if (body instanceof Error) {
-      const reply = new context.Reply(res, context, null)
-      return reply.send(body)
+      callback(body, requestContext)
+      return
     }
-    handler(context, params, req, res, body, query)
+    callback(null, requestContext)
   }
+
+  this.getHandler(contentType)(requestContext.req, done)
 }
 
 function buildContentTypeParser (c) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -117,13 +117,18 @@ function onSendEnd (reply, payload) {
   }
 
   if (!reply.res.getHeader('Content-Length')) {
-    reply.res.setHeader('Content-Length', '' + Buffer.byteLength(payload))
+    if (payload !== null && payload !== undefined) {
+      reply.res.setHeader('Content-Length', '' + Buffer.byteLength(payload))
+    } else {
+      reply.res.setHeader('Content-Length', '0')
+    }
   }
+
   reply.sent = true
   reply.res.end(payload)
 }
 
-function handleError (reply, err, cb) {
+function handleError (reply, err) {
   if (!reply.res.statusCode || reply.res.statusCode < 400) {
     reply.res.statusCode =
         (err === null || err === undefined) ? 500
@@ -149,11 +154,15 @@ function handleError (reply, err, cb) {
 
   reply.res.setHeader('Content-Type', 'application/json')
 
-  cb(reply, Object.assign({
+  reply.send(Object.assign({
     error: statusCodes[reply.res.statusCode + ''],
     message: (err || '') && err.message,
     statusCode: reply.res.statusCode
   }, reply._extendServerError && reply._extendServerError(err)))
+}
+
+Reply.prototype.sendError = function (error) {
+  handleError(this, error)
 }
 
 function buildReply (R) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -20,61 +20,8 @@ function Reply (res, context, request) {
   this.request = request
 }
 
-/**
- * Instead of using directly res.end(), we are using setImmediate(…)
- * This because we have observed that with this technique we are faster at responding to the various requests,
- * since the setImmediate forwards the res.end at the end of the poll phase of libuv in the event loop.
- * So we can gather multiple requests and then handle all the replies in a different moment,
- * causing a general improvement of performances, ~+10%.
- */
 Reply.prototype.send = function (payload) {
-  if (this.sent) {
-    this.res.log.warn(new Error('Reply already sent'))
-    return
-  }
-
-  this.sent = true
-
-  var _isError = this[isError]
-
-  if (payload === undefined && _isError !== true) {
-    this.res.setHeader('Content-Length', '0')
-    if (!this.res.getHeader('Content-Type')) {
-      this.res.setHeader('Content-Type', 'text/plain')
-    }
-    setImmediate(handleReplyEnd, this, '')
-    return
-  }
-
-  if (payload && payload.isBoom) {
-    this.res.log.error(payload)
-    this.res.statusCode = payload.output.statusCode
-
-    this.res.setHeader('Content-Type', 'application/json')
-    this.headers(payload.output.headers)
-
-    setImmediate(
-      handleReplyEnd,
-      this,
-      payload.output.payload
-    )
-    return
-  }
-
-  if (payload instanceof Error || _isError === true) {
-    handleError(this, payload, wrapHandleReplyEnd)
-    return
-  }
-
-  if (payload && payload._readableState) {
-    if (!this.res.getHeader('Content-Type')) {
-      this.res.setHeader('Content-Type', 'application/octet-stream')
-    }
-    return pump(payload, this.res, wrapPumpCallback(this))
-  }
-
-  setImmediate(handleReplyEnd, this, payload)
-  return
+  setImmediate(onSendEnd, this, payload)
 }
 
 Reply.prototype.header = function (key, value) {
@@ -116,14 +63,6 @@ Reply.prototype.redirect = function (code, url) {
   }
 
   this.header('Location', url).code(code).send()
-}
-
-function wrapHandleReplyEnd (reply, payload) {
-  setImmediate(
-    handleReplyEnd,
-    reply,
-    payload
-  )
 }
 
 function wrapPumpCallback (reply) {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "abstract-logging": "^1.0.0",
     "ajv": "^5.3.0",
     "avvio": "^3.2.0",
+    "fast-fast-series": "^0.1.0",
     "fast-iterator": "^0.2.1",
     "fast-json-stringify": "^0.15.1",
     "fastify-cli": "^0.11.0",


### PR DESCRIPTION
Hi folk!

This is a huge PR, please don't be scared, continue to read!

I'd like to move the `fastify` implementation of request handling into a different direction.

**Problem**
Our code is fulfilled with "if"s that are trivial: at "start up" time, `fastify` knows for each routes if an incoming request has `preHandle`, `onSend`... hooks. `fastify` already knows if the request has a body or not too. For example https://github.com/fastify/fastify/blob/61e35c83ab78384b38ee95b0467f229a5f7175ec/fastify.js#L174 https://github.com/fastify/fastify/blob/61e35c83ab78384b38ee95b0467f229a5f7175ec/fastify.js#L219 https://github.com/fastify/fastify/blob/61e35c83ab78384b38ee95b0467f229a5f7175ec/lib/handleRequest.js#L12 https://github.com/fastify/fastify/blob/61e35c83ab78384b38ee95b0467f229a5f7175ec/lib/handleRequest.js#L92

**Idea**
Use the knowledges in order to build the steps that each request have to step through. For instance each `GET` request enters **always** in the if body
https://github.com/fastify/fastify/blob/61e35c83ab78384b38ee95b0467f229a5f7175ec/lib/handleRequest.js#L12-L14

**Currently implementation**
For the time being, the route creation is made here
https://github.com/fastify/fastify/blob/61e35c83ab78384b38ee95b0467f229a5f7175ec/fastify.js#L384-L450
`find-my-way` calls `startHooks` passing `context` as 3th paramenter. After that each request for every routes makes the same steps

**About this PR**
Here
https://github.com/fastify/fastify/blob/df947b0740d7e085efb0e77cfa871a784f5a3f94/fastify.js#L460-L477
this PR introduces a new way for the request handling: according with our [docs](https://github.com/fastify/fastify/blob/61e35c83ab78384b38ee95b0467f229a5f7175ec/docs/Lifecycle.md) we can see that the request handling could be modelled using the pipeline pattern: add a "stage" only if needed. In this way in the `example/simple.js` the route `/` could add only the "validation", "userHandler", "_onResFinished" stages: "preHandling", "onSend", "onResponse" stages are not added at all!

Keeping in mind our goal (_Fast and low overhead web framework, for Node.js_), this PR aims to change the route handling in order to simplify the run time handling.

The main goals are:
- keep the performance at least equal
- keep the same features added to the framework
- improve the code quality without sacrificing the performance (= remove some "if"s)

I have run the benchmark on this branch (df947b0) 3 times and than on the master (61e35c8) another 3 times in order to compare in a better way the performance. The benchmarks are made against _example/simple.js_ script

**pipe-implementation-proposal**
```
Tommaso:fastify allevo$ autocannon -d 30 localhost:3000
Running 30s test @ http://localhost:3000
10 connections

Stat         Avg      Stdev  Max     
Latency (ms) 0.4      0.6    44      
Req/Sec      10450.07 753.44 11543   
Bytes/Sec    1.55 MB  115 kB 1.77 MB 

314k requests in 30s, 46.7 MB read
Tommaso:fastify allevo$ autocannon -d 30 localhost:3000
Running 30s test @ http://localhost:3000
10 connections

Stat         Avg      Stdev   Max    
Latency (ms) 0.38     0.54    48     
Req/Sec      10733.87 287.6   11327  
Bytes/Sec    1.6 MB   43.1 kB 1.7 MB 

322k requests in 30s, 48 MB read
Tommaso:fastify allevo$ autocannon -d 30 localhost:3000
Running 30s test @ http://localhost:3000
10 connections

Stat         Avg      Stdev  Max    
Latency (ms) 0.38     0.54   46     
Req/Sec      10846.67 375.34 11335  
Bytes/Sec    1.61 MB  58 kB  1.7 MB 

325k requests in 30s, 48.5 MB read
```

**master**
```
Tommaso:fastify allevo$ autocannon -d 30 localhost:3000
Running 30s test @ http://localhost:3000
10 connections

Stat         Avg     Stdev   Max     
Latency (ms) 0.41    0.58    45      
Req/Sec      9819.8  670.56  10431   
Bytes/Sec    1.46 MB 97.8 kB 1.57 MB 

295k requests in 30s, 43.9 MB read
Tommaso:fastify allevo$ autocannon -d 30 localhost:3000
Running 30s test @ http://localhost:3000
10 connections

Stat         Avg    Stdev   Max     
Latency (ms) 0.43   0.55    46      
Req/Sec      10060  279.89  10695   
Bytes/Sec    1.5 MB 49.6 kB 1.64 MB 

302k requests in 30s, 45 MB read
Tommaso:fastify allevo$ autocannon -d 30 localhost:3000
Running 30s test @ http://localhost:3000
10 connections

Stat         Avg      Stdev   Max     
Latency (ms) 0.39     0.54    45      
Req/Sec      10304.54 207.18  10703   
Bytes/Sec    1.54 MB  33.6 kB 1.64 MB 

309k requests in 30s, 46.1 MB read
```

As you can see, there's a little performance improvement.

This PR is WIP and don't cover yet all the fastify feature: the following features are not implemented
- preHandler
- beforeHander
- onSend

So the tests fails. I'd like to know the community thoughts/ideas/feedback around this different approach before continuing.

The implementation at df947b0 is bad. But as already said, I need to know if `fastify` team is ok.

Obviously this PR must not change the tests in order to keep the external behaviour compliant with the older one!

**pro**:
- faster (at least executing `example/simple.js`)
- cleaner code: remove "if"s

**cons:**
- huge refactoring: this PR could take a lot of time to complete (https://github.com/fastify/fastify/issues/229)
- more difficult of debugging: the requests could skip some steps
