### PR TITLE
Update instances of "jsonBodyLimit" to "bodyLimit"

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -192,7 +192,7 @@ fastify.addHook('onRoute', (routeOptions) => {
   routeOptions.method
   routeOptions.schema
   routeOptions.url
-  routeOptions.jsonBodyLimit
+  routeOptions.bodyLimit
   routeOptions.logLevel
   routeOptions.prefix
 })

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -25,7 +25,7 @@ They need to be in
 * `beforeHandler(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#before-handler) called just before the request handler, useful if you need to perform authentication at route level for example, it could also be and array of functions.
 * `handler(request, reply)`: the function that will handle this request.
 * `schemaCompiler(schema)`: the function that build the schema for the validations. See [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-compiler)
-* `jsonBodyLimit`: prevents the default JSON body parser from parsing request bodies larger than this number of bytes. Must be an integer. You may also set this option globally when first creating the Fastify instance with `fastify(options)`. Defaults to `1048576` (1 MiB).
+* `bodyLimit`: prevents the default JSON body parser from parsing request bodies larger than this number of bytes. Must be an integer. You may also set this option globally when first creating the Fastify instance with `fastify(options)`. Defaults to `1048576` (1 MiB).
 * `logLevel`: set log level for this route. See below.
 * `config`: object used to store custom configuration.
 

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -66,7 +66,7 @@ declare namespace fastify {
 
   interface ServerOptions {
     ignoreTrailingSlash?: boolean,
-    jsonBodyLimit?: number,
+    bodyLimit?: number,
     logger?: pino.LoggerOptions | true,
     maxParamLength?: number,
   }
@@ -103,7 +103,7 @@ declare namespace fastify {
     schema?: JSONSchema
     beforeHandler?: FastifyMiddleware<HttpServer, HttpRequest, HttpResponse> | Array<FastifyMiddleware<HttpServer, HttpRequest, HttpResponse>>
     schemaCompiler?: SchemaCompiler
-    jsonBodyLimit?: number,
+    bodyLimit?: number,
     logLevel?: string,
     config?: any
   }

--- a/test/bodyLimit.test.js
+++ b/test/bodyLimit.test.js
@@ -5,7 +5,7 @@ const sget = require('simple-get').concat
 const t = require('tap')
 const test = t.test
 
-test('jsonBodyLimit', t => {
+test('bodyLimit', t => {
   t.plan(5)
 
   try {

--- a/test/helper.js
+++ b/test/helper.js
@@ -61,7 +61,7 @@ module.exports.payloadMethod = function (method, t) {
     }
   })
 
-  test(`${upMethod} with jsonBodyLimit option`, t => {
+  test(`${upMethod} with bodyLimit option`, t => {
     t.plan(1)
     try {
       fastify[loMethod]('/with-limit', { bodyLimit: 1 }, function (req, reply) {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -449,9 +449,9 @@ test('onRoute hook should pass correct route with custom options', t => {
       t.strictEqual(route.method, 'GET')
       t.strictEqual(route.url, '/foo')
       t.strictEqual(route.logLevel, 'info')
-      t.strictEqual(route.jsonBodyLimit, 100)
+      t.strictEqual(route.bodyLimit, 100)
     })
-    instance.get('/foo', { logLevel: 'info', jsonBodyLimit: 100 }, function (req, reply) {
+    instance.get('/foo', { logLevel: 'info', bodyLimit: 100 }, function (req, reply) {
       reply.send()
     })
     next()

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -196,23 +196,23 @@ test('path can be specified in place of uri', t => {
   })
 })
 
-test('invalid jsonBodyLimit option - route', t => {
+test('invalid bodyLimit option - route', t => {
   t.plan(2)
 
   try {
     fastify.route({
-      jsonBodyLimit: false,
+      bodyLimit: false,
       method: 'PUT',
       handler: () => null
     })
-    t.fail('jsonBodyLimit must be an integer')
+    t.fail('bodyLimit must be an integer')
   } catch (err) {
     t.ok(err)
   }
 
   try {
-    fastify.post('/url', { jsonBodyLimit: 10000.1 }, () => null)
-    t.fail('jsonBodyLimit must be an integer')
+    fastify.post('/url', { bodyLimit: 10000.1 }, () => null)
+    t.fail('bodyLimit must be an integer')
   } catch (err) {
     t.ok(err)
   }

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -34,7 +34,7 @@ import { createReadStream, readFile } from 'fs'
   // other simple options
   const otherServer = fastify({
     ignoreTrailingSlash: true,
-    jsonBodyLimit: 1000,
+    bodyLimit: 1000,
     maxParamLength: 200,
   })
 
@@ -129,7 +129,7 @@ const opts = {
     }
   ],
   schemaCompiler: (schema: Object) => () => {},
-  jsonBodyLimit: 5000,
+  bodyLimit: 5000,
   logLevel: 'trace',
   config: { }
 }


### PR DESCRIPTION
#785 renamed the `jsonBodyLimit` option to `bodyLimit`. This changes the remaining instances of `jsonBodyLimit` to `bodyLimit`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
