### PR TITLE
add failing stream test

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -169,7 +169,7 @@ function onSendEnd (reply, payload) {
 
 function pumpCallback (reply) {
   return function _pumpCallback (err) {
-    if (err) {
+    if (err && !reply.res.headersSent) {
       handleError(reply, err)
     }
   }
@@ -227,7 +227,6 @@ function handleError (reply, error, cb) {
 
   payload = serializeError(payload)
   flatstr(payload)
-
   reply.res.setHeader('Content-Length', '' + Buffer.byteLength(payload))
   reply.res.setHeader('Content-Type', 'application/json')
   reply.sent = true


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

Found a bug, where if you stream back a large stream using `reply.send(stream)` and the client aborts the request before the stream is done, fastify throws an uncaughtException.

Will try and do a fix as well, but here is first a failing test case.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
