### PR TITLE
Fix decorateRequest example

### DIFF
--- a/docs/Plugins-Guide.md
+++ b/docs/Plugins-Guide.md
@@ -158,7 +158,7 @@ fastify.get('/happiness', (req, reply) => {
 Again, it works, but it can be way better!
 ```js
 fastify.decorateRequest('setHeader', function (header) {
-  this.isHappy = this.req.headers[header]
+  this.isHappy = this.headers[header]
 })
 
 fastify.decorateRequest('isHappy', false) // this will be added to the Request object prototype, yay speed!


### PR DESCRIPTION
Within `decorateRequest` handlers `this` is bound to the Fastify request object. Thus, there is no need to access the raw `IncomingRequest` to retrieve a specific header.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
