### PR TITLE
Allow parsing empty request bodies

### DIFF
--- a/lib/ContentTypeParser.js
+++ b/lib/ContentTypeParser.js
@@ -146,11 +146,6 @@ function rawBody (request, reply, options, parser, done) {
       return
     }
 
-    if (receivedLength === 0) {
-      reply.code(400).send(new Error('Unexpected end of body input'))
-      return
-    }
-
     if (asString === false) {
       body = Buffer.concat(body)
     }

--- a/test/custom-parser.test.js
+++ b/test/custom-parser.test.js
@@ -585,6 +585,71 @@ test('Should get the body as buffer', t => {
   })
 })
 
+test('Should parse empty bodies as a string', t => {
+  t.plan(5)
+  const fastify = Fastify()
+
+  fastify.post('/', (req, reply) => {
+    reply.send(req.body)
+  })
+
+  fastify.addContentTypeParser('text/plain', { parseAs: 'string' }, function (req, body, done) {
+    t.strictEqual(body, '')
+    done(null, body)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'POST',
+      url: 'http://localhost:' + fastify.server.address().port,
+      body: '',
+      headers: {
+        'Content-Type': 'text/plain'
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(body.toString(), '')
+      fastify.close()
+    })
+  })
+})
+
+test('Should parse empty bodies as a buffer', t => {
+  t.plan(6)
+  const fastify = Fastify()
+
+  fastify.post('/', (req, reply) => {
+    reply.send(req.body)
+  })
+
+  fastify.addContentTypeParser('text/plain', { parseAs: 'buffer' }, function (req, body, done) {
+    t.ok(body instanceof Buffer)
+    t.strictEqual(body.length, 0)
+    done(null, body)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'POST',
+      url: 'http://localhost:' + fastify.server.address().port,
+      body: '',
+      headers: {
+        'Content-Type': 'text/plain'
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(body.length, 0)
+      fastify.close()
+    })
+  })
+})
+
 test('The charset should not interfere with the content type handling', t => {
   t.plan(5)
   const fastify = Fastify()


### PR DESCRIPTION
Disallowing empty bodies was an optimization for parsing `application/json` requests (since JSON bodies are not valid if they are empty). However, now that the ContentTypeParser can be used to parse other content types, this has become a bug.

Fixes #894

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
