### PR TITLE
Don't let async handler send 204 response twice

### DIFF
--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -121,7 +121,7 @@ function preHandlerCallback (err, state) {
     result.then((payload) => {
       // this is for async functions that
       // are using reply.send directly
-      if (payload !== undefined || state.reply.res.statusCode === 204) {
+      if (payload !== undefined || (state.reply.res.statusCode === 204 && !state.reply.sent)) {
         state.reply.send(payload)
       }
     }).catch((err) => {

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -246,6 +246,26 @@ function asyncTest (t) {
     })
   })
 
+  test('does not call reply.send() twice if 204 reponse is already sent', t => {
+    t.plan(1)
+
+    const fastify = Fastify()
+
+    fastify.get('/', async (req, reply) => {
+      reply.code(204).send()
+      reply.send = () => {
+        throw new Error('reply.send() was called twice')
+      }
+    })
+
+    fastify.inject({
+      method: 'GET',
+      url: '/'
+    }, res => {
+      t.equal(res.statusCode, 204)
+    })
+  })
+
   test('inject async await', async t => {
     t.plan(1)
 


### PR DESCRIPTION
Fixes #548 

I did not implement my second suggestion from #548 because [this test](https://github.com/fastify/fastify/blob/67e111e8bc4e5f47d4aa93468a71bccdb8664037/test/async-await.js#L207-L230) made me realize that async functions can be mixed with callbacks, so it might be a bad idea for fastify call `reply.send()` when a handler resolves but the response hasn't been sent yet.