### PR TITLE
Updated request object

### DIFF
--- a/docs/Plugins-Guide.md
+++ b/docs/Plugins-Guide.md
@@ -147,7 +147,7 @@ fastify.decorate('getHeader', (req, header) => {
 })
 
 fastify.addHook('preHandler', (req, reply, done) => {
-  req.isHappy = fastify.getHeader(req.req, 'happy')
+  req.isHappy = fastify.getHeader(req.raw, 'happy')
   done()
 })
 

--- a/docs/Request.md
+++ b/docs/Request.md
@@ -7,7 +7,7 @@ Request is a core Fastify object containing the following fields:
 - `body` - the body
 - `params` - the params matching the URL
 - `headers` - the headers
-- `req` - the incoming HTTP request from Node core
+- `raw` - the incoming HTTP request from Node core *(you can use the alias `req`)*
 - `log` - the logger instance of the incoming request
 
 ```js
@@ -16,7 +16,7 @@ fastify.post('/:params', options, function (request, reply) {
   console.log(request.query)
   console.log(request.params)
   console.log(request.headers)
-  console.log(request.req)
+  console.log(request.raw)
   request.log.info('some info')
 })
 ```

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -53,7 +53,7 @@ const server: fastify.FastifyInstance<http.Server, CustomIncomingMessage, http.S
 
 server.get('/ping', (req, reply) => {
   // Access our custom method on the http prototype
-  const clientDeviceType = req.req.getClientDeviceType()
+  const clientDeviceType = req.raw.getClientDeviceType()
 
   reply.send({ clientDeviceType: `you called this endpoint from a ${clientDeviceType}` })
 })

