### PR TITLE
Promise handling

### DIFF
--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -85,13 +85,7 @@ function preHandlerCallback (err, reply) {
   var result = reply.context.handler(reply.request, reply)
   if (result && typeof result.then === 'function') {
     result
-      .then((payload) => {
-        // this is for async functions that
-        // are using reply.send directly
-        if (payload !== undefined || (reply.res.statusCode === 204 && !reply.sent)) {
-          reply.send(payload)
-        }
-      })
+      .then((payload) => reply.send(payload))
       .catch((err) => {
         reply.sent = false
         reply._isError = true


### PR DESCRIPTION
Hi, this PR includes following changes:

- The returned promise inside an `async` handler should fulfill the final payload.
- The returned promise with **no** payload inside an `async` handler shouldn't lead to a hanging response.
- The implementation about to avoid calling `reply.send` twice is handled by `reply` once.

In my opinion these modification are a good step in the right direction to align with the flow-control of `async/await`. This is a major change.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
