### PR TITLE
Return URL from listen method

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -23,7 +23,7 @@ fastify
       .send({ hello: 'world' })
   })
 
-fastify.listen(3000, err => {
+fastify.listen(3000, (err, address) => {
   if (err) throw err
   console.log(`server listening on ${fastify.server.address().port}`)
 })

--- a/fastify.js
+++ b/fastify.js
@@ -268,8 +268,8 @@ function build (options) {
             reject(err)
           } else {
             server.removeListener('error', errEventHandler)
-            logServerAddress(server.address(), options.https)
-            resolve()
+            var address = logServerAddress(server.address(), options.https) || null
+            resolve(address)
           }
         })
         // we set it afterwards because listen can throw

--- a/fastify.js
+++ b/fastify.js
@@ -299,9 +299,9 @@ function build (options) {
     if (cb === undefined) return listenPromise(port, address, backlog)
 
     fastify.ready(function (err) {
-      if (err) return cb(err, null)
+      if (err) return cb(err)
       if (listening) {
-        return cb(new Error('Fastify is already listening'), null)
+        return cb(new Error('Fastify is already listening'))
       }
 
       server.once('error', wrap)
@@ -315,7 +315,7 @@ function build (options) {
     })
 
     function wrap (err) {
-      var address = null
+      var address
       if (!err) {
         address = logServerAddress(server.address(), options.https)
       } else {

--- a/fastify.js
+++ b/fastify.js
@@ -268,8 +268,7 @@ function build (options) {
             reject(err)
           } else {
             server.removeListener('error', errEventHandler)
-            var address = logServerAddress(server.address(), options.https) || null
-            resolve(address)
+            resolve(logServerAddress(server.address(), options.https))
           }
         })
         // we set it afterwards because listen can throw

--- a/fastify.js
+++ b/fastify.js
@@ -300,9 +300,9 @@ function build (options) {
     if (cb === undefined) return listenPromise(port, address, backlog)
 
     fastify.ready(function (err) {
-      if (err) return cb(err)
+      if (err) return cb(err, null)
       if (listening) {
-        return cb(new Error('Fastify is already listening'))
+        return cb(new Error('Fastify is already listening'), null)
       }
 
       server.once('error', wrap)
@@ -316,13 +316,14 @@ function build (options) {
     })
 
     function wrap (err) {
+      var address = null
       if (!err) {
-        logServerAddress(server.address(), options.https)
+        address = logServerAddress(server.address(), options.https)
       } else {
         listening = false
       }
       server.removeListener('error', wrap)
-      cb(err)
+      cb(err, address)
     }
   }
 
@@ -336,6 +337,7 @@ function build (options) {
     }
     address = 'http' + (isHttps ? 's' : '') + '://' + address
     fastify.log.info('Server listening at ' + address)
+    return address
   }
 
   function State (req, res, params, context) {

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -138,8 +138,8 @@ test('double listen errors', t => {
 test('double listen err, address (first listen)', t => {
   t.plan(3)
   const fastify = Fastify()
-  fastify.listen(0, (err, address1) => {
-    t.is(address1, 'http://127.0.0.1:' + fastify.server.address().port)
+  fastify.listen(0, (err, address) => {
+    t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
     t.error(err)
     fastify.listen(fastify.server.address().port, (err) => {
       t.ok(err)
@@ -153,8 +153,8 @@ test('double listen err, address (second listen)', t => {
   const fastify = Fastify()
   fastify.listen(0, (err) => {
     t.error(err)
-    fastify.listen(fastify.server.address().port, (err, address2) => {
-      t.is(null, address2)
+    fastify.listen(fastify.server.address().port, (err, address) => {
+      t.is(null, address)
       t.ok(err)
       fastify.close()
     })
@@ -177,8 +177,8 @@ test('listen twice on the same port', t => {
 test('listen twice on the same port (first listen)', t => {
   t.plan(3)
   const fastify = Fastify()
-  fastify.listen(0, (err, address1) => {
-    t.is(address1, 'http://127.0.0.1:' + fastify.server.address().port)
+  fastify.listen(0, (err, address) => {
+    t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
     t.error(err)
     const s2 = Fastify()
     s2.listen(fastify.server.address().port, (err) => {
@@ -194,8 +194,8 @@ test('listen twice on the same port (second listen)', t => {
   fastify.listen(0, (err) => {
     t.error(err)
     const s2 = Fastify()
-    s2.listen(fastify.server.address().port, (err, address2) => {
-      t.is(null, address2)
+    s2.listen(fastify.server.address().port, (err, address) => {
+      t.is(null, address)
       fastify.close()
       t.ok(err)
     })
@@ -217,20 +217,6 @@ if (os.platform() !== 'win32') {
       fastify.close()
     })
   })
-
-  test('listen on socket with callback address', t => {
-    t.plan(2)
-    const fastify = Fastify()
-    const sockFile = path.join(os.tmpdir(), 'server.sock')
-    try {
-      fs.unlinkSync(sockFile)
-    } catch (e) { }
-    fastify.listen(sockFile, (err, address) => {
-      t.error(err)
-      t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
-      fastify.close()
-    })
-  })
 }
 
 test('listen without callback', t => {
@@ -241,6 +227,51 @@ test('listen without callback', t => {
       t.is(fastify.server.address().address, '127.0.0.1')
       fastify.close()
       t.end()
+    })
+})
+
+test('listen null without callback', t => {
+  t.plan(1)
+  const fastify = Fastify()
+  fastify.listen(null)
+    .then((address) => {
+      t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
+      fastify.close()
+      t.end()
+    })
+    .catch(err => {
+      t.ok(err)
+      fastify.close()
+    })
+})
+
+test('listen without port without callback', t => {
+  t.plan(1)
+  const fastify = Fastify()
+  fastify.listen()
+    .then((address) => {
+      t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
+      fastify.close()
+      t.end()
+    })
+    .catch(err => {
+      t.ok(err)
+      fastify.close()
+    })
+})
+
+test('listen with undefined without callback', t => {
+  t.plan(1)
+  const fastify = Fastify()
+  fastify.listen(undefined)
+    .then((address) => {
+      t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
+      fastify.close()
+      t.end()
+    })
+    .catch(err => {
+      t.ok(err)
+      fastify.close()
     })
 })
 
@@ -274,13 +305,13 @@ test('double listen without callback rejects', t => {
 })
 
 test('double listen without callback rejects and passing address in resolve', t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
   fastify.listen(0)
-    .then(() => {
+    .then((address) => {
+      t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
       fastify.listen(0)
-        .then((address) => {
-          t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
+        .then(() => {
           t.error(new Error('second call to fastify.listen resolved'))
           fastify.close()
         })

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -122,20 +122,6 @@ test('listen after Promise.resolve()', t => {
     })
 })
 
-test('listen after Promise.resolve() listen callback with (err, address)', t => {
-  t.plan(2)
-  const f = Fastify()
-  Promise.resolve()
-    .then(() => {
-      f.listen(0, (err, address) => {
-        f.server.unref()
-        t.is(address, 'http://127.0.0.1:' + f.server.address().port)
-        t.error(err)
-        return f.close()
-      })
-    })
-})
-
 test('register after listen using Promise.resolve()', t => {
   t.plan(1)
   const f = Fastify()

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -18,7 +18,29 @@ test('listen accepts a port and a callback', t => {
   })
 })
 
-test('listen accepts a port and a callback with err, address', t => {
+test('listen accepts a port and a callbac with (err, address)', t => {
+  t.plan(2)
+  const fastify = Fastify()
+  fastify.listen(0, (err, address) => {
+    fastify.server.unref()
+    t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
+    t.error(err)
+    fastify.close()
+  })
+})
+
+test('listen accepts a port, address, and callback', t => {
+  t.plan(2)
+  const fastify = Fastify()
+  fastify.listen(0, '127.0.0.1', (err) => {
+    fastify.server.unref()
+    t.error(err)
+    t.pass()
+    fastify.close()
+  })
+})
+
+test('listen accepts a port and a callback with (err, address)', t => {
   t.plan(3)
   const fastify = Fastify()
   fastify.listen(0, (err, address) => {
@@ -41,7 +63,7 @@ test('listen accepts a port, address, and callback', t => {
   })
 })
 
-test('listen accepts a port, address, and callback with err, address', t => {
+test('listen accepts a port, address, and callback with (err, address)', t => {
   t.plan(3)
   const fastify = Fastify()
   fastify.listen(0, '127.0.0.1', (err, address) => {
@@ -64,14 +86,24 @@ test('listen accepts a port, address, backlog and callback', t => {
   })
 })
 
-test('listen accepts a port, address, backlog and callback with err, address', t => {
-  t.plan(3)
+test('listen accepts a port, address, backlog and callback with (err, address)', t => {
+  t.plan(2)
   const fastify = Fastify()
   fastify.listen(0, '127.0.0.1', 511, (err, address) => {
     fastify.server.unref()
     t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
     t.error(err)
-    t.pass()
+    fastify.close()
+  })
+})
+
+test('listen accepts a port, address, backlog and callback with (err, address)', t => {
+  t.plan(2)
+  const fastify = Fastify()
+  fastify.listen(0, '127.0.0.1', 511, (err, address) => {
+    fastify.server.unref()
+    t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
+    t.error(err)
     fastify.close()
   })
 })
@@ -90,8 +122,8 @@ test('listen after Promise.resolve()', t => {
     })
 })
 
-test('listen after Promise.resolve() listen callback with err, address', t => {
-  t.plan(3)
+test('listen after Promise.resolve() listen callback with (err, address)', t => {
+  t.plan(2)
   const f = Fastify()
   Promise.resolve()
     .then(() => {
@@ -99,8 +131,7 @@ test('listen after Promise.resolve() listen callback with err, address', t => {
         f.server.unref()
         t.is(address, 'http://127.0.0.1:' + f.server.address().port)
         t.error(err)
-        t.pass()
-        f.close()
+        return f.close()
       })
     })
 })
@@ -127,6 +158,7 @@ test('double listen errors', t => {
   t.plan(2)
   const fastify = Fastify()
   fastify.listen(0, (err) => {
+    fastify.server.unref()
     t.error(err)
     fastify.listen(fastify.server.address().port, (err) => {
       t.ok(err)
@@ -135,26 +167,13 @@ test('double listen errors', t => {
   })
 })
 
-test('double listen err, address (first listen)', t => {
-  t.plan(3)
-  const fastify = Fastify()
-  fastify.listen(0, (err, address) => {
-    t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
-    t.error(err)
-    fastify.listen(fastify.server.address().port, (err) => {
-      t.ok(err)
-      fastify.close()
-    })
-  })
-})
-
-test('double listen err, address (second listen)', t => {
-  t.plan(3)
+test('double listen errors callback with (err, address)', t => {
+  t.plan(2)
   const fastify = Fastify()
   fastify.listen(0, (err) => {
+    fastify.server.unref()
     t.error(err)
-    fastify.listen(fastify.server.address().port, (err, address) => {
-      t.is(null, address)
+    fastify.listen(fastify.server.address().port, (err) => {
       t.ok(err)
       fastify.close()
     })
@@ -168,36 +187,23 @@ test('listen twice on the same port', t => {
     t.error(err)
     const s2 = Fastify()
     s2.listen(fastify.server.address().port, (err) => {
-      fastify.close()
       t.ok(err)
+      fastify.close()
     })
   })
 })
 
-test('listen twice on the same port (first listen)', t => {
-  t.plan(3)
+test('listen twice on the same port callback with (err, address)', t => {
+  t.plan(4)
   const fastify = Fastify()
   fastify.listen(0, (err, address) => {
+    t.error(err)
     t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
-    t.error(err)
-    const s2 = Fastify()
-    s2.listen(fastify.server.address().port, (err) => {
-      fastify.close()
-      t.ok(err)
-    })
-  })
-})
-
-test('listen twice on the same port (second listen)', t => {
-  t.plan(3)
-  const fastify = Fastify()
-  fastify.listen(0, (err) => {
-    t.error(err)
     const s2 = Fastify()
     s2.listen(fastify.server.address().port, (err, address) => {
-      t.is(null, address)
-      fastify.close()
+      t.is(address === undefined, true)
       t.ok(err)
+      fastify.close()
     })
   })
 })
@@ -230,7 +236,7 @@ test('listen without callback', t => {
     })
 })
 
-test('listen null without callback', t => {
+test('listen null without callback with (address)', t => {
   t.plan(1)
   const fastify = Fastify()
   fastify.listen(null)
@@ -245,7 +251,7 @@ test('listen null without callback', t => {
     })
 })
 
-test('listen without port without callback', t => {
+test('listen without port without callback with (address)', t => {
   t.plan(1)
   const fastify = Fastify()
   fastify.listen()
@@ -260,7 +266,7 @@ test('listen without port without callback', t => {
     })
 })
 
-test('listen with undefined without callback', t => {
+test('listen with undefined without callback with (address)', t => {
   t.plan(1)
   const fastify = Fastify()
   fastify.listen(undefined)
@@ -275,7 +281,7 @@ test('listen with undefined without callback', t => {
     })
 })
 
-test('listen without callback and pass address as params', t => {
+test('listen without callback with (address)', t => {
   t.plan(1)
   const fastify = Fastify()
   fastify.listen(0)
@@ -304,7 +310,7 @@ test('double listen without callback rejects', t => {
     .catch(err => t.error(err))
 })
 
-test('double listen without callback rejects and passing address in resolve', t => {
+test('double listen without callback with (address)', t => {
   t.plan(2)
   const fastify = Fastify()
   fastify.listen(0)
@@ -344,7 +350,7 @@ test('listen twice on the same port without callback rejects', t => {
     .catch(err => t.error(err))
 })
 
-test('listen twice on the same port without callback rejects along with pass address in resolve (first listen)', t => {
+test('listen twice on the same port without callback rejects with (address)', t => {
   t.plan(2)
   const fastify = Fastify()
 
@@ -353,32 +359,10 @@ test('listen twice on the same port without callback rejects along with pass add
       const s2 = Fastify()
       t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
       s2.listen(fastify.server.address().port)
-        .then(() => {
-          fastify.close()
-          s2.close()
-          t.error(new Error('listen on port already in use resolved'))
-        })
-        .catch(err => {
-          t.ok(err)
-          fastify.close()
-        })
-    })
-    .catch(err => t.error(err))
-})
-
-test('listen twice on the same port without callback rejects along with pass address in resolve (second listen)', t => {
-  t.plan(1)
-  const fastify = Fastify()
-
-  fastify.listen(0)
-    .then(() => {
-      const s2 = Fastify()
-      s2.listen(fastify.server.address().port)
         .then((address) => {
-          t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
-          fastify.close()
-          s2.close()
           t.error(new Error('listen on port already in use resolved'))
+          s2.close()
+          fastify.close()
         })
         .catch(err => {
           t.ok(err)
@@ -391,10 +375,10 @@ test('listen twice on the same port without callback rejects along with pass add
 test('listen on invalid port without callback rejects', t => {
   t.plan(1)
   const fastify = Fastify()
-  fastify.listen(-1)
+  return fastify.listen(-1)
     .catch(err => {
       t.ok(err)
-      fastify.close()
+      return fastify.close()
     })
 })
 


### PR DESCRIPTION
Full URL address can be passed in `fastify.listen()`. If listen() is a promise then address passed through resolve method or if it is a callback then passed along with error.

Fixed [issue:875](https://github.com/fastify/fastify/issues/875)

### Example
```js
fastify.listen(3000, '127.0.0.1')
  .then(address) => /* do whatever */)
  .catch(error) => /* error */);
```
or
```js
fastify.listen(3000, '127.0.0.1', (err, address) => /* do whatever */);
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] documentation is changed or added
- [x] tests are included
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
