### PR TITLE
Updated error handling

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -129,7 +129,6 @@ function build (options) {
   fastify.hasDecorator = decorator.exist
   fastify.decorateReply = decorator.decorateReply
   fastify.decorateRequest = decorator.decorateRequest
-  fastify.extendServerError = decorator.extendServerError
 
   fastify._Reply = Reply.buildReply(Reply)
   fastify._Request = Request.buildRequest(Request)

--- a/fastify.js
+++ b/fastify.js
@@ -372,7 +372,7 @@ function build (options) {
       onSend: options.onSend,
       config: options.config,
       middie: self._middie,
-      errorHander: self._errorHandler,
+      errorHandler: self._errorHandler,
       schemaCompiler: options.schemaCompiler
     })
   }
@@ -414,7 +414,7 @@ function build (options) {
         opts.Request || _fastify._Request,
         opts.contentTypeParser || _fastify._contentTypeParser,
         config,
-        opts.errorHander || _fastify._errorHandler,
+        opts.errorHandler || _fastify._errorHandler,
         opts.middie || _fastify._middie
       )
 

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -46,15 +46,6 @@ function decorateReply (name, fn, dependencies) {
   return this
 }
 
-function extendServerError (fn) {
-  if (typeof fn !== 'function') {
-    throw new TypeError('The server error object must be a function')
-  }
-
-  this._Reply.prototype['_extendServerError'] = fn
-  return this
-}
-
 function decorateRequest (name, fn, dependencies) {
   if (checkExistenceInPrototype(this._Request, name)) {
     throw new Error(`The decorator '${name}' has been already added to Request!`)
@@ -73,6 +64,5 @@ module.exports = {
   exist: checkExistence,
   dependencies: checkDependencies,
   decorateReply: decorateReply,
-  decorateRequest: decorateRequest,
-  extendServerError: extendServerError
+  decorateRequest: decorateRequest
 }

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -5,7 +5,6 @@ const fastJsonStringify = require('fast-json-stringify')
 const urlUtil = require('url')
 const validation = require('./validation')
 const validateSchema = validation.validate
-const isError = require('./reply').isError
 
 const schemas = require('./schemas.json')
 const inputSchemaError = fastJsonStringify(schemas.inputSchemaError)
@@ -129,7 +128,7 @@ function preHandlerCallback (err, state) {
         state.reply.send(payload)
       }
     }).catch((err) => {
-      state.reply[isError] = true
+      state.reply._isError = true
       state.reply.send(err)
     })
   }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -7,16 +7,24 @@ const validation = require('./validation')
 const serialize = validation.serialize
 const statusCodes = require('http').STATUS_CODES
 const flatstr = require('flatstr')
+const FJS = require('fast-json-stringify')
 
-const isError = Symbol('is-error')
+const serializeError = FJS({
+  type: 'object',
+  properties: {
+    statusCode: { type: 'number' },
+    error: { type: 'string' },
+    message: { type: 'string' }
+  }
+})
 
 function Reply (res, context, request) {
   this.res = res
   this.context = context
-  this[isError] = false
   this.sent = false
   this._serializer = null
-  this._errored = false
+  this._customError = false
+  this._isError = false
   this.request = request
 }
 
