### PR TITLE
Add basePath property to instance (fix #686)

### DIFF
--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -107,6 +107,22 @@ Function to add middlewares to Fastify, check [here](https://github.com/fastify/
 #### addHook
 Function to add a specific hook in the lifecycle of Fastify, check [here](https://github.com/fastify/fastify/blob/master/docs/Hooks.md).
 
+<a name="base-path"></a>
+#### basepath
+The full path that will be prefixed to a route.
+
+Example:
+
+```js
+fastify.register(function (instance, opts, next) {
+  instance.get('/foo', function (request, reply) {
+    // Will log "basePath: /v1"
+    request.log.info('basePath: %s', instance.basePath)
+    reply.send({basePath: instance.basePath})
+  })
+}, { prefix: '/v1' })
+```
+
 <a name="log"></a>
 #### log
 The logger instance, check [here](https://github.com/fastify/fastify/blob/master/docs/Logging.md).

--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -120,6 +120,18 @@ fastify.register(function (instance, opts, next) {
     request.log.info('basePath: %s', instance.basePath)
     reply.send({basePath: instance.basePath})
   })
+
+  instance.register(function (instance, opts, next) {
+    instance.get('/bar', function (request, reply) {
+      // Will log "basePath: /v1/v2"
+      request.log.info('basePath: %s', instance.basePath)
+      reply.send({basePath: instance.basePath})
+    })
+
+    next()
+  }, { prefix: '/v2' })
+
+  next()
 }, { prefix: '/v1' })
 ```
 

--- a/fastify.js
+++ b/fastify.js
@@ -127,6 +127,12 @@ function build (options) {
   fastify._routePrefix = ''
   fastify._logLevel = ''
 
+  Object.defineProperty(fastify, 'basePath', {
+    get: function () {
+      return this._routePrefix
+    }
+  })
+
   // expose logger instance
   fastify.log = log
 


### PR DESCRIPTION
This PR adds a `basePath` property to instances. It resolves #686.

#### Checklist

- [x] run `npm run test` ~and `npm run benchmark`~
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
