### PR TITLE
Run preHandler hooks for 404 handlers

### DIFF
--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -132,7 +132,7 @@ Set the schema compiler for all routes [here](https://github.com/fastify/fastify
 <a name="set-not-found-handler"></a>
 #### setNotFoundHandler
 
-`fastify.setNotFoundHandler(handler(request, reply))`: set the 404 handler. This call is fully encapsulated, so different plugins can set different not found handlers.
+`fastify.setNotFoundHandler(handler(request, reply))`: set the 404 handler. This call is fully encapsulated, so different plugins can set different not found handlers. The handler is treated like a regular route handler so requests will go through the full [Fastify lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md#lifecycle).
 
 <a name="set-error-handler"></a>
 #### setErrorHandler

--- a/fastify.js
+++ b/fastify.js
@@ -625,12 +625,14 @@ function build (options) {
       )
 
       const onRequest = this._hooks.onRequest
-      const onResponse = this._hooks.onResponse
+      const preHandler = this._hooks.preHandler
       const onSend = this._hooks.onSend
+      const onResponse = this._hooks.onResponse
 
       context.onRequest = onRequest.length ? fastIterator(onRequest, this) : null
-      context.onResponse = onResponse.length ? fastIterator(onResponse, this) : null
+      context.preHandler = preHandler.length ? fastIterator(preHandler, this) : null
       context.onSend = onSend.length ? fastIterator(onSend, this) : null
+      context.onResponse = onResponse.length ? fastIterator(onResponse, this) : null
 
       this._404Context = context
 

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -210,13 +210,17 @@ test('encapsulated 404', t => {
 })
 
 test('custom 404 hook and handler context', t => {
-  t.plan(16)
+  t.plan(19)
 
   const fastify = Fastify()
 
   fastify.decorate('foo', 42)
 
   fastify.addHook('onRequest', function (req, res, next) {
+    t.strictEqual(this.foo, 42)
+    next()
+  })
+  fastify.addHook('preHandler', function (request, reply, next) {
     t.strictEqual(this.foo, 42)
     next()
   })
@@ -238,6 +242,10 @@ test('custom 404 hook and handler context', t => {
     instance.decorate('bar', 84)
 
     instance.addHook('onRequest', function (req, res, next) {
+      t.strictEqual(this.bar, 84)
+      next()
+    })
+    instance.addHook('preHandler', function (request, reply, next) {
       t.strictEqual(this.bar, 84)
       next()
     })
@@ -270,13 +278,28 @@ test('custom 404 hook and handler context', t => {
   })
 })
 
-test('run hooks on default 404', t => {
-  t.plan(5)
+test('run hooks and middleware on default 404', t => {
+  t.plan(8)
 
   const fastify = Fastify()
 
   fastify.addHook('onRequest', function (req, res, next) {
     t.pass('onRequest called')
+    next()
+  })
+
+  fastify.use(function (req, res, next) {
+    t.pass('middleware called')
+    next()
+  })
+
+  fastify.addHook('preHandler', function (request, reply, next) {
+    t.pass('preHandler called')
+    next()
+  })
+
+  fastify.addHook('onSend', function (request, reply, payload, next) {
+    t.pass('onSend called')
     next()
   })
 
@@ -306,13 +329,28 @@ test('run hooks on default 404', t => {
   })
 })
 
-test('run hooks with encapsulated 404', t => {
-  t.plan(7)
+test('run hooks and middleware with encapsulated 404', t => {
+  t.plan(13)
 
   const fastify = Fastify()
 
   fastify.addHook('onRequest', function (req, res, next) {
     t.pass('onRequest called')
+    next()
+  })
+
+  fastify.use(function (req, res, next) {
+    t.pass('middleware called')
+    next()
+  })
+
+  fastify.addHook('preHandler', function (request, reply, next) {
+    t.pass('preHandler called')
+    next()
+  })
+
+  fastify.addHook('onSend', function (request, reply, payload, next) {
+    t.pass('onSend called')
     next()
   })
 
@@ -331,8 +369,24 @@ test('run hooks with encapsulated 404', t => {
       next()
     })
 
-    f.addHook('onResponse', function (req, res) {
+    f.use(function (req, res, next) {
+      t.pass('middleware 2 called')
+      next()
+    })
+
+    f.addHook('preHandler', function (request, reply, next) {
+      t.pass('preHandler 2 called')
+      next()
+    })
+
+    f.addHook('onSend', function (request, reply, payload, next) {
+      t.pass('onSend 2 called')
+      next()
+    })
+
+    f.addHook('onResponse', function (res, next) {
       t.pass('onResponse 2 called')
+      next()
     })
 
     next()


### PR DESCRIPTION
Running `preHandler` hooks for 404 handlers was missing (I'm assuming that was unintentional?). This PR adds that functionality and also adds tests to make sure all hooks and middlewares are run for 404 handlers.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

  
  
  
  