### PR TITLE
Updated hook and middleware encapsulation

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -5,7 +5,6 @@ const avvio = require('avvio')
 const http = require('http')
 const https = require('https')
 const Middie = require('middie')
-const hookRunner = require('./lib/hookRunner')
 const lightMyRequest = require('light-my-request')
 const abstractLogging = require('abstract-logging')
 
@@ -23,6 +22,7 @@ const Hooks = require('./lib/hooks')
 const Schemas = require('./lib/schemas')
 const loggerUtils = require('./lib/logger')
 const pluginUtils = require('./lib/pluginUtils')
+const runHooks = require('./lib/hookRunner')
 
 const DEFAULT_JSON_BODY_LIMIT = 1024 * 1024 // 1 MiB
 
@@ -80,7 +80,7 @@ function build (options) {
   var listening = false
   // true when Fastify is ready to go
   var started = false
-  app.on('start', () => {
+  app.on('preReady', () => {
     started = true
   })
 
@@ -178,7 +178,7 @@ function build (options) {
   fastify.use = use
   fastify._middlewares = []
 
-  // fake http injection (for testing purposes)
+  // fake http injection
   fastify.inject = inject
 
   var fourOhFour = FindMyWay({ defaultRoute: fourOhFourFallBack })
@@ -204,7 +204,8 @@ function build (options) {
     res.on('error', onResFinished)
 
     if (context.onRequest !== null) {
-      context.onRequest(
+      runHooks(
+        context.onRequest,
         hookIterator,
         new State(req, res, params, context),
         middlewareCallback
@@ -223,7 +224,8 @@ function build (options) {
     if (ctx && ctx.onResponse !== null) {
       // deferring this with setImmediate will
       // slow us by 10%
-      ctx.onResponse(
+      runHooks(
+        ctx.onResponse,
         onResponseIterator,
         this,
         onResponseCallback
@@ -471,7 +473,7 @@ function build (options) {
         _fastify._contentTypeParser,
         config,
         _fastify._errorHandler,
-        buildMiddie(_fastify._middlewares),
+        null,
         opts.jsonBodyLimit,
         opts.logLevel,
         _fastify
@@ -484,15 +486,15 @@ function build (options) {
         return
       }
 
-      const onRequest = _fastify._hooks.onRequest
-      const onResponse = _fastify._hooks.onResponse
-      const onSend = _fastify._hooks.onSend
-      const preHandler = _fastify._hooks.preHandler.concat(opts.beforeHandler || [])
-
-      context.onRequest = onRequest.length ? hookRunner(onRequest, _fastify) : null
-      context.onResponse = onResponse.length ? hookRunner(onResponse, _fastify) : null
-      context.onSend = onSend.length ? hookRunner(onSend, _fastify) : null
-      context.preHandler = preHandler.length ? hookRunner(preHandler, _fastify) : null
+      if (opts.beforeHandler) {
+        if (Array.isArray(opts.beforeHandler)) {
+          opts.beforeHandler.forEach((h, i) => {
+            opts.beforeHandler[i] = h.bind(_fastify)
+          })
+        } else {
+          opts.beforeHandler = opts.beforeHandler.bind(_fastify)
+        }
+      }
 
       try {
         router.on(opts.method, url, routeHandler, context)
@@ -500,6 +502,23 @@ function build (options) {
         done(err)
         return
       }
+
+      // It can happen that a user register a plugin with some hooks/middlewares *after*
+      // the route registration. To be sure to load also that hoooks/middlwares,
+      // we must listen for the avvio's preReady event, and update the context object accordingly.
+      app.once('preReady', () => {
+        const onRequest = _fastify._hooks.onRequest
+        const onResponse = _fastify._hooks.onResponse
+        const onSend = _fastify._hooks.onSend
+        const preHandler = _fastify._hooks.preHandler.concat(opts.beforeHandler || [])
+
+        context.onRequest = onRequest.length ? onRequest : null
+        context.preHandler = preHandler.length ? preHandler : null
+        context.onSend = onSend.length ? onSend : null
+        context.onResponse = onResponse.length ? onResponse : null
+
+        context._middie = buildMiddie(_fastify._middlewares)
+      })
 
       done(notHandledErr)
     })
@@ -568,7 +587,7 @@ function build (options) {
       this._hooks.validate(name, fn)
       onRouteHooks.push(fn)
     } else {
-      this._hooks.add(name, fn)
+      this._hooks.add(name, fn.bind(this))
     }
     return this
   }
@@ -626,7 +645,7 @@ function build (options) {
     req.log.warn('the default handler for 404 did not catch this, this is likely a fastify bug, please report it')
     req.log.warn(fourOhFour.prettyPrint())
     const request = new Request(null, req, null, req.headers, req.log)
-    const reply = new Reply(res, { onSend: hookRunner([], null) }, request)
+    const reply = new Reply(res, { onSend: [] }, request)
     reply.code(404).send(new Error('Not found'))
   }
 
@@ -672,10 +691,10 @@ function build (options) {
     const onSend = this._hooks.onSend
     const onResponse = this._hooks.onResponse
 
-    context.onRequest = onRequest.length ? hookRunner(onRequest, this) : null
-    context.preHandler = preHandler.length ? hookRunner(preHandler, this) : null
-    context.onSend = onSend.length ? hookRunner(onSend, this) : null
-    context.onResponse = onResponse.length ? hookRunner(onResponse, this) : null
+    context.onRequest = onRequest.length ? onRequest : null
+    context.preHandler = preHandler.length ? preHandler : null
+    context.onSend = onSend.length ? onSend : null
+    context.onResponse = onResponse.length ? onResponse : null
 
     if (this._404Context !== null) {
       Object.assign(this._404Context, context) // Replace the default 404 handler

--- a/fastify.js
+++ b/fastify.js
@@ -80,7 +80,7 @@ function build (options) {
   var listening = false
   // true when Fastify is ready to go
   var started = false
-  app.on('preReady', () => {
+  app.on('start', () => {
     started = true
   })
 

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -5,6 +5,7 @@ const fastJsonStringify = require('fast-json-stringify')
 const urlUtil = require('url')
 const validation = require('./validation')
 const validateSchema = validation.validate
+const runHooks = require('./hookRunner')
 
 const schemas = require('./schemas.json')
 const inputSchemaError = fastJsonStringify(schemas.inputSchemaError)
@@ -138,7 +139,8 @@ function handler (reply) {
 
   // preHandler hook
   if (reply.context.preHandler !== null) {
-    reply.context.preHandler(
+    runHooks(
+      reply.context.preHandler,
       hookIterator,
       reply,
       preHandlerCallback

--- a/lib/hookRunner.js
+++ b/lib/hookRunner.js
@@ -1,42 +1,38 @@
 'use strict'
 
-function hookRunner (functions, context) {
-  functions = functions.map(fn => fn.bind(context))
+function hookRunner (functions, runner, state, cb) {
+  var i = 0
 
-  return function runHooks (runner, state, cb) {
-    var i = 0
-
-    function next (err, value) {
-      if (err) {
-        cb(err, state)
-        return
-      }
-
-      if (value !== undefined) {
-        state = value
-      }
-
-      if (i === functions.length) {
-        cb(null, state)
-        return
-      }
-
-      const result = runner(functions[i++], state, next)
-      if (result && typeof result.then === 'function') {
-        result.then(handleResolve, handleReject)
-      }
-    }
-
-    function handleResolve (value) {
-      next(null, value)
-    }
-
-    function handleReject (err) {
+  function next (err, value) {
+    if (err) {
       cb(err, state)
+      return
     }
 
-    next()
+    if (value !== undefined) {
+      state = value
+    }
+
+    if (i === functions.length) {
+      cb(null, state)
+      return
+    }
+
+    const result = runner(functions[i++], state, next)
+    if (result && typeof result.then === 'function') {
+      result.then(handleResolve, handleReject)
+    }
   }
+
+  function handleResolve (value) {
+    next(null, value)
+  }
+
+  function handleReject (err) {
+    cb(err, state)
+  }
+
+  next()
 }
 
 module.exports = hookRunner

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -8,6 +8,7 @@ const serialize = validation.serialize
 const statusCodes = require('http').STATUS_CODES
 const flatstr = require('flatstr')
 const FJS = require('fast-json-stringify')
+const runHooks = require('./hookRunner')
 
 const serializeError = FJS({
   type: 'object',
@@ -119,7 +120,8 @@ Reply.prototype.redirect = function (code, url) {
 
 function onSendHook (reply, payload) {
   if (reply.context.onSend !== null) {
-    reply.context.onSend(
+    runHooks(
+      reply.context.onSend,
       hookIterator.bind(reply),
       payload,
       wrapOnSendEnd.bind(reply)

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@types/pino": "^4.7.1",
     "abstract-logging": "^1.0.0",
     "ajv": "^6.1.1",
-    "avvio": "^5.1.0",
+    "avvio": "^5.3.0",
     "end-of-stream": "^1.4.1",
     "fast-json-stringify": "^1.0.0",
     "find-my-way": "^1.10.1",

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -7,8 +7,6 @@ const internals = require('../../lib/handleRequest')[Symbol.for('internals')]
 const Request = require('../../lib/request')
 const Reply = require('../../lib/reply')
 const buildSchema = require('../../lib/validation').build
-const Hooks = require('../../lib/hooks')
-const runHooks = require('../../lib/hookRunner')
 const Schemas = require('../../lib/schemas')
 const sget = require('simple-get').concat
 
@@ -65,8 +63,8 @@ test('handler function - invalid schema', t => {
     handler: () => {},
     Reply: Reply,
     Request: Request,
-    preHandler: runHooks(new Hooks().preHandler, {}),
-    onSend: runHooks(new Hooks().onSend, {})
+    preHandler: [],
+    onSend: []
   }
   const schemas = new Schemas()
   buildSchema(context, schemaCompiler, schemas)
@@ -97,8 +95,8 @@ test('handler function - reply', t => {
     },
     Reply: Reply,
     Request: Request,
-    preHandler: runHooks(new Hooks().preHandler, {}),
-    onSend: runHooks(new Hooks().onSend, {})
+    preHandler: [],
+    onSend: []
   }
   buildSchema(context, schemaCompiler)
   internals.handler(new Reply(res, context, {}))

--- a/test/internals/hookRunner.test.js
+++ b/test/internals/hookRunner.test.js
@@ -2,10 +2,10 @@
 
 const t = require('tap')
 const test = t.test
-const Fast = require('../../lib/hookRunner')
+const runHooks = require('../../lib/hookRunner')
 
 test('Basic', t => {
-  t.plan(9)
+  t.plan(8)
 
   const v1 = { hello: 'world' }
   const v2 = { ciao: 'mondo' }
@@ -13,9 +13,7 @@ test('Basic', t => {
   const v4 = { winter: 'has come' }
   const context = { context: true }
 
-  const fast = Fast([fn1, fn2, fn3], context)
-  t.is(typeof fast, 'function')
-  fast(iterator.bind({ a: 'a', b: 'b' }), v1, done)
+  runHooks([fn1.bind(context), fn2.bind(context), fn3.bind(context)], iterator.bind({ a: 'a', b: 'b' }), v1, done)
 
   function iterator (fn, value, next) {
     return fn(this.a, this.b, value, next)
@@ -46,15 +44,13 @@ test('Basic', t => {
 })
 
 test('In case of error should skip to done', t => {
-  t.plan(7)
+  t.plan(6)
 
   const v1 = { hello: 'world' }
   const v2 = { ciao: 'mondo' }
   const context = { context: true }
 
-  const fast = Fast([fn1, fn2, fn3], context)
-  t.is(typeof fast, 'function')
-  fast(iterator.bind({ a: 'a', b: 'b' }), v1, done)
+  runHooks([fn1.bind(context), fn2.bind(context), fn3.bind(context)], iterator.bind({ a: 'a', b: 'b' }), v1, done)
 
   function iterator (fn, value, next) {
     return fn(this.a, this.b, value, next)
@@ -83,14 +79,12 @@ test('In case of error should skip to done', t => {
 })
 
 test('Clean next', t => {
-  t.plan(9)
+  t.plan(8)
 
   const v1 = { hello: 'world' }
   const context = { context: true }
 
-  const fast = Fast([fn1, fn2, fn3], context)
-  t.is(typeof fast, 'function')
-  fast(iterator.bind({ a: 'a', b: 'b' }), v1, done)
+  runHooks([fn1.bind(context), fn2.bind(context), fn3.bind(context)], iterator.bind({ a: 'a', b: 'b' }), v1, done)
 
   function iterator (fn, value, next) {
     return fn(this.a, this.b, value, next)
@@ -121,7 +115,7 @@ test('Clean next', t => {
 })
 
 test('Should handle promises', t => {
-  t.plan(9)
+  t.plan(8)
 
   const v1 = { hello: 'world' }
   const v2 = { ciao: 'mondo' }
@@ -129,9 +123,7 @@ test('Should handle promises', t => {
   const v4 = { winter: 'has come' }
   const context = { context: true }
 
-  const fast = Fast([fn1, fn2, fn3], context)
-  t.is(typeof fast, 'function')
-  fast(iterator.bind({ a: 'a', b: 'b' }), v1, done)
+  runHooks([fn1.bind(context), fn2.bind(context), fn3.bind(context)], iterator.bind({ a: 'a', b: 'b' }), v1, done)
 
   function iterator (fn, value, next) {
     return fn(this.a, this.b, value, next)
@@ -168,15 +160,13 @@ test('Should handle promises', t => {
 })
 
 test('In case of error should skip to done (with promises)', t => {
-  t.plan(7)
+  t.plan(6)
 
   const v1 = { hello: 'world' }
   const v2 = { ciao: 'mondo' }
   const context = { context: true }
 
-  const fast = Fast([fn1, fn2, fn3], context)
-  t.is(typeof fast, 'function')
-  fast(iterator.bind({ a: 'a', b: 'b' }), v1, done)
+  runHooks([fn1.bind(context), fn2.bind(context), fn3.bind(context)], iterator.bind({ a: 'a', b: 'b' }), v1, done)
 
   function iterator (fn, value, next) {
     return fn(this.a, this.b, value, next)
@@ -209,16 +199,14 @@ test('In case of error should skip to done (with promises)', t => {
 })
 
 test('Be able to exit before its natural end', t => {
-  t.plan(5)
+  t.plan(4)
 
   const v1 = { hello: 'world' }
   const v2 = { ciao: 'mondo' }
   const v3 = { winter: 'is coming' }
   const context = { context: true }
 
-  const fast = Fast([fn1, fn2, fn3], context)
-  t.is(typeof fast, 'function')
-  fast(iterator.bind({ a: 'a', b: 'b' }), v1, done)
+  runHooks([fn1.bind(context), fn2.bind(context), fn3.bind(context)], iterator.bind({ a: 'a', b: 'b' }), v1, done)
 
   function iterator (fn, value, next) {
     if (value.winter) {

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -515,7 +515,7 @@ test('middlewares should support encapsulation with prefix', t => {
 })
 
 test('middlewares should support non-encapsulated plugins', t => {
-  t.plan(5)
+  t.plan(6)
 
   const instance = fastify()
 
@@ -536,7 +536,7 @@ test('middlewares should support non-encapsulated plugins', t => {
 
   instance.register(fp(function (i, opts, done) {
     i.use(function (req, res, next) {
-      t.fail('middleware should not be called')
+      t.ok('middleware called')
       next()
     })
 


### PR DESCRIPTION
With this change we are able to register hooks and middlewares declared in a plugin *after* a route declaration in the same level.
The context update is postponed until `avvio` emits the `preReady` event (https://github.com/mcollina/avvio/pull/49).
I've also updated the hook runner since the context binding happens during the hook registration.

When using the hooks the benchmarks have improved by 1-2k req/sec.

Related: https://github.com/fastify/fastify/issues/748

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
