### PR TITLE
Fix typo in getting started documentation

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -102,7 +102,7 @@ module.exports = routes
 ```
 In this example we used the `register` API. This API is the core of the Fastify framework, and is the only way to register routes, plugins and so on.
 
-At the beginning of this guide we noted that Fastify provides a foundation that assists with the asynchronous bootstrapping of your an application. Why this is important?
+At the beginning of this guide we noted that Fastify provides a foundation that assists with the asynchronous bootstrapping of your application. Why this is important?
 Consider the scenario where a database connection is needed to handle data storage. Obviously the database connection needs to be available prior to the server accepting connections. How do we address this problem?<br>
 A typical solution is to use a complex callback, or promises, system that will mix the framework API with other libraries and the application code.<br>
 Fastify handles this internally, with minimum effort!


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

I went through the documentation and noticed a typo.