### PR TITLE
Support array syntax to handle multiple content types as the same

### DIFF
--- a/docs/ContentTypeParser.md
+++ b/docs/ContentTypeParser.md
@@ -14,6 +14,12 @@ fastify.addContentTypeParser('application/jsoff', function (req, done) {
     done(err, body)
   })
 })
+// handle multiple content types as the same
+fastify.addContentTypeParser(['text/xml', 'application/xml'], function (req, done) {
+  xmlParser(req, function (err, body) {
+    done(err, body)
+  })
+})
 // async also supported in Node versions >= 8.0.0
 fastify.addContentTypeParser('application/jsoff', async function (req) {
   var res = await new Promise((resolve, reject) => resolve(req))

--- a/fastify.js
+++ b/fastify.js
@@ -716,7 +716,12 @@ function build (options) {
       opts.bodyLimit = this._bodyLimit
     }
 
-    this._contentTypeParser.add(contentType, opts, parser)
+    if (Array.isArray(contentType)) {
+      contentType.forEach((type) => this._contentTypeParser.add(type, opts, parser))
+    } else {
+      this._contentTypeParser.add(contentType, opts, parser)
+    }
+
     return this
   }
 


### PR DESCRIPTION
As titled.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
