### PR TITLE
Add `request` to custom error handler parameters

### DIFF
--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -173,7 +173,13 @@ fastify.register(function (instance, options, next) {
 <a name="set-error-handler"></a>
 #### setErrorHandler
 
-`fastify.setErrorHandler(handler(error, reply))`: set a function that will be called whenever an error happens. The handler is fully encapsulated, so different plugins can set different error handlers, *async await* is supported as well.
+`fastify.setErrorHandler(handler(error, request, reply))`: Set a function that will be called whenever an error happens. The handler is fully encapsulated, so different plugins can set different error handlers. *async-await* is supported as well.
+
+```js
+fastify.setErrorHandler(function (error, request, reply) {
+  // Send error response
+})
+```
 
 <a name="print-routes"></a>
 #### printRoutes

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -347,7 +347,7 @@ declare namespace fastify {
     /**
      * Set a function that will be called whenever an error happens
      */
-    setErrorHandler(handler: (error: Error, reply: FastifyReply<HttpResponse>) => void): void
+    setErrorHandler(handler: (error: Error, request: FastifyRequest<HttpRequest>, reply: FastifyReply<HttpResponse>) => void): void
 
     /**
      * Create a shared schema

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -239,7 +239,7 @@ function handleError (reply, error, cb) {
     reply.sent = false
     reply._isError = false
     reply._customError = true
-    var result = customErrorHandler(error, reply)
+    var result = customErrorHandler(error, reply.request, reply)
     if (result && typeof result.then === 'function') {
       result.then(payload => reply.send(payload))
             .catch(err => reply.send(err))

--- a/test/500s.test.js
+++ b/test/500s.test.js
@@ -29,7 +29,7 @@ test('default 500', t => {
 })
 
 test('custom 500', t => {
-  t.plan(5)
+  t.plan(6)
 
   const fastify = Fastify()
 
@@ -39,6 +39,7 @@ test('custom 500', t => {
 
   fastify.setErrorHandler(function (err, request, reply) {
     t.type(request, 'object')
+    t.type(request, fastify._Request)
     reply
       .code(500)
       .type('text/plain')
@@ -57,7 +58,7 @@ test('custom 500', t => {
 })
 
 test('encapsulated 500', t => {
-  t.plan(9)
+  t.plan(10)
 
   const fastify = Fastify()
 
@@ -72,6 +73,7 @@ test('encapsulated 500', t => {
 
     f.setErrorHandler(function (err, request, reply) {
       t.type(request, 'object')
+      t.type(request, f._Request)
       reply
         .code(500)
         .type('text/plain')

--- a/test/500s.test.js
+++ b/test/500s.test.js
@@ -29,7 +29,7 @@ test('default 500', t => {
 })
 
 test('custom 500', t => {
-  t.plan(4)
+  t.plan(5)
 
   const fastify = Fastify()
 
@@ -37,7 +37,8 @@ test('custom 500', t => {
     reply.send(new Error('kaboom'))
   })
 
-  fastify.setErrorHandler(function (err, reply) {
+  fastify.setErrorHandler(function (err, request, reply) {
+    t.type(request, 'object')
     reply
       .code(500)
       .type('text/plain')
@@ -56,7 +57,7 @@ test('custom 500', t => {
 })
 
 test('encapsulated 500', t => {
-  t.plan(8)
+  t.plan(9)
 
   const fastify = Fastify()
 
@@ -69,7 +70,8 @@ test('encapsulated 500', t => {
       reply.send(new Error('kaboom'))
     })
 
-    f.setErrorHandler(function (err, reply) {
+    f.setErrorHandler(function (err, request, reply) {
+      t.type(request, 'object')
       reply
         .code(500)
         .type('text/plain')
@@ -113,7 +115,7 @@ test('custom 500 with hooks', t => {
     reply.send(new Error('kaboom'))
   })
 
-  fastify.setErrorHandler(function (err, reply) {
+  fastify.setErrorHandler(function (err, request, reply) {
     reply
       .code(500)
       .type('text/plain')

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -575,7 +575,7 @@ test('Should set the log level for the customized 500 handler', t => {
       reply.send(new Error('kaboom'))
     })
 
-    instance.setErrorHandler(function (e, reply) {
+    instance.setErrorHandler(function (e, request, reply) {
       reply.res.log.fatal('Hello')
       reply.code(500).send()
     })

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -234,7 +234,7 @@ test('Support rejection with values that are not Error instances', t => {
         return Promise.reject(nonErr)
       })
 
-      fastify.setErrorHandler((err, reply) => {
+      fastify.setErrorHandler((err, request, reply) => {
         if (typeof err === 'object') {
           t.deepEqual(err, nonErr)
         } else {
@@ -272,7 +272,7 @@ test('invalid schema - ajv', t => {
     t.fail('we should not be here')
   })
 
-  fastify.setErrorHandler((err, reply) => {
+  fastify.setErrorHandler((err, request, reply) => {
     t.ok(Array.isArray(err.validation))
     reply.send('error')
   })
@@ -323,7 +323,7 @@ test('should set the status code and the headers from the error object (from cus
     reply.send(error)
   })
 
-  fastify.setErrorHandler((err, reply) => {
+  fastify.setErrorHandler((err, request, reply) => {
     t.is(err.message, 'ouch')
     t.is(reply.res.statusCode, 401)
     const error = new Error('kaboom')

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -208,7 +208,7 @@ server.get('/test-decorated-inputs', (req, reply) => {
 server.setNotFoundHandler((req, reply) => {
 })
 
-server.setErrorHandler((err, reply) => {
+server.setErrorHandler((err, request, reply) => {
 })
 
 server.listen(3000, err => {


### PR DESCRIPTION
Before

```js
fastify.setErrorHandler(function (error, reply) {})
```

After
```js
fastify.setErrorHandler(function (error, request, reply) {})
```

Fixes #744

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
