### PR TITLE
Create Request and Reply objects with the right context

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -255,18 +255,20 @@ function build (options) {
 
   function middlewareCallback (err, state) {
     if (err) {
-      const request = new Request(state.params, state.req, null, null, state.req.headers, state.req.log)
-      const reply = new Reply(state.res, state.context, request)
+      const req = state.req
+      const request = new state.context.Request(state.params, req, null, null, req.headers, req.log)
+      const reply = new state.context.Reply(state.res, state.context, request)
       reply.send(err)
       return
     }
+
     state.context._middie.run(state.req, state.res, state)
   }
 
   function onRunMiddlewares (err, req, res, state) {
     if (err) {
-      const request = new Request(state.params, req, null, null, req.headers, req.log)
-      const reply = new Reply(res, state.context, request)
+      const request = new state.context.Request(state.params, req, null, null, req.headers, req.log)
+      const reply = new state.context.Reply(res, state.context, request)
       reply.send(err)
       return
     }

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -507,16 +507,20 @@ test('onSend hook throws', t => {
   })
 })
 
-test('onSend hook should receive a valid request object if onRequest hook fails', t => {
-  t.plan(2)
+test('onSend hook should receive valid request and reply objects if onRequest hook fails', t => {
+  t.plan(3)
   const fastify = Fastify()
+
+  fastify.decorateRequest('testDecorator', 'testDecoratorVal')
+  fastify.decorateReply('testDecorator', 'testDecoratorVal')
 
   fastify.addHook('onRequest', function (req, res, next) {
     next(new Error('onRequest hook failed'))
   })
 
   fastify.addHook('onSend', function (request, reply, payload, next) {
-    t.type(request, 'object')
+    t.strictEqual(request.testDecorator, 'testDecoratorVal')
+    t.strictEqual(reply.testDecorator, 'testDecoratorVal')
     next()
   })
 
@@ -532,16 +536,20 @@ test('onSend hook should receive a valid request object if onRequest hook fails'
   })
 })
 
-test('onSend hook should receive a valid request object if middleware fails', t => {
-  t.plan(2)
+test('onSend hook should receive valid request and reply objects if middleware fails', t => {
+  t.plan(3)
   const fastify = Fastify()
+
+  fastify.decorateRequest('testDecorator', 'testDecoratorVal')
+  fastify.decorateReply('testDecorator', 'testDecoratorVal')
 
   fastify.use(function (req, res, next) {
     next(new Error('middlware failed'))
   })
 
   fastify.addHook('onSend', function (request, reply, payload, next) {
-    t.type(request, 'object')
+    t.strictEqual(request.testDecorator, 'testDecoratorVal')
+    t.strictEqual(reply.testDecorator, 'testDecoratorVal')
     next()
   })
 
@@ -557,16 +565,20 @@ test('onSend hook should receive a valid request object if middleware fails', t 
   })
 })
 
-test('onSend hook should receive a valid request object if a custom content type parser fails', t => {
-  t.plan(2)
+test('onSend hook should receive valid request and reply objects if a custom content type parser fails', t => {
+  t.plan(3)
   const fastify = Fastify()
+
+  fastify.decorateRequest('testDecorator', 'testDecoratorVal')
+  fastify.decorateReply('testDecorator', 'testDecoratorVal')
 
   fastify.addContentTypeParser('*', function (req, done) {
     done(new Error('content type parser failed'))
   })
 
   fastify.addHook('onSend', function (request, reply, payload, next) {
-    t.type(request, 'object')
+    t.strictEqual(request.testDecorator, 'testDecoratorVal')
+    t.strictEqual(reply.testDecorator, 'testDecoratorVal')
     next()
   })
 


### PR DESCRIPTION
Fixes cases where only the generic `Request` and `Reply` objects would be created and passed to later hooks if the `onRequest` hook or some middleware failed.