### PR TITLE
Clean up binding hook and 404 handler context

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -6,7 +6,7 @@ const Ajv = require('ajv')
 const http = require('http')
 const https = require('https')
 const Middie = require('middie')
-const runHooks = require('fast-iterator')
+const fastIterator = require('fast-iterator')
 const lightMyRequest = require('light-my-request')
 const abstractLogging = require('abstract-logging')
 
@@ -436,16 +436,13 @@ function build (options) {
       preHandler.push.apply(preHandler, opts.preHandler || _fastify._hooks.preHandler)
       if (opts.beforeHandler) {
         opts.beforeHandler = Array.isArray(opts.beforeHandler) ? opts.beforeHandler : [opts.beforeHandler]
-        for (var i = 0; i < opts.beforeHandler.length; i++) {
-          opts.beforeHandler[i] = opts.beforeHandler[i].bind(_fastify)
-        }
         preHandler.push.apply(preHandler, opts.beforeHandler)
       }
 
-      context.onRequest = onRequest.length ? runHooks(onRequest, context) : null
-      context.onResponse = onResponse.length ? runHooks(onResponse, context) : null
-      context.onSend = onSend.length ? runHooks(onSend, context) : null
-      context.preHandler = preHandler.length ? runHooks(preHandler, context) : null
+      context.onRequest = onRequest.length ? fastIterator(onRequest, _fastify) : null
+      context.onResponse = onResponse.length ? fastIterator(onResponse, _fastify) : null
+      context.onSend = onSend.length ? fastIterator(onSend, _fastify) : null
+      context.preHandler = preHandler.length ? fastIterator(preHandler, _fastify) : null
 
       if (map.has(url)) {
         if (map.get(url)[opts.method]) {
@@ -560,7 +557,7 @@ function build (options) {
     if (name === 'onClose') {
       this.onClose(fn)
     } else {
-      this._hooks.add(name, fn.bind(this))
+      this._hooks.add(name, fn)
     }
     return this
   }
@@ -600,7 +597,7 @@ function build (options) {
     req.log.warn('the default handler for 404 did not catch this, this is likely a fastify bug, please report it')
     req.log.warn(fourOhFour.prettyPrint())
     const request = new Request(null, req, null, req.headers, req.log)
-    const reply = new Reply(res, { onSend: runHooks([], null) }, request)
+    const reply = new Reply(res, { onSend: fastIterator([], null) }, request)
     reply.code(404).send(new Error('Not found'))
   }
 
@@ -617,7 +614,7 @@ function build (options) {
       opts = undefined
     }
     opts = opts || {}
-    handler = handler || basic404
+    handler = handler ? handler.bind(this) : basic404
 
     if (!this._404Context) {
       const context = new Context(
@@ -635,9 +632,9 @@ function build (options) {
       const onResponse = this._hooks.onResponse
       const onSend = this._hooks.onSend
 
-      context.onRequest = onRequest.length ? runHooks(onRequest, context) : null
-      context.onResponse = onResponse.length ? runHooks(onResponse, context) : null
-      context.onSend = onSend.length ? runHooks(onSend, context) : null
+      context.onRequest = onRequest.length ? fastIterator(onRequest, this) : null
+      context.onResponse = onResponse.length ? fastIterator(onResponse, this) : null
+      context.onSend = onSend.length ? fastIterator(onSend, this) : null
 
       this._404Context = context
 

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -209,6 +209,67 @@ test('encapsulated 404', t => {
   })
 })
 
+test('custom 404 hook and handler context', t => {
+  t.plan(16)
+
+  const fastify = Fastify()
+
+  fastify.decorate('foo', 42)
+
+  fastify.addHook('onRequest', function (req, res, next) {
+    t.strictEqual(this.foo, 42)
+    next()
+  })
+  fastify.addHook('onSend', function (request, reply, payload, next) {
+    t.strictEqual(this.foo, 42)
+    next()
+  })
+  fastify.addHook('onResponse', function (res, next) {
+    t.strictEqual(this.foo, 42)
+    next()
+  })
+
+  fastify.setNotFoundHandler(function (req, reply) {
+    t.strictEqual(this.foo, 42)
+    reply.code(404).send('this was not found')
+  })
+
+  fastify.register(function (f, opts, next) {
+    f.decorate('bar', 84)
+
+    fastify.addHook('onRequest', function (req, res, next) {
+      t.strictEqual(this.bar, 84)
+      next()
+    })
+    fastify.addHook('onSend', function (request, reply, payload, next) {
+      t.strictEqual(this.bar, 84)
+      next()
+    })
+    fastify.addHook('onResponse', function (res, next) {
+      t.strictEqual(this.bar, 84)
+      next()
+    })
+
+    f.setNotFoundHandler(function (req, reply) {
+      t.strictEqual(this.foo, 42)
+      t.strictEqual(this.bar, 84)
+      reply.code(404).send('encapsulated was not found')
+    })
+
+    next()
+  }, { prefix: '/encapsulated' })
+
+  fastify.inject('/not-found', res => {
+    t.strictEqual(res.statusCode, 404)
+    t.strictEqual(res.payload, 'this was not found')
+  })
+
+  fastify.inject('/encapsulated/not-found', res => {
+    t.strictEqual(res.statusCode, 404)
+    t.strictEqual(res.payload, 'encapsulated was not found')
+  })
+})
+
 test('run hooks on default 404', t => {
   t.plan(5)
 


### PR DESCRIPTION
Use `fast-iterator` to bind hooks to the fastify instance.
404 handlers are also now bound to the fastify instance.

Based on [my comment](https://github.com/fastify/fastify/pull/592#issuecomment-354476787) in #592.