### PR TITLE
reply.send(string) documentation and test updates

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -71,7 +71,7 @@ reply
   .serializer(protoBuf.serialize)
 ```
 
-Note that if a string or buffer is passed to `reply.send` it is expected to already be serialized and skip the serialization step.
+Note that if a buffer is passed to `reply.send` it is expected to already be serialized and skip the serialization step.
 
 *Take a look [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#serialization) to understand how serialization is done.*
 
@@ -101,6 +101,15 @@ As noted above, if you are sending JSON objects, `send` will serialize the objec
 ```js
 fastify.get('/json', options, function (request, reply) {
   reply.send({ hello: 'world' })
+})
+```
+
+<a name="send-string"></a>
+#### Strings
+If you pass a string to `send` without a `Content-Type`, it will be sent as plain text. If you set the `Content-Type` header and pass a string to `send`, it will be serialized with the custom serializer if one is set, otherwise it will be sent unmodified (unless the `Content-Type` header is set to `application/json`, in which case it will be JSON-serialized like an object — see the section above).
+```js
+fastify.get('/json', options, function (request, reply) {
+  reply.send('plain string')
 })
 ```
 

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -282,7 +282,7 @@ test('buffer with content type should not send application/octet-stream', t => {
   })
 })
 
-test('plain string without content type shouls send a text/plain', t => {
+test('plain string without content type should send a text/plain', t => {
   t.plan(4)
 
   const fastify = require('../..')()
@@ -302,6 +302,57 @@ test('plain string without content type shouls send a text/plain', t => {
       t.error(err)
       t.strictEqual(response.headers['content-type'], 'text/plain')
       t.deepEqual(body.toString(), 'hello world!')
+    })
+  })
+})
+
+test('plain string with content type should be sent unmodified', t => {
+  t.plan(4)
+
+  const fastify = require('../..')()
+
+  fastify.get('/', function (req, reply) {
+    reply.type('text/css').send('hello world!')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.headers['content-type'], 'text/css')
+      t.deepEqual(body.toString(), 'hello world!')
+    })
+  })
+})
+
+test('plain string with content type and custom serializer should be serialized', t => {
+  t.plan(4)
+
+  const fastify = require('../..')()
+
+  fastify.get('/', function (req, reply) {
+    reply
+      .serializer(() => 'serialized')
+      .type('text/css')
+      .send('hello world!')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.headers['content-type'], 'text/css')
+      t.deepEqual(body.toString(), 'serialized')
     })
   })
 })


### PR DESCRIPTION
This aligns the documentation and tests with the current functionality of passing a string to `reply.send()`.

New documentation:
```
If you pass a string to `send` without a `Content-Type`, it will be sent as plain text.
If you set the `Content-Type` header and pass a string to `send`, it will be serialized
with the custom serializer if one is set, otherwise it will be sent unmodified (unless
the `Content-Type` header is set to `application/json`, in which case it will be
JSON-serialized like an object — see the section above).
```

If anyone thinks the functionality should be changed, this would be a good chance to discuss it.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
