### PR TITLE
Make the http requestListener the "fastify object"

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "snazzy": "^7.0.0",
     "split2": "^2.2.0",
     "standard": "^10.0.3",
+    "supertest": "^3.0.0",
     "tap": "^11.0.0",
     "then-sleep": "^1.0.1",
     "typescript": "^2.6.2",

--- a/test/supertest.test.js
+++ b/test/supertest.test.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('..')
+const supertest = require('supertest')
+
+test('fastify is compatible with supertest', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  fastify.get('/', (request, reply) => {
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.ready((err) => {
+    t.error(err)
+
+    supertest(fastify)
+      .get('/')
+      .expect(200)
+      .expect('Content-Type', 'application/json')
+      .expect('Content-Length', '17')
+      .end((err, res) => {
+        t.error(err)
+        t.deepEqual(res.body, { hello: 'world' })
+      })
+  })
+})


### PR DESCRIPTION
This restores Fastify's compatibility with other Node web frameworks and makes it compatible with `supertest` again (compatibility was lost in #639).

Fixes #704 

<details>
<summary>Benchmarks (no change)</summary>

**master**
```
[1] Stat         Avg     Stdev   Max
[1] Latency (ms) 3.07    10.94   368
[1] Req/Sec      31742.4 6240.06 35615
[1] Bytes/Sec    4.71 MB 949 kB  5.51 MB
[1]
[1] 159k requests in 5s, 23.6 MB read
...
[1] Stat         Avg     Stdev   Max
[1] Latency (ms) 3.12    10.95   344
[1] Req/Sec      31262.4 6223.24 36191
[1] Bytes/Sec    4.65 MB 932 kB  5.51 MB
[1]
[1] 156k requests in 5s, 23.3 MB read
```

**this PR**
```
[1] Stat         Avg     Stdev   Max
[1] Latency (ms) 3.04    10.96   304
[1] Req/Sec      32104   6473.63 36671
[1] Bytes/Sec    4.76 MB 977 kB  5.51 MB
[1]
[1] 161k requests in 5s, 23.9 MB read
...
[1] Stat         Avg     Stdev   Max
[1] Latency (ms) 3       10.64   353
[1] Req/Sec      32468.8 6542.62 37695
[1] Bytes/Sec    4.84 MB 964 kB  5.77 MB
[1]
[1] 162k requests in 5s, 24.2 MB read
```
</details>

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
