### PR TITLE
Set req.originalUrl on each request

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -156,6 +156,7 @@ function build (options) {
   function fastify (req, res) {
     req.id = genReqId(req)
     req.log = res.log = log.child({ reqId: req.id })
+    req.originalUrl = req.url
 
     req.log.info({ req }, 'incoming request')
 


### PR DESCRIPTION
Since `middie` needs `req.originalUrl` to be compatible with Express middleware, setting `req.originalUrl` at the beginning of each request will make `req` have the same shape throughout all Fastify code.

See fastify/middie#16 for the original discussion on why this should be added.