### PR TITLE
Support send

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -198,7 +198,13 @@ function forward (payload, res, reply) {
         reply.request.log.error(err, 'response terminated with an error with headers already sent')
       }
       if (sourceOpen) {
-        payload.destroy()
+        if (payload.destroy) {
+          payload.destroy()
+        } else if (typeof payload.close === 'function') {
+          payload.close(noop)
+        } else if (typeof payload.abort === 'function') {
+          payload.abort()
+        }
       }
     }
   })
@@ -274,6 +280,8 @@ function buildReply (R) {
   _Reply.prototype = new R()
   return _Reply
 }
+
+function noop () {}
 
 module.exports = Reply
 module.exports.buildReply = buildReply

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -2,7 +2,7 @@
 
 'use strict'
 
-const pump = require('pump')
+const eos = require('end-of-stream')
 const validation = require('./validation')
 const serialize = validation.serialize
 const statusCodes = require('http').STATUS_CODES
@@ -160,7 +160,7 @@ function onSendEnd (reply, payload) {
   }
 
   if (typeof payload.pipe === 'function') {
-    pump(payload, reply.res, pumpCallback(reply))
+    forward(payload, reply.res, reply)
     return
   }
 
@@ -176,15 +176,34 @@ function onSendEnd (reply, payload) {
   reply.res.end(payload)
 }
 
