### PR TITLE
Fix 540

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -162,15 +162,18 @@ function wrapOnSendEnd (err, payload) {
 }
 
 function onSendEnd (reply, payload) {
+  var contentType = reply.res.getHeader('Content-Type')
   if (payload && payload._readableState) {
-    if (!reply.res.getHeader('Content-Type')) {
+    if (!contentType) {
       reply.res.setHeader('Content-Type', 'application/octet-stream')
     }
     pump(payload, reply.res, wrapPumpCallback(reply))
     return reply.res
   }
 
-  if (!reply.res.getHeader('Content-Type') || reply.res.getHeader('Content-Type') === 'application/json') {
+  if (!contentType && typeof payload === 'string') {
+    reply.res.setHeader('Content-Type', 'text/plain')
+  } else if (!contentType || contentType === 'application/json') {
     reply.res.setHeader('Content-Type', 'application/json')
     // Here we are assuming that the custom serializer is a json serializer
     payload = reply._serializer ? reply._serializer(payload) : serialize(reply.context, payload, reply.res.statusCode)

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -72,12 +72,12 @@ test('customized 404', t => {
       sget({
         method: 'PUT',
         url: 'http://localhost:' + fastify.server.address().port,
-        body: {},
-        json: true
+        body: JSON.stringify({ hello: 'world' }),
+        headers: { 'Content-Type': 'application/json' }
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
-        t.strictEqual(body, 'this was not found')
+        t.strictEqual(body.toString(), 'this was not found')
       })
     })
 
@@ -85,13 +85,11 @@ test('customized 404', t => {
       t.plan(3)
       sget({
         method: 'GET',
-        url: 'http://localhost:' + fastify.server.address().port + '/notSupported',
-        body: {},
-        json: true
+        url: 'http://localhost:' + fastify.server.address().port + '/notSupported'
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
-        t.strictEqual(body, 'this was not found')
+        t.strictEqual(body.toString(), 'this was not found')
       })
     })
   })
@@ -135,12 +133,12 @@ test('encapsulated 404', t => {
       sget({
         method: 'PUT',
         url: 'http://localhost:' + fastify.server.address().port,
-        body: {},
-        json: true
+        body: JSON.stringify({ hello: 'world' }),
+        headers: { 'Content-Type': 'application/json' }
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
-        t.strictEqual(body, 'this was not found')
+        t.strictEqual(body.toString(), 'this was not found')
       })
     })
 
@@ -148,13 +146,11 @@ test('encapsulated 404', t => {
       t.plan(3)
       sget({
         method: 'GET',
-        url: 'http://localhost:' + fastify.server.address().port + '/notSupported',
-        body: {},
-        json: true
+        url: 'http://localhost:' + fastify.server.address().port + '/notSupported'
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
-        t.strictEqual(body, 'this was not found')
+        t.strictEqual(body.toString(), 'this was not found')
       })
     })
 
@@ -163,12 +159,12 @@ test('encapsulated 404', t => {
       sget({
         method: 'PUT',
         url: 'http://localhost:' + fastify.server.address().port + '/test',
-        body: {},
-        json: true
+        body: JSON.stringify({ hello: 'world' }),
+        headers: { 'Content-Type': 'application/json' }
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
-        t.strictEqual(body, 'this was not found 2')
+        t.strictEqual(body.toString(), 'this was not found 2')
       })
     })
 
@@ -176,13 +172,11 @@ test('encapsulated 404', t => {
       t.plan(3)
       sget({
         method: 'GET',
-        url: 'http://localhost:' + fastify.server.address().port + '/test/notSupported',
-        body: {},
-        json: true
+        url: 'http://localhost:' + fastify.server.address().port + '/test/notSupported'
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
-        t.strictEqual(body, 'this was not found 2')
+        t.strictEqual(body.toString(), 'this was not found 2')
       })
     })
 
@@ -191,12 +185,12 @@ test('encapsulated 404', t => {
       sget({
         method: 'PUT',
         url: 'http://localhost:' + fastify.server.address().port + '/test2',
-        body: {},
-        json: true
+        body: JSON.stringify({ hello: 'world' }),
+        headers: { 'Content-Type': 'application/json' }
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
-        t.strictEqual(body, 'this was not found 3')
+        t.strictEqual(body.toString(), 'this was not found 3')
       })
     })
 
@@ -204,13 +198,11 @@ test('encapsulated 404', t => {
       t.plan(3)
       sget({
         method: 'GET',
-        url: 'http://localhost:' + fastify.server.address().port + '/test2/notSupported',
-        body: {},
-        json: true
+        url: 'http://localhost:' + fastify.server.address().port + '/test2/notSupported'
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
-        t.strictEqual(body, 'this was not found 3')
+        t.strictEqual(body.toString(), 'this was not found 3')
       })
     })
   })
