### PR TITLE
log message when promise is fullfilled with undefined

### DIFF
--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -91,7 +91,7 @@ function preHandlerCallback (err, reply) {
         if (payload !== undefined || reply.res.statusCode === 204) {
           reply.send(payload)
         } else {
-          reply.res.log.warn(new Error(`Promise may not be fulfilled with 'undefined' when statusCode is not 204`))
+          reply.res.log.error(new Error(`Promise may not be fulfilled with 'undefined' when statusCode is not 204`))
         }
       })
       .catch((err) => {

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -88,8 +88,10 @@ function preHandlerCallback (err, reply) {
       .then((payload) => {
         // this is for async functions that
         // are using reply.send directly
-        if (payload !== undefined || (reply.res.statusCode === 204 && !reply.sent)) {
+        if (payload !== undefined || reply.res.statusCode === 204) {
           reply.send(payload)
+        } else {
+          reply.res.log.warn(new Error(`Promise may not be fulfilled with 'undefined' when statusCode is not 204`))
         }
       })
       .catch((err) => {

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -90,7 +90,7 @@ function preHandlerCallback (err, reply) {
         // are using reply.send directly
         if (payload !== undefined || reply.res.statusCode === 204) {
           reply.send(payload)
-        } else {
+        } else if (!reply.sent) {
           reply.res.log.error(new Error(`Promise may not be fulfilled with 'undefined' when statusCode is not 204`))
         }
       })

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -90,7 +90,7 @@ function preHandlerCallback (err, reply) {
         // are using reply.send directly
         if (payload !== undefined || reply.res.statusCode === 204) {
           reply.send(payload)
-        } else if (!reply.sent) {
+        } else if (reply.sent === false) {
           reply.res.log.error(new Error(`Promise may not be fulfilled with 'undefined' when statusCode is not 204`))
         }
       })

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -88,7 +88,7 @@ function preHandlerCallback (err, reply) {
       .then((payload) => {
         // this is for async functions that
         // are using reply.send directly
-        if (payload !== undefined || reply.res.statusCode === 204) {
+        if (payload !== undefined || (reply.res.statusCode === 204 && reply.sent === false)) {
           reply.send(payload)
         } else if (reply.sent === false) {
           reply.res.log.error(new Error(`Promise may not be fulfilled with 'undefined' when statusCode is not 204`))

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -249,27 +249,6 @@ function asyncTest (t) {
     })
   })
 
-  test('does not call reply.send() twice if 204 reponse is already sent', t => {
-    t.plan(2)
-
-    const fastify = Fastify()
-
-    fastify.get('/', async (req, reply) => {
-      reply.code(204).send()
-      reply.send = () => {
-        throw new Error('reply.send() was called twice')
-      }
-    })
-
-    fastify.inject({
-      method: 'GET',
-      url: '/'
-    }, (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 204)
-    })
-  })
-
   test('inject async await', async t => {
     t.plan(1)
 

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -357,7 +357,7 @@ function asyncTest (t) {
     })
 
     stream.once('data', line => {
-      t.ok(line.msg, 'Promise may not be fulfilled with \'undefined\' when statusCode is not 204')
+      t.strictEqual(line.msg, 'Promise may not be fulfilled with \'undefined\' when statusCode is not 204')
     })
 
     fastify.listen(0, (err) => {

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -313,6 +313,27 @@ function asyncTest (t) {
     }
   })
 
+  test('does not call reply.send() twice if 204 reponse is already sent', t => {
+    t.plan(2)
+
+    const fastify = Fastify()
+
+    fastify.get('/', async (req, reply) => {
+      reply.code(204).send()
+      reply.send = () => {
+        throw new Error('reply.send() was called twice')
+      }
+    })
+
+    fastify.inject({
+      method: 'GET',
+      url: '/'
+    }, (err, res) => {
+      t.error(err)
+      t.equal(res.statusCode, 204)
+    })
+  })
+
   test('error is logged because promise was fulfilled with undefined', t => {
     t.plan(3)
 


### PR DESCRIPTION
Hi,
* Log `error` when promise is fulfilled with undefined and no other message was sent through `reply.send`

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