-function pumpCallback (reply) {
-  return function _pumpCallback (err) {
-    if (!err) return
-    if (reply.res.headersSent) {
-      reply.request.log.error(err, 'response terminated with an error with headers already sent')
-    } else {
-      handleError(reply, err)
+function forward (payload, res, reply) {
+  var sourceOpen = true
+
+  eos(payload, { readable: true, writable: false }, function (err) {
+    sourceOpen = false
+    if (err) {
+      if (res.headersSent) {
+        reply.request.log.error(err, 'response terminated with an error with headers already sent')
+        res.destroy()
+      } else {
+        handleError(reply, err)
+      }
     }
-  }
+    // there is nothing to do if there is not an error
+  })
+
+  eos(res, function (err) {
+    if (err) {
+      if (res.headersSent) {
+        reply.request.log.error(err, 'response terminated with an error with headers already sent')
+      }
+      if (sourceOpen) {
+        payload.destroy()
+      }
+    }
+  })
+
+  payload.pipe(res)
 }
 
 function handleError (reply, error, cb) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -160,7 +160,7 @@ function onSendEnd (reply, payload) {
   }
 
   if (typeof payload.pipe === 'function') {
-    forward(payload, reply.res, reply)
+    sendStream(payload, reply.res, reply)
     return
   }
 
@@ -176,14 +176,14 @@ function onSendEnd (reply, payload) {
   reply.res.end(payload)
 }
 
-function forward (payload, res, reply) {
+function sendStream (payload, res, reply) {
   var sourceOpen = true
 
   eos(payload, { readable: true, writable: false }, function (err) {
     sourceOpen = false
     if (err) {
       if (res.headersSent) {
-        reply.request.log.error(err, 'response terminated with an error with headers already sent')
+        res.log.error(err, 'response terminated with an error with headers already sent')
         res.destroy()
       } else {
         handleError(reply, err)
@@ -195,7 +195,7 @@ function forward (payload, res, reply) {
   eos(res, function (err) {
     if (err) {
       if (res.headersSent) {
-        reply.request.log.error(err, 'response terminated with an error with headers already sent')
+        res.log.error(err, 'response terminated with an error with headers already sent')
       }
       if (sourceOpen) {
         if (payload.destroy) {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "tap": "^11.0.1",
     "then-sleep": "^1.0.1",
     "typescript": "^2.6.2",
+    "pump": "^2.0.1",
     "x-xss-protection": "^1.0.0"
   },
   "dependencies": {
@@ -99,13 +100,13 @@
     "abstract-logging": "^1.0.0",
     "ajv": "^6.1.0",
     "avvio": "^5.0.1",
+    "end-of-stream": "^1.4.1",
     "fast-json-stringify": "^0.17.0",
     "find-my-way": "^1.10.0",
     "flatstr": "^1.0.5",
     "light-my-request": "^2.0.1",
     "middie": "^3.1.0",
-    "pino": "^4.10.3",
-    "pump": "^2.0.1"
+    "pino": "^4.10.3"
   },
   "greenkeeper": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -83,7 +83,9 @@
     "ienoopen": "^1.0.0",
     "joi": "~11.3.4",
     "pre-commit": "^1.2.2",
+    "pump": "^2.0.1",
     "semver": "^5.5.0",
+    "send": "^0.16.1",
     "serve-static": "^1.13.1",
     "simple-get": "^2.7.0",
     "snazzy": "^7.0.0",
@@ -92,7 +94,6 @@
     "tap": "^11.0.1",
     "then-sleep": "^1.0.1",
     "typescript": "^2.6.2",
-    "pump": "^2.0.1",
     "x-xss-protection": "^1.0.0"
   },
   "dependencies": {

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -8,14 +8,16 @@ const resolve = require('path').resolve
 const zlib = require('zlib')
 const pump = require('pump')
 const Fastify = require('..')
+const errors = require('http-errors')
 const JSONStream = require('JSONStream')
+const Readable = require('stream').Readable
 
 test('should respond with a stream', t => {
-  t.plan(7)
+  t.plan(8)
   const fastify = Fastify()
 
   fastify.get('/', function (req, reply) {
-    const stream = fs.createReadStream(process.cwd() + '/test/stream.test.js', 'utf8')
+    const stream = fs.createReadStream(__filename, 'utf8')
     reply.code(200).send(stream)
   })
 
@@ -28,23 +30,20 @@ test('should respond with a stream', t => {
     t.error(err)
     fastify.server.unref()
 
-    sget(`http://localhost:${fastify.server.address().port}`, function (err, response) {
+    sget(`http://localhost:${fastify.server.address().port}`, function (err, response, data) {
       t.error(err)
       t.strictEqual(response.headers['content-type'], 'application/octet-stream')
       t.strictEqual(response.statusCode, 200)
 
-      response.on('error', err => {
+      fs.readFile(__filename, (err, expected) => {
         t.error(err)
-      })
-      response.on('end', () => {
-        t.pass('Correctly close the stream')
+        t.equal(expected.toString(), data.toString())
       })
     })
 
     sget(`http://localhost:${fastify.server.address().port}/error`, function (err, response) {
-      t.type(err, Error)
-      t.equal(err.code, 'ECONNRESET')
-      t.pass('Correctly close the stream')
+      t.error(err)
+      t.strictEqual(response.statusCode, 500)
     })
   })
 })
@@ -92,8 +91,8 @@ test('should trigger the onSend hook only once if pumping the stream fails', t =
     fastify.server.unref()
 
     sget(`http://localhost:${fastify.server.address().port}`, function (err, response) {
-      t.type(err, Error)
-      t.equal(err.code, 'ECONNRESET')
+      t.error(err)
+      t.strictEqual(response.statusCode, 500)
     })
   })
 })
@@ -192,6 +191,39 @@ test('should respond with a stream1', t => {
       t.strictEqual(response.headers['content-type'], 'application/json')
       t.strictEqual(response.statusCode, 200)
       t.deepEqual(JSON.parse(body), [{ hello: 'world' }, { a: 42 }])
+    })
+  })
+})
+
+test('return a 404 if the stream emits a 404 error', t => {
+  t.plan(5)
+
+  const fastify = Fastify()
+
+  fastify.get('/', function (request, reply) {
+    t.pass('Received request')
+
+    var reallyLongStream = new Readable({
+      read: function () {
+        setImmediate(() => {
+          this.emit('error', new errors.NotFound())
+        })
+      }
+    })
+
+    reply.send(reallyLongStream)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
+
+    var port = fastify.server.address().port
+
+    sget(`http://localhost:${port}`, function (err, response) {
+      t.error(err)
+      t.strictEqual(response.headers['content-type'], 'application/json')
+      t.strictEqual(response.statusCode, 404)
     })
   })
 })


### PR DESCRIPTION
I've improved the stream support to not close the destination stream directly if the payload errors, but rather pass it through our error pipeline.

Thanks to this, we can simplify https://github.com/fastify/fastify-static/blob/master/index.js#L34-L48, as the sendStream could be passed in directly

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
