### PR TITLE
Simplify error handling

### DIFF
--- a/docs/Error-Handling.md
+++ b/docs/Error-Handling.md
@@ -35,3 +35,22 @@ fastify.get('/', async (req, reply) => {
   await meow
 })
 ```
+
+## Use Error objects
+
+If you want to reject a promise with an error or send it as response payload, you have to use [`Error`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) objects (or subclasses). Any other value will throw an exception.
+
+Example:
+```js
+// Good
+fastify.get('/', opts, async (req, reply) => {
+  throw new Error('foo')
+})
+fastify.get('/', opts, async (req, reply) => {
+  reply.send(new Error('foo'))
+})
+// Bad
+fastify.get('/', async (req, reply) => {
+  throw 'foo'
+})
+```

--- a/docs/Error-Handling.md
+++ b/docs/Error-Handling.md
@@ -12,7 +12,7 @@ The main difference between these errors are that _System_ errors are handled by
 ### Background
 
 With the use of `promises` and `async/await` we are able to catch **any** synchronous error and return it back to the callee doesn't matter whether it's correct behavior or a syntax error. This is an anti-pattern because any unpredictable application state should exit your server so that it can come back in a clear state. This is useful for debugging and can prevent memory-leaks.
-In Node.js it's very common to derive from the `Error` type to build your own error hierarchy. If you are looking for a solution to work with http status codes we recommend [http-errors](https://github.com/jshttp/http-errors).
+In Node.js it's very common to derive from the [`Error`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) type to build your own error hierarchy. If you are looking for a solution to work with http status codes we recommend [http-errors](https://github.com/jshttp/http-errors).
 
 Example:
 ```js

--- a/fastify.js
+++ b/fastify.js
@@ -165,8 +165,16 @@ function build (options) {
     res._context = null
     res.on('finish', onResFinished)
     res.on('error', onResFinished)
+    res.on('close', onConnectionClosed)
 
     router.lookup(req, res)
+  }
+
+  function onConnectionClosed () {
+    this.log.error({
+      res: this,
+      responseTime: now() - this._startTime
+    }, 'client connection was terminated')
   }
 
   function onResFinished (err) {

--- a/lib/ContentTypeParser.js
+++ b/lib/ContentTypeParser.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const isSystem = require('./errorUtils').isSystem
+const handlePromiseError = require('./errorUtils').handlePromiseError
 
 function ContentTypeParser () {
   this.customParsers = {}
@@ -51,10 +51,7 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
   var result = this.getHandler(contentType)(request.req, done)
   if (result && typeof result.then === 'function') {
     result.then(body => done(null, body)).catch(err => {
-      if (isSystem(err)) {
-        reply.res.connection.destroy(err)
-        throw err
-      }
+      handlePromiseError(err, reply)
       done(err, null)
     })
   }

--- a/lib/errorUtils.js
+++ b/lib/errorUtils.js
@@ -25,6 +25,15 @@ function isSystem (err) {
   }
 }
 
+function handlePromiseError (err, reply) {
+  if (!(err instanceof Error)) {
+    throw new TypeError(`Attempted to reject a promise with a non-error value from type '${typeof err}'`)
+  } else if (isSystem(err)) {
+    reply.res.connection.destroy(err)
+    throw err
+  }
+}
+
 module.exports = {
-  isSystem
+  handlePromiseError
 }

--- a/lib/errorUtils.js
+++ b/lib/errorUtils.js
@@ -25,10 +25,15 @@ function isSystem (err) {
   }
 }
 
