### PR TITLE
Serialize req on error (fix #659)

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -192,9 +192,9 @@ function handleError (reply, error, cb) {
   reply.res.statusCode = statusCode
 
   if (statusCode >= 500) {
-    reply.res.log.error({ res: reply.res, err: error }, error && error.message)
+    reply.res.log.error({ req: reply.request.raw, res: reply.res, err: error }, error && error.message)
   } else if (statusCode >= 400) {
-    reply.res.log.info({ res: reply.res, err: error }, error && error.message)
+    reply.res.log.info({ req: reply.request.raw, res: reply.res, err: error }, error && error.message)
   }
 
   if (error && error.headers) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -194,7 +194,7 @@ function handleError (reply, error, cb) {
   if (statusCode >= 500) {
     reply.res.log.error({ req: reply.request.raw, res: reply.res, err: error }, error && error.message)
   } else if (statusCode >= 400) {
-    reply.res.log.info({ req: reply.request.raw, res: reply.res, err: error }, error && error.message)
+    reply.res.log.info({ res: reply.res, err: error }, error && error.message)
   }
 
   if (error && error.headers) {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "node": ">=4.5"
   },
   "devDependencies": {
+    "JSONStream": "^1.0.3",
     "autocannon": "^0.16.5",
     "branch-comparer": "^0.4.0",
     "concurrently": "^3.5.1",
@@ -72,6 +73,7 @@
     "dns-prefetch-control": "^0.1.0",
     "fast-json-body": "^1.1.0",
     "fastify-plugin": "^0.2.1",
+    "flush-write-stream": "^1.0.2",
     "frameguard": "^3.0.0",
     "h2url": "^0.1.2",
     "helmet": "^3.9.0",
@@ -80,7 +82,6 @@
     "http-errors": "^1.6.2",
     "ienoopen": "^1.0.0",
     "joi": "~11.3.4",
-    "JSONStream": "^1.0.3",
     "pre-commit": "^1.2.2",
     "semver": "^5.4.1",
     "serve-static": "^1.13.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "dns-prefetch-control": "^0.1.0",
     "fast-json-body": "^1.1.0",
     "fastify-plugin": "^0.2.1",
-    "flush-write-stream": "^1.0.2",
     "frameguard": "^3.0.0",
     "h2url": "^0.1.2",
     "helmet": "^3.9.0",

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -3,6 +3,7 @@
 const t = require('tap')
 const test = t.test
 const http = require('http')
+const stream = require('stream')
 const split = require('split2')
 const Fastify = require('..')
 const pino = require('pino')
@@ -566,5 +567,32 @@ test('The default 404 handler logs the incoming request', t => {
   }, (err, res) => {
     t.error(err)
     t.strictEqual(res.statusCode, 404)
+  })
+})
+
+test('should serialize request and response', t => {
+  t.plan(4)
+  const lines = []
+  const dest = new stream.Writable({
+    write: function (chunk, enc, cb) {
+      lines.push(JSON.parse(chunk))
+      cb()
+    }
+  })
+  const fastify = Fastify({logger: {level: 'info', stream: dest}})
+
+  fastify.get('/500', (req, reply) => {
+    reply.code(500).send(Error('500 error'))
+  })
+
+  fastify.inject({
+    url: '/500',
+    method: 'GET'
+  }, (e, res) => {
+    const l = lines.find((line) => line.res && line.res.statusCode === 500)
+    t.ok(l.req)
+    t.is(l.req.id, 1)
+    t.is(l.req.method, 'GET')
+    t.is(l.req.url, '/500')
   })
 })

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -3,7 +3,6 @@
 const t = require('tap')
 const test = t.test
 const net = require('net')
-const writeStream = require('flush-write-stream')
 const Fastify = require('..')
 const statusCodes = require('http').STATUS_CODES
 
@@ -392,45 +391,5 @@ test('should throw an error due to custom serializer can not handle the payload 
     method: 'GET'
   }, (e, res) => {
     t.fail('should not be called')
-  })
-})
-
-test('should serialize request and response', t => {
-  t.plan(8)
-  const lines = []
-  const stream = writeStream((data, enc, cb) => {
-    lines.push(JSON.parse(data.toString()))
-    cb()
-  })
-  const fastify = Fastify({logger: {level: 'info', stream}})
-
-  fastify.get('/400', (req, reply) => {
-    reply.code(400).send(Error('400 error'))
-  })
-
-  fastify.get('/500', (req, reply) => {
-    reply.code(500).send(Error('500 error'))
-  })
-
-  fastify.inject({
-    url: '/400',
-    method: 'GET'
-  }, (e, res) => {
-    const l = lines.find((line) => line.res && line.res.statusCode === 400)
-    t.ok(l.req)
-    t.is(l.req.id, 1)
-    t.is(l.req.method, 'GET')
-    t.is(l.req.url, '/400')
-  })
-
-  fastify.inject({
-    url: '/500',
-    method: 'GET'
-  }, (e, res) => {
-    const l = lines.find((line) => line.res && line.res.statusCode === 500)
-    t.ok(l.req)
-    t.is(l.req.id, 2)
-    t.is(l.req.method, 'GET')
-    t.is(l.req.url, '/500')
   })
 })

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -3,6 +3,7 @@
 const t = require('tap')
 const test = t.test
 const net = require('net')
+const writeStream = require('flush-write-stream')
 const Fastify = require('..')
 const statusCodes = require('http').STATUS_CODES
 
@@ -391,5 +392,45 @@ test('should throw an error due to custom serializer can not handle the payload 
     method: 'GET'
   }, (e, res) => {
     t.fail('should not be called')
+  })
+})
+
+test('should serialize request and response', t => {
+  t.plan(8)
+  const lines = []
+  const stream = writeStream((data, enc, cb) => {
+    lines.push(JSON.parse(data.toString()))
+    cb()
+  })
+  const fastify = Fastify({logger: {level: 'info', stream}})
+
+  fastify.get('/400', (req, reply) => {
+    reply.code(400).send(Error('400 error'))
+  })
+
+  fastify.get('/500', (req, reply) => {
+    reply.code(500).send(Error('500 error'))
+  })
+
+  fastify.inject({
+    url: '/400',
+    method: 'GET'
+  }, (e, res) => {
+    const l = lines.find((line) => line.res && line.res.statusCode === 400)
+    t.ok(l.req)
+    t.is(l.req.id, 1)
+    t.is(l.req.method, 'GET')
+    t.is(l.req.url, '/400')
+  })
+
+  fastify.inject({
+    url: '/500',
+    method: 'GET'
+  }, (e, res) => {
+    const l = lines.find((line) => line.res && line.res.statusCode === 500)
+    t.ok(l.req)
+    t.is(l.req.id, 2)
+    t.is(l.req.method, 'GET')
+    t.is(l.req.url, '/500')
   })
 })


### PR DESCRIPTION
This PR adds the request to the logs in `handleError` as requested in issue #659.

#### Checklist

- [x] run `npm run test` ~and `npm run benchmark`~
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
