### PR TITLE
Add fastify-webhook to community plugins list

### DIFF
--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -65,4 +65,5 @@ Plugins maintained by the fastify team are listed under [Core](#core) while plug
 - [`fastify-session`](https://github.com/SerayaEryn/fastify-session) a session plugin for Fastify.
 - [`fastify-sse`](https://github.com/lolo32/fastify-sse) to provide Server-Sent Events with `reply.sse( … )` to Fastify.
 - [`fastify-tls-keygen`](https://gitlab.com/sebdeckers/fastify-tls-keygen) Automatically generate a browser-compatible, trusted, self-signed, localhost-only, TLS certificate.
+- [`fastify-webhook`](https://github.com/smartiniOnGitHub/fastify-webhook) Fastify Plugin to serve webhooks with useful default settings but overridable.
 - [`fastify-ws`](https://github.com/gj/fastify-ws) WebSocket integration for Fastify — with support for WebSocket lifecycle hooks instead of a single handler function. Built upon [ws](https://github.com/websockets/ws) and [uws](https://github.com/uNetworking/bindings/tree/master/nodejs).


### PR DESCRIPTION
Add 'fastify-webhook' in Community Plugins.
It's used even in this sample project: [fastify-example](https://github.com/smartiniOnGitHub/fastify-example) .

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
