### PR TITLE
Fix/improve custom 404 handlers usage with plugins

### DIFF
--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -132,7 +132,20 @@ Set the schema compiler for all routes [here](https://github.com/fastify/fastify
 <a name="set-not-found-handler"></a>
 #### setNotFoundHandler
 
-`fastify.setNotFoundHandler(handler(request, reply))`: set the 404 handler. This call is fully encapsulated, so different plugins can set different not found handlers. The handler is treated like a regular route handler so requests will go through the full [Fastify lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md#lifecycle).
+`fastify.setNotFoundHandler(handler(request, reply))`: set the 404 handler. This call is encapsulated by prefix, so different plugins can set different not found handlers if a different [`prefix` option](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#route-prefixing-option) is passed to `fastify.register()`. The handler is treated like a regular route handler so requests will go through the full [Fastify lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md#lifecycle).
+
+```js
+fastify.setNotFoundHandler(function (request, reply) {
+  // Default not found handler  
+})
+
+fastify.register(function (instance, options, next) {
+  instance.setNotFoundHandler(function (request, reply) {
+    // Handle not found request to URLs that begin with '/v1'
+  })
+  next()
+}, { prefix: '/v1' })
+```
 
 <a name="set-error-handler"></a>
 #### setErrorHandler


### PR DESCRIPTION
#### Fix

Make sure plugin hooks will be run for the 404 handler.

Fixes this:
```js
fastify.register(require('fastify-cookie'))

fastify.setNotFoundHandler((request, reply) => {
  // cookie preHandler hook has not been run!
})
```

#### Improvement

Return an error with a helpful message if multiple 404 handlers are set for the same encapsulation level. Previously, the second handler would silently replace the original.

For more of an explanation of why this is helpful, see [this comment](https://github.com/fastify/fastify/pull/638#discussion_r160441071).

**Update:** I have updated the `setNotFoundHandler` documentation to better explain how not found handlers are encapsulated.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)