### PR TITLE
Feature: onAuth hook

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -6,8 +6,9 @@ Hooks are registered with the `fastify.addHook` method and allow you to listen t
 
 ## Request/Response Hooks
 
-By using the hooks you can interact directly inside the lifecycle of Fastify. There are four different Hooks that you can use *(in order of execution)*:
+By using the hooks you can interact directly inside the lifecycle of Fastify. There are five different Hooks that you can use *(in order of execution)*:
 - `'onRequest'`
+- `'onAuth'`
 - `'preHandler'`
 - `'onSend'`
 - `'onResponse'`
@@ -15,6 +16,11 @@ By using the hooks you can interact directly inside the lifecycle of Fastify. Th
 Example:
 ```js
 fastify.addHook('onRequest', (req, res, next) => {
+  // some code
+  next()
+})
+
+fastify.addHook('onAuth', (request, reply, next) => {
   // some code
   next()
 })
@@ -37,6 +43,16 @@ fastify.addHook('onResponse', (res, next) => {
 Or `async/await`
 ```js
 fastify.addHook('onRequest', async (req, res) => {
+  // some code
+  await asyncMethod()
+  // error occurred
+  if (err) {
+    throw new Error('some errors occurred.')
+  }
+  return
+})
+
+fastify.addHook('onAuth', async (request, reply) => {
   // some code
   await asyncMethod()
   // error occurred

--- a/fastify.js
+++ b/fastify.js
@@ -591,7 +591,10 @@ function build (options) {
         const onRequest = _fastify._hooks.onRequest
         const onResponse = _fastify._hooks.onResponse
         const onSend = _fastify._hooks.onSend
-        const preHandler = _fastify._hooks.preHandler.concat(opts.beforeHandler || [])
+        const onAuth = _fastify._hooks.onAuth
+        const preHandler = onAuth.concat(
+          _fastify._hooks.preHandler.concat(opts.beforeHandler || [])
+        )
 
         context.onRequest = onRequest.length ? onRequest : null
         context.preHandler = preHandler.length ? preHandler : null

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -2,6 +2,7 @@
 
 const supportedHooks = [
   'onRequest',
+  'onAuth',
   'preHandler',
   'onResponse',
   'onSend',
@@ -12,6 +13,7 @@ const supportedHooks = [
 
 function Hooks () {
   this.onRequest = []
+  this.onAuth = []
   this.preHandler = []
   this.onResponse = []
   this.onSend = []
@@ -33,6 +35,7 @@ Hooks.prototype.add = function (hook, fn) {
 function buildHooks (h) {
   const hooks = new Hooks()
   hooks.onRequest = h.onRequest.slice()
+  hooks.onAuth = h.onAuth.slice()
   hooks.preHandler = h.preHandler.slice()
   hooks.onSend = h.onSend.slice()
   hooks.onResponse = h.onResponse.slice()

--- a/test/internals/hooks.test.js
+++ b/test/internals/hooks.test.js
@@ -7,21 +7,26 @@ const Hooks = require('../../lib/hooks')
 const noop = () => {}
 
 test('hooks should have 4 array with the registered hooks', t => {
-  t.plan(5)
+  t.plan(6)
   const hooks = new Hooks()
   t.is(typeof hooks, 'object')
   t.ok(Array.isArray(hooks.onRequest))
   t.ok(Array.isArray(hooks.onSend))
+  t.ok(Array.isArray(hooks.onAuth))
   t.ok(Array.isArray(hooks.preHandler))
   t.ok(Array.isArray(hooks.onResponse))
 })
 
 test('hooks.add should add a hook to the given hook', t => {
-  t.plan(8)
+  t.plan(10)
   const hooks = new Hooks()
   hooks.add('onRequest', noop)
   t.is(hooks.onRequest.length, 1)
   t.is(typeof hooks.onRequest[0], 'function')
+
+  hooks.add('onAuth', noop)
+  t.is(hooks.onAuth.length, 1)
+  t.is(typeof hooks.onAuth[0], 'function')
 
   hooks.add('preHandler', noop)
   t.is(hooks.preHandler.length, 1)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->
Hi folks!

With this pr we are introducing a new hook: `onAuth`.

**Why this is needed?**
Give to our users a specific moment to perform authentication could be useful.
It is less confusing and it does not introduce any overhead.

**How it is implemented?**
The idea is that future hooks will be sharing the same runner, but we will give them an order by using their name.
This `onAuth` is an example and probably the first of more hooks that we could add in the future.

What do you think?

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
