### PR TITLE
Add request.id

### DIFF
--- a/docs/Request.md
+++ b/docs/Request.md
@@ -8,6 +8,7 @@ Request is a core Fastify object containing the following fields:
 - `params` - the params matching the URL
 - `headers` - the headers
 - `raw` - the incoming HTTP request from Node core *(you can use the alias `req`)*
+- `id` - the id generated for this request
 - `log` - the logger instance of the incoming request
 
 ```js
@@ -17,6 +18,7 @@ fastify.post('/:params', options, function (request, reply) {
   console.log(request.params)
   console.log(request.headers)
   console.log(request.raw)
+  console.log(request.id)
   request.log.info('some info')
 })
 ```

--- a/docs/Request.md
+++ b/docs/Request.md
@@ -8,7 +8,7 @@ Request is a core Fastify object containing the following fields:
 - `params` - the params matching the URL
 - `headers` - the headers
 - `raw` - the incoming HTTP request from Node core *(you can use the alias `req`)*
-- `id` - the id generated for this request
+- `id` - the request id
 - `log` - the logger instance of the incoming request
 
 ```js

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -39,6 +39,8 @@ declare namespace fastify {
 
     body: any,
 
+    id: any,
+
     req: HttpRequest,
     log: pino.Logger
   }

--- a/lib/request.js
+++ b/lib/request.js
@@ -23,15 +23,16 @@ function buildRequest (R) {
   return _Request
 }
 
-Object.defineProperty(Request.prototype, 'req', {
-  get: function () {
-    return this.raw
-  }
-})
-
-Object.defineProperty(Request.prototype, 'id', {
-  get: function () {
-    return this.raw.id
+Object.defineProperties(Request.prototype, {
+  'req': {
+    get: function () {
+      return this.raw
+    }
+  },
+  'id': {
+    get: function () {
+      return this.raw.id
+    }
   }
 })
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -29,5 +29,11 @@ Object.defineProperty(Request.prototype, 'req', {
   }
 })
 
+Object.defineProperty(Request.prototype, 'id', {
+  get: function () {
+    return this.raw.id
+  }
+})
+
 module.exports = Request
 module.exports.buildRequest = buildRequest

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -123,7 +123,7 @@ server
       reply.send({ hello: 'route' })
     },
     beforeHandler: (req, reply, done) => {
-      req.log.info(`before handler for "${req.req.url}"`);
+      req.log.info(`before handler for "${req.req.url}" ${req.id}`);
       done();
     }
   })


### PR DESCRIPTION
As titled. I like to have `request.id` as alias `request.raw.id`

Do you agree?

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

~~I don't know where to test it.
I'll update the docs asap.~~

I add the typescript definition too.