### PR TITLE
Fix linking to factory function options from Server Methods

### DIFF
--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -4,7 +4,7 @@
 
 <a name="server"></a>
 #### server
-`fastify.server`: The Node core [server](https://nodejs.org/api/http.html#http_class_http_server) object as returned by the <a href="https://github.com/fastify/fastify/blob/master/docs/Factory.md"><code><b>Fastify factory function</b></code></a>.
+`fastify.server`: The Node core [server](https://nodejs.org/api/http.html#http_class_http_server) object as returned by the [**`Fastify factory function`**](https://github.com/fastify/fastify/blob/master/docs/Factory.md).
 
 <a name="ready"></a>
 #### ready


### PR DESCRIPTION
Addresses the specific issue mentioned in #801.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
