### PR TITLE
Remove `reply.serializer`

### DIFF
--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -132,8 +132,6 @@ const schema = {
 fastify.post('/the/url', { schema }, handler)
 ```
 
-*If you need a custom serializer in a very specific part of your code, you can always set one with `reply.serializer(...)`.*
-
 <a name="resources"></a>
 ### Resources
 - [JSON Schema](http://json-schema.org/)

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -54,7 +54,6 @@ declare namespace fastify {
     type: (contentType: string) => FastifyReply<HttpResponse>
     redirect: (statusCode: number, url: string) => FastifyReply<HttpResponse>
     serialize: (payload: any) => string
-    serializer: (fn: Function) => FastifyReply<HttpResponse>
     send: (payload?: string|Array<any>|Object|Error|Promise<any>|NodeJS.ReadableStream) => FastifyReply<HttpResponse>
     sent: boolean
     res: HttpResponse

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -22,7 +22,6 @@ function Reply (res, context, request) {
   this.res = res
   this.context = context
   this.sent = false
-  this._serializer = null
   this._customError = false
   this._isError = false
   this.request = request
@@ -65,9 +64,7 @@ Reply.prototype.send = function (payload) {
     }
   }
 
-  if (this._serializer) {
-    payload = this._serializer(payload)
-  } else if (contentTypeNotSet || contentType === 'application/json') {
+  if (contentTypeNotSet || contentType === 'application/json') {
     this.res.setHeader('Content-Type', 'application/json')
     payload = serialize(this.context, payload, this.res.statusCode)
     flatstr(payload)
@@ -96,11 +93,6 @@ Reply.prototype.code = function (code) {
 
 Reply.prototype.serialize = function (payload) {
   return serialize(this.context, payload, this.res.statusCode)
-}
-
-Reply.prototype.serializer = function (fn) {
-  this._serializer = fn
-  return this
 }
 
 Reply.prototype.type = function (type) {
@@ -249,7 +241,6 @@ function buildReply (R) {
     this._isError = false
     this._customError = false
     this.sent = false
-    this._serializer = null
     this.request = request
   }
   _Reply.prototype = new R()

--- a/test/context-config.test.js
+++ b/test/context-config.test.js
@@ -14,7 +14,7 @@ const schema = {
 }
 
 function handler (req, reply) {
-  reply.serializer(JSON.stringify).send(reply.context.config)
+  reply.send(reply.context.config)
 }
 
 test('config', t => {

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -172,23 +172,6 @@ test('wrong object for schema - get', t => {
   }
 })
 
-test('custom serializer - get', t => {
-  t.plan(1)
-
-  function customSerializer (data) {
-    return JSON.stringify(data)
-  }
-
-  try {
-    fastify.get('/custom-serializer', numberSchema, function (req, reply) {
-      reply.code(200).serializer(customSerializer).send({ hello: 'world' })
-    })
-    t.pass()
-  } catch (e) {
-    t.fail()
-  }
-})
-
 test('empty response', t => {
   t.plan(1)
   try {
@@ -364,19 +347,6 @@ fastify.listen(0, err => {
       t.strictEqual(response.statusCode, 200)
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.deepEqual(JSON.parse(body), { hello: null })
-    })
-  })
-
-  test('shorthand - custom serializer', t => {
-    t.plan(4)
-    sget({
-      method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port + '/custom-serializer'
-    }, (err, response, body) => {
-      t.error(err)
-      t.strictEqual(response.statusCode, 200)
-      t.strictEqual(response.headers['content-length'], '' + body.length)
-      t.deepEqual(JSON.parse(body), { hello: 'world' })
     })
   })
 

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -649,7 +649,7 @@ test('onSend hook should support encapsulation / 2', t => {
 })
 
 test('onSend hook is called after payload is serialized and headers are set', t => {
-  t.plan(30)
+  t.plan(24)
   const fastify = Fastify()
 
   fastify.register((instance, opts, next) => {
@@ -720,25 +720,6 @@ test('onSend hook is called after payload is serialized and headers are set', t 
     next()
   })
 
-  fastify.register((instance, opts, next) => {
-    const serializedPayload = 'serialized'
-
-    instance.addHook('onSend', function (request, reply, payload, next) {
-      t.strictEqual(payload, serializedPayload)
-      t.strictEqual(reply.res.getHeader('Content-Type'), 'text/custom')
-      next()
-    })
-
-    instance.get('/custom-serializer', (request, reply) => {
-      reply
-        .serializer(() => serializedPayload)
-        .type('text/custom')
-        .send('needs to be serialized')
-    })
-
-    next()
-  })
-
   fastify.inject({
     method: 'GET',
     url: '/json'
@@ -778,19 +759,9 @@ test('onSend hook is called after payload is serialized and headers are set', t 
     t.deepEqual(res.payload, 'stream payload')
     t.strictEqual(res.headers['transfer-encoding'], 'chunked')
   })
-
-  fastify.inject({
-    method: 'GET',
-    url: '/custom-serializer'
-  }, (err, res) => {
-    t.error(err)
-    t.strictEqual(res.statusCode, 200)
-    t.deepEqual(res.payload, 'serialized')
-    t.strictEqual(res.headers['content-type'], 'text/custom')
-  })
 })
 
-test('modify payload', t => {
+test('onSend hook can modify payload', t => {
   t.plan(10)
   const fastify = Fastify()
   const payload = { hello: 'world' }
@@ -831,7 +802,7 @@ test('modify payload', t => {
   })
 })
 
-test('clear payload', t => {
+test('onSend hook can clear payload', t => {
   t.plan(6)
   const fastify = Fastify()
 
@@ -854,6 +825,29 @@ test('clear payload', t => {
     t.strictEqual(res.payload, '')
     t.strictEqual(res.headers['content-length'], undefined)
     t.strictEqual(res.headers['content-type'], 'application/json')
+  })
+})
+
+test('onSend hook can serialize payload', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.addHook('onSend', function (request, reply, payload, next) {
+    next(null, JSON.stringify(payload))
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.type('text/custom').send({ hello: 'world' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual(res.headers['content-type'], 'text/custom')
+    t.deepEqual(JSON.parse(res.payload), { hello: 'world' })
   })
 })
 

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -8,7 +8,7 @@ const http = require('http')
 const Reply = require('../../lib/reply')
 
 test('Once called, Reply should return an object with methods', t => {
-  t.plan(10)
+  t.plan(9)
   const response = { res: 'res' }
   function context () {}
   function request () {}
@@ -19,7 +19,6 @@ test('Once called, Reply should return an object with methods', t => {
   t.is(typeof reply.send, 'function')
   t.is(typeof reply.code, 'function')
   t.is(typeof reply.header, 'function')
-  t.is(typeof reply.serialize, 'function')
   t.strictEqual(reply.res, response)
   t.strictEqual(reply.context, context)
   t.strictEqual(reply.request, request)
@@ -35,14 +34,6 @@ test('reply.send throw with circular JSON', t => {
     obj.obj = obj
     reply.send(JSON.stringify(obj))
   })
-})
-
-test('reply.serializer should set a custom serializer', t => {
-  t.plan(2)
-  const reply = new Reply(null, null, null)
-  t.equal(reply._serializer, null)
-  reply.serializer('serializer')
-  t.equal(reply._serializer, 'serializer')
 })
 
 test('within an instance', t => {
@@ -73,15 +64,6 @@ test('within an instance', t => {
     reply.redirect(301, '/')
   })
 
-  fastify.get('/custom-serializer', function (req, reply) {
-    reply.code(200)
-    reply.type('text/plain')
-    reply.serializer(function (body) {
-      return require('querystring').stringify(body)
-    })
-    reply.send({hello: 'world!'})
-  })
-
   fastify.register(function (instance, options, next) {
     fastify.addHook('onSend', function (req, reply, payload, next) {
       reply.header('x-onsend', 'yes')
@@ -96,18 +78,6 @@ test('within an instance', t => {
   fastify.listen(0, err => {
     t.error(err)
     fastify.server.unref()
-
-    test('custom serializer should be used', t => {
-      t.plan(3)
-      sget({
-        method: 'GET',
-        url: 'http://localhost:' + fastify.server.address().port + '/custom-serializer'
-      }, (err, response, body) => {
-        t.error(err)
-        t.strictEqual(response.headers['content-type'], 'text/plain')
-        t.deepEqual(body.toString(), 'hello=world!')
-      })
-    })
 
     test('status code and content-type should be correct', t => {
       t.plan(4)
@@ -295,33 +265,6 @@ test('plain string with content type should be sent unmodified', t => {
       t.error(err)
       t.strictEqual(response.headers['content-type'], 'text/css')
       t.deepEqual(body.toString(), 'hello world!')
-    })
-  })
-})
-
-test('plain string with content type and custom serializer should be serialized', t => {
-  t.plan(4)
-
-  const fastify = require('../..')()
-
-  fastify.get('/', function (req, reply) {
-    reply
-      .serializer(() => 'serialized')
-      .type('text/css')
-      .send('hello world!')
-  })
-
-  fastify.listen(0, err => {
-    t.error(err)
-    fastify.server.unref()
-
-    sget({
-      method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port
-    }, (err, response, body) => {
-      t.error(err)
-      t.strictEqual(response.headers['content-type'], 'text/css')
-      t.deepEqual(body.toString(), 'serialized')
     })
   })
 })

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -348,7 +348,7 @@ test('should set the status code and the headers from the error object (from cus
 })
 
 // Issue 595 https://github.com/fastify/fastify/issues/595
-test('\'*\' should throw an error due to serializer can not handle the payload type', t => {
+test('should throw an error when sending a payload with an invalid type that does not get serialized', t => {
   t.plan(2)
   const fastify = Fastify()
 
@@ -356,30 +356,6 @@ test('\'*\' should throw an error due to serializer can not handle the payload t
     reply.type('text/html')
     try {
       reply.send({})
-    } catch (err) {
-      t.type(err, TypeError)
-      t.strictEqual(err.message, "Attempted to send payload of invalid type 'object'. Expected a string or Buffer.")
-    }
-  })
-
-  fastify.inject({
-    url: '/',
-    method: 'GET'
-  }, (e, res) => {
-    t.fail('should not be called')
-  })
-})
-
-test('should throw an error if the custom serializer does not serialize the payload to a valid type', t => {
-  t.plan(2)
-  const fastify = Fastify()
-
-  fastify.get('/', (req, reply) => {
-    try {
-      reply
-      .type('text/html')
-      .serializer(payload => payload)
-      .send({})
     } catch (err) {
       t.type(err, TypeError)
       t.strictEqual(err.message, "Attempted to send payload of invalid type 'object'. Expected a string or Buffer.")


### PR DESCRIPTION
As titled. The discussion for this started in #717.
This PR also improves the documentation that explains which types can be sent.

For reference, after this change, this code:

```js
reply.serializer(mySerializer).send(payload)
```

should be changed to this:

```js
reply.send(mySerializer(payload))
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
