### PR TITLE
Plugin log level

### DIFF
--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -182,3 +182,27 @@ Now your clients will have access to the following routes:
 
 You can do this as many times as you want, it works also for nested `register` and routes parameter are supported as well.
 Be aware that if you use [`fastify-plugin`](https://github.com/fastify/fastify-plugin) this option won't work.
+
+<a name="custom-log-level"></a>
+### Custom Log Level
+It could happen that you need different log levels in your routes, with Fastify achieve this is very straightforward.<br/>
+You just need to pass the option `logLevel` to the plugin option or the route option with the [value](https://github.com/pinojs/pino/blob/master/docs/API.md#discussion-3) that you need.
+
+Be aware that if you set the `logLevel` at plugin level, also the [`setNotFoundHandler`](https://github.com/fastify/fastify/blob/master/docs/Server-Methods.md#setnotfoundhandler) and [`setErrorHandler`](https://github.com/fastify/fastify/blob/master/docs/Server-Methods.md#seterrorhandler) will be affected.
+
+```js
+// server.js
+const fastify = require('fastify')({ logger: true })
+
+fastify.register(require('./routes/user'), { logLevel: 'warn' })
+fastify.register(require('./routes/events'), { logLevel: 'debug' })
+
+fastify.listen(3000)
+```
+Or you can directly pass it to a route:
+```js
+fastify.get('/', { logLevel: 'warn' }, (req, reply) => {
+  reply.send({ hello: 'world' })
+})
+```
+*Remember that the custom log level is applied only to the routes, and not to the global Fastify Logger, accessible with `fastify.log`*

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -543,3 +543,28 @@ test('Should set a custom log level for a specific route', t => {
     t.deepEqual(payload, { hello: 'world' })
   })
 })
+
+test('The default 404 handler logs the incoming request', t => {
+  t.plan(5)
+
+  const expectedMessages = ['incoming request', 'Not found', 'request completed']
+
+  const splitStream = split(JSON.parse)
+  splitStream.on('data', (line) => {
+    t.is(line.msg, expectedMessages.shift())
+  })
+
+  const logger = pino({ level: 'trace' }, splitStream)
+
+  const fastify = Fastify({
+    logger
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/not-found'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 404)
+  })
+})

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -283,3 +283,263 @@ test('logger can be silented', t => {
   t.is(typeof childLog.trace, 'function')
   t.is(typeof childLog.child, 'function')
 })
+
+test('Should set a custom logLevel for a plugin', t => {
+  const lines = ['incoming request', 'Hello', 'request completed']
+  t.plan(7)
+
+  const splitStream = split(JSON.parse)
+  splitStream.on('data', (line) => {
+    t.is(line.msg, lines.shift())
+  })
+
+  const logger = pino({ level: 'error' }, splitStream)
+
+  const fastify = Fastify({
+    logger
+  })
+
+  fastify.get('/', (req, reply) => {
+    req.log.info('Hello') // we should not see this log
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.register(function (instance, opts, next) {
+    instance.get('/plugin', (req, reply) => {
+      req.log.info('Hello') // we should see this log
+      reply.send({ hello: 'world' })
+    })
+    next()
+  }, { logLevel: 'info' })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.deepEqual(payload, { hello: 'world' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/plugin'
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.deepEqual(payload, { hello: 'world' })
+  })
+})
+
+test('Should set a custom logLevel for every plugin', t => {
+  const lines = ['incoming request', 'request completed', 'info', 'debug']
+  t.plan(18)
+
+  const splitStream = split(JSON.parse)
+  splitStream.on('data', (line) => {
+    t.ok(line.level === 30 || line.level === 20)
+    t.ok(lines.indexOf(line.msg) > -1)
+  })
+
+  const logger = pino({ level: 'error' }, splitStream)
+
+  const fastify = Fastify({
+    logger
+  })
+
+  fastify.get('/', (req, reply) => {
+    req.log.warn('Hello') // we should not see this log
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.register(function (instance, opts, next) {
+    instance.get('/info', (req, reply) => {
+      req.log.info('info') // we should see this log
+      req.log.debug('hidden log')
+      reply.send({ hello: 'world' })
+    })
+    next()
+  }, { logLevel: 'info' })
+
+  fastify.register(function (instance, opts, next) {
+    instance.get('/debug', (req, reply) => {
+      req.log.debug('debug') // we should see this log
+      req.log.trace('hidden log')
+      reply.send({ hello: 'world' })
+    })
+    next()
+  }, { logLevel: 'debug' })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.deepEqual(payload, { hello: 'world' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/info'
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.deepEqual(payload, { hello: 'world' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/debug'
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.deepEqual(payload, { hello: 'world' })
+  })
+})
+
+test('Should increase the log level for a specific plugin', t => {
+  t.plan(4)
+
+  const splitStream = split(JSON.parse)
+  splitStream.on('data', (line) => {
+    t.is(line.msg, 'Hello')
+    t.ok(line.level === 50)
+  })
+
+  const logger = pino({ level: 'info' }, splitStream)
+
+  const fastify = Fastify({
+    logger
+  })
+
+  fastify.register(function (instance, opts, next) {
+    instance.get('/', (req, reply) => {
+      req.log.error('Hello') // we should see this log
+      reply.send({ hello: 'world' })
+    })
+    next()
+  }, { logLevel: 'error' })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.deepEqual(payload, { hello: 'world' })
+  })
+})
+
+test('Should set the log level for the customized 404 handler', t => {
+  t.plan(4)
+
+  const splitStream = split(JSON.parse)
+  splitStream.on('data', (line) => {
+    t.is(line.msg, 'Hello')
+    t.ok(line.level === 50)
+  })
+
+  const logger = pino({ level: 'warn' }, splitStream)
+
+  const fastify = Fastify({
+    logger
+  })
+
+  fastify.register(function (instance, opts, next) {
+    instance.setNotFoundHandler(function (req, reply) {
+      req.log.error('Hello')
+      reply.code(404).send()
+    })
+    next()
+  }, { logLevel: 'error' })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 404)
+  })
+})
+
+test('Should set the log level for the customized 500 handler', t => {
+  t.plan(4)
+
+  const splitStream = split(JSON.parse)
+  splitStream.on('data', (line) => {
+    t.is(line.msg, 'Hello')
+    t.ok(line.level === 60)
+  })
+
+  const logger = pino({ level: 'warn' }, splitStream)
+
+  const fastify = Fastify({
+    logger
+  })
+
+  fastify.register(function (instance, opts, next) {
+    instance.get('/', (req, reply) => {
+      req.log.error('kaboom')
+      reply.send(new Error('kaboom'))
+    })
+
+    instance.setErrorHandler(function (e, reply) {
+      reply.res.log.fatal('Hello')
+      reply.code(500).send()
+    })
+    next()
+  }, { logLevel: 'fatal' })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 500)
+  })
+})
+
+test('Should set a custom log level for a specific route', t => {
+  const lines = ['incoming request', 'Hello', 'request completed']
+  t.plan(7)
+
+  const splitStream = split(JSON.parse)
+  splitStream.on('data', (line) => {
+    t.is(line.msg, lines.shift())
+  })
+
+  const logger = pino({ level: 'error' }, splitStream)
+
+  const fastify = Fastify({
+    logger
+  })
+
+  fastify.get('/log', { logLevel: 'info' }, (req, reply) => {
+    req.log.info('Hello')
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.get('/no-log', (req, reply) => {
+    req.log.info('Hello')
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/log'
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.deepEqual(payload, { hello: 'world' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/no-log'
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.deepEqual(payload, { hello: 'world' })
+  })
+})


### PR DESCRIPTION
With this pr we introduce a shine new feature ideated by @allevo.
We will have the possibility to set a custom log level for a plugin or even a single route, respecting the encapsulation model :)

The internals has been changed because to support this feature without loosing performances we must create the child logger directly with the new log level and not setting it afterwards, otherwise V8 will deoptimize the code and we lose about 10% req/sec.

Following a brief example:
```js
fastify.register(require('./routes/user'), { logLevel: 'warn' })
fastify.register(require('./routes/events'), { logLevel: 'debug' })

fastify.get('/', { logLevel: 'info' }, (req, reply) => {
  reply.send({ hello: 'world' })
})
```
Related: https://github.com/fastify/fastify/issues/636

#### Benchmarks
*master*
```
Running 5s test @ http://localhost:3000/
100 connections with 10 pipelining factor

Stat         Avg     Stdev   Max
Latency (ms) 3.09    9.82    276
Req/Sec      31481.6 3704.73 34399
Bytes/Sec    4.71 MB 563 kB  5.24 MB

157k requests in 5s, 23.5 MB read
```
*plugin-log-level*
```
Running 5s test @ http://localhost:3000/
100 connections with 10 pipelining factor

Stat         Avg     Stdev   Max
Latency (ms) 2.97    9.43    189
Req/Sec      32737.6 4339.72 36095
Bytes/Sec    4.92 MB 666 kB  5.51 MB

164k requests in 5s, 24.4 MB read
```
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
