### PR TITLE
throw error async to trigger uncaughtException, update tests

### DIFF
--- a/docs/Error-Handling.md
+++ b/docs/Error-Handling.md
@@ -7,7 +7,7 @@ Fastify classifies errors into two different groups:
 - System: any instance of type `EvalError`, `RangeError`, `ReferenceError`, `SyntaxError`, `TypeError`, `URIError` or `AssertionError`
 - Business: any instance of type `Error`
 
-The main difference between these errors are that _System_ errors are handled by Fastify and result in an [`unhandled rejection`](#unhandled-rejections).
+The main difference between these errors are that _System_ errors are handled by Fastify and result in an `uncaughtException` and abort the client connection without a response.
 
 ### Background
 
@@ -38,7 +38,7 @@ fastify.get('/', async (req, reply) => {
 
 ## Use Error objects
 
-If you want to reject a promise with an error or send it as response payload, you have to use [`Error`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) objects (or subclasses). Any other value will throw an exception.
+If you want to reject a promise with an error or send it as response payload, you have to use [`Error`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) objects (or subclasses). Any other value will throw an `uncaughtException` and abort the client connection without a response.
 
 Example:
 ```js

--- a/lib/ContentTypeParser.js
+++ b/lib/ContentTypeParser.js
@@ -51,7 +51,7 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
   var result = this.getHandler(contentType)(request.req, done)
   if (result && typeof result.then === 'function') {
     result.then(body => done(null, body)).catch(err => {
-      handlePromiseError(err, reply)
+      if (handlePromiseError(err, reply)) return
       done(err, null)
     })
   }

--- a/lib/errorUtils.js
+++ b/lib/errorUtils.js
@@ -30,24 +30,25 @@ function causedBy (err, cause) {
   return err
 }
 
+function throwError (err) {
+  throw err
+}
+
 function handlePromiseError (err, reply) {
   if (!(err instanceof Error)) {
     var error = new TypeError(`Attempted to reject a promise with a non-error value from type '${typeof err}'`)
-    setImmediate(() => {
-      throw error
-    })
+    setImmediate(throwError, error)
     var errWithCause = causedBy(error, err)
-    reply.res.log.error(errWithCause, 'client error')
+    reply.request.log.error(errWithCause, 'client error')
     reply.res.connection.destroy(errWithCause)
     return true
   } else if (isSystem(err)) {
-    setImmediate(() => {
-      throw err
-    })
-    reply.res.log.error(err, 'client error')
+    setImmediate(throwError, err)
+    reply.request.log.error(err, 'client error')
     reply.res.connection.destroy(err)
     return true
   }
+  return false
 }
 
 module.exports = {

--- a/lib/errorUtils.js
+++ b/lib/errorUtils.js
@@ -33,11 +33,20 @@ function causedBy (err, cause) {
 function handlePromiseError (err, reply) {
   if (!(err instanceof Error)) {
     var error = new TypeError(`Attempted to reject a promise with a non-error value from type '${typeof err}'`)
-    reply.res.connection.emit('error', causedBy(error, err))
-    throw error
+    setImmediate(() => {
+      throw error
+    })
+    var errWithCause = causedBy(error, err)
+    reply.res.log.error(errWithCause, 'client error')
+    reply.res.connection.destroy(errWithCause)
+    return true
   } else if (isSystem(err)) {
-    reply.res.connection.emit('error', err)
-    throw err
+    setImmediate(() => {
+      throw err
+    })
+    reply.res.log.error(err, 'client error')
+    reply.res.connection.destroy(err)
+    return true
   }
 }
 

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -119,7 +119,7 @@ function preHandlerCallback (err, reply) {
         reply.send(payload)
       }
     }).catch((err) => {
-      handlePromiseError(err, reply)
+      if (handlePromiseError(err, reply)) return
       reply._isError = true
       reply.send(err)
     })

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -207,7 +207,7 @@ function handleError (reply, error, cb) {
     if (result && typeof result.then === 'function') {
       result.then(payload => reply.send(payload))
             .catch(err => {
-              handlePromiseError(err, reply)
+              if (handlePromiseError(err, reply)) return
               reply.send(err)
             })
     }

--- a/test/custom-parser-system-errors.test.js
+++ b/test/custom-parser-system-errors.test.js
@@ -39,12 +39,12 @@ fastify.listen(0, err => {
 
   // Tap patched this event and we have no chance to listen on it.
   // Since any test runs in a seperate process we don't have to restore it
-  process.removeAllListeners('unhandledRejection')
+  process.removeAllListeners('uncaughtException')
 
   test('Should exit due to EvalError', t => {
     t.plan(2)
 
-    process.once('unhandledRejection', (err) => {
+    process.once('uncaughtException', (err) => {
       req.abort()
       t.type(err, systemErrors.EvalError)
     })
@@ -64,7 +64,7 @@ fastify.listen(0, err => {
   test('Should exit due to RangeError', t => {
     t.plan(2)
 
-    process.once('unhandledRejection', (err) => {
+    process.once('uncaughtException', (err) => {
       req.abort()
       t.type(err, systemErrors.RangeError)
     })
@@ -84,7 +84,7 @@ fastify.listen(0, err => {
   test('Should exit due to ReferenceError', t => {
     t.plan(2)
 
-    process.once('unhandledRejection', (err) => {
+    process.once('uncaughtException', (err) => {
       req.abort()
       t.type(err, systemErrors.ReferenceError)
     })
@@ -104,7 +104,7 @@ fastify.listen(0, err => {
   test('Should exit due to SyntaxError', t => {
     t.plan(2)
 
-    process.once('unhandledRejection', (err) => {
+    process.once('uncaughtException', (err) => {
       req.abort()
       t.type(err, systemErrors.SyntaxError)
     })
@@ -124,7 +124,7 @@ fastify.listen(0, err => {
   test('Should exit due to TypeError', t => {
     t.plan(2)
 
-    process.once('unhandledRejection', (err) => {
+    process.once('uncaughtException', (err) => {
       req.abort()
       t.type(err, systemErrors.TypeError)
     })
@@ -144,7 +144,7 @@ fastify.listen(0, err => {
   test('Should exit due to AssertionError', t => {
     t.plan(2)
 
-    process.once('unhandledRejection', (err) => {
+    process.once('uncaughtException', (err) => {
       req.abort()
       t.type(err, systemErrors.AssertionError)
     })

--- a/test/error-handler-system-errors.test.js
+++ b/test/error-handler-system-errors.test.js
@@ -36,12 +36,12 @@ fastify.listen(0, err => {
 
   // Tap patched this event and we have no chance to listen on it.
   // Since any test runs in a seperate process we don't have to restore it
-  process.removeAllListeners('unhandledRejection')
+  process.removeAllListeners('uncaughtException')
 
   test('Should exit due to EvalError', t => {
     t.plan(2)
 
-    process.once('unhandledRejection', (err) => {
+    process.once('uncaughtException', (err) => {
       req.abort()
       t.type(err, systemErrors.EvalError)
     })
@@ -57,7 +57,7 @@ fastify.listen(0, err => {
   test('Should exit due to RangeError', t => {
     t.plan(2)
 
-    process.once('unhandledRejection', (err) => {
+    process.once('uncaughtException', (err) => {
       req.abort()
       t.type(err, systemErrors.RangeError)
     })
@@ -73,7 +73,7 @@ fastify.listen(0, err => {
   test('Should exit due to ReferenceError', t => {
     t.plan(2)
 
-    process.once('unhandledRejection', (err) => {
+    process.once('uncaughtException', (err) => {
       req.abort()
       t.type(err, systemErrors.ReferenceError)
     })
@@ -89,7 +89,7 @@ fastify.listen(0, err => {
   test('Should exit due to SyntaxError', t => {
     t.plan(2)
 
-    process.once('unhandledRejection', (err) => {
+    process.once('uncaughtException', (err) => {
       req.abort()
       t.type(err, systemErrors.SyntaxError)
     })
@@ -105,7 +105,7 @@ fastify.listen(0, err => {
   test('Should exit due to TypeError', t => {
     t.plan(2)
 
-    process.once('unhandledRejection', (err) => {
+    process.once('uncaughtException', (err) => {
       req.abort()
       t.type(err, systemErrors.TypeError)
     })
@@ -121,7 +121,7 @@ fastify.listen(0, err => {
   test('Should exit due to AssertionError', t => {
     t.plan(2)
 
-    process.once('unhandledRejection', (err) => {
+    process.once('uncaughtException', (err) => {
       req.abort()
       t.type(err, systemErrors.AssertionError)
     })

--- a/test/promise-error.test.js
+++ b/test/promise-error.test.js
@@ -1,31 +1,33 @@
 'use strict'
 
 const t = require('tap')
-const test = t.test
 const Fastify = require('..')
+const sget = require('simple-get').concat
 
-test('Should throw when non-error value is used to reject a promise', t => {
-  t.plan(3)
+t.plan(4)
 
-  process.removeAllListeners('uncaughtException')
+process.removeAllListeners('uncaughtException')
 
-  process.once('uncaughtException', (err) => {
-    t.type(err, TypeError)
-    t.strictEqual(err.message, "Attempted to reject a promise with a non-error value from type 'string'")
-    t.strictEqual(err.cause, 'string')
-  })
+process.on('uncaughtException', (err) => {
+  t.type(err, TypeError)
+  t.strictEqual(err.message, "Attempted to reject a promise with a non-error value from type 'string'")
+  t.strictEqual(err.cause, 'string')
+})
 
-  const fastify = Fastify()
+const fastify = Fastify()
 
-  const noneError = 'string'
-  fastify.get('/', () => {
-    return Promise.reject(noneError)
-  })
+const noneError = 'string'
+fastify.get('/', () => {
+  return Promise.reject(noneError)
+})
 
-  fastify.inject({
+fastify.listen(0, () => {
+  fastify.server.unref()
+
+  sget({
     method: 'GET',
-    url: '/'
-  }, res => {
-    t.fail('should not be called')
+    url: `http://localhost:${fastify.server.address().port}/`
+  }, err => {
+    t.ok(err)
   })
 })

