### PR TITLE
Simplify building Hooks and ContentTypeParser

### DIFF
--- a/lib/ContentTypeParser.js
+++ b/lib/ContentTypeParser.js
@@ -70,12 +70,10 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
 }
 
 function buildContentTypeParser (c) {
-  function _ContentTypeParser () {}
-  _ContentTypeParser.prototype = new ContentTypeParser()
-  const C = new _ContentTypeParser()
-  C.customParsers = Object.create(c.customParsers)
-  C.parserList = Object.create(c.parserList)
-  return C
+  const contentTypeParser = new ContentTypeParser()
+  Object.assign(contentTypeParser.customParsers, c.customParsers)
+  contentTypeParser.parserList = c.parserList.slice()
+  return contentTypeParser
 }
 
 module.exports = ContentTypeParser

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -26,14 +26,12 @@ Hooks.prototype.add = function (hook, fn) {
 }
 
 function buildHooks (h) {
-  function _Hooks () {}
-  _Hooks.prototype = new Hooks()
-  const H = new _Hooks()
-  H.onRequest = Object.create(h.onRequest)
-  H.preHandler = Object.create(h.preHandler)
-  H.onResponse = Object.create(h.onResponse)
-  H.onSend = Object.create(h.onSend)
-  return H
+  const hooks = new Hooks()
+  hooks.onRequest = h.onRequest.slice()
+  hooks.preHandler = h.preHandler.slice()
+  hooks.onSend = h.onSend.slice()
+  hooks.onResponse = h.onResponse.slice()
+  return hooks
 }
 
 module.exports = Hooks


### PR DESCRIPTION
Creating a new constructor and inheriting from the old one isn't necessary for `Hooks` and `ContentTypeParser`. Simply creating a new instance and cloning the values is all that's needed.

This also improves debugging, general code compatibility, and possibly performance since the hooks and `parsersList` will now be real arrays instead of array-like objects.