### PR TITLE
Add middleware to routes the same as hooks

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -167,7 +167,6 @@ function build (options) {
 
   // middleware support
   fastify.use = use
-  fastify._middie = Middie(onRunMiddlewares)
   fastify._middlewares = []
 
   // fake http injection (for testing purposes)
@@ -295,7 +294,11 @@ function build (options) {
       return
     }
 
-    state.context._middie.run(state.req, state.res, state)
+    if (state.context._middie !== null) {
+      state.context._middie.run(state.req, state.res, state)
+    } else {
+      onRunMiddlewares(null, state.req, state.res, state)
+    }
   }
 
   function onRunMiddlewares (err, req, res, state) {
@@ -315,7 +318,6 @@ function build (options) {
       return old
     }
 
-    const middlewares = Object.assign([], old._middlewares)
     const instance = Object.create(old)
     instance._Reply = Reply.buildReply(instance._Reply)
     instance._Request = Request.buildRequest(instance._Request)
@@ -323,17 +325,12 @@ function build (options) {
     instance._hooks = Hooks.buildHooks(instance._hooks)
     instance._routePrefix = buildRoutePrefix(instance._routePrefix, opts.prefix)
     instance._logLevel = opts.logLevel || instance._logLevel
-    instance._middlewares = []
-    instance._middie = Middie(onRunMiddlewares)
+    instance._middlewares = old._middlewares.slice()
     instance[pluginUtils.registeredPlugins] = Object.create(instance[pluginUtils.registeredPlugins])
 
     if (opts.prefix) {
       instance._notFoundHandler = null
       instance._404Context = null
-    }
-
-    for (var i = 0; i < middlewares.length; i++) {
-      instance.use.apply(instance, middlewares[i])
     }
 
     return instance
@@ -463,7 +460,7 @@ function build (options) {
         _fastify._contentTypeParser,
         config,
         _fastify._errorHandler,
-        _fastify._middie,
+        buildMiddie(_fastify._middlewares),
         opts.jsonBodyLimit,
         opts.logLevel,
         _fastify
@@ -547,7 +544,6 @@ function build (options) {
       url = prefix + (url === '/' && prefix.length > 0 ? '' : url)
     }
     this._middlewares.push([url, fn])
-    this._middie.use(url, fn)
     return this
   }
 
@@ -648,7 +644,7 @@ function build (options) {
       this._contentTypeParser,
       opts.config || {},
       this._errorHandler,
-      this._middie,
+      buildMiddie(this._middlewares),
       this._jsonBodyLimit,
       this._logLevel,
       null
@@ -689,6 +685,19 @@ function build (options) {
 
     this._errorHandler = func
     return this
+  }
+
+  function buildMiddie (middlewares) {
+    if (!middlewares.length) {
+      return null
+    }
+
+    const middie = Middie(onRunMiddlewares)
+    for (var i = 0; i < middlewares.length; i++) {
+      middie.use.apply(middie, middlewares[i])
+    }
+
+    return middie
   }
 }
 

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -514,7 +514,7 @@ test('middlewares should support encapsulation with prefix', t => {
   })
 })
 
-test('middlewares should support plugins', t => {
+test('middlewares should support non-encapsulated plugins', t => {
   t.plan(5)
 
   const instance = fastify()

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -4,6 +4,7 @@ const t = require('tap')
 const test = t.test
 const sget = require('simple-get').concat
 const fastify = require('..')
+const fp = require('fastify-plugin')
 const cors = require('cors')
 const helmet = require('helmet')
 const serveStatic = require('serve-static')
@@ -510,6 +511,45 @@ test('middlewares should support encapsulation with prefix', t => {
         })
       })
     })
+  })
+})
+
+test('middlewares should support plugins', t => {
+  t.plan(5)
+
+  const instance = fastify()
+
+  instance.register(fp(function (i, opts, done) {
+    i.use(function (req, res, next) {
+      t.ok('middleware called')
+      req.midval = 10
+      next()
+    })
+
+    done()
+  }))
+
+  instance.get('/', function (request, reply) {
+    t.strictEqual(request.raw.midval, 10)
+    reply.send({ hello: 'world' })
+  })
+
+  instance.register(fp(function (i, opts, done) {
+    i.use(function (req, res, next) {
+      t.fail('middleware should not be called')
+      next()
+    })
+
+    done()
+  }))
+
+  instance.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { hello: 'world' })
   })
 })
 


### PR DESCRIPTION
This makes adding middleware to routes consistent with how hooks are added to routes.

Fixes #696

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
