### PR TITLE
Improve handling undefined payloads

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -170,4 +170,4 @@ If you want to completely customize the error response, checkout [`setErrorHandl
 
 <a name="payload-type"></a>
 #### Type of the final payload
-It is crucial that the sent payload is a `string` or a `Buffer`, otherwise *send* will throw at runtime.
+It is crucial that the sent payload (if not `undefined`) is a `string` or a `Buffer`, otherwise *send* will throw at runtime.

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -37,15 +37,6 @@ Reply.prototype.send = function (payload) {
 
   this.sent = true
 
-  if (payload === undefined && this._isError === false) {
-    this.res.setHeader('Content-Length', '0')
-    if (!this.res.getHeader('Content-Type')) {
-      this.res.setHeader('Content-Type', 'text/plain')
-    }
-    onSendHook(this, '')
-    return
-  }
-
   if (payload instanceof Error || this._isError === true) {
     handleError(this, payload, onSendHook)
     return
@@ -132,8 +123,14 @@ function wrapOnSendEnd (err, payload) {
 }
 
 function onSendEnd (reply, payload) {
+  if (payload === undefined) {
+    reply.sent = true
+    reply.res.end()
+    return
+  }
+
   var contentType = reply.res.getHeader('Content-Type')
-  if (payload && payload._readableState) {
+  if (payload !== null && payload._readableState) {
     if (!contentType) {
       reply.res.setHeader('Content-Type', 'application/octet-stream')
     }

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -233,7 +233,7 @@ test('use reply.serialize in onSend hook', t => {
   })
 })
 
-test('plain string without content type shouls send a text/plain', t => {
+test('plain string without content type should send a text/plain', t => {
   t.plan(4)
 
   const fastify = require('../..')()
@@ -277,6 +277,36 @@ test('plain string with content type application/json should be serialized as js
       t.error(err)
       t.strictEqual(response.headers['content-type'], 'application/json')
       t.deepEqual(body.toString(), '"hello world!"')
+    })
+  })
+})
+
+test('undefined payload should be sent as-is', t => {
+  t.plan(6)
+
+  const fastify = require('../..')()
+
+  fastify.addHook('onSend', function (request, reply, payload, next) {
+    t.strictEqual(payload, undefined)
+    next()
+  })
+
+  fastify.get('/', function (req, reply) {
+    reply.code(204).send()
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
+
+    sget({
+      method: 'GET',
+      url: `http://localhost:${fastify.server.address().port}`
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.headers['content-type'], undefined)
+      t.strictEqual(response.headers['content-length'], undefined)
+      t.strictEqual(body.length, 0)
     })
   })
 })


### PR DESCRIPTION
According to [RFC 7230 Section 3.3.2](https://tools.ietf.org/html/rfc7230#section-3.3.2), there are cases when a server must not send a `Content-Length` header (such as with a 204 response). This change makes Fastify follow the spec more closely by passing the payload through the `onSend` hooks as-is and not setting the `Content-Length` header on a response with an `undefined` payload.

Other benefits from this are a 20% perf boost for undefined payloads and better alignment with developer expectations (if I call `reply.send()` I expect `payload` to be `undefined` in the `onSend` hooks and no `Content-Type` header in the response).

<details>
<summary>undefined payload benchmark</summary>

**master**

```
[1] Stat         Avg     Stdev   Max
[1] Latency (ms) 2.11    7.88    325
[1] Req/Sec      46027.2 8726.47 51551
[1] Bytes/Sec    6.17 MB 1.17 MB 7.08 MB
[1]
[1] 230k requests in 5s, 30.6 MB read
...
[1] Stat         Avg     Stdev   Max
[1] Latency (ms) 2.15    8.01    324
[1] Req/Sec      45140.8 8530.33 50687
[1] Bytes/Sec    5.99 MB 1.13 MB 6.82 MB
[1]
[1] 226k requests in 5s, 30 MB read
```

**this PR**

```
[1] Stat         Avg     Stdev   Max
[1] Latency (ms) 1.76    6.7     289
[1] Req/Sec      54825.6 9761.32 61023
[1] Bytes/Sec    4.86 MB 897 kB  5.51 MB
[1]
[1] 274k requests in 5s, 24.1 MB read
...
[1] Stat         Avg     Stdev   Max
[1] Latency (ms) 1.83    6.97    243
[1] Req/Sec      52860.8 9832.11 59487
[1] Bytes/Sec    4.63 MB 845 kB  5.24 MB
[1]
[1] 264k requests in 5s, 23.3 MB read
```
</details>

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)