### PR TITLE
Improve how stream errors are logged

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -168,13 +168,11 @@ function onSendEnd (reply, payload) {
 
 function pumpCallback (reply) {
   return function _pumpCallback (err) {
-    const headersSent = reply.res.headersSent
-    if (err) {
-      if (!headersSent) {
-        handleError(reply, err)
-      } else {
-        reply.res.log.info('response terminated with an error with headers already sent')
-      }
+    if (!err) return
+    if (reply.res.headersSent) {
+      reply.request.log.error(err, 'response terminated with an error with headers already sent')
+    } else {
+      handleError(reply, err)
     }
   }
 }


### PR DESCRIPTION
Log with `error` severity and log the error object.

Supersedes #634

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