@@ -28,33 +36,17 @@ Reply.prototype.send = function (payload) {
 
   this.sent = true
 
-  var _isError = this[isError]
-
-  if (payload === undefined && _isError !== true) {
+  if (payload === undefined && this._isError === false) {
     this.res.setHeader('Content-Length', '0')
     if (!this.res.getHeader('Content-Type')) {
       this.res.setHeader('Content-Type', 'text/plain')
     }
-    handleReplyEnd(this, '')
+    onSendHook(this, '')
     return
   }
 
-  if (payload && payload.isBoom) {
-    this.res.log.error(payload)
-    this.res.statusCode = payload.output.statusCode
-
-    this.res.setHeader('Content-Type', 'application/json')
-    this.headers(payload.output.headers)
-
-    handleReplyEnd(
-      this,
-      payload.output.payload
-    )
-    return
-  }
-
-  if (payload instanceof Error || _isError === true) {
-    handleError(this, payload, wrapHandleReplyEnd)
+  if (payload instanceof Error || this._isError === true) {
+    handleError(this, payload, onSendHook)
     return
   }
 
@@ -62,11 +54,11 @@ Reply.prototype.send = function (payload) {
     if (!this.res.getHeader('Content-Type')) {
       this.res.setHeader('Content-Type', 'application/octet-stream')
     }
-    pump(payload, this.res, wrapPumpCallback(this))
+    pump(payload, this.res, pumpCallback(this))
     return this.res
   }
 
-  handleReplyEnd(this, payload)
+  onSendHook(this, payload)
   return
 }
 
@@ -111,23 +103,16 @@ Reply.prototype.redirect = function (code, url) {
   this.header('Location', url).code(code).send()
 }
 
-function wrapHandleReplyEnd (reply, payload) {
-  handleReplyEnd(
-    reply,
-    payload
-  )
-}
-
-function wrapPumpCallback (reply) {
-  return function pumpCallback (err) {
+function pumpCallback (reply) {
+  return function _pumpCallback (err) {
     if (err) {
       reply.res.log.error(err)
-      handleReplyEnd(reply, '')
+      onSendHook(reply, '')
     }
   }
 }
 
-function handleReplyEnd (reply, payload) {
+function onSendHook (reply, payload) {
   if (reply.context.onSend !== null) {
     reply.context.onSend(
       hookIterator.bind(reply),
@@ -135,7 +120,7 @@ function handleReplyEnd (reply, payload) {
       wrapOnSendEnd.bind(reply)
     )
   } else {
-    wrapOnSendEnd.call(reply, null, payload)
+    onSendEnd(reply, payload)
   }
 }
 
@@ -145,10 +130,10 @@ function hookIterator (fn, payload, next) {
 
 function wrapOnSendEnd (err, payload) {
   if (err) {
-    handleError(this, err, onSendEnd)
-    return
+    handleError(this, err)
+  } else {
+    onSendEnd(this, payload)
   }
-  onSendEnd(this, payload)
 }
 
 function onSendEnd (reply, payload) {
@@ -157,19 +142,18 @@ function onSendEnd (reply, payload) {
     if (!contentType) {
       reply.res.setHeader('Content-Type', 'application/octet-stream')
     }
-    pump(payload, reply.res, wrapPumpCallback(reply))
+    pump(payload, reply.res, pumpCallback(reply))
     return reply.res
   }
 
   if (!contentType && typeof payload === 'string') {
     reply.res.setHeader('Content-Type', 'text/plain')
+  } else if (reply._serializer) {
+    payload = reply._serializer(payload)
   } else if (!contentType || contentType === 'application/json') {
     reply.res.setHeader('Content-Type', 'application/json')
-    // Here we are assuming that the custom serializer is a json serializer
-    payload = reply._serializer ? reply._serializer(payload) : serialize(reply.context, payload, reply.res.statusCode)
+    payload = serialize(reply.context, payload, reply.res.statusCode)
     flatstr(payload)
-  } else if (reply._serializer) { // All the code below must have a 'content-type' setted
-    payload = reply._serializer(payload)
   }
 
   if (!reply.res.getHeader('Content-Length')) {
@@ -179,39 +163,69 @@ function onSendEnd (reply, payload) {
   reply.res.end(payload)
 }
 
-function handleError (reply, err, cb) {
-  if (!reply.res.statusCode || reply.res.statusCode < 400) {
-    reply.res.statusCode =
-        (err === null || err === undefined) ? 500
-      : (err.status >= 400) ? err.status
-      : (err.statusCode >= 400) ? err.statusCode
-      : 500
+function handleError (reply, error, cb) {
+  var statusCode = reply.res.statusCode
+  if (error == null) {
+    statusCode = statusCode || 500
+  } else if (error.status >= 400) {
+    statusCode = error.status
+  } else if (error.statusCode >= 400) {
+    statusCode = error.statusCode
+  } else {
+    statusCode = statusCode || 500
+  }
+  if (statusCode < 400) statusCode = 500
+  reply.res.statusCode = statusCode
+
+  if (statusCode >= 500) {
+    reply.res.log.error({ res: reply.res, err: error }, error && error.message)
+  } else if (statusCode >= 400) {
+    reply.res.log.info({ res: reply.res, err: error }, error && error.message)
   }
 
-  if (reply.res.statusCode >= 500) {
-    reply.res.log.error({ res: reply.res, err }, err && err.message)
-  } else if (reply.res.statusCode >= 400) {
-    reply.res.log.info({ res: reply.res, err }, err && err.message)
+  if (error && error.headers) {
+    reply.headers(error.headers)
   }
 
-  var errorHandler = reply.context.errorHandler
-
-  if (errorHandler && !reply._errored) {
+  var customErrorHandler = reply.context.errorHandler
+  if (customErrorHandler && reply._customError === false) {
     reply.sent = false
-    reply._errored = true
-    errorHandler(err, reply)
+    reply._isError = false
+    reply._customError = true
+    var result = customErrorHandler(error, reply)
+    if (result && typeof result.then === 'function') {
+      result.then(payload => reply.send(payload))
+            .catch(err => reply.send(err))
+    }
     return
   }
 
-  reply.res.setHeader('Content-Type', 'application/json')
+  var payload = {
+    error: statusCodes[statusCode + ''],
+    message: error ? error.message : '',
+    statusCode: statusCode
+  }
 
+  if (cb) {
+    cb(reply, payload)
+    return
+  }
+
+  payload = serializeError(payload)
+  flatstr(payload)
+
+  reply.res.setHeader('Content-Length', '' + Buffer.byteLength(payload))
+  reply.res.setHeader('Content-Type', 'application/json')
+  reply.sent = true
+  reply.res.end(payload)
 }
 
 function buildReply (R) {
   function _Reply (res, context, request) {
     this.res = res
     this.context = context
-    this[isError] = false
+    this._isError = false
+    this._customError = false
     this.sent = false
     this._serializer = null
     this.request = request
@@ -222,4 +236,3 @@ function buildReply (R) {
 
 module.exports = Reply
 module.exports.buildReply = buildReply
-module.exports.isError = isError

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -205,11 +205,6 @@ function handleError (reply, err, cb) {
 
   reply.res.setHeader('Content-Type', 'application/json')
 
-  cb(reply, Object.assign({
-    error: statusCodes[reply.res.statusCode + ''],
-    message: (err || '') && err.message,
-    statusCode: reply.res.statusCode
-  }, reply._extendServerError && reply._extendServerError(err)))
 }
 
 function buildReply (R) {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
   },
   "devDependencies": {
     "autocannon": "^0.16.5",
-    "boom": "~5.1.0",
     "branch-comparer": "^0.4.0",
     "concurrently": "^3.5.1",
     "cors": "^2.8.4",

--- a/test/500s.test.js
+++ b/test/500s.test.js
@@ -37,7 +37,10 @@ test('custom 500', t => {
   })
 
   fastify.setErrorHandler(function (err, reply) {
-    reply.type('text/plain').send('an error happened: ' + err.message)
+    reply
+      .code(500)
+      .type('text/plain')
+      .send('an error happened: ' + err.message)
   })
 
   fastify.inject({
@@ -65,7 +68,10 @@ test('encapsulated 500', t => {
     })
 
     f.setErrorHandler(function (err, reply) {
-      reply.type('text/plain').send('an error happened: ' + err.message)
+      reply
+        .code(500)
+        .type('text/plain')
+        .send('an error happened: ' + err.message)
     })
 
     next()
@@ -104,7 +110,10 @@ test('custom 500 with hooks', t => {
   })
 
   fastify.setErrorHandler(function (err, reply) {
-    reply.type('text/plain').send('an error happened: ' + err.message)
+    reply
+      .code(500)
+      .type('text/plain')
+      .send('an error happened: ' + err.message)
   })
 
   fastify.addHook('onSend', (req, res, payload, next) => {

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -341,6 +341,40 @@ function asyncTest (t) {
       )
     })
   })
+
+  test('customErrorHandler support', t => {
+    t.plan(3)
+
+    const fastify = Fastify()
+
+    fastify.get('/', async (req, reply) => {
+      const error = new Error('ouch')
+      error.statusCode = 400
+      throw error
+    })
+
+    fastify.setErrorHandler(async err => {
+      t.is(err.message, 'ouch')
+      const error = new Error('kaboom')
+      error.statusCode = 401
+      throw error
+    })
+
+    fastify.inject({
+      method: 'GET',
+      url: '/'
+    }, res => {
+      t.strictEqual(res.statusCode, 401)
+      t.deepEqual(
+        {
+          error: statusCodes['401'],
+          message: 'kaboom',
+          statusCode: 401
+        },
+        JSON.parse(res.payload)
+      )
+    })
+  })
 }
 
 module.exports = asyncTest

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -70,43 +70,6 @@ test('handler function - invalid schema', t => {
   internals.handler(context, null, {}, res, { hello: 'world' }, null)
 })
 
-test('handler function - invalid schema - ajv', t => {
-  t.plan(1)
-  const res = {}
-  res.end = () => {
-    Reply.prototype._extendServerError = null
-    return
-  }
-  res.setHeader = (key, value) => {
-    return
-  }
-  res.getHeader = (key) => {
-    return
-  }
-  res.log = { error: () => {}, info: () => {} }
-  const context = {
-    schema: {
-      body: {
-        type: 'object',
-        properties: {
-          hello: { type: 'number' }
-        }
-      }
-    },
-    handler: () => {},
-    Reply: Reply,
-    Request: Request,
-    preHandler: runHooks(new Hooks().preHandler, {}),
-    onSend: runHooks(new Hooks().onSend, {})
-  }
-  Reply.prototype._extendServerError = (err) => {
-    t.ok(Array.isArray(err.validation))
-    return
-  }
-  buildSchema(context, schemaCompiler)
-  internals.handler(context, null, {}, res, { hello: 'world' }, null)
-})
-
 test('handler function - reply', t => {
   t.plan(3)
   const res = {}

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -9,13 +9,14 @@ const zlib = require('zlib')
 const Reply = require('../../lib/reply')
 
 test('Once called, Reply should return an object with methods', t => {
-  t.plan(9)
+  t.plan(10)
   const response = { res: 'res' }
   function context () {}
   function request () {}
   const reply = new Reply(response, context, request)
   t.is(typeof reply, 'object')
-  t.is(typeof reply[Reply.isError], 'boolean')
+  t.is(typeof reply._isError, 'boolean')
+  t.is(typeof reply._customError, 'boolean')
   t.is(typeof reply.send, 'function')
   t.is(typeof reply.code, 'function')
   t.is(typeof reply.header, 'function')


### PR DESCRIPTION
Hi folks!
During the past months we did a huge amount of work on the error handling, but we have never refactored the code, so it has become a mess.

What has been done in this pr:
- Public API
  - Dropped `extendServerError` api.
It was an element of confusion and often was in conflict with the custom error handler.
  - Dropped the support for Boom #542 
  - Added async await support for the `setErrorHandler` api
  - The error object can set the headers as well
- Internals
  - `handleError` will serialize and send the error instead of `onSendEnd` (if needed)
  - Heavy refactor

If we all agree with this changes I can proceed to update the docs.
Needless to say that this is a breaking change (hopefully one of the last).