### PR TITLE
Run onSend hooks when sending a stream

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -50,14 +50,6 @@ Reply.prototype.send = function (payload) {
     return
   }
 
-  if (payload && payload._readableState) {
-    if (!this.res.getHeader('Content-Type')) {
-      this.res.setHeader('Content-Type', 'application/octet-stream')
-    }
-    pump(payload, this.res, pumpCallback(this))
-    return this.res
-  }
-
   onSendHook(this, payload)
   return
 }
@@ -103,15 +95,6 @@ Reply.prototype.redirect = function (code, url) {
   this.header('Location', url).code(code).send()
 }
 
-function pumpCallback (reply) {
-  return function _pumpCallback (err) {
-    if (err) {
-      reply.res.log.error(err)
-      onSendHook(reply, '')
-    }
-  }
-}
-
 function onSendHook (reply, payload) {
   if (reply.context.onSend !== null) {
     reply.context.onSend(
@@ -143,7 +126,7 @@ function onSendEnd (reply, payload) {
       reply.res.setHeader('Content-Type', 'application/octet-stream')
     }
     pump(payload, reply.res, pumpCallback(reply))
-    return reply.res
+    return
   }
 
   if (!contentType && typeof payload === 'string') {
@@ -161,6 +144,14 @@ function onSendEnd (reply, payload) {
   }
   reply.sent = true
   reply.res.end(payload)
+}
+
+function pumpCallback (reply) {
+  return function _pumpCallback (err) {
+    if (err) {
+      handleError(reply, err)
+    }
+  }
 }
 
 function handleError (reply, error, cb) {

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -48,6 +48,54 @@ test('should respond with a stream', t => {
   })
 })
 
+test('should trigger the onSend hook', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.get('/', (req, reply) => {
+    reply.send(fs.createReadStream(__filename, 'utf8'))
+  })
+
+  fastify.addHook('onSend', (req, reply, payload, next) => {
+    t.ok(payload._readableState)
+    reply.header('Content-Type', 'application/javascript')
+    next()
+  })
+
+  fastify.inject({
+    url: '/'
+  }, res => {
+    t.strictEqual(res.headers['content-type'], 'application/javascript')
+    t.strictEqual(res.payload, fs.readFileSync(__filename, 'utf8'))
+    fastify.close()
+  })
+})
+
+test('should trigger the onSend hook only once if pumping the stream fails', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.get('/', (req, reply) => {
+    reply.send(fs.createReadStream('not-existing-file', 'utf8'))
+  })
+
+  fastify.addHook('onSend', (req, reply, payload, next) => {
+    t.ok(payload._readableState)
+    next()
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    fastify.server.unref()
+
+    sget(`http://localhost:${fastify.server.address().port}`, function (err, response) {
+      t.type(err, Error)
+      t.equal(err.code, 'ECONNRESET')
+    })
+  })
+})
+
 test('onSend hook stream', t => {
   t.plan(3)
   const fastify = Fastify()


### PR DESCRIPTION
Previously, `onSend` hooks were being skipped if a stream was passed to `reply.send()`.

This could be considered a breaking change since `reply.send()` no longer returns the `res` object when passed a stream.