### PR TITLE
Default to listening on 127.0.0.1

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -25,7 +25,7 @@ fastify.get('/', function (request, reply) {
 // Run the server!
 fastify.listen(3000, function (err) {
   if (err) throw err
-  fastify.log.info(`server listening on ${fastify.server.address().port}`)
+  fastify.log.info('Fastify rocks 🤘')
 })
 ```
 
@@ -40,13 +40,24 @@ fastify.get('/', async (request, reply) => {
 
 fastify.listen(3000, function (err) {
   if (err) throw err
-  fastify.log.info(`server listening on ${fastify.server.address().port}`)
+  fastify.log.info('Fastify rocks 🤘')
 })
 ```
 
 Awesome, that was easy.<br>
 Unfortunately, writing a complex application requires significantly more code than this example. A classic problem when you are building a new application is how handle multiple files, asynchronous bootstrapping and the architecture of your code.<br>
 Fastify offers an easy platform that helps solve all of problems, and more.
+
+> ## Note
+> The above examples, and subsequent examples in this document, default to listening *only* on the localhost `127.0.0.1` interface. To listen on all available IPv4 interfaces the example should be modified to listen on `0.0.0.0` like so:
+>
+> ```js
+> fastify.listen(3000, '0.0.0.0', function (err) {
+>   if (err) throw err
+>   fastify.log.info('Fastify rocks 🤘')
+> })
+>
+> When deploying to a Docker, or other type of, container this would be the easiest method for exposing the application.
 
 <a name="first-plugin"></a>
 ### Your first plugin
@@ -60,7 +71,7 @@ fastify.register(require('./our-first-route'))
 
 fastify.listen(3000, function (err) {
   if (err) throw err
-  fastify.log.info(`server listening on ${fastify.server.address().port}`)
+  fastify.log.info('Fastify rocks 🤘')
 })
 ```
 
@@ -94,7 +105,7 @@ fastify.register(require('./our-first-route'))
 
 fastify.listen(3000, function (err) {
   if (err) throw err
-  fastify.log.info(`server listening on ${fastify.server.address().port}`)
+  fastify.log.info('Fastify rocks 🤘')
 })
 ```
 
@@ -124,7 +135,7 @@ async function routes (fastify, options) {
   fastify.get('/', async (request, reply) => {
     return { hello: 'world' }
   })
-  
+
   fastify.get('/search/:id', async (request, reply) => {
     try {
       return await collection.findOne({ id: request.params.id })

--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -27,7 +27,8 @@ fastify.ready().then(() => {
 
 <a name="listen"></a>
 #### listen
-Starts the server on the given port after all the plugins are loaded, internally waits for the `.ready()` event. The callback is the same as the Node core.
+Starts the server on the given port after all the plugins are loaded, internally waits for the `.ready()` event. The callback is the same as the Node core. By default, the server will listen on address `127.0.0.1` when no specific address is provided.
+
 ```js
 fastify.listen(3000, err => {
   if (err) throw err
@@ -108,7 +109,7 @@ Set the schema compiler for all routes [here](https://github.com/fastify/fastify
 
 ```js
 fastify.setNotFoundHandler(function (request, reply) {
-  // Default not found handler  
+  // Default not found handler
 })
 
 fastify.register(function (instance, options, next) {

--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -65,6 +65,14 @@ fastify.listen(3000, '127.0.0.1')
   })
 ```
 
+When deploying to a Docker, and potentially other, containers, it is advisable to listen on `0.0.0.0` because they do not default to exposing mapped ports to `127.0.0.1`:
+
+```js
+fastify.listen(3000, '0.0.0.0', (err) => {
+  if (err) throw err
+})
+```
+
 <a name="route"></a>
 #### route
 Method to add routes to the server, it also have shorthands functions, check [here](https://github.com/fastify/fastify/blob/master/docs/Routes.md).

--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -31,7 +31,10 @@ Starts the server on the given port after all the plugins are loaded, internally
 
 ```js
 fastify.listen(3000, err => {
-  if (err) throw err
+  if (err) {
+    fastify.log.error(err)
+    process.exit(1)
+  }
 })
 ```
 
@@ -39,7 +42,10 @@ Specifying an address is also supported:
 
 ```js
 fastify.listen(3000, '127.0.0.1', err => {
-  if (err) throw err
+  if (err) {
+    fastify.log.error(err)
+    process.exit(1)
+  }
 })
 ```
 
@@ -69,7 +75,10 @@ When deploying to a Docker, and potentially other, containers, it is advisable t
 
 ```js
 fastify.listen(3000, '0.0.0.0', (err) => {
-  if (err) throw err
+  if (err) {
+    fastify.log.error(err)
+    process.exit(1)
+  }
 })
 ```
 

--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -27,7 +27,7 @@ fastify.ready().then(() => {
 
 <a name="listen"></a>
 #### listen
-Starts the server on the given port after all the plugins are loaded, internally waits for the `.ready()` event. The callback is the same as the Node core. By default, the server will listen on address `127.0.0.1` when no specific address is provided.
+Starts the server on the given port after all the plugins are loaded, internally waits for the `.ready()` event. The callback is the same as the Node core. By default, the server will listen on address `127.0.0.1` when no specific address is provided. If listening on any available interface is desired, then specifying `0.0.0.0` for the address will listen on all IPv4 address. Using `::` for the address will listen on all IPv6 addresses, and, depending on OS, may also listen on all IPv4 addresses. Be careful when deciding to listen on all interfaces; it comes with inherent [security risks](https://web.archive.org/web/20170831174611/https://snyk.io/blog/mongodb-hack-and-secure-defaults/).
 
 ```js
 fastify.listen(3000, err => {

--- a/fastify.js
+++ b/fastify.js
@@ -218,8 +218,9 @@ function build (options) {
     /* Deal with listen (port, cb) */
     if (typeof address === 'function') {
       cb = address
-      address = '127.0.0.1'
+      address = undefined
     }
+    address = address || '127.0.0.1'
 
     if (cb === undefined) {
       return new Promise((resolve, reject) => {

--- a/fastify.js
+++ b/fastify.js
@@ -218,7 +218,7 @@ function build (options) {
     /* Deal with listen (port, cb) */
     if (typeof address === 'function') {
       cb = address
-      address = undefined
+      address = '127.0.0.1'
     }
 
     if (cb === undefined) {
@@ -233,8 +233,6 @@ function build (options) {
       })
     }
 
-    const hasAddress = address !== undefined
-
     fastify.ready(function (err) {
       if (err) return cb(err)
       if (listening) {
@@ -242,11 +240,7 @@ function build (options) {
       }
 
       server.on('error', wrap)
-      if (hasAddress) {
-        server.listen(port, address, wrap)
-      } else {
-        server.listen(port, wrap)
-      }
+      server.listen(port, address, wrap)
       listening = true
     })
 

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -104,9 +104,11 @@ if (os.platform() !== 'win32') {
 }
 
 test('listen without callback', t => {
+  t.plan(1)
   const fastify = Fastify()
   fastify.listen(0)
     .then(() => {
+      t.is(fastify.server.address().address, '127.0.0.1')
       fastify.close()
       t.end()
     })

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -7,10 +7,11 @@ const test = require('tap').test
 const Fastify = require('..')
 
 test('listen accepts a port and a callback', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
   fastify.listen(0, (err) => {
     fastify.server.unref()
+    t.is(fastify.server.address().address, '127.0.0.1')
     t.error(err)
     t.pass()
     fastify.close()


### PR DESCRIPTION
This is related to #665. This PR defaults the server to listen only on address `127.0.0.1`. With this PR, in order to listen on any other address the user must do:

```js
// Listen on all IPv4 interfaces
fastify.listen(8000, '0.0.0.0', (err) => {
  if (err) throw err
})
```

This eliminates non-deterministic behavior from core (https://nodejs.org/dist/latest-v8.x/docs/api/net.html#net_server_listen_port_host_backlog_callback):

> If host is omitted, the server will accept connections on the unspecified IPv6 address (::) when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise.
>
> Note: In most operating systems, listening to the unspecified IPv6 address (::) may cause the net.Server to also listen on the unspecified IPv4 address (0.0.0.0).

This is a breaking change because people may already be expecting the non-deterministic behavior.

This should be accepted because:

1. It is clearly defined behavior.
2. It is good security practice to listen only on localhost by default. The implementor should explicitly choose to listen on any public interfaces.


#### Checklist

- [x] run `npm run test` ~and `npm run benchmark`~
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
