### PR TITLE
Do not use setImmediate

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ Do you want to know more? Head to the <a href="https://github.com/fastify/fastif
 
 ### Core features
 
-- **100% asynchronous:** all the core is implemented with asynchronous code, in this way not even a millisecond is wasted.
-- **Highly performant:** as far as we know, Fastify is one of the fastest web frameworks in town, depending on the code complexity we can serve up to 34000 requests per second.
+- **Highly performant:** as far as we know, Fastify is one of the fastest web frameworks in town, depending on the code complexity we can serve up to 30 thousands requests per second.
 - **Extendible:** Fastify is fully extensible via its hooks, plugins and decorators.
 - **Schema based:** even if it is not mandatory we recommend to use [JSON Schema](http://json-schema.org/) to validate your routes and serialize your outputs, internally Fastify compiles the schema in a highly performant function.
 - **Logging:** logs are extremely important but are costly; we chose the best logger to almost remove this cost, [Pino](https://github.com/pinojs/pino)!
@@ -77,29 +76,26 @@ __Method:__: `autocannon -c 100 -d 40 -p 10 localhost:3000` * 2, taking the seco
 
 | Framework          | Version                    | Router?      |  Requests/sec |
 | :----------------- | :------------------------- | :----------: | ------------: |
-| hapi               | 17.0.1                     | &#10003;     | 20,816        |
-| Express            | 4.16.1                     | &#10003;     | 22,006        |
-| total.js           | 2.9.0                      | &#10003;     | 22,870        |
-| Koa (`koa-router`) | 2.4.1 (`koa-router@7.3.0`) | &#10003;     | 23,511        |
-| Restify            | 6.3.2                      | &#10003;     | 23,848        |
-| Koa                | 2.4.1                      | &#10007;     | 26,425        |
-| take-five          | 1.3.4                      | &#10003;     | 27,797        |
-| micro (`micro-router`) | 9.0.0 (`micro-router@2.2.3` ) | &#10003; | 28,564     |
-| micro              | 9.0.1                      | &#10007;     | 33,727        |
-| connect (`router`) | 3.6.5 (`router@1.3.2`)     | &#10003;     | 34,009        |
-| **Fastify**        | **0.35.0**                 | **&#10003;** | **34,389**    |
-| connect            | 3.6.5                      | &#10007;     | 38,616        |
+| hapi               | 17.1.1                     | &#10003;     | 19,824        |
+| Express            | 4.16.2                     | &#10003;     | 20,690        |
+| total.js           | 2.9.1                      | &#10003;     | 21,949        |
+| Restify            | 6.3.4                      | &#10003;     | 22,989        |
+| Koa (`koa-router`) | 2.4.1 (`koa-router@7.3.0`) | &#10003;     | 25,017        |
+| take-five          | 1.3.4                      | &#10003;     | 24,540        |
+| Koa                | 2.4.1                      | &#10007;     | 25,017        |
+| micro (`micro-router`) | 9.0.2 (`microrouter@3.0.0` ) | &#10003; | 27,892      |
+| connect (`router`) | 3.6.5 (`router@1.3.2`)     | &#10003;     | 29,527        |
+| **Fastify**        | **0.35.6**                 | **&#10003;** | **31,319**    |
+| micro              | 9.0.1                      | &#10007;     | 33,406        |
+| connect            | 3.6.5                      | &#10007;     | 35,803        |
 | -                  |                            |              |               |
-| `http.Server`      | 8.9.1                      | &#10007;     | 38,929        |
+| `http.Server`      | 8.9.1                      | &#10007;     | 36,278        |
 
 Benchmarks taken using https://github.com/fastify/benchmarks. This is a
 synthetic, "hello world" benchmark that aims to evaluate the framework
 overhead. The overhead that each framework has on your application
 depends on your application, you should __always__ benchmark if performance
 matters to you.
-
-The relative overhead of micro, connect and fastify is too small to measure, and
-they perform very closely on this benchmarks.
 
 ## Documentation
 * <a href="https://github.com/fastify/fastify/blob/master/docs/Getting-Started.md"><code><b>Getting Started</b></code></a>

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -24,7 +24,7 @@ function handleRequest (req, res, params, context) {
       return context.contentTypeParser.run(req.headers['content-type'], handler, context, params, req, res, urlUtil.parse(req.url, true).query)
     }
 
-    setImmediate(wrapReplyEnd, context, req, res, 415, params, null, urlUtil.parse(req.url, true).query, null)
+    wrapReplyEnd(context, req, res, 415, params, null, urlUtil.parse(req.url, true).query, null)
     return
   }
 
@@ -38,13 +38,13 @@ function handleRequest (req, res, params, context) {
         return context.contentTypeParser.run(req.headers['content-type'], handler, context, params, req, res, urlUtil.parse(req.url, true).query)
       }
 
-      setImmediate(wrapReplyEnd, context, req, res, 415, params, null, urlUtil.parse(req.url, true).query, null)
+      wrapReplyEnd(context, req, res, 415, params, null, urlUtil.parse(req.url, true).query, null)
       return
     }
     return handler(context, params, req, res, null, urlUtil.parse(req.url, true).query)
   }
 
