### PR TITLE
fix(): return url from listen method

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ npm i fastify --save
 
 ```js
 // Require the framework and instantiate it
-const fastify = require('fastify')()
+const fastify = require('fastify')({
+  logger: true
+})
 
 // Declare a route
 fastify.get('/', function (request, reply) {
@@ -47,14 +49,16 @@ fastify.get('/', function (request, reply) {
 // Run the server!
 fastify.listen(3000, (err, address) => {
   if (err) throw err
-  console.log(`server listening on ${address}`)
+  fastify.log.info(`server listening on ${address}`)
 })
 ```
 
 with async-await:
 
 ```js
-const fastify = require('fastify')()
+const fastify = require('fastify')({
+  logger: true
+})
 
 fastify.get('/', async (request, reply) => {
   reply.type('application/json').code(200)
@@ -63,7 +67,7 @@ fastify.get('/', async (request, reply) => {
 
 fastify.listen(3000, (err, address) => {
   if (err) throw err
-  console.log(`server listening on ${address}`)
+  fastify.log.info(`server listening on ${address}`)
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ fastify.get('/', function (request, reply) {
 })
 
 // Run the server!
-fastify.listen(3000, '127.0.0.1', function (err) {
+fastify.listen(3000, (err, address) => {
   if (err) throw err
-  console.log(`server listening on ${fastify.server.address().port}`)
+  console.log(`server listening on ${address}`)
 })
 ```
 
@@ -61,9 +61,9 @@ fastify.get('/', async (request, reply) => {
   return { hello: 'world' }
 })
 
