### PR TITLE
Make the root fastify instance a plain object

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -54,6 +54,7 @@ function build (options) {
     log = loggerUtils.createLogger(options.logger)
   }
 
+  const fastify = {}
   const router = FindMyWay({
     defaultRoute: defaultRoute,
     ignoreTrailingSlash: options.ignoreTrailingSlash
@@ -184,7 +185,7 @@ function build (options) {
 
   return fastify
 
-  function fastify (req, res, params, context) {
+  function routeHandler (req, res, params, context) {
     res._context = context
     req.id = genReqId(req)
     req.log = res.log = log.child({ reqId: req.id, level: context.logLevel })
@@ -488,7 +489,7 @@ function build (options) {
       context.preHandler = preHandler.length ? fastIterator(preHandler, _fastify) : null
 
       try {
-        router.on(opts.method, url, fastify, context)
+        router.on(opts.method, url, routeHandler, context)
       } catch (err) {
         done(err)
         return
@@ -673,8 +674,8 @@ function build (options) {
 
     const prefix = this._routePrefix
 
-    fourOhFour.all(prefix + (prefix.endsWith('/') ? '*' : '/*'), fastify, context)
-    fourOhFour.all(prefix || '/', fastify, context)
+    fourOhFour.all(prefix + (prefix.endsWith('/') ? '*' : '/*'), routeHandler, context)
+    fourOhFour.all(prefix || '/', routeHandler, context)
   }
 
   function setSchemaCompiler (schemaCompiler) {

--- a/test/fastify-instance.test.js
+++ b/test/fastify-instance.test.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('..')
+
+test('root fastify instance is an object', t => {
+  t.plan(1)
+  t.type(Fastify(), 'object')
+})


### PR DESCRIPTION
Supersedes #705 

As @mcollina said in #705, Fastify shouldn't export a function. This PR makes Fastify export a plain object as the root Fastify instance instead of a function.

Adding support for `supertest` can be done separately if it's not too much of a burden.

This makes no difference to benchmarks.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