--- a/test/promise-error.test.js
+++ b/test/promise-error.test.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('..')
+
+test('Should throw when non-error value is used to reject a promise', t => {
+  t.plan(3)
+
+  process.removeAllListeners('uncaughtException')
+
+  process.once('uncaughtException', (err) => {
+    t.type(err, TypeError)
+    t.strictEqual(err.message, "Attempted to reject a promise with a non-error value from type 'string'")
+    t.strictEqual(err.cause, 'string')
+  })
+
+  const fastify = Fastify()
+
+  const noneError = 'string'
+  fastify.get('/', () => {
+    return Promise.reject(noneError)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, res => {
+    t.fail('should not be called')
+  })
+})

--- a/test/promise-system-errors.test.js
+++ b/test/promise-system-errors.test.js
@@ -36,12 +36,12 @@ fastify.listen(0, err => {
 
   // Tap patched this event and we have no chance to listen on it.
   // Since any test runs in a seperate process we don't have to restore it
-  process.removeAllListeners('unhandledRejection')
+  process.removeAllListeners('uncaughtException')
 
   test('Should exit due to EvalError', t => {
     t.plan(2)
 
-    process.once('unhandledRejection', (err) => {
+    process.once('uncaughtException', (err) => {
       req.abort()
       t.type(err, systemErrors.EvalError)
     })
@@ -57,7 +57,7 @@ fastify.listen(0, err => {
   test('Should exit due to RangeError', t => {
     t.plan(2)
 
-    process.once('unhandledRejection', (err) => {
+    process.once('uncaughtException', (err) => {
       req.abort()
       t.type(err, systemErrors.RangeError)
     })
@@ -73,7 +73,7 @@ fastify.listen(0, err => {
   test('Should exit due to ReferenceError', t => {
     t.plan(2)
 
-    process.once('unhandledRejection', (err) => {
+    process.once('uncaughtException', (err) => {
       req.abort()
       t.type(err, systemErrors.ReferenceError)
     })
@@ -89,7 +89,7 @@ fastify.listen(0, err => {
   test('Should exit due to SyntaxError', t => {
     t.plan(2)
 
-    process.once('unhandledRejection', (err) => {
+    process.once('uncaughtException', (err) => {
       req.abort()
       t.type(err, systemErrors.SyntaxError)
     })
@@ -105,7 +105,7 @@ fastify.listen(0, err => {
   test('Should exit due to TypeError', t => {
     t.plan(2)
 
-    process.once('unhandledRejection', (err) => {
+    process.once('uncaughtException', (err) => {
       req.abort()
       t.type(err, systemErrors.TypeError)
     })
@@ -121,7 +121,7 @@ fastify.listen(0, err => {
   test('Should exit due to AssertionError', t => {
     t.plan(2)
 
-    process.once('unhandledRejection', (err) => {
+    process.once('uncaughtException', (err) => {
       req.abort()
       t.type(err, systemErrors.AssertionError)
     })

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -293,35 +293,6 @@ test('should set the status code and the headers from the error object (from cus
   })
 })
 
-test('Should throw when non-error value is used to reject a promise', t => {
-  t.plan(3)
-
-  // Tap patched this event and we have no chance to listen on it.
-  const listeners = process.listeners('unhandledRejection')
-  process.removeAllListeners('unhandledRejection')
-
-  process.once('unhandledRejection', (err) => {
-    t.type(err, TypeError)
-    t.strictEqual(err.message, "Attempted to reject a promise with a non-error value from type 'string'")
-    t.strictEqual(err.cause, 'string')
-    process.addListener.apply(process, ['unhandledRejection'].concat(listeners))
-  })
-
-  const fastify = Fastify()
-
-  const noneError = 'string'
-  fastify.get('/', () => {
-    return Promise.reject(noneError)
-  })
-
-  fastify.inject({
-    method: 'GET',
-    url: '/'
-  }, res => {
-    t.fail('should not be called')
-  })
-})
-
 // Issue 595 https://github.com/fastify/fastify/issues/595
 test('\'*\' should throw an error due to serializer can not handle the payload type', t => {
   t.plan(2)


### PR DESCRIPTION
#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

Due to https://github.com/fastify/fastify/pull/591#issuecomment-355350335 we will defer the throwing of the error to trigger an `uncaughtException` instead `unhandledRejection`.

- Destroy the connection instead emit an error because we want to exit the server without any post-processing.
- Log client error
- **Includes a failing test**

All tests were updated and works fine except [this](https://github.com/StarpTech/fastify/blob/53ef1da76bd5ea2259ad795457e593866496554e/test/promise-error.test.js) could you check it @delvedor the `uncaughtException` handler is never fired but without tap it works. I don't know why :suspect:

  
  