@@ -243,8 +235,8 @@ test('run hooks on default 404', t => {
     sget({
       method: 'PUT',
       url: 'http://localhost:' + fastify.server.address().port,
-      body: {},
-      json: true
+      body: JSON.stringify({ hello: 'world' }),
+      headers: { 'Content-Type': 'application/json' }
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 404)
@@ -292,8 +284,8 @@ test('run hooks with encapsulated 404', t => {
     sget({
       method: 'PUT',
       url: 'http://localhost:' + fastify.server.address().port + '/test',
-      body: {},
-      json: true
+      body: JSON.stringify({ hello: 'world' }),
+      headers: { 'Content-Type': 'application/json' }
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 404)
@@ -323,8 +315,8 @@ test('run middlewares on default 404', t => {
     sget({
       method: 'PUT',
       url: 'http://localhost:' + fastify.server.address().port,
-      body: {},
-      json: true
+      body: JSON.stringify({ hello: 'world' }),
+      headers: { 'Content-Type': 'application/json' }
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 404)
@@ -363,8 +355,8 @@ test('run middlewares with encapsulated 404', t => {
     sget({
       method: 'PUT',
       url: 'http://localhost:' + fastify.server.address().port + '/test',
-      body: {},
-      json: true
+      body: JSON.stringify({ hello: 'world' }),
+      headers: { 'Content-Type': 'application/json' }
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 404)
@@ -403,8 +395,8 @@ test('hooks check 404', t => {
     sget({
       method: 'PUT',
       url: 'http://localhost:' + fastify.server.address().port + '?foo=asd',
-      body: {},
-      json: true
+      body: JSON.stringify({ hello: 'world' }),
+      headers: { 'Content-Type': 'application/json' }
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 404)
@@ -412,9 +404,7 @@ test('hooks check 404', t => {
 
     sget({
       method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port + '/notSupported?foo=asd',
-      body: {},
-      json: true
+      url: 'http://localhost:' + fastify.server.address().port + '/notSupported?foo=asd'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 404)

--- a/test/custom-parser.test.js
+++ b/test/custom-parser.test.js
@@ -318,7 +318,7 @@ test('catch all content type parser', t => {
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
-      t.deepEqual(body.toString(), '"hello"')
+      t.deepEqual(body.toString(), 'hello')
 
       sget({
         method: 'POST',
@@ -330,7 +330,7 @@ test('catch all content type parser', t => {
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
-        t.deepEqual(body.toString(), '"hello"')
+        t.deepEqual(body.toString(), 'hello')
         fastify.close()
       })
     })
@@ -385,7 +385,7 @@ test('catch all content type parser should not interfere with other conte type p
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
-        t.deepEqual(body.toString(), '"hello"')
+        t.deepEqual(body.toString(), 'hello')
         fastify.close()
       })
     })

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -383,7 +383,7 @@ test('nested plugins', t => {
       url: 'http://localhost:' + fastify.server.address().port + '/parent/child1'
     }, (err, response, body) => {
       t.error(err)
-      t.deepEqual(JSON.parse(body), 'I am child 1')
+      t.deepEqual(body.toString(), 'I am child 1')
     })
 
     sget({
@@ -391,7 +391,7 @@ test('nested plugins', t => {
       url: 'http://localhost:' + fastify.server.address().port + '/parent/child2'
     }, (err, response, body) => {
       t.error(err)
-      t.deepEqual(JSON.parse(body), 'I am child 2')
+      t.deepEqual(body.toString(), 'I am child 2')
     })
   })
 })


### PR DESCRIPTION
As titled, see #540 for context.

This solution is based on the content type and the type of the payload.
What do you think about directly checking the payload type and serialize accordingly?
Eg:
```js
var payloadType = typeof payload
if (payloadType === 'object') {
  // serialize object and set header
} else if (payloadType === 'string') {
  // just set the header
}
```

I haven't ran the benchmark yet, but this could be faster because JSON data is very commonly used.
What do you think?