### PR TITLE
Fix formatting of IPv6 URL

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -260,7 +260,11 @@ function build (options) {
       if (!err) {
         let address = server.address()
         if (typeof address === 'object') {
-          address = address.address + ':' + address.port
+          if (address.address.indexOf(':') === -1) {
+            address = address.address + ':' + address.port
+          } else {
+            address = '[' + address.address + ']:' + address.port
+          }
         }
         address = 'http' + (options.https ? 's' : '') + '://' + address
         fastify.log.info('Server listening at ' + address)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

This fixes the invalid URL that is logged when using IPv6 address.

Before:
```json
{ "msg": "Server listening at https://:::7777" }
```

After:
```json
{ "msg": "Server listening at https://[::]:7777" }
```

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [x] ~~documentation is changed or added~~
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
