### PR TITLE
Handle prefix with trailing slash when setting not-found handler

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -663,7 +663,7 @@ function build (options) {
 
     const prefix = this._routePrefix
 
-    fourOhFour.all(prefix + '/*', fastify, context)
+    fourOhFour.all(prefix + (prefix.endsWith('/') ? '*' : '/*'), fastify, context)
     fourOhFour.all(prefix || '/', fastify, context)
   }
 


### PR DESCRIPTION
Looks like I missed this case when writing #676.

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
