### PR TITLE
enforce utf8 as default charset

### DIFF
--- a/docs/ContentTypeParser.md
+++ b/docs/ContentTypeParser.md
@@ -1,7 +1,7 @@
 <h1 align="center">Fastify</h1>
 
 ## Content Type Parser
-Natively, Fastify only supports the `'application/json'` content type. If you need to support different content types, you can use the `addContentTypeParser` API. *The default JSON parser can be changed.*
+Natively, Fastify only supports the `'application/json'` content type. The default charset is `utf-8`. If you need to support different content types, you can use the `addContentTypeParser` API. *The default JSON parser can be changed.*
 
 As with the other APIs, `addContentTypeParser` is encapsulated in the scope in which it is declared. This means that if you declare it in the root scope it will be available everywhere, while if you declare it inside a register it will be available only in that scope and its children.
 

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -21,7 +21,7 @@ fastify.get('/', options, function (request, reply) {
   // Your code
   reply
     .code(200)
-    .header('Content-Type', 'application/json')
+    .header('Content-Type', 'application/json;charset=utf-8')
     .send({ hello: 'world' })
 })
 ```
@@ -118,7 +118,7 @@ fastify.get('/json', options, function (request, reply) {
 
 <a name="send-string"></a>
 #### Strings
-If you pass a string to `send` without a `Content-Type`, it will be sent as plain text. If you set the `Content-Type` header and pass a string to `send`, it will be serialized with the custom serializer if one is set, otherwise it will be sent unmodified (unless the `Content-Type` header is set to `application/json`, in which case it will be JSON-serialized like an object — see the section above).
+If you pass a string to `send` without a `Content-Type`, it will be sent as `text/plain;charset=utf-8`. If you set the `Content-Type` header and pass a string to `send`, it will be serialized with the custom serializer if one is set, otherwise it will be sent unmodified (unless the `Content-Type` header is set to `application/json;charset=utf-8`, in which case it will be JSON-serialized like an object — see the section above).
 ```js
 fastify.get('/json', options, function (request, reply) {
   reply.send('plain string')

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -21,7 +21,7 @@ fastify.get('/', options, function (request, reply) {
   // Your code
   reply
     .code(200)
-    .header('Content-Type', 'application/json;charset=utf-8')
+    .header('Content-Type', 'application/json; charset=utf-8')
     .send({ hello: 'world' })
 })
 ```
@@ -118,7 +118,7 @@ fastify.get('/json', options, function (request, reply) {
 
 <a name="send-string"></a>
 #### Strings
-If you pass a string to `send` without a `Content-Type`, it will be sent as `text/plain;charset=utf-8`. If you set the `Content-Type` header and pass a string to `send`, it will be serialized with the custom serializer if one is set, otherwise it will be sent unmodified (unless the `Content-Type` header is set to `application/json;charset=utf-8`, in which case it will be JSON-serialized like an object — see the section above).
+If you pass a string to `send` without a `Content-Type`, it will be sent as `text/plain; charset=utf-8`. If you set the `Content-Type` header and pass a string to `send`, it will be serialized with the custom serializer if one is set, otherwise it will be sent unmodified (unless the `Content-Type` header is set to `application/json; charset=utf-8`, in which case it will be JSON-serialized like an object — see the section above).
 ```js
 fastify.get('/json', options, function (request, reply) {
   reply.send('plain string')

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -86,7 +86,7 @@ tap.test('GET `/` route', t => {
   }, (err, response) => {
     t.error(err)
     t.strictEqual(response.statusCode, 200)
-    t.strictEqual(response.headers['content-type'], 'application/json')
+    t.strictEqual(response.headers['content-type'], 'application/json;charset=utf-8')
     t.deepEqual(JSON.parse(response.payload), { hello: 'world' })
   })
 })
@@ -121,7 +121,7 @@ tap.test('GET `/` route', t => {
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
-      t.strictEqual(response.headers['content-type'], 'application/json')
+      t.strictEqual(response.headers['content-type'], 'application/json;charset=utf-8')
       t.deepEqual(JSON.parse(body), { hello: 'world' })
     })
   })
@@ -144,7 +144,7 @@ tap.test('GET `/` route', async (t) => {
   const response = await supertest(fastify.server)
     .get('/')
     .expect(200)
-    .expect('Content-Type', 'application/json')
+    .expect('Content-Type', 'application/json;charset=utf-8')
   t.deepEqual(response.body, { hello: 'world' })
 })
 ```

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -86,7 +86,7 @@ tap.test('GET `/` route', t => {
   }, (err, response) => {
     t.error(err)
     t.strictEqual(response.statusCode, 200)
-    t.strictEqual(response.headers['content-type'], 'application/json;charset=utf-8')
+    t.strictEqual(response.headers['content-type'], 'application/json; charset=utf-8')
     t.deepEqual(JSON.parse(response.payload), { hello: 'world' })
   })
 })
@@ -121,7 +121,7 @@ tap.test('GET `/` route', t => {
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
-      t.strictEqual(response.headers['content-type'], 'application/json;charset=utf-8')
+      t.strictEqual(response.headers['content-type'], 'application/json; charset=utf-8')
       t.deepEqual(JSON.parse(body), { hello: 'world' })
     })
   })
@@ -144,7 +144,7 @@ tap.test('GET `/` route', async (t) => {
   const response = await supertest(fastify.server)
     .get('/')
     .expect(200)
-    .expect('Content-Type', 'application/json;charset=utf-8')
+    .expect('Content-Type', 'application/json; charset=utf-8')
   t.deepEqual(response.body, { hello: 'world' })
 })
 ```

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -51,19 +51,19 @@ Reply.prototype.send = function (payload) {
   }
 
   var contentType = getHeader(this, 'content-type')