--- a/lib/ContentTypeParser.js
+++ b/lib/ContentTypeParser.js
@@ -46,7 +46,7 @@ ContentTypeParser.prototype.getHandler = function (contentType) {
 }
 
 ContentTypeParser.prototype.run = function (contentType, handler, request, reply) {
-  var result = this.getHandler(contentType)(request.req, done)
+  var result = this.getHandler(contentType)(request.raw, done)
   if (result && typeof result.then === 'function') {
     result.then(body => done(null, body)).catch(err => done(err, null))
   }

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -70,7 +70,7 @@ function jsonBody (request, reply, options) {
 
   var receivedLength = 0
   var body = ''
-  var req = request.req
+  var req = request.raw
 
   req.on('data', onData)
   req.on('end', onEnd)

--- a/lib/request.js
+++ b/lib/request.js
@@ -2,7 +2,7 @@
 
 function Request (params, req, query, headers, log) {
   this.params = params
-  this.req = req
+  this.raw = req
   this.query = query
   this.headers = headers
   this.log = log
@@ -12,15 +12,22 @@ function Request (params, req, query, headers, log) {
 function buildRequest (R) {
   function _Request (params, req, query, headers, log) {
     this.params = params
-    this.req = req
+    this.raw = req
     this.query = query
     this.headers = headers
     this.log = log
     this.body = null
   }
   _Request.prototype = new R()
+
   return _Request
 }
+
+Object.defineProperty(Request.prototype, 'req', {
+  get: function () {
+    return this.raw
+  }
+})
 
 module.exports = Request
 module.exports.buildRequest = buildRequest

--- a/test/hooks-async.js
+++ b/test/hooks-async.js
@@ -23,7 +23,7 @@ function asyncHookTest (t) {
       await sleep(1)
       request.test = 'the request is coming'
       reply.test = 'the reply has come'
-      if (request.req.method === 'HEAD') {
+      if (request.raw.method === 'HEAD') {
         throw new Error('some error')
       }
     })
@@ -39,7 +39,7 @@ function asyncHookTest (t) {
     })
 
     fastify.get('/', function (request, reply) {
-      t.is(request.req.raw, 'the request is coming')
+      t.is(request.raw.raw, 'the request is coming')
       t.is(reply.res.raw, 'the reply has come')
       t.is(request.test, 'the request is coming')
       t.is(reply.test, 'the reply has come')

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -15,7 +15,7 @@ test('hooks', t => {
     fastify.addHook('preHandler', function (request, reply, next) {
       request.test = 'the request is coming'
       reply.test = 'the reply has come'
-      if (request.req.method === 'HEAD') {
+      if (request.raw.method === 'HEAD') {
         next(new Error('some error'))
       } else {
         next()
@@ -52,7 +52,7 @@ test('hooks', t => {
   })
 
   fastify.get('/', function (req, reply) {
-    t.is(req.req.raw, 'the request is coming')
+    t.is(req.raw.raw, 'the request is coming')
     t.is(reply.res.raw, 'the reply has come')
     t.is(req.test, 'the request is coming')
     t.is(reply.test, 'the reply has come')
@@ -148,8 +148,8 @@ test('onRequest hook should support encapsulation / 3', t => {
   fastify.decorate('hello2', 'world')
 
   fastify.get('/first', (req, reply) => {
-    t.ok(req.req.first)
-    t.notOk(req.req.second)
+    t.ok(req.raw.first)
+    t.notOk(req.raw.second)
     reply.send({ hello: 'world' })
   })
 
@@ -164,8 +164,8 @@ test('onRequest hook should support encapsulation / 3', t => {
     })
 
     instance.get('/second', (req, reply) => {
-      t.ok(req.req.first)
-      t.ok(req.req.second)
+      t.ok(req.raw.first)
+      t.ok(req.raw.second)
       reply.send({ hello: 'world' })
     })
 
@@ -471,7 +471,7 @@ test('onSend hook throws', t => {
   t.plan(7)
   const fastify = Fastify()
   fastify.addHook('onSend', function (request, reply, payload, next) {
-    if (request.req.method === 'DELETE') {
+    if (request.raw.method === 'DELETE') {
       next(new Error('some error'))
       return
     }

--- a/test/internals/all.test.js
+++ b/test/internals/all.test.js
@@ -11,7 +11,7 @@ test('fastify.all should add all the methods to the same url', t => {
   const fastify = Fastify()
 
   fastify.all('/', (req, reply) => {
-    reply.send({ method: req.req.method })
+    reply.send({ method: req.raw.method })
   })
 
   supportedMethods.forEach(injectRequest)

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -26,15 +26,16 @@ function schemaCompiler (schema) {
 }
 
 test('Request object', t => {
-  t.plan(7)
+  t.plan(8)
   const req = new Request('params', 'req', 'query', 'headers', 'log')
   t.type(req, Request)
   t.equal(req.params, 'params')
-  t.deepEqual(req.req, 'req')
+  t.deepEqual(req.raw, 'req')
+  t.deepEqual(req.req, req.raw)
   t.equal(req.query, 'query')
   t.equal(req.headers, 'headers')
   t.equal(req.log, 'log')
-  t.equal(req.body, null)
+  t.strictDeepEqual(req.body, null)
 })
 
 test('handler function - invalid schema', t => {
@@ -114,7 +115,7 @@ test('request should be defined in onSend Hook on post request with content type
 
   fastify.addHook('onSend', (request, reply, payload, done) => {
     t.ok(request)
-    t.ok(request.req)
+    t.ok(request.raw)
     t.ok(request.params)
     t.ok(request.query)
     done()
@@ -145,7 +146,7 @@ test('request should be defined in onSend Hook on post request with content type
 
   fastify.addHook('onSend', (request, reply, payload, done) => {
     t.ok(request)
-    t.ok(request.req)
+    t.ok(request.raw)
     t.ok(request.params)
     t.ok(request.query)
     done()
@@ -176,7 +177,7 @@ test('request should be defined in onSend Hook on options request with content t
 
   fastify.addHook('onSend', (request, reply, payload, done) => {
     t.ok(request)
-    t.ok(request.req)
+    t.ok(request.raw)
     t.ok(request.params)
     t.ok(request.query)
     done()

--- a/test/internals/logger.test.js
+++ b/test/internals/logger.test.js
@@ -16,8 +16,8 @@ test('The logger should add a unique id for every request', t => {
 
   const fastify = Fastify()
   fastify.get('/', (req, reply) => {
-    t.ok(req.req.id)
-    reply.send({ id: req.req.id })
+    t.ok(req.raw.id)
+    reply.send({ id: req.raw.id })
   })
 
   fastify.listen(0, err => {
@@ -49,8 +49,8 @@ test('The logger should add a unique id for every request', t => {
 test('The logger should reuse request id header for req.id', t => {
   const fastify = Fastify()
   fastify.get('/', (req, reply) => {
-    t.ok(req.req.id)
-    reply.send({ id: req.req.id })
+    t.ok(req.raw.id)
+    reply.send({ id: req.raw.id })
   })
 
   fastify.listen(0, err => {

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -208,8 +208,8 @@ test('The logger should accept a custom genReqId function', t => {
   })
 
   fastify.get('/', (req, reply) => {
-    t.ok(req.req.id)
-    reply.send({ id: req.req.id })
+    t.ok(req.raw.id)
+    reply.send({ id: req.raw.id })
   })
 
   fastify.listen(0, err => {

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -177,8 +177,8 @@ test('middlewares should support encapsulation / 2', t => {
     })
 
     i.get('/local', function (request, reply) {
-      t.ok(request.req.global)
-      t.ok(request.req.local)
+      t.ok(request.raw.global)
+      t.ok(request.raw.local)
       reply.send({ hello: 'world' })
     })
 
@@ -186,8 +186,8 @@ test('middlewares should support encapsulation / 2', t => {
   })
 
   instance.get('/global', function (request, reply) {
-    t.ok(request.req.global)
-    t.notOk(request.req.local)
+    t.ok(request.raw.global)
+    t.notOk(request.raw.local)
     reply.send({ hello: 'world' })
   })
 
@@ -239,9 +239,9 @@ test('middlewares should support encapsulation / 3', t => {
     })
 
     i.get('/local', function (request, reply) {
-      t.ok(request.req.global)
-      t.ok(request.req.firstLocal)
-      t.ok(request.req.secondLocal)
+      t.ok(request.raw.global)
+      t.ok(request.raw.firstLocal)
+      t.ok(request.raw.secondLocal)
       reply.send({ hello: 'world' })
     })
 
@@ -249,9 +249,9 @@ test('middlewares should support encapsulation / 3', t => {
   })
 
   instance.get('/global', function (request, reply) {
-    t.ok(request.req.global)
-    t.notOk(request.req.firstLocal)
-    t.notOk(request.req.secondLocal)
+    t.ok(request.raw.global)
+    t.notOk(request.raw.firstLocal)
+    t.notOk(request.raw.secondLocal)
     reply.send({ hello: 'world' })
   })
 
@@ -304,10 +304,10 @@ test('middlewares should support encapsulation / 4', t => {
       })
 
       f.get('/secondLocal', function (request, reply) {
-        t.ok(request.req.global)
-        t.ok(request.req.firstLocal)
-        t.ok(request.req.secondLocal)
-        t.ok(request.req.thirdLocal)
+        t.ok(request.raw.global)
+        t.ok(request.raw.firstLocal)
+        t.ok(request.raw.secondLocal)
+        t.ok(request.raw.thirdLocal)
         reply.send({ hello: 'world' })
       })
 
@@ -320,10 +320,10 @@ test('middlewares should support encapsulation / 4', t => {
     })
 
     i.get('/firstLocal', function (request, reply) {
-      t.ok(request.req.global)
-      t.ok(request.req.firstLocal)
-      t.notOk(request.req.secondLocal)
-      t.notOk(request.req.thirdLocal)
+      t.ok(request.raw.global)
+      t.ok(request.raw.firstLocal)
+      t.notOk(request.raw.secondLocal)
+      t.notOk(request.raw.thirdLocal)
       reply.send({ hello: 'world' })
     })
 
@@ -331,10 +331,10 @@ test('middlewares should support encapsulation / 4', t => {
   })
 
   instance.get('/global', function (request, reply) {
-    t.ok(request.req.global)
-    t.notOk(request.req.firstLocal)
-    t.notOk(request.req.secondLocal)
-    t.notOk(request.req.thirdLocal)
+    t.ok(request.raw.global)
+    t.notOk(request.raw.firstLocal)
+    t.notOk(request.raw.secondLocal)
+    t.notOk(request.raw.thirdLocal)
     reply.send({ hello: 'world' })
   })
 
@@ -397,7 +397,7 @@ test('middlewares should support encapsulation / 5', t => {
   })
 
   instance.get('/global', function (request, reply) {
-    t.ok(request.req.global)
+    t.ok(request.raw.global)
     reply.send({ hello: 'world' })
   })
 
@@ -453,7 +453,7 @@ test('middlewares should support encapsulation with prefix', t => {
   }, { prefix: '/local' })
 
   instance.get('/global', function (request, reply) {
-    t.ok(request.req.global)
+    t.ok(request.raw.global)
     reply.send({ hello: 'world' })
   })
 
@@ -532,11 +532,11 @@ test('middlewares with prefix', t => {
 
   function handler (request, reply) {
     reply.send({
-      prefixed: request.req.prefixed,
-      slashed: request.req.slashed,
-      global: request.req.global,
-      global2: request.req.global2,
-      root: request.req.root
+      prefixed: request.raw.prefixed,
+      slashed: request.raw.slashed,
+      global: request.raw.global,
+      global2: request.raw.global2,
+      root: request.raw.root
     })
   }
 


### PR DESCRIPTION
Before release v1.0.0 I would like to propose the following changes to request object:
- rename `req` to `raw`
- add `rawBody` property

The first one becase doing `req.req` or `request.req` is awkward and counterintuitive.
The second because it could happen that a plugin or a user needs the raw body (maybe to perform some kind of forwarding).

cc @fastify/fastify 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
