### PR TITLE
Add documentation for the options to the factory function

### DIFF
--- a/docs/Factory.md
+++ b/docs/Factory.md
@@ -1,0 +1,105 @@
+<h1 align="center">Fastify</h1>
+
+<a name="factory"></a>
+## Factory
+
+The Fastify module exports a factory function that is used to create new
+<a href="https://github.com/fastify/fastify/blob/master/docs/Server-Methods.md"><code><b>Fastify server</b></code></a>
+instances. This factory function accepts an options object which is used to
+customize the resulting instance. This document describes the properties
+available in that options object.
+
+<a name="factory-http2"></a>
+### `http2` (Status: experimental)
+
+A truthy value that can be used to enable Node.js core's
+[HTTP/2](https://nodejs.org/dist/latest-v8.x/docs/api/http2.html) socket.
+
++ Default: `undefined` or `false`
+
+<a name="factory-https"></a>
+### `https`
+
+An object used to configure the server's listening socket for TLS. The options
+are the same as the Node.js core
+[`createServer` method](https://nodejs.org/dist/latest-v8.x/docs/api/https.html#https_https_createserver_options_requestlistener). When this property is a falsy value, the socket will not be
+configured for TLS.
+
+This option also applies when the
+<a href="https://github.com/fastify/fastify/blob/master/docs/Factory.md#factory-http2">
+<code><b>http2</b></code>
+</a> option is set.
+
++ Default: `undefined` or `false`
+
+<a name="factory-ignore-slash"></a>
+### `ignoreTrailingSlash`
+
+Fastify uses [find-my-way](https://github.com/delvedor/find-my-way) to handle
+routing. This option may be set to `true` to ignore traling slashes in routes.
+This option applies to *all* route registrations for the resulting server
+instance.
+
++ Default: `undefined` or `false`
+
+#### Example
+
+```js
+const fastify = require('fastify')({
+  ignoreTrailingSlash: true
+})
+
+// registers both "/foo" and "/foo/"
+fastify.get('/foo/', function (req, reply) {
+  res.send('foo')
+})
+
+// registers both "/bar" and "/bar/"
+fastify.get('/bar', function (req, reply) {
+  res.send('bar')
+})
+```
+
+<a name="factory-json-limit"></a>
+### `jsonBodyLimit`
+
+Defines the maximum payload, in bytes, the server is allowed to accept for
+`PUT` and `POST` bodies when using the internal `application/json` content type
+parser.
+
+Default: `1048576` (1MiB)
+
+<a name="factory-logger"></a>
+### `logger`
+
+Fastify includes built-in logging via the [Pino](https://getpino.io/) logger.
+This property is used to configure the internal logger instance.
+
+The possible values this property may have are:
+
++ `undefined` or `false` (Default): the logger is disabled. All logging methods
+will point to a null logger [abstract-logging](https://npm.im/abstract-logging)
+instance.
+
++ `pinoInstance`: a previously instantiated instance of Pino. The internal
+logger will point to this instance.
+
++ `object`: a standard Pino [options object](https://github.com/pinojs/pino/blob/c77d8ec5ce/docs/API.md#constructor).
+This will be passed directly to the Pino constructor. If the following properties
+are not present on the object, they will be added accordingly:
+    * `genReqId`: a synchronous function that will be used to generate identifiers
+    for incoming requests. The default function generates sequential identifiers.
+    * `level`: the minimum logging level. If not set, it will be set to `'info'`.
+    * `serializers`: a hash of serialization functions. By default, serializers
+      are added for `req` (incoming request objects), `res` (outgoing repsonse
+      objets), and `err` (standard `Error` objects). When a log method receives
+      and object with any of these properties then the respective serializer will
+      be used for that property. For example:
+        ```js
+        fastify.get('/foo', function (req, res) {
+          req.log.info({req}) // log the serialized request object
+          res.send('foo')
+        })
+        ```
+      Any user supplied serializer will override the default serializer of the
+      corresponding property.

--- a/docs/Factory.md
+++ b/docs/Factory.md
@@ -12,10 +12,10 @@ available in that options object.
 <a name="factory-http2"></a>
 ### `http2` (Status: experimental)
 
-A truthy value that can be used to enable Node.js core's
-[HTTP/2](https://nodejs.org/dist/latest-v8.x/docs/api/http2.html) socket.
+If `true` Node.js core's [HTTP/2](https://nodejs.org/dist/latest-v8.x/docs/api/http2.html)
+HTTP/2 module is used for binding the socket.
 
-+ Default: `undefined` or `false`
++ Default: `false`
 
 <a name="factory-https"></a>
 ### `https`
@@ -30,7 +30,7 @@ This option also applies when the
 <code><b>http2</b></code>
 </a> option is set.
 
-+ Default: `undefined` or `false`
++ Default: `null`
 
 <a name="factory-ignore-slash"></a>
 ### `ignoreTrailingSlash`
@@ -40,7 +40,7 @@ routing. This option may be set to `true` to ignore trailing slashes in routes.
 This option applies to *all* route registrations for the resulting server
 instance.
 
-+ Default: `undefined` or `false`
++ Default: `false`
 
 #### Example
 

--- a/docs/Factory.md
+++ b/docs/Factory.md
@@ -67,7 +67,7 @@ Defines the maximum payload, in bytes, the server is allowed to accept for
 `PUT` and `POST` bodies when using the internal `application/json` content type
 parser.
 
-Default: `1048576` (1MiB)
++ Default: `1048576` (1MiB)
 
 <a name="factory-logger"></a>
 ### `logger`
@@ -77,7 +77,7 @@ This property is used to configure the internal logger instance.
 
 The possible values this property may have are:
 
-+ `undefined` or `false` (Default): the logger is disabled. All logging methods
++ Default: `undefined` or `false`. The logger is disabled. All logging methods
 will point to a null logger [abstract-logging](https://npm.im/abstract-logging)
 instance.
 

--- a/docs/Factory.md
+++ b/docs/Factory.md
@@ -22,8 +22,8 @@ HTTP/2 module is used for binding the socket.
 
 An object used to configure the server's listening socket for TLS. The options
 are the same as the Node.js core
-[`createServer` method](https://nodejs.org/dist/latest-v8.x/docs/api/https.html#https_https_createserver_options_requestlistener). When this property is a falsy value, the socket will not be
-configured for TLS.
+[`createServer` method](https://nodejs.org/dist/latest-v8.x/docs/api/https.html#https_https_createserver_options_requestlistener).
+When this property is `null`, the socket will not be configured for TLS.
 
 This option also applies when the
 <a href="https://github.com/fastify/fastify/blob/master/docs/Factory.md#factory-http2">
@@ -76,9 +76,8 @@ This property is used to configure the internal logger instance.
 
 The possible values this property may have are:
 
-+ Default: `undefined` or `false`. The logger is disabled. All logging methods
-will point to a null logger [abstract-logging](https://npm.im/abstract-logging)
-instance.
++ Default: `false`. The logger is disabled. All logging methods will point to a
+null logger [abstract-logging](https://npm.im/abstract-logging) instance.
 
 + `pinoInstance`: a previously instantiated instance of Pino. The internal
 logger will point to this instance.

--- a/docs/Factory.md
+++ b/docs/Factory.md
@@ -36,7 +36,7 @@ This option also applies when the
 ### `ignoreTrailingSlash`
 
 Fastify uses [find-my-way](https://github.com/delvedor/find-my-way) to handle
-routing. This option may be set to `true` to ignore traling slashes in routes.
+routing. This option may be set to `true` to ignore trailing slashes in routes.
 This option applies to *all* route registrations for the resulting server
 instance.
 
@@ -64,8 +64,7 @@ fastify.get('/bar', function (req, reply) {
 ### `jsonBodyLimit`
 
 Defines the maximum payload, in bytes, the server is allowed to accept for
-`PUT` and `POST` bodies when using the internal `application/json` content type
-parser.
+request bodies when using the internal `application/json` content type parser.
 
 + Default: `1048576` (1MiB)
 

--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -4,7 +4,7 @@
 
 <a name="server"></a>
 #### server
-`fastify.server`: The Node core [server](https://nodejs.org/api/http.html#http_class_http_server) object
+`fastify.server`: The Node core [server](https://nodejs.org/api/http.html#http_class_http_server) object as returned by the <a href="https://github.com/fastify/fastify/blob/master/docs/Factory.md"><code><b>Fastify factory function</b></code></a>.
 
 <a name="ready"></a>
 #### ready


### PR DESCRIPTION
This PR adds documentation for the options available when constructing new Fastify instances.

@fastify/fastify please review to make sure I didn't miss any options.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
