### PR TITLE
Add content type parser typedefs

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -255,6 +255,7 @@ declare namespace fastify {
      * Node core.
      */
     listen(port: number, hostname: string, callback?: (err: Error) => void): http.Server
+    listen(port: number, hostname: string): Promise<void>
 
     /**
      * Starts the server on the given port after all the plugins are loaded,
@@ -263,6 +264,8 @@ declare namespace fastify {
      */
     listen(port: number, callback?: (err: Error) => void): http.Server
     listen(path: string, callback?: (err: Error) => void): http.Server
+    listen(port: number): Promise<void>
+    listen(path: string): Promise<void>
 
     /**
      * Registers a listener function that is invoked when all the plugins have

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -403,7 +403,7 @@ declare namespace fastify {
      * Add a content type parser
      */
     addContentTypeParser(contentType: string, parser?: AsyncContentTypeParser<HttpRequest> | ContentTypeParser<HttpRequest>): void;
-    addContentTypeParser(contentType: string, opts: object | AsyncContentTypeParser<HttpRequest> | ContentTypeParser<HttpRequest>, parser?: AsyncContentTypeParser<HttpRequest> | ContentTypeParser<HttpRequest>): void;
+    addContentTypeParser(contentType: string, opts: AddContentParserOptions | AsyncContentTypeParser<HttpRequest> | ContentTypeParser<HttpRequest>, parser?: AsyncContentTypeParser<HttpRequest> | ContentTypeParser<HttpRequest>): void;
 
     /**
      * Check if a parser for the specified content type exists

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -168,6 +168,14 @@ declare namespace fastify {
   }
 
   /**
+   * 
+   */
+  interface AddContentParserOptions {
+    parseAs?: 'string' | 'buffer',
+    bodyLimit?: number
+  }
+
+  /**
    * Represents the fastify instance created by the factory function the module exports.
    */
   interface FastifyInstance<HttpServer = http.Server, HttpRequest = http.IncomingMessage, HttpResponse = http.ServerResponse> {
@@ -394,6 +402,7 @@ declare namespace fastify {
     /**
      * Add a content type parser
      */
+    addContentTypeParser(contentType: string, parser?: AsyncContentTypeParser<HttpRequest> | ContentTypeParser<HttpRequest>): void;
     addContentTypeParser(contentType: string, opts: object | AsyncContentTypeParser<HttpRequest> | ContentTypeParser<HttpRequest>, parser?: AsyncContentTypeParser<HttpRequest> | ContentTypeParser<HttpRequest>): void;
 
     /**

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -269,9 +269,15 @@ server.setSchemaCompiler(function (schema: object) {
 
 server.addSchema({})
 
+server.addContentTypeParser('foo/bar', (req, done) => {
+  done!(null, {})
+})
+
 server.addContentTypeParser('foo/bar', {}, (req, done) => {
   done!(null, {})
 })
+
+server.addContentTypeParser('foo/bar', async (req: http2.Http2ServerRequest) => [])
 
 server.addContentTypeParser('foo/bar', {}, async (req: http2.Http2ServerRequest) => [])
 


### PR DESCRIPTION
fastify.addContentTypeParser() can be used without options. These signatures were missing in the typedefs and are added by this bugfix. Also the options are typed now.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