-  var contentTypeNotSet = contentType === undefined
+  var hasContentType = contentType !== undefined
 
   if (payload !== null) {
     if (Buffer.isBuffer(payload) || typeof payload.pipe === 'function') {
-      if (contentTypeNotSet) {
+      if (hasContentType === false) {
         this._headers['content-type'] = 'application/octet-stream'
       }
       onSendHook(this, payload)
       return
     }
 
-    if (contentTypeNotSet && typeof payload === 'string') {
-      this._headers['content-type'] = 'text/plain'
+    if (hasContentType === false && typeof payload === 'string') {
+      this._headers['content-type'] = 'text/plain;charset=utf-8'
       onSendHook(this, payload)
       return
     }
@@ -71,8 +71,8 @@ Reply.prototype.send = function (payload) {
 
   if (this._serializer) {
     payload = this._serializer(payload)
-  } else if (contentTypeNotSet || contentType === 'application/json') {
-    this._headers['content-type'] = 'application/json'
+  } else if (hasContentType === false || contentType === 'application/json') {
+    this._headers['content-type'] = 'application/json;charset=utf-8'
     payload = serialize(this.context, payload, this.res.statusCode)
     flatstr(payload)
   }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -63,7 +63,7 @@ Reply.prototype.send = function (payload) {
     }
 
     if (hasContentType === false && typeof payload === 'string') {
-      this._headers['content-type'] = 'text/plain;charset=utf-8'
+      this._headers['content-type'] = 'text/plain; charset=utf-8'
       onSendHook(this, payload)
       return
     }
@@ -72,7 +72,7 @@ Reply.prototype.send = function (payload) {
   if (this._serializer) {
     payload = this._serializer(payload)
   } else if (hasContentType === false || contentType === 'application/json') {
-    this._headers['content-type'] = 'application/json;charset=utf-8'
+    this._headers['content-type'] = 'application/json; charset=utf-8'
     payload = serialize(this.context, payload, this.res.statusCode)
     flatstr(payload)
   }

--- a/test/helper.js
+++ b/test/helper.js
@@ -119,7 +119,7 @@ module.exports.payloadMethod = function (method, t) {
         url: 'http://localhost:' + fastify.server.address().port,
         body: JSON.stringify({ hello: 'world' }),
         headers: {
-          'content-type': 'application/json;charset=utf-8'
+          'content-type': 'application/json; charset=utf-8'
         }
       }, (err, response, body) => {
         t.error(err)

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -717,7 +717,7 @@ test('onSend hook is called after payload is serialized and headers are set', t 
 
     instance.addHook('onSend', function (request, reply, payload, next) {
       t.deepEqual(JSON.parse(payload), thePayload)
-      t.strictEqual(reply._headers['content-type'], 'application/json')
+      t.strictEqual(reply._headers['content-type'], 'application/json;charset=utf-8')
       next()
     })
 
@@ -731,7 +731,7 @@ test('onSend hook is called after payload is serialized and headers are set', t 
   fastify.register((instance, opts, next) => {
     instance.addHook('onSend', function (request, reply, payload, next) {
       t.strictEqual(payload, 'some text')
-      t.strictEqual(reply._headers['content-type'], 'text/plain')
+      t.strictEqual(reply._headers['content-type'], 'text/plain;charset=utf-8')
       next()
     })
 
@@ -913,7 +913,7 @@ test('clear payload', t => {
     t.strictEqual(res.statusCode, 304)
     t.strictEqual(res.payload, '')
     t.strictEqual(res.headers['content-length'], undefined)
-    t.strictEqual(res.headers['content-type'], 'application/json')
+    t.strictEqual(res.headers['content-type'], 'application/json;charset=utf-8')
   })
 })
 
@@ -1711,7 +1711,7 @@ test('If a response header has been set inside an hook it shoulod not be overwri
   fastify.inject('/', (err, res) => {
     t.error(err)
     t.strictEqual(res.headers['x-custom-header'], 'hello')
-    t.strictEqual(res.headers['content-type'], 'text/plain')
+    t.strictEqual(res.headers['content-type'], 'text/plain;charset=utf-8')
     t.strictEqual(res.statusCode, 200)
     t.strictEqual(res.payload, 'hello')
   })

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -717,7 +717,7 @@ test('onSend hook is called after payload is serialized and headers are set', t 
 
     instance.addHook('onSend', function (request, reply, payload, next) {
       t.deepEqual(JSON.parse(payload), thePayload)
-      t.strictEqual(reply._headers['content-type'], 'application/json;charset=utf-8')
+      t.strictEqual(reply._headers['content-type'], 'application/json; charset=utf-8')
       next()
     })
 
@@ -731,7 +731,7 @@ test('onSend hook is called after payload is serialized and headers are set', t 
   fastify.register((instance, opts, next) => {
     instance.addHook('onSend', function (request, reply, payload, next) {
       t.strictEqual(payload, 'some text')
-      t.strictEqual(reply._headers['content-type'], 'text/plain;charset=utf-8')
+      t.strictEqual(reply._headers['content-type'], 'text/plain; charset=utf-8')
       next()
     })
 
@@ -913,7 +913,7 @@ test('clear payload', t => {
     t.strictEqual(res.statusCode, 304)
     t.strictEqual(res.payload, '')
     t.strictEqual(res.headers['content-length'], undefined)
-    t.strictEqual(res.headers['content-type'], 'application/json;charset=utf-8')
+    t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
   })
 })
 
@@ -1711,7 +1711,7 @@ test('If a response header has been set inside an hook it shoulod not be overwri
   fastify.inject('/', (err, res) => {
     t.error(err)
     t.strictEqual(res.headers['x-custom-header'], 'hello')
-    t.strictEqual(res.headers['content-type'], 'text/plain;charset=utf-8')
+    t.strictEqual(res.headers['content-type'], 'text/plain; charset=utf-8')
     t.strictEqual(res.statusCode, 200)
     t.strictEqual(res.payload, 'hello')
   })

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -310,7 +310,7 @@ test('plain string without content type should send a text/plain', t => {
       url: 'http://localhost:' + fastify.server.address().port
     }, (err, response, body) => {
       t.error(err)
-      t.strictEqual(response.headers['content-type'], 'text/plain')
+      t.strictEqual(response.headers['content-type'], 'text/plain;charset=utf-8')
       t.deepEqual(body.toString(), 'hello world!')
     })
   })
@@ -385,7 +385,7 @@ test('plain string with content type application/json should be serialized as js
       url: 'http://localhost:' + fastify.server.address().port
     }, (err, response, body) => {
       t.error(err)
-      t.strictEqual(response.headers['content-type'], 'application/json')
+      t.strictEqual(response.headers['content-type'], 'application/json;charset=utf-8')
       t.deepEqual(body.toString(), '"hello world!"')
     })
   })
@@ -501,7 +501,7 @@ test('reply.send(new NotFound()) should invoke the 404 handler', t => {
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 404)
-      t.strictEqual(response.headers['content-type'], 'text/plain')
+      t.strictEqual(response.headers['content-type'], 'text/plain;charset=utf-8')
       t.deepEqual(body.toString(), 'Custom not found response')
     })
   })
@@ -535,7 +535,7 @@ test('reply.send(new NotFound()) should log a warning and send a basic response 
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 404)
-      t.strictEqual(response.headers['content-type'], 'text/plain')
+      t.strictEqual(response.headers['content-type'], 'text/plain;charset=utf-8')
       t.deepEqual(body.toString(), '404 Not Found')
     })
   })

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -310,7 +310,7 @@ test('plain string without content type should send a text/plain', t => {
       url: 'http://localhost:' + fastify.server.address().port
     }, (err, response, body) => {
       t.error(err)
-      t.strictEqual(response.headers['content-type'], 'text/plain;charset=utf-8')
+      t.strictEqual(response.headers['content-type'], 'text/plain; charset=utf-8')
       t.deepEqual(body.toString(), 'hello world!')
     })
   })
