### PR TITLE
Update fastify.d.ts to include onSend hook

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -105,18 +105,20 @@ fastify.addHook('preHandler', (request, reply, next) => {
 
 Note that in the `'preHandler'` and `'onSend'` hook the request and reply objects are different from `'onRequest'`, because the two arguments are [`request`](https://github.com/fastify/fastify/blob/master/docs/Request.md) and [`reply`](https://github.com/fastify/fastify/blob/master/docs/Reply.md) core Fastify objects.
 
-If you are using the `onSend` hook you can update the payload, but not overwrite it, for example:
+If you are using the `onSend` hook you can update the payload, for example:
 ```js
-// this is valid
+
 fastify.addHook('onSend', (request, reply, payload, next) => {
+  var err = null;
   payload.hello = 'world'
-  next()
+  next(err, payload)
 })
 
-// this is not valid
+// Or
 fastify.addHook('onSend', (request, reply, payload, next) => {
-  payload = { hello: 'world' }
-  next()
+  var err = null;
+  var newPayload = payload.replace('some-text', 'some-new-text')
+  next(err, newPayload)
 })
 ```
 

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -311,6 +311,12 @@ declare namespace fastify {
     addHook(name: 'preHandler', hook: FastifyMiddleware<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
+     * Hook that is fired after a request is processed, but before the "onResponse"
+     * hook
+     */
+     addHook(name: 'onSend', hook: (req: FastifyRequest<HttpRequest>, reply: FastifyReply<HttpResponse>, payload: any, done: (err?: Error, value?: any) => void) => void): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    
+     /**
      * Hook that is called when a response is about to be sent to a client
      */
     addHook(name: 'onResponse', hook: (res: http.OutgoingMessage, next: (err?: Error) => void) => void): FastifyInstance<HttpServer, HttpRequest, HttpResponse>


### PR DESCRIPTION
From [docs](https://github.com/fastify/fastify/blob/master/docs/Hooks.md):

_If you are using the onSend hook you can update the payload, but not overwrite it, for example:_

_// this is valid_
```
fastify.addHook('onSend', (request, reply, payload, next) => {
  payload.hello = 'world'
  next()
})
```

_// this is not valid_
```
fastify.addHook('onSend', (request, reply, payload, next) => {
  payload = { hello: 'world' }
  next()
})
```
But how if payload is a primitive string? Sincerly I don't know any method to manipulate a string without to create a new one.

Reading the code [here](https://github.com/delvedor/fast-iterator/blob/master/index.js):

```
this._done = function (err, value) {
      if (err) {
        that.done.call(that.context, err, that.value)
        holder.release(that)
        return
      }
      if (value !== undefined) that.value = value
      that._next()
    }
```
this is the function that is handled by **next()** method.

You can see that it receives a _value_ argument that can replace the _value_ property of the instance.

So I expected the following code to work.:

```
app.addHook("onSend", (request, reply, payload, next) => {
  const newPayload = payload.replace('some-text', 'new-text'); 
   next(null ,newPayload);
});
```
but, oddly enough, the **error** arg takes on the payload value and the **value** arg is null.

Just out of curiosity I tried this:

`next.call( null, null, newPayload);`

and it works.



