### PR TITLE
WIP: Refactor content type parser

### DIFF
--- a/docs/ContentTypeParser.md
+++ b/docs/ContentTypeParser.md
@@ -1,11 +1,13 @@
 <h1 align="center">Fastify</h1>
 
 ## Content Type Parser
-Natively, Fastify only supports the `'application/json'` content type. If you need to support different content types, you can use the `addContentTypeParser` API. *Note that you can't add a custom content type parser for `'application/json'` because Fastify has a fast case for it.*
+Natively, Fastify only supports the `'application/json'` content type. If you need to support different content types, you can use the `addContentTypeParser` API. *The default JSON parser can be changed.*
 
 As with the other APIs, `addContentTypeParser` is encapsulated in the scope in which it is declared. This means that if you declare it in the root scope it will be available everywhere, while if you declare it inside a register it will be available only in that scope and its children.
 
-#### Usage
+Fastify adds automatically the parsed request payload to the [Fastify request](https://github.com/fastify/fastify/blob/master/docs/Request.md) object, you can reach it with `request.body`.
+
+### Usage
 ```js
 fastify.addContentTypeParser('application/jsoff', function (req, done) {
   jsoffParser(req, function (err, body) {
@@ -24,14 +26,29 @@ You can also use the `hasContentTypeParser` API to find if a specific content ty
 ```js
 if (!fastify.hasContentTypeParser('application/jsoff')){
   fastify.addContentTypeParser('application/jsoff', function (req, done) {
-    //code to parse request body /payload for given content type 
+    //code to parse request body /payload for given content type
   })
 }
 ```
 
+#### Body Parser
+You can parse the body of the request in two ways. The first one is shown above: you add a custom content type parser and handle the request stream. In the second one you should pass a `parseAs` option to the `addContentTypeParser` API, where you declare how you want to get the body, it could be `'string'` or `'buffer'`. If you use the `parseAs` option Fastify will internally handle the stream and perform some checks, such as the [maximum size](https://github.com/fastify/fastify/blob/master/docs/Factory.md#factory-body-limit) of the body and the content length.
+```js
+fastify.addContentTypeParser('application/json', { parseAs: 'string' }, function (req, body, done) {
+  try {
+    var json = JSON.parse(body)
+    done(null, json)
+  } catch (err) {
+    err.statusCode = 400
+    done(err, undefined)
+  }
+})
+```
+As you can see, now the function signature is `(req, body, done)` instead of `(req, done)`.
+
 See [`example/parser.js`](https://github.com/fastify/fastify/blob/master/examples/parser.js) for an example.
 
-##### Catch All
+#### Catch All
 There are some cases where you need to catch all requests regardless of their content type. With Fastify, you just need to add the `'*'` content type.
 ```js
 fastify.addContentTypeParser('*', function (req, done) {
@@ -43,4 +60,4 @@ fastify.addContentTypeParser('*', function (req, done) {
 })
 ```
 
-In this way, all of the requests that do not have a corresponding content type parser will be handled by the specified function. *Remember that `'application/json'` is always handled by Fastify.*
+In this way, all of the requests that do not have a corresponding content type parser will be handled by the specified function.

--- a/docs/Factory.md
+++ b/docs/Factory.md
@@ -61,14 +61,13 @@ fastify.get('/bar', function (req, reply) {
 <a name="factory-max-param-length"></a>
 ### `maxParamLength`
 You can set a custom length for parameters in parametric (standard, regex and multi) routes by using `maxParamLength` option, the default value is 100 characters.<br>
-This can be useful especially if you have some regex based route, protecting you against [DoS attacks](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS).<br> 
+This can be useful especially if you have some regex based route, protecting you against [DoS attacks](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS).<br>
 *If the maximum length limit is reached, the not found route will be invoked.*
 
-<a name="factory-json-limit"></a>
-### `jsonBodyLimit`
+<a name="factory-body-limit"></a>
+### `bodyLimit`
 
-Defines the maximum payload, in bytes, the server is allowed to accept for
-request bodies when using the internal `application/json` content type parser.
+Defines the maximum payload, in bytes, the server is allowed to accept.
 
 + Default: `1048576` (1MiB)
 

--- a/fastify.js
+++ b/fastify.js
@@ -24,12 +24,12 @@ const loggerUtils = require('./lib/logger')
 const pluginUtils = require('./lib/pluginUtils')
 const runHooks = require('./lib/hookRunner')
 
-const DEFAULT_JSON_BODY_LIMIT = 1024 * 1024 // 1 MiB
+const DEFAULT_BODY_LIMIT = 1024 * 1024 // 1 MiB
 
-function validateBodyLimitOption (jsonBodyLimit) {
-  if (jsonBodyLimit === undefined) return
-  if (!Number.isInteger(jsonBodyLimit) || jsonBodyLimit <= 0) {
-    throw new TypeError(`'jsonBodyLimit' option must be an integer > 0. Got '${jsonBodyLimit}'`)
+function validateBodyLimitOption (bodyLimit) {
+  if (bodyLimit === undefined) return
+  if (!Number.isInteger(bodyLimit) || bodyLimit <= 0) {
+    throw new TypeError(`'bodyLimit' option must be an integer > 0. Got '${bodyLimit}'`)
   }
 }
 
@@ -114,9 +114,9 @@ function build (options) {
     server.on('clientError', handleClientError)
   }
 
-  // JSON body limit option
-  validateBodyLimitOption(options.jsonBodyLimit)
-  fastify._jsonBodyLimit = options.jsonBodyLimit || DEFAULT_JSON_BODY_LIMIT
+  // body limit option
+  validateBodyLimitOption(options.bodyLimit)
+  fastify._bodyLimit = options.bodyLimit || DEFAULT_BODY_LIMIT
 
   // shorthand methods
   fastify.delete = _delete
@@ -448,7 +448,7 @@ function build (options) {
       throw new Error(`Missing handler function for ${opts.method}:${opts.url} route.`)
     }
 
-    validateBodyLimitOption(opts.jsonBodyLimit)
+    validateBodyLimitOption(opts.bodyLimit)
 
     _fastify.after(function afterRouteAdded (notHandledErr, done) {
       const prefix = _fastify._routePrefix
@@ -466,7 +466,7 @@ function build (options) {
       opts.path = url
       opts.prefix = prefix
       opts.logLevel = opts.logLevel || _fastify._logLevel
-      opts.jsonBodyLimit = opts.jsonBodyLimit || _fastify._jsonBodyLimit
+      opts.bodyLimit = opts.bodyLimit || _fastify._bodyLimit
 
       // run 'onRoute' hooks
       for (var h of onRouteHooks) {
@@ -484,7 +484,7 @@ function build (options) {
         _fastify._contentTypeParser,
         config,
         _fastify._errorHandler,
-        opts.jsonBodyLimit,
+        opts.bodyLimit,
         opts.logLevel,
         _fastify
       )
@@ -537,7 +537,7 @@ function build (options) {
     return _fastify
   }
 
-  function Context (schema, handler, Reply, Request, contentTypeParser, config, errorHandler, jsonBodyLimit, logLevel, fastify) {
+  function Context (schema, handler, Reply, Request, contentTypeParser, config, errorHandler, bodyLimit, logLevel, fastify) {
     this.schema = schema
     this.handler = handler
     this.Reply = Reply
@@ -550,8 +550,8 @@ function build (options) {
     this.config = config
     this.errorHandler = errorHandler
     this._middie = null
-    this._jsonParserOptions = {
-      limit: jsonBodyLimit
+    this._parserOptions = {
+      limit: bodyLimit
     }
     this._fastify = fastify
     this.logLevel = logLevel
@@ -608,10 +608,15 @@ function build (options) {
     return this
   }
 
-  function addContentTypeParser (contentType, fn) {
+  function addContentTypeParser (contentType, opts, parser) {
     throwIfAlreadyStarted('Cannot call "addContentTypeParser" when fastify instance is already started!')
 
-    this._contentTypeParser.add(contentType, fn)
+    if (typeof opts === 'function') {
+      parser = opts
+      opts = {}
+    }
+
+    this._contentTypeParser.add(contentType, opts, parser)
     return this
   }
 
@@ -690,7 +695,7 @@ function build (options) {
       this._contentTypeParser,
       opts.config || {},
       this._errorHandler,
-      this._jsonBodyLimit,
+      this._bodyLimit,
       this._logLevel,
       null
     )

--- a/lib/ContentTypeParser.js
+++ b/lib/ContentTypeParser.js
@@ -19,6 +19,12 @@ ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
     throw new Error(`Content type parser '${contentType}' already present.`)
   }
 
+  if (opts.parseAs !== undefined) {
+    if (opts.parseAs !== 'string' && opts.parseAs !== 'buffer') {
+      throw new Error(`The body parser can only parse your data as 'string' or 'buffer', you asked '${opts.parseAs}' which is not supported.`)
+    }
+  }
+
   const parser = new Parser(
     opts.parseAs === 'string',
     opts.parseAs === 'buffer',

--- a/lib/ContentTypeParser.js
+++ b/lib/ContentTypeParser.js
@@ -43,13 +43,6 @@ ContentTypeParser.prototype.hasParser = function (contentType) {
   return contentType in this.customParsers
 }
 
-ContentTypeParser.prototype.fastHasHeader = function (contentType) {
-  for (var i = 0; i < this.parserList.length; i++) {
-    if (contentType.indexOf(this.parserList[i]) > -1) return true
-  }
-  return false
-}
-
 ContentTypeParser.prototype.getParser = function (contentType) {
   for (var i = 0; i < this.parserList.length; i++) {
     if (contentType.indexOf(this.parserList[i]) > -1) {

--- a/lib/ContentTypeParser.js
+++ b/lib/ContentTypeParser.js
@@ -1,67 +1,174 @@
+/* eslint-disable no-useless-return */
 'use strict'
+
+const lru = require('tiny-lru')
 
 function ContentTypeParser () {
   this.customParsers = {}
-  this.parserList = []
+  this.customParsers['application/json'] = defaultJsonParser
+  this.parserList = ['application/json']
+  this.cache = lru(100)
 }
 
-ContentTypeParser.prototype.add = function (contentType, fn) {
+ContentTypeParser.prototype.add = function (contentType, opts, parser) {
   if (typeof contentType !== 'string') throw new Error('The content type should be a string')
   if (contentType.length === 0) throw new Error('The content type cannot be an empty string')
-  if (typeof fn !== 'function') throw new Error('The content type handler should be a function')
+  if (typeof parser !== 'function') throw new Error('The content type handler should be a function')
 
   if (this.hasParser(contentType)) {
     throw new Error(`Content type parser '${contentType}' already present.`)
   }
+
+  parser.asString = opts.asString === true
+  parser.asBuffer = opts.asBuffer === true
+
   if (contentType === '*') {
     this.parserList.push('')
-    this.customParsers[''] = fn
+    this.customParsers[''] = parser
   } else {
-    this.parserList.unshift(contentType)
-    this.customParsers[contentType] = fn
+    if (contentType !== 'application/json') {
+      this.parserList.unshift(contentType)
+    }
+    this.customParsers[contentType] = parser
   }
 }
 
 ContentTypeParser.prototype.hasParser = function (contentType) {
+  if (contentType === 'application/json') {
+    return this.customParsers['application/json'] !== defaultJsonParser
+  }
   return contentType in this.customParsers
 }
 
 ContentTypeParser.prototype.fastHasHeader = function (contentType) {
-  if (!contentType) return this.hasParser('')
-
   for (var i = 0; i < this.parserList.length; i++) {
     if (contentType.indexOf(this.parserList[i]) > -1) return true
   }
   return false
 }
 
-ContentTypeParser.prototype.getHandler = function (contentType) {
-  if (contentType === undefined) return this.customParsers['']
-
+ContentTypeParser.prototype.getParser = function (contentType) {
   for (var i = 0; i < this.parserList.length; i++) {
     if (contentType.indexOf(this.parserList[i]) > -1) {
-      return this.customParsers[this.parserList[i]]
+      var parser = this.customParsers[this.parserList[i]]
+      this.cache.set(contentType, parser)
+      return parser
     }
   }
+
+  return this.customParsers['']
 }
 
 ContentTypeParser.prototype.run = function (contentType, handler, request, reply) {
-  var result = this.getHandler(contentType)(request.raw, done)
-  if (result && typeof result.then === 'function') {
-    result
-      .then(body => done(null, body))
-      .catch(done)
+  var parser = this.cache.get[contentType] || this.getParser(contentType)
+  if (parser === undefined) {
+    reply.code(415).send(new Error('Unsupported Media Type: ' + contentType))
+  } else {
+    if (parser.asString === true || parser.asBuffer === true) {
+      rawBody(
+        request,
+        reply,
+        reply.context._parserOptions,
+        parser,
+        done
+      )
+    } else {
+      var result = parser(request.raw, done)
+      if (result && typeof result.then === 'function') {
+        result.then(body => done(null, body), done)
+      }
+    }
   }
 
   function done (error, body) {
     if (error) {
-      return reply.send(error)
+      reply.send(error)
+    } else {
+      request.body = body
+      handler(reply)
     }
-
-    request.body = body
-    handler(reply)
   }
 }
+
+function rawBody (request, reply, options, parser, done) {
+  var asString = parser.asString
+  var limit = options.limit
+  var contentLength = request.headers['content-length'] === undefined
+    ? NaN
+    : Number.parseInt(request.headers['content-length'], 10)
+
+  if (contentLength > limit) {
+    reply.code(413).send(new Error('Request body is too large'))
+    return
+  }
+
+  var receivedLength = 0
+  var body = asString === true ? '' : []
+  var req = request.raw
+
+  req.on('data', onData)
+  req.on('end', onEnd)
+  req.on('error', onEnd)
+
+  function onData (chunk) {
+    receivedLength += chunk.length
+
+    if (receivedLength > limit) {
+      req.removeListener('data', onData)
+      req.removeListener('end', onEnd)
+      req.removeListener('error', onEnd)
+      reply.code(413).send(new Error('Request body is too large'))
+      return
+    }
+
+    if (asString === true) {
+      body += chunk.toString()
+    } else {
+      body.push(chunk)
+    }
+  }
+
+  function onEnd (err) {
+    req.removeListener('data', onData)
+    req.removeListener('end', onEnd)
+    req.removeListener('error', onEnd)
+
+    if (err !== undefined) {
+      reply.code(400).send(err)
+      return
+    }
+
+    if (!Number.isNaN(contentLength) && receivedLength !== contentLength) {
+      reply.code(400).send(new Error('Request body size did not match Content-Length'))
+      return
+    }
+
+    if (receivedLength === 0) {
+      reply.code(400).send(new Error('Unexpected end of body input'))
+      return
+    }
+
+    if (asString === false) {
+      body = Buffer.concat(body)
+    }
+
+    var result = parser(request, reply, body, done)
+    if (result && typeof result.then === 'function') {
+      result.then(body => done(null, body), done)
+    }
+  }
+}
+
+function defaultJsonParser (request, reply, body, done) {
+  try {
+    var json = JSON.parse(body)
+  } catch (err) {
+    err.statusCode = 400
+    return done(err, undefined)
+  }
+  done(null, json)
+}
+defaultJsonParser.asString = true
 
 function buildContentTypeParser (c) {
   const contentTypeParser = new ContentTypeParser()

--- a/lib/ContentTypeParser.js
+++ b/lib/ContentTypeParser.js
@@ -5,22 +5,25 @@ const lru = require('tiny-lru')
 
 function ContentTypeParser () {
   this.customParsers = {}
-  this.customParsers['application/json'] = defaultJsonParser
+  this.customParsers['application/json'] = new Parser(true, false, defaultJsonParser)
   this.parserList = ['application/json']
   this.cache = lru(100)
 }
 
-ContentTypeParser.prototype.add = function (contentType, opts, parser) {
+ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
   if (typeof contentType !== 'string') throw new Error('The content type should be a string')
   if (contentType.length === 0) throw new Error('The content type cannot be an empty string')
-  if (typeof parser !== 'function') throw new Error('The content type handler should be a function')
+  if (typeof parserFn !== 'function') throw new Error('The content type handler should be a function')
 
   if (this.hasParser(contentType)) {
     throw new Error(`Content type parser '${contentType}' already present.`)
   }
 
-  parser.asString = opts.asString === true
-  parser.asBuffer = opts.asBuffer === true
+  const parser = new Parser(
+    opts.parseAs === 'string',
+    opts.parseAs === 'buffer',
+    parserFn
+  )
 
   if (contentType === '*') {
     this.parserList.push('')
@@ -35,7 +38,7 @@ ContentTypeParser.prototype.add = function (contentType, opts, parser) {
 
 ContentTypeParser.prototype.hasParser = function (contentType) {
   if (contentType === 'application/json') {
-    return this.customParsers['application/json'] !== defaultJsonParser
+    return this.customParsers['application/json'].fn !== defaultJsonParser
   }
   return contentType in this.customParsers
 }
@@ -60,7 +63,7 @@ ContentTypeParser.prototype.getParser = function (contentType) {
 }
 
 ContentTypeParser.prototype.run = function (contentType, handler, request, reply) {
-  var parser = this.cache.get[contentType] || this.getParser(contentType)
+  var parser = this.cache.get(contentType) || this.getParser(contentType)
   if (parser === undefined) {
     reply.code(415).send(new Error('Unsupported Media Type: ' + contentType))
   } else {
@@ -73,7 +76,7 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
         done
       )
     } else {
-      var result = parser(request.raw, done)
+      var result = parser.fn(request.raw, done)
       if (result && typeof result.then === 'function') {
         result.then(body => done(null, body), done)
       }
@@ -152,7 +155,7 @@ function rawBody (request, reply, options, parser, done) {
       body = Buffer.concat(body)
     }
 
-    var result = parser(request, reply, body, done)
+    var result = parser.fn(request, reply, body, done)
     if (result && typeof result.then === 'function') {
       result.then(body => done(null, body), done)
     }
@@ -168,13 +171,18 @@ function defaultJsonParser (request, reply, body, done) {
   }
   done(null, json)
 }
-defaultJsonParser.asString = true
 
 function buildContentTypeParser (c) {
   const contentTypeParser = new ContentTypeParser()
   Object.assign(contentTypeParser.customParsers, c.customParsers)
   contentTypeParser.parserList = c.parserList.slice()
   return contentTypeParser
+}
+
+function Parser (asString, asBuffer, fn) {
+  this.asString = asString
+  this.asBuffer = asBuffer
+  this.fn = fn
 }
 
 module.exports = ContentTypeParser

--- a/lib/ContentTypeParser.js
+++ b/lib/ContentTypeParser.js
@@ -154,14 +154,14 @@ function rawBody (request, reply, options, parser, done) {
       body = Buffer.concat(body)
     }
 
-    var result = parser.fn(request, reply, body, done)
+    var result = parser.fn(req, body, done)
     if (result && typeof result.then === 'function') {
       result.then(body => done(null, body), done)
     }
   }
 }
 
-function defaultJsonParser (request, reply, body, done) {
+function defaultJsonParser (req, body, done) {
   try {
     var json = JSON.parse(body)
   } catch (err) {

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -30,109 +30,25 @@ function handleRequest (req, res, params, context) {
         (headers['content-length'] === '0' || headers['content-length'] === undefined)
       ) { // Request has no body to parse
         handler(reply)
-        return
+      } else {
+        context.contentTypeParser.run('', handler, request, reply)
       }
-      // Fall through to check for a custom parser
-    } else if (contentType.indexOf('application/json') > -1) {
-      jsonBody(request, reply, context._jsonParserOptions)
-      return
-    }
-
-    // custom parser for a given content type
-    if (context.contentTypeParser.fastHasHeader(contentType)) {
+    } else {
       context.contentTypeParser.run(contentType, handler, request, reply)
-      return
     }
-
-    reply.code(415).send(new Error('Unsupported Media Type: ' + contentType))
     return
   }
 
   if (method === 'OPTIONS' || method === 'DELETE') {
-    if (!contentType) {
+    if (contentType === undefined) {
       handler(reply)
-      return
-    }
-
-    // application/json content type
-    if (contentType.indexOf('application/json') > -1) {
-      jsonBody(request, reply, context._jsonParserOptions)
-      return
-    }
-    // custom parser for a given content type
-    if (context.contentTypeParser.fastHasHeader(contentType)) {
+    } else {
       context.contentTypeParser.run(contentType, handler, request, reply)
-      return
     }
-
-    reply.code(415).send(new Error('Unsupported Media Type: ' + contentType))
     return
   }
 
   reply.code(405).send(new Error('Method Not Allowed: ' + method))
-}
-
-function jsonBody (request, reply, options) {
-  const limit = options.limit
-  const contentLength = request.headers['content-length'] === undefined
-    ? NaN
-    : Number.parseInt(request.headers['content-length'], 10)
-
-  if (contentLength > limit) {
-    reply.code(413).send(new Error('Request body is too large'))
-    return
-  }
-
-  var receivedLength = 0
-  var body = ''
-  var req = request.raw
-
-  req.on('data', onData)
-  req.on('end', onEnd)
-  req.on('error', onEnd)
-
-  function onData (chunk) {
-    receivedLength += chunk.length
-
-    if (receivedLength > limit) {
-      req.removeListener('data', onData)
-      req.removeListener('end', onEnd)
-      req.removeListener('error', onEnd)
-      reply.code(413).send(new Error('Request body is too large'))
-      return
-    }
-
-    body += chunk.toString()
-  }
-
-  function onEnd (err) {
-    req.removeListener('data', onData)
-    req.removeListener('end', onEnd)
-    req.removeListener('error', onEnd)
-
-    if (err !== undefined) {
-      reply.code(400).send(err)
-      return
-    }
-
-    if (!Number.isNaN(contentLength) && receivedLength !== contentLength) {
-      reply.code(400).send(new Error('Request body size did not match Content-Length'))
-      return
-    }
-
-    if (receivedLength === 0) { // Body is invalid JSON
-      reply.code(400).send(new Error('Unexpected end of JSON input'))
-      return
-    }
-
-    try {
-      request.body = JSON.parse(body)
-    } catch (err) {
-      reply.code(400).send(err)
-      return
-    }
-    handler(reply)
-  }
 }
 
 function handler (reply) {
@@ -195,4 +111,4 @@ function wrapValidationError (valid) {
 }
 
 module.exports = handleRequest
-module.exports[Symbol.for('internals')] = { jsonBody, handler }
+module.exports[Symbol.for('internals')] = { handler }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
     "flatstr": "^1.0.5",
     "light-my-request": "^2.0.1",
     "middie": "^3.1.0",
-    "pino": "^4.10.4"
+    "pino": "^4.10.4",
+    "tiny-lru": "^1.5.0"
   },
   "greenkeeper": {
     "ignore": [

--- a/test/custom-parser-async.js
+++ b/test/custom-parser-async.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const t = require('tap')
 const test = t.test
 const sget = require('simple-get').concat

--- a/test/custom-parser.test.js
+++ b/test/custom-parser.test.js
@@ -515,7 +515,7 @@ test('Should get the body as string', t => {
     reply.send(req.body)
   })
 
-  fastify.addContentTypeParser('application/json', { asString: true }, function (req, reply, body, done) {
+  fastify.addContentTypeParser('application/json', { parseAs: 'string' }, function (req, reply, body, done) {
     t.ok('called')
     t.ok(typeof body === 'string')
     try {
@@ -554,7 +554,7 @@ test('Should get the body as buffer', t => {
     reply.send(req.body)
   })
 
-  fastify.addContentTypeParser('application/json', { asBuffer: true }, function (req, reply, body, done) {
+  fastify.addContentTypeParser('application/json', { parseAs: 'buffer' }, function (req, reply, body, done) {
     t.ok('called')
     t.ok(Buffer.isBuffer(body))
     try {

--- a/test/custom-parser.test.js
+++ b/test/custom-parser.test.js
@@ -515,7 +515,7 @@ test('Should get the body as string', t => {
     reply.send(req.body)
   })
 
-  fastify.addContentTypeParser('application/json', { parseAs: 'string' }, function (req, reply, body, done) {
+  fastify.addContentTypeParser('application/json', { parseAs: 'string' }, function (req, body, done) {
     t.ok('called')
     t.ok(typeof body === 'string')
     try {
@@ -554,9 +554,9 @@ test('Should get the body as buffer', t => {
     reply.send(req.body)
   })
 
-  fastify.addContentTypeParser('application/json', { parseAs: 'buffer' }, function (req, reply, body, done) {
+  fastify.addContentTypeParser('application/json', { parseAs: 'buffer' }, function (req, body, done) {
     t.ok('called')
-    t.ok(Buffer.isBuffer(body))
+    t.ok(body instanceof Buffer)
     try {
       var json = JSON.parse(body)
       done(null, json)

--- a/test/custom-parser.test.js
+++ b/test/custom-parser.test.js
@@ -618,3 +618,15 @@ test('The charset should not interfere with the content type handling', t => {
     })
   })
 })
+
+test('Wrong parseAs parameter', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  try {
+    fastify.addContentTypeParser('application/json', { parseAs: 'fireworks' }, () => {})
+    t.fail('should throw')
+  } catch (err) {
+    t.is(err.message, 'The body parser can only parse your data as \'string\' or \'buffer\', you asked \'fireworks\' which is not supported.')
+  }
+})

--- a/test/helper.js
+++ b/test/helper.js
@@ -64,7 +64,7 @@ module.exports.payloadMethod = function (method, t) {
   test(`${upMethod} with jsonBodyLimit option`, t => {
     t.plan(1)
     try {
-      fastify[loMethod]('/with-limit', { jsonBodyLimit: 1 }, function (req, reply) {
+      fastify[loMethod]('/with-limit', { bodyLimit: 1 }, function (req, reply) {
         reply.send(req.body)
       })
       t.pass()

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -102,13 +102,6 @@ test('handler function - reply', t => {
   internals.handler(new Reply(res, context, {}))
 })
 
-test('jsonBody should be a function', t => {
-  t.plan(2)
-
-  t.is(typeof internals.jsonBody, 'function')
-  t.is(internals.jsonBody.length, 3)
-})
-
 test('request should be defined in onSend Hook on post request with content type application/json', t => {
   t.plan(7)
   const fastify = require('../..')()

--- a/test/jsonBodyLimit.test.js
+++ b/test/jsonBodyLimit.test.js
@@ -9,20 +9,20 @@ test('jsonBodyLimit', t => {
   t.plan(5)
 
   try {
-    Fastify({ jsonBodyLimit: 1.3 })
+    Fastify({ bodyLimit: 1.3 })
     t.fail('option must be an integer')
   } catch (err) {
     t.ok(err)
   }
 
   try {
-    Fastify({ jsonBodyLimit: [] })
+    Fastify({ bodyLimit: [] })
     t.fail('option must be an integer')
   } catch (err) {
     t.ok(err)
   }
 
-  const fastify = Fastify({ jsonBodyLimit: 1 })
+  const fastify = Fastify({ bodyLimit: 1 })
 
   fastify.post('/', (request, reply) => {
     reply.send({error: 'handler should not be called'})


### PR DESCRIPTION
Hi all!
With this pr we change how works our internal body parsers, some users asked us if we could provide a better content type parser API, not everybody wants to handle a stream and we are already doing that internally (with a very low overhead). This pr updates the `addContentTypeParser` API by adding an options object, if the user passes  `{ asString: true }` it will get the body as string, with `{ asBuffer: true }` it will get the body as buffer.

To avoid breaking the compatibility with the ecosystem if the option object is not provided the callback function will be the same as before `function (rawRequest, done)`, instead, if the options object is provided (with the above options) the function signature will be  `function (request, reply, body, done)`.

The only breaking change we are introducing in the API, is the rename of `jsonBodyLimit` option, that becomes `bodyLimit`.

From now it will be possible overwrite our default JSON parser.
I'll update the documentation once we all agree on the API.

There are no significant changes in the benchmarks 🎉 

Related: #643 #707 #782

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
