### PR TITLE
Fix 677

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -278,6 +278,7 @@ function build (options) {
   }
 
   function middlewareCallback (err, state) {
+    if (state.res.finished === true) return
     if (err) {
       const req = state.req
       const request = new state.context.Request(state.params, req, null, req.headers, req.log)

--- a/fastify.js
+++ b/fastify.js
@@ -272,7 +272,8 @@ function build (options) {
     this.context = context
   }
 
-  function hookIterator (fn, state, next) {
+  function hookIterator (fn, state, next, release) {
+    if (state.res.finished === true) return release()
     return fn(state.req, state.res, next)
   }
 

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -154,6 +154,7 @@ function hookIterator (fn, reply, next, release) {
 }
 
 function preHandlerCallback (err, reply) {
+  if (reply.res.finished === true) return
   if (err) {
     reply.send(err)
     return

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -148,7 +148,8 @@ function handler (reply) {
   }
 }
 
-function hookIterator (fn, reply, next) {
+function hookIterator (fn, reply, next, release) {
+  if (reply.sent === true) return release()
   return fn(reply.request, reply, next)
 }
 

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -149,7 +149,7 @@ function handler (reply) {
 }
 
 function hookIterator (fn, reply, next, release) {
-  if (reply.sent === true) return release()
+  if (reply.res.finished === true) return release()
   return fn(reply.request, reply, next)
 }
 

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "abstract-logging": "^1.0.0",
     "ajv": "^6.0.1",
     "avvio": "^5.0.0",
-    "fast-iterator": "^0.2.1",
+    "fast-iterator": "^0.3.0",
     "fast-json-stringify": "^0.17.0",
     "find-my-way": "^1.9.0",
     "flatstr": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "find-my-way": "^1.9.0",
     "flatstr": "^1.0.5",
     "light-my-request": "^2.0.1",
-    "middie": "^3.0.0",
+    "middie": "^3.1.0",
     "pino": "^4.10.2",
     "pump": "^2.0.0"
   },

--- a/test/hooks-async.js
+++ b/test/hooks-async.js
@@ -3,6 +3,7 @@
 const sget = require('simple-get').concat
 const sleep = require('then-sleep')
 const Fastify = require('..')
+const fs = require('fs')
 
 function asyncHookTest (t) {
   const test = t.test
@@ -196,6 +197,96 @@ function asyncHookTest (t) {
       t.error(err)
       t.is(res.statusCode, 200)
       t.is(res.payload, 'hello')
+    })
+  })
+
+  test('onRequest respond with a stream', t => {
+    t.plan(3)
+    const fastify = Fastify()
+
+    fastify.addHook('onRequest', async (req, res) => {
+      return new Promise((resolve, reject) => {
+        const stream = fs.createReadStream(process.cwd() + '/test/stream.test.js', 'utf8')
+        stream.pipe(res)
+        res.once('finish', resolve)
+      })
+    })
+
+    fastify.addHook('onRequest', async (req, res) => {
+      t.fail('this should not be called')
+    })
+
+    fastify.addHook('preHandler', async (req, reply) => {
+      t.fail('this should not be called')
+    })
+
+    fastify.addHook('onSend', async (req, reply, payload) => {
+      t.fail('this should not be called')
+    })
+
+    fastify.addHook('onResponse', async (res) => {
+      t.ok('called')
+    })
+
+    fastify.get('/', function (request, reply) {
+      t.fail('we should not be here')
+    })
+
+    fastify.inject({
+      url: '/',
+      method: 'GET'
+    }, (err, res) => {
+      t.error(err)
+      t.is(res.statusCode, 200)
+    })
+  })
+
+  test('preHandler respond with a stream', t => {
+    t.plan(7)
+    const fastify = Fastify()
+
+    fastify.addHook('onRequest', async (req, res) => {
+      t.ok('called')
+    })
+
+    // we are calling `reply.send` inside the `preHandler` hook with a stream,
+    // this triggers the `onSend` hook event if `preHanlder` has not yet finished
+    const order = [1, 2]
+
+    fastify.addHook('preHandler', async (req, reply) => {
+      return new Promise((resolve, reject) => {
+        const stream = fs.createReadStream(process.cwd() + '/test/stream.test.js', 'utf8')
+        reply.send(stream)
+        reply.res.once('finish', () => {
+          t.is(order.shift(), 2)
+          resolve()
+        })
+      })
+    })
+
+    fastify.addHook('preHandler', async (req, reply) => {
+      t.fail('this should not be called')
+    })
+
+    fastify.addHook('onSend', async (req, reply, payload) => {
+      t.is(order.shift(), 1)
+      t.is(typeof payload.pipe, 'function')
+    })
+
+    fastify.addHook('onResponse', async (res) => {
+      t.ok('called')
+    })
+
+    fastify.get('/', function (request, reply) {
+      t.fail('we should not be here')
+    })
+
+    fastify.inject({
+      url: '/',
+      method: 'GET'
+    }, (err, res) => {
+      t.error(err)
+      t.is(res.statusCode, 200)
     })
   })
 }

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -919,6 +919,75 @@ test('preHandler hooks should be able to block a request', t => {
   })
 })
 
