### PR TITLE
Add reply.notFound() method

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -10,6 +10,7 @@ Reply is a core Fastify object that exposes the following functions:
 - `.redirect([code,] url)` - Redirect to the specified url, the status code is optional (default to `302`).
 - `.serialize(payload)` - Serializes the specified payload using the default json serializer and returns the serialized payload.
 - `.serializer(function)` - Sets a custom serializer for the payload.
+- `.notFound()` - Invokes the 404 handler.
 - `.send(payload)` - Sends the payload to the user, could be a plain text, JSON, stream, or an Error object.
 - `.sent` - A boolean value that you can use if you need to know it `send` has already been called.
 
@@ -70,6 +71,22 @@ reply
   .serializer(protoBuf.serialize)
 ```
 *Take a look [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#serialization) to understand how serialization is done.*
+
+<a name="notfound"></a>
+### NotFound
+Invokes the 404 handler. This is useful inside handlers for routes with a wildcard `*` where you may want to forward the request to the 404 handler if some condition is not met.
+
+A custom 404 handler can be set with [`fastify.setNotFoundHandler()`](https://github.com/fastify/fastify/blob/master/docs/Server-Methods.md#setnotfoundhandler).
+
+```js
+fastify.get('/*', options, function (request, reply) {
+  if (!someCondition) {
+    reply.notFound()
+    return
+  }
+  // Handle the request
+})
+```
 
 <a name="send"></a>
 ### Send

--- a/fastify.js
+++ b/fastify.js
@@ -419,7 +419,8 @@ function build (options) {
         opts.contentTypeParser || _fastify._contentTypeParser,
         config,
         opts.errorHandler || _fastify._errorHandler,
-        opts.middie || _fastify._middie
+        opts.middie || _fastify._middie,
+        _fastify
       )
 
       try {
@@ -476,7 +477,7 @@ function build (options) {
     return _fastify
   }
 
-  function Context (schema, handler, Reply, Request, contentTypeParser, config, errorHandler, middie) {
+  function Context (schema, handler, Reply, Request, contentTypeParser, config, errorHandler, middie, fastify) {
     this.schema = schema
     this.handler = handler
     this.Reply = Reply
@@ -489,6 +490,7 @@ function build (options) {
     this.config = config
     this.errorHandler = errorHandler
     this._middie = middie
+    this._fastify = fastify
   }
 
   function iterator () {
@@ -625,7 +627,8 @@ function build (options) {
         opts.contentTypeParser || this._contentTypeParser,
         opts.config || {},
         this._errorHandler,
-        this._middie
+        this._middie,
+        null
       )
 
       const onRequest = this._hooks.onRequest

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -95,6 +95,17 @@ Reply.prototype.redirect = function (code, url) {
   this.header('Location', url).code(code).send()
 }
 
+Reply.prototype.notFound = function () {
+  if (this.context._fastify === null) {
+    this.res.log.warn('"reply.notFound()" called inside a 404 handler. Sending basic 404 response.')
+    this.code(404).send('404 Not Found')
+    return
+  }
+
+  this.context = this.context._fastify._404Context
+  this.context.handler(this.request, this)
+}
+
 function onSendHook (reply, payload) {
   if (reply.context.onSend !== null) {
     reply.context.onSend(


### PR DESCRIPTION
Sometimes handlers for a route need to act like the route wasn't matched, so they need a way to forward the request to the 404 handler. This is mainly necessary for the `fastify-static` plugin and was suggested by @mcollina in [this comment](https://github.com/fastify/fastify-static/pull/27#discussion_r158830732).