### PR TITLE
Remove unnecessary quotes in HTTP response header

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -705,7 +705,7 @@ function build (options) {
       statusCode: 400
     })
     log.error(e, 'client error')
-    socket.end(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: 'application/json'\r\n\r\n${body}`)
+    socket.end(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n${body}`)
   }
 
   function defaultRoute (req, res) {

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -123,7 +123,7 @@ if (semver.gt(process.versions.node, '6.0.0')) {
           message: 'Client Error',
           statusCode: 400
         })
-        t.equal(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: 'application/json'\r\n\r\n${body}`, chunks)
+        t.equal(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n${body}`, chunks)
         fastify.close()
       })
     })


### PR DESCRIPTION
The `Content-Type: application/json` response header value should not contain quotes.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
