### PR TITLE
Preserve validation errors from Ajv as an array

### DIFF
--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -1,10 +1,14 @@
 /* eslint-disable no-useless-return */
 'use strict'
 
+const fastJsonStringify = require('fast-json-stringify')
 const urlUtil = require('url')
 const validation = require('./validation')
 const validateSchema = validation.validate
 const isError = require('./reply').isError
+
+const schemas = require('./schemas.json')
+const inputSchemaError = fastJsonStringify(schemas.inputSchemaError)
 
 function handleRequest (req, res, params, context) {
   var method = req.method
@@ -84,7 +88,7 @@ function handler (context, params, req, res, body, query, headers) {
   var request = new context.Request(params, req, body, query, req.headers, req.log)
   var valid = validateSchema(context, request)
   if (valid !== true) {
-    wrapReplyEnd(context, req, res, 400, params, body, query, valid)
+    wrapReplyEnd(context, req, res, 400, params, body, query, wrapValidationError(valid))
     return
   }
 
@@ -140,6 +144,15 @@ function wrapReplyEnd (context, req, res, statusCode, params, body, query, paylo
     reply.code(statusCode).send(new Error(payload || ''))
   }
   return
+}
+
+function wrapValidationError (valid) {
+  if (valid instanceof Error) {
+    return valid
+  }
+  var error = new Error(inputSchemaError(valid))
+  error.validation = valid
+  return error
 }
 
 module.exports = handleRequest

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -8,9 +8,6 @@ const paramsSchema = Symbol('params-schema')
 const responseSchema = Symbol('response-schema')
 const headersSchema = Symbol('headers-schema')
 
-const schemas = require('./schemas.json')
-const inputSchemaError = fastJsonStringify(schemas.inputSchemaError)
-
 function getValidatorForStatusCodeSchema (statusCodeDefinition) {
   return fastJsonStringify(statusCodeDefinition)
 }
@@ -63,7 +60,7 @@ function build (opts, compile) {
 
 function validateParam (validatorFunction, request, paramName) {
   var ret = validatorFunction && validatorFunction(request[paramName])
-  if (ret === false) return inputSchemaError(validatorFunction.errors)
+  if (ret === false) return validatorFunction.errors
   if (ret && ret.error) return ret.error
   if (ret && ret.value) request[paramName] = ret.value
   return false


### PR DESCRIPTION
Does the same as before, but adds one more property **validation** that has the Ajv error as is. Without stringifying it.