### PR TITLE
Update ContentParser API

### DIFF
--- a/docs/ContentTypeParser.md
+++ b/docs/ContentTypeParser.md
@@ -9,8 +9,13 @@ As with the other APIs, `addContentTypeParser` is encapsulated in the scope in w
 ```js
 fastify.addContentTypeParser('application/jsoff', function (req, done) {
   jsoffParser(req, function (err, body) {
-    done(err || body)
+    done(err, body)
   })
+})
+// async also supported in Node versions >= 8.0.0
+fastify.addContentTypeParser('application/jsoff', async function (req) {
+  var res = await new Promise((resolve, reject) => resolve(req))
+  return res
 })
 ```
 
@@ -23,7 +28,7 @@ fastify.addContentTypeParser('*', function (req, done) {
   var data = ''
   req.on('data', chunk => { data += chunk })
   req.on('end', () => {
-    done(data)
+    done(null, data)
   })
 })
 ```

--- a/lib/ContentTypeParser.js
+++ b/lib/ContentTypeParser.js
@@ -46,12 +46,14 @@ ContentTypeParser.prototype.getHandler = function (contentType) {
 }
 
 ContentTypeParser.prototype.run = function (contentType, handler, context, params, req, res, query) {
-  this.getHandler(contentType)(req, done)
-
-  function done (body) {
-    if (body instanceof Error) {
+  var result = this.getHandler(contentType)(req, done)
+  if (result && typeof result.then === 'function') {
+    result.then(body => done(null, body)).catch(err => done(err, null))
+  }
+  function done (error, body) {
+    if (error) {
       const reply = new context.Reply(res, context, null)
-      return reply.send(body)
+      return reply.send(error)
     }
     handler(context, params, req, res, body, query)
   }

--- a/test/custom-parser-async.js
+++ b/test/custom-parser-async.js
@@ -1,0 +1,62 @@
+const t = require('tap')
+const test = t.test
+const sget = require('simple-get').concat
+const Fastify = require('..')
+
+test('contentTypeParser should add a custom async parser', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.post('/', (req, reply) => {
+    reply.send(req.body)
+  })
+
+  fastify.options('/', (req, reply) => {
+    reply.send(req.body)
+  })
+
+  fastify.addContentTypeParser('application/jsoff', async function (req) {
+    var res = await new Promise((resolve, reject) => resolve(req))
+    return res
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    t.tearDown(() => fastify.close())
+
+    t.test('in POST', t => {
+      t.plan(3)
+
+      sget({
+        method: 'POST',
+        url: 'http://localhost:' + fastify.server.address().port,
+        body: '{"hello":"world"}',
+        headers: {
+          'Content-Type': 'application/jsoff'
+        }
+      }, (err, response, body) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 200)
+        t.deepEqual(body.toString(), JSON.stringify({ hello: 'world' }))
+      })
+    })
+
+    t.test('in OPTIONS', t => {
+      t.plan(3)
+
+      sget({
+        method: 'OPTIONS',
+        url: 'http://localhost:' + fastify.server.address().port,
+        body: '{"hello":"world"}',
+        headers: {
+          'Content-Type': 'application/jsoff'
+        }
+      }, (err, response, body) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 200)
+        t.deepEqual(body.toString(), JSON.stringify({ hello: 'world' }))
+      })
+    })
+  })
+})

--- a/test/custom-parser.test.js
+++ b/test/custom-parser.test.js
@@ -3,10 +3,13 @@
 const fs = require('fs')
 const t = require('tap')
 const test = t.test
+const semver = require('semver')
 const sget = require('simple-get').concat
 const Fastify = require('..')
 const jsonParser = require('fast-json-body')
-
+if (semver.gt(process.versions.node, '8.0.0')) {
+  require('./custom-parser-async')
+}
 test('contentTypeParser method should exist', t => {
   t.plan(1)
   const fastify = Fastify()
@@ -27,8 +30,7 @@ test('contentTypeParser should add a custom parser', t => {
 
   fastify.addContentTypeParser('application/jsoff', function (req, done) {
     jsonParser(req, function (err, body) {
-      if (err) return done(err)
-      done(body)
+      done(err, body)
     })
   })
 
@@ -87,8 +89,7 @@ test('contentTypeParser should handle multiple custom parsers', t => {
 
   function customParser (req, done) {
     jsonParser(req, function (err, body) {
-      if (err) return done(err)
-      done(body)
+      done(err, body)
     })
   }
 
@@ -136,7 +137,7 @@ test('contentTypeParser should handle errors', t => {
   })
 
   fastify.addContentTypeParser('application/jsoff', function (req, done) {
-    done(new Error('kaboom!'))
+    done(new Error('kaboom!'), {})
   })
 
   fastify.listen(0, err => {
@@ -193,8 +194,7 @@ test('contentTypeParser should support encapsulation, second try', t => {
 
     instance.addContentTypeParser('application/jsoff', function (req, done) {
       jsonParser(req, function (err, body) {
-        if (err) return done(err)
-        done(body)
+        done(err, body)
       })
     })
 
@@ -230,8 +230,7 @@ test('contentTypeParser shouldn\'t support request with undefined "Content-Type"
 
   fastify.addContentTypeParser('application/jsoff', function (req, done) {
     jsonParser(req, function (err, body) {
-      if (err) return done(err)
-      done(body)
+      done(err, body)
     })
   })
 
@@ -301,7 +300,7 @@ test('catch all content type parser', t => {
     var data = ''
     req.on('data', chunk => { data += chunk })
     req.on('end', () => {
-      done(data)
+      done(null, data)
     })
   })
 
@@ -349,14 +348,13 @@ test('catch all content type parser should not interfere with other conte type p
     var data = ''
     req.on('data', chunk => { data += chunk })
     req.on('end', () => {
-      done(data)
+      done(null, data)
     })
   })
 
   fastify.addContentTypeParser('application/jsoff', function (req, done) {
     jsonParser(req, function (err, body) {
-      if (err) return done(err)
-      done(body)
+      done(err, body)
     })
   })
 
@@ -404,7 +402,7 @@ test('\'*\' catch undefined Content-Type requests', t => {
     var data = ''
     req.on('data', chunk => { data += chunk })
     req.on('end', () => {
-      done(data)
+      done(null, data)
     })
   })
 


### PR DESCRIPTION
Ref #525 
Need to update the ContentParser `done()` method. Originally it only took one argument `body`. Split into `error, data`, then promisify the method.
- [x] Split body parameter into error, data in done() method
- [x] Promisify API
- [x] Add test for async case
- [x] Update docs
- [x] Update docs again with async changes