-  setImmediate(wrapReplyEnd, context, req, res, 405, params, null, urlUtil.parse(req.url, true).query, null)
+  wrapReplyEnd(context, req, res, 405, params, null, urlUtil.parse(req.url, true).query, null)
   return
 }
 
@@ -60,9 +60,6 @@ function jsonBody (req, res, params, context) {
     body += chunk
   }
   function onEnd () {
-    setImmediate(parse, body)
-  }
-  function parse (json) {
     var parsed
     try {
       parsed = JSON.parse(body)
@@ -77,7 +74,7 @@ function jsonBody (req, res, params, context) {
 function jsonBodyParsed (err, body, req, res, params, context) {
   var query = urlUtil.parse(req.url, true).query
   if (err) {
-    setImmediate(wrapReplyEnd, context, req, res, 422, params, body, query, null)
+    wrapReplyEnd(context, req, res, 422, params, body, query, null)
     return
   }
   handler(context, params, req, res, body, query)
@@ -87,14 +84,13 @@ function handler (context, params, req, res, body, query, headers) {
   var request = new context.Request(params, req, body, query, req.headers, req.log)
   var valid = validateSchema(context, request)
   if (valid !== true) {
-    setImmediate(wrapReplyEnd, context, req, res, 400, params, body, query, valid)
+    wrapReplyEnd(context, req, res, 400, params, body, query, valid)
     return
   }
 
   // preHandler hook
   if (context.preHandler !== null) {
-    setImmediate(
-      context.preHandler,
+    context.preHandler(
       hookIterator,
       new State(request, new context.Reply(res, context, request), context),
       preHandlerCallback

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -20,13 +20,6 @@ function Reply (res, context, request) {
   this.request = request
 }
 
-/**
- * Instead of using directly res.end(), we are using setImmediate(…)
- * This because we have observed that with this technique we are faster at responding to the various requests,
- * since the setImmediate forwards the res.end at the end of the poll phase of libuv in the event loop.
- * So we can gather multiple requests and then handle all the replies in a different moment,
- * causing a general improvement of performances, ~+10%.
- */
 Reply.prototype.send = function (payload) {
   if (this.sent) {
     this.res.log.warn(new Error('Reply already sent'))
@@ -42,7 +35,7 @@ Reply.prototype.send = function (payload) {
     if (!this.res.getHeader('Content-Type')) {
       this.res.setHeader('Content-Type', 'text/plain')
     }
-    setImmediate(handleReplyEnd, this, '')
+    handleReplyEnd(this, '')
     return
   }
 
@@ -53,8 +46,7 @@ Reply.prototype.send = function (payload) {
     this.res.setHeader('Content-Type', 'application/json')
     this.headers(payload.output.headers)
 
-    setImmediate(
-      handleReplyEnd,
+    handleReplyEnd(
       this,
       payload.output.payload
     )
@@ -74,7 +66,7 @@ Reply.prototype.send = function (payload) {
     return this.res
   }
 
-  setImmediate(handleReplyEnd, this, payload)
+  handleReplyEnd(this, payload)
   return
 }
 
@@ -120,8 +112,7 @@ Reply.prototype.redirect = function (code, url) {
 }
 
 function wrapHandleReplyEnd (reply, payload) {
-  setImmediate(
-    handleReplyEnd,
+  handleReplyEnd(
     reply,
     payload
   )
@@ -131,15 +122,14 @@ function wrapPumpCallback (reply) {
   return function pumpCallback (err) {
     if (err) {
       reply.res.log.error(err)
-      setImmediate(handleReplyEnd, reply, '')
+      handleReplyEnd(reply, '')
     }
   }
 }
 
 function handleReplyEnd (reply, payload) {
   if (reply.context.onSend !== null) {
-    setImmediate(
-      reply.context.onSend,
+    reply.context.onSend(
       hookIterator.bind(reply),
       payload,
       wrapOnSendEnd.bind(reply)

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -125,7 +125,7 @@ function asyncTest (t) {
   })
 
   test('server logs an error if reply.send is called and a value is returned via async/await', t => {
-    const lines = ['incoming request', 'Reply already sent', 'request completed']
+    const lines = ['incoming request', 'request completed', 'Reply already sent']
     t.plan(lines.length + 1)
 
     const splitStream = split(JSON.parse)

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -213,7 +213,7 @@ test('The logger should accept a custom genReqId function', t => {
 })
 
 test('reply.send logs an error if called twice in a row', t => {
-  const lines = ['incoming request', 'Reply already sent', 'Reply already sent', 'request completed']
+  const lines = ['incoming request', 'request completed', 'Reply already sent', 'Reply already sent']
   t.plan(lines.length + 1)
 
   const splitStream = split(JSON.parse)


### PR DESCRIPTION
This removes setImmediate usage. Even thought this gives us 10% more throughput in a "happy path", under extreme load it **halves** it. This happens because the gc time goes at about 26% of our execution time, ultimately making this framework pointless.

I would like to thank @hueuniverse for finding this bad bug.

I have updated the results as well, after fixing https://github.com/fastify/benchmarks/issues/39.