### PR TITLE
Handle invalid schemas

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -419,7 +419,12 @@ function build (options) {
         opts.middie || _fastify._middie
       )
 
-      buildSchema(context, opts.schemaCompiler || _fastify._schemaCompiler)
+      try {
+        buildSchema(context, opts.schemaCompiler || _fastify._schemaCompiler)
+      } catch (error) {
+        done(error)
+        return
+      }
 
       const onRequest = opts.onRequest || _fastify._hooks.onRequest
       const onResponse = opts.onResponse || _fastify._hooks.onResponse

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -49,6 +49,29 @@ test('missing schema - route', t => {
   }
 })
 
+test('invalid schema - route', t => {
+  t.plan(1)
+  try {
+    fastify.route({
+      method: 'GET',
+      url: '/invalid',
+      schema: {
+        querystring: {
+          id: 'string'
+        }
+      },
+      handler: function (req, reply) {
+        reply.send({ hello: 'world' })
+      }
+    })
+    fastify.after(err => {
+      t.ok(err instanceof Error)
+    })
+  } catch (e) {
+    t.fail()
+  }
+})
+
 test('Multiple methods', t => {
   t.plan(1)
   try {


### PR DESCRIPTION
Currently, when (for some reason) you enter an invalid schema, the whole app will shutdown since the thrown error from Ajv is not handled anywhere. 
This should log the error and in case a request is made to that endpoint, it will continue logging an error.