### PR TITLE
Add TypeScript definition for onRoute hook

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -371,7 +371,7 @@ declare namespace fastify {
      * routeOptions object as the sole parameter.
      * The interface is synchronous, and, as such, the listeners do not get passed a callback.
      */
-    addHook(name: 'onRoute', hook: (opts: RouteOptions<HttpServer, HttpRequest, HttpResponse>) => void): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    addHook(name: 'onRoute', hook: (opts: RouteOptions<HttpServer, HttpRequest, HttpResponse> & { path?: string, prefix?: string }) => void): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Useful for testing http requests without running a sever

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -367,6 +367,13 @@ declare namespace fastify {
     addHook(name: 'onClose', hook: (instance: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, done: () => void) => void): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
+     * Adds a hook that is triggered when a new route is registered. Listeners are passed a
+     * routeOptions object as the sole parameter.
+     * The interface is synchronous, and, as such, the listeners do not get passed a callback.
+     */
+    addHook(name: 'onRoute', hook: (opts: RouteOptions<HttpServer, HttpRequest, HttpResponse>) => void): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+
+    /**
      * Useful for testing http requests without running a sever
      */
     inject(opts: HTTPInjectOptions | string, cb: (err: Error, res: HTTPInjectResponse) => void): void

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -371,7 +371,7 @@ declare namespace fastify {
      * routeOptions object as the sole parameter.
      * The interface is synchronous, and, as such, the listeners do not get passed a callback.
      */
-    addHook(name: 'onRoute', hook: (opts: RouteOptions<HttpServer, HttpRequest, HttpResponse> & { path?: string, prefix?: string }) => void): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    addHook(name: 'onRoute', hook: (opts: RouteOptions<HttpServer, HttpRequest, HttpResponse> & { path: string, prefix: string }) => void): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Useful for testing http requests without running a sever

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -120,6 +120,9 @@ server.addHook('onClose', (instance, done) => {
   done()
 })
 
+server.addHook('onRoute', (opts) => {
+})
+
 const opts: fastify.RouteShorthandOptions<http2.Http2Server, http2.Http2ServerRequest, http2.Http2ServerResponse> = {
   schema: {
     response: {


### PR DESCRIPTION
This PR adds the missing TypeScript definition for hook event `onRoute` and provides to the called function the fields `path` and `prefix` added to `opts` by the function `afterRouteAdded`.
https://github.com/fastify/fastify/blob/71dfd8be932e598c801ae664eacfc45739e9098f/fastify.js#L520-L521

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)