### PR TITLE
check for writeable payload value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ profile-*
 
 # vscode
 .vscode
+*code-workspace
 
 # flamegraphs
 profile*

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,6 @@ profile-*
 
 # vscode
 .vscode
-*code-workspace
 
 # flamegraphs
 profile*

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -129,7 +129,9 @@ function onSendEnd (reply, payload) {
     return
   }
 
-  if (!contentType && typeof payload === 'string') {
+  var payloadType = typeof payload
+
+  if (!contentType && payloadType === 'string') {
     reply.res.setHeader('Content-Type', 'text/plain')
   } else if (reply._serializer) {
     payload = reply._serializer(payload)
@@ -140,8 +142,8 @@ function onSendEnd (reply, payload) {
     reply.res.setHeader('Content-Type', 'application/json')
     payload = serialize(reply.context, payload, reply.res.statusCode)
     flatstr(payload)
-  } else if (typeof payload !== 'string' && !Buffer.isBuffer(payload)) {
-    throw new TypeError(`Attempted to send payload of invalid type '${typeof payload}' without serialization. Expected a string or Buffer.`)
+  } else if (payloadType !== 'string' && !Buffer.isBuffer(payload)) {
+    throw new TypeError(`Attempted to send payload of invalid type '${payloadType}' without serialization. Expected a string or Buffer.`)
   }
 
   if (!reply.res.getHeader('Content-Length')) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -139,9 +139,15 @@ function onSendEnd (reply, payload) {
     flatstr(payload)
   }
 
+  if (typeof payload !== 'string' && !Buffer.isBuffer(payload)) {
+    handleError(reply, new Error(`Serializer for Content-Type '${contentType}' can not handle payload of type '${typeof payload}'`))
+    return
+  }
+
   if (!reply.res.getHeader('Content-Length')) {
     reply.res.setHeader('Content-Length', '' + Buffer.byteLength(payload))
   }
+
   reply.sent = true
   reply.res.end(payload)
 }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -133,14 +133,15 @@ function onSendEnd (reply, payload) {
     reply.res.setHeader('Content-Type', 'text/plain')
   } else if (reply._serializer) {
     payload = reply._serializer(payload)
+    if (typeof payload !== 'string' && !Buffer.isBuffer(payload)) {
+      throw new Error(`Serializer for Content-Type '${contentType}' returned invalid payload of type '${typeof payload}'. Expected a string or Buffer.`)
+    }
   } else if (!contentType || contentType === 'application/json') {
     reply.res.setHeader('Content-Type', 'application/json')
     payload = serialize(reply.context, payload, reply.res.statusCode)
     flatstr(payload)
-  }
-
-  if (typeof payload !== 'string' && !Buffer.isBuffer(payload)) {
-    throw new Error(`Serializer for Content-Type '${contentType}' can not handle payload of type '${typeof payload}'`)
+  } else if (typeof payload !== 'string' && !Buffer.isBuffer(payload)) {
+    throw new Error(`Attempted to send payload of invalid type '${typeof payload}' without serialization. Expected a string or Buffer.`)
   }
 
   if (!reply.res.getHeader('Content-Length')) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -134,14 +134,14 @@ function onSendEnd (reply, payload) {
   } else if (reply._serializer) {
     payload = reply._serializer(payload)
     if (typeof payload !== 'string' && !Buffer.isBuffer(payload)) {
-      throw new Error(`Serializer for Content-Type '${contentType}' returned invalid payload of type '${typeof payload}'. Expected a string or Buffer.`)
+      throw new TypeError(`Serializer for Content-Type '${contentType}' returned invalid payload of type '${typeof payload}'. Expected a string or Buffer.`)
     }
   } else if (!contentType || contentType === 'application/json') {
     reply.res.setHeader('Content-Type', 'application/json')
     payload = serialize(reply.context, payload, reply.res.statusCode)
     flatstr(payload)
   } else if (typeof payload !== 'string' && !Buffer.isBuffer(payload)) {
-    throw new Error(`Attempted to send payload of invalid type '${typeof payload}' without serialization. Expected a string or Buffer.`)
+    throw new TypeError(`Attempted to send payload of invalid type '${typeof payload}' without serialization. Expected a string or Buffer.`)
   }
 
   if (!reply.res.getHeader('Content-Length')) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -140,8 +140,7 @@ function onSendEnd (reply, payload) {
   }
 
   if (typeof payload !== 'string' && !Buffer.isBuffer(payload)) {
-    handleError(reply, new Error(`Serializer for Content-Type '${contentType}' can not handle payload of type '${typeof payload}'`))
-    return
+    throw new Error(`Serializer for Content-Type '${contentType}' can not handle payload of type '${typeof payload}'`)
   }
 
   if (!reply.res.getHeader('Content-Length')) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -129,9 +129,9 @@ function onSendEnd (reply, payload) {
     return
   }
 
-  var payloadType = typeof payload
+  var isPayloadString = typeof payload === 'string'
 
-  if (!contentType && payloadType === 'string') {
+  if (!contentType && isPayloadString) {
     reply.res.setHeader('Content-Type', 'text/plain')
   } else if (reply._serializer) {
     payload = reply._serializer(payload)
@@ -142,8 +142,8 @@ function onSendEnd (reply, payload) {
     reply.res.setHeader('Content-Type', 'application/json')
     payload = serialize(reply.context, payload, reply.res.statusCode)
     flatstr(payload)
-  } else if (payloadType !== 'string' && !Buffer.isBuffer(payload)) {
-    throw new TypeError(`Attempted to send payload of invalid type '${payloadType}' without serialization. Expected a string or Buffer.`)
+  } else if (!isPayloadString && !Buffer.isBuffer(payload)) {
+    throw new TypeError(`Attempted to send payload of invalid type '${typeof payload}' without serialization. Expected a string or Buffer.`)
   }
 
   if (!reply.res.getHeader('Content-Length')) {

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -348,7 +348,31 @@ test('\'*\' should throw an error due to serializer can not handle the payload t
       reply.send({})
     } catch (err) {
       t.type(err, Error)
-      t.strictEqual(err.message, "Serializer for Content-Type 'text/html' can not handle payload of type 'object'")
+      t.strictEqual(err.message, "Attempted to send payload of invalid type 'object' without serialization. Expected a string or Buffer.")
+    }
+  })
+
+  fastify.inject({
+    url: '/',
+    method: 'GET'
+  }, res => {
+    t.fail('should not be called')
+  })
+})
+
+test('should throw an error due to custom serializer can not handle the payload type', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.get('/', (req, reply) => {
+    try {
+      reply
+      .type('text/html')
+      .serializer(payload => payload)
+      .send({})
+    } catch (err) {
+      t.type(err, Error)
+      t.strictEqual(err.message, "Serializer for Content-Type 'text/html' returned invalid payload of type 'object'. Expected a string or Buffer.")
     }
   })
 

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -344,18 +344,18 @@ test('\'*\' should respond with 500 code due to serializer can not handle the pa
 
   fastify.get('/', (req, reply) => {
     reply.type('text/html')
-    reply.send({})
+    try {
+      reply.send({})
+    } catch (err) {
+      t.type(err, Error)
+      t.strictEqual(err.message, "Serializer for Content-Type 'text/html' can not handle payload of type 'object'")
+    }
   })
 
   fastify.inject({
     url: '/',
     method: 'GET'
   }, res => {
-    t.strictEqual(res.statusCode, 500)
-    t.deepEqual(JSON.parse(res.payload), {
-      statusCode: 500,
-      error: 'Internal Server Error',
-      message: "Serializer for Content-Type 'text/html' can not handle payload of type 'object'"
-    })
+    t.fail('should not be called')
   })
 })

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -338,7 +338,7 @@ test('should set the status code and the headers from the error object (from cus
 })
 
 // Issue 595 https://github.com/fastify/fastify/issues/595
