### PR TITLE
Fix setting header multiple times and add utility methods (fix #834)

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -6,6 +6,8 @@ Reply is a core Fastify object that exposes the following functions:
 
 - `.code(statusCode)` - Sets the status code.
 - `.header(name, value)` - Sets a response header.
+- `.getHeader(name)` - Retrieve value of already set header.
+- `.hasHeader(name)` = Determine if a header has been set.
 - `.type(value)` - Sets the header `Content-Type`.
 - `.redirect([code,] url)` - Redirect to the specified url, the status code is optional (default to `302`).
 - `.serialize(payload)` - Serializes the specified payload using the default json serializer and returns the serialized payload.
@@ -41,6 +43,18 @@ If not set via `reply.code`, the resulting `statusCode` will be `200`.
 Sets a response header.
 
 For more information, see [`http.ServerResponse#setHeader`](https://nodejs.org/dist/latest/docs/api/http.html#http_response_setheader_name_value).
+
+<a name="getHeader"></a>
+### GetHeader
+Retrieves the value of a previously set header.
+```js
+reply.header('x-foo', 'foo')
+reply.getHeader('x-foo') // 'foo'
+```
+
+<a name="hasHeader"></a>
+### HasHeader
+Returns a boolean indicating if the specified header has been set.
 
 <a name="redirect"></a>
 ### Redirect

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -85,7 +85,7 @@ Reply.prototype.getHeader = function (key) {
 }
 
 Reply.prototype.hasHeader = function (key) {
-  return Object.keys(this._headers).indexOf(key.toLowerCase()) > -1
+  return this._headers[key.toLowerCase()] !== undefined
 }
 
 Reply.prototype.header = function (key, value) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -80,8 +80,21 @@ Reply.prototype.send = function (payload) {
   onSendHook(this, payload)
 }
 
+Reply.prototype.getHeader = function (key) {
+  return getHeader(this, key)
+}
+
+Reply.prototype.hasHeader = function (key) {
+  return Object.keys(this._headers).indexOf(key.toLowerCase()) > -1
+}
+
 Reply.prototype.header = function (key, value) {
-  this._headers[key.toLowerCase()] = value
+  var _key = key.toLowerCase()
+  if (this._headers[_key]) {
+    this._headers[_key] = [this._headers[_key]].concat(value)
+  } else {
+    this._headers[_key] = value
+  }
   return this
 }
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -90,7 +90,8 @@ Reply.prototype.hasHeader = function (key) {
 
 Reply.prototype.header = function (key, value) {
   var _key = key.toLowerCase()
-  if (this._headers[_key]) {
+  // https://tools.ietf.org/html/rfc7230#section-3.2.2
+  if (this._headers[_key] && _key === 'set-cookie') {
     this._headers[_key] = [this._headers[_key]].concat(value)
   } else {
     this._headers[_key] = value

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -551,7 +551,7 @@ test('reply.hasHeader returns correct values', t => {
 })
 
 test('reply.getHeader returns correct values', t => {
-  t.plan(3)
+  t.plan(4)
 
   const fastify = require('../../')()
 
@@ -560,7 +560,11 @@ test('reply.getHeader returns correct values', t => {
     t.is(reply.getHeader('x-foo'), 'foo')
 
     reply.header('x-foo', 'bar')
-    t.strictDeepEqual(reply.getHeader('x-foo'), ['foo', 'bar'])
+    t.strictDeepEqual(reply.getHeader('x-foo'), 'bar')
+
+    reply.header('set-cookie', 'one')
+    reply.header('set-cookie', 'two')
+    t.strictDeepEqual(reply.getHeader('set-cookie'), ['one', 'two'])
 
     reply.send()
   })

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -500,3 +500,77 @@ test('reply.send(new NotFound()) should log a warning and send a basic response 
     })
   })
 })
+
+test('reply can set multiple instances of same header', t => {
+  t.plan(4)
+
+  const fastify = require('../../')()
+
+  fastify.get('/headers', function (req, reply) {
+    reply
+      .header('set-cookie', 'one')
+      .header('set-cookie', 'two')
+      .send({})
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port + '/headers'
+    }, (err, response, body) => {
+      t.error(err)
+      t.ok(response.headers['set-cookie'])
+      t.strictDeepEqual(response.headers['set-cookie'], ['one', 'two'])
+    })
+  })
+})
+
+test('reply.hasHeader returns correct values', t => {
+  t.plan(3)
+
+  const fastify = require('../../')()
+
+  fastify.get('/headers', function (req, reply) {
+    reply.header('x-foo', 'foo')
+    t.is(reply.hasHeader('x-foo'), true)
+    t.is(reply.hasHeader('x-bar'), false)
+    reply.send()
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port + '/headers'
+    }, () => {})
+  })
+})
+
+test('reply.getHeader returns correct values', t => {
+  t.plan(3)
+
+  const fastify = require('../../')()
+
+  fastify.get('/headers', function (req, reply) {
+    reply.header('x-foo', 'foo')
+    t.is(reply.getHeader('x-foo'), 'foo')
+
+    reply.header('x-foo', 'bar')
+    t.strictDeepEqual(reply.getHeader('x-foo'), ['foo', 'bar'])
+
+    reply.send()
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port + '/headers'
+    }, () => {})
+  })
+})


### PR DESCRIPTION
This is pushed with a failing test. I have done so because I think that test is wrong, but I want others opinion. The failing test is:

https://github.com/fastify/fastify/blob/6aaa14abbdd317280af68a032a618984d07c38a3/test/stream.test.js#L52-L74

It fails, because now the resulting header is:

```
+++ found
--- wanted
-"application/javascript"
+[
+  "application/octet-stream"
+  "application/javascript"
+]
```

The wrong bit about the test is that the response *should* be `application/octet-stream` since a stream has been sent. However, it could also be wrong that the content type has been set twice.

I feel like we are heading into a mine field with maintaining headers on the `Reply` object ourselves. See https://tools.ietf.org/html/rfc2616#section-4.2:

> Multiple message-header fields with the same field-name MAY be
   present in a message if and only if the entire field-value for that
   header field is defined as a comma-separated list [i.e., #(values)].
   It MUST be possible to combine the multiple header fields into one
   "field-name: field-value" pair, without changing the semantics of the
   message, by appending each subsequent field-value to the first, each
   separated by a comma. The order in which header fields with the same
   field-name are received is therefore significant to the
   interpretation of the combined field value, and thus a proxy MUST NOT
   change the order of these field values when a message is forwarded.

So is it right to blindly accept multiple values for every header? Or should we be maintaining a list of headers that are allowed to have multiple values?

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
