### PR TITLE
Allow overwrite logger serializer, one by one

### DIFF
--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -68,7 +68,7 @@ const fastify = require('fastify')({
 })
 ```
 
-*This option will be ignored by any other logger than Pino.*
+*This option will be ignored by any logger other than Pino.*
 
 You can also supply your own logger instance. Instead of passing configuration options, simply pass the instance.
 The logger you supply must conform to the Pino interface; that is, it must have the following methods:

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -55,6 +55,20 @@ const fastify = require('fastify')({
 })
 ```
 
+By default fastify provides default serializers. List of serialiazers is: `req`, `res` and `err`.
+Additionally, `serializers` option can be used to overwrite one or more serializers.
+```js
+const fastify = require('fastify')({
+  logger: {
+    serializers: {
+      req: function (req) { 
+        return { url: req.url } 
+      }
+    }
+  }
+})
+```
+
 You can also supply your own logger instance. Instead of passing configuration options, simply pass the instance.
 The logger you supply must conform to the Pino interface; that is, it must have the following methods:
 `info`, `error`, `debug`, `fatal`, `warn`, `trace`, `child`.

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -55,8 +55,7 @@ const fastify = require('fastify')({
 })
 ```
 
-By default fastify provides default serializers. List of serialiazers is: `req`, `res` and `err`.
-Additionally, `serializers` option can be used to overwrite one or more serializers.
+The default logger is configured with a set of standard serializers that serialize objects with `req`, `res`, and `err` properties. This behavior can be customized by specifying custom serializers.
 ```js
 const fastify = require('fastify')({
   logger: {
@@ -68,6 +67,8 @@ const fastify = require('fastify')({
   }
 })
 ```
+
+*This option will be ignored by any other logger than Pino.*
 
 You can also supply your own logger instance. Instead of passing configuration options, simply pass the instance.
 The logger you supply must conform to the Pino interface; that is, it must have the following methods:

--- a/fastify.js
+++ b/fastify.js
@@ -42,7 +42,7 @@ function build (options) {
   if (isValidLogger(options.logger)) {
     log = loggerUtils.createLogger({
       logger: options.logger,
-      serializers: Object.assign(loggerUtils.serializers, options.logger.serializers)
+      serializers: Object.assign({}, loggerUtils.serializers, options.logger.serializers)
     })
   } else if (!options.logger) {
     log = Object.create(abstractLogging)
@@ -50,7 +50,7 @@ function build (options) {
   } else {
     options.logger = typeof options.logger === 'object' ? options.logger : {}
     options.logger.level = options.logger.level || 'info'
-    options.logger.serializers = Object.assign(loggerUtils.serializers, options.logger.serializers)
+    options.logger.serializers = Object.assign({}, loggerUtils.serializers, options.logger.serializers)
     log = loggerUtils.createLogger(options.logger)
   }
 

--- a/fastify.js
+++ b/fastify.js
@@ -42,7 +42,7 @@ function build (options) {
   if (isValidLogger(options.logger)) {
     log = loggerUtils.createLogger({
       logger: options.logger,
-      serializers: Object.assign({}, loggerUtils.serializers, options.logger.serializers)
+      serializers: Object.assign(loggerUtils.serializers, options.logger.serializers)
     })
   } else if (!options.logger) {
     log = Object.create(abstractLogging)
@@ -50,7 +50,7 @@ function build (options) {
   } else {
     options.logger = typeof options.logger === 'object' ? options.logger : {}
     options.logger.level = options.logger.level || 'info'
-    options.logger.serializers = Object.assign({}, loggerUtils.serializers, options.logger.serializers)
+    options.logger.serializers = Object.assign(loggerUtils.serializers, options.logger.serializers)
     log = loggerUtils.createLogger(options.logger)
   }
 

--- a/fastify.js
+++ b/fastify.js
@@ -40,14 +40,17 @@ function build (options) {
 
   var log
   if (isValidLogger(options.logger)) {
-    log = loggerUtils.createLogger({ logger: options.logger, serializers: loggerUtils.serializers })
+    log = loggerUtils.createLogger({
+      logger: options.logger,
+      serializers: Object.assign({}, loggerUtils.serializers, options.logger.serializers || {})
+    })
   } else if (!options.logger) {
     log = Object.create(abstractLogging)
     log.child = () => log
   } else {
     options.logger = typeof options.logger === 'object' ? options.logger : {}
     options.logger.level = options.logger.level || 'info'
-    options.logger.serializers = options.logger.serializers || loggerUtils.serializers
+    options.logger.serializers = Object.assign({}, loggerUtils.serializers, options.logger.serializers || {})
     log = loggerUtils.createLogger(options.logger)
   }
 

--- a/fastify.js
+++ b/fastify.js
@@ -42,7 +42,7 @@ function build (options) {
   if (isValidLogger(options.logger)) {
     log = loggerUtils.createLogger({
       logger: options.logger,
-      serializers: Object.assign({}, loggerUtils.serializers, options.logger.serializers || {})
+      serializers: Object.assign({}, loggerUtils.serializers, options.logger.serializers)
     })
   } else if (!options.logger) {
     log = Object.create(abstractLogging)
@@ -50,7 +50,7 @@ function build (options) {
   } else {
     options.logger = typeof options.logger === 'object' ? options.logger : {}
     options.logger.level = options.logger.level || 'info'
-    options.logger.serializers = Object.assign({}, loggerUtils.serializers, options.logger.serializers || {})
+    options.logger.serializers = Object.assign({}, loggerUtils.serializers, options.logger.serializers)
     log = loggerUtils.createLogger(options.logger)
   }
 

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -176,7 +176,7 @@ test('can use external logger instance', t => {
   })
 })
 
-test('can use external logger instance with custom serialiser', t => {
+test('can use external logger instance with custom serializer', t => {
   const lines = [['level', 30], ['req', { url: '/foo' }], ['level', 30], ['res', { statusCode: 200 }]]
   t.plan(lines.length + 2)
 
@@ -271,25 +271,21 @@ test('The logger should accept a custom genReqId function', t => {
 
 t.test('The logger should accept custom serializer', t => {
   t.plan(9)
-  var fastify = null
-  var stream = split(JSON.parse)
-  try {
-    fastify = Fastify({
-      logger: {
-        stream: stream,
-        level: 'info',
-        serializers: {
-          req: function (req) {
-            return {
-              url: req.url
-            }
+
+  const stream = split(JSON.parse)
+  const fastify = Fastify({
+    logger: {
+      stream: stream,
+      level: 'info',
+      serializers: {
+        req: function (req) {
+          return {
+            url: req.url
           }
         }
       }
-    })
-  } catch (e) {
-    t.fail()
-  }
+    }
+  })
 
   fastify.get('/custom', function (req, reply) {
     t.ok(req.log)

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -186,11 +186,7 @@ test('can use external logger instance with custom serialiser', t => {
     const key = check[0]
     const value = check[1]
 
-    if (typeof value === 'object') {
-      t.deepEqual(line[key], value)
-    } else {
-      t.equal(line[key], value)
-    }
+    t.deepEqual(line[key], value)
   })
 
   const logger = require('pino')({
@@ -274,7 +270,7 @@ test('The logger should accept a custom genReqId function', t => {
 })
 
 t.test('The logger should accept custom serializer', t => {
-  t.plan(8)
+  t.plan(9)
   var fastify = null
   var stream = split(JSON.parse)
   try {
@@ -297,7 +293,7 @@ t.test('The logger should accept custom serializer', t => {
 
   fastify.get('/custom', function (req, reply) {
     t.ok(req.log)
-    reply.send(new Error({ hello: 'world' }))
+    reply.send(new Error('kaboom'))
   })
 
   fastify.listen(0, err => {
@@ -315,6 +311,7 @@ t.test('The logger should accept custom serializer', t => {
 
         stream.once('data', line => {
           t.ok(line.res, 'res is defined')
+          t.equal(line.msg, 'kaboom', 'message is set')
           t.deepEqual(line.res, { statusCode: 500 }, 'default res serialiser is use')
         })
       })


### PR DESCRIPTION
When we use a custom logger, it's not possible to provide serializers in configuration.
When we do not use a custom logger, we can only provide serializers which contains all of them, not only overwrite one (`res` for example).

This PR fixes those 2 cases.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
