### PR TITLE
add github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,13 +1,13 @@
 ** DO NOT ERASE THESE INSTRUCTIONS WITHOUT READING THEM FIRST! **
 
 Please read this entire template before posting any issue. If you ignore these instructions
-and post an issue here that does not follow the instructions, your issue will be closed,
+and post an issue here that does not follow the instructions, your issue might be closed,
 locked, and assigned the `missing discussion` label.
 
 #### You have already researched for similiar issues?
 It's not uncommon that somebody already opened an issue or in best case it's already fixed but not merged. That's the reason why you should [search](https://github.com/fastify/fastify/issues) at first before submitting a new one.
 
-#### Are you sure this is an issue with the fastify server or are you just looking for some help?
+#### Are you sure this is an issue with the fastify or are you just looking for some help?
 
 Issues should only be posted in this repository after you have been able to reproduce
 them and confirm that they are a bug or incorrect/missing information in the [docs](https://github.com/fastify/fastify/docs).
@@ -15,7 +15,7 @@ them and confirm that they are a bug or incorrect/missing information in the [do
 For all other questions, requests, help resolving an issue, or if you are not sure if this is
 the right place, please do not open an issue here. Instead, try to find a solution in the community [Gitter Chat](https://gitter.im/fastify).
 
-If you have issues with the fastify.io site, please open an issue [here](https://github.com/fastify/website/issues).
+If you have issues with the [fastify.io](https://www.fastify.io) site, please open an issue [here](https://github.com/fastify/website/issues).
 
 #### Is this a security related issue?
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,45 @@
+** DO NOT ERASE THESE INSTRUCTIONS WITHOUT READING THEM FIRST! **
+
+Please read this entire template before posting any issue. If you ignore these instructions
+and post an issue here that does not follow the instructions, your issue will be closed,
+locked, and assigned the `missing discussion` label.
+
+#### You have already researched for similiar issues?
+It's not uncommon that somebody already opened an issue or in best case it's already fixed but not merged. That's the reason why you should [search](https://github.com/fastify/fastify/issues) at first before submitting a new one.
+
+#### Are you sure this is an issue with the fastify server or are you just looking for some help?
+
+Issues should only be posted in this repository after you have been able to reproduce
+them and confirm that they are a bug or incorrect/missing information in the [docs](https://github.com/fastify/fastify/docs).
+
+For all other questions, requests, help resolving an issue, or if you are not sure if this is
+the right place, please do not open an issue here. Instead, try to find a solution in the community [Gitter Chat](https://gitter.im/fastify).
+
+If you have issues with the fastify.io site, please open an issue [here](https://github.com/fastify/website/issues).
+
+#### Is this a security related issue?
+
+Do not open issues that might have security implications. It is critical that security related issues
+are reported privately so we have time to address them before they become public knowledge. Please
+email all security related issues to the [Fastify Team](https://github.com/fastify/fastify#team).
+
+#### What are you trying to achieve or the steps to reproduce?
+
+Describe your issue here, include as much detail as neccessary to reproduce the issue
+or implement a missing functionality. If you are reporting a bug, you will get faster response
+if you submit a pull request with a failing test.
+
+```js
+// Wrap code in markdown source tags
+```
+
+#### What was the result you received?
+
+#### What did you expect?
+
+#### Context
+
+* *node version*: 4,5,6,7,8,9
+* *fastify version*: >=0.37.0
+* *os*: Mac, Windows
+* *any other relevant information*:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,3 @@
-** DO NOT ERASE THESE INSTRUCTIONS WITHOUT READING THEM FIRST! **
-
-Please read this entire template before posting any issue. If you ignore these instructions
-and post an issue here that does not follow the instructions, your issue might be closed,
-locked, and assigned the `missing discussion` label.
-
 #### You have already researched for similiar issues?
 It's not uncommon that somebody already opened an issue or in best case it's already fixed but not merged. That's the reason why you should [search](https://github.com/fastify/fastify/issues) at first before submitting a new one.
 
@@ -43,3 +37,7 @@ if you submit a pull request with a failing test.
 * *fastify version*: >=0.37.0
 * *os*: Mac, Windows
 * *any other relevant information*:
+
+**Please read this entire template before posting any issue. If you ignore these instructions
+and post an issue here that does not follow the instructions, your issue might be closed,
+locked, and assigned the `missing discussion` label.**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,17 @@
-**Before submitting a pull request,** please make sure the following is done:
+<!--
+Thank you for your pull request. Please provide a description above and review
+the requirements below.
 
-1. Fork [the repository](https://github.com/fastify/fastify) and create your branch from `master`.
-2. Run `npm install` in the repository root.
-3. If you've fixed a bug or added code that should be tested, add tests!
-4. Ensure the test suite passes (`npm run test`).
-5. Run `npm run benchmark` to test the performance impact of your changes. Tip: `npm run bench` to compare branches interactively.
-6. If you haven't already, complete the CLA.
+Bug fixes and new features should include tests and possibly benchmarks.
 
-**Learn more about contributing:** https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
+Tip: `npm run bench` to compare branches interactively.
+
+Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
+-->
+
+#### Checklist
+
+- [ ] run `npm run test` and `npm run benchmark`
+- [ ] tests and/or benchmarks are included
+- [ ] documentation is changed or added
+- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+**Before submitting a pull request,** please make sure the following is done:
+
+1. Fork [the repository](https://github.com/fastify/fastify) and create your branch from `master`.
+2. Run `npm install` in the repository root.
+3. If you've fixed a bug or added code that should be tested, add tests!
+4. Ensure the test suite passes (`npm run test`).
+5. Run `npm run benchmark` to test the performance impact of your changes. Tip: `npm run bench` to compare branches interactively.
+6. If you haven't already, complete the CLA.
+
+**Learn more about contributing:** https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
Most of the code was copied from the Hapi issue template. I think that should not be a problem. I added the `You have already researched for similiar issues?` section and added removed some sections.