### PR TITLE
Resolve issue #777 - unhandled exceptions when registering plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@types/pino": "^4.7.1",
     "abstract-logging": "^1.0.0",
     "ajv": "^6.1.1",
-    "avvio": "^5.3.0",
+    "avvio": "^5.4.0",
     "end-of-stream": "^1.4.1",
     "fast-json-stringify": "^1.0.0",
     "find-my-way": "^1.10.1",

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -60,6 +60,27 @@ test('decorate should throw if a declared dependency is not present', t => {
   fastify.ready(() => t.pass())
 })
 
+// issue #777
+test('should throw for missing request decorator', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  try {
+    const plugin = fp(function (instance, opts, next) {
+      next()
+    }, {
+      decorators: {
+        request: ['foo']
+      }
+    })
+    fastify
+      .register(plugin)
+      .ready(t.pass)
+  } catch (e) {
+    t.pass()
+  }
+})
+
 test('decorateReply inside register', t => {
   t.plan(12)
   const fastify = Fastify()

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -61,24 +61,23 @@ test('decorate should throw if a declared dependency is not present', t => {
 })
 
 // issue #777
-test('should throw for missing request decorator', t => {
+test('should pass error for missing request decorator', t => {
   t.plan(2)
   const fastify = Fastify()
 
-  try {
-    const plugin = fp(function (instance, opts, next) {
-      next()
-    }, {
-      decorators: {
-        request: ['foo']
-      }
+  const plugin = fp(function (instance, opts, next) {
+    next()
+  }, {
+    decorators: {
+      request: ['foo']
+    }
+  })
+  fastify
+    .register(plugin)
+    .ready((err) => {
+      t.type(err, Error)
+      t.match(err, /The decorator 'foo'/)
     })
-    fastify
-      .register(plugin)
-      .ready(t.pass)
-  } catch (e) {
-    t.pass()
-  }
 })
 
 test('decorateReply inside register', t => {


### PR DESCRIPTION
This is a work in progress. Thus far, only a failing test is added.

The issue is that plugins are actually loaded asynchronously via `avvio`. This internal handling creates a new call stack that does not get handled by the `try/catch` block as desired.

It may be that this has to be resolved in `avvio`. Any ideas @mcollina ?

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