+test('onRequest hooks should be able to block a request (last hook)', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.addHook('onRequest', (req, res, next) => {
+    res.end('hello')
+    next()
+  })
+
+  fastify.addHook('preHandler', (req, reply, next) => {
+    t.fail('this should not be called')
+  })
+
+  fastify.addHook('onSend', (req, reply, payload, next) => {
+    t.fail('this should not be called')
+  })
+
+  fastify.addHook('onResponse', (res, next) => {
+    t.ok('called')
+    next()
+  })
+
+  fastify.get('/', function (request, reply) {
+    t.fail('we should not be here')
+  })
+
+  fastify.inject({
+    url: '/',
+    method: 'GET'
+  }, (err, res) => {
+    t.error(err)
+    t.is(res.statusCode, 200)
+    t.is(res.payload, 'hello')
+  })
+})
+
+test('preHandler hooks should be able to block a request (last hook)', t => {
+  t.plan(5)
+  const fastify = Fastify()
+
+  fastify.addHook('preHandler', (req, reply, next) => {
+    reply.send('hello')
+    next()
+  })
+
+  fastify.addHook('onSend', (req, reply, payload, next) => {
+    t.equal(payload, 'hello')
+    next()
+  })
+
+  fastify.addHook('onResponse', (res, next) => {
+    t.ok('called')
+    next()
+  })
+
+  fastify.get('/', function (request, reply) {
+    t.fail('we should not be here')
+  })
+
+  fastify.inject({
+    url: '/',
+    method: 'GET'
+  }, (err, res) => {
+    t.error(err)
+    t.is(res.statusCode, 200)
+    t.is(res.payload, 'hello')
+  })
+})
+
 test('onRequest respond with a stream', t => {
   t.plan(3)
   const fastify = Fastify()

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -692,3 +692,49 @@ test('res.end should block middleware execution', t => {
     t.is(res.payload, 'hello')
   })
 })
+
+test('middlewares should be able to respond with a stream', t => {
+  t.plan(4)
+
+  const instance = fastify()
+
+  instance.addHook('onRequest', (req, res, next) => {
+    t.ok('called')
+    next()
+  })
+
+  instance.use(function (req, res, next) {
+    const stream = fs.createReadStream(process.cwd() + '/test/middleware.test.js', 'utf8')
+    stream.pipe(res)
+    res.once('finish', next)
+  })
+
+  instance.use(function (req, res, next) {
+    t.fail('we should not be here')
+  })
+
+  instance.addHook('preHandler', (req, reply, next) => {
+    t.fail('this should not be called')
+  })
+
+  instance.addHook('onSend', (req, reply, payload, next) => {
+    t.fail('this should not be called')
+  })
+
+  instance.addHook('onResponse', (res, next) => {
+    t.ok('called')
+    next()
+  })
+
+  instance.get('/', function (request, reply) {
+    t.fail('we should no be here')
+  })
+
+  instance.inject({
+    url: '/',
+    method: 'GET'
+  }, (err, res) => {
+    t.error(err)
+    t.is(res.statusCode, 200)
+  })
+})


### PR DESCRIPTION
This pr fixes #677.
In addition will release the reusify holder which is running the hooks, in this way the memory usage will not increase during time.

Related: https://github.com/delvedor/fast-iterator/pull/8 and https://github.com/fastify/middie/pull/17.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
