### PR TITLE
Normalize route paths with a prefix that has a trailing slash

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -338,8 +338,10 @@ function build (options) {
       return instancePrefix
     }
 
+    // Ensure that there is a '/' between the prefixes
     if (instancePrefix.endsWith('/')) {
       if (pluginPrefix[0] === '/') {
+        // Remove the extra '/' to avoid: '/first//second'
         pluginPrefix = pluginPrefix.slice(1)
       }
     } else if (pluginPrefix[0] !== '/') {
@@ -425,8 +427,10 @@ function build (options) {
       const prefix = _fastify._routePrefix
       var path = opts.url || opts.path
       if (path === '/' && prefix.length > 0) {
+        // Ensure that '/prefix' + '/' gets registered as '/prefix'
         path = ''
       } else if (path[0] === '/' && prefix.endsWith('/')) {
+        // Ensure that '/prefix/' + '/route' gets registered as '/prefix/route'
         path = path.slice(1)
       }
       const url = prefix + path

--- a/fastify.js
+++ b/fastify.js
@@ -338,9 +338,14 @@ function build (options) {
       return instancePrefix
     }
 
-    if (pluginPrefix[0] !== '/') {
+    if (instancePrefix.endsWith('/')) {
+      if (pluginPrefix[0] === '/') {
+        pluginPrefix = pluginPrefix.slice(1)
+      }
+    } else if (pluginPrefix[0] !== '/') {
       pluginPrefix = '/' + pluginPrefix
     }
+
     return instancePrefix + pluginPrefix
   }
 
@@ -417,9 +422,14 @@ function build (options) {
     validateBodyLimitOption(opts.jsonBodyLimit)
 
     _fastify.after(function afterRouteAdded (notHandledErr, done) {
-      const path = opts.url || opts.path
       const prefix = _fastify._routePrefix
-      const url = prefix + (path === '/' && prefix.length > 0 ? '' : path)
+      var path = opts.url || opts.path
+      if (path === '/' && prefix.length > 0) {
+        path = ''
+      } else if (path[0] === '/' && prefix.endsWith('/')) {
+        path = path.slice(1)
+      }
+      const url = prefix + path
 
       opts.url = url
       opts.path = url

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -178,17 +178,20 @@ test('Prefix without /', t => {
 })
 
 test('Prefix with trailing /', t => {
-  t.plan(4)
+  t.plan(6)
   const fastify = Fastify()
 
   fastify.register(function (fastify, opts, next) {
-    fastify.get('/route', (req, reply) => {
-      reply.send({ hello: 'world' })
+    fastify.get('/route1', (req, reply) => {
+      reply.send({ hello: 'world1' })
+    })
+    fastify.get('route2', (req, reply) => {
+      reply.send({ hello: 'world2' })
     })
 
     fastify.register(function (fastify, opts, next) {
-      fastify.get('/route2', (req, reply) => {
-        reply.send({ hello: 'world2' })
+      fastify.get('/route3', (req, reply) => {
+        reply.send({ hello: 'world3' })
       })
       next()
     }, { prefix: '/inner/' })
@@ -198,18 +201,26 @@ test('Prefix with trailing /', t => {
 
   fastify.inject({
     method: 'GET',
-    url: '/v1/route'
+    url: '/v1/route1'
   }, (err, res) => {
     t.error(err)
-    t.same(JSON.parse(res.payload), { hello: 'world' })
+    t.same(JSON.parse(res.payload), { hello: 'world1' })
   })
 
   fastify.inject({
     method: 'GET',
-    url: '/v1/inner/route2'
+    url: '/v1/route2'
   }, (err, res) => {
     t.error(err)
     t.same(JSON.parse(res.payload), { hello: 'world2' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/v1/inner/route3'
+  }, (err, res) => {
+    t.error(err)
+    t.same(JSON.parse(res.payload), { hello: 'world3' })
   })
 })
 

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -177,6 +177,42 @@ test('Prefix without /', t => {
   })
 })
 
+test('Prefix with trailing /', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.register(function (fastify, opts, next) {
+    fastify.get('/route', (req, reply) => {
+      reply.send({ hello: 'world' })
+    })
+
+    fastify.register(function (fastify, opts, next) {
+      fastify.get('/route2', (req, reply) => {
+        reply.send({ hello: 'world2' })
+      })
+      next()
+    }, { prefix: '/inner/' })
+
+    next()
+  }, { prefix: '/v1/' })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/v1/route'
+  }, (err, res) => {
+    t.error(err)
+    t.same(JSON.parse(res.payload), { hello: 'world' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/v1/inner/route2'
+  }, (err, res) => {
+    t.error(err)
+    t.same(JSON.parse(res.payload), { hello: 'world2' })
+  })
+})
+
 test('Prefix works multiple levels deep', t => {
   t.plan(2)
   const fastify = Fastify()


### PR DESCRIPTION
Handles trailing slashes in the route `prefix` so that:

```js
fastify.register(function (fastify, opts, next) {
  fastify.register(function (fastify, opts, next) {
    fastify.get('/route', (req, reply) => {
      reply.send({ hello: 'world' })
    })
    next()
  }, { prefix: '/inner/' })
  next()
}, { prefix: '/v1/' })
```

registers `/v1/inner/route` instead of `/v1//inner//route`.

See the discussion in #584.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
