### PR TITLE
Segregate `async/await` and  `next` hook forms in documentation

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -77,7 +77,7 @@ fastify.addHook('onResponse', async (res) => {
 })
 ```
 
-If the `async`/`await` form is used, (or equivalently, if the hook returns a `Promise`), be sure to not call `next`. Otherwise you will duplicate the execution of any further handlers.
+**Notice:** the `next` callback is not available when using `async`/`await` or returning a `Promise`. If you do invoke a `next` callback in this situation unexpected behavior may occur, e.g. duplicate invocation of handlers.
 
 | Parameter   |  Description  |
 |-------------|-------------|

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -77,6 +77,8 @@ fastify.addHook('onResponse', async (res) => {
 })
 ```
 
+If the `async`/`await` form is used, (or equivalently, if the hook returns a `Promise`), be sure to not call `next`. Otherwise you will duplicate the execution of any further handlers.
+
 | Parameter   |  Description  |
 |-------------|-------------|
 | req |  Node.js [IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage) |


### PR DESCRIPTION
Based on Fastify/Lobby Gitter discussion today 16:30, it turns out that if using the promise-returning variant of hook handlers, one should not call the `next` function provided within.

I made this limitation explicit in the documentation.