### PR TITLE
Add documentation about options collision [skip-ci]

### DIFF
--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -13,7 +13,7 @@ fastify.register(plugin, [options])
 
 <a name="plugin-options"></a>
 ### Plugin Options
-The optional `options` parameter for `fastify.register` gets supports a predefined set of options that Fastify itself will use. This options object will also be passed to the plugin upon invocation. The currently supported list of Fastify specific options is:
+The optional `options` parameter for `fastify.register` supports a predefined set of options that Fastify itself will use. This options object will also be passed to the plugin upon invocation. The currently supported list of Fastify specific options is:
 
 + [`logLevel`](https://github.com/fastify/fastify/blob/master/docs/Routes.md#custom-log-level)
 + [`prefix`](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#route-prefixing-options)

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -13,7 +13,7 @@ fastify.register(plugin, [options])
 
 <a name="plugin-options"></a>
 ### Plugin Options
-The optional `options` parameter for `fastify.register` supports a predefined set of options that Fastify itself will use. This options object will also be passed to the plugin, when it has been wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin), upon invocation. The currently supported list of Fastify specific options is:
+The optional `options` parameter for `fastify.register` supports a predefined set of options that Fastify itself will use when the plugin has been wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This options object will also be passed to the plugin upon invocation, regardless of whether or not the plugin has been wrapped. The currently supported list of Fastify specific options is:
 
 + [`logLevel`](https://github.com/fastify/fastify/blob/master/docs/Routes.md#custom-log-level)
 + [`prefix`](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#route-prefixing-options)

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -13,7 +13,7 @@ fastify.register(plugin, [options])
 
 <a name="plugin-options"></a>
 ### Plugin Options
-The optional `options` parameter for `fastify.register` supports a predefined set of options that Fastify itself will use when the plugin has been wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This options object will also be passed to the plugin upon invocation, regardless of whether or not the plugin has been wrapped. The currently supported list of Fastify specific options is:
+The optional `options` parameter for `fastify.register` supports a predefined set of options that Fastify itself will use, except when the plugin has been wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This options object will also be passed to the plugin upon invocation, regardless of whether or not the plugin has been wrapped. The currently supported list of Fastify specific options is:
 
 + [`logLevel`](https://github.com/fastify/fastify/blob/master/docs/Routes.md#custom-log-level)
 + [`prefix`](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#route-prefixing-options)

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -13,7 +13,7 @@ fastify.register(plugin, [options])
 
 <a name="plugin-options"></a>
 ### Plugin Options
-The optional `options` parameter for `fastify.register` supports a predefined set of options that Fastify itself will use. This options object will also be passed to the plugin upon invocation. The currently supported list of Fastify specific options is:
+The optional `options` parameter for `fastify.register` supports a predefined set of options that Fastify itself will use. This options object will also be passed to the plugin, when it has been wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin), upon invocation. The currently supported list of Fastify specific options is:
 
 + [`logLevel`](https://github.com/fastify/fastify/blob/master/docs/Routes.md#custom-log-level)
 + [`prefix`](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#route-prefixing-options)

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -11,6 +11,34 @@ You already see in the [getting started](https://github.com/fastify/fastify/blob
 fastify.register(plugin, [options])
 ```
 
+<a name="plugin-options"></a>
+### Plugin Options
+The optional `options` parameter for `fastify.register` gets supports a predefined set of options that Fastify itself will use. This options object will also be passed to the plugin upon invocation. The currently supported list of Fastify specific options is:
+
++ [`prefix`](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#route-prefixing-options)
+
+It is possible that Fastify will directly support other options in the future. Thus, to avoid collisions, a plugin should consider namespacing its options. For example, a plugin `foo` might be registered like so:
+
+```js
+fatify.register(require('fastify-foo'), {
+  prefix: '/foo',
+  foo: {
+    fooOption1: 'value',
+    fooOption2: 'value'
+  }
+})
+```
+
+If collisions are not a concern, the plugin may simply accept the options object as-is:
+
+```js
+fatify.register(require('fastify-foo'), {
+  prefix: '/foo',
+  fooOption1: 'value',
+  fooOption2: 'value'
+})
+```
+
 <a name="route-prefixing-option"></a>
 #### Route Prefixing option
 If you pass an option with the key `prefix` with a `string` value, Fastify will use it to prefix all the routes inside the register, for more info check [here](https://github.com/fastify/fastify/blob/master/docs/Routes.md#route-prefixing).<br>

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -15,6 +15,7 @@ fastify.register(plugin, [options])
 ### Plugin Options
 The optional `options` parameter for `fastify.register` gets supports a predefined set of options that Fastify itself will use. This options object will also be passed to the plugin upon invocation. The currently supported list of Fastify specific options is:
 
++ [`logLevel`](https://github.com/fastify/fastify/blob/master/docs/Routes.md#custom-log-level)
 + [`prefix`](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#route-prefixing-options)
 
 It is possible that Fastify will directly support other options in the future. Thus, to avoid collisions, a plugin should consider namespacing its options. For example, a plugin `foo` might be registered like so:


### PR DESCRIPTION
This PR documents the potential for options collision when registering plugins. Upon investigating how to add direct support for namespaced options I determined that this would be easiest, least intrusive, solution.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
