### PR TITLE
Avoid body parsing for requests with no Content-Type and no body

### DIFF
--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -11,18 +11,27 @@ const inputSchemaError = fastJsonStringify(schemas.inputSchemaError)
 
 function handleRequest (req, res, params, context) {
   var method = req.method
-  var request = new context.Request(params, req, urlUtil.parse(req.url, true).query, req.headers, req.log)
+  var headers = req.headers
+  var request = new context.Request(params, req, urlUtil.parse(req.url, true).query, headers, req.log)
   var reply = new context.Reply(res, context, request)
 
   if (method === 'GET' || method === 'HEAD') {
     return handler(reply)
   }
 
-  var contentType = req.headers['content-type']
+  var contentType = headers['content-type']
 
   if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
-    // application/json content type
-    if (contentType && contentType.indexOf('application/json') > -1) {
+    if (contentType === undefined) {
+      if (
+        headers['transfer-encoding'] === undefined &&
+        (headers['content-length'] === '0' || headers['content-length'] === undefined)
+      ) { // Request has no body to parse
+        handler(reply)
+        return
+      }
+      // Fall through to check for a custom parser
+    } else if (contentType.indexOf('application/json') > -1) {
       return jsonBody(request, reply, context._jsonParserOptions)
     }
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -160,6 +160,31 @@ module.exports.payloadMethod = function (method, t) {
       })
     })
 
+    test(`${upMethod} with no body - correctly replies`, t => {
+      t.plan(6)
+
+      sget({
+        method: upMethod,
+        url: 'http://localhost:' + fastify.server.address().port + '/missing',
+        headers: { 'Content-Length': '0' },
+        timeout: 500
+      }, (err, response, body) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 200)
+        t.strictEqual(JSON.parse(body.toString()), null)
+      })
+
+      // Must use inject to make a request without a Content-Length header
+      fastify.inject({
+        method: upMethod,
+        url: 'http://localhost:' + fastify.server.address().port + '/missing'
+      }, (err, res) => {
+        t.error(err)
+        t.strictEqual(res.statusCode, 200)
+        t.strictEqual(JSON.parse(res.payload), null)
+      })
+    })
+
     test(`${upMethod} returns 415 - incorrect media type if body is not json`, t => {
       t.plan(2)
       sget({

--- a/test/helper.js
+++ b/test/helper.js
@@ -177,7 +177,7 @@ module.exports.payloadMethod = function (method, t) {
       // Must use inject to make a request without a Content-Length header
       fastify.inject({
         method: upMethod,
-        url: 'http://localhost:' + fastify.server.address().port + '/missing'
+        url: '/missing'
       }, (err, res) => {
         t.error(err)
         t.strictEqual(res.statusCode, 200)


### PR DESCRIPTION
Several issues have been opened in the past because by default, Fastify responds with an error to POST requests without a body. People expect requests without a body to work without having to set a "catch all" content type parser. It's counter-intuitive to have to set a body parser to be able to handle requests without a body.

This change avoids running any content type parser if the request has no `Content-Type` header and no body. From [RFC 7230 Section 3.3](https://tools.ietf.org/html/rfc7230#section-3.3), we can determine if a request has a body by checking the `Transfer-Encoding` and `Content-Type` headers.

> The presence of a message body in a request is signaled by a Content-Length or Transfer-Encoding header field.

The rest of that section does use "SHOULD" a lot, but it looks like most tools (including Node, curl, and the browser's `fetch()` API) automatically set one of those headers. If someone ever sends a request that has a body but no `Content-Length` header, no `Transfer-Encoding` header, *and* no `Content-Type` header, it seems fair to tell them that they *should* set one of those headers (as opposed to giving an error to people who have done nothing wrong by sending a request without a body).

Fixes #297, #450, #537
This would have helped with #419 as well

<details>
<summary>Benchmarks</summary>

**master**
```
[1] Stat         Avg     Stdev   Max
[1] Latency (ms) 3.1     10.95   361
[1] Req/Sec      31422.4 6177.53 35647
[1] Bytes/Sec    4.71 MB 949 kB  5.51 MB
[1]
[1] 157k requests in 5s, 23.4 MB read
...
[1] Stat         Avg     Stdev   Max
[1] Latency (ms) 2.99    10.71   372
[1] Req/Sec      32587.2 6824.94 37791
[1] Bytes/Sec    4.86 MB 1.04 MB 5.77 MB
[1]
[1] 163k requests in 5s, 24.3 MB read
```

**this PR**
```
[1] Stat         Avg     Stdev   Max
[1] Latency (ms) 2.93    10.44   251
[1] Req/Sec      33342.4 6996.48 38751
[1] Bytes/Sec    4.99 MB 1.04 MB 6.03 MB
[1]
[1] 167k requests in 5s, 24.8 MB read
...
[1] Stat         Avg     Stdev   Max
[1] Latency (ms) 3.03    10.85   392
[1] Req/Sec      32244.8 6703.57 37183
[1] Bytes/Sec    4.81 MB 1.01 MB 5.77 MB
[1]
[1] 161k requests in 5s, 24 MB read
```
</details>

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)