### PR TITLE
Refactor handleRequest

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -257,7 +257,7 @@ function build (options) {
   function middlewareCallback (err, state) {
     if (err) {
       const req = state.req
-      const request = new state.context.Request(state.params, req, null, null, req.headers, req.log)
+      const request = new state.context.Request(state.params, req, null, req.headers, req.log)
       const reply = new state.context.Reply(state.res, state.context, request)
       reply.send(err)
       return
@@ -268,7 +268,7 @@ function build (options) {
 
   function onRunMiddlewares (err, req, res, state) {
     if (err) {
-      const request = new state.context.Request(state.params, req, null, null, req.headers, req.log)
+      const request = new state.context.Request(state.params, req, null, req.headers, req.log)
       const reply = new state.context.Reply(res, state.context, request)
       reply.send(err)
       return
@@ -596,7 +596,7 @@ function build (options) {
     // we can
     req.log.warn('the default handler for 404 did not catch this, this is likely a fastify bug, please report it')
     req.log.warn(fourOhFour.prettyPrint())
-    const request = new Request(null, req, null, null, req.headers, req.log)
+    const request = new Request(null, req, null, req.headers, req.log)
     const reply = new Reply(res, { onSend: runHooks([], null) }, request)
     reply.code(404).send(new Error('Not found'))
   }

--- a/lib/ContentTypeParser.js
+++ b/lib/ContentTypeParser.js
@@ -45,18 +45,19 @@ ContentTypeParser.prototype.getHandler = function (contentType) {
   }
 }
 
-ContentTypeParser.prototype.run = function (contentType, handler, context, params, req, res, query) {
-  var result = this.getHandler(contentType)(req, done)
+ContentTypeParser.prototype.run = function (contentType, handler, request, reply) {
+  var result = this.getHandler(contentType)(request.req, done)
   if (result && typeof result.then === 'function') {
     result.then(body => done(null, body)).catch(err => done(err, null))
   }
+
   function done (error, body) {
     if (error) {
-      const request = new context.Request(params, req, null, query, req.headers, req.log)
-      const reply = new context.Reply(res, context, request)
       return reply.send(error)
     }
-    handler(context, params, req, res, body, query)
+
+    request.body = body
+    handler(reply)
   }
 }
 

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -11,138 +11,117 @@ const inputSchemaError = fastJsonStringify(schemas.inputSchemaError)
 
 function handleRequest (req, res, params, context) {
   var method = req.method
+  var request = new context.Request(params, req, urlUtil.parse(req.url, true).query, req.headers, req.log)
+  var reply = new context.Reply(res, context, request)
 
   if (method === 'GET' || method === 'HEAD') {
-    return handler(context, params, req, res, null, urlUtil.parse(req.url, true).query)
+    return handler(reply)
   }
+
+  var contentType = req.headers['content-type']
 
   if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
     // application/json content type
-    if (req.headers['content-type'] && req.headers['content-type'].indexOf('application/json') > -1) {
-      return jsonBody(req, res, params, context)
+    if (contentType && contentType.indexOf('application/json') > -1) {
+      return jsonBody(request, reply)
     }
 
     // custom parser for a given content type
-    if (context.contentTypeParser.fastHasHeader(req.headers['content-type'])) {
-      return context.contentTypeParser.run(req.headers['content-type'], handler, context, params, req, res, urlUtil.parse(req.url, true).query)
+    if (context.contentTypeParser.fastHasHeader(contentType)) {
+      return context.contentTypeParser.run(contentType, handler, request, reply)
     }
 
-    wrapReplyEnd(context, req, res, 415, params, null, urlUtil.parse(req.url, true).query, null)
+    reply.code(415).send(new Error('Unsupported Media Type: ' + contentType))
     return
   }
 
   if (method === 'OPTIONS' || method === 'DELETE') {
-    if (req.headers['content-type']) {
-      // application/json content type
-      if (req.headers['content-type'].indexOf('application/json') > -1) {
-        return jsonBody(req, res, params, context)
-      // custom parser for a given content type
-      } else if (context.contentTypeParser.fastHasHeader(req.headers['content-type'])) {
-        return context.contentTypeParser.run(req.headers['content-type'], handler, context, params, req, res, urlUtil.parse(req.url, true).query)
-      }
-
-      wrapReplyEnd(context, req, res, 415, params, null, urlUtil.parse(req.url, true).query, null)
-      return
+    if (!contentType) {
+      return handler(reply)
     }
-    return handler(context, params, req, res, null, urlUtil.parse(req.url, true).query)
+
+    // application/json content type
+    if (contentType.indexOf('application/json') > -1) {
+      return jsonBody(request, reply)
+    }
+    // custom parser for a given content type
+    if (context.contentTypeParser.fastHasHeader(contentType)) {
+      return context.contentTypeParser.run(contentType, handler, request, reply)
+    }
+
+    reply.code(415).send(new Error('Unsupported Media Type: ' + contentType))
+    return
   }
 
-  wrapReplyEnd(context, req, res, 405, params, null, urlUtil.parse(req.url, true).query, null)
+  reply.code(405).send(new Error('Method Not Allowed: ' + method))
   return
 }
 
-function jsonBody (req, res, params, context) {
+function jsonBody (request, reply) {
   var body = ''
+  var req = request.req
   req.on('error', onError)
   req.on('data', onData)
   req.on('end', onEnd)
   function onError (err) {
-    jsonBodyParsed(err, null, req, res, params, context)
+    reply.code(422).send(err)
   }
   function onData (chunk) {
     body += chunk
   }
   function onEnd () {
-    var parsed
     try {
-      parsed = JSON.parse(body)
+      request.body = JSON.parse(body)
     } catch (err) {
-      jsonBodyParsed(err, null, req, res, params, context)
+      reply.code(422).send(err)
       return
     }
-    jsonBodyParsed(null, parsed, req, res, params, context)
+    handler(reply)
   }
 }
 
-function jsonBodyParsed (err, body, req, res, params, context) {
-  var query = urlUtil.parse(req.url, true).query
-  if (err) {
-    wrapReplyEnd(context, req, res, 422, params, body, query, null)
-    return
-  }
-  handler(context, params, req, res, body, query)
-}
-
-function handler (context, params, req, res, body, query, headers) {
-  var request = new context.Request(params, req, body, query, req.headers, req.log)
-  var valid = validateSchema(context, request)
+function handler (reply) {
+  var valid = validateSchema(reply.context, reply.request)
   if (valid !== true) {
-    wrapReplyEnd(context, req, res, 400, params, body, query, wrapValidationError(valid))
+    reply.code(400).send(wrapValidationError(valid))
     return
   }
 
   // preHandler hook
-  if (context.preHandler !== null) {
-    context.preHandler(
+  if (reply.context.preHandler !== null) {
+    reply.context.preHandler(
       hookIterator,
-      new State(request, new context.Reply(res, context, request), context),
+      reply,
       preHandlerCallback
     )
   } else {
-    preHandlerCallback(null, new State(request, new context.Reply(res, context, request), context))
+    preHandlerCallback(null, reply)
   }
 }
 
-function State (request, reply, context) {
-  this.request = request
-  this.reply = reply
-  this.context = context
+function hookIterator (fn, reply, next) {
+  return fn(reply.request, reply, next)
 }
 
-function hookIterator (fn, state, next) {
-  return fn(state.request, state.reply, next)
-}
-
-function preHandlerCallback (err, state) {
+function preHandlerCallback (err, reply) {
   if (err) {
-    state.reply.send(err)
+    reply.send(err)
     return
   }
 
-  var result = state.context.handler(state.request, state.reply)
+  var result = reply.context.handler(reply.request, reply)
   if (result && typeof result.then === 'function') {
     result.then((payload) => {
       // this is for async functions that
       // are using reply.send directly
-      if (payload !== undefined || (state.reply.res.statusCode === 204 && !state.reply.sent)) {
-        state.reply.send(payload)
+      if (payload !== undefined || (reply.res.statusCode === 204 && !reply.sent)) {
+        reply.send(payload)
       }
     }).catch((err) => {
-      state.reply._isError = true
-      state.reply.send(err)
+      reply._isError = true
+      reply.send(err)
     })
   }
-}
-
-function wrapReplyEnd (context, req, res, statusCode, params, body, query, payload) {
-  const request = new context.Request(params, req, body, query, req.headers, req.log)
-  const reply = new context.Reply(res, context, request)
-  if (payload instanceof Error) {
-    reply.code(statusCode).send(payload)
-  } else {
-    reply.code(statusCode).send(new Error(payload || ''))
-  }
-  return
 }
 
 function wrapValidationError (valid) {
@@ -155,4 +134,4 @@ function wrapValidationError (valid) {
 }
 
 module.exports = handleRequest
-module.exports[Symbol.for('internals')] = { jsonBody, jsonBodyParsed, handler }
+module.exports[Symbol.for('internals')] = { jsonBody, handler }

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,22 +1,22 @@
 'use strict'
 
-function Request (params, req, body, query, headers, log) {
+function Request (params, req, query, headers, log) {
   this.params = params
   this.req = req
-  this.body = body
   this.query = query
   this.headers = headers
   this.log = log
+  this.body = null
 }
 
 function buildRequest (R) {
-  function _Request (params, req, body, query, headers, log) {
+  function _Request (params, req, query, headers, log) {
     this.params = params
     this.req = req
-    this.body = body
     this.query = query
     this.headers = headers
     this.log = log
+    this.body = null
   }
   _Request.prototype = new R()
   return _Request

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -27,14 +27,14 @@ function schemaCompiler (schema) {
 
 test('Request object', t => {
   t.plan(7)
-  const req = new Request('params', 'req', 'body', 'query', 'headers', 'log')
+  const req = new Request('params', 'req', 'query', 'headers', 'log')
   t.type(req, Request)
   t.equal(req.params, 'params')
   t.deepEqual(req.req, 'req')
-  t.equal(req.body, 'body')
   t.equal(req.query, 'query')
   t.equal(req.headers, 'headers')
   t.equal(req.log, 'log')
+  t.equal(req.body, null)
 })
 
 test('handler function - invalid schema', t => {
@@ -67,7 +67,10 @@ test('handler function - invalid schema', t => {
     onSend: runHooks(new Hooks().onSend, {})
   }
   buildSchema(context, schemaCompiler)
-  internals.handler(context, null, {}, res, { hello: 'world' }, null)
+  const request = {
+    body: { hello: 'world' }
+  }
+  internals.handler(new Reply(res, context, request))
 })
 
 test('handler function - reply', t => {
@@ -95,28 +98,14 @@ test('handler function - reply', t => {
     onSend: runHooks(new Hooks().onSend, {})
   }
   buildSchema(context, schemaCompiler)
-  internals.handler(context, null, { log: null }, res, null, null)
+  internals.handler(new Reply(res, context, {}))
 })
 
-test('jsonBody and jsonBodyParsed should be functions', t => {
-  t.plan(4)
+test('jsonBody should be a function', t => {
+  t.plan(2)
 
   t.is(typeof internals.jsonBody, 'function')
-  t.is(internals.jsonBody.length, 4)
-
-  t.is(typeof internals.jsonBodyParsed, 'function')
-  t.is(internals.jsonBodyParsed.length, 6)
-})
-
-test('jsonBody error handler', t => {
-  t.plan(1)
-
-  try {
-    internals.jsonBody({ on: 'error' }, {})
-    t.fail('jsonBody error')
-  } catch (e) {
-    t.pass('jsonBody error')
-  }
+  t.is(internals.jsonBody.length, 2)
 })
 
 test('request should be defined in onSend Hook on post request with content type application/json', t => {


### PR DESCRIPTION
By removing the `body` parameter from the `Request` constructor's parameters and setting `body` to `null` by default, the `Request` and `Reply` objects can be created at the beginning of `handleRequest`, which allows the rest of the code to be dramatically simplified.

The request body is now simply set by doing `request.body = parsedBody` after the body content is parsed.