### PR TITLE
Use separate Fastify instances for route tests

### DIFF
--- a/test/route.test.js
+++ b/test/route.test.js
@@ -3,178 +3,185 @@
 const t = require('tap')
 const test = t.test
 const sget = require('simple-get').concat
-const fastify = require('..')()
+const Fastify = require('..')
 
-test('route - get', t => {
-  t.plan(1)
-  try {
-    fastify.route({
-      method: 'GET',
-      url: '/',
-      schema: {
-        response: {
-          '2xx': {
-            type: 'object',
-            properties: {
-              hello: {
-                type: 'string'
-              }
-            }
-          }
-        }
-      },
-      handler: function (req, reply) {
-        reply.send({ hello: 'world' })
-      }
-    })
-    t.pass()
-  } catch (e) {
-    t.fail()
-  }
-})
+test('route', t => {
+  t.plan(9)
+  const test = t.test
+  const fastify = Fastify()
 
-test('missing schema - route', t => {
-  t.plan(1)
-  try {
-    fastify.route({
-      method: 'GET',
-      url: '/missing',
-      handler: function (req, reply) {
-        reply.send({ hello: 'world' })
-      }
-    })
-    t.pass()
-  } catch (e) {
-    t.fail()
-  }
-})
-
-test('invalid schema - route', t => {
-  t.plan(1)
-  try {
-    fastify.route({
-      method: 'GET',
-      url: '/invalid',
-      schema: {
-        querystring: {
-          id: 'string'
-        }
-      },
-      handler: function (req, reply) {
-        reply.send({ hello: 'world' })
-      }
-    })
-    fastify.after(err => {
-      t.ok(err instanceof Error)
-    })
-  } catch (e) {
-    t.fail()
-  }
-})
-
-test('Multiple methods', t => {
-  t.plan(1)
-  try {
-    fastify.route({
-      method: ['GET', 'DELETE'],
-      url: '/multiple',
-      handler: function (req, reply) {
-        reply.send({ hello: 'world' })
-      }
-    })
-    t.pass()
-  } catch (e) {
-    t.fail()
-  }
-})
-
-test('Add multiple methods', t => {
-  t.plan(1)
-  try {
-    fastify.get('/add-multiple', function (req, reply) {
-      reply.send({hello: 'Bob!'})
-    })
-    fastify.route({
-      method: ['PUT', 'DELETE'],
-      url: '/add-multiple',
-      handler: function (req, reply) {
-        reply.send({ hello: 'world' })
-      }
-    })
-    t.pass()
-  } catch (e) {
-    t.fail()
-  }
-})
-
-fastify.listen(0, function (err) {
-  if (err) t.error(err)
-  fastify.server.unref()
-
-  test('cannot add another route after binding', t => {
+  test('route - get', t => {
     t.plan(1)
     try {
       fastify.route({
         method: 'GET',
-        url: '/another-get-route',
+        url: '/',
+        schema: {
+          response: {
+            '2xx': {
+              type: 'object',
+              properties: {
+                hello: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        },
         handler: function (req, reply) {
           reply.send({ hello: 'world' })
         }
       })
-      t.fail()
-    } catch (e) {
       t.pass()
+    } catch (e) {
+      t.fail()
     }
   })
 
-  test('route - get', t => {
-    t.plan(3)
-    sget({
-      method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port
-    }, (err, response, body) => {
-      t.error(err)
-      t.strictEqual(response.statusCode, 200)
-      t.deepEqual(JSON.parse(body), { hello: 'world' })
-    })
+  test('missing schema - route', t => {
+    t.plan(1)
+    try {
+      fastify.route({
+        method: 'GET',
+        url: '/missing',
+        handler: function (req, reply) {
+          reply.send({ hello: 'world' })
+        }
+      })
+      t.pass()
+    } catch (e) {
+      t.fail()
+    }
   })
 
-  test('route - missing schema', t => {
-    t.plan(3)
-    sget({
-      method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port + '/missing'
-    }, (err, response, body) => {
-      t.error(err)
-      t.strictEqual(response.statusCode, 200)
-      t.deepEqual(JSON.parse(body), { hello: 'world' })
-    })
+  test('invalid schema - route', t => {
+    t.plan(1)
+    try {
+      fastify.route({
+        method: 'GET',
+        url: '/invalid',
+        schema: {
+          querystring: {
+            id: 'string'
+          }
+        },
+        handler: function (req, reply) {
+          reply.send({ hello: 'world' })
+        }
+      })
+      fastify.after(err => {
+        t.ok(err instanceof Error)
+      })
+    } catch (e) {
+      t.fail()
+    }
   })
 
-  test('route - multiple methods', t => {
-    t.plan(6)
-    sget({
-      method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port + '/multiple'
-    }, (err, response, body) => {
-      t.error(err)
-      t.strictEqual(response.statusCode, 200)
-      t.deepEqual(JSON.parse(body), { hello: 'world' })
+  test('Multiple methods', t => {
+    t.plan(1)
+    try {
+      fastify.route({
+        method: ['GET', 'DELETE'],
+        url: '/multiple',
+        handler: function (req, reply) {
+          reply.send({ hello: 'world' })
+        }
+      })
+      t.pass()
+    } catch (e) {
+      t.fail()
+    }
+  })
+
+  test('Add multiple methods', t => {
+    t.plan(1)
+    try {
+      fastify.get('/add-multiple', function (req, reply) {
+        reply.send({hello: 'Bob!'})
+      })
+      fastify.route({
+        method: ['PUT', 'DELETE'],
+        url: '/add-multiple',
+        handler: function (req, reply) {
+          reply.send({ hello: 'world' })
+        }
+      })
+      t.pass()
+    } catch (e) {
+      t.fail()
+    }
+  })
+
+  fastify.listen(0, function (err) {
+    if (err) t.error(err)
+    fastify.server.unref()
+
+    test('cannot add another route after binding', t => {
+      t.plan(1)
+      try {
+        fastify.route({
+          method: 'GET',
+          url: '/another-get-route',
+          handler: function (req, reply) {
+            reply.send({ hello: 'world' })
+          }
+        })
+        t.fail()
+      } catch (e) {
+        t.pass()
+      }
     })
 
-    sget({
-      method: 'DELETE',
-      url: 'http://localhost:' + fastify.server.address().port + '/multiple'
-    }, (err, response, body) => {
-      t.error(err)
-      t.strictEqual(response.statusCode, 200)
-      t.deepEqual(JSON.parse(body), { hello: 'world' })
+    test('route - get', t => {
+      t.plan(3)
+      sget({
+        method: 'GET',
+        url: 'http://localhost:' + fastify.server.address().port
+      }, (err, response, body) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 200)
+        t.deepEqual(JSON.parse(body), { hello: 'world' })
+      })
+    })
+
+    test('route - missing schema', t => {
+      t.plan(3)
+      sget({
+        method: 'GET',
+        url: 'http://localhost:' + fastify.server.address().port + '/missing'
+      }, (err, response, body) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 200)
+        t.deepEqual(JSON.parse(body), { hello: 'world' })
+      })
+    })
+
+    test('route - multiple methods', t => {
+      t.plan(6)
+      sget({
+        method: 'GET',
+        url: 'http://localhost:' + fastify.server.address().port + '/multiple'
+      }, (err, response, body) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 200)
+        t.deepEqual(JSON.parse(body), { hello: 'world' })
+      })
+
+      sget({
+        method: 'DELETE',
+        url: 'http://localhost:' + fastify.server.address().port + '/multiple'
+      }, (err, response, body) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 200)
+        t.deepEqual(JSON.parse(body), { hello: 'world' })
+      })
     })
   })
 })
 
 test('path can be specified in place of uri', t => {
   t.plan(3)
+  const fastify = Fastify()
 
   fastify.route({
     method: 'GET',
@@ -198,6 +205,7 @@ test('path can be specified in place of uri', t => {
 
 test('invalid bodyLimit option - route', t => {
   t.plan(2)
+  const fastify = Fastify()
 
   try {
     fastify.route({
@@ -207,13 +215,13 @@ test('invalid bodyLimit option - route', t => {
     })
     t.fail('bodyLimit must be an integer')
   } catch (err) {
-    t.ok(err)
+    t.strictEqual(err.message, "'bodyLimit' option must be an integer > 0. Got 'false'")
   }
 
   try {
     fastify.post('/url', { bodyLimit: 10000.1 }, () => null)
     t.fail('bodyLimit must be an integer')
   } catch (err) {
-    t.ok(err)
+    t.strictEqual(err.message, "'bodyLimit' option must be an integer > 0. Got '10000.1'")
   }
 })


### PR DESCRIPTION
While making #828, I was surprised that [this test](https://github.com/fastify/fastify/pull/828/files#diff-b546326f3ba2fced1af5691d01a323b5R199) wasn't failing. Turns out an error was being thrown (which is what the test wanted), but it was the wrong error. A `bodyLimit` error should have been thrown but a "fastify already started" error was what was actually thrown.

This PR changes the tests in `test/routes.test.js` so that different tests use a different Fastify instance and fixes the `bodyLimit` option test.

It may be helpful to view the file changes [without whitespace](https://github.com/fastify/fastify/pull/831/files?w=1).

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
