### PR TITLE
If parsing a JSON body fails, respond with 400 status instead of 422

### DIFF
--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -115,14 +115,14 @@ function jsonBody (request, reply, options) {
     }
 
     if (receivedLength === 0) { // Body is invalid JSON
-      reply.code(422).send(new Error('Unexpected end of JSON input'))
+      reply.code(400).send(new Error('Unexpected end of JSON input'))
       return
     }
 
     try {
       request.body = JSON.parse(body)
     } catch (err) {
-      reply.code(422).send(err)
+      reply.code(400).send(err)
       return
     }
     handler(reply)

--- a/test/helper.js
+++ b/test/helper.js
@@ -220,7 +220,7 @@ module.exports.payloadMethod = function (method, t) {
       })
     }
 
-    test(`${upMethod} returns 422 - Unprocessable Entity`, t => {
+    test(`${upMethod} returns 400 - Bad Request`, t => {
       t.plan(4)
 
       sget({
@@ -233,7 +233,7 @@ module.exports.payloadMethod = function (method, t) {
         timeout: 500
       }, (err, response, body) => {
         t.error(err)
-        t.strictEqual(response.statusCode, 422)
+        t.strictEqual(response.statusCode, 400)
       })
 
       sget({
@@ -244,7 +244,7 @@ module.exports.payloadMethod = function (method, t) {
         timeout: 500
       }, (err, response, body) => {
         t.error(err)
-        t.strictEqual(response.statusCode, 422)
+        t.strictEqual(response.statusCode, 400)
       })
     })
 

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -134,8 +134,8 @@ test('request should be defined in onSend Hook on post request with content type
       }
     }, (err, response, body) => {
       t.error(err)
-      // a 422 error is expected because of no body
-      t.strictEqual(response.statusCode, 422)
+      // a 400 error is expected because of no body
+      t.strictEqual(response.statusCode, 400)
     })
   })
 })


### PR DESCRIPTION
According to [RFC 7231 Section 6.5.1](https://tools.ietf.org/html/rfc7231#section-6.5.1):

> 6.5.1.  400 Bad Request
>
>   The 400 (Bad Request) status code indicates that the server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).

Therefore 400 (Bad Request) would be the right status code  to send because getting an error while parsing the body means that either the syntax was malformed or the payload was too big to be processed by `JSON.parse()` (although that will usually be caught by the `jsonBodyLimit` to respond with a 413 - Payload Too Large).

The [422 Unprocessable Entity](https://tools.ietf.org/html/rfc4918#section-11.2) status is mainly for WebDAV and requires the syntax of the request to always be correct.

(Side Note: This is the last breaking change I'll try to get in for v1.0.0)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