-test('\'*\' should respond with 500 code due to serializer can not handle the payload type', t => {
+test('\'*\' should throw an error due to serializer can not handle the payload type', t => {
   t.plan(2)
   const fastify = Fastify()
 

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -347,7 +347,7 @@ test('\'*\' should throw an error due to serializer can not handle the payload t
     try {
       reply.send({})
     } catch (err) {
-      t.type(err, Error)
+      t.type(err, TypeError)
       t.strictEqual(err.message, "Attempted to send payload of invalid type 'object' without serialization. Expected a string or Buffer.")
     }
   })
@@ -371,7 +371,7 @@ test('should throw an error due to custom serializer can not handle the payload 
       .serializer(payload => payload)
       .send({})
     } catch (err) {
-      t.type(err, Error)
+      t.type(err, TypeError)
       t.strictEqual(err.message, "Serializer for Content-Type 'text/html' returned invalid payload of type 'object'. Expected a string or Buffer.")
     }
   })

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -336,3 +336,26 @@ test('should set the status code and the headers from the error object (from cus
     })
   })
 })
+
+// Issue 595 https://github.com/fastify/fastify/issues/595
+test('\'*\' should respond with 500 code due to serializer can not handle the payload type', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.get('/', (req, reply) => {
+    reply.type('text/html')
+    reply.send({})
+  })
+
+  fastify.inject({
+    url: '/',
+    method: 'GET'
+  }, res => {
+    t.strictEqual(res.statusCode, 500)
+    t.deepEqual(JSON.parse(res.payload), {
+      statusCode: 500,
+      error: 'Internal Server Error',
+      message: "Serializer for Content-Type 'text/html' can not handle payload of type 'object'"
+    })
+  })
+})


### PR DESCRIPTION
This PR fixes https://github.com/fastify/fastify/issues/595 when the user responds with a value where no compatible serializer exists. The result is a hanging request with no errors. It's better to fail first instead to convert the payload somehow.