### PR TITLE
Fix #492

### DIFF
--- a/lib/ContentTypeParser.js
+++ b/lib/ContentTypeParser.js
@@ -27,7 +27,7 @@ ContentTypeParser.prototype.hasParser = function (contentType) {
 }
 
 ContentTypeParser.prototype.fastHasHeader = function (contentType) {
-  if (!contentType) return false
+  if (!contentType) return this.hasParser('')
 
   for (var i = 0; i < this.parserList.length; i++) {
     if (contentType.indexOf(this.parserList[i]) > -1) return true
@@ -36,6 +36,8 @@ ContentTypeParser.prototype.fastHasHeader = function (contentType) {
 }
 
 ContentTypeParser.prototype.getHandler = function (contentType) {
+  if (contentType === undefined) return this.customParsers['']
+
   for (var i = 0; i < this.parserList.length; i++) {
     if (contentType.indexOf(this.parserList[i]) > -1) {
       return this.customParsers[this.parserList[i]]

--- a/test/issue-492.test.js
+++ b/test/issue-492.test.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const t = require('tap')
+const sget = require('simple-get')
+const fs = require('fs')
+
+const test = t.test
+const Fastify = require('..')
+
+test('default 500', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.addContentTypeParser('*', function (req, done) {
+    var data = ''
+    req.on('data', chunk => { data += chunk })
+    req.on('end', () => {
+      done(data)
+    })
+  })
+
+  fastify.post('/', (req, res) => {
+    res.send(req.body)
+  })
+
+  fastify.listen(0, function (err) {
+    t.error(err)
+
+    const fileStream = fs.createReadStream(__filename)
+
+    sget({
+      method: 'POST',
+      url: 'http://localhost:' + fastify.server.address().port + '/',
+      body: fileStream
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+    })
+  })
+})


### PR DESCRIPTION
As titled

Should the '*' content type parser match a request without a content type?
Still now it doesn't. With this PR it does.
