### PR TITLE
return await is useless

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -123,9 +123,14 @@ async function routes (fastify, options) {
   fastify.get('/', async (request, reply) => {
     return { hello: 'world' }
   })
-
+  
   fastify.get('/search/:id', async (request, reply) => {
-    return collection.findOne({ id: request.params.id })
+    try {
+      return await collection.findOne({ id: request.params.id })
+    } catch (err) {
+      reg.log.error(err)
+      return new Error('Something went wrong')
+    }
   })
 }
 

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -125,7 +125,7 @@ async function routes (fastify, options) {
   })
 
   fastify.get('/search/:id', async (request, reply) => {
-    return await collection.findOne({ id: request.params.id })
+    return collection.findOne({ id: request.params.id })
   })
 }
 


### PR DESCRIPTION
"Inside an async function, return await is useless. Since the return value of an async function is always wrapped in Promise.resolve, return await doesn’t actually do anything except add extra time before the overarching Promise resolves or rejects. This pattern is almost certainly due to programmer ignorance of the return semantics of async functions."

https://eslint.org/docs/rules/no-return-await