### PR TITLE
Add config to docs

### DIFF
--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -230,3 +230,24 @@ fastify.get('/', { logLevel: 'warn' }, (request, reply) => {
 })
 ```
 *Remember that the custom log level is applied only to the routes, and not to the global Fastify Logger, accessible with `fastify.log`*
+
+
+<a name="routes-config"></a>
+### Config
+Registering a new handler, you can pass a configuration object to it and retrieve it in the handler.
+
+```js
+// server.js
+const fastify = require('fastify')()
+
+function handler (req, reply) {
+  reply.send(reply.context.config.output)
+}
+
+fastify.register('/en', { config: { output: 'hello world!' } }, handler)
+fastify.register('/it', { config: { output: 'ciao mondo!' } }, handler)
+
+fastify.listen(3000)
+```
+
+*Remember to not abuse of this feature. Please consider to use `decorate`, `decorateRequest` and `decorateReply` methods before*

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -244,10 +244,8 @@ function handler (req, reply) {
   reply.send(reply.context.config.output)
 }
 
-fastify.register('/en', { config: { output: 'hello world!' } }, handler)
-fastify.register('/it', { config: { output: 'ciao mondo!' } }, handler)
+fastify.get('/en', { config: { output: 'hello world!' } }, handler)
+fastify.get('/it', { config: { output: 'ciao mondo!' } }, handler)
 
 fastify.listen(3000)
 ```
-
-*Remember to not abuse of this feature. Please consider to use `decorate`, `decorateRequest` and `decorateReply` methods before*

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -34,6 +34,10 @@ declare namespace fastify {
   type AsyncContentTypeParser<HttpRequest> = (req: HttpRequest) => Promise<any>;
   type ContentTypeParser<HttpRequest> = (req: HttpRequest, done: (err: Error | null, body?: any) => void) => void;
 
+  interface FastifyContext {
+    config: any
+  }
+
   /**
    * fastify's wrapped version of node.js IncomingMessage
    */
@@ -69,7 +73,7 @@ declare namespace fastify {
     send: (payload?: any) => FastifyReply<HttpResponse>
     sent: boolean
     res: HttpResponse
-    context: any
+    context: FastifyContext
   }
 
   interface ServerOptions {

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -8,8 +8,8 @@ import * as https from 'https';
 import * as pino from 'pino';
 
 declare function fastify<
-  HttpServer extends (http.Server | http2.Http2Server) = http.Server, 
-  HttpRequest extends (http.IncomingMessage | http2.Http2ServerRequest) = http.IncomingMessage, 
+  HttpServer extends (http.Server | http2.Http2Server) = http.Server,
+  HttpRequest extends (http.IncomingMessage | http2.Http2ServerRequest) = http.IncomingMessage,
   HttpResponse extends (http.ServerResponse | http2.Http2ServerResponse) = http.ServerResponse
 >(opts?: fastify.ServerOptions): fastify.FastifyInstance<HttpServer, HttpRequest, HttpResponse>;
 declare function fastify(opts?: fastify.ServerOptionsAsHttp): fastify.FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>;
@@ -69,6 +69,7 @@ declare namespace fastify {
     send: (payload?: any) => FastifyReply<HttpResponse>
     sent: boolean
     res: HttpResponse
+    context: any
   }
 
   interface ServerOptions {

--- a/test/context-config.test.js
+++ b/test/context-config.test.js
@@ -2,7 +2,6 @@
 
 const t = require('tap')
 const test = t.test
-const sget = require('simple-get').concat
 const Fastify = require('..')
 
 const schema = {
@@ -18,7 +17,7 @@ function handler (req, reply) {
 }
 
 test('config', t => {
-  t.plan(10)
+  t.plan(9)
   const fastify = Fastify()
 
   fastify.get('/get', {
@@ -41,38 +40,30 @@ test('config', t => {
     handler: handler
   })
 
-  fastify.listen(0, err => {
+  fastify.inject({
+    method: 'GET',
+    url: '/get'
+  }, (err, response) => {
     t.error(err)
-    fastify.server.unref()
+    t.strictEqual(response.statusCode, 200)
+    t.deepEquals(JSON.parse(response.payload), Object.assign({url: '/get'}, schema.config))
+  })
 
-    sget({
-      method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port + '/get',
-      json: true
-    }, (err, response, body) => {
-      t.error(err)
-      t.strictEqual(response.statusCode, 200)
-      t.deepEquals(body, Object.assign({url: '/get'}, schema.config))
-    })
+  fastify.inject({
+    method: 'GET',
+    url: '/route'
+  }, (err, response) => {
+    t.error(err)
+    t.strictEqual(response.statusCode, 200)
+    t.deepEquals(JSON.parse(response.payload), Object.assign({url: '/route'}, schema.config))
+  })
 
-    sget({
-      method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port + '/route',
-      json: true
-    }, (err, response, body) => {
-      t.error(err)
-      t.strictEqual(response.statusCode, 200)
-      t.deepEquals(body, Object.assign({url: '/route'}, schema.config))
-    })
-
-    sget({
-      method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port + '/no-config',
-      json: true
-    }, (err, response, body) => {
-      t.error(err)
-      t.strictEqual(response.statusCode, 200)
-      t.deepEquals(body, {url: '/no-config'})
-    })
+  fastify.inject({
+    method: 'GET',
+    url: '/no-config'
+  }, (err, response) => {
+    t.error(err)
+    t.strictEqual(response.statusCode, 200)
+    t.deepEquals(JSON.parse(response.payload), {url: '/no-config'})
   })
 })

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -210,6 +210,14 @@ server
       reply.send({ hello: 'world' })
     }
   })
+  .route({
+    method: 'GET',
+    url: '/with-config',
+    config: { foo: 'bar' },
+    handler: function (req, reply) {
+      reply.send(reply.context.config)
+    }
+  })
   .register(function (instance, options, done) {
     instance.get('/route', opts, function (req, reply) {
       reply.send({ hello: 'world' })


### PR DESCRIPTION
Add `reply.context.config` to documentation.
Add typescript definition too

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
