### PR TITLE
Serialize the payload before running onSend hooks

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -83,6 +83,7 @@ fastify.addHook('onResponse', async (res) => {
 | res | Node.js [ServerResponse](https://nodejs.org/api/http.html#http_class_http_serverresponse) |
 | request | Fastify [Request](https://github.com/fastify/fastify/blob/master/docs/Request.md) interface |
 | reply | Fastify [Reply](https://github.com/fastify/fastify/blob/master/docs/Reply.md) interface |
+| payload | The serialized payload |
 | next | Function to continue with the [lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md) |
 
 It is pretty easy to understand where each hook is executed by looking at the [lifecycle page](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md).<br>
@@ -108,22 +109,37 @@ fastify.addHook('preHandler', (request, reply, next) => {
 
 Note that in the `'preHandler'` and `'onSend'` hook the request and reply objects are different from `'onRequest'`, because the two arguments are [`request`](https://github.com/fastify/fastify/blob/master/docs/Request.md) and [`reply`](https://github.com/fastify/fastify/blob/master/docs/Reply.md) core Fastify objects.
 
-If you are using the `onSend` hook you can update the payload, for example:
+#### The `onSend` Hook
+
+If you are using the `onSend` hook, you can change the payload. For example:
+
 ```js
-
-fastify.addHook('onSend', (request, reply, payload, next) => {
-  var err = null;
-  payload.hello = 'world'
-  next(err, payload)
-})
-
-// Or
 fastify.addHook('onSend', (request, reply, payload, next) => {
   var err = null;
   var newPayload = payload.replace('some-text', 'some-new-text')
   next(err, newPayload)
 })
+
+// Or async
+fastify.addHook('onSend', async (request, reply, payload) => {
+  var newPayload = payload.replace('some-text', 'some-new-text')
+  return newPayload
+})
 ```
+
+You can also clear the payload to send a response with an empty body by replacing the payload with `null`:
+
+```js
+fastify.addHook('onSend', (request, reply, payload, next) => {
+  reply.code(304)
+  const newPayload = null
+  next(null, newPayload)
+})
+```
+
+> You can also send an empty body by replacing the payload with the empty string `''`, but be aware that this will cause the `Content-Length` header to be set to `0`, whereas the `Content-Length` header will not be set if the payload is `null`.
+
+Note: If you change the payload, you may only change it to a `string`, a `Buffer`, a `stream`, or `null`.
 
 ## Application Hooks
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -41,8 +41,39 @@ Reply.prototype.send = function (payload) {
     return
   }
 
+  if (payload === undefined) {
+    onSendHook(this, payload)
+    return
+  }
+
+  const contentType = this.res.getHeader('Content-Type')
+  const contentTypeNotSet = contentType === undefined
+
+  if (payload !== null) {
+    if (Buffer.isBuffer(payload) || typeof payload.pipe === 'function') {
+      if (contentTypeNotSet) {
+        this.res.setHeader('Content-Type', 'application/octet-stream')
+      }
+      onSendHook(this, payload)
+      return
+    }
+
+    if (contentTypeNotSet && typeof payload === 'string') {
+      this.res.setHeader('Content-Type', 'text/plain')
+      onSendHook(this, payload)
+      return
+    }
+  }
+
+  if (this._serializer) {
+    payload = this._serializer(payload)
+  } else if (contentTypeNotSet || contentType === 'application/json') {
+    this.res.setHeader('Content-Type', 'application/json')
+    payload = serialize(this.context, payload, this.res.statusCode)
+    flatstr(payload)
+  }
+
   onSendHook(this, payload)
-  return
 }
 
 Reply.prototype.header = function (key, value) {
@@ -122,40 +153,19 @@ function wrapOnSendEnd (err, payload) {
 }
 
 function onSendEnd (reply, payload) {
-  if (payload === undefined) {
+  if (payload === undefined || payload === null) {
     reply.sent = true
     reply.res.end()
     return
   }
 
-  var contentType = reply.res.getHeader('Content-Type')
-  if (payload !== null && typeof payload.pipe === 'function') {
-    if (!contentType) {
-      reply.res.setHeader('Content-Type', 'application/octet-stream')
-    }
+  if (typeof payload.pipe === 'function') {
     pump(payload, reply.res, pumpCallback(reply))
     return
   }
 
-  var isPayloadString = typeof payload === 'string'
-
-  if (!contentType && isPayloadString) {
-    reply.res.setHeader('Content-Type', 'text/plain')
-  } else if (Buffer.isBuffer(payload)) {
-    if (!contentType) {
-      reply.res.setHeader('Content-Type', 'application/octet-stream')
-    }
-  } else if (reply._serializer) {
-    payload = reply._serializer(payload)
-    if (typeof payload !== 'string' && !Buffer.isBuffer(payload)) {
-      throw new TypeError(`Serializer for Content-Type '${contentType}' returned invalid payload of type '${typeof payload}'. Expected a string or Buffer.`)
-    }
-  } else if (!contentType || contentType === 'application/json') {
-    reply.res.setHeader('Content-Type', 'application/json')
-    payload = serialize(reply.context, payload, reply.res.statusCode)
-    flatstr(payload)
-  } else if (!isPayloadString && !Buffer.isBuffer(payload)) {
-    throw new TypeError(`Attempted to send payload of invalid type '${typeof payload}' without serialization. Expected a string or Buffer.`)
+  if (typeof payload !== 'string' && !Buffer.isBuffer(payload)) {
+    throw new TypeError(`Attempted to send payload of invalid type '${typeof payload}'. Expected a string or Buffer.`)
   }
 
   if (!reply.res.getHeader('Content-Length')) {
@@ -214,20 +224,18 @@ function handleError (reply, error, cb) {
     return
   }
 
-  var payload = {
+  var payload = serializeError({
     error: statusCodes[statusCode + ''],
     message: error ? error.message : '',
     statusCode: statusCode
-  }
+  })
+  flatstr(payload)
   reply.res.setHeader('Content-Type', 'application/json')
 
   if (cb) {
     cb(reply, payload)
     return
   }
-
-  payload = serializeError(payload)
-  flatstr(payload)
 
   reply.res.setHeader('Content-Length', '' + Buffer.byteLength(payload))
   reply.sent = true

--- a/test/hooks-async.js
+++ b/test/hooks-async.js
@@ -91,25 +91,23 @@ function asyncHookTest (t) {
     const fastify = Fastify()
     const payload = { hello: 'world' }
     const modifiedPayload = { hello: 'modified' }
-    const anotherPayload = { winter: 'is coming' }
+    const anotherPayload = '"winter is coming"'
 
     fastify.addHook('onSend', async function (request, reply, thePayload) {
       t.ok('onSend called')
-      t.deepEqual(thePayload, payload)
-      // onSend allows only to modify Object keys and not the full object's reference
-      thePayload.hello = 'modified'
-      return thePayload
+      t.deepEqual(JSON.parse(thePayload), payload)
+      return thePayload.replace('world', 'modified')
     })
 
     fastify.addHook('onSend', async function (request, reply, thePayload) {
       t.ok('onSend called')
-      t.deepEqual(thePayload, modifiedPayload)
+      t.deepEqual(JSON.parse(thePayload), modifiedPayload)
       return anotherPayload
     })
 
     fastify.addHook('onSend', async function (request, reply, thePayload) {
       t.ok('onSend called')
-      t.deepEqual(thePayload, anotherPayload)
+      t.strictEqual(thePayload, anotherPayload)
     })
 
     fastify.get('/', (req, reply) => {
@@ -121,9 +119,9 @@ function asyncHookTest (t) {
       url: '/'
     }, (err, res) => {
       t.error(err)
-      t.deepEqual(anotherPayload, JSON.parse(res.payload))
+      t.strictEqual(res.payload, anotherPayload)
       t.strictEqual(res.statusCode, 200)
-      t.strictEqual(res.headers['content-length'], '22')
+      t.strictEqual(res.headers['content-length'], '18')
     })
   })
 }

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -220,7 +220,7 @@ test('request should respond with an error if an unserialized payload is sent in
     t.strictEqual(res.statusCode, 500)
     t.deepEqual(JSON.parse(res.payload), {
       error: 'Internal Server Error',
-      message: 'Attempted to send payload of invalid type \'object\' without serialization. Expected a string or Buffer.',
+      message: 'Attempted to send payload of invalid type \'object\'. Expected a string or Buffer.',
       statusCode: 500
     })
   })

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -4,7 +4,6 @@ const t = require('tap')
 const test = t.test
 const sget = require('simple-get').concat
 const http = require('http')
-const zlib = require('zlib')
 
 const Reply = require('../../lib/reply')
 
@@ -200,36 +199,6 @@ test('within an instance', t => {
     })
 
     t.end()
-  })
-})
-
-test('use reply.serialize in onSend hook', t => {
-  t.plan(4)
-
-  const fastify = require('../..')()
-  fastify.addHook('onSend', (request, reply, payload, next) => {
-    function _serialize () {
-      const _payload = reply.serialize(payload)
-      return zlib.gzipSync(_payload)
-    }
-    reply.serializer(_serialize)
-    reply.header('Content-Encoding', 'gzip')
-    next()
-  })
-  fastify.get('/', (request, reply) => {
-    reply.send({ hello: 'world' })
-  })
-  fastify.listen(0, err => {
-    t.error(err)
-    fastify.server.unref()
-    sget({
-      method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port
-    }, (err, response, body) => {
-      t.error(err)
-      t.strictEqual(response.statusCode, 200)
-      t.deepEqual(JSON.parse(body), { hello: 'world' })
-    })
   })
 })
 
@@ -478,7 +447,11 @@ test('reply.notFound() should invoke the 404 handler', t => {
       t.error(err)
       t.strictEqual(response.statusCode, 404)
       t.strictEqual(response.headers['content-type'], 'application/json')
-      t.deepEqual(body.toString(), '{"error":"Not Found","message":"Not found","statusCode":404}')
+      t.deepEqual(JSON.parse(body.toString()), {
+        statusCode: 404,
+        error: 'Not Found',
+        message: 'Not found'
+      })
     })
 
     sget({

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -358,7 +358,7 @@ test('\'*\' should throw an error due to serializer can not handle the payload t
       reply.send({})
     } catch (err) {
       t.type(err, TypeError)
-      t.strictEqual(err.message, "Attempted to send payload of invalid type 'object' without serialization. Expected a string or Buffer.")
+      t.strictEqual(err.message, "Attempted to send payload of invalid type 'object'. Expected a string or Buffer.")
     }
   })
 
@@ -370,7 +370,7 @@ test('\'*\' should throw an error due to serializer can not handle the payload t
   })
 })
 
-test('should throw an error due to custom serializer can not handle the payload type', t => {
+test('should throw an error if the custom serializer does not serialize the payload to a valid type', t => {
   t.plan(2)
   const fastify = Fastify()
 
@@ -382,7 +382,7 @@ test('should throw an error due to custom serializer can not handle the payload 
       .send({})
     } catch (err) {
       t.type(err, TypeError)
-      t.strictEqual(err.message, "Serializer for Content-Type 'text/html' returned invalid payload of type 'object'. Expected a string or Buffer.")
+      t.strictEqual(err.message, "Attempted to send payload of invalid type 'object'. Expected a string or Buffer.")
     }
   })
 


### PR DESCRIPTION
Serialization now happens before the `onSend` hooks, so the hooks receive the serialized payload.

This also adds a feature where an `onSend` hook can replace the payload with `null` to send a response with an empty body without having the `Content-Type` header get set to `0`. This was not possible before because `null` would either get serialized as JSON or be considered an unserialized value and cause an error to be thrown. (It would be preferable to do this by setting the payload to `undefined` in the hook, but `undefined` currently means that the payload was not changed.)

Fixes #672 

<details>
<summary>Benchmarks</summary>

**master**
```
[1] Stat         Avg     Stdev   Max
[1] Latency (ms) 3       10.65   354
[1] Req/Sec      32459.2 6549.24 37215
[1] Bytes/Sec    4.89 MB 984 kB  5.77 MB
[1]
[1] 162k requests in 5s, 24.2 MB read
...
[1] Stat         Avg     Stdev   Max
[1] Latency (ms) 2.98    10.58   376
[1] Req/Sec      32734.4 6533.01 37695
[1] Bytes/Sec    4.89 MB 984 kB  5.77 MB
[1]
[1] 164k requests in 5s, 24.4 MB read
```

**this PR**
```
[1] Stat         Avg     Stdev   Max
[1] Latency (ms) 3       10.45   341
[1] Req/Sec      32497.6 6392.17 37535
[1] Bytes/Sec    4.84 MB 964 kB  5.77 MB
[1]
[1] 162k requests in 5s, 24.2 MB read
...
[1] Stat         Avg     Stdev   Max
[1] Latency (ms) 3.01    10.63   295
[1] Req/Sec      32372.8 6272.62 37503
[1] Bytes/Sec    4.78 MB 940 kB  5.77 MB
[1]
[1] 162k requests in 5s, 24.1 MB read
```
</details>

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
