### PR TITLE
[doc] Fix listen already log server listening address in getting started

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -23,7 +23,7 @@ fastify.get('/', function (request, reply) {
 })
 
 // Run the server!
-fastify.listen(3000, 'localhost', function (err) {
+fastify.listen(3000, function (err) {
   if (err) {
     fastify.log.error(err)
     process.exit(1)
@@ -42,7 +42,7 @@ fastify.get('/', async (request, reply) => {
 
 const start = async () => {
   try {
-    await fastify.listen(3000, 'localhost')
+    await fastify.listen(3000)
   } catch (err) {
     fastify.log.error(err)
     process.exit(1)
@@ -65,8 +65,11 @@ const fastify = require('fastify')()
 
 fastify.register(require('./our-first-route'))
 
-fastify.listen(3000, 'localhost', function (err) {
-  if (err) throw err
+fastify.listen(3000, function (err) {
+  if (err) {
+    fastify.log.error(err)
+    process.exit(1)
+  }
 })
 ```
 
@@ -98,8 +101,11 @@ fastify.register(require('./our-db-connector'), {
 })
 fastify.register(require('./our-first-route'))
 
-fastify.listen(3000, 'localhost', function (err) {
-  if (err) throw err
+fastify.listen(3000, function (err) {
+  if (err) {
+    fastify.log.error(err)
+    process.exit(1)
+  }
 })
 ```
 

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -23,9 +23,11 @@ fastify.get('/', function (request, reply) {
 })
 
 // Run the server!
-fastify.listen(3000, function (err) {
-  if (err) throw err
-  fastify.log.info(`server listening on ${fastify.server.address().port}`)
+fastify.listen(3000, 'localhost', function (err) {
+  if (err) {
+    fastify.log.error(err)
+    process.exit(1)
+  }
 })
 ```
 
@@ -38,10 +40,15 @@ fastify.get('/', async (request, reply) => {
   return { hello: 'world' }
 })
 
-fastify.listen(3000, function (err) {
-  if (err) throw err
-  fastify.log.info(`server listening on ${fastify.server.address().port}`)
-})
+const start = async () => {
+  try {
+    await fastify.listen(3000, 'localhost')
+  } catch (err) {
+    fastify.log.error(err)
+    process.exit(1)
+  }
+}
+start()
 ```
 
 Awesome, that was easy.<br>
@@ -58,9 +65,8 @@ const fastify = require('fastify')()
 
 fastify.register(require('./our-first-route'))
 
-fastify.listen(3000, function (err) {
+fastify.listen(3000, 'localhost', function (err) {
   if (err) throw err
-  fastify.log.info(`server listening on ${fastify.server.address().port}`)
 })
 ```
 
@@ -92,9 +98,8 @@ fastify.register(require('./our-db-connector'), {
 })
 fastify.register(require('./our-first-route'))
 
-fastify.listen(3000, function (err) {
+fastify.listen(3000, 'localhost', function (err) {
   if (err) throw err
-  fastify.log.info(`server listening on ${fastify.server.address().port}`)
 })
 ```
 


### PR DESCRIPTION
Since 3417842968462474a0eeac1b3e2b1fde790ae33d, log for server listening at is already sent.
~~But, if do not set any address, it will display `Server listening at http://:::3000` which is not very comprehensive and we can't click on it! So I added `localhost` as address argument value in examples.~~

I also take some enhancements from Fastify website homepage: I think it's better to log an error than throw this error in case of listen error.

I will also be updated `fastify-website` home template whith those fixes if this PR is ok for you.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
