### PR TITLE
Allow error handler to log stream errors

### DIFF
--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -139,7 +139,7 @@ Set the schema compiler for all routes [here](https://github.com/fastify/fastify
 
 `fastify.setErrorHandler(handler(error, reply))`: set a function that will be called whenever an error happens. The handler is fully encapsulated, so different plugins can set different error handlers, *async await* is supported as well.
 
-This handler can be called if an error occurs after headers are already sent. If this happens you will not be able to send a response, so you can avoid any unnecessary sending logic by checking the `reply.sent` property.
+This handler can be called if an error occurs after headers are already sent. If this happens you will not be able to set any headers or send a response. You can avoid any logic that sets headers or sends a response by checking the `reply.sent` property.
 
 ```js
 fastify.setErrorHandler(function (error, reply) {

--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -138,3 +138,14 @@ Set the schema compiler for all routes [here](https://github.com/fastify/fastify
 #### setErrorHandler
 
 `fastify.setErrorHandler(handler(error, reply))`: set a function that will be called whenever an error happens. The handler is fully encapsulated, so different plugins can set different error handlers, *async await* is supported as well.
+
+This handler can be called if an error occurs after headers are already sent. If this happens you will not be able to send a response, so you can avoid any unnecessary sending logic by checking the `res.headersSent` property.
+
+```js
+fastify.setErrorHandler(function (error, reply) {
+  if (reply.res.headersSent) {
+    return
+  }
+  ... // Send an error response
+})
+```

--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -139,11 +139,11 @@ Set the schema compiler for all routes [here](https://github.com/fastify/fastify
 
 `fastify.setErrorHandler(handler(error, reply))`: set a function that will be called whenever an error happens. The handler is fully encapsulated, so different plugins can set different error handlers, *async await* is supported as well.
 
-This handler can be called if an error occurs after headers are already sent. If this happens you will not be able to send a response, so you can avoid any unnecessary sending logic by checking the `res.headersSent` property.
+This handler can be called if an error occurs after headers are already sent. If this happens you will not be able to send a response, so you can avoid any unnecessary sending logic by checking the `reply.sent` property.
 
 ```js
 fastify.setErrorHandler(function (error, reply) {
-  if (reply.res.headersSent) {
+  if (reply.sent) {
     return
   }
   ... // Send an error response

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -168,13 +168,8 @@ function onSendEnd (reply, payload) {
 
 function pumpCallback (reply) {
   return function _pumpCallback (err) {
-    const headersSent = reply.res.headersSent
     if (err) {
-      if (!headersSent) {
-        handleError(reply, err)
-      } else {
-        reply.res.log.info('response terminated with an error with headers already sent')
-      }
+      handleError(reply, err)
     }
   }
 }
@@ -205,7 +200,7 @@ function handleError (reply, error, cb) {
 
   var customErrorHandler = reply.context.errorHandler
   if (customErrorHandler && reply._customError === false) {
-    reply.sent = false
+    reply.sent = reply.res.headersSent
     reply._isError = false
     reply._customError = true
     var result = customErrorHandler(error, reply)
@@ -213,6 +208,11 @@ function handleError (reply, error, cb) {
       result.then(payload => reply.send(payload))
             .catch(err => reply.send(err))
     }
+    return
+  }
+
+  if (reply.res.headersSent) {
+    reply.res.log.info('response terminated with an error with headers already sent')
     return
   }
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -195,7 +195,8 @@ function handleError (reply, error, cb) {
     log.info({ res: reply.res, err: error }, error && error.message)
   }
 
-  if (error && error.headers) {
+  var headersSent = reply.res.headersSent
+  if (!headersSent && error && error.headers) {
     reply.headers(error.headers)
   }
 
@@ -212,7 +213,7 @@ function handleError (reply, error, cb) {
     return
   }
 
-  if (reply.res.headersSent) {
+  if (headersSent) {
     log.info('response terminated with an error with headers already sent')
     return
   }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -188,10 +188,11 @@ function handleError (reply, error, cb) {
   if (statusCode < 400) statusCode = 500
   reply.res.statusCode = statusCode
 
+  var log = reply.request.log
   if (statusCode >= 500) {
-    reply.res.log.error({ res: reply.res, err: error }, error && error.message)
+    log.error({ res: reply.res, err: error }, error && error.message)
   } else if (statusCode >= 400) {
-    reply.res.log.info({ res: reply.res, err: error }, error && error.message)
+    log.info({ res: reply.res, err: error }, error && error.message)
   }
 
   if (error && error.headers) {
@@ -212,7 +213,7 @@ function handleError (reply, error, cb) {
   }
 
   if (reply.res.headersSent) {
-    reply.res.log.info('response terminated with an error with headers already sent')
+    log.info('response terminated with an error with headers already sent')
     return
   }
 

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -50,7 +50,6 @@ test('handler function - invalid schema', t => {
   res.getHeader = (key) => {
     return
   }
-  res.log = { error: () => {}, info: () => {} }
   const context = {
     schema: {
       body: {
@@ -68,6 +67,7 @@ test('handler function - invalid schema', t => {
   }
   buildSchema(context, schemaCompiler)
   const request = {
+    log: { error: () => {}, info: () => {} },
     body: { hello: 'world' }
   }
   internals.handler(new Reply(res, context, request))

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -172,7 +172,7 @@ test('Destroying streams prematurely', t => {
 })
 
 test('Destroying streams prematurely with custom error handler set', t => {
-  t.plan(6)
+  t.plan(7)
 
   const fastify = Fastify()
   const stream = require('stream')
@@ -180,17 +180,18 @@ test('Destroying streams prematurely with custom error handler set', t => {
 
   fastify.setErrorHandler(function (err, reply) {
     t.type(err, Error)
+    t.strictEqual(reply.sent, true)
 
     try {
       reply.send('error message')
-      t.pass('sending a response after headers are sent should do nothing')
+      t.pass('sending a response after headers are sent should not error')
     } catch (error) {
       t.fail(error)
     }
 
     try {
       reply.send(new Error('error message'))
-      t.pass('sending an error response after headers are sent should do nothing')
+      t.pass('sending an error response after headers are sent should not error')
     } catch (error) {
       t.fail(error)
     }

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -170,3 +170,62 @@ test('Destroying streams prematurely', t => {
     })
   })
 })
+
+test('Destroying streams prematurely with custom error handler set', t => {
+  t.plan(6)
+
+  const fastify = Fastify()
+  const stream = require('stream')
+  const http = require('http')
+
+  fastify.setErrorHandler(function (err, reply) {
+    t.type(err, Error)
+
+    try {
+      reply.send('error message')
+      t.pass('sending a response after headers are sent should do nothing')
+    } catch (error) {
+      t.fail(error)
+    }
+
+    try {
+      reply.send(new Error('error message'))
+      t.pass('sending an error response after headers are sent should do nothing')
+    } catch (error) {
+      t.fail(error)
+    }
+  })
+
+  fastify.get('/', function (request, reply) {
+    t.pass('Received request')
+
+    var sent = false
+    var reallyLongStream = new stream.Readable({
+      read: function () {
+        if (!sent) {
+          this.push(Buffer.from('hello\n'))
+        }
+        sent = true
+      }
+    })
+
+    reply.send(reallyLongStream)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
+
+    var port = fastify.server.address().port
+
+    http.get(`http://localhost:${port}`, function (response) {
+      t.strictEqual(response.statusCode, 200)
+      response.on('readable', function () {
+        response.destroy()
+      })
+      response.on('close', function () {
+        t.pass('Response closed')
+      })
+    })
+  })
+})


### PR DESCRIPTION
This lets custom error handlers have a chance to handle the error (mainly to log it) which fixes a bug where stream errors are completely lost if the built-in logger is not turned on.

This change also makes Fastify log stream errors with all of the information of any other error.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