+function causedBy (err, cause) {
+  err.cause = cause
+  return err
+}
+
 function handlePromiseError (err, reply) {
   if (!(err instanceof Error)) {
     var error = new TypeError(`Attempted to reject a promise with a non-error value from type '${typeof err}'`)
-    reply.res.connection.emit('error', error)
+    reply.res.connection.emit('error', causedBy(error, err))
     throw error
   } else if (isSystem(err)) {
     reply.res.connection.emit('error', err)

--- a/lib/errorUtils.js
+++ b/lib/errorUtils.js
@@ -28,10 +28,10 @@ function isSystem (err) {
 function handlePromiseError (err, reply) {
   if (!(err instanceof Error)) {
     var error = new TypeError(`Attempted to reject a promise with a non-error value from type '${typeof err}'`)
-    reply.res.emit('error', error)
+    reply.res.connection.emit('error', error)
     throw error
   } else if (isSystem(err)) {
-    reply.res.emit('error', err)
+    reply.res.connection.emit('error', err)
     throw err
   }
 }

--- a/lib/errorUtils.js
+++ b/lib/errorUtils.js
@@ -27,9 +27,11 @@ function isSystem (err) {
 
 function handlePromiseError (err, reply) {
   if (!(err instanceof Error)) {
-    throw new TypeError(`Attempted to reject a promise with a non-error value from type '${typeof err}'`)
+    var error = new TypeError(`Attempted to reject a promise with a non-error value from type '${typeof err}'`)
+    reply.res.emit('error', error)
+    throw error
   } else if (isSystem(err)) {
-    reply.res.connection.destroy(err)
+    reply.res.emit('error', err)
     throw err
   }
 }

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -4,7 +4,7 @@
 const fastJsonStringify = require('fast-json-stringify')
 const urlUtil = require('url')
 const validation = require('./validation')
-const isSystem = require('./errorUtils').isSystem
+const handlePromiseError = require('./errorUtils').handlePromiseError
 const validateSchema = validation.validate
 
 const schemas = require('./schemas.json')
@@ -119,10 +119,7 @@ function preHandlerCallback (err, reply) {
         reply.send(payload)
       }
     }).catch((err) => {
-      if (isSystem(err)) {
-        reply.res.connection.destroy(err)
-        throw err
-      }
+      handlePromiseError(err, reply)
       reply._isError = true
       reply.send(err)
     })

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -162,7 +162,7 @@ function handleError (reply, error, cb) {
     statusCode = error.status
   } else if (error.statusCode >= 400) {
     statusCode = error.statusCode
-  } else if (error && statusCode < 400) {
+  } else if (statusCode < 400) {
     statusCode = 500
   }
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -158,14 +158,12 @@ function pumpCallback (reply) {
 function handleError (reply, error, cb) {
   var statusCode = reply.res.statusCode
 
-  if (error) {
-    if (error.status >= 400) {
-      statusCode = error.status
-    } else if (error.statusCode >= 400) {
-      statusCode = error.statusCode
-    } else if (statusCode < 400) {
-      statusCode = 500
-    }
+  if (error.status >= 400) {
+    statusCode = error.status
+  } else if (error.statusCode >= 400) {
+    statusCode = error.statusCode
+  } else if (error && statusCode < 400) {
+    statusCode = 500
   }
 
   reply.res.statusCode = statusCode

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -162,7 +162,7 @@ function handleError (reply, error, cb) {
       statusCode = error.status
     } else if (error.statusCode >= 400) {
       statusCode = error.statusCode
-    } else if (statusCode === 200) { // default status code
+    } else if (statusCode < 400) {
       statusCode = 500
     }
   }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -156,16 +156,17 @@ function pumpCallback (reply) {
 
 function handleError (reply, error, cb) {
   var statusCode = reply.res.statusCode
-  if (error == null) {
-    statusCode = statusCode || 500
-  } else if (error.status >= 400) {
-    statusCode = error.status
-  } else if (error.statusCode >= 400) {
-    statusCode = error.statusCode
-  } else {
-    statusCode = statusCode || 500
+
+  if (error) {
+    if (error.status >= 400) {
+      statusCode = error.status
+    } else if (error.statusCode >= 400) {
+      statusCode = error.statusCode
+    } else if (statusCode === 200) { // default status code
+      statusCode = 500
+    }
   }
-  if (statusCode < 400) statusCode = 500
+
   reply.res.statusCode = statusCode
 
   if (statusCode >= 500) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -4,7 +4,7 @@
 
 const pump = require('pump')
 const validation = require('./validation')
-const isSystem = require('./errorUtils').isSystem
+const handlePromiseError = require('./errorUtils').handlePromiseError
 const serialize = validation.serialize
 const statusCodes = require('http').STATUS_CODES
 const flatstr = require('flatstr')
@@ -189,10 +189,7 @@ function handleError (reply, error, cb) {
     if (result && typeof result.then === 'function') {
       result.then(payload => reply.send(payload))
             .catch(err => {
-              if (isSystem(err)) {
-                reply.res.connection.destroy(err)
-                throw err
-              }
+              handlePromiseError(err, reply)
               reply.send(err)
             })
     }

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -204,50 +204,6 @@ test('Error.status property support', t => {
   })
 })
 
-test('Support rejection with values that are not Error instances', t => {
-  const objs = [
-    0,
-    '',
-    [],
-    {},
-    null,
-    undefined,
-    123,
-    'abc',
-    new RegExp(),
-    new Date(),
-    new Uint8Array()
-  ]
-  t.plan(objs.length)
-  for (const nonErr of objs) {
-    t.test('Type: ' + typeof nonErr, t => {
-      t.plan(3)
-      const fastify = Fastify()
-
-      fastify.get('/', () => {
-        return Promise.reject(nonErr)
-      })
-
-      fastify.setErrorHandler((err, reply) => {
-        if (typeof err === 'object') {
-          t.deepEqual(err, nonErr)
-        } else {
-          t.strictEqual(err, nonErr)
-        }
-        reply.send('error')
-      })
-
-      fastify.inject({
-        method: 'GET',
-        url: '/'
-      }, res => {
-        t.strictEqual(res.statusCode, 500)
-        t.strictEqual(res.payload, 'error')
-      })
-    })
-  }
-})
-
 test('invalid schema - ajv', t => {
   t.plan(3)
 

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -294,7 +294,7 @@ test('should set the status code and the headers from the error object (from cus
 })
 
 test('Should throw when non-error value is used to reject a promise', t => {
-  t.plan(2)
+  t.plan(3)
 
   // Tap patched this event and we have no chance to listen on it.
   process.removeAllListeners('unhandledRejection')
@@ -302,6 +302,7 @@ test('Should throw when non-error value is used to reject a promise', t => {
   process.prependOnceListener('unhandledRejection', (err) => {
     t.type(err, TypeError)
     t.strictEqual(err.message, "Attempted to reject a promise with a non-error value from type 'string'")
+    t.strictEqual(err.cause, 'string')
   })
 
   const fastify = Fastify()

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -299,7 +299,7 @@ test('Should throw when non-error value is used to reject a promise', t => {
   // Tap patched this event and we have no chance to listen on it.
   process.removeAllListeners('unhandledRejection')
 
-  process.once('unhandledRejection', (err) => {
+  process.prependOnceListener('unhandledRejection', (err) => {
     t.type(err, TypeError)
     t.strictEqual(err.message, "Attempted to reject a promise with a non-error value from type 'string'")
   })

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -297,12 +297,14 @@ test('Should throw when non-error value is used to reject a promise', t => {
   t.plan(3)
 
   // Tap patched this event and we have no chance to listen on it.
+  const listeners = process.listeners('unhandledRejection')
   process.removeAllListeners('unhandledRejection')
 
-  process.prependOnceListener('unhandledRejection', (err) => {
+  process.once('unhandledRejection', (err) => {
     t.type(err, TypeError)
     t.strictEqual(err.message, "Attempted to reject a promise with a non-error value from type 'string'")
     t.strictEqual(err.cause, 'string')
+    process.addListener.apply(process, ['unhandledRejection'].concat(listeners))
   })
 
   const fastify = Fastify()

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -301,7 +301,7 @@ test('Should throw when non-error value is used to reject a promise', t => {
 
   process.once('unhandledRejection', (err) => {
     t.type(err, TypeError)
-    t.strictEqual(err.message, 'Attempted to reject a promise with a non-error value from type \'string\'')
+    t.strictEqual(err.message, "Attempted to reject a promise with a non-error value from type 'string'")
   })
 
   const fastify = Fastify()

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -292,3 +292,29 @@ test('should set the status code and the headers from the error object (from cus
     })
   })
 })
+
+test('Should throw when non-error value is used to reject a promise', t => {
+  t.plan(2)
+
+  // Tap patched this event and we have no chance to listen on it.
+  process.removeAllListeners('unhandledRejection')
+
+  process.once('unhandledRejection', (err) => {
+    t.type(err, TypeError)
+    t.strictEqual(err.message, 'Attempted to reject a promise with a non-error value from type \'string\'')
+  })
+
+  const fastify = Fastify()
+
+  const noneError = 'string'
+  fastify.get('/', () => {
+    return Promise.reject(noneError)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, res => {
+    t.fail('should not be called')
+  })
+})


### PR DESCRIPTION
This PR includes inter alia issue https://github.com/fastify/fastify/issues/599 where the user was restricted with setting a status code when an error was passed. The current implementation was really hard to read.

I removed the support for none error values as errors ~~(truthy values can be still passed)~~ because it's widely known as an anti-pattern and the developer should use the `Error` object.

We shouldn't provide a space for anti-pattern. Due to this change, I could simplify the code.
When https://github.com/fastify/fastify/pull/591 is merged I will add this behavior to the docs.

If you are passing an error and with a status code smaller than 400, Fastify will automatically set it at 500.

References:
https://www.joyent.com/node-js/production/design/errors
https://github.com/petkaantonov/bluebird/blob/master/docs/docs/warning-explanations.md#warning-a-promise-was-rejected-with-a-non-error

## TODO

- [x] Wait for https://github.com/fastify/fastify/pull/591
- [x] Throw error when promise was rejected with non-error
- [x] Emit connection error instead destroy itself.
- [x] Log connection close events
- [x] Add tests
  