### PR TITLE
Fix 595 and a bug when sending an Error object

### DIFF
--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -158,6 +158,7 @@ function preHandlerCallback (err, reply) {
         reply.send(payload)
       }
     }).catch((err) => {
+      reply.sent = false
       reply._isError = true
       reply.send(err)
     })

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -219,6 +219,7 @@ function handleError (reply, error, cb) {
     message: error ? error.message : '',
     statusCode: statusCode
   }
+  reply.res.setHeader('Content-Type', 'application/json')
 
   if (cb) {
     cb(reply, payload)
@@ -229,7 +230,6 @@ function handleError (reply, error, cb) {
   flatstr(payload)
 
   reply.res.setHeader('Content-Length', '' + Buffer.byteLength(payload))
-  reply.res.setHeader('Content-Type', 'application/json')
   reply.sent = true
   reply.res.end(payload)
 }

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -202,7 +202,7 @@ test('request should be defined in onSend Hook on options request with content t
 })
 
 test('request should respond with an error if an unserialized payload is sent inside an an async handler', t => {
-  t.plan(2)
+  t.plan(3)
 
   const fastify = require('../..')()
 
@@ -217,5 +217,10 @@ test('request should respond with an error if an unserialized payload is sent in
   }, (err, res) => {
     t.error(err)
     t.strictEqual(res.statusCode, 500)
+    t.deepEqual(JSON.parse(res.payload), {
+      error: 'Internal Server Error',
+      message: 'Attempted to send payload of invalid type \'object\' without serialization. Expected a string or Buffer.',
+      statusCode: 500
+    })
   })
 })

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -200,3 +200,22 @@ test('request should be defined in onSend Hook on options request with content t
     })
   })
 })
+
+test('request should respond with an error if an unserialized payload is sent inside an an async handler', t => {
+  t.plan(2)
+
+  const fastify = require('../..')()
+
+  fastify.get('/', (request, reply) => {
+    reply.type('text/html')
+    return Promise.resolve(request.headers)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 500)
+  })
+})

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -381,6 +381,38 @@ test('plain string with content type application/json should be serialized as js
   })
 })
 
+test('error object with a content type that is not application/json should work', t => {
+  t.plan(4)
+
+  const fastify = require('../..')()
+
+  fastify.get('/text', function (req, reply) {
+    reply.type('text/plain')
+    reply.send(new Error('some application error'))
+  })
+
+  fastify.get('/html', function (req, reply) {
+    reply.type('text/html')
+    reply.send(new Error('some application error'))
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/text'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 500)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/html'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 500)
+  })
+})
+
 test('undefined payload should be sent as-is', t => {
   t.plan(6)
 

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -382,7 +382,7 @@ test('plain string with content type application/json should be serialized as js
 })
 
 test('error object with a content type that is not application/json should work', t => {
-  t.plan(4)
+  t.plan(6)
 
   const fastify = require('../..')()
 
@@ -402,6 +402,7 @@ test('error object with a content type that is not application/json should work'
   }, (err, res) => {
     t.error(err)
     t.strictEqual(res.statusCode, 500)
+    t.strictEqual(JSON.parse(res.payload).message, 'some application error')
   })
 
   fastify.inject({
@@ -410,6 +411,7 @@ test('error object with a content type that is not application/json should work'
   }, (err, res) => {
     t.error(err)
     t.strictEqual(res.statusCode, 500)
+    t.strictEqual(JSON.parse(res.payload).message, 'some application error')
   })
 })
 


### PR DESCRIPTION
Since all of the code for re-throwing system errors was reverted, issue #595 became a problem again. This fixes it.

This also fixes a bug where doing `reply.send(errorObject)` would throw if a `Content-Type` header was previously set because [the payload](https://github.com/fastify/fastify/blob/6c23c92e8261ed3eef4248861692a5c50194a93f/lib/reply.js#L217-L221) wouldn't get serialized in [`onSendEnd`](https://github.com/fastify/fastify/blob/6c23c92e8261ed3eef4248861692a5c50194a93f/lib/reply.js#L124-L167).

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
