### PR TITLE
Add option to limit the size of request bodies for the default body parser

### DIFF
--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -25,6 +25,7 @@ They need to be in
 * `beforeHandler(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#before-handler) called just before the request handler, useful if you need to perform authentication at route level for example, it could also be and array of functions.
 * `handler(request, reply)`: the function that will handle this request.
 * `schemaCompiler(schema)`: the function that build the schema for the validations. See [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-compiler)
+* `jsonBodyLimit`: prevents the default JSON body parser from parsing request bodies larger than this number of bytes. Must be an integer. You may also set this option globally when first creating the Fastify instance with `fastify(options)`. Defaults to `1000000` (1 MB).
 
   `request` is defined in [Request](https://github.com/fastify/fastify/blob/master/docs/Request.md).
 

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -25,7 +25,7 @@ They need to be in
 * `beforeHandler(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#before-handler) called just before the request handler, useful if you need to perform authentication at route level for example, it could also be and array of functions.
 * `handler(request, reply)`: the function that will handle this request.
 * `schemaCompiler(schema)`: the function that build the schema for the validations. See [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-compiler)
-* `jsonBodyLimit`: prevents the default JSON body parser from parsing request bodies larger than this number of bytes. Must be an integer. You may also set this option globally when first creating the Fastify instance with `fastify(options)`. Defaults to `1000000` (1 MB).
+* `jsonBodyLimit`: prevents the default JSON body parser from parsing request bodies larger than this number of bytes. Must be an integer. You may also set this option globally when first creating the Fastify instance with `fastify(options)`. Defaults to `1048576` (1 MiB).
 
   `request` is defined in [Request](https://github.com/fastify/fastify/blob/master/docs/Request.md).
 

--- a/fastify.js
+++ b/fastify.js
@@ -494,7 +494,9 @@ function build (options) {
     this.config = config
     this.errorHandler = errorHandler
     this._middie = middie
-    this._jsonBodyLimit = jsonBodyLimit
+    this._jsonParserOptions = {
+      limit: jsonBodyLimit
+    }
     this._fastify = fastify
   }
 

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -23,7 +23,7 @@ function handleRequest (req, res, params, context) {
   if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
     // application/json content type
     if (contentType && contentType.indexOf('application/json') > -1) {
-      return jsonBody(request, reply, context._jsonBodyLimit)
+      return jsonBody(request, reply, context._jsonParserOptions)
     }
 
     // custom parser for a given content type
@@ -42,7 +42,7 @@ function handleRequest (req, res, params, context) {
 
     // application/json content type
     if (contentType.indexOf('application/json') > -1) {
-      return jsonBody(request, reply, context._jsonBodyLimit)
+      return jsonBody(request, reply, context._jsonParserOptions)
     }
     // custom parser for a given content type
     if (context.contentTypeParser.fastHasHeader(contentType)) {
@@ -57,7 +57,8 @@ function handleRequest (req, res, params, context) {
   return
 }
 
-function jsonBody (request, reply, limit) {
+function jsonBody (request, reply, options) {
+  const limit = options.limit
   const contentLength = request.headers['content-length'] === undefined
     ? NaN
     : Number.parseInt(request.headers['content-length'], 10)

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -58,40 +58,41 @@ function handleRequest (req, res, params, context) {
 }
 
 function jsonBody (request, reply, limit) {
-  const contentLength = Number.parseInt(request.headers['content-length'], 10)
+  const contentLength = request.headers['content-length'] === undefined
+    ? NaN
+    : Number.parseInt(request.headers['content-length'], 10)
+
   if (contentLength > limit) {
     reply.code(413).send(new Error('Request body is too large'))
     return
   }
 
-  const req = request.req
-  const chunks = []
   var receivedLength = 0
+  var body = ''
+  var req = request.req
 
   req.on('data', onData)
   req.on('end', onEnd)
   req.on('error', onEnd)
 
-  function removeHandlers () {
-    req.removeListener('data', onData)
-    req.removeListener('end', onEnd)
-    req.removeListener('error', onEnd)
-  }
-
   function onData (chunk) {
     receivedLength += chunk.length
 
     if (receivedLength > limit) {
-      removeHandlers()
+      req.removeListener('data', onData)
+      req.removeListener('end', onEnd)
+      req.removeListener('error', onEnd)
       reply.code(413).send(new Error('Request body is too large'))
       return
     }
 
-    chunks.push(chunk)
+    body += chunk.toString()
   }
 
   function onEnd (err) {
-    removeHandlers()
+    req.removeListener('data', onData)
+    req.removeListener('end', onEnd)
+    req.removeListener('error', onEnd)
 
     if (err !== undefined) {
       reply.code(400).send(err)
@@ -108,9 +109,6 @@ function jsonBody (request, reply, limit) {
       return
     }
 
-    const body = chunks.length === 1
-      ? chunks[0].toString()
-      : chunks.join('')
     try {
       request.body = JSON.parse(body)
     } catch (err) {

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -23,7 +23,7 @@ function handleRequest (req, res, params, context) {
   if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
     // application/json content type
     if (contentType && contentType.indexOf('application/json') > -1) {
-      return jsonBody(request, reply)
+      return jsonBody(request, reply, context._jsonBodyLimit)
     }
 
     // custom parser for a given content type
@@ -42,7 +42,7 @@ function handleRequest (req, res, params, context) {
 
     // application/json content type
     if (contentType.indexOf('application/json') > -1) {
-      return jsonBody(request, reply)
+      return jsonBody(request, reply, context._jsonBodyLimit)
     }
     // custom parser for a given content type
     if (context.contentTypeParser.fastHasHeader(contentType)) {
@@ -57,19 +57,60 @@ function handleRequest (req, res, params, context) {
   return
 }
 
-function jsonBody (request, reply) {
-  var body = ''
-  var req = request.req
-  req.on('error', onError)
+function jsonBody (request, reply, limit) {
+  const contentLength = Number.parseInt(request.headers['content-length'], 10)
+  if (contentLength > limit) {
+    reply.code(413).send(new Error('Request body is too large'))
+    return
+  }
+
+  const req = request.req
+  const chunks = []
+  var receivedLength = 0
+
   req.on('data', onData)
   req.on('end', onEnd)
-  function onError (err) {
-    reply.code(422).send(err)
+  req.on('error', onEnd)
+
+  function removeHandlers () {
+    req.removeListener('data', onData)
+    req.removeListener('end', onEnd)
+    req.removeListener('error', onEnd)
   }
+
   function onData (chunk) {
-    body += chunk
+    receivedLength += chunk.length
+
+    if (receivedLength > limit) {
+      removeHandlers()
+      reply.code(413).send(new Error('Request body is too large'))
+      return
+    }
+
+    chunks.push(chunk)
   }
-  function onEnd () {
+
+  function onEnd (err) {
+    removeHandlers()
+
+    if (err !== undefined) {
+      reply.code(400).send(err)
+      return
+    }
+
+    if (!Number.isNaN(contentLength) && receivedLength !== contentLength) {
+      reply.code(400).send(new Error('Request body size did not match Content-Length'))
+      return
+    }
+
+    if (receivedLength === 0) { // Body is invalid JSON
+      reply.code(422).send(new Error('Unexpected end of JSON input'))
+      return
+    }
+
+    const body = chunks.length === 1
+      ? chunks[0].toString()
+      : chunks.join('')
     try {
       request.body = JSON.parse(body)
     } catch (err) {

--- a/test/fastify-options.test.js
+++ b/test/fastify-options.test.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const Fastify = require('..')
+const sget = require('simple-get').concat
+const t = require('tap')
+const test = t.test
+
+test('jsonBodyLimit option', t => {
+  t.plan(5)
+
+  try {
+    Fastify({ jsonBodyLimit: 1.3 })
+    t.fail('option must be an integer')
+  } catch (err) {
+    t.ok(err)
+  }
+
+  try {
+    Fastify({ jsonBodyLimit: [] })
+    t.fail('option must be an integer')
+  } catch (err) {
+    t.ok(err)
+  }
+
+  const fastify = Fastify({ jsonBodyLimit: 1 })
+
+  fastify.post('/', (request, reply) => {
+    reply.send({error: 'handler should not be called'})
+  })
+
+  fastify.listen(0, function (err) {
+    t.error(err)
+    fastify.server.unref()
+
+    sget({
+      method: 'POST',
+      url: 'http://localhost:' + fastify.server.address().port,
+      headers: { 'Content-Type': 'application/json' },
+      body: [],
+      json: true
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 413)
+    })
+  })
+})

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const sget = require('simple-get').concat
+const stream = require('stream')
 
 module.exports.payloadMethod = function (method, t) {
   const test = t.test
@@ -60,6 +61,18 @@ module.exports.payloadMethod = function (method, t) {
     }
   })
 
+  test(`${upMethod} with jsonBodyLimit option`, t => {
+    t.plan(1)
+    try {
+      fastify[loMethod]('/with-limit', { jsonBodyLimit: 1 }, function (req, reply) {
+        reply.send(req.body)
+      })
+      t.pass()
+    } catch (e) {
+      t.fail()
+    }
+  })
+
   fastify.listen(0, function (err) {
     if (err) {
       t.error(err)
@@ -80,6 +93,22 @@ module.exports.payloadMethod = function (method, t) {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
         t.deepEqual(body, { hello: 'world' })
+      })
+    })
+
+    test(`${upMethod} - correctly replies with very large body`, t => {
+      t.plan(3)
+
+      const largeString = 'world'.repeat(13200)
+      sget({
+        method: upMethod,
+        url: 'http://localhost:' + fastify.server.address().port,
+        body: { hello: largeString },
+        json: true
+      }, (err, response, body) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 200)
+        t.deepEqual(body, { hello: largeString })
       })
     })
 
@@ -167,7 +196,8 @@ module.exports.payloadMethod = function (method, t) {
     }
 
     test(`${upMethod} returns 422 - Unprocessable Entity`, t => {
-      t.plan(2)
+      t.plan(4)
+
       sget({
         method: upMethod,
         url: 'http://localhost:' + fastify.server.address().port,
@@ -179,6 +209,68 @@ module.exports.payloadMethod = function (method, t) {
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 422)
+      })
+
+      sget({
+        method: upMethod,
+        url: 'http://localhost:' + fastify.server.address().port,
+        body: '',
+        headers: { 'Content-Type': 'application/json' },
+        timeout: 500
+      }, (err, response, body) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 422)
+      })
+    })
+
+    test(`${upMethod} returns 413 - Payload Too Large`, t => {
+      t.plan(6)
+
+      sget({
+        method: upMethod,
+        url: 'http://localhost:' + fastify.server.address().port,
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': '1000001'
+        }
+      }, (err, response, body) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 413)
+      })
+
+      var chunk = Buffer.allocUnsafe(1000 * 1000 + 1)
+      const largeStream = new stream.Readable({
+        read () {
+          this.push(chunk)
+          chunk = null
+        }
+      })
+      sget({
+        method: upMethod,
+        url: 'http://localhost:' + fastify.server.address().port,
+        headers: { 'Content-Type': 'application/json' },
+        body: largeStream,
+        timeout: 500
+      }, (err, response, body) => {
+        t.error(err)
+        if (upMethod === 'OPTIONS') {
+          // Node errors with a 400 Bad Request for OPTIONS requests
+          // with a stream body and no Content-Length header
+          t.strictEqual(response.statusCode, 400)
+        } else {
+          t.strictEqual(response.statusCode, 413)
+        }
+      })
+
+      sget({
+        method: upMethod,
+        url: `http://localhost:${fastify.server.address().port}/with-limit`,
+        headers: { 'Content-Type': 'application/json' },
+        body: {},
+        json: true
+      }, (err, response, body) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 413)
       })
     })
   })

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -105,7 +105,7 @@ test('jsonBody should be a function', t => {
   t.plan(2)
 
   t.is(typeof internals.jsonBody, 'function')
-  t.is(internals.jsonBody.length, 2)
+  t.is(internals.jsonBody.length, 3)
 })
 
 test('request should be defined in onSend Hook on post request with content type application/json', t => {

--- a/test/jsonBodyLimit.test.js
+++ b/test/jsonBodyLimit.test.js
@@ -5,7 +5,7 @@ const sget = require('simple-get').concat
 const t = require('tap')
 const test = t.test
 
-test('jsonBodyLimit option', t => {
+test('jsonBodyLimit', t => {
   t.plan(5)
 
   try {

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -178,3 +178,25 @@ test('path can be specified in place of uri', t => {
     t.deepEqual(JSON.parse(res.payload), { hello: 'world' })
   })
 })
+
+test('invalid jsonBodyLimit option - route', t => {
+  t.plan(2)
+
+  try {
+    fastify.route({
+      jsonBodyLimit: false,
+      method: 'PUT',
+      handler: () => null
+    })
+    t.fail('jsonBodyLimit must be an integer')
+  } catch (err) {
+    t.ok(err)
+  }
+
+  try {
+    fastify.post('/url', { jsonBodyLimit: 10000.1 }, () => null)
+    t.fail('jsonBodyLimit must be an integer')
+  } catch (err) {
+    t.ok(err)
+  }
+})


### PR DESCRIPTION
Adds a `jsonBodyLimit` option that can be configured with the initial `fastify` call and at routes.

```js
const fastify = require('fastify')({ jsonBodyLimit: 1000 })

fastify.route({
  method: 'POST'
  url: '/form',
  jsonBodyLimit: 10000, 
  handler() { ... }
})
```

Default limit is `1 MiB`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

  