### PR TITLE
Fix typescript address test

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -1,11 +1,14 @@
+/* eslint no-unused-vars: 0 */
+/* eslint no-undef: 0 */
+/* eslint space-infix-ops: 0 */
 
 /// <reference types="node" />
 /// <reference types="pino" />
 
-import * as http from 'http';
-import * as http2 from 'http2';
-import * as https from 'https';
-import * as pino from 'pino';
+import * as http from 'http'
+import * as http2 from 'http2'
+import * as https from 'https'
+import * as pino from 'pino'
 
 declare function fastify<
   HttpServer extends (http.Server | http2.Http2Server) = http.Server,
@@ -19,20 +22,20 @@ declare function fastify(opts?: fastify.ServerOptionsAsSecureHttp2): fastify.Fas
 
 declare namespace fastify {
 
-  type Plugin<HttpServer, HttpRequest, HttpResponse, T> = (instance: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, opts: T, callback: (err?: Error) => void) => void
+  type Plugin < HttpServer, HttpRequest, HttpResponse, T > = (instance: FastifyInstance< HttpServer, HttpRequest, HttpResponse >, opts: T, callback: (err?: Error) => void) => void
 
-  type Middleware<HttpServer, HttpRequest, HttpResponse> = (this: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, req: HttpRequest, res: HttpResponse, callback: (err?: Error) => void) => void
+  type Middleware < HttpServer, HttpRequest, HttpResponse > = (this: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, req: HttpRequest, res: HttpResponse, callback: (err?: Error) => void) => void
 
-  type HTTPMethod = 'DELETE' | 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'OPTIONS';
+  type HTTPMethod = 'DELETE' | 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'OPTIONS'
 
-  type FastifyMiddleware<HttpServer, HttpRequest, HttpResponse> = (this: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, req: FastifyRequest<HttpRequest>, reply: FastifyReply<HttpResponse>, done: (err?: Error) => void) => void
+  type FastifyMiddleware < HttpServer, HttpRequest, HttpResponse > = (this: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, req: FastifyRequest<HttpRequest>, reply: FastifyReply<HttpResponse>, done: (err?: Error) => void) => void
 
-  type RequestHandler<HttpRequest, HttpResponse> = (request: FastifyRequest<HttpRequest>, reply: FastifyReply<HttpResponse>) => void | Promise<any>
+  type RequestHandler < HttpRequest, HttpResponse > = (request: FastifyRequest<HttpRequest>, reply: FastifyReply<HttpResponse>) => void | Promise<any>
 
   type SchemaCompiler = (schema: Object) => Function
 
-  type AsyncContentTypeParser<HttpRequest> = (req: HttpRequest) => Promise<any>;
-  type ContentTypeParser<HttpRequest> = (req: HttpRequest, done: (err: Error | null, body?: any) => void) => void;
+  type AsyncContentTypeParser < HttpRequest > = (req: HttpRequest) => Promise<any>
+  type ContentTypeParser < HttpRequest > = (req: HttpRequest, done: (err: Error | null, body?: any) => void) => void
 
   interface FastifyContext {
     config: any
@@ -338,7 +341,7 @@ declare namespace fastify {
     /**
      * Add a hook that is triggered when a request is initially received
      */
-    addHook(name: 'onRequest', hook: Middleware<HttpServer,HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    addHook(name: 'onRequest', hook: Middleware<HttpServer, HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Hook that is fired before a request is processed, but after the "onRequest"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "fastify.js",
   "typings": "fastify.d.ts",
   "scripts": {
-    "lint": "standard | snazzy",
-    "linttypescript": "standard --parser typescript-eslint-parser --plugin typescript test/types/*.ts fastify.d.ts",
+    "lint": "standard | snazzy && npm run lint:typescript",
+    "lint:typescript": "standard --parser typescript-eslint-parser --plugin typescript test/types/*.ts fastify.d.ts",
     "unit": "tap -j4 test/*.test.js test/*/*.test.js",
     "typescript": "tsc --project ./test/types/tsconfig.json",
     "test": "npm run lint && npm run unit && npm run typescript",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "typings": "fastify.d.ts",
   "scripts": {
     "lint": "standard | snazzy",
+    "linttypescript": "standard --parser typescript-eslint-parser --plugin typescript test/types/*.ts fastify.d.ts",
     "unit": "tap -j4 test/*.test.js test/*/*.test.js",
     "typescript": "tsc --project ./test/types/tsconfig.json",
     "test": "npm run lint && npm run unit && npm run typescript",
@@ -72,6 +73,7 @@
     "cors": "^2.8.4",
     "coveralls": "^3.0.0",
     "dns-prefetch-control": "^0.1.0",
+    "eslint-plugin-typescript": "^0.12.0",
     "fast-json-body": "^1.1.0",
     "fastify-plugin": "^1.0.1",
     "frameguard": "^3.0.0",
@@ -95,6 +97,7 @@
     "tap": "^11.1.4",
     "then-sleep": "^1.0.1",
     "typescript": "^2.8.3",
+    "typescript-eslint-parser": "^15.0.0",
     "x-xss-protection": "^1.1.0"
   },
   "dependencies": {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,29 +1,28 @@
-
+/* eslint no-unused-vars: 0 */
+/* eslint no-undef: 0 */
 // This file will be passed to the TypeScript CLI to verify our typings compile
 
 import * as fastify from '../../fastify'
-import { AddressInfo } from "net";
-import * as http from 'http';
-import * as http2 from 'http2';
+import * as http from 'http'
+import * as http2 from 'http2'
 import { readFileSync } from 'fs'
-import { createReadStream, readFile } from 'fs'
 
 // were importing cors using require, which causes it to be an `any`. This is done because `cors` exports
 // itself as an express.RequestHandler which is not compatible with the fastify TypeScript types
-const cors = require('cors');
+const cors = require('cors')
 
 {
   // http
-  const h1Server = fastify();
+  const h1Server = fastify()
   // https
   const h1SecureServer = fastify({
     https: {
       cert: readFileSync('path/to/cert.pem'),
       key: readFileSync('path/to/key.pem')
     }
-  });
+  })
   // http2
-  const h2Server = fastify({http2: true});
+  const h2Server = fastify({http2: true})
   // secure http2
   const h2SecureServer = fastify({
     http2: true,
@@ -31,38 +30,38 @@ const cors = require('cors');
       cert: readFileSync('path/to/cert.pem'),
       key: readFileSync('path/to/key.pem')
     }
-  });
+  })
   // logger true
-  const logAllServer = fastify({ logger: true });
+  const logAllServer = fastify({ logger: true })
   logAllServer.addHook('onRequest', (req, res, next) => {
-    console.log('can access req', req.headers);
-    next();
-  });
+    console.log('can access req', req.headers)
+    next()
+  })
 
   // other simple options
   const otherServer = fastify({
     ignoreTrailingSlash: true,
     bodyLimit: 1000,
-    maxParamLength: 200,
+    maxParamLength: 200
   })
 
   // custom types
   interface CustomIncomingMessage extends http.IncomingMessage {
     getDeviceType: () => string;
   }
-  const customServer: fastify.FastifyInstance<http.Server, CustomIncomingMessage, http.ServerResponse> = fastify();
+  const customServer: fastify.FastifyInstance<http.Server, CustomIncomingMessage, http.ServerResponse> = fastify()
   customServer.use((req, res, next) => {
-    console.log('can access props from CustomIncomingMessage', req.getDeviceType());
+    console.log('can access props from CustomIncomingMessage', req.getDeviceType())
   })
 
   interface CustomHttp2IncomingMessage extends http2.Http2ServerRequest {
     getDeviceType: () => string;
   }
 
-  const customHttp2Server: fastify.FastifyInstance<http2.Http2Server, CustomHttp2IncomingMessage, http2.Http2ServerResponse> = fastify();
+  const customHttp2Server: fastify.FastifyInstance<http2.Http2Server, CustomHttp2IncomingMessage, http2.Http2ServerResponse> = fastify()
   customHttp2Server.use((req, res, next) => {
-    console.log('can access props from CustomIncomingMessage', req.getDeviceType());
-  });
+    console.log('can access props from CustomIncomingMessage', req.getDeviceType())
+  })
 }
 
 const server = fastify({
@@ -70,7 +69,7 @@ const server = fastify({
     cert: readFileSync('path/to/cert.pem'),
     key: readFileSync('path/to/key.pem')
   },
-  http2: true,
+  http2: true
 })
 
 // Third party middleware
@@ -78,47 +77,47 @@ server.use(cors())
 
 // Custom middleware
 server.use('/', (req, res, next) => {
-  console.log(`${req.method} ${req.url}`);
+  console.log(`${req.method} ${req.url}`)
 })
 
 /**
  * Test various hooks and different signatures
  */
-server.addHook('preHandler', function(req, reply, next) {
-  this.log.debug("`this` is not `any`");
+server.addHook('preHandler', function (req, reply, next) {
+  this.log.debug('`this` is not `any`')
   if (req.body.error) {
-    next(new Error('testing if middleware errors can be passed'));
+    next(new Error('testing if middleware errors can be passed'))
   } else {
     // `stream` can be accessed correctly because `server` is an http2 server.
-    console.log('req stream', req.req.stream);
-    console.log('res stream', reply.res.stream);
-    reply.code(200).send('ok');
+    console.log('req stream', req.req.stream)
+    console.log('res stream', reply.res.stream)
+    reply.code(200).send('ok')
   }
 })
 
-server.addHook('onRequest', function(req, res, next) {
-  this.log.debug("`this` is not `any`");
-  console.log(`${req.method} ${req.url}`);
-  next();
+server.addHook('onRequest', function (req, res, next) {
+  this.log.debug('`this` is not `any`')
+  console.log(`${req.method} ${req.url}`)
+  next()
 })
 
 server.addHook('onResponse', function (res, next) {
-  this.log.debug("`this` is not `any`");
-  this.log.debug({ code: res.statusCode }, "res has a statusCode");
-  setTimeout(function() {
-    console.log('response is finished after 100ms?', res.finished);
-    next();
-  }, 100);
+  this.log.debug('`this` is not `any`')
+  this.log.debug({ code: res.statusCode }, 'res has a statusCode')
+  setTimeout(function () {
+    console.log('response is finished after 100ms?', res.finished)
+    next()
+  }, 100)
 })
 
-server.addHook('onSend', function(req, reply, payload, next) {
-  this.log.debug("`this` is not `any`");
-  console.log(`${req.req.method} ${req.req.url}`);
-  next();
+server.addHook('onSend', function (req, reply, payload, next) {
+  this.log.debug('`this` is not `any`')
+  console.log(`${req.req.method} ${req.req.url}`)
+  next()
 })
 
 server.addHook('onClose', (instance, done) => {
-  done();
+  done()
 })
 
 const opts: fastify.RouteShorthandOptions<http2.Http2Server, http2.Http2ServerRequest, http2.Http2ServerResponse> = {
@@ -144,8 +143,8 @@ const opts: fastify.RouteShorthandOptions<http2.Http2Server, http2.Http2ServerRe
   },
   beforeHandler: [
     (request, reply, next) => {
-      request.log.info(`before handler for "${request.raw.url}" ${request.id}`);
-      next();
+      request.log.info(`before handler for "${request.raw.url}" ${request.id}`)
+      next()
     }
   ],
   schemaCompiler: (schema: Object) => () => {},
@@ -163,8 +162,8 @@ server
       reply.send({ hello: 'route' })
     },
     beforeHandler: (req, reply, done) => {
-      req.log.info(`before handler for "${req.req.url}" ${req.id}`);
-      done();
+      req.log.info(`before handler for "${req.req.url}" ${req.id}`)
+      done()
     }
   })
   .get('/', opts, function (req, reply) {
@@ -200,7 +199,7 @@ server
     reply.send({ hello: 'world' })
   })
   .patch('/:id', opts, function (req, reply) {
-    req.log.info(`incoming id is ${req.params.id}`);
+    req.log.info(`incoming id is ${req.params.id}`)
 
     reply.send({ hello: 'world' })
   })
@@ -226,7 +225,6 @@ server
     done()
   }, { prefix: 'v1', hello: 'world' })
 
-
 // Using decorate requires casting so the compiler knows about new properties
 server.decorate('utility', () => {})
 
@@ -236,7 +234,7 @@ interface DecoratedInstance extends fastify.FastifyInstance<http2.Http2SecureSer
 }
 
 // Use the custom decorator. Could also do "let f = server as DecoratedInstance"
-(server as DecoratedInstance).utility();
+(server as DecoratedInstance).utility()
 
 // Decorating a request or reply works in much the same way as decorate
 interface DecoratedRequest extends fastify.FastifyRequest<http2.Http2ServerRequest> {
@@ -249,13 +247,14 @@ interface DecoratedReply extends fastify.FastifyReply<http2.Http2ServerResponse>
 
 server.get('/test-decorated-inputs', (req, reply) => {
   (req as DecoratedRequest).utility();
-  (reply as DecoratedReply).utility();
-});
+  (reply as DecoratedReply).utility()
+})
 
 server.setNotFoundHandler((req, reply) => {
 })
 
 server.setErrorHandler((err, request, reply) => {
+  reply.send(err)
 })
 
 server.listen(3000, err => {
@@ -269,13 +268,13 @@ server.listen(3000, err => {
 })
 
 // http injections
-server.inject({ url: "/test" }, (err: Error, res: fastify.HTTPInjectResponse) => {
-  server.log.debug(err);
-  server.log.debug(res.payload);
-});
+server.inject({ url: '/test' }, (err: Error, res: fastify.HTTPInjectResponse) => {
+  server.log.debug(err)
+  server.log.debug(res.payload)
+})
 
-server.inject({ url: "/testAgain" })
-  .then((res: fastify.HTTPInjectResponse) => console.log(res.payload));
+server.inject({ url: '/testAgain' })
+  .then((res: fastify.HTTPInjectResponse) => console.log(res.payload))
 
 server.setSchemaCompiler(function (schema: object) {
   return () => true
@@ -331,6 +330,6 @@ server.after(function (err: Error, context: fastify.FastifyInstance<http2.Http2S
 
 {
   const server: fastify.FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse> = fastify({
-    logger: process.env.NODE_ENV === 'dev' ? true : false
+    logger: process.env.NODE_ENV === 'dev'
   })
 }

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -2,6 +2,7 @@
 // This file will be passed to the TypeScript CLI to verify our typings compile
 
 import * as fastify from '../../fastify'
+import { AddressInfo } from "net";
 import * as http from 'http';
 import * as http2 from 'http2';
 import { readFileSync } from 'fs'
@@ -259,7 +260,12 @@ server.setErrorHandler((err, request, reply) => {
 
 server.listen(3000, err => {
   if (err) throw err
-  server.log.info(`server listening on ${server.server.address().port}`)
+  const address = server.server.address()
+  if (typeof address === 'object') {
+    server.log.info(`server listening on ${(<AddressInfo>server.server.address()).port}`)
+  } else {
+    server.log.info(`server listening on ${server.server.address()}`)
+  }
 })
 
 // http injections

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -262,9 +262,9 @@ server.listen(3000, err => {
   if (err) throw err
   const address = server.server.address()
   if (typeof address === 'object') {
-    server.log.info(`server listening on ${(<AddressInfo>server.server.address()).port}`)
+    server.log.info(`server listening on ${address.port}`)
   } else {
-    server.log.info(`server listening on ${server.server.address()}`)
+    server.log.info(`server listening on ${address}`)
   }
 })
 


### PR DESCRIPTION
@types/node v9 defines the parameter returned from the `address` function `AddressInfo | string`
Currently the test on master is broken

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/v9/index.d.ts#L2829

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

