### PR TITLE
Update pump to latest version.

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -70,7 +70,8 @@ Reply.prototype.send = function (payload) {
     if (!this.res.getHeader('Content-Type')) {
       this.res.setHeader('Content-Type', 'application/octet-stream')
     }
-    return pump(payload, this.res, wrapPumpCallback(this))
+    pump(payload, this.res, wrapPumpCallback(this))
+    return this.res
   }
 
   setImmediate(handleReplyEnd, this, payload)
@@ -165,7 +166,8 @@ function onSendEnd (reply, payload) {
     if (!reply.res.getHeader('Content-Type')) {
       reply.res.setHeader('Content-Type', 'application/octet-stream')
     }
-    return pump(payload, reply.res, wrapPumpCallback(reply))
+    pump(payload, reply.res, wrapPumpCallback(reply))
+    return reply.res
   }
 
   if (!reply.res.getHeader('Content-Type') || reply.res.getHeader('Content-Type') === 'application/json') {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "light-my-request": "^1.1.1",
     "middie": "^2.1.1",
     "pino": "^4.10.1",
-    "pump": "^1.0.3"
+    "pump": "^2.0.0"
   },
   "greenkeeper": {
     "ignore": [

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -57,12 +57,15 @@ test('onSend hook stream', t => {
   })
 
   fastify.addHook('onSend', (req, reply, payload, next) => {
+    const gzStream = zlib.createGzip()
+
     reply.header('Content-Encoding', 'gzip')
-    next(null, pump(
+    pump(
       fs.createReadStream(resolve(process.cwd() + '/test/stream.test.js'), 'utf8'),
-      zlib.createGzip(),
+      gzStream,
       t.error
-    ))
+    )
+    next(null, gzStream)
   })
 
   fastify.inject({


### PR DESCRIPTION
The updated version of pump no longer returns the last stream added to
the pipe.  Update fastify so values returned from functions are unchanged.

Completes #503.  Sorry if I did this wrong, should I do a pull request adding a commit to greenkeeper/pump-2.0.0 instead?