### PR TITLE
Always use a Request object when creating a Reply object

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -252,7 +252,8 @@ function build (options) {
 
   function middlewareCallback (err, state) {
     if (err) {
-      const reply = new Reply(state.res, state.context, null)
+      const request = new Request(state.params, state.req, null, null, state.req.headers, state.req.log)
+      const reply = new Reply(state.res, state.context, request)
       reply.send(err)
       return
     }
@@ -261,7 +262,8 @@ function build (options) {
 
   function onRunMiddlewares (err, req, res, state) {
     if (err) {
-      const reply = new Reply(res, state.context, null)
+      const request = new Request(state.params, req, null, null, req.headers, req.log)
+      const reply = new Reply(res, state.context, request)
       reply.send(err)
       return
     }
@@ -581,7 +583,8 @@ function build (options) {
     // we can
     req.log.warn('the default handler for 404 did not catch this, this is likely a fastify bug, please report it')
     req.log.warn(fourOhFour.prettyPrint())
-    const reply = new Reply(res, { onSend: runHooks([], null) }, null)
+    const request = new Request(null, req, null, null, req.headers, req.log)
+    const reply = new Reply(res, { onSend: runHooks([], null) }, request)
     reply.code(404).send(new Error('Not found'))
   }
 

--- a/lib/ContentTypeParser.js
+++ b/lib/ContentTypeParser.js
@@ -52,7 +52,8 @@ ContentTypeParser.prototype.run = function (contentType, handler, context, param
   }
   function done (error, body) {
     if (error) {
-      const reply = new context.Reply(res, context, null)
+      const request = new context.Request(params, req, null, query, req.headers, req.log)
+      const reply = new context.Reply(res, context, request)
       return reply.send(error)
     }
     handler(context, params, req, res, body, query)


### PR DESCRIPTION
This ensures that the onSend hook will always receive a valid Request object.
Fixes #550