### PR TITLE
Make hooks/middleware run in the order in which they are defined

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -26,7 +26,7 @@ const runHooks = require('./lib/hookRunner')
 
 const DEFAULT_JSON_BODY_LIMIT = 1024 * 1024 // 1 MiB
 
-const childrenKey = Symbol('children')
+const childrenKey = Symbol('fastify.children')
 
 function validateBodyLimitOption (jsonBodyLimit) {
   if (jsonBodyLimit === undefined) return

--- a/fastify.js
+++ b/fastify.js
@@ -389,12 +389,7 @@ function build (options) {
 
     for (var i = 0; i < children.length; i++) {
       const childInstance = children[i]
-      const hooks = childInstance._hooks
-
-      hooks.onRequest.unshift.apply(hooks.onRequest, parentHooks.onRequest)
-      hooks.preHandler.unshift.apply(hooks.preHandler, parentHooks.preHandler)
-      hooks.onSend.unshift.apply(hooks.onSend, parentHooks.onSend)
-      hooks.onResponse.unshift.apply(hooks.onResponse, parentHooks.onResponse)
+      childInstance._hooks.prependHooks(parentHooks)
 
       const middlewares = childInstance._middlewares
       middlewares.unshift.apply(middlewares, instance._middlewares)

--- a/fastify.js
+++ b/fastify.js
@@ -396,6 +396,8 @@ function build (options) {
 
       cascadeHooksAndMiddlewares(childInstance)
     }
+
+    instance._children = null // Saves memory since the children array is not needed after this
   }
 
   // Shorthand methods

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -30,11 +30,14 @@ Hooks.prototype.add = function (hook, fn) {
   this[hook].push(fn)
 }
 
-Hooks.prototype.prependHooks = function (hooks) {
-  this.onRequest.unshift.apply(this.onRequest, hooks.onRequest)
-  this.preHandler.unshift.apply(this.preHandler, hooks.preHandler)
-  this.onSend.unshift.apply(this.onSend, hooks.onSend)
-  this.onResponse.unshift.apply(this.onResponse, hooks.onResponse)
+function buildHooks (h) {
+  const hooks = new Hooks()
+  hooks.onRequest = h.onRequest.slice()
+  hooks.preHandler = h.preHandler.slice()
+  hooks.onSend = h.onSend.slice()
+  hooks.onResponse = h.onResponse.slice()
+  return hooks
 }
 
 module.exports = Hooks
+module.exports.buildHooks = buildHooks

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -30,14 +30,4 @@ Hooks.prototype.add = function (hook, fn) {
   this[hook].push(fn)
 }
 
-function buildHooks (h) {
-  const hooks = new Hooks()
-  hooks.onRequest = h.onRequest.slice()
-  hooks.preHandler = h.preHandler.slice()
-  hooks.onSend = h.onSend.slice()
-  hooks.onResponse = h.onResponse.slice()
-  return hooks
-}
-
 module.exports = Hooks
-module.exports.buildHooks = buildHooks

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -30,4 +30,11 @@ Hooks.prototype.add = function (hook, fn) {
   this[hook].push(fn)
 }
 
+Hooks.prototype.prependHooks = function (hooks) {
+  this.onRequest.unshift.apply(this.onRequest, hooks.onRequest)
+  this.preHandler.unshift.apply(this.preHandler, hooks.preHandler)
+  this.onSend.unshift.apply(this.onSend, hooks.onSend)
+  this.onResponse.unshift.apply(this.onResponse, hooks.onResponse)
+}
+
 module.exports = Hooks

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -103,18 +103,34 @@ test('hooks', t => {
 })
 
 test('onRequest hook should support encapsulation / 1', t => {
-  t.plan(3)
+  t.plan(5)
   const fastify = Fastify()
 
   fastify.register((instance, opts, next) => {
-    instance.addHook('onRequest', () => {})
-    t.is(instance._hooks.onRequest.length, 1)
+    instance.addHook('onRequest', (req, res, next) => {
+      t.strictEqual(req.url, '/plugin')
+      next()
+    })
+
+    instance.get('/plugin', (request, reply) => {
+      reply.send()
+    })
+
     next()
   })
 
-  fastify.ready(err => {
+  fastify.get('/root', (request, reply) => {
+    reply.send()
+  })
+
+  fastify.inject('/root', (err, res) => {
     t.error(err)
-    t.is(fastify._hooks.onRequest.length, 0)
+    t.strictEqual(res.statusCode, 200)
+  })
+
+  fastify.inject('/plugin', (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
   })
 })
 
@@ -486,18 +502,35 @@ test('onRoute hook should preserve system route configuration', t => {
 })
 
 test('onResponse hook should support encapsulation / 1', t => {
-  t.plan(3)
+  t.plan(5)
   const fastify = Fastify()
 
   fastify.register((instance, opts, next) => {
-    instance.addHook('onResponse', () => {})
-    t.is(instance._hooks.onResponse.length, 1)
+    instance.addHook('onResponse', (res, next) => {
+      t.strictEqual(res.plugin, true)
+      next()
+    })
+
+    instance.get('/plugin', (request, reply) => {
+      reply.res.plugin = true
+      reply.send()
+    })
+
     next()
   })
 
-  fastify.ready(err => {
+  fastify.get('/root', (request, reply) => {
+    reply.send()
+  })
+
+  fastify.inject('/root', (err, res) => {
     t.error(err)
-    t.is(fastify._hooks.onResponse.length, 0)
+    t.strictEqual(res.statusCode, 200)
+  })
+
+  fastify.inject('/plugin', (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
   })
 })
 
@@ -1341,15 +1374,10 @@ test('Register an hook after a plugin inside a plugin (with beforeHandler)', t =
 })
 
 test('Register hooks inside a plugin after an encapsulated plugin', t => {
-  t.plan(8)
+  t.plan(7)
   const fastify = Fastify()
 
   fastify.register(function (instance, opts, next) {
-    instance.addHook('preHandler', function (request, reply, next) {
-      t.is(request.topLevelCalledFirst, true)
-      next()
-    })
-
     instance.get('/', function (request, reply) {
       reply.send({ hello: 'world' })
     })
@@ -1364,7 +1392,6 @@ test('Register hooks inside a plugin after an encapsulated plugin', t => {
     })
 
     instance.addHook('preHandler', function (request, reply, next) {
-      request.topLevelCalledFirst = true
       t.ok('called')
       next()
     })
@@ -1382,12 +1409,245 @@ test('Register hooks inside a plugin after an encapsulated plugin', t => {
     next()
   }))
 
-  fastify.inject({
-    url: '/',
-    method: 'GET'
-  }, (err, res) => {
+  fastify.inject('/', (err, res) => {
     t.error(err)
     t.is(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { hello: 'world' })
+  })
+})
+
+test('onRequest hooks should run in the order in which they are defined', t => {
+  t.plan(9)
+  const fastify = Fastify()
+
+  fastify.register(function (instance, opts, next) {
+    instance.addHook('onRequest', function (req, res, next) {
+      t.strictEqual(req.previous, undefined)
+      req.previous = 1
+      next()
+    })
+
+    instance.get('/', function (request, reply) {
+      t.strictEqual(request.req.previous, 5)
+      reply.send({ hello: 'world' })
+    })
+
+    instance.register(fp(function (i, opts, next) {
+      i.addHook('onRequest', function (req, res, next) {
+        t.strictEqual(req.previous, 1)
+        req.previous = 2
+        next()
+      })
+      next()
+    }))
+
+    next()
+  })
+
+  fastify.register(fp(function (instance, opts, next) {
+    instance.addHook('onRequest', function (req, res, next) {
+      t.strictEqual(req.previous, 2)
+      req.previous = 3
+      next()
+    })
+
+    instance.register(fp(function (i, opts, next) {
+      i.addHook('onRequest', function (req, res, next) {
+        t.strictEqual(req.previous, 3)
+        req.previous = 4
+        next()
+      })
+      next()
+    }))
+
+    instance.addHook('onRequest', function (req, res, next) {
+      t.strictEqual(req.previous, 4)
+      req.previous = 5
+      next()
+    })
+
+    next()
+  }))
+
+  fastify.inject('/', (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { hello: 'world' })
+  })
+})
+
+test('preHandler hooks should run in the order in which they are defined', t => {
+  t.plan(9)
+  const fastify = Fastify()
+
+  fastify.register(function (instance, opts, next) {
+    instance.addHook('preHandler', function (request, reply, next) {
+      t.strictEqual(request.previous, undefined)
+      request.previous = 1
+      next()
+    })
+
+    instance.get('/', function (request, reply) {
+      t.strictEqual(request.previous, 5)
+      reply.send({ hello: 'world' })
+    })
+
+    instance.register(fp(function (i, opts, next) {
+      i.addHook('preHandler', function (request, reply, next) {
+        t.strictEqual(request.previous, 1)
+        request.previous = 2
+        next()
+      })
+      next()
+    }))
+
+    next()
+  })
+
+  fastify.register(fp(function (instance, opts, next) {
+    instance.addHook('preHandler', function (request, reply, next) {
+      t.strictEqual(request.previous, 2)
+      request.previous = 3
+      next()
+    })
+
+    instance.register(fp(function (i, opts, next) {
+      i.addHook('preHandler', function (request, reply, next) {
+        t.strictEqual(request.previous, 3)
+        request.previous = 4
+        next()
+      })
+      next()
+    }))
+
+    instance.addHook('preHandler', function (request, reply, next) {
+      t.strictEqual(request.previous, 4)
+      request.previous = 5
+      next()
+    })
+
+    next()
+  }))
+
+  fastify.inject('/', (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { hello: 'world' })
+  })
+})
+
+test('onSend hooks should run in the order in which they are defined', t => {
+  t.plan(8)
+  const fastify = Fastify()
+
+  fastify.register(function (instance, opts, next) {
+    instance.addHook('onSend', function (request, reply, payload, next) {
+      t.strictEqual(request.previous, undefined)
+      request.previous = 1
+      next()
+    })
+
+    instance.get('/', function (request, reply) {
+      reply.send({})
+    })
+
+    instance.register(fp(function (i, opts, next) {
+      i.addHook('onSend', function (request, reply, payload, next) {
+        t.strictEqual(request.previous, 1)
+        request.previous = 2
+        next()
+      })
+      next()
+    }))
+
+    next()
+  })
+
+  fastify.register(fp(function (instance, opts, next) {
+    instance.addHook('onSend', function (request, reply, payload, next) {
+      t.strictEqual(request.previous, 2)
+      request.previous = 3
+      next()
+    })
+
+    instance.register(fp(function (i, opts, next) {
+      i.addHook('onSend', function (request, reply, payload, next) {
+        t.strictEqual(request.previous, 3)
+        request.previous = 4
+        next()
+      })
+      next()
+    }))
+
+    instance.addHook('onSend', function (request, reply, payload, next) {
+      t.strictEqual(request.previous, 4)
+      next(null, '5')
+    })
+
+    next()
+  }))
+
+  fastify.inject('/', (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), 5)
+  })
+})
+
+test('onResponse hooks should run in the order in which they are defined', t => {
+  t.plan(8)
+  const fastify = Fastify()
+
+  fastify.register(function (instance, opts, next) {
+    instance.addHook('onResponse', function (res, next) {
+      t.strictEqual(res.previous, undefined)
+      res.previous = 1
+      next()
+    })
+
+    instance.get('/', function (request, reply) {
+      reply.send({ hello: 'world' })
+    })
+
+    instance.register(fp(function (i, opts, next) {
+      i.addHook('onResponse', function (res, next) {
+        t.strictEqual(res.previous, 1)
+        res.previous = 2
+        next()
+      })
+      next()
+    }))
+
+    next()
+  })
+
+  fastify.register(fp(function (instance, opts, next) {
+    instance.addHook('onResponse', function (res, next) {
+      t.strictEqual(res.previous, 2)
+      res.previous = 3
+      next()
+    })
+
+    instance.register(fp(function (i, opts, next) {
+      i.addHook('onResponse', function (res, next) {
+        t.strictEqual(res.previous, 3)
+        res.previous = 4
+        next()
+      })
+      next()
+    }))
+
+    instance.addHook('onResponse', function (res, next) {
+      t.strictEqual(res.previous, 4)
+      next()
+    })
+
+    next()
+  }))
+
+  fastify.inject('/', (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
     t.deepEqual(JSON.parse(res.payload), { hello: 'world' })
   })
 })


### PR DESCRIPTION
Make hooks/middleware always run in the order in which they are defined.
This also makes Fastify instance "levels" consistent by fixing this bug:

```js
const fastify = require('fastify')() // master branch

fastify.get('/', function handler (request, reply) {
  reply.send(request.cookies)
})

fastify.register(function (instance, opts, next) {
  instance.get('/encap', function (request, reply) {
    reply.send(request.cookies)
  })
  next()
})

fastify.register(require('fastify-cookie'))

fastify.inject({
  url: '/',
  headers: { Cookie: 'foo=bar' }
}, (err, res) => {
  console.log('/      -', res.payload) // {"foo":"bar"}
})

fastify.inject({
  url: '/encap',
  headers: { Cookie: 'foo=bar' }
}, (err, res) => {
  console.log('/encap -', res.payload) // {}
})
```

With this change, the `preHandler` hook from `fastify-cookie` will run before both routes.

Fixes #748

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
