### PR TITLE
Added support for streams1 in reply.send()

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -129,7 +129,7 @@ function onSendEnd (reply, payload) {
   }
 
   var contentType = reply.res.getHeader('Content-Type')
-  if (payload !== null && payload.readable === true && typeof payload.pipe === 'function') {
+  if (payload !== null && typeof payload.pipe === 'function') {
     if (!contentType) {
       reply.res.setHeader('Content-Type', 'application/octet-stream')
     }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -129,7 +129,7 @@ function onSendEnd (reply, payload) {
   }
 
   var contentType = reply.res.getHeader('Content-Type')
-  if (payload !== null && payload._readableState) {
+  if (payload !== null && payload.readable === true && typeof payload.pipe === 'function') {
     if (!contentType) {
       reply.res.setHeader('Content-Type', 'application/octet-stream')
     }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "http-errors": "^1.6.2",
     "ienoopen": "^1.0.0",
     "joi": "~11.3.4",
+    "jsonstream": "^1.0.3",
     "pre-commit": "^1.2.2",
     "semver": "^5.4.1",
     "serve-static": "^1.13.1",


### PR DESCRIPTION

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