-fastify.listen(3000, '127.0.0.1', function (err) {
+fastify.listen(3000, (err, address) => {
   if (err) throw err
-  console.log(`server listening on ${fastify.server.address().port}`)
+  console.log(`server listening on ${address}`)
 })
 ```
 

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -6,13 +6,19 @@ This document aims to be a gentle introduction to the framework and its features
 Let's start!
 
 <a name="install"></a>
+
 ### Install
+
 ```
 npm i fastify --save
 ```
+
 <a name="first-server"></a>
+
 ### Your first server
+
 Let's write our first server:
+
 ```js
 // Require the framework and instantiate it
 const fastify = require('fastify')()
@@ -23,16 +29,18 @@ fastify.get('/', function (request, reply) {
 })
 
 // Run the server!
-fastify.listen(3000, function (err) {
+fastify.listen(3000, function (err, address) {
   if (err) {
     fastify.log.error(err)
     process.exit(1)
   }
+  console.log(`server listening on ${address}`)
 })
 ```
 
 Do you prefer to use `async/await`? Fastify supports it out-of-the-box.<br>
 *(we also suggest using [make-promises-safe](https://github.com/mcollina/make-promises-safe) to avoid file descriptor and memory leaks)*
+
 ```js
 const fastify = require('fastify')()
 
@@ -59,11 +67,12 @@ Fastify offers an easy platform that helps solve all of problems, and more.
 > The above examples, and subsequent examples in this document, default to listening *only* on the localhost `127.0.0.1` interface. To listen on all available IPv4 interfaces the example should be modified to listen on `0.0.0.0` like so:
 >
 > ```js
-> fastify.listen(3000, '0.0.0.0', function (err) {
+> fastify.listen(3000, '0.0.0.0', function (err, address) {
 >   if (err) {
 >     fastify.log.error(err)
 >     process.exit(1)
 >   }
+>   console.log(`server listening on ${address}`)
 > })
 > ```
 >
@@ -72,20 +81,24 @@ Fastify offers an easy platform that helps solve all of problems, and more.
 > When deploying to a Docker, or other type of, container this would be the easiest method for exposing the application.
 
 <a name="first-plugin"></a>
+
 ### Your first plugin
+
 As with JavaScript everything is an object, with Fastify everything is a plugin.<br>
 Before digging into it, let's see how it works!<br>
 Let's declare our basic server, but instead of declaring the route inside the entry point, we'll declare it in an external file (checkout the [route declaration](https://github.com/fastify/fastify/blob/master/docs/Routes.md) docs).
+
 ```js
 const fastify = require('fastify')()
 
 fastify.register(require('./our-first-route'))
 
-fastify.listen(3000, function (err) {
+fastify.listen(3000, function (err, address) {
   if (err) {
     fastify.log.error(err)
     process.exit(1)
   }
+  console.log(`server listening on ${address}`)
 })
 ```
 
@@ -100,6 +113,7 @@ async function routes (fastify, options) {
 
 module.exports = routes
 ```
+
 In this example we used the `register` API. This API is the core of the Fastify framework, and is the only way to register routes, plugins and so on.
 
 At the beginning of this guide we noted that Fastify provides a foundation that assists with the asynchronous bootstrapping of your application. Why this is important?
@@ -111,6 +125,7 @@ Let's rewrite the above example with a database connection.<br>
 *(we will use a simple example, for a robust solution consider using [`fastify-mongo`](https://github.com/fastify/fastify-mongodb) or another in the Fastify [ecosystem](https://github.com/fastify/fastify/blob/master/docs/Ecosystem.md))*
 
 **server.js**
+
 ```js
 const fastify = require('fastify')()
 
@@ -119,11 +134,12 @@ fastify.register(require('./our-db-connector'), {
 })
 fastify.register(require('./our-first-route'))
 
-fastify.listen(3000, function (err) {
+fastify.listen(3000, function (err, address) {
   if (err) {
     fastify.log.error(err)
     process.exit(1)
   }
+  console.log(`server listening on ${address}`)
 })
 ```
 
@@ -146,6 +162,7 @@ module.exports = fastifyPlugin(dbConnector)
 ```
 
 **our-first-route.js**
+
 ```js
 async function routes (fastify, options) {
   const database = fastify.mongo.db('db')
@@ -179,18 +196,23 @@ To solve this Fastify offers the `decorate` API, which adds custom objects to th
 To dig deeper into how Fastify plugins work, how to develop new plugins, and for details on how to use the whole Fastify API to deal with the complexity of asynchronously bootstrapping an application, read [the hitchhiker's guide to plugins](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md).
 
 <a name="plugin-loading-order"></a>
+
 ### Loading order of your plugins
+
 To guarantee a consistent and predictable behavior of your application, we highly recommend to always load your code as shown below:
-```
+
+```bash
 └── plugins (from the Fastify ecosystem)
 └── your plugins (your custom plugins)
 └── decorators
 └── hooks and middlewares
 └── your services
 ```
+
 In this way you will always have access to all of the properties declared in the current scope.<br/>
 As discussed previously, Fastify offers a solid encapsulation model, to help you build your application as single and independent services. If you want to register a plugin only for a subset of routes, you have just to replicate the above structure.
-```
+
+```bash
 └── plugins (from the Fastify ecosystem)
 └── your plugins (your custom plugins)
 └── decorators
@@ -213,10 +235,13 @@ As discussed previously, Fastify offers a solid encapsulation model, to help you
 ```
 
 <a name="validate-data"></a>
+
 ### Validate your data
+
 Data validation is extremely important and is a core concept of the framework.<br>
 To validate incoming requests, Fastify uses [JSON Schema](http://json-schema.org/).
 Let's look at an example demonstrating validation for routes:
+
 ```js
 const opts = {
   schema: {
@@ -234,13 +259,17 @@ fastify.post('/', opts, async (request, reply) => {
   return { hello: 'world' }
 })
 ```
+
 This example shows how to pass an options object to the route, which accepts a `schema` key, that contains all of the schemas for route, `body`, `querystring`, `params` and `headers`.<br>
 Read [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) to learn more.
 
 <a name="serialize-data"></a>
+
 ### Serialize your data
+
 Fastify has first class support for JSON. It is extremely optimized to parse a JSON body and to serialize JSON output.<br>
 To speed up JSON serialization (yes, it is slow!) use the `response` key of the schema option like so:
+
 ```js
 const opts = {
   schema: {
@@ -259,33 +288,41 @@ fastify.get('/', opts, async (request, reply) => {
   return { hello: 'world' }
 })
 ```
+
 Simply by specifying a schema as shown, a speed up your of serialization by 2x or even 3x can be achieved. This also helps protect against leaking of sensitive data, since Fastify will serialize only the data present in the response schema.
 Read [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) to learn more.
 
 <a name="extend-server"></a>
+
 ### Extend your server
+
 Fastify is built to be extremely extensible and very minimal, We believe that a bare minimum framework is all that is necessary to make great applications possible.<br>
 In other words, Fastify is not a "batteries included" framework, and relies on an amazing [ecosystem](https://github.com/fastify/fastify/blob/master/docs/Ecosystem.md)!
 
 <a name="test-server"></a>
+
 ### Test your server
+
 Fastify does not offer a testing framework, but we do recommend a way to write your tests that uses the features and the architecture of Fastify.<br>
 Read the [testing](https://github.com/fastify/fastify/blob/master/docs/Testing.md) documentation to learn more!
 
 <a name="cli"></a>
+
 ### Run your server from CLI
+
 Fastify also has CLI integration thanks to
 [fastify-cli](https://github.com/fastify/fastify-cli).
 
 First, install `fastify-cli`:
 
-```
+```bash
 npm i fastify-cli
 ```
 
 You can also install it globally with `-g`.
 
 Then, add the following lines to `package.json`:
+
 ```json
 {
   "scripts": {
@@ -295,6 +332,7 @@ Then, add the following lines to `package.json`:
 ```
 
 And create your server file(s):
+
 ```js
 // server.js
 'use strict'
@@ -307,12 +345,15 @@ module.exports = async function (fastify, opts) {
 ```
 
 Then run your server with:
+
 ```bash
 npm start
 ```
 
 <a name="slides"></a>
+
 ### Slides and Videos
+
 - Slides
   - [Take your HTTP server to ludicrous speed](https://mcollina.github.io/take-your-http-server-to-ludicrous-speed) by [@mcollina](https://github.com/mcollina)
   - [What if I told you that HTTP can be fast](https://delvedor.github.io/What-if-I-told-you-that-HTTP-can-be-fast) by [@delvedor](https://github.com/delvedor)

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -16,7 +16,9 @@ npm i fastify --save
 Let's write our first server:
 ```js
 // Require the framework and instantiate it
-const fastify = require('fastify')()
+const fastify = require('fastify')({
+  logger: true
+})
 
 // Declare a route
 fastify.get('/', function (request, reply) {
@@ -29,7 +31,7 @@ fastify.listen(3000, function (err, address) {
     fastify.log.error(err)
     process.exit(1)
   }
-  console.log(`server listening on ${address}`)
+  fastify.log.info(`server listening on ${address}`)
 })
 ```
 
@@ -66,7 +68,7 @@ Fastify offers an easy platform that helps solve all of problems, and more.
 >     fastify.log.error(err)
 >     process.exit(1)
 >   }
->   console.log(`server listening on ${address}`)
+>   fastify.log.info(`server listening on ${address}`)
 > })
 > ```
 >
@@ -80,7 +82,9 @@ As with JavaScript everything is an object, with Fastify everything is a plugin.
 Before digging into it, let's see how it works!<br>
 Let's declare our basic server, but instead of declaring the route inside the entry point, we'll declare it in an external file (checkout the [route declaration](https://github.com/fastify/fastify/blob/master/docs/Routes.md) docs).
 ```js
-const fastify = require('fastify')()
+const fastify = require('fastify')({
+  logger: true
+})
 
 fastify.register(require('./our-first-route'))
 
@@ -89,7 +93,7 @@ fastify.listen(3000, function (err, address) {
     fastify.log.error(err)
     process.exit(1)
   }
-  console.log(`server listening on ${address}`)
+  fastify.log.info(`server listening on ${address}`)
 })
 ```
 
@@ -116,7 +120,9 @@ Let's rewrite the above example with a database connection.<br>
 
 **server.js**
 ```js
-const fastify = require('fastify')()
+const fastify = require('fastify')({
+  logger: true
+})
 
 fastify.register(require('./our-db-connector'), {
   url: 'mongodb://localhost:27017/'
@@ -128,7 +134,7 @@ fastify.listen(3000, function (err, address) {
     fastify.log.error(err)
     process.exit(1)
   }
-  console.log(`server listening on ${address}`)
+  fastify.log.info(`server listening on ${address}`)
 })
 ```
 

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -6,19 +6,14 @@ This document aims to be a gentle introduction to the framework and its features
 Let's start!
 
 <a name="install"></a>
-
 ### Install
-
 ```
 npm i fastify --save
 ```
 
 <a name="first-server"></a>
-
 ### Your first server
-
 Let's write our first server:
-
 ```js
 // Require the framework and instantiate it
 const fastify = require('fastify')()
@@ -40,7 +35,6 @@ fastify.listen(3000, function (err, address) {
 
 Do you prefer to use `async/await`? Fastify supports it out-of-the-box.<br>
 *(we also suggest using [make-promises-safe](https://github.com/mcollina/make-promises-safe) to avoid file descriptor and memory leaks)*
-
 ```js
 const fastify = require('fastify')()
 
@@ -246,7 +240,6 @@ fastify.post('/', opts, async (request, reply) => {
   return { hello: 'world' }
 })
 ```
-
 This example shows how to pass an options object to the route, which accepts a `schema` key, that contains all of the schemas for route, `body`, `querystring`, `params` and `headers`.<br>
 Read [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) to learn more.
 
@@ -254,7 +247,6 @@ Read [Validation and Serialization](https://github.com/fastify/fastify/blob/mast
 ### Serialize your data
 Fastify has first class support for JSON. It is extremely optimized to parse a JSON body and to serialize JSON output.<br>
 To speed up JSON serialization (yes, it is slow!) use the `response` key of the schema option like so:
-
 ```js
 const opts = {
   schema: {
@@ -293,7 +285,7 @@ Fastify also has CLI integration thanks to
 
 First, install `fastify-cli`:
 
-```bash
+```
 npm i fastify-cli
 ```
 

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -81,13 +81,10 @@ Fastify offers an easy platform that helps solve all of problems, and more.
 > When deploying to a Docker, or other type of, container this would be the easiest method for exposing the application.
 
 <a name="first-plugin"></a>
-
 ### Your first plugin
-
 As with JavaScript everything is an object, with Fastify everything is a plugin.<br>
 Before digging into it, let's see how it works!<br>
 Let's declare our basic server, but instead of declaring the route inside the entry point, we'll declare it in an external file (checkout the [route declaration](https://github.com/fastify/fastify/blob/master/docs/Routes.md) docs).
-
 ```js
 const fastify = require('fastify')()
 
@@ -113,7 +110,6 @@ async function routes (fastify, options) {
 
 module.exports = routes
 ```
-
 In this example we used the `register` API. This API is the core of the Fastify framework, and is the only way to register routes, plugins and so on.
 
 At the beginning of this guide we noted that Fastify provides a foundation that assists with the asynchronous bootstrapping of your application. Why this is important?
@@ -125,7 +121,6 @@ Let's rewrite the above example with a database connection.<br>
 *(we will use a simple example, for a robust solution consider using [`fastify-mongo`](https://github.com/fastify/fastify-mongodb) or another in the Fastify [ecosystem](https://github.com/fastify/fastify/blob/master/docs/Ecosystem.md))*
 
 **server.js**
-
 ```js
 const fastify = require('fastify')()
 
@@ -162,7 +157,6 @@ module.exports = fastifyPlugin(dbConnector)
 ```
 
 **our-first-route.js**
-
 ```js
 async function routes (fastify, options) {
   const database = fastify.mongo.db('db')
@@ -196,23 +190,18 @@ To solve this Fastify offers the `decorate` API, which adds custom objects to th
 To dig deeper into how Fastify plugins work, how to develop new plugins, and for details on how to use the whole Fastify API to deal with the complexity of asynchronously bootstrapping an application, read [the hitchhiker's guide to plugins](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md).
 
 <a name="plugin-loading-order"></a>
-
 ### Loading order of your plugins
-
 To guarantee a consistent and predictable behavior of your application, we highly recommend to always load your code as shown below:
-
-```bash
+```
 └── plugins (from the Fastify ecosystem)
 └── your plugins (your custom plugins)
 └── decorators
 └── hooks and middlewares
 └── your services
 ```
-
 In this way you will always have access to all of the properties declared in the current scope.<br/>
 As discussed previously, Fastify offers a solid encapsulation model, to help you build your application as single and independent services. If you want to register a plugin only for a subset of routes, you have just to replicate the above structure.
-
-```bash
+```
 └── plugins (from the Fastify ecosystem)
 └── your plugins (your custom plugins)
 └── decorators
@@ -235,9 +224,7 @@ As discussed previously, Fastify offers a solid encapsulation model, to help you
 ```
 
 <a name="validate-data"></a>
-
 ### Validate your data
-
 Data validation is extremely important and is a core concept of the framework.<br>
 To validate incoming requests, Fastify uses [JSON Schema](http://json-schema.org/).
 Let's look at an example demonstrating validation for routes:
@@ -264,9 +251,7 @@ This example shows how to pass an options object to the route, which accepts a `
 Read [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) to learn more.
 
 <a name="serialize-data"></a>
-
 ### Serialize your data
-
 Fastify has first class support for JSON. It is extremely optimized to parse a JSON body and to serialize JSON output.<br>
 To speed up JSON serialization (yes, it is slow!) use the `response` key of the schema option like so:
 
@@ -288,28 +273,21 @@ fastify.get('/', opts, async (request, reply) => {
   return { hello: 'world' }
 })
 ```
-
 Simply by specifying a schema as shown, a speed up your of serialization by 2x or even 3x can be achieved. This also helps protect against leaking of sensitive data, since Fastify will serialize only the data present in the response schema.
 Read [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) to learn more.
 
 <a name="extend-server"></a>
-
 ### Extend your server
-
 Fastify is built to be extremely extensible and very minimal, We believe that a bare minimum framework is all that is necessary to make great applications possible.<br>
 In other words, Fastify is not a "batteries included" framework, and relies on an amazing [ecosystem](https://github.com/fastify/fastify/blob/master/docs/Ecosystem.md)!
 
 <a name="test-server"></a>
-
 ### Test your server
-
 Fastify does not offer a testing framework, but we do recommend a way to write your tests that uses the features and the architecture of Fastify.<br>
 Read the [testing](https://github.com/fastify/fastify/blob/master/docs/Testing.md) documentation to learn more!
 
 <a name="cli"></a>
-
 ### Run your server from CLI
-
 Fastify also has CLI integration thanks to
 [fastify-cli](https://github.com/fastify/fastify-cli).
 
@@ -322,7 +300,6 @@ npm i fastify-cli
 You can also install it globally with `-g`.
 
 Then, add the following lines to `package.json`:
-
 ```json
 {
   "scripts": {
@@ -332,7 +309,6 @@ Then, add the following lines to `package.json`:
 ```
 
 And create your server file(s):
-
 ```js
 // server.js
 'use strict'
@@ -345,15 +321,12 @@ module.exports = async function (fastify, opts) {
 ```
 
 Then run your server with:
-
 ```bash
 npm start
 ```
 
 <a name="slides"></a>
-
 ### Slides and Videos
-
 - Slides
   - [Take your HTTP server to ludicrous speed](https://mcollina.github.io/take-your-http-server-to-ludicrous-speed) by [@mcollina](https://github.com/mcollina)
   - [What if I told you that HTTP can be fast](https://delvedor.github.io/What-if-I-told-you-that-HTTP-can-be-fast) by [@delvedor](https://github.com/delvedor)

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -222,7 +222,6 @@ As discussed previously, Fastify offers a solid encapsulation model, to help you
 Data validation is extremely important and is a core concept of the framework.<br>
 To validate incoming requests, Fastify uses [JSON Schema](http://json-schema.org/).
 Let's look at an example demonstrating validation for routes:
-
 ```js
 const opts = {
   schema: {

--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -54,7 +54,7 @@ fastify.ready().then(() => {
 Starts the server on the given port after all the plugins are loaded, internally waits for the `.ready()` event. The callback is the same as the Node core. By default, the server will listen on address `127.0.0.1` when no specific address is provided. If listening on any available interface is desired, then specifying `0.0.0.0` for the address will listen on all IPv4 address. Using `::` for the address will listen on all IPv6 addresses, and, depending on OS, may also listen on all IPv4 addresses. Be careful when deciding to listen on all interfaces; it comes with inherent [security risks](https://web.archive.org/web/20170831174611/https://snyk.io/blog/mongodb-hack-and-secure-defaults/).
 
 ```js
-fastify.listen(3000, err => {
+fastify.listen(3000, (err, address) => {
   if (err) {
     fastify.log.error(err)
     process.exit(1)
@@ -65,7 +65,7 @@ fastify.listen(3000, err => {
 Specifying an address is also supported:
 
 ```js
-fastify.listen(3000, '127.0.0.1', err => {
+fastify.listen(3000, '127.0.0.1', (err, address) => {
   if (err) {
     fastify.log.error(err)
     process.exit(1)
@@ -76,7 +76,7 @@ fastify.listen(3000, '127.0.0.1', err => {
 Specifying a backlog queue size is also supported:
 
 ```js
-fastify.listen(3000, '127.0.0.1', 511, err => {
+fastify.listen(3000, '127.0.0.1', 511, (err, address) => {
   if (err) {
     fastify.log.error(err)
     process.exit(1)
@@ -88,7 +88,7 @@ If no callback is provided a Promise is returned:
 
 ```js
 fastify.listen(3000)
-  .then(() => console.log('Listening'))
+  .then((address) => console.log(`server listening on ${address}`))
   .catch(err => {
     console.log('Error starting server:', err)
     process.exit(1)
@@ -99,7 +99,7 @@ Specifying an address without a callback is also supported:
 
 ```js
 fastify.listen(3000, '127.0.0.1')
-  .then(() => console.log('Listening'))
+  .then((adress) => console.log(`server listening on ${address}`))
   .catch(err => {
     console.log('Error starting server:', err)
     process.exit(1)
@@ -109,7 +109,7 @@ fastify.listen(3000, '127.0.0.1')
 When deploying to a Docker, and potentially other, containers, it is advisable to listen on `0.0.0.0` because they do not default to exposing mapped ports to `127.0.0.1`:
 
 ```js
-fastify.listen(3000, '0.0.0.0', (err) => {
+fastify.listen(3000, '0.0.0.0', (err, address) => {
   if (err) {
     fastify.log.error(err)
     process.exit(1)

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -25,5 +25,5 @@ fastify
 
 fastify.listen(3000, (err, address) => {
   if (err) throw err
-  console.log(`server listening on ${fastify.server.address().port}`)
+  console.log(`server listening on ${address}`)
 })

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,6 +1,8 @@
 'use strict'
 
-const fastify = require('../fastify')()
+const fastify = require('../fastify')({
+  logger: true
+})
 
 const schema = {
   schema: {
@@ -25,5 +27,5 @@ fastify
 
 fastify.listen(3000, (err, address) => {
   if (err) throw err
-  console.log(`server listening on ${address}`)
+  fastify.log.info(`server listening on ${address}`)
 })

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -23,7 +23,7 @@ fastify
       .send({ hello: 'world' })
   })
 
-fastify.listen(3000, err => {
+fastify.listen(3000, (err, address) => {
   if (err) throw err
   console.log(`server listening on ${fastify.server.address().port}`)
 })

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -268,15 +268,15 @@ declare namespace fastify {
      * internally waits for the .ready() event. The callback is the same as the
      * Node core.
      */
-    listen(port: number, hostname: string, callback?: (err: Error) => void): http.Server
+    listen(port: number, hostname: string, callback?: (err: Error, address: string) => void): http.Server
 
     /**
      * Starts the server on the given port after all the plugins are loaded,
      * internally waits for the .ready() event. The callback is the same as the
      * Node core.
      */
-    listen(port: number, callback?: (err: Error) => void): http.Server
-    listen(path: string, callback?: (err: Error) => void): http.Server
+    listen(port: number, callback?: (err: Error, address: string) => void): http.Server
+    listen(path: string, callback?: (err: Error, address: string) => void): http.Server
 
     /**
      * Registers a listener function that is invoked when all the plugins have

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -422,7 +422,7 @@ declare namespace fastify {
     /**
      * Add a content type parser
      */
-    addContentTypeParser(contentType: string, opts: object | AsyncContentTypeParser<HttpRequest> | ContentTypeParser<HttpRequest>, parser?: AsyncContentTypeParser<HttpRequest> | ContentTypeParser<HttpRequest>): void;
+    addContentTypeParser(contentType: string, opts: {parseAs?: string, bodyLimit?: number} | AsyncContentTypeParser<HttpRequest> | ContentTypeParser<HttpRequest>, parser?: AsyncContentTypeParser<HttpRequest> | ContentTypeParser<HttpRequest>): void;
 
     /**
      * Check if a parser for the specified content type exists

--- a/fastify.js
+++ b/fastify.js
@@ -287,8 +287,7 @@ function build (options) {
             reject(err)
           } else {
             server.removeListener('error', errEventHandler)
-            logServerAddress(server.address(), options.https)
-            resolve()
+            resolve(logServerAddress(server.address(), options.https))
           }
         })
         // we set it afterwards because listen can throw
@@ -335,13 +334,14 @@ function build (options) {
     })
 
     function wrap (err) {
+      server.removeListener('error', wrap)
       if (!err) {
-        logServerAddress(server.address(), options.https)
+        address = logServerAddress(server.address(), options.https)
+        cb(err, address)
       } else {
         listening = false
+        cb(err, null)
       }
-      server.removeListener('error', wrap)
-      cb(err)
     }
   }
 
@@ -355,6 +355,7 @@ function build (options) {
     }
     address = 'http' + (isHttps ? 's' : '') + '://' + address
     fastify.log.info('Server listening at ' + address)
+    return address
   }
 
   function State (req, res, params, context) {

--- a/fastify.js
+++ b/fastify.js
@@ -314,6 +314,7 @@ function build (options) {
 
     fastify.ready(function (err) {
       if (err) return cb(err)
+
       if (listening) {
         return cb(new Error('Fastify is already listening'), null)
       }

--- a/fastify.js
+++ b/fastify.js
@@ -281,14 +281,9 @@ function build (options) {
         server.once('error', errEventHandler)
       })
       var listen = new Promise((resolve, reject) => {
-        server.listen(port, address, backlog, (err) => {
-          if (err) {
-            listening = false
-            reject(err)
-          } else {
-            server.removeListener('error', errEventHandler)
-            resolve(logServerAddress(server.address(), options.https))
-          }
+        server.listen(port, address, backlog, () => {
+          server.removeListener('error', errEventHandler)
+          resolve(logServerAddress(server.address(), options.https))
         })
         // we set it afterwards because listen can throw
         listening = true

--- a/fastify.js
+++ b/fastify.js
@@ -320,7 +320,7 @@ function build (options) {
     fastify.ready(function (err) {
       if (err) return cb(err)
       if (listening) {
-        return cb(new Error('Fastify is already listening'))
+        return cb(new Error('Fastify is already listening'), null)
       }
 
       server.once('error', wrap)
@@ -337,7 +337,7 @@ function build (options) {
       server.removeListener('error', wrap)
       if (!err) {
         address = logServerAddress(server.address(), options.https)
-        cb(err, address)
+        cb(null, address)
       } else {
         listening = false
         cb(err, null)

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -9,92 +9,93 @@ const Fastify = require('..')
 test('listen accepts a port and a callback', t => {
   t.plan(3)
   const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, (err) => {
     fastify.server.unref()
     t.is(fastify.server.address().address, '127.0.0.1')
     t.error(err)
     t.pass()
-    fastify.close()
-  })
-})
-
-test('listen accepts a port and a callback with (err, address)', t => {
-  t.plan(2)
-  const fastify = Fastify()
-  fastify.listen(0, (err, address) => {
-    fastify.server.unref()
-    t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
-    t.error(err)
-    fastify.close()
-  })
-})
-
-test('listen accepts a port, address, and callback', t => {
-  t.plan(2)
-  const fastify = Fastify()
-  fastify.listen(0, '127.0.0.1', (err) => {
-    fastify.server.unref()
-    t.error(err)
-    t.pass()
-    fastify.close()
   })
 })
 
 test('listen accepts a port and a callback with (err, address)', t => {
   t.plan(3)
   const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, (err, address) => {
     fastify.server.unref()
     t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
     t.error(err)
     t.pass()
-    fastify.close()
+  })
+})
+
+test('listen accepts a port, address, and callback', t => {
+  t.plan(2)
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+  fastify.listen(0, '127.0.0.1', (err) => {
+    fastify.server.unref()
+    t.error(err)
+    t.pass()
+  })
+})
+
+test('listen accepts a port and a callback with (err, address)', t => {
+  t.plan(3)
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+  fastify.listen(0, (err, address) => {
+    fastify.server.unref()
+    t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
+    t.error(err)
+    t.pass()
   })
 })
 
 test('listen accepts a port, address, backlog and callback', t => {
   t.plan(2)
   const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, '127.0.0.1', 511, (err) => {
     fastify.server.unref()
     t.error(err)
     t.pass()
-    fastify.close()
   })
 })
 
 test('listen accepts a port, address, backlog and callback with (err, address)', t => {
   t.plan(2)
   const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, '127.0.0.1', 511, (err, address) => {
     fastify.server.unref()
     t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
     t.error(err)
-    fastify.close()
   })
 })
 
 test('listen accepts a port, address, backlog and callback with (err, address)', t => {
   t.plan(2)
   const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, '127.0.0.1', 511, (err, address) => {
     fastify.server.unref()
     t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
     t.error(err)
-    fastify.close()
   })
 })
 
 test('listen after Promise.resolve()', t => {
   t.plan(2)
   const f = Fastify()
+  t.tearDown(f.close.bind(f))
   Promise.resolve()
     .then(() => {
       f.listen(0, (err) => {
         f.server.unref()
         t.error(err)
         t.pass()
-        f.close()
       })
     })
 })
@@ -120,11 +121,11 @@ test('register after listen using Promise.resolve()', t => {
 test('double listen errors', t => {
   t.plan(2)
   const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, (err) => {
     t.error(err)
     fastify.listen(fastify.server.address().port, (err) => {
       t.ok(err)
-      fastify.close()
     })
   })
 })
@@ -132,12 +133,12 @@ test('double listen errors', t => {
 test('double listen errors callback with (err, address)', t => {
   t.plan(2)
   const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, (err) => {
     fastify.server.unref()
     t.error(err)
     fastify.listen(fastify.server.address().port, (err) => {
       t.ok(err)
-      fastify.close()
     })
   })
 })
@@ -145,11 +146,11 @@ test('double listen errors callback with (err, address)', t => {
 test('listen twice on the same port', t => {
   t.plan(2)
   const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, (err) => {
     t.error(err)
     const s2 = Fastify()
     s2.listen(fastify.server.address().port, (err) => {
-      fastify.close()
       t.ok(err)
     })
   })
@@ -158,6 +159,7 @@ test('listen twice on the same port', t => {
 test('listen twice on the same port callback with (err, address)', t => {
   t.plan(4)
   const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, (err, address1) => {
     const _port = fastify.server.address().port
     t.error(err)
@@ -166,7 +168,6 @@ test('listen twice on the same port callback with (err, address)', t => {
     s2.listen(_port, (err, address2) => {
       t.is(address2, null)
       t.ok(err)
-      fastify.close()
     })
   })
 })
@@ -176,6 +177,7 @@ if (os.platform() !== 'win32') {
   test('listen on socket', t => {
     t.plan(2)
     const fastify = Fastify()
+    t.tearDown(fastify.close.bind(fastify))
     const sockFile = path.join(os.tmpdir(), 'server.sock')
     try {
       fs.unlinkSync(sockFile)
@@ -183,7 +185,6 @@ if (os.platform() !== 'win32') {
     fastify.listen(sockFile, (err) => {
       t.error(err)
       t.equal(sockFile, fastify.server.address())
-      fastify.close()
     })
   })
 }
@@ -191,10 +192,10 @@ if (os.platform() !== 'win32') {
 test('listen without callback', t => {
   t.plan(1)
   const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0)
     .then(() => {
       t.is(fastify.server.address().address, '127.0.0.1')
-      fastify.close()
       t.end()
     })
 })
@@ -202,71 +203,67 @@ test('listen without callback', t => {
 test('listen null without callback with (address)', t => {
   t.plan(1)
   const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
   fastify.listen(null)
     .then((address) => {
       t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
-      fastify.close()
       t.end()
     })
     .catch(err => {
       t.ok(err)
-      fastify.close()
     })
 })
 
 test('listen without port without callback with (address)', t => {
   t.plan(1)
   const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
   fastify.listen()
     .then((address) => {
       t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
-      fastify.close()
       t.end()
     })
     .catch(err => {
       t.ok(err)
-      fastify.close()
     })
 })
 
 test('listen with undefined without callback with (address)', t => {
   t.plan(1)
   const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
   fastify.listen(undefined)
     .then((address) => {
       t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
-      fastify.close()
       t.end()
     })
     .catch(err => {
       t.ok(err)
-      fastify.close()
     })
 })
 
 test('listen without callback with (address)', t => {
   t.plan(1)
   const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0)
     .then((address) => {
       t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
-      fastify.close()
       t.end()
     })
 })
 test('double listen without callback rejects', t => {
   t.plan(1)
   const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0)
     .then(() => {
       fastify.listen(0)
         .then(() => {
           t.error(new Error('second call to fastify.listen resolved'))
-          fastify.close()
         })
         .catch(err => {
           t.ok(err)
-          fastify.close()
         })
     })
     .catch(err => t.error(err))
@@ -275,17 +272,16 @@ test('double listen without callback rejects', t => {
 test('double listen without callback with (address)', t => {
   t.plan(2)
   const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0)
     .then((address) => {
       t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
       fastify.listen(0)
         .then(() => {
           t.error(new Error('second call to fastify.listen resolved'))
-          fastify.close()
         })
         .catch(err => {
           t.ok(err)
-          fastify.close()
         })
     })
     .catch(err => t.error(err))
@@ -294,19 +290,18 @@ test('double listen without callback with (address)', t => {
 test('listen twice on the same port without callback rejects', t => {
   t.plan(1)
   const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
 
   fastify.listen(0)
     .then(() => {
       const s2 = Fastify()
+      t.tearDown(s2.close.bind(s2))
       s2.listen(fastify.server.address().port)
         .then(() => {
-          fastify.close()
-          s2.close()
           t.error(new Error('listen on port already in use resolved'))
         })
         .catch(err => {
           t.ok(err)
-          fastify.close()
         })
     })
     .catch(err => t.error(err))
@@ -315,20 +310,18 @@ test('listen twice on the same port without callback rejects', t => {
 test('listen twice on the same port without callback rejects with (address)', t => {
   t.plan(2)
   const fastify = Fastify()
-
+  t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0)
     .then((address) => {
       const s2 = Fastify()
+      t.tearDown(s2.close.bind(s2))
       t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
       s2.listen(fastify.server.address().port)
-        .then((address) => {
+        .then(() => {
           t.error(new Error('listen on port already in use resolved'))
-          s2.close()
-          fastify.close()
         })
         .catch(err => {
           t.ok(err)
-          fastify.close()
         })
     })
     .catch(err => t.error(err))
@@ -336,19 +329,18 @@ test('listen twice on the same port without callback rejects with (address)', t 
 
 test('listen on invalid port without callback rejects', t => {
   const fastify = Fastify()
-
+  t.tearDown(fastify.close.bind(fastify))
   return fastify.listen(-1)
     .catch(err => {
       t.ok(err)
-      return fastify.close()
+      return true
     })
 })
 
 test('listen logs the port as info', t => {
   t.plan(1)
   const fastify = Fastify()
-
-  t.teardown(() => fastify.close())
+  t.tearDown(fastify.close.bind(fastify))
 
   const msgs = []
   fastify.log.info = function (msg) {

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -7,60 +7,60 @@ const test = require('tap').test
 const Fastify = require('..')
 
 test('listen accepts a port and a callback', t => {
-  t.plan(3)
+  t.plan(2)
   const fastify = Fastify()
   t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, (err) => {
     fastify.server.unref()
     t.is(fastify.server.address().address, '127.0.0.1')
     t.error(err)
-    t.pass()
+    // t.pass()
   })
 })
 
 test('listen accepts a port and a callback with (err, address)', t => {
-  t.plan(3)
+  t.plan(2)
   const fastify = Fastify()
   t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, (err, address) => {
     fastify.server.unref()
     t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
     t.error(err)
-    t.pass()
+    // t.pass()
   })
 })
 
 test('listen accepts a port, address, and callback', t => {
-  t.plan(2)
+  t.plan(1)
   const fastify = Fastify()
   t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, '127.0.0.1', (err) => {
     fastify.server.unref()
     t.error(err)
-    t.pass()
+    // t.pass()
   })
 })
 
 test('listen accepts a port and a callback with (err, address)', t => {
-  t.plan(3)
+  t.plan(2)
   const fastify = Fastify()
   t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, (err, address) => {
     fastify.server.unref()
     t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
     t.error(err)
-    t.pass()
+    // t.pass()
   })
 })
 
 test('listen accepts a port, address, backlog and callback', t => {
-  t.plan(2)
+  t.plan(1)
   const fastify = Fastify()
   t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, '127.0.0.1', 511, (err) => {
     fastify.server.unref()
     t.error(err)
-    t.pass()
+    // t.pass()
   })
 })
 
@@ -87,7 +87,7 @@ test('listen accepts a port, address, backlog and callback with (err, address)',
 })
 
 test('listen after Promise.resolve()', t => {
-  t.plan(2)
+  t.plan(1)
   const f = Fastify()
   t.tearDown(f.close.bind(f))
   Promise.resolve()
@@ -95,7 +95,7 @@ test('listen after Promise.resolve()', t => {
       f.listen(0, (err) => {
         f.server.unref()
         t.error(err)
-        t.pass()
+        // t.pass()
       })
     })
 })
@@ -221,7 +221,7 @@ test('listen without port without callback with (address)', t => {
   fastify.listen()
     .then((address) => {
       t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
-      t.end()
+      // t.end()
     })
     .catch(err => {
       t.ok(err)
@@ -238,7 +238,7 @@ test('listen with undefined without callback with (address)', t => {
       t.end()
     })
     .catch(err => {
-      t.ok(err)
+      t.error(err)
     })
 })
 

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -11,7 +11,6 @@ test('listen accepts a port and a callback', t => {
   const fastify = Fastify()
   t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, (err) => {
-    fastify.server.unref()
     t.is(fastify.server.address().address, '127.0.0.1')
     t.error(err)
   })
@@ -22,7 +21,6 @@ test('listen accepts a port and a callback with (err, address)', t => {
   const fastify = Fastify()
   t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, (err, address) => {
-    fastify.server.unref()
     t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
     t.error(err)
   })
@@ -33,7 +31,6 @@ test('listen accepts a port, address, and callback', t => {
   const fastify = Fastify()
   t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, '127.0.0.1', (err) => {
-    fastify.server.unref()
     t.error(err)
   })
 })
@@ -43,7 +40,6 @@ test('listen accepts a port and a callback with (err, address)', t => {
   const fastify = Fastify()
   t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, (err, address) => {
-    fastify.server.unref()
     t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
     t.error(err)
   })
@@ -54,7 +50,6 @@ test('listen accepts a port, address, backlog and callback', t => {
   const fastify = Fastify()
   t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, '127.0.0.1', 511, (err) => {
-    fastify.server.unref()
     t.error(err)
   })
 })
@@ -64,9 +59,8 @@ test('listen accepts a port, address, backlog and callback with (err, address)',
   const fastify = Fastify()
   t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, '127.0.0.1', 511, (err, address) => {
-    fastify.server.unref()
     t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
-    t.is(err, null)
+    t.error(err)
   })
 })
 
@@ -75,9 +69,8 @@ test('listen accepts a port, address, backlog and callback with (err, address)',
   const fastify = Fastify()
   t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, '127.0.0.1', 511, (err, address) => {
-    fastify.server.unref()
     t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
-    t.is(err, null)
+    t.error(err)
   })
 })
 
@@ -90,7 +83,7 @@ test('listen after Promise.resolve()', t => {
       f.listen(0, (err, address) => {
         f.server.unref()
         t.is(address, 'http://127.0.0.1:' + f.server.address().port)
-        t.is(err, null)
+        t.error(err)
       })
     })
 })
@@ -131,9 +124,8 @@ test('double listen errors callback with (err, address)', t => {
   const fastify = Fastify()
   t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, (err1, address1) => {
-    fastify.server.unref()
     t.is(address1, 'http://127.0.0.1:' + fastify.server.address().port)
-    t.is(err1, null)
+    t.error(err1)
     fastify.listen(fastify.server.address().port, (err2, address2) => {
       t.is(address2, null)
       t.ok(err2)
@@ -147,7 +139,7 @@ test('listen twice on the same port', t => {
   t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, (err1, address1) => {
     t.is(address1, 'http://127.0.0.1:' + fastify.server.address().port)
-    t.is(err1, null)
+    t.error(err1)
     const s2 = Fastify()
     t.tearDown(s2.close.bind(s2))
     s2.listen(fastify.server.address().port, (err2, address2) => {
@@ -164,7 +156,7 @@ test('listen twice on the same port callback with (err, address)', t => {
   fastify.listen(0, (err1, address1) => {
     const _port = fastify.server.address().port
     t.is(address1, 'http://127.0.0.1:' + _port)
-    t.is(err1, null)
+    t.error(err1)
     const s2 = Fastify()
     t.tearDown(s2.close.bind(s2))
     s2.listen(_port, (err2, address2) => {
@@ -198,7 +190,6 @@ test('listen without callback', t => {
   fastify.listen(0)
     .then(() => {
       t.is(fastify.server.address().address, '127.0.0.1')
-      t.end()
     })
 })
 
@@ -209,7 +200,6 @@ test('listen null without callback with (address)', t => {
   fastify.listen(null)
     .then(address => {
       t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
-      t.end()
     })
 })
 
@@ -230,7 +220,6 @@ test('listen with undefined without callback with (address)', t => {
   fastify.listen(undefined)
     .then(address => {
       t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
-      t.end()
     })
 })
 
@@ -241,7 +230,6 @@ test('listen without callback with (address)', t => {
   fastify.listen(0)
     .then(address => {
       t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
-      t.end()
     })
 })
 

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -171,7 +171,6 @@ if (os.platform() !== 'win32') {
   test('listen on socket', t => {
     t.plan(2)
     const fastify = Fastify()
-    t.tearDown(fastify.close.bind(fastify))
     const sockFile = path.join(os.tmpdir(), 'server.sock')
     try {
       fs.unlinkSync(sockFile)
@@ -179,6 +178,7 @@ if (os.platform() !== 'win32') {
     fastify.listen(sockFile, (err) => {
       t.error(err)
       t.equal(sockFile, fastify.server.address())
+      fastify.close()
     })
   })
 }

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -295,6 +295,14 @@ server.addContentTypeParser('foo/bar', {}, (req, done) => {
   done!(null, {})
 })
 
+server.addContentTypeParser('foo/bar', {parseAs: 'string'}, (req, done) => {
+  done!(null, {})
+})
+
+server.addContentTypeParser('foo/bar', {bodyLimit: 20}, (req, done) => {
+  done!(null, {})
+})
+
 server.addContentTypeParser('foo/bar', {}, async (req: http2.Http2ServerRequest) => [])
 
 if (typeof server.hasContentTypeParser('foo/bar') !== 'boolean') {


### PR DESCRIPTION
Full URL address can be passed in `fastify.listen()`. If listen() is a promise then address passed through resolve method or if it is a callback then passed along with an error. Fixed #875 

Note: Missing "listen on socket" test. Same as previously closed PR #926. Special thanks @allevo, @mcollina, @jsumners, @delvedor 

### Example
```js
fastify.listen(3000, '127.0.0.1')
  .then(address) => /* do whatever */)
  .catch(error) => /* error */);
```
or
```js
fastify.listen(3000, '127.0.0.1', (err, address) => /* do whatever */);
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] documentation is changed or added
- [x] tests are included
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)