### PR TITLE
add a single nextTick

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -19,8 +19,12 @@ const opts = {
 
 fastify
   .get('/', opts, function (req, reply) {
-    reply.header('Content-Type', 'application/json').code(200)
-    reply.send({ hello: 'world' })
+    reply.code(200).send({ hello: 'world' })
+  })
+  .get('/delayed', opts, function (req, reply) {
+    setTimeout(() => {
+      reply.send({ hello: 'world' })
+    }, 10)
   })
   .get('/promise', opts, function (req, reply) {
     const promise = new Promise(function (resolve, reject) {

--- a/fastify.js
+++ b/fastify.js
@@ -293,7 +293,7 @@ function build (options) {
       return
     }
 
-    handleRequest(req, res, state.params, state.context)
+    process.nextTick(handleRequest, req, res, state.params, state.context)
   }
 
   function override (old, fn, opts) {


### PR DESCRIPTION

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

__before__:

```
$ autocannon -c 100 -d 5 -p 10 localhost:3000
Running 5s test @ http://localhost:3000
100 connections with 10 pipelining factor

Stat         Avg     Stdev   Max
Latency (ms) 5.04    15.49   171
Req/Sec      19444.8 1337.68 21567
Bytes/Sec    2.9 MB  213 kB  3.28 MB

97k requests in 5s, 14.5 MB read
```

__after__:

```
$ autocannon -c 100 -d 5 -p 10 localhost:3000
Running 5s test @ http://localhost:3000
100 connections with 10 pipelining factor

Stat         Avg     Stdev   Max
Latency (ms) 4.83    14.76   157
Req/Sec      20308.8 1352.91 21983
Bytes/Sec    3.03 MB 196 kB  3.28 MB

102k requests in 5s, 15.1 MB read
```

Can someone else confirm?

I have already checked it should not reintroduce the bug I fixed in #545, but please check and confirm.