### PR TITLE
Replace fast-safe-stringify with an inline function

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "coveralls": "^3.0.0",
     "dns-prefetch-control": "^0.1.0",
     "fast-json-body": "^1.1.0",
-    "fast-safe-stringify": "^1.2.3",
     "fastify-plugin": "^0.2.1",
     "frameguard": "^3.0.0",
     "h2url": "^0.1.2",

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -4,7 +4,6 @@ const t = require('tap')
 const test = t.test
 const sget = require('simple-get').concat
 const fastify = require('..')()
-const safeStringify = require('fast-safe-stringify')
 
 const schema = {
   schema: {
@@ -175,9 +174,14 @@ test('wrong object for schema - get', t => {
 
 test('custom serializer - get', t => {
   t.plan(1)
+
+  function customSerializer (data) {
+    return JSON.stringify(data)
+  }
+
   try {
     fastify.get('/custom-serializer', numberSchema, function (req, reply) {
-      reply.code(200).serializer(safeStringify).send({ hello: 'world' })
+      reply.code(200).serializer(customSerializer).send({ hello: 'world' })
     })
     t.pass()
   } catch (e) {


### PR DESCRIPTION
As [mentioned](https://github.com/fastify/fastify/pull/656#issuecomment-357352748) by @delvedor in #656.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
