### PR TITLE
Route 404 errors to the 404 handler

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -10,7 +10,6 @@ Reply is a core Fastify object that exposes the following functions:
 - `.redirect([code,] url)` - Redirect to the specified url, the status code is optional (default to `302`).
 - `.serialize(payload)` - Serializes the specified payload using the default json serializer and returns the serialized payload.
 - `.serializer(function)` - Sets a custom serializer for the payload.
-- `.notFound()` - Invokes the 404 handler.
 - `.send(payload)` - Sends the payload to the user, could be a plain text, a buffer, JSON, stream, or an Error object.
 - `.sent` - A boolean value that you can use if you need to know it `send` has already been called.
 
@@ -74,22 +73,6 @@ reply
 Note that if a buffer is passed to `reply.send` it is expected to already be serialized and skip the serialization step.
 
 *Take a look [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#serialization) to understand how serialization is done.*
-
-<a name="notfound"></a>
-### NotFound
-Invokes the 404 handler. This is useful inside handlers for routes with a wildcard `*` where you may want to forward the request to the 404 handler if some condition is not met.
-
-A custom 404 handler can be set with [`fastify.setNotFoundHandler()`](https://github.com/fastify/fastify/blob/master/docs/Server-Methods.md#setnotfoundhandler).
-
-```js
-fastify.get('/*', options, function (request, reply) {
-  if (!someCondition) {
-    reply.notFound()
-    return
-  }
-  // Handle the request
-})
-```
 
 <a name="send"></a>
 ### Send
@@ -179,6 +162,19 @@ fastify.get('/', function (request, reply) {
 ```
 
 If you want to completely customize the error response, checkout [`setErrorHandler`](https://github.com/fastify/fastify/blob/error-docs/docs/Server-Methods.md#seterrorhandler) API.
+
+Errors with a `status` or `statusCode` property equal to `404` will be routed to the not found handler, checkout
+the [`server.setNotFoundHandler`](https://github.com/fastify/fastify/blob/error-docs/docs/Server-Methods.md#setnotfoundhandler) API to know how to modify that:
+
+```js
+fastify.setNotFoundHandler(function (request, reply) {
+  reply.type('text/plain').send('a custom not found')
+})
+
+fastify.get('/', function (request, reply) {
+  reply.send(new httpErrors.NotFound())
+})
+```
 
 <a name="payload-type"></a>
 #### Type of the final payload

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -163,8 +163,9 @@ fastify.get('/', function (request, reply) {
 
 If you want to completely customize the error response, checkout [`setErrorHandler`](https://github.com/fastify/fastify/blob/error-docs/docs/Server-Methods.md#seterrorhandler) API.
 
-Errors with a `status` or `statusCode` property equal to `404` will be routed to the not found handler, checkout
-the [`server.setNotFoundHandler`](https://github.com/fastify/fastify/blob/error-docs/docs/Server-Methods.md#setnotfoundhandler) API to know how to modify that:
+Errors with a `status` or `statusCode` property equal to `404` will be routed to the not found handler.
+See [`server.setNotFoundHandler`](https://github.com/fastify/fastify/blob/error-docs/docs/Server-Methods.md#setnotfoundhandler)
+API to learn more about handling such cases:
 
 ```js
 fastify.setNotFoundHandler(function (request, reply) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -117,17 +117,6 @@ Reply.prototype.redirect = function (code, url) {
   this.header('Location', url).code(code).send()
 }
 
-Reply.prototype.notFound = function () {
-  if (this.context._fastify === null) {
-    this.res.log.warn('"reply.notFound()" called inside a 404 handler. Sending basic 404 response.')
-    this.code(404).send('404 Not Found')
-    return
-  }
-
-  this.context = this.context._fastify._404Context
-  this.context.handler(this.request, this)
-}
-
 function onSendHook (reply, payload) {
   if (reply.context.onSend !== null) {
     reply.context.onSend(
@@ -217,21 +206,17 @@ function handleError (reply, error, cb) {
   if (error == null) {
     statusCode = statusCode || 500
   } else if (error.status >= 400) {
-    statusCode = error.status
     if (error.status === 404) {
-      reply.sent = false
-      reply._isError = false
-      reply.notFound()
+      notFound(reply)
       return
     }
+    statusCode = error.status
   } else if (error.statusCode >= 400) {
-    statusCode = error.statusCode
     if (error.statusCode === 404) {
-      reply.sent = false
-      reply._isError = false
-      reply.notFound()
+      notFound(reply)
       return
     }
+    statusCode = error.statusCode
   } else {
     statusCode = statusCode || 500
   }
@@ -292,6 +277,20 @@ function buildReply (R) {
   }
   _Reply.prototype = new R()
   return _Reply
+}
+
+function notFound (reply) {
+  reply.sent = false
+  reply._isError = false
+
+  if (reply.context._fastify === null) {
+    reply.res.log.warn('Trying to send a NotFound error inside a 404 handler. Sending basic 404 response.')
+    reply.code(404).send('404 Not Found')
+    return
+  }
+
+  reply.context = reply.context._fastify._404Context
+  reply.context.handler(reply.request, reply)
 }
 
 function noop () {}

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -218,11 +218,24 @@ function handleError (reply, error, cb) {
     statusCode = statusCode || 500
   } else if (error.status >= 400) {
     statusCode = error.status
+    if (error.status === 404) {
+      reply.sent = false
+      reply._isError = false
+      reply.notFound()
+      return
+    }
   } else if (error.statusCode >= 400) {
     statusCode = error.statusCode
+    if (error.statusCode === 404) {
+      reply.sent = false
+      reply._isError = false
+      reply.notFound()
+      return
+    }
   } else {
     statusCode = statusCode || 500
   }
+
   if (statusCode < 400) statusCode = 500
   reply.res.statusCode = statusCode
 

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -834,7 +834,7 @@ test('recognizes errors from the http-errors module', t => {
   const fastify = Fastify()
 
   fastify.get('/', function (req, reply) {
-    reply.send(httpErrors.Forbidden())
+    reply.send(httpErrors.NotFound())
   })
 
   t.tearDown(fastify.close.bind(fastify))
@@ -847,15 +847,15 @@ test('recognizes errors from the http-errors module', t => {
       url: '/'
     }, (err, res) => {
       t.error(err)
-      t.strictEqual(res.statusCode, 403)
+      t.strictEqual(res.statusCode, 404)
 
       sget('http://localhost:' + fastify.server.address().port, (err, response, body) => {
         t.error(err)
         const obj = JSON.parse(body.toString())
         t.strictDeepEqual(obj, {
-          error: 'Forbidden',
-          message: 'Forbidden',
-          statusCode: 403
+          error: 'Not Found',
+          message: 'Not found',
+          statusCode: 404
         })
       })
     })

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -4,7 +4,7 @@ const t = require('tap')
 const test = t.test
 const sget = require('simple-get').concat
 const http = require('http')
-
+const NotFound = require('http-errors').NotFound
 const Reply = require('../../lib/reply')
 
 test('Once called, Reply should return an object with methods', t => {
@@ -414,18 +414,18 @@ test('undefined payload should be sent as-is', t => {
   })
 })
 
-test('reply.notFound() should invoke the 404 handler', t => {
+test('reply.send(new NotFound()) should invoke the 404 handler', t => {
   t.plan(9)
 
   const fastify = require('../..')()
 
   fastify.get('/not-found', function (req, reply) {
-    reply.notFound()
+    reply.send(new NotFound())
   })
 
   fastify.register(function (instance, options, next) {
     instance.get('/not-found', function (req, reply) {
-      reply.notFound()
+      reply.send(new NotFound())
     })
 
     instance.setNotFoundHandler(function (req, reply) {
@@ -466,21 +466,21 @@ test('reply.notFound() should invoke the 404 handler', t => {
   })
 })
 
-test('reply.notFound() should log a warning and send a basic response if called inside a 404 handler', t => {
+test('reply.send(new NotFound()) should log a warning and send a basic response if called inside a 404 handler', t => {
   t.plan(6)
 
   const fastify = require('../..')()
 
   fastify.get('/not-found', function (req, reply) {
-    reply.notFound()
+    reply.send(new NotFound())
   })
 
   fastify.setNotFoundHandler(function (req, reply) {
     reply.res.log.warn = function mockWarn (message) {
-      t.type(message, 'string')
+      t.equal(message, 'Trying to send a NotFound error inside a 404 handler. Sending basic 404 response.')
     }
 
-    reply.notFound()
+    reply.send(new NotFound())
   })
 
   fastify.listen(0, err => {


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

As titled. Does this needs a doc change? I think this fixes a bug in our current error handling logic.

(I need this for #724 to fully work)