### PR TITLE
Add .gitattributes to normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set
+* text=auto
+
+# Require Unix line endings
+* text eol=lf


### PR DESCRIPTION
The .editorconfig requires LF line endings and npm has some line endings bugs so this should make contributing easier for people on Windows.

#### Checklist

- [x] run `npm run test`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
