### PR TITLE
Throw error for avoiding `fastify` changes after binding

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -78,7 +78,7 @@ function build (options) {
     started = true
   })
 
-  function throwIfAlreadyBinded (msg) {
+  function throwIfAlreadyBound (msg) {
     if (listening) throw new Error(msg)
   }
 
@@ -394,7 +394,7 @@ function build (options) {
 
   // Route management
   function route (opts) {
-    throwIfAlreadyBinded('Cannot add route when fastify instance is already started!')
+    throwIfAlreadyBound('Cannot add route when fastify instance is already started!')
 
     const _fastify = this
 
@@ -521,7 +521,7 @@ function build (options) {
   }
 
   function use (url, fn) {
-    throwIfAlreadyBinded('Cannot call "use" when fastify instance is already started!')
+    throwIfAlreadyBound('Cannot call "use" when fastify instance is already started!')
     if (typeof url === 'string') {
       const prefix = this._routePrefix
       url = prefix + (url === '/' && prefix.length > 0 ? '' : url)
@@ -532,7 +532,7 @@ function build (options) {
   }
 
   function addHook (name, fn) {
-    throwIfAlreadyBinded('Cannot call "addHook" when fastify instance is already started!')
+    throwIfAlreadyBound('Cannot call "addHook" when fastify instance is already started!')
 
     if (name === 'onClose') {
       this._hooks.validate(name, fn)
@@ -547,7 +547,7 @@ function build (options) {
   }
 
   function addContentTypeParser (contentType, fn) {
-    throwIfAlreadyBinded('Cannot call "addContentTypeParser" when fastify instance is already started!')
+    throwIfAlreadyBound('Cannot call "addContentTypeParser" when fastify instance is already started!')
 
     this._contentTypeParser.add(contentType, fn)
     return this
@@ -598,7 +598,7 @@ function build (options) {
   }
 
   function setNotFoundHandler (opts, handler) {
-    throwIfAlreadyBinded('Cannot call "setNotFoundHandler" when fastify instance is already started!')
+    throwIfAlreadyBound('Cannot call "setNotFoundHandler" when fastify instance is already started!')
 
     if (this._notFoundHandler !== null && this._notFoundHandler !== basic404) {
       throw new Error(`Not found handler already set for Fastify instance with prefix: '${this._routePrefix || '/'}'`)
@@ -658,14 +658,14 @@ function build (options) {
   }
 
   function setSchemaCompiler (schemaCompiler) {
-    throwIfAlreadyBinded('Cannot call "setSchemaCompiler" when fastify instance is already started!')
+    throwIfAlreadyBound('Cannot call "setSchemaCompiler" when fastify instance is already started!')
 
     this._schemaCompiler = schemaCompiler
     return this
   }
 
   function setErrorHandler (func) {
-    throwIfAlreadyBinded('Cannot call "setErrorHandler" when fastify instance is already started!')
+    throwIfAlreadyBound('Cannot call "setErrorHandler" when fastify instance is already started!')
 
     this._errorHandler = func
     return this

--- a/fastify.js
+++ b/fastify.js
@@ -78,6 +78,10 @@ function build (options) {
     started = true
   })
 
+  function throwIfAlreadyStarted (msg) {
+    if (started) throw new Error(msg)
+  }
+
   var server
   const httpHandler = router.lookup.bind(router)
   if (options.https) {
@@ -390,6 +394,8 @@ function build (options) {
 
   // Route management
   function route (opts) {
+    throwIfAlreadyStarted('Cannot add route when fastify instance is already started!')
+
     const _fastify = this
 
     if (Array.isArray(opts.method)) {
@@ -515,6 +521,7 @@ function build (options) {
   }
 
   function use (url, fn) {
+    throwIfAlreadyStarted('Cannot call "use" when fastify instance is already started!')
     if (typeof url === 'string') {
       const prefix = this._routePrefix
       url = prefix + (url === '/' && prefix.length > 0 ? '' : url)
@@ -525,6 +532,8 @@ function build (options) {
   }
 
   function addHook (name, fn) {
+    throwIfAlreadyStarted('Cannot call "addHook" when fastify instance is already started!')
+
     if (name === 'onClose') {
       this._hooks.validate(name, fn)
       this.onClose(fn)
@@ -538,6 +547,8 @@ function build (options) {
   }
 
   function addContentTypeParser (contentType, fn) {
+    throwIfAlreadyStarted('Cannot call "addContentTypeParser" when fastify instance is already started!')
+
     this._contentTypeParser.add(contentType, fn)
     return this
   }
@@ -587,6 +598,8 @@ function build (options) {
   }
 
   function setNotFoundHandler (opts, handler) {
+    throwIfAlreadyStarted('Cannot call "setNotFoundHandler" when fastify instance is already started!')
+
     if (this._notFoundHandler !== null && this._notFoundHandler !== basic404) {
       throw new Error(`Not found handler already set for Fastify instance with prefix: '${this._routePrefix || '/'}'`)
     }
@@ -645,11 +658,15 @@ function build (options) {
   }
 
   function setSchemaCompiler (schemaCompiler) {
+    throwIfAlreadyStarted('Cannot call "setSchemaCompiler" when fastify instance is already started!')
+
     this._schemaCompiler = schemaCompiler
     return this
   }
 
   function setErrorHandler (func) {
+    throwIfAlreadyStarted('Cannot call "setErrorHandler" when fastify instance is already started!')
+
     this._errorHandler = func
     return this
   }

--- a/fastify.js
+++ b/fastify.js
@@ -78,8 +78,8 @@ function build (options) {
     started = true
   })
 
-  function throwIfAlreadyStarted (msg) {
-    if (started) throw new Error(msg)
+  function throwIfAlreadyBinded (msg) {
+    if (listening) throw new Error(msg)
   }
 
   var server
@@ -394,7 +394,7 @@ function build (options) {
 
   // Route management
   function route (opts) {
-    throwIfAlreadyStarted('Cannot add route when fastify instance is already started!')
+    throwIfAlreadyBinded('Cannot add route when fastify instance is already started!')
 
     const _fastify = this
 
@@ -521,7 +521,7 @@ function build (options) {
   }
 
   function use (url, fn) {
-    throwIfAlreadyStarted('Cannot call "use" when fastify instance is already started!')
+    throwIfAlreadyBinded('Cannot call "use" when fastify instance is already started!')
     if (typeof url === 'string') {
       const prefix = this._routePrefix
       url = prefix + (url === '/' && prefix.length > 0 ? '' : url)
@@ -532,7 +532,7 @@ function build (options) {
   }
 
   function addHook (name, fn) {
-    throwIfAlreadyStarted('Cannot call "addHook" when fastify instance is already started!')
+    throwIfAlreadyBinded('Cannot call "addHook" when fastify instance is already started!')
 
     if (name === 'onClose') {
       this._hooks.validate(name, fn)
@@ -547,7 +547,7 @@ function build (options) {
   }
 
   function addContentTypeParser (contentType, fn) {
-    throwIfAlreadyStarted('Cannot call "addContentTypeParser" when fastify instance is already started!')
+    throwIfAlreadyBinded('Cannot call "addContentTypeParser" when fastify instance is already started!')
 
     this._contentTypeParser.add(contentType, fn)
     return this
@@ -598,7 +598,7 @@ function build (options) {
   }
 
   function setNotFoundHandler (opts, handler) {
-    throwIfAlreadyStarted('Cannot call "setNotFoundHandler" when fastify instance is already started!')
+    throwIfAlreadyBinded('Cannot call "setNotFoundHandler" when fastify instance is already started!')
 
     if (this._notFoundHandler !== null && this._notFoundHandler !== basic404) {
       throw new Error(`Not found handler already set for Fastify instance with prefix: '${this._routePrefix || '/'}'`)
@@ -658,14 +658,14 @@ function build (options) {
   }
 
   function setSchemaCompiler (schemaCompiler) {
-    throwIfAlreadyStarted('Cannot call "setSchemaCompiler" when fastify instance is already started!')
+    throwIfAlreadyBinded('Cannot call "setSchemaCompiler" when fastify instance is already started!')
 
     this._schemaCompiler = schemaCompiler
     return this
   }
 
   function setErrorHandler (func) {
-    throwIfAlreadyStarted('Cannot call "setErrorHandler" when fastify instance is already started!')
+    throwIfAlreadyBinded('Cannot call "setErrorHandler" when fastify instance is already started!')
 
     this._errorHandler = func
     return this

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -811,3 +811,21 @@ test('recognizes errors from the http-errors module', t => {
     })
   })
 })
+
+test('cannot set notFoundHandler after binding', t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    try {
+      fastify.setNotFoundHandler(() => { })
+      t.fail()
+    } catch (e) {
+      t.pass()
+    }
+  })
+})

--- a/test/500s.test.js
+++ b/test/500s.test.js
@@ -143,3 +143,21 @@ test('custom 500 with hooks', t => {
     t.deepEqual(res.payload.toString(), 'an error happened: kaboom')
   })
 })
+
+test('cannot set errorHandler after binding', t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    try {
+      fastify.setErrorHandler(() => { })
+      t.fail()
+    } catch (e) {
+      t.pass()
+    }
+  })
+})

--- a/test/custom-parser.test.js
+++ b/test/custom-parser.test.js
@@ -427,3 +427,26 @@ test('\'*\' catch undefined Content-Type requests', t => {
     })
   })
 })
+
+test('cannot add custom parser after binding', t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.post('/', (req, res) => {
+    res.type('text/plain').send(req.body)
+  })
+
+  fastify.listen(0, function (err) {
+    t.error(err)
+
+    try {
+      fastify.addContentTypeParser('*', () => {})
+      t.fail()
+    } catch (e) {
+      t.pass()
+    }
+  })
+})

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -820,6 +820,27 @@ test('onSend hook should receive valid request and reply objects if a custom con
   })
 })
 
+test('cannot add hook after binding', t => {
+  t.plan(2)
+  const instance = Fastify()
+
+  instance.get('/', function (request, reply) {
+    reply.send({ hello: 'world' })
+  })
+
+  instance.listen(0, err => {
+    t.error(err)
+    t.tearDown(instance.server.close.bind(instance.server))
+
+    try {
+      instance.addHook('onRequest', () => {})
+      t.fail()
+    } catch (e) {
+      t.pass()
+    }
+  })
+})
+
 if (Number(process.versions.node[0]) >= 8) {
   require('./hooks-async')(t)
 } else {

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -43,6 +43,33 @@ test('use a middleware', t => {
   })
 })
 
+test('cannot add middleware after binding', t => {
+  t.plan(2)
+  const instance = fastify()
+
+  instance.get('/', function (request, reply) {
+    reply.send({ hello: 'world' })
+  })
+
+  instance.listen(0, err => {
+    t.error(err)
+    t.tearDown(instance.server.close.bind(instance.server))
+
+    try {
+      instance.route({
+        method: 'GET',
+        url: '/another-get-route',
+        handler: function (req, reply) {
+          reply.send({ hello: 'world' })
+        }
+      })
+      t.fail()
+    } catch (e) {
+      t.pass()
+    }
+  })
+})
+
 test('use cors', t => {
   t.plan(3)
 

--- a/test/post.test.js
+++ b/test/post.test.js
@@ -3,3 +3,23 @@
 const t = require('tap')
 require('./helper').payloadMethod('post', t)
 require('./input-validation').payloadMethod('post', t)
+
+const Fastify = require('..')
+
+t.test('cannot set schemaCompiler after binding', t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    try {
+      fastify.setSchemaCompiler(() => { })
+      t.fail()
+    } catch (e) {
+      t.pass()
+    }
+  })
+})

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -111,6 +111,22 @@ fastify.listen(0, function (err) {
   if (err) t.error(err)
   fastify.server.unref()
 
+  test('cannot add another route after binding', t => {
+    t.plan(1)
+    try {
+      fastify.route({
+        method: 'GET',
+        url: '/another-get-route',
+        handler: function (req, reply) {
+          reply.send({ hello: 'world' })
+        }
+      })
+      t.fail()
+    } catch (e) {
+      t.pass()
+    }
+  })
+
   test('route - get', t => {
     t.plan(3)
     sget({


### PR DESCRIPTION
Truly this is a breaking change. But changing the `fastify` instance after the server is started is a bad practice.

Fix #594 


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)