### PR TITLE
Add support for ignoring trailing slashes in routes

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -54,7 +54,10 @@ function build (options) {
     log = loggerUtils.createLogger(options.logger)
   }
 
-  const router = FindMyWay({ defaultRoute: defaultRoute })
+  const router = FindMyWay({
+    defaultRoute: defaultRoute,
+    ignoreTrailingSlash: options.ignoreTrailingSlash
+  })
 
   // logger utils
   const customGenReqId = options.logger ? options.logger.genReqId : null

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "avvio": "^5.0.0",
     "fast-iterator": "^0.2.1",
     "fast-json-stringify": "^0.17.0",
-    "find-my-way": "^1.8.1",
+    "find-my-way": "^1.9.0",
     "flatstr": "^1.0.5",
     "light-my-request": "^2.0.1",
     "middie": "^3.0.0",

--- a/test/ignoreTrailingSlash.test.js
+++ b/test/ignoreTrailingSlash.test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const test = require('tap').test
+const sget = require('simple-get')
+const Fastify = require('../')
+
+test('honors ignoreTrailingSlash option', t => {
+  t.plan(4)
+  const fastify = Fastify({
+    ignoreTrailingSlash: true
+  })
+
+  fastify.get('/test', (req, res) => {
+    res.send('test')
+  })
+
+  fastify.listen(0, (err) => {
+    fastify.server.unref()
+    if (err) t.threw(err)
+
+    const baseUrl = 'http://127.0.0.1:' + fastify.server.address().port
+
+    sget.concat(baseUrl + '/test', (err, res, data) => {
+      if (err) t.threw(err)
+      t.is(res.statusCode, 200)
+      t.is(data.toString(), 'test')
+    })
+
+    sget.concat(baseUrl + '/test/', (err, res, data) => {
+      if (err) t.threw(err)
+      t.is(res.statusCode, 200)
+      t.is(data.toString(), 'test')
+    })
+  })
+})


### PR DESCRIPTION
This PR adds support for ignoring trailing slashes as discussed in #584. This is an all or nothing setting. For example:

```js
const fastify = require('fastify')({
  ignoreTrailingSlash: true
})

// maps to both "/test/" and "/test"
fastify.get('/test/', (req, reply) => {
  reply.send('test')
})
```

Documentation is not included because we don't have any documentation that describes the factory function and the options it accepts. A PR should be opened to rectify that problem.

#### Checklist

- [x] run `npm run test` ~and `npm run benchmark`~
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
