### PR TITLE
Header name is case insensitive in the schema definition

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -29,13 +29,16 @@ function build (context, compile, schemas) {
   context.schema = schemas.resolveRefs(context.schema)
 
   if (context.schema.headers) {
-    // see https://github.com/fastify/fastify/pull/816
+    // The header keys are case insensitive
+    //  https://tools.ietf.org/html/rfc2616#section-4.2
     const headersSchemaLowerCase = {}
     for (const k in context.schema.headers) {
       headersSchemaLowerCase[k] = context.schema.headers[k]
     }
-    for (const k in context.schema.headers.properties) {
-      headersSchemaLowerCase.properties[k.toLowerCase()] = context.schema.headers.properties[k]
+    if (context.schema.headers.properties) {
+      for (const k in context.schema.headers.properties) {
+        headersSchemaLowerCase.properties[k.toLowerCase()] = context.schema.headers.properties[k]
+      }
     }
     context[headersSchema] = compile(headersSchemaLowerCase)
   }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -31,13 +31,17 @@ function build (context, compile, schemas) {
   if (context.schema.headers) {
     // The header keys are case insensitive
     //  https://tools.ietf.org/html/rfc2616#section-4.2
+    const headers = context.schema.headers
     const headersSchemaLowerCase = {}
-    for (const k in context.schema.headers) {
-      headersSchemaLowerCase[k] = context.schema.headers[k]
+    for (const k in headers) {
+      if (headers.hasOwnProperty(k) !== true) continue
+      headersSchemaLowerCase[k] = headers[k]
     }
-    if (context.schema.headers.properties) {
-      for (const k in context.schema.headers.properties) {
-        headersSchemaLowerCase.properties[k.toLowerCase()] = context.schema.headers.properties[k]
+    if (headers.properties) {
+      const properties = headers.properties
+      for (const k in properties) {
+        if (properties.hasOwnProperty(k) !== true) continue
+        headersSchemaLowerCase.properties[k.toLowerCase()] = properties[k]
       }
     }
     context[headersSchema] = compile(headersSchemaLowerCase)

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -29,7 +29,15 @@ function build (context, compile, schemas) {
   context.schema = schemas.resolveRefs(context.schema)
 
   if (context.schema.headers) {
-    context[headersSchema] = compile(context.schema.headers)
+    // see https://github.com/fastify/fastify/pull/816
+    const headersSchemaLowerCase = {}
+    for (const k in context.schema.headers) {
+      headersSchemaLowerCase[k] = context.schema.headers[k]
+    }
+    for (const k in context.schema.headers.properties) {
+      headersSchemaLowerCase.properties[k.toLowerCase()] = context.schema.headers.properties[k]
+    }
+    context[headersSchema] = compile(headersSchemaLowerCase)
   }
 
   if (context.schema.response) {

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -81,6 +81,9 @@ const headersSchema = {
       properties: {
         'x-test': {
           type: 'number'
+        },
+        'Y-Test': {
+          type: 'number'
         }
       }
     }
@@ -257,14 +260,16 @@ fastify.listen(0, err => {
     sget({
       method: 'GET',
       headers: {
-        'x-test': 1
+        'x-test': '1',
+        'Y-Test': '3'
       },
+      json: true,
       url: 'http://localhost:' + fastify.server.address().port + '/headers'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
-      t.strictEqual(response.headers['content-length'], '' + body.length)
-      t.strictEqual(JSON.parse(body)['x-test'], 1)
+      t.strictEqual(body['x-test'], 1)
+      t.strictEqual(body['y-test'], 3)
     })
   })
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

As titled, the rfc https://tools.ietf.org/html/rfc2616#section-4.2 defines the header key as case insensitive.

```
const schema = {
  headers: {
    UppErCaSe: { type: 'number' }
  }
}
fastify.get('/', { schema }, myHandler)
```

The problem is when I curl with `uppercase: 3` header because nodejs force to use to lower case.

I'm working on to fix this.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
