### PR TITLE
Add missing typedefs for listen()

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -254,18 +254,18 @@ declare namespace fastify {
      * internally waits for the .ready() event. The callback is the same as the
      * Node core.
      */
-    listen(port: number, hostname: string, callback?: (err: Error) => void): http.Server
-    listen(port: number, hostname: string): Promise<void>
+    listen(port: number, host: string): Promise<void>
+    listen(port: number, host: string, callback?: (err: Error) => void): http.Server
 
     /**
      * Starts the server on the given port after all the plugins are loaded,
      * internally waits for the .ready() event. The callback is the same as the
      * Node core.
      */
-    listen(port: number, callback?: (err: Error) => void): http.Server
-    listen(path: string, callback?: (err: Error) => void): http.Server
     listen(port: number): Promise<void>
     listen(path: string): Promise<void>
+    listen(port: number, callback?: (err: Error) => void): http.Server
+    listen(path: string, callback?: (err: Error) => void): http.Server
 
     /**
      * Registers a listener function that is invoked when all the plugins have

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -255,6 +255,7 @@ declare namespace fastify {
      * Node core.
      */
     listen(port: number, hostname: string, callback?: (err: Error) => void): http.Server
+    listen(port: number, hostname: string): Promise<void>
 
     /**
      * Starts the server on the given port after all the plugins are loaded,
@@ -263,6 +264,8 @@ declare namespace fastify {
      */
     listen(port: number, callback?: (err: Error) => void): http.Server
     listen(path: string, callback?: (err: Error) => void): http.Server
+    listen(port: number): Promise<void>
+    listen(path: string): Promise<void>
 
     /**
      * Registers a listener function that is invoked when all the plugins have

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -254,6 +254,23 @@ server.listen(3000, err => {
   server.log.info(`server listening on ${server.server.address().port}`)
 })
 
+server.listen(3000, '0.0.0.0', err => {
+  if (err) throw err
+  server.log.info(`server listening on ${server.server.address().port}`)
+})
+
+server.listen(3000).then(() => {
+  server.log.info(`server listening on ${server.server.address().port}`)
+}).catch((error: Error) => {
+  throw error
+})
+
+server.listen(3000, '0.0.0.0').then(() => {
+  server.log.info(`server listening on ${server.server.address().port}`)
+}).catch((error: Error) => {
+  throw error
+})
+
 // http injections
 server.inject({ url: "/test" }, (err: Error, res: fastify.HTTPInjectResponse) => {
   server.log.debug(err);


### PR DESCRIPTION
fastify.listen() can be used without a callback and return a promise instead. These signatures were missing in the typedefs and are added by this bugfix.
Thanks for your awesome work!

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
