### PR TITLE
Future-proof checking Node version

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -117,7 +117,7 @@ function build (options) {
     }
   })
 
-  if (Number(process.versions.node[0]) >= 6) {
+  if (Number(process.version.match(/v(\d+)/)[1]) >= 6) {
     server.on('clientError', handleClientError)
   }
 

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -2,6 +2,7 @@
 
 const t = require('tap')
 const test = t.test
+const semver = require('semver')
 const sget = require('simple-get').concat
 const stream = require('stream')
 const Fastify = require('..')
@@ -1719,7 +1720,7 @@ test('If the content type has been set inside an hook it should not be changed',
   })
 })
 
-if (Number(process.versions.node[0]) >= 8) {
+if (semver.gt(process.versions.node, '8.0.0')) {
   require('./hooks-async')(t)
 } else {
   t.pass('Skip because Node version < 8')

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -3,6 +3,7 @@
 const t = require('tap')
 const test = t.test
 const net = require('net')
+const semver = require('semver')
 const Fastify = require('..')
 const statusCodes = require('http').STATUS_CODES
 
@@ -100,7 +101,7 @@ test('onRequest hook error handling with external done', t => {
   })
 })
 
-if (Number(process.versions.node[0]) >= 6) {
+if (semver.gt(process.versions.node, '6.0.0')) {
   test('Should reply 400 on client error', t => {
     t.plan(2)
 


### PR DESCRIPTION
Fix code that checks the Node version that would break with Node 10 (handle version numbers with multiple digits).

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
