### PR TITLE
Create a separate hook runner for onSend hooks

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -22,7 +22,7 @@ const Hooks = require('./lib/hooks')
 const Schemas = require('./lib/schemas')
 const loggerUtils = require('./lib/logger')
 const pluginUtils = require('./lib/pluginUtils')
-const runHooks = require('./lib/hookRunner')
+const runHooks = require('./lib/hookRunner').hookRunner
 
 const DEFAULT_BODY_LIMIT = 1024 * 1024 // 1 MiB
 const childrenKey = Symbol('fastify.children')

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -5,7 +5,7 @@ const fastJsonStringify = require('fast-json-stringify')
 const urlUtil = require('url')
 const validation = require('./validation')
 const validateSchema = validation.validate
-const runHooks = require('./hookRunner')
+const runHooks = require('./hookRunner').hookRunner
 
 const schemas = require('./schemas.json')
 const inputSchemaError = fastJsonStringify(schemas.inputSchemaError)

--- a/lib/hookRunner.js
+++ b/lib/hookRunner.js
@@ -3,18 +3,9 @@
 function hookRunner (functions, runner, state, cb) {
   var i = 0
 
-  function next (err, value) {
-    if (err) {
+  function next (err) {
+    if (err || i === functions.length) {
       cb(err, state)
-      return
-    }
-
-    if (value !== undefined) {
-      state = value
-    }
-
-    if (i === functions.length) {
-      cb(null, state)
       return
     }
 
@@ -24,8 +15,8 @@ function hookRunner (functions, runner, state, cb) {
     }
   }
 
-  function handleResolve (value) {
-    next(null, value)
+  function handleResolve () {
+    next()
   }
 
   function handleReject (err) {
@@ -35,4 +26,39 @@ function hookRunner (functions, runner, state, cb) {
   next()
 }
 
-module.exports = hookRunner
+function onSendHookRunner (functions, reply, payload, cb) {
+  var i = 0
+
+  function next (err, newPayload) {
+    if (err) {
+      cb(err, reply, payload)
+      return
+    }
+
+    if (newPayload !== undefined) {
+      payload = newPayload
+    }
+
+    if (i === functions.length) {
+      cb(null, reply, payload)
+      return
+    }
+
+    const result = functions[i++](reply.request, reply, payload, next)
+    if (result && typeof result.then === 'function') {
+      result.then(handleResolve, handleReject)
+    }
+  }
+
+  function handleResolve (newPayload) {
+    next(null, newPayload)
+  }
+
+  function handleReject (err) {
+    cb(err, reply, payload)
+  }
+
+  next()
+}
+
+module.exports = { hookRunner, onSendHookRunner }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -8,7 +8,7 @@ const serialize = validation.serialize
 const statusCodes = require('http').STATUS_CODES
 const flatstr = require('flatstr')
 const FJS = require('fast-json-stringify')
-const runHooks = require('./hookRunner')
+const runHooks = require('./hookRunner').onSendHookRunner
 
 const serializeError = FJS({
   type: 'object',
@@ -122,24 +122,20 @@ function onSendHook (reply, payload) {
   if (reply.context.onSend !== null) {
     runHooks(
       reply.context.onSend,
-      hookIterator.bind(reply),
+      reply,
       payload,
-      wrapOnSendEnd.bind(reply)
+      wrapOnSendEnd
     )
   } else {
     onSendEnd(reply, payload)
   }
 }
 
-function hookIterator (fn, payload, next) {
-  return fn(this.request, this, payload, next)
-}
-
-function wrapOnSendEnd (err, payload) {
+function wrapOnSendEnd (err, reply, payload) {
   if (err) {
-    handleError(this, err)
+    handleError(reply, err)
   } else {
-    onSendEnd(this, payload)
+    onSendEnd(reply, payload)
   }
 }
 

--- a/test/internals/hookRunner.test.js
+++ b/test/internals/hookRunner.test.js
@@ -2,229 +2,413 @@
 
 const t = require('tap')
 const test = t.test
-const runHooks = require('../../lib/hookRunner')
+const runHooks = require('../../lib/hookRunner').hookRunner
+const runOnSendHooks = require('../../lib/hookRunner').onSendHookRunner
 
-test('Basic', t => {
+test('hookRunner - Basic', t => {
   t.plan(8)
 
-  const v1 = { hello: 'world' }
-  const v2 = { ciao: 'mondo' }
-  const v3 = { winter: 'is coming' }
-  const v4 = { winter: 'has come' }
-  const context = { context: true }
+  const originalState = { a: 'a', b: 'b' }
 
-  runHooks([fn1.bind(context), fn2.bind(context), fn3.bind(context)], iterator.bind({ a: 'a', b: 'b' }), v1, done)
+  runHooks([fn1, fn2, fn3], iterator, originalState, done)
 
-  function iterator (fn, value, next) {
-    return fn(this.a, this.b, value, next)
+  function iterator (fn, state, next) {
+    return fn(state.a, state.b, next)
   }
 
-  function fn1 (a, b, value, done) {
-    t.strictEqual(value, v1)
-    t.strictEqual(this, context)
-    done(null, v2)
+  function fn1 (a, b, next) {
+    t.strictEqual(a, 'a')
+    t.strictEqual(b, 'b')
+    next()
   }
 
-  function fn2 (a, b, value, done) {
-    t.strictEqual(value, v2)
-    t.strictEqual(this, context)
-    done(null, v3)
+  function fn2 (a, b, next) {
+    t.strictEqual(a, 'a')
+    t.strictEqual(b, 'b')
+    next()
   }
 
-  function fn3 (a, b, value, done) {
-    t.strictEqual(value, v3)
-    t.strictEqual(this, context)
-    done(null, v4)
+  function fn3 (a, b, next) {
+    t.strictEqual(a, 'a')
+    t.strictEqual(b, 'b')
+    next()
   }
 
-  function done (err, value) {
+  function done (err, state) {
     t.error(err)
-    t.strictEqual(value, v4)
+    t.strictEqual(state, originalState)
   }
 })
 
-test('In case of error should skip to done', t => {
+test('hookRunner - In case of error should skip to done', t => {
   t.plan(6)
 
-  const v1 = { hello: 'world' }
-  const v2 = { ciao: 'mondo' }
-  const context = { context: true }
+  const originalState = { a: 'a', b: 'b' }
 
-  runHooks([fn1.bind(context), fn2.bind(context), fn3.bind(context)], iterator.bind({ a: 'a', b: 'b' }), v1, done)
+  runHooks([fn1, fn2, fn3], iterator, originalState, done)
 
-  function iterator (fn, value, next) {
-    return fn(this.a, this.b, value, next)
+  function iterator (fn, state, next) {
+    return fn(state.a, state.b, next)
   }
 
-  function fn1 (a, b, value, done) {
-    t.strictEqual(value, v1)
-    t.strictEqual(this, context)
-    done(null, v2)
+  function fn1 (a, b, next) {
+    t.strictEqual(a, 'a')
+    t.strictEqual(b, 'b')
+    next()
   }
 
-  function fn2 (a, b, value, done) {
-    t.strictEqual(value, v2)
-    t.strictEqual(this, context)
-    done(new Error('kaboom'))
+  function fn2 (a, b, next) {
+    t.strictEqual(a, 'a')
+    t.strictEqual(b, 'b')
+    next(new Error('kaboom'))
   }
 
-  function fn3 (a, b, value, done) {
+  function fn3 () {
     t.fail('We should not be here')
   }
 
-  function done (err, value) {
-    t.is(err.message, 'kaboom')
-    t.strictEqual(value, v2)
+  function done (err, state) {
+    t.strictEqual(err.message, 'kaboom')
+    t.strictEqual(state, originalState)
   }
 })
 
-test('Clean next', t => {
+test('hookRunner - Should handle promises', t => {
   t.plan(8)
 
-  const v1 = { hello: 'world' }
-  const context = { context: true }
+  const originalState = { a: 'a', b: 'b' }
 
-  runHooks([fn1.bind(context), fn2.bind(context), fn3.bind(context)], iterator.bind({ a: 'a', b: 'b' }), v1, done)
+  runHooks([fn1, fn2, fn3], iterator, originalState, done)
 
-  function iterator (fn, value, next) {
-    return fn(this.a, this.b, value, next)
+  function iterator (fn, state, next) {
+    return fn(state.a, state.b, next)
   }
 
-  function fn1 (a, b, value, done) {
-    t.strictEqual(value, v1)
-    t.strictEqual(this, context)
-    done()
+  function fn1 (a, b) {
+    t.strictEqual(a, 'a')
+    t.strictEqual(b, 'b')
+    return Promise.resolve()
   }
 
-  function fn2 (a, b, value, done) {
-    t.strictEqual(value, v1)
-    t.strictEqual(this, context)
-    done()
+  function fn2 (a, b) {
+    t.strictEqual(a, 'a')
+    t.strictEqual(b, 'b')
+    return Promise.resolve()
   }
 
-  function fn3 (a, b, value, done) {
-    t.strictEqual(value, v1)
-    t.strictEqual(this, context)
-    done()
+  function fn3 (a, b) {
+    t.strictEqual(a, 'a')
+    t.strictEqual(b, 'b')
+    return Promise.resolve()
   }
 
-  function done (err, value) {
+  function done (err, state) {
     t.error(err)
-    t.strictEqual(value, v1)
+    t.strictEqual(state, originalState)
   }
 })
 
-test('Should handle promises', t => {
-  t.plan(8)
-
-  const v1 = { hello: 'world' }
-  const v2 = { ciao: 'mondo' }
-  const v3 = { winter: 'is coming' }
-  const v4 = { winter: 'has come' }
-  const context = { context: true }
-
-  runHooks([fn1.bind(context), fn2.bind(context), fn3.bind(context)], iterator.bind({ a: 'a', b: 'b' }), v1, done)
-
-  function iterator (fn, value, next) {
-    return fn(this.a, this.b, value, next)
-  }
-
-  function fn1 (a, b, value) {
-    t.strictEqual(value, v1)
-    t.strictEqual(this, context)
-    return new Promise((resolve, reject) => {
-      resolve(v2)
-    })
-  }
-
-  function fn2 (a, b, value, done) {
-    t.strictEqual(value, v2)
-    t.strictEqual(this, context)
-    return new Promise((resolve, reject) => {
-      resolve(v3)
-    })
-  }
-
-  function fn3 (a, b, value, done) {
-    t.strictEqual(value, v3)
-    t.strictEqual(this, context)
-    return new Promise((resolve, reject) => {
-      resolve(v4)
-    })
-  }
-
-  function done (err, value) {
-    t.error(err)
-    t.strictEqual(value, v4)
-  }
-})
-
-test('In case of error should skip to done (with promises)', t => {
+test('hookRunner - In case of error should skip to done (with promises)', t => {
   t.plan(6)
 
-  const v1 = { hello: 'world' }
-  const v2 = { ciao: 'mondo' }
-  const context = { context: true }
+  const originalState = { a: 'a', b: 'b' }
 
-  runHooks([fn1.bind(context), fn2.bind(context), fn3.bind(context)], iterator.bind({ a: 'a', b: 'b' }), v1, done)
+  runHooks([fn1, fn2, fn3], iterator, originalState, done)
 
-  function iterator (fn, value, next) {
-    return fn(this.a, this.b, value, next)
+  function iterator (fn, state, next) {
+    return fn(state.a, state.b, next)
   }
 
-  function fn1 (a, b, value, done) {
-    t.strictEqual(value, v1)
-    t.strictEqual(this, context)
-    return new Promise((resolve, reject) => {
-      resolve(v2)
-    })
+  function fn1 (a, b) {
+    t.strictEqual(a, 'a')
+    t.strictEqual(b, 'b')
+    return Promise.resolve()
   }
 
-  function fn2 (a, b, value, done) {
-    t.strictEqual(value, v2)
-    t.strictEqual(this, context)
-    return new Promise((resolve, reject) => {
-      reject(new Error('kaboom'))
-    })
+  function fn2 (a, b) {
+    t.strictEqual(a, 'a')
+    t.strictEqual(b, 'b')
+    return Promise.reject(new Error('kaboom'))
   }
 
-  function fn3 (a, b, value, done) {
+  function fn3 () {
     t.fail('We should not be here')
   }
 
-  function done (err, value) {
-    t.is(err.message, 'kaboom')
-    t.strictEqual(value, v2)
+  function done (err, state) {
+    t.strictEqual(err.message, 'kaboom')
+    t.strictEqual(state, originalState)
   }
 })
 
-test('Be able to exit before its natural end', t => {
-  t.plan(4)
+test('hookRunner - Be able to exit before its natural end', t => {
+  t.plan(2)
 
-  const v1 = { hello: 'world' }
-  const v2 = { ciao: 'mondo' }
-  const v3 = { winter: 'is coming' }
-  const context = { context: true }
+  const originalState = { a: 'a', b: 'b' }
 
-  runHooks([fn1.bind(context), fn2.bind(context), fn3.bind(context)], iterator.bind({ a: 'a', b: 'b' }), v1, done)
+  runHooks([fn1, fn2, fn3], iterator, originalState, done)
 
-  function iterator (fn, value, next) {
-    if (value.winter) {
+  function iterator (fn, state, next) {
+    if (state.stop) {
       return undefined
     }
-    return fn(this.a, this.b, value, next)
+    return fn(state, next)
   }
 
-  function fn1 (a, b, value, done) {
-    t.strictEqual(value, v1)
-    t.strictEqual(this, context)
-    done(null, v2)
+  function fn1 (state, next) {
+    t.strictEqual(state, originalState)
+    next()
   }
 
-  function fn2 (a, b, value, done) {
-    t.strictEqual(value, v2)
-    t.strictEqual(this, context)
-    done(null, v3)
+  function fn2 (state) {
+    t.strictEqual(state, originalState)
+    state.stop = true
+    return Promise.resolve()
+  }
+
+  function fn3 () {
+    t.fail('this should not be called')
+  }
+
+  function done () {
+    t.fail('this should not be called')
+  }
+})
+
+test('hookRunner - Promises that resolve to a value do not change the state', t => {
+  t.plan(5)
+
+  const originalState = { a: 'a', b: 'b' }
+
+  runHooks([fn1, fn2, fn3], iterator, originalState, done)
+
+  function iterator (fn, state, next) {
+    return fn(state, next)
+  }
+
+  function fn1 (state, next) {
+    t.strictEqual(state, originalState)
+    return Promise.resolve(null)
+  }
+
+  function fn2 (state, next) {
+    t.strictEqual(state, originalState)
+    return Promise.resolve('string')
+  }
+
+  function fn3 (state, next) {
+    t.strictEqual(state, originalState)
+    return Promise.resolve({ object: true })
+  }
+
+  function done (err, state) {
+    t.error(err)
+    t.strictEqual(state, originalState)
+  }
+})
+
+test('onSendHookRunner - Basic', t => {
+  t.plan(12)
+
+  const originalReply = { request: {} }
+  const originalPayload = 'payload'
+
+  runOnSendHooks([fn1, fn2, fn3], originalReply, originalPayload, done)
+
+  function fn1 (request, reply, payload, next) {
+    t.strictEqual(request, originalReply.request)
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, originalPayload)
+    next()
+  }
+
+  function fn2 (request, reply, payload, next) {
+    t.strictEqual(request, originalReply.request)
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, originalPayload)
+    next()
+  }
+
+  function fn3 (request, reply, payload, next) {
+    t.strictEqual(request, originalReply.request)
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, originalPayload)
+    next()
+  }
+
+  function done (err, reply, payload) {
+    t.error(err)
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, originalPayload)
+  }
+})
+
+test('onSendHookRunner - Can change the payload', t => {
+  t.plan(12)
+
+  const originalReply = { request: {} }
+  const v1 = { hello: 'world' }
+  const v2 = { ciao: 'mondo' }
+  const v3 = { winter: 'is coming' }
+  const v4 = { winter: 'has come' }
+
+  runOnSendHooks([fn1, fn2, fn3], originalReply, v1, done)
+
+  function fn1 (request, reply, payload, next) {
+    t.strictEqual(request, originalReply.request)
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, v1)
+    next(null, v2)
+  }
+
+  function fn2 (request, reply, payload, next) {
+    t.strictEqual(request, originalReply.request)
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, v2)
+    next(null, v3)
+  }
+
+  function fn3 (request, reply, payload, next) {
+    t.strictEqual(request, originalReply.request)
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, v3)
+    next(null, v4)
+  }
+
+  function done (err, reply, payload) {
+    t.error(err)
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, v4)
+  }
+})
+
+test('onSendHookRunner - In case of error should skip to done', t => {
+  t.plan(9)
+
+  const originalReply = { request: {} }
+  const v1 = { hello: 'world' }
+  const v2 = { ciao: 'mondo' }
+
+  runOnSendHooks([fn1, fn2, fn3], originalReply, v1, done)
+
+  function fn1 (request, reply, payload, next) {
+    t.strictEqual(request, originalReply.request)
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, v1)
+    next(null, v2)
+  }
+
+  function fn2 (request, reply, payload, next) {
+    t.strictEqual(request, originalReply.request)
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, v2)
+    next(new Error('kaboom'))
+  }
+
+  function fn3 () {
+    t.fail('We should not be here')
+  }
+
+  function done (err, reply, payload) {
+    t.strictEqual(err.message, 'kaboom')
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, v2)
+  }
+})
+
+test('onSendHookRunner - Should handle promises', t => {
+  t.plan(12)
+
+  const originalReply = { request: {} }
+  const v1 = { hello: 'world' }
+  const v2 = { ciao: 'mondo' }
+  const v3 = { winter: 'is coming' }
+  const v4 = { winter: 'has come' }
+
+  runOnSendHooks([fn1, fn2, fn3], originalReply, v1, done)
+
+  function fn1 (request, reply, payload) {
+    t.strictEqual(request, originalReply.request)
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, v1)
+    return Promise.resolve(v2)
+  }
+
+  function fn2 (request, reply, payload) {
+    t.strictEqual(request, originalReply.request)
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, v2)
+    return Promise.resolve(v3)
+  }
+
+  function fn3 (request, reply, payload) {
+    t.strictEqual(request, originalReply.request)
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, v3)
+    return Promise.resolve(v4)
+  }
+
+  function done (err, reply, payload) {
+    t.error(err)
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, v4)
+  }
+})
+
+test('onSendHookRunner - In case of error should skip to done (with promises)', t => {
+  t.plan(9)
+
+  const originalReply = { request: {} }
+  const v1 = { hello: 'world' }
+  const v2 = { ciao: 'mondo' }
+
+  runOnSendHooks([fn1, fn2, fn3], originalReply, v1, done)
+
+  function fn1 (request, reply, payload) {
+    t.strictEqual(request, originalReply.request)
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, v1)
+    return Promise.resolve(v2)
+  }
+
+  function fn2 (request, reply, payload) {
+    t.strictEqual(request, originalReply.request)
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, v2)
+    return Promise.reject(new Error('kaboom'))
+  }
+
+  function fn3 () {
+    t.fail('We should not be here')
+  }
+
+  function done (err, reply, payload) {
+    t.strictEqual(err.message, 'kaboom')
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, v2)
+  }
+})
+
+test('onSendHookRunner - Be able to exit before its natural end', t => {
+  t.plan(6)
+
+  const originalReply = { request: {} }
+  const v1 = { hello: 'world' }
+  const v2 = { ciao: 'mondo' }
+
+  runOnSendHooks([fn1, fn2, fn3], originalReply, v1, done)
+
+  function fn1 (request, reply, payload, next) {
+    t.strictEqual(request, originalReply.request)
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, v1)
+    next(null, v2)
+  }
+
+  function fn2 (request, reply, payload) {
+    t.strictEqual(request, originalReply.request)
+    t.strictEqual(reply, originalReply)
+    t.strictEqual(payload, v2)
   }
 
   function fn3 () {


### PR DESCRIPTION
The `onSend` hooks are a special case because they need extra logic for changing the payload. This extra logic is not needed for the other hooks and it makes the other hooks prone to a bug where the hook runner's internal state will be changed if a hook function returns a promise that resolves to a value other than `undefined`.

<details>
<summary>Example of the bug that this change prevents</summary>

```js
const fastify = require('./')()

fastify.addHook('preHandler', (request, reply) => {
  return Promise.resolve() // OK
})

fastify.addHook('preHandler', (request, reply) => {
  return Promise.resolve(true) // Causes crash
})

fastify.get('/', (request, reply) => {
  reply.send('hello')
})

fastify.inject('/', (err, res) => {
  console.log('Will not reach here')
})
```

```
(node:12944) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'finished' of undefined
    at preHandlerCallback (~/fastify/lib/handleRequest.js:80:17)
    at next (~/fastify/lib/hookRunner.js:17:7)
    at handleResolve (~/fastify/lib/hookRunner.js:28:5)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:160:7)
    at Function.Module.runMain (module.js:703:11)
    at startup (bootstrap_node.js:190:16)
    at bootstrap_node.js:662:3
```
</details><br>

This change adds a second hook runner just for `onSend` hooks that helps make the code that starts the hooks cleaner (it's no longer necessary to call `.bind(reply)` during a request) and the main hook runner is simplified so that changing its internal state is no longer possible.

This also improves the hooks benchmark by 450-600 req/sec.

<details>
<summary>Benchmark</summary>

**Before**
```
[1] Stat         Avg     Stdev   Max
[1] Latency (ms) 2.58    6.92    195.71
[1] Req/Sec      35211.2 6839.11 39080
[1] Bytes/Sec    5.26 MB 1.03 MB 5.82 MB
[1]
[1] 176k requests in 5s, 26.2 MB read
...
[1] Stat         Avg     Stdev   Max
[1] Latency (ms) 2.61    6.8     165.82
[1] Req/Sec      34753.6 7256.24 39432
[1] Bytes/Sec    5.23 MB 1.08 MB 5.88 MB
[1]
[1] 174k requests in 5s, 25.9 MB read
```

**After**
```
[1] Stat         Avg      Stdev   Max
[1] Latency (ms) 2.57     7.03    198.39
[1] Req/Sec      35204.81 7148.29 40124
[1] Bytes/Sec    5.23 MB  1.08 MB 5.98 MB
[1]
[1] 176k requests in 5s, 26.2 MB read
...
[1] Stat         Avg      Stdev   Max
[1] Latency (ms) 2.53     6.8     190.88
[1] Req/Sec      35812.81 6979.73 39894
[1] Bytes/Sec    5.31 MB  1.05 MB 5.94 MB
[1]
[1] 179k requests in 5s, 26.7 MB read
```
</details>

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
