### PR TITLE
Added backlog parameter to listen method #767

### DIFF
--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -49,6 +49,17 @@ fastify.listen(3000, '127.0.0.1', err => {
 })
 ```
 
+Specifying a backlog queue size is also supported:
+
+```js
+fastify.listen(3000, '127.0.0.1', 511, err => {
+  if (err) {
+    fastify.log.error(err)
+    process.exit(1)
+  }
+})
+```
+
 If no callback is provided a Promise is returned:
 
 ```js

--- a/fastify.js
+++ b/fastify.js
@@ -235,13 +235,19 @@ function build (options) {
     }
   }
 
-  function listen (port, address, cb) {
+  function listen (port, address, backlog, cb) {
     /* Deal with listen (port, cb) */
     if (typeof address === 'function') {
       cb = address
       address = undefined
     }
     address = address || '127.0.0.1'
+
+    /* Deal with listen (port, address, cb) */
+    if (typeof backlog === 'function') {
+      cb = backlog
+      backlog = undefined
+    }
 
     if (cb === undefined) {
       return new Promise((resolve, reject) => {
@@ -262,7 +268,12 @@ function build (options) {
       }
 
       server.on('error', wrap)
-      server.listen(port, address, wrap)
+      if (backlog) {
+        server.listen(port, address, backlog, wrap)
+      } else {
+        server.listen(port, address, wrap)
+      }
+
       listening = true
     })
 

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -29,6 +29,17 @@ test('listen accepts a port, address, and callback', t => {
   })
 })
 
+test('listen accepts a port, address, backlog and callback', t => {
+  t.plan(2)
+  const fastify = Fastify()
+  fastify.listen(0, '127.0.0.1', 511, (err) => {
+    fastify.server.unref()
+    t.error(err)
+    t.pass()
+    fastify.close()
+  })
+})
+
 test('listen after Promise.resolve()', t => {
   t.plan(2)
   const f = Fastify()


### PR DESCRIPTION
Added backlog parameter to listen method 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
