### PR TITLE
Add LTS documentation (fix #670)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ matters to you.
 _Fastify_ is the result of the work of a great community.
 Team members are listed in alphabetical order.
 
+## Long Term Support
+
+Fastify's support schedule is detailed in the [LTS document](https://github.com/fastify/fastify/blob/master/docs/LTS.md).
+
 ### Lead Maintainers
 
 * [__Matteo Collina__](https://github.com/mcollina), <https://twitter.com/matteocollina>, <https://www.npmjs.com/~matteo.collina>

--- a/docs/LTS.md
+++ b/docs/LTS.md
@@ -1,5 +1,7 @@
+<h1 align="center">Fastify</h1>
+
 <a name="lts"></a>
-# Long Term Support
+## Long Term Support
 
 Fastify's Long Term Support (LTS) is provided according the schedule laid
 out in this document:
@@ -17,7 +19,7 @@ A "month" is to be a period of 30 consecutive days.
 [semver]: https://semver.org/
 
 <a name="lts-schedule"></a>
-## Schedule
+### Schedule
 
 | Version | Release Date | End Of LTS Date |
 |:--------|:-------------|:----------------|

--- a/docs/LTS.md
+++ b/docs/LTS.md
@@ -1,0 +1,24 @@
+<a name="lts"></a>
+# Long Term Support
+
+Fastify's Long Term Support (LTS) is provided according the schedule laid
+out in this document:
+
+1. Major releases, "X" release of [semantic versioning][semver] X.Y.Z release
+versions, are supported for a minimum period of six months from their release
+date. The release date of any specific version can be found at
+[https://github.com/fastify/fastify/releases](https://github.com/fastify/fastify/releases).
+
+1. Major releases will receive security updates for an additional six months
+from the release of the next major release.
+
+A "month" is to be a period of 30 consecutive days.
+
+[semver]: https://semver.org/
+
+<a name="lts-schedule"></a>
+## Schedule
+
+| Version | Release Date | End Of LTS Date |
+|:--------|:-------------|:----------------|
+| 1.0.0   | TBD          | TBD             |


### PR DESCRIPTION
This PR adds a document to codify the LTS strategy outlined in #670. The included table should eventually look something like this:

| Version | Release Date | End Of LTS Date |
|:--------|:-------------|:----------------|
| 1.0.0 | 2018-02-01 | 2019-02-27 |
| 2.0.0 | 2018-08-31 | TBD |

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
