### PR TITLE
Add files field to reduce package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
     "type": "git",
     "url": "git+https://github.com/fastify/fastify.git"
   },
+  "files": [
+    "$npm_package_main",
+    "fastify.d.ts",
+    "lib"
+  ],
   "keywords": [
     "web",
     "framework",


### PR DESCRIPTION
Only include the needed files and typescript types by using the `files` field. This brings down the package size from 105kB to 21kB (-80%).
I've tested locally using `npm pack` and `npm install <output.tgz>` with the 'hello world' example code but please double check to make sure I didn't break anything!