### PR TITLE
TypeScript Documentation

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -2,10 +2,16 @@
 
 <a id="typescript"></a>
 ## TypeScript
-Fastify is shipped with the a typings file so it should "just work" when used in a TypeScript application.
+Fastify is shipped with the a typings file, but it still require to install `@types/node`, depending on the Node.js version that you are using.
+
+## Types support
+We do care about the TypeScript community, but the framework is written in plain JavaScript and currently no one of the core team is a TypeScript user while only one of the collaborators is.
+We do our best to have the typing updated with the latest version of the API, but *it can happen* that the typings are not in sync.<br/>
+Luckly this is Open Source and you can contribute to fix them, we will be very happy to accept the fix and release it as soon as possible as a patch release. Checkout the [contributing](#contributing) rules!
 
 Plugins may or may not include typings. See [Plugin Types](#plugin-types) for more information.
 
+## Example
 This example TypeScript app closely aligns with the JavaScript examples:
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
   },
   "devDependencies": {
     "@types/node": "^8.5.8",
-    "@types/pino": "^4.7.0",
     "JSONStream": "^1.0.3",
     "autocannon": "^0.16.5",
     "branch-comparer": "^0.4.0",
@@ -96,6 +95,7 @@
     "x-xss-protection": "^1.0.0"
   },
   "dependencies": {
+    "@types/pino": "^4.7.0",
     "abstract-logging": "^1.0.0",
     "ajv": "^6.0.1",
     "avvio": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     "node": ">=4.5"
   },
   "devDependencies": {
+    "@types/node": "^8.5.8",
+    "@types/pino": "^4.7.0",
     "JSONStream": "^1.0.3",
     "autocannon": "^0.16.5",
     "branch-comparer": "^0.4.0",
@@ -94,8 +96,6 @@
     "x-xss-protection": "^1.0.0"
   },
   "dependencies": {
-    "@types/node": "^8.5.8",
-    "@types/pino": "^4.7.0",
     "abstract-logging": "^1.0.0",
     "ajv": "^6.0.1",
     "avvio": "^5.0.0",
@@ -111,7 +111,9 @@
   "greenkeeper": {
     "ignore": [
       "boom",
-      "joi"
+      "joi",
+      "@types/node",
+      "@types/pino"
     ]
   }
 }


### PR DESCRIPTION
Me and @mcollina think that the types should stay inside the repo and shipped with the project.
We all discussed a lot in #649 about this, and this is our proposal.

Again, this is the best that thing we can offer, if someone does not agree with this, then he/she/them can start to contribute to the project and take care of this.

I've also moved the `@types` dependencies as dev dependencies, because it is not a good idea ship them directly as dependency. Then I added the `@types` dependencies inside the greenkeeper ignore, because every time there is a new release of the types for some unknown reason our CI will complain.

cc @fastify/fastify 

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
