### PR TITLE
Store the 404 Context directly on the route Context

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -495,8 +495,7 @@ function build (options) {
         config,
         _fastify._errorHandler,
         opts.bodyLimit,
-        opts.logLevel,
-        _fastify
+        opts.logLevel
       )
 
       try {
@@ -538,6 +537,10 @@ function build (options) {
         context.onResponse = onResponse.length ? onResponse : null
 
         context._middie = buildMiddie(_fastify._middlewares)
+
+        // Must store the 404 Context in 'preReady' because it is only guaranteed to
+        // be available after all of the plugins and routes have been loaded.
+        context._404Context = _fastify._404Context
       })
 
       done(notHandledErr)
@@ -547,7 +550,7 @@ function build (options) {
     return _fastify
   }
 
-  function Context (schema, handler, Reply, Request, contentTypeParser, config, errorHandler, bodyLimit, logLevel, fastify) {
+  function Context (schema, handler, Reply, Request, contentTypeParser, config, errorHandler, bodyLimit, logLevel) {
     this.schema = schema
     this.handler = handler
     this.Reply = Reply
@@ -563,8 +566,8 @@ function build (options) {
     this._parserOptions = {
       limit: bodyLimit || null
     }
-    this._fastify = fastify
     this.logLevel = logLevel
+    this._404Context = null
   }
 
   function inject (opts, cb) {
@@ -729,8 +732,7 @@ function build (options) {
       opts.config || {},
       this._errorHandler,
       this._bodyLimit,
-      this._logLevel,
-      null
+      this._logLevel
     )
 
     app.once('preReady', () => {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -310,13 +310,13 @@ function notFound (reply) {
   reply.sent = false
   reply._isError = false
 
-  if (reply.context._fastify === null) {
+  if (reply.context._404Context === null) {
     reply.res.log.warn('Trying to send a NotFound error inside a 404 handler. Sending basic 404 response.')
     reply.code(404).send('404 Not Found')
     return
   }
 
-  reply.context = reply.context._fastify._404Context
+  reply.context = reply.context._404Context
   reply.context.handler(reply.request, reply)
 }
 


### PR DESCRIPTION
When I wrote #588 I stored the Fastify instance on the route Context as a hack because that was the only way to get a reference to the right 404 Context during a request (since when a route is defined, the associated 404 handler might not have been defined yet).

Now that the `'preReady'` event from `avvio` exists, it is possible to use that to get the right 404 Context to store on the route Context.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
