### PR TITLE
Fix incorrect test

### DIFF
--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -234,23 +234,23 @@ test('custom 404 hook and handler context', t => {
     reply.code(404).send('this was not found')
   })
 
-  fastify.register(function (f, opts, next) {
-    f.decorate('bar', 84)
+  fastify.register(function (instance, opts, next) {
+    instance.decorate('bar', 84)
 
-    fastify.addHook('onRequest', function (req, res, next) {
+    instance.addHook('onRequest', function (req, res, next) {
       t.strictEqual(this.bar, 84)
       next()
     })
-    fastify.addHook('onSend', function (request, reply, payload, next) {
+    instance.addHook('onSend', function (request, reply, payload, next) {
       t.strictEqual(this.bar, 84)
       next()
     })
-    fastify.addHook('onResponse', function (res, next) {
+    instance.addHook('onResponse', function (res, next) {
       t.strictEqual(this.bar, 84)
       next()
     })
 
-    f.setNotFoundHandler(function (req, reply) {
+    instance.setNotFoundHandler(function (req, reply) {
       t.strictEqual(this.foo, 42)
       t.strictEqual(this.bar, 84)
       reply.code(404).send('encapsulated was not found')


### PR DESCRIPTION
The problem was introduced in 25a65a7 by using the wrong fastify instance inside a `register()` call.

I'm not sure how the tests passed when I made that commit or even on CI. They only started failing locally for me when I updated my branch to include the latest changes on master. Anyway, this corrects the problem.
  