### PR TITLE
Misc TypeScript fixes

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -6,7 +6,6 @@ import * as http from 'http';
 import * as http2 from 'http2';
 import * as https from 'https';
 import * as pino from 'pino';
-import * as express from 'express';
 
 declare function fastify<
   HttpServer extends http.Server = http.Server, 
@@ -280,13 +279,11 @@ declare namespace fastify {
      * Apply the given middleware to all incoming requests
      */
     use(middleware: Middleware<HttpServer, HttpRequest, HttpResponse>): void
-    use(middleware: express.RequestHandler): void
 
     /**
      * Apply the given middleware to routes matching the given path
      */
     use(path: string, middleware: Middleware<HttpServer, HttpRequest, HttpResponse>): void
-    use(path: string, middleware: express.RequestHandler): void
 
     /**
      * Registers a plugin

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -103,7 +103,7 @@ declare namespace fastify {
   /**
    * Optional configuration parameters for the route being created
    */
-  interface RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse> {
+  interface RouteShorthandOptions<HttpServer = http.Server, HttpRequest = http.IncomingMessage, HttpResponse = http.ServerResponse> {
     schema?: JSONSchema
     beforeHandler?: FastifyMiddleware<HttpServer, HttpRequest, HttpResponse> | Array<FastifyMiddleware<HttpServer, HttpRequest, HttpResponse>>
     schemaCompiler?: SchemaCompiler
@@ -167,7 +167,7 @@ declare namespace fastify {
   /**
    * Represents the fastify instance created by the factory function the module exports.
    */
-  interface FastifyInstance<HttpServer, HttpRequest, HttpResponse> {
+  interface FastifyInstance<HttpServer = http.Server, HttpRequest = http.IncomingMessage, HttpResponse = http.ServerResponse> {
     server: HttpServer
     log: pino.Logger
 

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -8,9 +8,9 @@ import * as https from 'https';
 import * as pino from 'pino';
 
 declare function fastify<
-  HttpServer extends http.Server = http.Server, 
-  HttpRequest extends http.IncomingMessage = http.IncomingMessage, 
-  HttpResponse extends http.ServerResponse = http.ServerResponse
+  HttpServer extends (http.Server | http2.Http2Server) = http.Server, 
+  HttpRequest extends (http.IncomingMessage | http2.Http2ServerRequest) = http.IncomingMessage, 
+  HttpResponse extends (http.ServerResponse | http2.Http2ServerResponse) = http.ServerResponse
 >(opts?: fastify.ServerOptions): fastify.FastifyInstance<HttpServer, HttpRequest, HttpResponse>;
 declare function fastify(opts?: fastify.ServerOptionsAsHttp): fastify.FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>;
 declare function fastify(opts?: fastify.ServerOptionsAsSecureHttp): fastify.FastifyInstance<https.Server, http.IncomingMessage, http.ServerResponse>;

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -16,9 +16,9 @@ declare function fastify(opts?: fastify.ServerOptionsAsSecureHttp2): fastify.Fas
 
 declare namespace fastify {
 
-  type Plugin<HttpServer, HttpRequest, HttpResponse, T> = (instance: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, opts: T, callback?: (err?: Error) => void) => void
+  type Plugin<HttpServer, HttpRequest, HttpResponse, T> = (instance: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, opts: T, callback: (err?: Error) => void) => void
 
-  type Middleware<HttpServer, HttpRequest, HttpResponse> = (this: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, req: HttpRequest, res: HttpResponse, callback?: (err?: Error) => void) => void
+  type Middleware<HttpServer, HttpRequest, HttpResponse> = (this: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, req: HttpRequest, res: HttpResponse, callback: (err?: Error) => void) => void
 
   type HTTPMethod = 'DELETE' | 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'OPTIONS';
 

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -6,6 +6,7 @@ import * as http from 'http';
 import * as http2 from 'http2';
 import * as https from 'https';
 import * as pino from 'pino';
+import * as express from 'express';
 
 declare function fastify<HttpServer, HttpRequest, HttpResponse>(opts?: fastify.ServerOptions): fastify.FastifyInstance<HttpServer, HttpRequest, HttpResponse>;
 declare function fastify(opts?: fastify.ServerOptionsAsHttp): fastify.FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>;
@@ -275,11 +276,13 @@ declare namespace fastify {
      * Apply the given middleware to all incoming requests
      */
     use(middleware: Middleware<HttpServer, HttpRequest, HttpResponse>): void
+    use(middleware: express.RequestHandler): void
 
     /**
      * Apply the given middleware to routes matching the given path
      */
     use(path: string, middleware: Middleware<HttpServer, HttpRequest, HttpResponse>): void
+    use(path: string, middleware: express.RequestHandler): void
 
     /**
      * Registers a plugin

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -8,7 +8,11 @@ import * as https from 'https';
 import * as pino from 'pino';
 import * as express from 'express';
 
-declare function fastify<HttpServer, HttpRequest, HttpResponse>(opts?: fastify.ServerOptions): fastify.FastifyInstance<HttpServer, HttpRequest, HttpResponse>;
+declare function fastify<
+  HttpServer extends http.Server = http.Server, 
+  HttpRequest extends http.IncomingMessage = http.IncomingMessage, 
+  HttpResponse extends http.ServerResponse = http.ServerResponse
+>(opts?: fastify.ServerOptions): fastify.FastifyInstance<HttpServer, HttpRequest, HttpResponse>;
 declare function fastify(opts?: fastify.ServerOptionsAsHttp): fastify.FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>;
 declare function fastify(opts?: fastify.ServerOptionsAsSecureHttp): fastify.FastifyInstance<https.Server, http.IncomingMessage, http.ServerResponse>;
 declare function fastify(opts?: fastify.ServerOptionsAsHttp2): fastify.FastifyInstance<http2.Http2Server, http2.Http2ServerRequest, http2.Http2ServerResponse>;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "standard | snazzy",
     "unit": "tap -j4 test/*.test.js test/*/*.test.js",
-    "typescript": "tsc test/types/index.ts --target es6 --module commonjs --noEmit --noImplicitThis",
+    "typescript": "tsc --project ./test/types/tsconfig.json",
     "test": "npm run lint && npm run unit && npm run typescript",
     "coverage": "npm run unit -- --cov --coverage-report=html",
     "coveralls": "npm run unit --  --cov",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "x-xss-protection": "^1.0.0"
   },
   "dependencies": {
+    "@types/express": "^4.11.0",
     "@types/pino": "^4.7.1",
     "abstract-logging": "^1.0.0",
     "ajv": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "x-xss-protection": "^1.0.0"
   },
   "dependencies": {
-    "@types/express": "^4.11.0",
     "@types/pino": "^4.7.1",
     "abstract-logging": "^1.0.0",
     "ajv": "^6.2.0",

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -7,6 +7,8 @@ import * as http2 from 'http2';
 import { readFileSync } from 'fs'
 import { createReadStream, readFile } from 'fs'
 
+// were importing cors using require, which causes it to be an `any`. This is done because `cors` exports
+// itself as an express.RequestHandler which is not compatible with the fastify TypeScript types
 const cors = require('cors');
 
 {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -30,6 +30,10 @@ import { createReadStream, readFile } from 'fs'
   });
   // logger true
   const logAllServer = fastify({ logger: true });
+  logAllServer.addHook('onRequest', (req, res, next) => {
+    console.log('can access req', req.headers);
+    next();
+  });
 
   // other simple options
   const otherServer = fastify({

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -120,7 +120,7 @@ server.addHook('onClose', (instance, done) => {
   done();
 })
 
-const opts = {
+const opts: fastify.RouteShorthandOptions<http2.Http2Server, http2.Http2ServerRequest, http2.Http2ServerResponse> = {
   schema: {
     response: {
       200: {
@@ -275,11 +275,11 @@ server.ready(function (err) {
   if (err) throw err
 })
 
-server.ready(function (err, done) {
+server.ready(function (err: Error, done: Function) {
   done(err)
 })
 
-server.ready(function (err, context, done) {
+server.ready(function (err: Error, context: fastify.FastifyInstance<http2.Http2SecureServer, http2.Http2ServerRequest, http2.Http2ServerResponse>, done: Function) {
   server.log.debug(context)
   done(err)
 })
@@ -296,11 +296,11 @@ server.after(function (err) {
   if (err) throw err
 })
 
-server.after(function (err, done) {
+server.after(function (err: Error, done: Function) {
   done(err)
 })
 
-server.after(function (err, context, done) {
+server.after(function (err: Error, context: fastify.FastifyInstance<http2.Http2SecureServer, http2.Http2ServerRequest, http2.Http2ServerResponse>, done: Function) {
   server.log.debug(context)
   done(err)
 })

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -47,6 +47,9 @@ import { createReadStream, readFile } from 'fs'
     getDeviceType: () => string;
   }
   const customServer: fastify.FastifyInstance<http.Server, CustomIncomingMessage, http.ServerResponse> = fastify();
+  customServer.use((req, res, next) => {
+    console.log('can access props from CustomIncomingMessage', req.getDeviceType());
+  })
 }
 
 const server = fastify({

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -2,11 +2,12 @@
 // This file will be passed to the TypeScript CLI to verify our typings compile
 
 import * as fastify from '../../fastify'
-import * as cors from 'cors'
 import * as http from 'http';
 import * as http2 from 'http2';
 import { readFileSync } from 'fs'
 import { createReadStream, readFile } from 'fs'
+
+const cors = require('cors');
 
 {
   // http

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -51,6 +51,15 @@ const cors = require('cors');
   customServer.use((req, res, next) => {
     console.log('can access props from CustomIncomingMessage', req.getDeviceType());
   })
+
+  interface CustomHttp2IncomingMessage extends http2.Http2ServerRequest {
+    getDeviceType: () => string;
+  }
+
+  const customHttp2Server: fastify.FastifyInstance<http2.Http2Server, CustomHttp2IncomingMessage, http2.Http2ServerResponse> = fastify();
+  customHttp2Server.use((req, res, next) => {
+    console.log('can access props from CustomIncomingMessage', req.getDeviceType());
+  });
 }
 
 const server = fastify({

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "noEmit": true,
+    "strict": true,
+  },
+  "files": [
+    "./index.ts"
+  ]
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

This PR introduces a few updates to the TypeScript setup and typings.

Reviewing type changes can sometimes be confusing for me, so in attempt to make it easier to review I made each change in its own commit. If you have questions or would like any changes let me know.

I'll explain the changes in each commit in a more detail  below.
_**Note:** none of the changes should break any existing types, all the changes should be making existing types more correct and better defined._

#### move config to a `tsconfig.json` file and enable strict mode
The switch to a `tsconfig.json` was just made to get matching config settings when using an IDE.
Enabling strict mode is to fix and prevent problems when using this fastify from a within a project with strict mode enabled.

#### add types for `cors` library
Once strict mode is enabled it wants types for all imports, so we add the types for `cors` as a dev dependency

#### add overload to allow `.use` to accept express middleware
The current types only allow passing fastify middleware which was giving a type error when trying to use `cors` (since `cors` is a type of `express.RequestHandler`). This commit adds a overload to allow passing either fastify middleware or express middleware to `use`

#### always pass a callback to middleware
another strict mode fix:)
The types for the callback specified that the callback would be optionally passed to middleware.
_(types currently are `callback?: (err?: Error) => void` note the `?` after callback)_
This means that in strict mode you would never be able to call `next` directly, since it would be possibly `undefined`. 
For example this was giving a types error
```ts
app.addHook('onRequest', (req, res, next) => {
	next(); // next is possibly 'undefined'.
});
```
This changes the type to specify that the callbacks will always be passed.
Note: This does not mean that all middleware must take a callback middleware.
This will still work as expected after this change
```ts
app.addHook('onRequest', (req, res) => {
	res.end('Hello World');
});
```

#### default and constrain generic types
When falling back to the generic instance of `fastify()` if you did not specify generic params then it would end up being a generic of `<{}, {}, {}>`. This means that the below case give type errors.
```ts
// current definition
declare function fastify<HttpServer, HttpRequest, HttpResponse>...

const app = fastify({ logger: true });
// app is now a FastifyInstance<{}, {}, {}>
app.addHook('onRequest', (req, res) => {
	res.end('Hello World'); // Property 'end' does not exist on type '{}'.
});

// defaulting generics
declare function fastify<
  HttpServer = http.Server, 
  HttpRequest = http.IncomingMessage, 
  HttpResponse = http.ServerResponse
>...
const app = fastify({ logger: true });
// app is now a FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>
```

as for constraining generics, it requires that the generic being passed in extends from the base type whic we expect...
```ts
// types were allowing this...
const app = fastify<number, string, boolean>({ logger: true });

//constrain generics
declare function fastify<
  HttpServer extends http.Server
  HttpRequest extends http.IncomingMessage
  HttpResponse extends http.ServerResponse
>
// the is no longer valid
const app = fastify<number, string, boolean>({ logger: true });
```

Putting together defaults and constraints looks like 
```ts
declare function fastify<
  HttpServer extends http.Server = http.Server, 
  HttpRequest extends http.IncomingMessage = http.IncomingMessage, 
  HttpResponse extends http.ServerResponse = http.ServerResponse
>...
```

_**fin**_ 
Sorry that this got a bit wordy, I figured its better to explain than to just open a PR with a bunch of  changes to the types 😄


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
