### PR TITLE
Remove `error` parameter from node `listen` callback

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -281,15 +281,10 @@ function build (options) {
         server.once('error', errEventHandler)
       })
       var listen = new Promise((resolve, reject) => {
-        server.listen(port, address, backlog, (err) => {
-          if (err) {
-            listening = false
-            reject(err)
-          } else {
-            server.removeListener('error', errEventHandler)
-            logServerAddress(server.address(), options.https)
-            resolve()
-          }
+        server.listen(port, address, backlog, () => {
+          server.removeListener('error', errEventHandler)
+          logServerAddress(server.address(), options.https)
+          resolve()
         })
         // we set it afterwards because listen can throw
         listening = true


### PR DESCRIPTION
According to the nodejs documentation the callback parameter of the listen method is attached to `listening` event that no takes any parameters.

This PR remove the error parameter (and increase the coverage)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