@@ -385,7 +385,7 @@ test('plain string with content type application/json should be serialized as js
       url: 'http://localhost:' + fastify.server.address().port
     }, (err, response, body) => {
       t.error(err)
-      t.strictEqual(response.headers['content-type'], 'application/json;charset=utf-8')
+      t.strictEqual(response.headers['content-type'], 'application/json; charset=utf-8')
       t.deepEqual(body.toString(), '"hello world!"')
     })
   })
@@ -501,7 +501,7 @@ test('reply.send(new NotFound()) should invoke the 404 handler', t => {
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 404)
-      t.strictEqual(response.headers['content-type'], 'text/plain;charset=utf-8')
+      t.strictEqual(response.headers['content-type'], 'text/plain; charset=utf-8')
       t.deepEqual(body.toString(), 'Custom not found response')
     })
   })
@@ -535,7 +535,7 @@ test('reply.send(new NotFound()) should log a warning and send a basic response 
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 404)
-      t.strictEqual(response.headers['content-type'], 'text/plain;charset=utf-8')
+      t.strictEqual(response.headers['content-type'], 'text/plain; charset=utf-8')
       t.deepEqual(body.toString(), '404 Not Found')
     })
   })


### PR DESCRIPTION
Fix #913 

I updated all docs to promote good practice.

This should be handled as minor change. The charset of JSON is `utf8`. The default charset of `text` isn't given but we can protect users against crazy misinterpretations. `utf8` [is widely adopted](https://w3techs.com/technologies/overview/character_encoding/all) and defacto standard and most supported charset.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
