### PR TITLE
makes input schema required headers validation case insensitive

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -37,6 +37,9 @@ function build (context, compile, schemas) {
       if (headers.hasOwnProperty(k) !== true) continue
       headersSchemaLowerCase[k] = headers[k]
     }
+    if (headersSchemaLowerCase.required instanceof Array) {
+      headersSchemaLowerCase.required = headersSchemaLowerCase.required.join(':').toLowerCase().split(':')
+    }
     if (headers.properties) {
       const properties = headers.properties
       for (const k in properties) {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -38,7 +38,7 @@ function build (context, compile, schemas) {
       headersSchemaLowerCase[k] = headers[k]
     }
     if (headersSchemaLowerCase.required instanceof Array) {
-      headersSchemaLowerCase.required = headersSchemaLowerCase.required.join(':').toLowerCase().split(':')
+      headersSchemaLowerCase.required = headersSchemaLowerCase.required.map(h => h.toLowerCase())
     }
     if (headers.properties) {
       const properties = headers.properties

--- a/test/input-validation.test.js
+++ b/test/input-validation.test.js
@@ -4,34 +4,32 @@ const t = require('tap')
 const test = t.test
 const fastify = require('..')()
 
-test('case insensitive header validation', async t => {
-  t.plan(1)
-  try {
-    fastify.route({
-      method: 'GET',
-      url: '/',
-      handler: (req, reply) => {
-        reply.code(200).send(req.headers.foobar)
-      },
-      schema: {
-        headers: {
-          type: 'object',
-          required: ['FooBar'],
-          properties: {
-            FooBar: { type: 'string' }
-          }
+test('case insensitive header validation', t => {
+  t.plan(2)
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    handler: (req, reply) => {
+      reply.code(200).send(req.headers.foobar)
+    },
+    schema: {
+      headers: {
+        type: 'object',
+        required: ['FooBar'],
+        properties: {
+          FooBar: { type: 'string' }
         }
       }
-    })
-    const res = await fastify.inject({
-      method: 'GET',
-      url: '/',
-      headers: {
-        'FooBar': 'Baz'
-      }
-    })
-    t.equal(res.payload, 'Baz')
-  } catch (err) {
+    }
+  })
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      'FooBar': 'Baz'
+    }
+  }, (err, res) => {
     t.error(err)
-  }
+    t.equal(res.payload, 'Baz')
+  })
 })

--- a/test/input-validation.test.js
+++ b/test/input-validation.test.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const fastify = require('..')()
+
+test('case insensitive header validation', async t => {
+  t.plan(1)
+  try {
+    fastify.route({
+      method: 'GET',
+      url: '/',
+      handler: (req, reply) => {
+        reply.code(200).send(req.headers.foobar)
+      },
+      schema: {
+        headers: {
+          type: 'object',
+          required: ['FooBar'],
+          properties: {
+            FooBar: { type: 'string' }
+          }
+        }
+      }
+    })
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/',
+      headers: {
+        'FooBar': 'Baz'
+      }
+    })
+    t.equal(res.payload, 'Baz')
+  } catch (err) {
+    t.error(err)
+  }
+})


### PR DESCRIPTION
When validating incoming headers both the schema header properties and the incoming header properties are converted to lower case, However the property names in the schema required array are not converted to lower case which cause validation to fail.

**schema**
```javascript
schema: {
  headers: {
    type: 'object',
    required: ['FooBar'],
    properties: {
      FooBar: { type: 'string' }
    }
  }
}
```

**request**
```javascript
{
  method: 'GET',
  url: '/',
  headers: {
    'FooBar': 'Baz'
  }
}
```

**error**
```json
{"statusCode":400,"error":"Bad Request","message":"headers should have required property 'FooBar'"}
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
