### PR TITLE
Updated Getting-Started.md, fixed command for fastify start

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -289,7 +289,7 @@ Then, add the following lines to `package.json`:
 ```json
 {
   "scripts": {
-    "start": "fastify server.js"
+    "start": "fastify start server.js"
   }
 }
 ```


### PR DESCRIPTION
`fastify server.js` wouldn't start the server, according to `fastify-cli` correct command to start server is `fastify start server.js`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
