### PR TITLE
Make reply.redirect honor registered hooks

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -115,8 +115,7 @@ Reply.prototype.redirect = function (code, url) {
     code = 302
   }
 
-  this.res.writeHead(code, { Location: url })
-  this.res.end()
+  this.header('Location', url).code(code).send()
 }
 
 function wrapHandleReplyEnd (reply, payload) {

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -189,15 +189,12 @@ test('within an instance', t => {
     })
 
     test('redirect to `/` - 5', t => {
-      t.plan(4)
-      sget({
-        method: 'GET',
-        url: 'http://localhost:' + fastify.server.address().port + '/redirect-onsend'
-      }, (err, response, body) => {
-        t.error(err)
-        t.strictEqual(response.statusCode, 200)
-        t.strictEqual(response.headers['content-type'], 'text/plain')
-        t.deepEqual(body.toString(), 'hello world!')
+      t.plan(3)
+      const url = 'http://localhost:' + fastify.server.address().port + '/redirect-onsend'
+      http.get(url, (response) => {
+        t.strictEqual(response.headers['x-onsend'], 'yes')
+        t.strictEqual(response.headers['content-length'], '0')
+        t.strictEqual(response.headers['location'], '/')
       })
     })
 


### PR DESCRIPTION
Currently, the `reply.redirect` method skips any registered hooks, e.g. `onSend`. This PR rectifies that situation.

~Unfortunately, there isn't any way to verify that the header in the added test gets set within the redirect. This is because there isn't any way to watch/inspect the redirects within `simple-get`.~ Doing too many things today. I wasn't thinking; this problem is solved.

```
Checking out "master"
Execute "npm run benchmark"

> fastify@0.35.2 benchmark /Users/jsumners/Projects/oss/fastify
> npx concurrently -k -s first "node ./examples/simple.js" "npx autocannon -c 100 -d 5 -p 10 localhost:3000/"

[0] server listening on 3000
[1] Running 5s test @ http://localhost:3000/
[1] 100 connections with 10 pipelining factor
[1]
[1] Stat         Avg    Stdev  Max
[1] Latency (ms) 74.81  228.41 1188
[1] Req/Sec      1241   322.8  1618
[1] Bytes/Sec    775 kB 203 kB 1.02 MB
[1]
[1] 6k requests in 5s, 3.88 MB read
[1] npx autocannon -c 100 -d 5 -p 10 localhost:3000/ exited with code 0
--> Sending SIGTERM to other processes..
[0] node ./examples/simple.js exited with code null
Executed: "npm run benchmark" and exited with code: 0
Execute "npm run benchmark"

> fastify@0.35.2 benchmark /Users/jsumners/Projects/oss/fastify
> npx concurrently -k -s first "node ./examples/simple.js" "npx autocannon -c 100 -d 5 -p 10 localhost:3000/"

[0] server listening on 3000
[1] Running 5s test @ http://localhost:3000/
[1] 100 connections with 10 pipelining factor
[1]
[1] Stat         Avg     Stdev  Max
[1] Latency (ms) 57.41   174.2  790
[1] Req/Sec      1667.6  236.13 2049
[1] Bytes/Sec    1.05 MB 147 kB 1.31 MB
[1]
[1] 8k requests in 5s, 5.22 MB read
[1] npx autocannon -c 100 -d 5 -p 10 localhost:3000/ exited with code 0
--> Sending SIGTERM to other processes..
[0] node ./examples/simple.js exited with code null
Executed: "npm run benchmark" and exited with code: 0
Checking out "redirect-onsend"
Execute "npm run benchmark"

> fastify@0.35.2 benchmark /Users/jsumners/Projects/oss/fastify
> npx concurrently -k -s first "node ./examples/simple.js" "npx autocannon -c 100 -d 5 -p 10 localhost:3000/"

[0] server listening on 3000
[1] Running 5s test @ http://localhost:3000/
[1] 100 connections with 10 pipelining factor
[1]
[1] Stat         Avg     Stdev  Max
[1] Latency (ms) 47.13   159.31 969
[1] Req/Sec      1881.8  768.31 3291
[1] Bytes/Sec    1.17 MB 482 kB 2.1 MB
[1]
[1] 9k requests in 5s, 5.89 MB read
[1] 1 errors (0 timeouts)
[1] npx autocannon -c 100 -d 5 -p 10 localhost:3000/ exited with code 0
--> Sending SIGTERM to other processes..
[0] node ./examples/simple.js exited with code null
Executed: "npm run benchmark" and exited with code: 0
Execute "npm run benchmark"

> fastify@0.35.2 benchmark /Users/jsumners/Projects/oss/fastify
> npx concurrently -k -s first "node ./examples/simple.js" "npx autocannon -c 100 -d 5 -p 10 localhost:3000/"

[0] server listening on 3000
[1] Running 5s test @ http://localhost:3000/
[1] 100 connections with 10 pipelining factor
[1]
[1] Stat         Avg     Stdev  Max
[1] Latency (ms) 45.68   155.81 913
[1] Req/Sec      1996    736.11 3039
[1] Bytes/Sec    1.26 MB 475 kB 1.97 MB
[1]
[1] 10k requests in 5s, 6.24 MB read
[1] npx autocannon -c 100 -d 5 -p 10 localhost:3000/ exited with code 0
--> Sending SIGTERM to other processes..
[0] node ./examples/simple.js exited with code null
Executed: "npm run benchmark" and exited with code: 0
Back to redirect-onsend 10489d4
```