### PR TITLE
Allow object stream only if serializer is given

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -157,6 +157,16 @@ fastify.get('/streams', function (request, reply) {
 })
 ```
 
+*send* method handles stream in [`objectMode`](https://nodejs.org/api/stream.html#stream_object_mode) too. This kind of stream needs to have a *serializer* set.
+```js
+fastify.get('/objStreams', function (request, reply) {
+  const stream = getMyObjectModeStream()
+  reply
+    .serializer(objectModeStreamToStringStreamSerializer)
+    .send(stream)
+})
+```
+
 <a name="errors"></a>
 #### Errors
 If you pass to *send* an object that is an instance of *Error*, Fastify will automatically create an error structured as the following:

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -64,7 +64,7 @@ Reply.prototype.send = function (payload) {
         onSendHook(this, payload)
       } else {
         if (!this._serializer) {
-          throw new TypeError('AA')
+          throw new TypeError('Unable to serialize an objectMode stream')
         }
         onSendHook(this, this._serializer(payload))
       }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -50,11 +50,24 @@ Reply.prototype.send = function (payload) {
   const contentTypeNotSet = contentType === undefined
 
   if (payload !== null) {
-    if (Buffer.isBuffer(payload) || typeof payload.pipe === 'function') {
+    const isStream = typeof payload.pipe === 'function'
+    const isStringStream = isStream && (
+        (payload._readableState && !payload._readableState.objectMode) ||
+        !payload._readableState)
+
+    if (Buffer.isBuffer(payload) || isStream) {
       if (contentTypeNotSet) {
         this.res.setHeader('Content-Type', 'application/octet-stream')
       }
-      onSendHook(this, payload)
+
+      if (!isStream || isStringStream) {
+        onSendHook(this, payload)
+      } else {
+        if (!this._serializer) {
+          throw new TypeError('AA')
+        }
+        onSendHook(this, this._serializer(payload))
+      }
       return
     }
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -51,15 +51,13 @@ Reply.prototype.send = function (payload) {
 
   if (payload !== null) {
     const isStream = typeof payload.pipe === 'function'
-    const isStringStream = isStream && (
-        (payload._readableState && !payload._readableState.objectMode) ||
-        !payload._readableState)
 
     if (Buffer.isBuffer(payload) || isStream) {
       if (contentTypeNotSet) {
         this.res.setHeader('Content-Type', 'application/octet-stream')
       }
 
+      const isStringStream = isStream && (!payload._readableState || !payload._readableState.objectMode)
       if (!isStream || isStringStream) {
         onSendHook(this, payload)
       } else {


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

This PR allow the developer to send an ObjectMode stream only if the serializer is given. See the test for an example

I'll update the Documentation accordingly

## benchmark

`node example/example.js`

**object-stream** branch
```
$ autocannon localhost:3000/stream
Running 10s test @ http://localhost:3000/stream
10 connections

Stat         Avg     Stdev   Max     
Latency (ms) 3.55    2.44    46      
Req/Sec      2524.4  114.72  2645    
Bytes/Sec    1.06 MB 48.3 kB 1.18 MB 

25k requests in 10s, 10.7 MB read
```

**master** branch
```
$ autocannon localhost:3000/stream
Running 10s test @ http://localhost:3000/stream
10 connections

Stat         Avg     Stdev  Max     
Latency (ms) 3.59    1.85   64      
Req/Sec      2472    385.36 2811    
Bytes/Sec    1.05 MB 163 kB 1.25 MB 

25k requests in 10s, 10.4 MB read
```