### PR TITLE
Fix #520: Enable caching + reusing schemas across routes, support for $refs

### DIFF
--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -30,9 +30,9 @@ They need to be in
   `request` is defined in [Request](https://github.com/fastify/fastify/blob/master/docs/Request.md).
 
   `reply` is defined in [Reply](https://github.com/fastify/fastify/blob/master/docs/Reply.md).
-* `schemaResolver(key, allSchemas)`: passes in a custom schema resolver. See [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#sharing-schemas-cached-validation-serialization)
+* `schemaResolver(keyRef, allSchemas)`: passes in a custom schema resolver. See [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#sharing-schemas-cached-validation-serialization)
 
-  `key` is a string key referencing a schema.
+  `keyRef` is a string key referencing a schema.
 
   `allSchemas` is a dictionary of the schemas that have been added through `addSchema`.
 

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -29,6 +29,13 @@ They need to be in
   `request` is defined in [Request](https://github.com/fastify/fastify/blob/master/docs/Request.md).
 
   `reply` is defined in [Reply](https://github.com/fastify/fastify/blob/master/docs/Reply.md).
+* `schemaResolver(key, allSchemas)`: passes in a custom schema resolver. See [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#sharing-schemas-cached-validation-serialization)
+
+  `key` is a string key referencing a schema.
+
+  `allSchemas` is a dictionary of the schemas that have been added through `addSchema`.
+
+  The return value will be passed into `schemaCompiler`.
 
 
 Example:

--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -129,6 +129,18 @@ Fake http injection (for testing purposes) [here](https://github.com/fastify/fas
 #### setSchemaCompiler
 Set the schema compiler for all routes [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-compiler).
 
+<a name="set-schema-resolver"></a>
+#### setSchemaResolver
+Set the schema resolver for all routes. See documentation on referenced schemas [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#sharing-schemas-cached-validation-serialization).
+
+<a name="add-schema"></a>
+#### addSchema
+Adds a schema that can be referenced. See full documentation [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#sharing-schemas-cached-validation-serialization).
+
+<a name="get-schema"></a>
+#### getSchema
+Gets a cached validation function, resolving schemas as needed. See full documentation [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#sharing-schemas-cached-validation-serialization).
+
 <a name="set-not-found-handler"></a>
 #### setNotFoundHandler
 

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -82,6 +82,8 @@ In that case the function returned by `schemaCompiler` returns an object like:
 * `error`: filled with an instance of `Error` or a string that describes the validation error
 * `value`: the coerced value that passed the validation
 
+If you are using the same `schemaCompiler` for all endpoints, you can call `fastify.setSchemaCompiler` to set the default schema compiler.
+
 <a name="serialization"></a>
 ### Serialization
 Usually you will send your data to the clients via JSON, and Fastify has a powerful tool to help you, [fast-json-stringify](https://www.npmjs.com/package/fast-json-stringify), which is used if you have provided an output schema in the route options. We encourage you to use an output schema, as it will increase your throughput by 100-400% depending on your payload and will prevent accidental disclosure of sensitive information.
@@ -184,7 +186,20 @@ const schema = {
 }
 ```
 
-Additional examples are available [here](../examples/shared-schemas.js)
+Shared schemas are referenced by an id. This id comes from (in order of prefence):
+- an optional second argument passed into `addSchema`
+- the `$id` field on the schema, which is consistent with JSON Schema draft 6
+- the `id` field on the schema, which is consistent with JSON Schema draft 4
+
+When trying to resolve a reference, fastify will call `schemaResolver` with two arguments:
+- `keyRef`: the reference to the schema
+- `allSchemas`: the dictionary of all schemas added to the library
+
+This is expected to return the same output as a `schemaCompiler` would. If you want to use your own `schemaResolver` function, you can pass it in either on route options or through `setSchemaResolver`.
+
+Note that calls to `schemaResolver` are cached, so if two APIs ask for the same schema it is not going to be called twice.
+
+Additional examples are available [here](../examples/shared-schemas.js) and [here](../examples/shared-custom-schemas.js)
 
 <a name="resources"></a>
 ### Resources

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -124,6 +124,68 @@ const schema = {
 
 *If you need a custom serializer in a very specific part of your code, you can always set one with `reply.serializer(...)`.*
 
+
+<a name="sharing-schemas-cached-validation-serialization"></a>
+#### Sharing Schemas + Cached Validation/Serialization
+If you are re-using the same schemas in multiple places, or want to take advantage of JSON Schema's ability to reference external documents, you can alternatively add your schemas in one step and then reference them in your route options.
+
+For example, this:
+```js
+const schema = {
+  response: {
+    200: {
+      type: 'object',
+      properties: {
+        value: { type: 'string' },
+        otherValue: { type: 'boolean' }
+      }
+    },
+    '4xx': {
+      type: 'object',
+      properties: {
+        message: { type: 'string' },
+        code: { type: 'string' }
+      }
+    },
+    '5xx': {
+      type: 'object',
+      properties: {
+        message: { type: 'string' },
+        code: { type: 'string' }
+      }
+    }
+  }
+}
+```
+
+Becomes:
+```js
+fastify.addSchema({
+  $id: 'error',
+  type: 'object',
+  properties: {
+    message: { type: 'string' },
+    code: { type: 'string' }
+  }
+})
+
+const schema = {
+  response: {
+    200: {
+      type: 'object',
+      properties: {
+        value: { type: 'string' },
+        otherValue: { type: 'boolean' }
+      }
+    },
+    '4xx': 'error#',
+    '5xx': 'error#'
+  }
+}
+```
+
+Additional examples are available [here](../examples/shared-schemas.js)
+
 <a name="resources"></a>
 ### Resources
 - [JSON Schema](http://json-schema.org/)

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -126,7 +126,7 @@ const schema = {
 
 
 <a name="sharing-schemas-cached-validation-serialization"></a>
-#### Sharing Schemas + Cached Validation/Serialization
+#### Sharing Schemas and Cached Validation/Serialization
 If you are re-using the same schemas in multiple places, or want to take advantage of JSON Schema's ability to reference external documents, you can alternatively add your schemas in one step and then reference them in your route options.
 
 For example, this:

--- a/examples/shared-custom-schemas.js
+++ b/examples/shared-custom-schemas.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const fastify = require('../fastify')()
+
+const Joi = require('joi')
+
+const compile = schema => data => {
+  return Joi.validate(data, schema)
+}
+fastify.setSchemaCompiler(compile)
+fastify.setSchemaResolver((keyRef, allSchemas) => {
+  return allSchemas[keyRef]
+})
+
+fastify
+  .addSchema(
+    Joi.object().keys({
+      hello: Joi.string().required()
+    }).required(),
+    'hello-world'
+  )
+  .post('/the/url', { schema: { body: 'hello-world' } }, async function (req, reply) {
+    return req.body
+  })
+
+fastify.listen(3000, err => {
+  if (err) throw err
+  console.log(`server listening on ${fastify.server.address().port}`)
+})

--- a/examples/shared-schemas.js
+++ b/examples/shared-schemas.js
@@ -1,0 +1,108 @@
+'use strict'
+
+const fastify = require('../fastify')()
+
+fastify.addSchema({
+  $id: 'error',
+  type: 'object',
+  properties: {
+    message: { type: 'string' },
+    code: { type: 'string' }
+  }
+})
+
+fastify.addSchema({
+  $id: 'todo-item',
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    id: { type: 'string' }
+  }
+})
+
+const getInstanceOpts = {
+  schema: {
+    response: {
+      200: 'todo-item#',
+      '4xx': 'error#'
+    }
+  }
+}
+
+const postInstanceOpts = {
+  schema: {
+    body: 'todo-item#',
+    response: {
+      200: 'todo-item#',
+      '4xx': 'error#',
+      '5xx': 'error#'
+    }
+  }
+}
+
+const listInstanceOpts = {
+  schema: {
+    response: {
+      200: {
+        type: 'object',
+        properties: {
+          list: {
+            type: 'array',
+            items: {
+              $ref: 'todo-item#'
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+const cache = {
+  '1234': 'Do the dishes',
+  '4567': 'Clean the pantry',
+  '8901': 'Do laundry'
+}
+
+fastify
+  .get('/', listInstanceOpts, async function (req, reply) {
+    const list = Object.keys(cache).map(id => ({
+      id,
+      name: cache[id]
+    }))
+    return { list }
+  })
+  .get('/:id', getInstanceOpts, async function (req, reply) {
+    if (cache[req.params.id]) {
+      return {
+        id: req.params.id,
+        name: cache[req.params.id]
+      }
+    } else {
+      reply.code(404).send({
+        message: 'Instance not found',
+        code: 'CACHE-MISSING-KEY'
+      })
+    }
+  })
+  .post('/', postInstanceOpts, async function (req, reply) {
+    if (cache[req.body.id]) {
+      reply.code(400).send({
+        message: 'Instance already exists',
+        code: 'CACHE-HAS-KEY'
+      })
+    } else if (req.body.id[0] === '1') {
+      reply.code(500).send({
+        message: 'Something went wrong',
+        code: 'STARTED-WITH-1'
+      })
+    } else {
+      cache[req.body.id] = req.body.name
+      return req.body
+    }
+  })
+
+fastify.listen(3000, err => {
+  if (err) throw err
+  console.log(`server listening on ${fastify.server.address().port}`)
+})

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -1,11 +1,13 @@
 
 /// <reference types="node" />
 /// <reference types="pino" />
+/// <reference types="ajv" />
 
 import * as http from 'http';
 import * as http2 from 'http2';
 import * as https from 'https';
 import * as pino from 'pino';
+import * as Ajv from 'ajv';
 
 declare function fastify<HttpServer, HttpRequest, HttpResponse>(opts?: fastify.ServerOptions): fastify.FastifyInstance<HttpServer, HttpRequest, HttpResponse>;
 declare function fastify(opts?: fastify.ServerOptionsAsHttp): fastify.FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>;
@@ -60,6 +62,7 @@ declare namespace fastify {
 
   interface ServerOptions {
     logger?: pino.LoggerOptions,
+    ajv?: Ajv.Options
   }
   interface ServerOptionsAsSecure extends ServerOptions {
     https: {
@@ -76,14 +79,16 @@ declare namespace fastify {
   }
   interface ServerOptionsAsSecureHttp2 extends ServerOptionsAsHttp2, ServerOptionsAsSecure {}
 
+  // TODO - define/import JSONSchema types
+  type JSONSchemaInstance = Object
+
   interface JSONSchema {
-    // TODO - define/import JSONSchema types
-    body?: Object
-    querystring?: Object
-    params?: Object
+    body?: JSONSchemaInstance
+    querystring?: JSONSchemaInstance
+    params?: JSONSchemaInstance
     response?: {
-      [code: number]: Object,
-      [code: string]: Object
+      [code: number]: JSONSchemaInstance,
+      [code: string]: JSONSchemaInstance
     }
   }
 
@@ -340,6 +345,31 @@ declare namespace fastify {
      * Set a function that will be called whenever an error happens
      */
     setErrorHandler(handler: (error: Error, reply: FastifyReply<HttpResponse>) => void): void
+
+    /**
+     * Adds a schema
+     */
+    addSchema(schema: JSONSchemaInstance, keyRef?: string): void
+
+    /**
+     * Gets a function to validate using a saved schema
+     */
+    getSchema(keyRef: string): Ajv.ValidateFunction
+
+    /**
+     * Validates an object using a saved schema - errors are inaccessible
+     */
+    validate(keyRef: string, payload: Object): boolean
+
+    /**
+     * Gets a function to stringify an object using a saved schema
+     */
+    getStringify(keyRef: string): (payload: Object) => string
+
+    /**
+     * Stringifies an object using a saved schema
+     */
+    stringify(keyRef: string, payload: Object): string
   }
 }
 

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -81,16 +81,14 @@ declare namespace fastify {
   }
   interface ServerOptionsAsSecureHttp2 extends ServerOptionsAsHttp2, ServerOptionsAsSecure {}
 
-  // TODO - define/import JSONSchema types
-  type JSONSchemaInstance = Object
-
   interface JSONSchema {
-    body?: JSONSchemaInstance
-    querystring?: JSONSchemaInstance
-    params?: JSONSchemaInstance
+    // TODO - define/import JSONSchema types
+    body?: Object
+    querystring?: Object
+    params?: Object
     response?: {
-      [code: number]: JSONSchemaInstance,
-      [code: string]: JSONSchemaInstance
+      [code: number]: Object,
+      [code: string]: Object
     }
   }
 
@@ -362,27 +360,12 @@ declare namespace fastify {
     /**
      * Adds a schema
      */
-    addSchema(schema: JSONSchemaInstance, keyRef?: string): void
+    addSchema(schema: Object, keyRef?: string): void
 
     /**
      * Gets a function to validate using a saved schema
      */
     getSchema(keyRef: string): ValidateFunction
-
-    /**
-     * Validates an object using a saved schema - errors are inaccessible
-     */
-    validate(keyRef: string, payload: Object): boolean
-
-    /**
-     * Gets a function to stringify an object using a saved schema
-     */
-    getStringify(keyRef: string): (payload: Object) => string
-
-    /**
-     * Stringifies an object using a saved schema
-     */
-    stringify(keyRef: string, payload: Object): string
   }
 }
 

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -1,13 +1,11 @@
 
 /// <reference types="node" />
 /// <reference types="pino" />
-/// <reference types="ajv" />
 
 import * as http from 'http';
 import * as http2 from 'http2';
 import * as https from 'https';
 import * as pino from 'pino';
-import * as Ajv from 'ajv';
 
 declare function fastify<HttpServer, HttpRequest, HttpResponse>(opts?: fastify.ServerOptions): fastify.FastifyInstance<HttpServer, HttpRequest, HttpResponse>;
 declare function fastify(opts?: fastify.ServerOptionsAsHttp): fastify.FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>;
@@ -26,6 +24,10 @@ declare namespace fastify {
   type FastifyMiddleware<HttpRequest, HttpResponse> = (req: FastifyRequest<HttpRequest>, reply: FastifyReply<HttpResponse>, done: (err?: Error) => void) => void
 
   type RequestHandler<HttpRequest, HttpResponse> = (req: FastifyRequest<HttpRequest>, res: FastifyReply<HttpResponse>) => void
+
+  type ValidateFunction = (data: Object) => boolean
+
+  type SchemaResolver = (keyRef: string, allSchemas: { [key: string]: Object }) => ValidateFunction | Object
 
   /**
    * fastify's wrapped version of node.js IncomingMessage
@@ -62,7 +64,7 @@ declare namespace fastify {
 
   interface ServerOptions {
     logger?: pino.LoggerOptions,
-    ajv?: Ajv.Options
+    ajv?: Object
   }
   interface ServerOptionsAsSecure extends ServerOptions {
     https: {
@@ -347,6 +349,11 @@ declare namespace fastify {
     setErrorHandler(handler: (error: Error, reply: FastifyReply<HttpResponse>) => void): void
 
     /**
+     * Sets a resolver to use when trying to resolve schemas
+     */
+    setSchemaResolver(resolver: SchemaResolver): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+
+    /**
      * Adds a schema
      */
     addSchema(schema: JSONSchemaInstance, keyRef?: string): void
@@ -354,7 +361,7 @@ declare namespace fastify {
     /**
      * Gets a function to validate using a saved schema
      */
-    getSchema(keyRef: string): Ajv.ValidateFunction
+    getSchema(keyRef: string): ValidateFunction
 
     /**
      * Validates an object using a saved schema - errors are inaccessible

--- a/fastify.js
+++ b/fastify.js
@@ -95,6 +95,7 @@ function build (options) {
   const allSchemas = {}
   const ajvContext = { ajv }
   const defaultSchemaResolver = schemaCompiler.bind(ajvContext, null)
+  const resolveStringifier = createMapCache(createStringifier)
 
   // shorthand methods
   fastify.delete = _delete
@@ -150,7 +151,6 @@ function build (options) {
   // schema methods
   fastify.addSchema = addSchema
   fastify.getSchema = createMapCache(getSchema)
-  fastify.resolveStringifier = createMapCache(createStringifier)
 
   // exposes the routes map
   fastify[Symbol.iterator] = iterator
@@ -436,7 +436,7 @@ function build (options) {
         opts.schemaCompiler || _fastify._schemaCompiler,
         // using the getSchema to re-use the cache created for that
         opts.schemaResolver || _fastify.getSchema,
-        _fastify.resolveStringify,
+        resolveStringifier,
         allSchemas
       )
 

--- a/fastify.js
+++ b/fastify.js
@@ -664,9 +664,9 @@ function build (options) {
   }
 
   function getStringify (keyRef) {
-    const { schema, root } = ajv.getSchema(keyRef)
+    const schema = ajv.getSchema(keyRef)
 
-    return getSchemaStringify(keyRef, schema, root)
+    return getSchemaStringify(keyRef, schema.schema, schema.root)
   }
 
   function stringify (keyRef, payload) {

--- a/fastify.js
+++ b/fastify.js
@@ -17,7 +17,7 @@ const buildSchema = require('./lib/validation').build
 const handleRequest = require('./lib/handleRequest')
 const isValidLogger = require('./lib/validation').isValidLogger
 const schemaCompiler = require('./lib/validation').schemaCompiler
-const getSchemaStringify = require('./lib/validation').getCachedStringify
+const createStringifier = require('./lib/validation').createStringifier
 const createMapCache = require('./lib/mapCache')
 const decorator = require('./lib/decorate')
 const ContentTypeParser = require('./lib/ContentTypeParser')
@@ -150,9 +150,7 @@ function build (options) {
   // schema methods
   fastify.addSchema = addSchema
   fastify.getSchema = createMapCache(getSchema)
-  fastify.validate = validate
-  fastify.getStringify = getStringify
-  fastify.stringify = stringify
+  fastify.resolveStringifier = createMapCache(createStringifier)
 
   // exposes the routes map
   fastify[Symbol.iterator] = iterator
@@ -438,6 +436,7 @@ function build (options) {
         opts.schemaCompiler || _fastify._schemaCompiler,
         // using the getSchema to re-use the cache created for that
         opts.schemaResolver || _fastify.getSchema,
+        _fastify.resolveStringify,
         allSchemas
       )
 
@@ -687,20 +686,6 @@ function build (options) {
 
   function getSchema (keyRef) {
     return fastify._schemaResolver(keyRef, allSchemas)
-  }
-
-  function validate (keyRef, payload) {
-    return this.getSchema(keyRef)(payload)
-  }
-
-  function getStringify (keyRef) {
-    const schema = this.getSchema(keyRef)
-
-    return getSchemaStringify(keyRef, schema.schema, schema.root)
-  }
-
-  function stringify (keyRef, payload) {
-    return this.getStringify(keyRef)(payload)
   }
 }
 

--- a/fastify.js
+++ b/fastify.js
@@ -423,7 +423,7 @@ function build (options) {
         opts.middie || _fastify._middie
       )
 
-      buildSchema(context, opts.schemaCompiler || _fastify._schemaCompiler, getSchema)
+      buildSchema(context, opts.schemaCompiler || _fastify._schemaCompiler)
 
       const onRequest = opts.onRequest || _fastify._hooks.onRequest
       const onResponse = opts.onResponse || _fastify._hooks.onResponse

--- a/fastify.js
+++ b/fastify.js
@@ -390,7 +390,8 @@ function build (options) {
       config: options.config,
       middie: self._middie,
       errorHandler: self._errorHandler,
-      schemaCompiler: options.schemaCompiler
+      schemaCompiler: options.schemaCompiler,
+      schemaResolver: options.schemaResolver
     })
   }
 

--- a/fastify.js
+++ b/fastify.js
@@ -17,7 +17,7 @@ const buildSchema = require('./lib/validation').build
 const handleRequest = require('./lib/handleRequest')
 const isValidLogger = require('./lib/validation').isValidLogger
 const schemaCompiler = require('./lib/validation').schemaCompiler
-const getSchemaStringify = require('./lib/validation').getStringify
+const getSchemaStringify = require('./lib/validation').getCachedStringify
 const addSchema = require('./lib/validation').addSchema
 const decorator = require('./lib/decorate')
 const ContentTypeParser = require('./lib/ContentTypeParser')
@@ -666,7 +666,7 @@ function build (options) {
   function getStringify (keyRef) {
     const { schema, root } = ajv.getSchema(keyRef)
 
-    return getSchemaStringify(schema, root, keyRef)
+    return getSchemaStringify(keyRef, schema, root)
   }
 
   function stringify (keyRef, payload) {

--- a/lib/mapCache.js
+++ b/lib/mapCache.js
@@ -1,0 +1,16 @@
+'use strict'
+
+module.exports = function createMapCache (fetch, fallback) {
+  const cache = new Map()
+
+  return function get (id) {
+    if (id) {
+      if (!cache.has(id)) {
+        cache.set(id, fetch.apply(null, arguments))
+      }
+      return cache.get(id)
+    } else {
+      return (fallback || fetch).apply(null, arguments)
+    }
+  }
+}

--- a/lib/mapCache.js
+++ b/lib/mapCache.js
@@ -1,16 +1,40 @@
 'use strict'
 
-module.exports = function createMapCache (fetch, fallback) {
+/**
+ * Map caches are used to store schemas and stringifiers for re-use. They take a
+ * function and return a function with the same signature, but anytime the first
+ * parameter matches one that has already been called, it returns the previous
+ * call.
+ *
+ * For example:
+ *
+ * let calls = 0;
+ * const cache = createMapCache(function (id, increment) {
+ *   calls = calls + increment;
+ *   return calls;
+ * })
+ *
+ * cache.get('a', 1) // returns 1 - the function was called with ('a', 1)
+ * cache.get('a', 2) // returns 1 - the cached value was used
+ * cache.get('b', 3) // returns 4 - the function was called with ('b', 3)
+ *
+ * They should only be read from during bootstrapping.
+ */
+module.exports = function createMapCache (fetch) {
   const cache = new Map()
 
   return function get (id) {
+    // copying arguments over to an array to avoid a performance cliff in Node 4 and 6
+    var args = new Array(arguments.length)
+    for (var i = 0; i < args.length; i++) { args[i] = arguments[i] }
+
     if (id) {
       if (!cache.has(id)) {
-        cache.set(id, fetch.apply(null, arguments))
+        cache.set(id, fetch.apply(null, args))
       }
       return cache.get(id)
     } else {
-      return (fallback || fetch).apply(null, arguments)
+      return fetch.apply(null, args)
     }
   }
 }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -35,51 +35,51 @@ function marshalSchema (potential, getSchema) {
   }
 }
 
-function getResponseSchema (responseSchemaDefinition, getSchema) {
+function getResponseSchema (responseSchemaDefinition, compile) {
   var statusCodes = Object.keys(responseSchemaDefinition)
   return statusCodes.reduce(function (r, statusCode) {
-    r[statusCode] = marshalSchema(responseSchemaDefinition[statusCode], getSchema)
+    r[statusCode] = marshalSchema(responseSchemaDefinition[statusCode], compile)
     return r
   }, {})
 }
 
-function getSchemaAnyway (schema, getSchema) {
-  if (typeof schema === 'object' && (!schema.type || !schema.properties)) {
-    return {
+function getSchemaAnyway (schema, compile, allowInline) {
+  if (typeof schema === 'object' && (!schema.type || !schema.properties) && allowInline) {
+    return compile({
       type: 'object',
       properties: schema
-    }
+    })
   } else if (typeof schema === 'string') {
-    return getSchema(null, schema).schema
+    return compile(null, schema)
   }
-  return schema
+  return compile(schema)
 }
 
-function build (opts, compile, getSchema) {
+function build (opts, compile) {
   if (!opts.schema) {
     return
   }
 
   if (opts.schema.headers) {
     // headers will always be an object, allow schema def to skip this
-    opts[headersSchema] = compile(getSchemaAnyway(opts.schema.headers, getSchema))
+    opts[headersSchema] = getSchemaAnyway(opts.schema.headers, compile, true)
   }
 
   if (opts.schema.response) {
-    opts[responseSchema] = getResponseSchema(opts.schema.response, compile, getSchema)
+    opts[responseSchema] = getResponseSchema(opts.schema.response, compile)
   }
 
   if (opts.schema.body) {
-    opts[bodySchema] = compile(opts.schema.body)
+    opts[bodySchema] = getSchemaAnyway(opts.schema.body, compile)
   }
 
   if (opts.schema.querystring) {
     // querystring will always be an object, allow schema def to skip this
-    opts[querystringSchema] = compile(getSchemaAnyway(opts.schema.querystring, getSchema))
+    opts[querystringSchema] = getSchemaAnyway(opts.schema.querystring, compile, true)
   }
 
   if (opts.schema.params) {
-    opts[paramsSchema] = compile(opts.schema.params)
+    opts[paramsSchema] = getSchemaAnyway(opts.schema.params, compile)
   }
 }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -9,31 +9,80 @@ const responseSchema = Symbol('response-schema')
 const headersSchema = Symbol('headers-schema')
 
 const schemas = require('./schemas.json')
+
 const inputSchemaError = fastJsonStringify(schemas.inputSchemaError)
 
-function getValidatorForStatusCodeSchema (statusCodeDefinition) {
-  return fastJsonStringify(statusCodeDefinition)
+// This is not a map so that it can be passed directly into fastJsonStringify
+const allSchemas = {}
+const cachedValidators = new Map()
+const cachedStringifiers = new Map()
+
+// The or is to support both JSON Schema draft 4 and draft 6, with preference to 6
+function id (schema) {
+  return schema.$id || schema.id
 }
 
-function getResponseSchema (responseSchemaDefinition) {
+function getStringify (schema, root, keyRef) {
+  const schemaId =
+    typeof keyRef === 'string'
+      ? keyRef
+      : id(schema)
+
+  if (schemaId) {
+    if (!cachedStringifiers.has(schemaId)) {
+      let externalSchemas = allSchemas
+
+      if (root) {
+        externalSchemas = Object.assign(
+          {
+            [id(root.schema)]: root.schema
+          },
+          allSchemas
+        )
+      }
+
+      const stringify = fastJsonStringify(schema, { schema: externalSchemas })
+      cachedStringifiers.set(schemaId, stringify)
+    }
+    return cachedStringifiers.get(schemaId)
+  } else {
+    return fastJsonStringify(schema, { schema: allSchemas })
+  }
+}
+
+function marshalSchema (potential, getSchema) {
+  if (typeof potential === 'object') {
+    // If an object, it is the schema directly
+    return { schema: potential }
+  } else if (typeof potential === 'string') {
+    // If not an object, get the schema
+    return getSchema(null, potential)
+  }
+}
+
+function getResponseSchema (responseSchemaDefinition, getSchema) {
   var statusCodes = Object.keys(responseSchemaDefinition)
   return statusCodes.reduce(function (r, statusCode) {
-    r[statusCode] = getValidatorForStatusCodeSchema(responseSchemaDefinition[statusCode])
+    const configured = responseSchemaDefinition[statusCode]
+    let { schema, root } = marshalSchema(configured, getSchema)
+    r[statusCode] = getStringify(schema, root, configured)
     return r
   }, {})
 }
 
-function getSchemaAnyway (schema) {
-  if (!schema.type || !schema.properties) {
+function getSchemaAnyway (schema, getSchema) {
+  if (typeof schema === 'object' && (!schema.type || !schema.properties)) {
     return {
       type: 'object',
       properties: schema
     }
+  } else if (typeof schema === 'string') {
+    return getSchema(null, schema).schema
   }
   return schema
 }
 
-function build (opts, compile) {
+function build (opts, compile, getSchema) {
   if (!opts.schema) {
     return
   }
@@ -44,7 +93,7 @@ function build (opts, compile) {
   }
 
   if (opts.schema.response) {
-    opts[responseSchema] = getResponseSchema(opts.schema.response)
+    opts[responseSchema] = getResponseSchema(opts.schema.response, compile, getSchema)
   }
 
   if (opts.schema.body) {
@@ -108,9 +157,28 @@ function isValidLogger (logger) {
   return result
 }
 
-function schemaCompiler (schema) {
-  return this.ajv.compile(schema)
+function schemaCompiler (schema, keyRef) {
+  const schemaId = keyRef || id(schema)
+  if (schemaId) {
+    if (!cachedValidators.has(schemaId)) {
+      let validator
+      try {
+        validator = this.ajv.getSchema(schemaId)
+      } catch (err) {
+        validator = this.ajv.compile(schema)
+      }
+      cachedValidators.set(schemaId, validator)
+    }
+    return cachedValidators.get(schemaId)
+  } else {
+    return this.ajv.compile(schema)
+  }
 }
 
-module.exports = { build, validate, serialize, isValidLogger, schemaCompiler }
+function addSchema (schema) {
+  this.ajv.addSchema(schema)
+  allSchemas[id(schema)] = schema
+}
+
+module.exports = { build, validate, serialize, isValidLogger, schemaCompiler, getStringify, addSchema }
 module.exports.symbols = { bodySchema, querystringSchema, responseSchema, paramsSchema, headersSchema }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -9,63 +9,36 @@ const responseSchema = Symbol('response-schema')
 const headersSchema = Symbol('headers-schema')
 
 const schemas = require('./schemas.json')
+const createMapCache = require('./mapCache')
 
 const inputSchemaError = fastJsonStringify(schemas.inputSchemaError)
 
 // This is not a map so that it can be passed directly into fastJsonStringify
 const allSchemas = {}
-const cachedValidators = new Map()
-const cachedStringifiers = new Map()
+
+const getCachedStringify = createMapCache(createStringifier)
+const getCachedSchema = createMapCache(getOrCompileSchema, compileSchema)
 
 // The or is to support both JSON Schema draft 4 and draft 6, with preference to 6
 function id (schema) {
   return schema.$id || schema.id
 }
 
-function getStringify (schema, root, keyRef) {
-  const schemaId =
-    typeof keyRef === 'string'
-      ? keyRef
-      : id(schema)
-
-  if (schemaId) {
-    if (!cachedStringifiers.has(schemaId)) {
-      let externalSchemas = allSchemas
-
-      if (root) {
-        externalSchemas = Object.assign(
-          {
-            [id(root.schema)]: root.schema
-          },
-          allSchemas
-        )
-      }
-
-      const stringify = fastJsonStringify(schema, { schema: externalSchemas })
-      cachedStringifiers.set(schemaId, stringify)
-    }
-    return cachedStringifiers.get(schemaId)
-  } else {
-    return fastJsonStringify(schema, { schema: allSchemas })
-  }
-}
-
 function marshalSchema (potential, getSchema) {
-  if (typeof potential === 'object') {
+  if (typeof potential === 'object' && potential != null) {
     // If an object, it is the schema directly
-    return { schema: potential }
+    return getCachedStringify(null, potential)
   } else if (typeof potential === 'string') {
-    // If not an object, get the schema
-    return getSchema(null, potential)
+    // If not an object, get the schema, and use the potential as the keyRef
+    let { schema, root } = getSchema(null, potential)
+    return getCachedStringify(potential, schema, root)
   }
 }
 
 function getResponseSchema (responseSchemaDefinition, getSchema) {
   var statusCodes = Object.keys(responseSchemaDefinition)
   return statusCodes.reduce(function (r, statusCode) {
-    const configured = responseSchemaDefinition[statusCode]
-    let { schema, root } = marshalSchema(configured, getSchema)
-    r[statusCode] = getStringify(schema, root, configured)
+    r[statusCode] = marshalSchema(responseSchemaDefinition[statusCode], getSchema)
     return r
   }, {})
 }
@@ -89,7 +62,7 @@ function build (opts, compile, getSchema) {
 
   if (opts.schema.headers) {
     // headers will always be an object, allow schema def to skip this
-    opts[headersSchema] = compile(getSchemaAnyway(opts.schema.headers))
+    opts[headersSchema] = compile(getSchemaAnyway(opts.schema.headers, getSchema))
   }
 
   if (opts.schema.response) {
@@ -102,7 +75,7 @@ function build (opts, compile, getSchema) {
 
   if (opts.schema.querystring) {
     // querystring will always be an object, allow schema def to skip this
-    opts[querystringSchema] = compile(getSchemaAnyway(opts.schema.querystring))
+    opts[querystringSchema] = compile(getSchemaAnyway(opts.schema.querystring, getSchema))
   }
 
   if (opts.schema.params) {
@@ -159,20 +132,7 @@ function isValidLogger (logger) {
 
 function schemaCompiler (schema, keyRef) {
   const schemaId = keyRef || id(schema)
-  if (schemaId) {
-    if (!cachedValidators.has(schemaId)) {
-      let validator
-      try {
-        validator = this.ajv.getSchema(schemaId)
-      } catch (err) {
-        validator = this.ajv.compile(schema)
-      }
-      cachedValidators.set(schemaId, validator)
-    }
-    return cachedValidators.get(schemaId)
-  } else {
-    return this.ajv.compile(schema)
-  }
+  return getCachedSchema(schemaId, schema, this.ajv)
 }
 
 function addSchema (schema, keyRef) {
@@ -180,5 +140,34 @@ function addSchema (schema, keyRef) {
   allSchemas[keyRef || id(schema)] = schema
 }
 
-module.exports = { build, validate, serialize, isValidLogger, schemaCompiler, getStringify, addSchema }
+// skips the first argument of the id since it is not needed
+function createStringifier (_, schema, root) {
+  let externalSchemas = allSchemas
+
+  if (root) {
+    externalSchemas = Object.assign(
+      {
+        [id(root.schema)]: root.schema
+      },
+      allSchemas
+    )
+  }
+
+  return fastJsonStringify(schema, { schema: externalSchemas })
+}
+
+function getOrCompileSchema (keyRef, schema, ajv) {
+  try {
+    return ajv.getSchema(keyRef)
+  } catch (err) {
+    return ajv.compile(schema)
+  }
+}
+
+// skips the first argument of the id since it is not needed
+function compileSchema (_, schema, ajv) {
+  return ajv.compile(schema)
+}
+
+module.exports = { build, validate, serialize, isValidLogger, schemaCompiler, getCachedStringify, addSchema }
 module.exports.symbols = { bodySchema, querystringSchema, responseSchema, paramsSchema, headersSchema }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -13,9 +13,6 @@ const createMapCache = require('./mapCache')
 
 const inputSchemaError = fastJsonStringify(schemas.inputSchemaError)
 
-// This is not a map so that it can be passed directly into fastJsonStringify
-const allSchemas = {}
-
 const getCachedStringify = createMapCache(createStringifier)
 const getCachedSchema = createMapCache(getOrCompileSchema, compileSchema)
 
@@ -24,62 +21,75 @@ function id (schema) {
   return schema.$id || schema.id
 }
 
-function marshalSchema (potential, getSchema) {
+function marshalSchema (potential, compile, resolve, allSchemas) {
   if (typeof potential === 'object' && potential != null) {
     // If an object, it is the schema directly
-    return getCachedStringify(null, potential)
+    return getCachedStringify(null, potential, null, allSchemas)
   } else if (typeof potential === 'string') {
     // If not an object, get the schema, and use the potential as the keyRef
-    let schema = getSchema(null, potential)
-    return getCachedStringify(potential, schema.schema, schema.root)
+    let schema = resolve(potential, allSchemas)
+    return getCachedStringify(potential, schema.schema, schema.root, allSchemas)
   }
 }
 
-function getResponseSchema (responseSchemaDefinition, compile) {
+function marshalResolve (compile, resolver) {
+  return function (keyRef, allSchemas) {
+    const result = resolver(keyRef, allSchemas)
+    if (typeof result === 'function') {
+      return result
+    } else {
+      return compile(result)
+    }
+  }
+}
+
+function getResponseSchema (responseSchemaDefinition, compile, resolve, allSchemas) {
   var statusCodes = Object.keys(responseSchemaDefinition)
   return statusCodes.reduce(function (r, statusCode) {
-    r[statusCode] = marshalSchema(responseSchemaDefinition[statusCode], compile)
+    r[statusCode] = marshalSchema(responseSchemaDefinition[statusCode], compile, resolve, allSchemas)
     return r
   }, {})
 }
 
-function getSchemaAnyway (schema, compile, allowInline) {
+function getSchemaAnyway (schema, compile, resolve, allSchemas, allowInline) {
   if (typeof schema === 'object' && (!schema.type || !schema.properties) && allowInline) {
     return compile({
       type: 'object',
       properties: schema
     })
   } else if (typeof schema === 'string') {
-    return compile(null, schema)
+    return resolve(schema, allSchemas)
   }
   return compile(schema)
 }
 
-function build (opts, compile) {
+function build (opts, compile, resolver, allSchemas) {
+  const resolve = marshalResolve(compile, resolver)
+
   if (!opts.schema) {
     return
   }
 
   if (opts.schema.headers) {
     // headers will always be an object, allow schema def to skip this
-    opts[headersSchema] = getSchemaAnyway(opts.schema.headers, compile, true)
+    opts[headersSchema] = getSchemaAnyway(opts.schema.headers, compile, resolve, allSchemas, true)
   }
 
   if (opts.schema.response) {
-    opts[responseSchema] = getResponseSchema(opts.schema.response, compile)
+    opts[responseSchema] = getResponseSchema(opts.schema.response, compile, resolve, allSchemas)
   }
 
   if (opts.schema.body) {
-    opts[bodySchema] = getSchemaAnyway(opts.schema.body, compile)
+    opts[bodySchema] = getSchemaAnyway(opts.schema.body, compile, resolve, allSchemas)
   }
 
   if (opts.schema.querystring) {
     // querystring will always be an object, allow schema def to skip this
-    opts[querystringSchema] = getSchemaAnyway(opts.schema.querystring, compile, true)
+    opts[querystringSchema] = getSchemaAnyway(opts.schema.querystring, compile, resolve, allSchemas, true)
   }
 
   if (opts.schema.params) {
-    opts[paramsSchema] = getSchemaAnyway(opts.schema.params, compile)
+    opts[paramsSchema] = getSchemaAnyway(opts.schema.params, compile, resolve, allSchemas)
   }
 }
 
@@ -135,13 +145,8 @@ function schemaCompiler (schema, keyRef) {
   return getCachedSchema(schemaId, schema, this.ajv)
 }
 
-function addSchema (schema, keyRef) {
-  this.ajv.addSchema(schema, keyRef)
-  allSchemas[keyRef || id(schema)] = schema
-}
-
 // skips the first argument of the id since it is not needed
-function createStringifier (_, schema, root) {
+function createStringifier (_, schema, root, allSchemas) {
   let externalSchemas = allSchemas
 
   if (root) {
@@ -169,5 +174,5 @@ function compileSchema (_, schema, ajv) {
   return ajv.compile(schema)
 }
 
-module.exports = { build, validate, serialize, isValidLogger, schemaCompiler, getCachedStringify, addSchema }
+module.exports = { build, validate, serialize, isValidLogger, schemaCompiler, getCachedStringify }
 module.exports.symbols = { bodySchema, querystringSchema, responseSchema, paramsSchema, headersSchema }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -8,24 +8,19 @@ const paramsSchema = Symbol('params-schema')
 const responseSchema = Symbol('response-schema')
 const headersSchema = Symbol('headers-schema')
 
-const createMapCache = require('./mapCache')
-
-const getCachedStringify = createMapCache(createStringifier)
-const getCachedSchema = createMapCache(getOrCompileSchema, compileSchema)
-
 // The or is to support both JSON Schema draft 4 and draft 6, with preference to 6
 function id (schema) {
   return schema.$id || schema.id
 }
 
-function marshalSchema (potential, compile, resolve, allSchemas) {
+function marshalSchema (potential, compile, resolve, resolveStringify, allSchemas) {
   if (typeof potential === 'object' && potential != null) {
     // If an object, it is the schema directly
-    return getCachedStringify(null, potential, null, allSchemas)
+    return createStringifier(null, potential, null, allSchemas)
   } else if (typeof potential === 'string') {
     // If not an object, get the schema, and use the potential as the keyRef
     let schema = resolve(potential, allSchemas)
-    return getCachedStringify(potential, schema.schema, schema.root, allSchemas)
+    return createStringifier(potential, schema.schema, schema.root, allSchemas)
   }
 }
 
@@ -40,10 +35,10 @@ function marshalResolve (compile, resolver) {
   }
 }
 
-function getResponseSchema (responseSchemaDefinition, compile, resolve, allSchemas) {
+function getResponseSchema (responseSchemaDefinition, compile, resolve, resolveStringify, allSchemas) {
   var statusCodes = Object.keys(responseSchemaDefinition)
   return statusCodes.reduce(function (r, statusCode) {
-    r[statusCode] = marshalSchema(responseSchemaDefinition[statusCode], compile, resolve, allSchemas)
+    r[statusCode] = marshalSchema(responseSchemaDefinition[statusCode], compile, resolve, resolveStringify, allSchemas)
     return r
   }, {})
 }
@@ -60,7 +55,7 @@ function getSchemaAnyway (schema, compile, resolve, allSchemas, allowInline) {
   return compile(schema)
 }
 
-function build (opts, compile, resolver, allSchemas) {
+function build (opts, compile, resolver, resolveStringify, allSchemas) {
   const resolve = marshalResolve(compile, resolver)
 
   if (!opts.schema) {
@@ -73,7 +68,7 @@ function build (opts, compile, resolver, allSchemas) {
   }
 
   if (opts.schema.response) {
-    opts[responseSchema] = getResponseSchema(opts.schema.response, compile, resolve, allSchemas)
+    opts[responseSchema] = getResponseSchema(opts.schema.response, compile, resolve, resolveStringify, allSchemas)
   }
 
   if (opts.schema.body) {
@@ -139,10 +134,22 @@ function isValidLogger (logger) {
 
 function schemaCompiler (schema, keyRef) {
   const schemaId = keyRef || id(schema)
-  return getCachedSchema(schemaId, schema, this.ajv)
+  if (schemaId) {
+    const cachedSchema = this.ajv.getSchema(schemaId)
+
+    if (cachedSchema) {
+      return cachedSchema
+    }
+  }
+
+  return this.ajv.compile(schema)
 }
 
 // skips the first argument of the id since it is not needed
+// schema is the actual schema we're compiling
+// root is the root document the schema was found in
+// - if we reference #/definitions/test, this is #
+// allSchemas is a dictionary of all the schemas currently stored in the system
 function createStringifier (_, schema, root, allSchemas) {
   let externalSchemas = allSchemas
 
@@ -158,18 +165,5 @@ function createStringifier (_, schema, root, allSchemas) {
   return fastJsonStringify(schema, { schema: externalSchemas })
 }
 
-function getOrCompileSchema (keyRef, schema, ajv) {
-  try {
-    return ajv.getSchema(keyRef)
-  } catch (err) {
-    return ajv.compile(schema)
-  }
-}
-
-// skips the first argument of the id since it is not needed
-function compileSchema (_, schema, ajv) {
-  return ajv.compile(schema)
-}
-
-module.exports = { build, validate, serialize, isValidLogger, schemaCompiler, getCachedStringify }
+module.exports = { build, validate, serialize, isValidLogger, schemaCompiler, createStringifier }
 module.exports.symbols = { bodySchema, querystringSchema, responseSchema, paramsSchema, headersSchema }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -30,8 +30,8 @@ function marshalSchema (potential, getSchema) {
     return getCachedStringify(null, potential)
   } else if (typeof potential === 'string') {
     // If not an object, get the schema, and use the potential as the keyRef
-    let { schema, root } = getSchema(null, potential)
-    return getCachedStringify(potential, schema, root)
+    let schema = getSchema(null, potential)
+    return getCachedStringify(potential, schema.schema, schema.root)
   }
 }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -175,9 +175,9 @@ function schemaCompiler (schema, keyRef) {
   }
 }
 
-function addSchema (schema) {
-  this.ajv.addSchema(schema)
-  allSchemas[id(schema)] = schema
+function addSchema (schema, keyRef) {
+  this.ajv.addSchema(schema, keyRef)
+  allSchemas[keyRef || id(schema)] = schema
 }
 
 module.exports = { build, validate, serialize, isValidLogger, schemaCompiler, getStringify, addSchema }

--- a/test/output-validation.test.js
+++ b/test/output-validation.test.js
@@ -69,6 +69,19 @@ const referenceOpts = {
   }
 }
 
+const deepReferenceOpts = {
+  schema: {
+    response: {
+      200: {
+        type: 'object',
+        properties: {
+          obj: { $ref: 'defs#/definitions/200' }
+        }
+      }
+    }
+  }
+}
+
 test('shorthand - output string', t => {
   t.plan(1)
   try {
@@ -136,6 +149,18 @@ test('reference - 200', t => {
   try {
     fastify.get('/reference/200', referenceOpts, function (req, reply) {
       reply.code(200).send({ str: 'TEST' })
+    })
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+})
+
+test('deep reference - 200', t => {
+  t.plan(1)
+  try {
+    fastify.get('/reference/deep', deepReferenceOpts, function (req, reply) {
+      reply.code(200).send({ obj: { str: 'TEST' } })
     })
     t.pass()
   } catch (e) {
@@ -243,6 +268,18 @@ fastify.listen(0, err => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
       t.deepEqual(JSON.parse(body), { str: 'TEST' })
+    })
+  })
+
+  test('deep reference shorthand - 200', t => {
+    t.plan(3)
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port + '/reference/deep'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.deepEqual(JSON.parse(body), { obj: { str: 'TEST' } })
     })
   })
 

--- a/test/output-validation.test.js
+++ b/test/output-validation.test.js
@@ -29,7 +29,7 @@ const opts = {
 }
 
 fastify.addSchema({
-  $id: 'defs.json',
+  $id: 'defs',
   definitions: {
     error: {
       type: 'object',
@@ -46,13 +46,13 @@ fastify.addSchema({
     '4xx': {
       type: 'object',
       properties: {
-        err: { $ref: 'defs.json#/definitions/error' }
+        err: { $ref: 'defs#/definitions/error' }
       }
     },
     '5xx': {
       type: 'object',
       properties: {
-        err: { $ref: 'defs.json#/definitions/error' },
+        err: { $ref: 'defs#/definitions/error' },
         stack: { type: 'string' }
       }
     }
@@ -62,9 +62,9 @@ fastify.addSchema({
 const referenceOpts = {
   schema: {
     response: {
-      200: 'defs.json#/definitions/200',
-      '4xx': 'defs.json#/definitions/4xx',
-      '5xx': 'defs.json#/definitions/5xx'
+      200: 'defs#/definitions/200',
+      '4xx': 'defs#/definitions/4xx',
+      '5xx': 'defs#/definitions/5xx'
     }
   }
 }

--- a/test/schemas.test.js
+++ b/test/schemas.test.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('../fastify')
+
+test('fastify can add schemas and get cached schemas + stringifiers out', t => {
+  t.plan(6)
+  const fastify = Fastify()
+
+  fastify.addSchema({
+    id: 'defs.json',
+    definitions: {
+      ref: {
+        type: 'object',
+        properties: {
+          str: { type: 'string' }
+        }
+      }
+    }
+  })
+
+  const validate = fastify.getSchema('defs.json#/definitions/ref')
+  const stringify = fastify.getStringify('defs.json#/definitions/ref')
+
+  t.is(typeof validate, 'function')
+  t.is(typeof stringify, 'function')
+
+  const valid = validate({
+    str: 'test'
+  })
+
+  const payload = stringify({
+    str: 'test'
+  })
+
+  t.ok(valid)
+  t.is(payload, '{"str":"test"}')
+
+  const cachedValidate = fastify.getSchema('defs.json#/definitions/ref')
+  const cachedStringify = fastify.getStringify('defs.json#/definitions/ref')
+
+  t.ok(validate === cachedValidate)
+  t.ok(stringify === cachedStringify)
+})
+
+test('fastify schema shorthand uses correct schema', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.addSchema({
+    id: 'defs.json',
+    definitions: {
+      ref: {
+        type: 'object',
+        properties: {
+          str: { type: 'string' }
+        }
+      }
+    }
+  })
+
+  const valid = fastify.validate('defs.json#/definitions/ref', {
+    str: 'test'
+  })
+
+  const payload = fastify.stringify('defs.json#/definitions/ref', {
+    str: 'test'
+  })
+
+  t.ok(valid)
+  t.is(payload, '{"str":"test"}')
+})

--- a/test/schemas.test.js
+++ b/test/schemas.test.js
@@ -71,3 +71,24 @@ test('fastify schema shorthand uses correct schema', t => {
   t.ok(valid)
   t.is(payload, '{"str":"test"}')
 })
+
+test('fastify uses custom schemaResolver with cached results', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  const validator = function () {
+    return true
+  }
+
+  fastify.setSchemaResolver(function (keyRef, allSchemas) {
+    t.is(keyRef, 'reference')
+    t.deepEqual(allSchemas, { 'reference': { test: 'abcdef' } })
+    return validator
+  })
+
+  fastify.addSchema({ test: 'abcdef' }, 'reference')
+
+  const validate = fastify.getSchema('reference')
+  t.is(validate, validator)
+  t.is(validate, fastify.getSchema('reference'))
+})


### PR DESCRIPTION
This resolves #520, but still has a couple open discussion points:

1. Should the public API include `addSchema`, or should users go through `options.ajv.schemas` to seed it?
2. Should the public API include `addKeyword`?

Additionally, couple questions that came up during implementation:

1. ~Should this expose the AJV Typescript dependency?~ No, better to hide the AJV dependency if it changes later
2. ~Style note: what approach suits this codebase best around the reusable helper 'MapCache' that I've added? Should this be in the same file as the validator? Should it be a class? etc.~ Better to be a function. Will leave as is since it's now shared across a couple files.
3. ~How many versions back in Node should I run the tests? I tested it with `v8.0.0`~ Should be tested back to v4.5
4. Is it preferred to squash all the commits or leave them individually?

Feedback very welcome!