### PR TITLE
support for error headers in 404 handler

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -259,7 +259,7 @@ function handleError (reply, error, cb) {
   statusCode = (statusCode >= 400) ? statusCode : 500
   // treat undefined and null as same
   if (error != null) {
-    if (error.headers) {
+    if (error.headers !== undefined) {
       reply.headers(error.headers)
     }
     if (error.status >= 400) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -258,6 +258,9 @@ function handleError (reply, error, cb) {
   var statusCode = res.statusCode
   statusCode = (statusCode >= 400) ? statusCode : 500
   if (error != null) {
+    if (error.headers) {
+      reply.headers(error.headers)
+    }
     if (error.status >= 400) {
       if (error.status === 404) {
         notFound(reply)
@@ -279,10 +282,6 @@ function handleError (reply, error, cb) {
     res.log.error({ req: reply.request.raw, res: res, err: error }, error && error.message)
   } else if (statusCode >= 400) {
     res.log.info({ res: res, err: error }, error && error.message)
-  }
-
-  if (error && error.headers) {
-    reply.headers(error.headers)
   }
 
   var customErrorHandler = reply.context.errorHandler

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -257,6 +257,7 @@ function handleError (reply, error, cb) {
   var res = reply.res
   var statusCode = res.statusCode
   statusCode = (statusCode >= 400) ? statusCode : 500
+  // treat undefined and null as same
   if (error != null) {
     if (error.headers) {
       reply.headers(error.headers)

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -125,6 +125,7 @@ test('customized 404', t => {
         url: 'http://localhost:' + fastify.server.address().port + '/with-error-custom-header'
       }, (err, response, body) => {
         t.error(err)
+
         t.strictEqual(response.statusCode, 404)
         t.strictEqual(response.headers['x-foo'], 'bar')
         t.strictEqual(body.toString(), 'this was not found')

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -118,7 +118,7 @@ test('customized 404', t => {
       })
     })
 
-    test('with error object and custom headers property', t => {
+    test('error object with headers property', t => {
       t.plan(4)
       sget({
         method: 'GET',
@@ -133,7 +133,7 @@ test('customized 404', t => {
   })
 })
 
-test('custom headers in notFound handler', t => {
+test('custom header in notFound handler', t => {
   t.plan(2)
 
   const test = t.test

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -125,7 +125,6 @@ test('customized 404', t => {
         url: 'http://localhost:' + fastify.server.address().port + '/with-error-custom-header'
       }, (err, response, body) => {
         t.error(err)
-
         t.strictEqual(response.statusCode, 404)
         t.strictEqual(response.headers['x-foo'], 'bar')
         t.strictEqual(body.toString(), 'this was not found')

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -52,7 +52,7 @@ test('default 404', t => {
 })
 
 test('customized 404', t => {
-  t.plan(4)
+  t.plan(5)
 
   const test = t.test
   const fastify = Fastify()
@@ -63,6 +63,12 @@ test('customized 404', t => {
 
   fastify.get('/with-error', function (req, reply) {
     reply.send(new errors.NotFound())
+  })
+
+  fastify.get('/with-error-custom-header', function (req, reply) {
+    const err = new errors.NotFound()
+    err.headers = { 'x-foo': 'bar' }
+    reply.send(err)
   })
 
   fastify.setNotFoundHandler(function (req, reply) {
@@ -108,6 +114,49 @@ test('customized 404', t => {
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
+        t.strictEqual(body.toString(), 'this was not found')
+      })
+    })
+
+    test('with error object and custom headers property', t => {
+      t.plan(4)
+      sget({
+        method: 'GET',
+        url: 'http://localhost:' + fastify.server.address().port + '/with-error-custom-header'
+      }, (err, response, body) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 404)
+        t.strictEqual(response.headers['x-foo'], 'bar')
+        t.strictEqual(body.toString(), 'this was not found')
+      })
+    })
+  })
+})
+
+test('custom headers in notFound handler', t => {
+  t.plan(2)
+
+  const test = t.test
+  const fastify = Fastify()
+
+  fastify.setNotFoundHandler(function (req, reply) {
+    reply.code(404).header('x-foo', 'bar').send('this was not found')
+  })
+
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    test('not found with custom header', t => {
+      t.plan(4)
+      sget({
+        method: 'GET',
+        url: 'http://localhost:' + fastify.server.address().port + '/notSupported'
+      }, (err, response, body) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 404)
+        t.strictEqual(response.headers['x-foo'], 'bar')
         t.strictEqual(body.toString(), 'this was not found')
       })
     })


### PR DESCRIPTION
As titled.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
