### PR TITLE
Run onSend hooks when an encapsulated handler invokes the notFound handler

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -551,7 +551,9 @@ function build (options) {
 
         // Must store the 404 Context in 'preReady' because it is only guaranteed to
         // be available after all of the plugins and routes have been loaded.
-        context._404Context = _fastify._404Context
+        const _404Context = Object.assign({}, _fastify._404Context)
+        _404Context.onSend = context.onSend
+        context._404Context = _404Context
       })
 
       done(notHandledErr)

--- a/fastify.js
+++ b/fastify.js
@@ -688,7 +688,7 @@ function build (options) {
   }
 
   function basic404 (req, reply) {
-    reply.code(404).send(new Error('Not found'))
+    reply.code(404).send(new Error('Not Found'))
   }
 
   function fourOhFourFallBack (req, res) {
@@ -710,7 +710,7 @@ function build (options) {
     req.log.warn(fourOhFour.prettyPrint())
     const request = new Request(null, req, null, req.headers, req.log)
     const reply = new Reply(res, { onSend: [] }, request)
-    reply.code(404).send(new Error('Not found'))
+    reply.code(404).send(new Error('Not Found'))
   }
 
   function setNotFoundHandler (opts, handler) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -330,8 +330,12 @@ function notFound (reply) {
     return
   }
 
-  reply.context = reply.context._404Context
-  reply.context.handler(reply.request, reply)
+  // Use a copy of the 404 context with the original context's onSend hooks
+  const context = Object.assign({}, reply.context._404Context)
+  context.onSend = reply.context.onSend
+  reply.context = context
+
+  context.handler(reply.request, reply)
 }
 
 function noop () {}

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -330,12 +330,8 @@ function notFound (reply) {
     return
   }
 
-  // Use a copy of the 404 context with the original context's onSend hooks
-  const context = Object.assign({}, reply.context._404Context)
-  context.onSend = reply.context.onSend
-  reply.context = context
-
-  context.handler(reply.request, reply)
+  reply.context = reply.context._404Context
+  reply.context.handler(reply.request, reply)
 }
 
 function noop () {}

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -919,7 +919,7 @@ test('log debug for 404', t => {
 
       const INFO_LEVEL = 30
       t.strictEqual(JSON.parse(logStream.logs[0]).msg, 'incoming request')
-      t.strictEqual(JSON.parse(logStream.logs[1]).msg, 'Not found')
+      t.strictEqual(JSON.parse(logStream.logs[1]).msg, 'Not Found')
       t.strictEqual(JSON.parse(logStream.logs[1]).level, INFO_LEVEL)
       t.strictEqual(JSON.parse(logStream.logs[2]).msg, 'request completed')
       t.strictEqual(logStream.logs.length, 3)
@@ -953,7 +953,7 @@ test('recognizes errors from the http-errors module', t => {
         const obj = JSON.parse(body.toString())
         t.strictDeepEqual(obj, {
           error: 'Not Found',
-          message: 'Not found',
+          message: 'Not Found',
           statusCode: 404
         })
       })
@@ -979,7 +979,7 @@ test('the default 404 handler can be invoked inside a prefixed plugin', t => {
     t.strictEqual(res.statusCode, 404)
     t.strictDeepEqual(JSON.parse(res.payload), {
       error: 'Not Found',
-      message: 'Not found',
+      message: 'Not Found',
       statusCode: 404
     })
   })

--- a/test/internals/logger.test.js
+++ b/test/internals/logger.test.js
@@ -91,7 +91,7 @@ test('The logger should add a timestamp if logging to stdout', t => {
   stream.once('data', (line) => {
     t.equal(line.msg, 'incoming request')
     stream.once('data', (line) => {
-      t.equal(line.msg, 'Not found')
+      t.equal(line.msg, 'Not Found')
       stream.once('data', (line) => {
         t.equal(line.msg, 'request completed')
         t.ok(line.responseTime, 'responseTime exists')

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -491,7 +491,7 @@ test('reply.send(new NotFound()) should invoke the 404 handler', t => {
       t.deepEqual(JSON.parse(body.toString()), {
         statusCode: 404,
         error: 'Not Found',
-        message: 'Not found'
+        message: 'Not Found'
       })
     })
 

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -640,7 +640,7 @@ test('Should set a custom log level for a specific route', t => {
 test('The default 404 handler logs the incoming request', t => {
   t.plan(5)
 
-  const expectedMessages = ['incoming request', 'Not found', 'request completed']
+  const expectedMessages = ['incoming request', 'Not Found', 'request completed']
 
   const splitStream = split(JSON.parse)
   splitStream.on('data', (line) => {


### PR DESCRIPTION
If a route is encapsulated, it may have more `onSend` hooks than the *notFound* handler associated with the route. This PR makes sure that if a route invokes the *notFound* handler, all of the route's `onSend` hooks will run.

Fixes #868 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
