### PR TITLE
Feature/consistent docs formatting

### DIFF
--- a/docs/Benchmarking.md
+++ b/docs/Benchmarking.md
@@ -1,9 +1,11 @@
 <h1 align="center">Fastify</h1>
 
 ## Benchmarking
+
 Benchmarking is important if you want to measure how a change can impact your application performance. We provide a simple way to benchmark your application from the point of view of a user and contributor. The setup allows you to automate benchmarks in different branches on different Node.js versions.
 
 The modules we'll use:
+
 - [Autocannon](https://github.com/mcollina/autocannon): A HTTP/1.1 benchmarking tool written in node.
 - [Branch-comparer](https://github.com/StarpTech/branch-comparer): Checkout multiple git branches, execute scripts and log the results.
 - [Concurrently](https://github.com/kimmobrunfeldt/concurrently): Run commands concurrently.
@@ -12,11 +14,13 @@ The modules we'll use:
 ## Simple
 
 ### Run the test in the current branch
+
 ```sh
 npm run benchmark
 ```
 
 ### Run the test against different Node.js versions ✨
+
 ```sh
 npx -p node@6 -- npm run benchmark
 ```
@@ -24,20 +28,25 @@ npx -p node@6 -- npm run benchmark
 ## Advanced
 
 ### Run the test in different branches
+
 ```sh
 branchcmp --rounds 2 --script "npm run benchmark"
 ```
 
 ### Run the test in different branches against different Node.js versions ✨
+
 ```sh
 branchcmp --rounds 2 --script "npm run benchmark"
 ```
 
 ### Compare current branch with master (Gitflow)
+
 ```sh
 branchcmp --rounds 2 --gitflow --script "npm run benchmark"
 ```
+
 or
+
 ```sh
 npm run bench
 ```

--- a/docs/ContentTypeParser.md
+++ b/docs/ContentTypeParser.md
@@ -1,27 +1,32 @@
 <h1 align="center">Fastify</h1>
 
 ## Content Type Parser
-Natively, Fastify only supports the `'application/json'` content type. The default charset is `utf-8`. If you need to support different content types, you can use the `addContentTypeParser` API. *The default JSON parser can be changed.*
+
+Natively, Fastify only supports the `'application/json'` content type. The default charset is `utf-8`. If you need to support different content types, you can use the `addContentTypeParser` API. _The default JSON parser can be changed._
 
 As with the other APIs, `addContentTypeParser` is encapsulated in the scope in which it is declared. This means that if you declare it in the root scope it will be available everywhere, while if you declare it inside a register it will be available only in that scope and its children.
 
 Fastify adds automatically the parsed request payload to the [Fastify request](https://github.com/fastify/fastify/blob/master/docs/Request.md) object, you can reach it with `request.body`.
 
 ### Usage
+
 ```js
-fastify.addContentTypeParser('application/jsoff', function (req, done) {
-  jsoffParser(req, function (err, body) {
+fastify.addContentTypeParser('application/jsoff', function(req, done) {
+  jsoffParser(req, function(err, body) {
     done(err, body)
   })
 })
 // handle multiple content types as the same
-fastify.addContentTypeParser(['text/xml', 'application/xml'], function (req, done) {
-  xmlParser(req, function (err, body) {
+fastify.addContentTypeParser(['text/xml', 'application/xml'], function(
+  req,
+  done
+) {
+  xmlParser(req, function(err, body) {
     done(err, body)
   })
 })
 // async also supported in Node versions >= 8.0.0
-fastify.addContentTypeParser('application/jsoff', async function (req) {
+fastify.addContentTypeParser('application/jsoff', async function(req) {
   var res = await new Promise((resolve, reject) => resolve(req))
   return res
 })
@@ -30,40 +35,52 @@ fastify.addContentTypeParser('application/jsoff', async function (req) {
 You can also use the `hasContentTypeParser` API to find if a specific content type parser already exists.
 
 ```js
-if (!fastify.hasContentTypeParser('application/jsoff')){
-  fastify.addContentTypeParser('application/jsoff', function (req, done) {
+if (!fastify.hasContentTypeParser('application/jsoff')) {
+  fastify.addContentTypeParser('application/jsoff', function(req, done) {
     //code to parse request body /payload for given content type
   })
 }
 ```
 
 #### Body Parser
+
 You can parse the body of the request in two ways. The first one is shown above: you add a custom content type parser and handle the request stream. In the second one you should pass a `parseAs` option to the `addContentTypeParser` API, where you declare how you want to get the body, it could be `'string'` or `'buffer'`. If you use the `parseAs` option Fastify will internally handle the stream and perform some checks, such as the [maximum size](https://github.com/fastify/fastify/blob/master/docs/Factory.md#factory-body-limit) of the body and the content length. If the limit is exceeded the custom parser will not be invoked.
+
 ```js
-fastify.addContentTypeParser('application/json', { parseAs: 'string' }, function (req, body, done) {
-  try {
-    var json = JSON.parse(body)
-    done(null, json)
-  } catch (err) {
-    err.statusCode = 400
-    done(err, undefined)
+fastify.addContentTypeParser(
+  'application/json',
+  { parseAs: 'string' },
+  function(req, body, done) {
+    try {
+      var json = JSON.parse(body)
+      done(null, json)
+    } catch (err) {
+      err.statusCode = 400
+      done(err, undefined)
+    }
   }
-})
+)
 ```
+
 As you can see, now the function signature is `(req, body, done)` instead of `(req, done)`.
 
 See [`example/parser.js`](https://github.com/fastify/fastify/blob/master/examples/parser.js) for an example.
 
 ##### Custom Parser Options
-+ `parseAs` (string): Either `'string'` or `'buffer'` to designate how the incoming data should be collected. Default: `'buffer'`.
-+ `bodyLimit` (number): The maximum payload size, in bytes, that the custom parser will accept. Defaults to the global body limit passed to the [`Fastify factory function`](https://github.com/fastify/fastify/blob/master/docs/Factory.md#bodylimit).
+
+- `parseAs` (string): Either `'string'` or `'buffer'` to designate how the incoming data should be collected. Default: `'buffer'`.
+- `bodyLimit` (number): The maximum payload size, in bytes, that the custom parser will accept. Defaults to the global body limit passed to the [`Fastify factory function`](https://github.com/fastify/fastify/blob/master/docs/Factory.md#bodylimit).
 
 #### Catch All
+
 There are some cases where you need to catch all requests regardless of their content type. With Fastify, you just need to add the `'*'` content type.
+
 ```js
-fastify.addContentTypeParser('*', function (req, done) {
+fastify.addContentTypeParser('*', function(req, done) {
   var data = ''
-  req.on('data', chunk => { data += chunk })
+  req.on('data', chunk => {
+    data += chunk
+  })
   req.on('end', () => {
     done(null, data)
   })

--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -7,10 +7,13 @@ If you need to add functionality to the Fastify instance, the `decorate` API is 
 The API allows you to add new properties to the Fastify instance. A value is not restricted to a function and could also be an object or a string, for example.
 
 <a name="usage"></a>
+
 ### Usage
+
 <a name="decorate"></a>
 **decorate**
 Just call the `decorate` API and pass the name of the new property and its value.
+
 ```js
 fastify.decorate('utility', () => {
   // something very useful
@@ -18,6 +21,7 @@ fastify.decorate('utility', () => {
 ```
 
 As said above, you can also decorate the instance with non-function values:
+
 ```js
 fastify.decorate('conf', {
   db: 'some.db',
@@ -26,19 +30,21 @@ fastify.decorate('conf', {
 ```
 
 Once you decorate the instance, you can access the value by using the name you passed as a parameter:
+
 ```js
 fastify.utility()
 
 console.log(fastify.conf.db)
 ```
 
-Decorators are not *overwritable*. If you try to declare a decorator that was previously declared *(in other words, use the same name)*, `decorate` will throw an exception.
+Decorators are not _overwritable_. If you try to declare a decorator that was previously declared _(in other words, use the same name)_, `decorate` will throw an exception.
 
 <a name="decorate-reply"></a>
 **decorateReply**
 As the name suggests, this API is needed if you want to add new methods to the `Reply` core object. Just call the `decorateReply` API and pass the name of the new property and its value:
+
 ```js
-fastify.decorateReply('utility', function () {
+fastify.decorateReply('utility', function() {
   // something very useful
 })
 ```
@@ -48,8 +54,9 @@ Note: using an arrow function will break the binding of `this` to the Fastify `r
 <a name="decorate-request"></a>
 **decorateRequest**
 As above, this API is needed if you want to add new methods to the `Request` core object. Just call the `decorateRequest` API and pass the name of the new property and its value:
+
 ```js
-fastify.decorateRequest('utility', function () {
+fastify.decorateRequest('utility', function() {
   // something very useful
 })
 ```
@@ -57,7 +64,9 @@ fastify.decorateRequest('utility', function () {
 Note: using an arrow function will break the binding of `this` to the Fastify `request` instance.
 
 <a name="usage_notes"></a>
+
 #### Usage Notes
+
 `decorateReply` and `decorateRequest` are used to modify the `Reply` and `Request` constructors respectively by adding methods or properties. To update these properties you should directly access the desired property of the `Reply` or `Request` object.
 
 As an example let's add a user property to the `Request` object:
@@ -76,15 +85,21 @@ fastify.get('/', (req, reply) => {
   reply.send(`Hello ${req.user}!`)
 })
 ```
+
 Note: The usage of `decorateReply` and `decorateRequest` is optional in this case but will allow Fastify to optimize for performance.
 
 <a name="sync-async"></a>
+
 #### Sync and Async
-`decorate` is a *synchronous* API. If you need to add a decorator that has an *asynchronous* bootstrap, Fastify could boot up before your decorator is ready. To avoid this issue, you must use the `register` API in combination with `fastify-plugin`. To learn more, check out the [Plugins](https://github.com/fastify/fastify/blob/master/docs/Plugins.md) documentation as well.
+
+`decorate` is a _synchronous_ API. If you need to add a decorator that has an _asynchronous_ bootstrap, Fastify could boot up before your decorator is ready. To avoid this issue, you must use the `register` API in combination with `fastify-plugin`. To learn more, check out the [Plugins](https://github.com/fastify/fastify/blob/master/docs/Plugins.md) documentation as well.
 
 <a name="dependencies"></a>
+
 #### Dependencies
+
 If your decorator depends on another decorator, you can easily declare the other decorator as a dependency. You just need to add an array of strings (representing the names of the decorators on which yours depends) as the third parameter:
+
 ```js
 fastify.decorate('utility', fn, ['greet', 'log'])
 ```
@@ -92,22 +107,31 @@ fastify.decorate('utility', fn, ['greet', 'log'])
 If a dependency is not satisfied, `decorate` will throw an exception, but don't worry: the dependency check is executed before the server boots up, so it won't ever happen at runtime.
 
 <a name="has-decorator"></a>
+
 #### hasDecorator
+
 You can check for the presence of a decorator with the `hasDecorator` API:
+
 ```js
 fastify.hasDecorator('utility')
 ```
 
 <a name="has-request-decorator"></a>
+
 #### hasRequestDecorator
+
 You can check for the presence of a Request decorator with the `hasRequestDecorator` API:
+
 ```js
 fastify.hasRequestDecorator('utility')
 ```
 
 <a name="has-reply-decorator"></a>
+
 #### hasReplyDecorator
+
 You can check for the presence of a Reply decorator with the `hasReplyDecorator` API:
+
 ```js
 fastify.hasReplyDecorator('utility')
 ```

--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -1,9 +1,11 @@
 <h1 align="center">Fastify</h1>
 
 ## Ecosystem
+
 Plugins maintained by the fastify team are listed under [Core](#core) while plugins maintained by the community are listed in the [Community](#community) section.
 
 #### [Core](#core)
+
 - [`fastify-accepts`](https://github.com/fastify/fastify-accepts) to have [accepts](https://www.npmjs.com/package/accepts) in your request object.
 - [`fastify-accepts-serializer`](https://github.com/fastify/fastify-accepts-serializer) to serialize to output according to `Accept` header.
 - [`fastify-auth`](https://github.com/fastify/fastify-auth) Run multiple auth functions in Fastify.
@@ -33,10 +35,11 @@ Plugins maintained by the fastify team are listed under [Core](#core) while plug
 - [`fastify-swagger`](https://github.com/fastify/fastify-swagger) Swagger documentation generator for Fastify.
 - [`fastify-websocket`](https://github.com/fastify/fastify-websocket) WebSocket support for Fastify. Built upon [websocket-stream](https://github.com/maxogden/websocket-stream).
 - [`fastify-url-data`](https://github.com/fastify/fastify-url-data) Decorate the `Request` object with a method to access raw URL components.
-- [`point-of-view`](https://github.com/fastify/point-of-view) Templates rendering (*ejs, pug, handlebars, marko*) plugin support for Fastify.
-- [`under-pressure`](https://github.com/fastify/under-pressure) Measure process load with automatic handling of *"Service Unavailable"* plugin for Fastify.
+- [`point-of-view`](https://github.com/fastify/point-of-view) Templates rendering (_ejs, pug, handlebars, marko_) plugin support for Fastify.
+- [`under-pressure`](https://github.com/fastify/under-pressure) Measure process load with automatic handling of _"Service Unavailable"_ plugin for Fastify.
 
 #### [Community](#community)
+
 - [`fastify-angular-universal`](https://github.com/exequiel09/fastify-angular-universal) Angular server-side rendering support using [`@angular/platform-server`](https://github.com/angular/angular/tree/master/packages/platform-server) for Fastify
 - [`fastify-apollo`](https://github.com/coopnd/fastify-apollo) Run an [Apollo Server](https://github.com/apollographql/apollo-server) to serve GraphQL with Fastify.
 - [`fastify-blipp`](https://github.com/PavelPolyakov/fastify-blipp) Prints your routes to the console, so you definitely know which endpoints are available.

--- a/docs/Factory.md
+++ b/docs/Factory.md
@@ -1,6 +1,7 @@
 <h1 align="center">Fastify</h1>
 
 <a name="factory"></a>
+
 ## Factory
 
 The Fastify module exports a factory function that is used to create new
@@ -10,14 +11,16 @@ customize the resulting instance. This document describes the properties
 available in that options object.
 
 <a name="factory-http2"></a>
+
 ### `http2` (Status: experimental)
 
 If `true` Node.js core's [HTTP/2](https://nodejs.org/dist/latest-v8.x/docs/api/http2.html)
 HTTP/2 module is used for binding the socket.
 
-+ Default: `false`
+- Default: `false`
 
 <a name="factory-https"></a>
+
 ### `https`
 
 An object used to configure the server's listening socket for TLS. The options
@@ -30,17 +33,18 @@ This option also applies when the
 <code><b>http2</b></code>
 </a> option is set.
 
-+ Default: `null`
+- Default: `null`
 
 <a name="factory-ignore-slash"></a>
+
 ### `ignoreTrailingSlash`
 
 Fastify uses [find-my-way](https://github.com/delvedor/find-my-way) to handle
 routing. This option may be set to `true` to ignore trailing slashes in routes.
-This option applies to *all* route registrations for the resulting server
+This option applies to _all_ route registrations for the resulting server
 instance.
 
-+ Default: `false`
+- Default: `false`
 
 ```js
 const fastify = require('fastify')({
@@ -48,30 +52,34 @@ const fastify = require('fastify')({
 })
 
 // registers both "/foo" and "/foo/"
-fastify.get('/foo/', function (req, reply) {
+fastify.get('/foo/', function(req, reply) {
   res.send('foo')
 })
 
 // registers both "/bar" and "/bar/"
-fastify.get('/bar', function (req, reply) {
+fastify.get('/bar', function(req, reply) {
   res.send('bar')
 })
 ```
 
 <a name="factory-max-param-length"></a>
+
 ### `maxParamLength`
+
 You can set a custom length for parameters in parametric (standard, regex and multi) routes by using `maxParamLength` option, the default value is 100 characters.<br>
 This can be useful especially if you have some regex based route, protecting you against [DoS attacks](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS).<br>
-*If the maximum length limit is reached, the not found route will be invoked.*
+_If the maximum length limit is reached, the not found route will be invoked._
 
 <a name="factory-body-limit"></a>
+
 ### `bodyLimit`
 
 Defines the maximum payload, in bytes, the server is allowed to accept.
 
-+ Default: `1048576` (1MiB)
+- Default: `1048576` (1MiB)
 
 <a name="factory-logger"></a>
+
 ### `logger`
 
 Fastify includes built-in logging via the [Pino](https://getpino.io/) logger.
@@ -79,34 +87,30 @@ This property is used to configure the internal logger instance.
 
 The possible values this property may have are:
 
-+ Default: `false`. The logger is disabled. All logging methods will point to a
-null logger [abstract-logging](https://npm.im/abstract-logging) instance.
+- Default: `false`. The logger is disabled. All logging methods will point to a
+  null logger [abstract-logging](https://npm.im/abstract-logging) instance.
 
-+ `pinoInstance`: a previously instantiated instance of Pino. The internal
-logger will point to this instance.
+- `pinoInstance`: a previously instantiated instance of Pino. The internal
+  logger will point to this instance.
 
-+ `object`: a standard Pino [options object](https://github.com/pinojs/pino/blob/c77d8ec5ce/docs/API.md#constructor).
-This will be passed directly to the Pino constructor. If the following properties
-are not present on the object, they will be added accordingly:
-    * `genReqId`: a synchronous function that will be used to generate identifiers
-    for incoming requests. The default function generates sequential identifiers.
-    * `level`: the minimum logging level. If not set, it will be set to `'info'`.
-    * `serializers`: a hash of serialization functions. By default, serializers
-      are added for `req` (incoming request objects), `res` (outgoing repsonse
-      objets), and `err` (standard `Error` objects). When a log method receives
-      and object with any of these properties then the respective serializer will
-      be used for that property. For example:
-        ```js
-        fastify.get('/foo', function (req, res) {
-          req.log.info({req}) // log the serialized request object
-          res.send('foo')
-        })
-        ```
-      Any user supplied serializer will override the default serializer of the
-      corresponding property.
+- `object`: a standard Pino [options object](https://github.com/pinojs/pino/blob/c77d8ec5ce/docs/API.md#constructor).
+  This will be passed directly to the Pino constructor. If the following properties
+  are not present on the object, they will be added accordingly:
+  _ `genReqId`: a synchronous function that will be used to generate identifiers
+  for incoming requests. The default function generates sequential identifiers.
+  _ `level`: the minimum logging level. If not set, it will be set to `'info'`. \* `serializers`: a hash of serialization functions. By default, serializers
+  are added for `req` (incoming request objects), `res` (outgoing repsonse
+  objets), and `err` (standard `Error` objects). When a log method receives
+  and object with any of these properties then the respective serializer will
+  be used for that property. For example:
+  `js fastify.get('/foo', function (req, res) { req.log.info({req}) // log the serialized request object res.send('foo') })`
+  Any user supplied serializer will override the default serializer of the
+  corresponding property.
 
 <a name="custom-http-server"></a>
+
 ### `serverFactory`
+
 You can pass a custom http server to Fastify by using the `serverFactory` option.<br/>
 `serverFactory` is a function that takes an `handler` parameter, which takes the `request` and `response` objects as parameters, and an options object, which is the same you have passed to Fastify.
 

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -1,29 +1,36 @@
 <h1 align="center">Fastify</h1>
 
 ## Getting Started
+
 Hello! Thank you for checking out Fastify!<br>
 This document aims to be a gentle introduction to the framework and its features. It is an elementary introduction with examples and links to other parts of the documentation.<br>
 Let's start!
 
 <a name="install"></a>
+
 ### Install
+
 ```
 npm i fastify --save
 ```
+
 <a name="first-server"></a>
+
 ### Your first server
+
 Let's write our first server:
+
 ```js
 // Require the framework and instantiate it
 const fastify = require('fastify')()
 
 // Declare a route
-fastify.get('/', function (request, reply) {
+fastify.get('/', function(request, reply) {
   reply.send({ hello: 'world' })
 })
 
 // Run the server!
-fastify.listen(3000, function (err) {
+fastify.listen(3000, function(err) {
   if (err) {
     fastify.log.error(err)
     process.exit(1)
@@ -32,7 +39,8 @@ fastify.listen(3000, function (err) {
 ```
 
 Do you prefer to use `async/await`? Fastify supports it out-of-the-box.<br>
-*(we also suggest using [make-promises-safe](https://github.com/mcollina/make-promises-safe) to avoid file descriptor and memory leaks)*
+_(we also suggest using [make-promises-safe](https://github.com/mcollina/make-promises-safe) to avoid file descriptor and memory leaks)_
+
 ```js
 const fastify = require('fastify')()
 
@@ -56,10 +64,11 @@ Unfortunately, writing a complex application requires significantly more code th
 Fastify offers an easy platform that helps solve all of problems, and more.
 
 > ## Note
-> The above examples, and subsequent examples in this document, default to listening *only* on the localhost `127.0.0.1` interface. To listen on all available IPv4 interfaces the example should be modified to listen on `0.0.0.0` like so:
+>
+> The above examples, and subsequent examples in this document, default to listening _only_ on the localhost `127.0.0.1` interface. To listen on all available IPv4 interfaces the example should be modified to listen on `0.0.0.0` like so:
 >
 > ```js
-> fastify.listen(3000, '0.0.0.0', function (err) {
+> fastify.listen(3000, '0.0.0.0', function(err) {
 >   if (err) {
 >     fastify.log.error(err)
 >     process.exit(1)
@@ -72,16 +81,19 @@ Fastify offers an easy platform that helps solve all of problems, and more.
 > When deploying to a Docker, or other type of, container this would be the easiest method for exposing the application.
 
 <a name="first-plugin"></a>
+
 ### Your first plugin
+
 As with JavaScript everything is an object, with Fastify everything is a plugin.<br>
 Before digging into it, let's see how it works!<br>
 Let's declare our basic server, but instead of declaring the route inside the entry point, we'll declare it in an external file (checkout the [route declaration](https://github.com/fastify/fastify/blob/master/docs/Routes.md) docs).
+
 ```js
 const fastify = require('fastify')()
 
 fastify.register(require('./our-first-route'))
 
-fastify.listen(3000, function (err) {
+fastify.listen(3000, function(err) {
   if (err) {
     fastify.log.error(err)
     process.exit(1)
@@ -92,7 +104,7 @@ fastify.listen(3000, function (err) {
 ```js
 // our-first-route.js
 
-async function routes (fastify, options) {
+async function routes(fastify, options) {
   fastify.get('/', async (request, reply) => {
     return { hello: 'world' }
   })
@@ -100,6 +112,7 @@ async function routes (fastify, options) {
 
 module.exports = routes
 ```
+
 In this example we used the `register` API. This API is the core of the Fastify framework, and is the only way to register routes, plugins and so on.
 
 At the beginning of this guide we noted that Fastify provides a foundation that assists with the asynchronous bootstrapping of your application. Why this is important?
@@ -108,9 +121,10 @@ A typical solution is to use a complex callback, or promises, system that will m
 Fastify handles this internally, with minimum effort!
 
 Let's rewrite the above example with a database connection.<br>
-*(we will use a simple example, for a robust solution consider using [`fastify-mongo`](https://github.com/fastify/fastify-mongodb) or another in the Fastify [ecosystem](https://github.com/fastify/fastify/blob/master/docs/Ecosystem.md))*
+_(we will use a simple example, for a robust solution consider using [`fastify-mongo`](https://github.com/fastify/fastify-mongodb) or another in the Fastify [ecosystem](https://github.com/fastify/fastify/blob/master/docs/Ecosystem.md))_
 
 **server.js**
+
 ```js
 const fastify = require('fastify')()
 
@@ -119,7 +133,7 @@ fastify.register(require('./our-db-connector'), {
 })
 fastify.register(require('./our-first-route'))
 
-fastify.listen(3000, function (err) {
+fastify.listen(3000, function(err) {
   if (err) {
     fastify.log.error(err)
     process.exit(1)
@@ -128,15 +142,19 @@ fastify.listen(3000, function (err) {
 ```
 
 **our-db-connector.js**
+
 ```js
 const fastifyPlugin = require('fastify-plugin')
 const MongoClient = require('mongodb').MongoClient
 
-async function dbConnector (fastify, options) {
+async function dbConnector(fastify, options) {
   const url = options.url
   delete options.url
 
-  const db = await MongoClient.connect(url, options)
+  const db = await MongoClient.connect(
+    url,
+    options
+  )
   fastify.decorate('mongo', db)
 }
 
@@ -146,8 +164,9 @@ module.exports = fastifyPlugin(dbConnector)
 ```
 
 **our-first-route.js**
+
 ```js
-async function routes (fastify, options) {
+async function routes(fastify, options) {
   const database = fastify.mongo.db('db')
   const collection = database.collection('test')
 
@@ -170,7 +189,7 @@ module.exports = routes
 Wow, that was fast!<br>
 Let's recap what we have done here since we've introduced some new concepts.<br>
 As you can see, we used `register` both for the database connector and the routes registration.
-This is one of the best features of Fastify, it will load your plugins in the same order you declare them, and it will load the next plugin only once the current one has been loaded. In this way we can register the database connector in the first plugin and use it in the second *(read [here](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#handle-the-scope) to understand how to handle the scope of a plugin)*.
+This is one of the best features of Fastify, it will load your plugins in the same order you declare them, and it will load the next plugin only once the current one has been loaded. In this way we can register the database connector in the first plugin and use it in the second _(read [here](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#handle-the-scope) to understand how to handle the scope of a plugin)_.
 Plugin loading starts when you call `fastify.listen()`, `fastify.inject()` or `fastify.ready()`
 
 We have used the `decorate` API. Let's take a moment to understand what it is and how it works. A scenario is to use the same code/library in different parts of an application. A solution is to require the code/library that it is needed. This works, but is annoying because of duplicated code repeated and, if needed, long refactors.<br>
@@ -179,8 +198,11 @@ To solve this Fastify offers the `decorate` API, which adds custom objects to th
 To dig deeper into how Fastify plugins work, how to develop new plugins, and for details on how to use the whole Fastify API to deal with the complexity of asynchronously bootstrapping an application, read [the hitchhiker's guide to plugins](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md).
 
 <a name="plugin-loading-order"></a>
+
 ### Loading order of your plugins
+
 To guarantee a consistent and predictable behavior of your application, we highly recommend to always load your code as shown below:
+
 ```
 └── plugins (from the Fastify ecosystem)
 └── your plugins (your custom plugins)
@@ -188,8 +210,10 @@ To guarantee a consistent and predictable behavior of your application, we highl
 └── hooks and middlewares
 └── your services
 ```
+
 In this way you will always have access to all of the properties declared in the current scope.<br/>
 As discussed previously, Fastify offers a solid encapsulation model, to help you build your application as single and independent services. If you want to register a plugin only for a subset of routes, you have just to replicate the above structure.
+
 ```
 └── plugins (from the Fastify ecosystem)
 └── your plugins (your custom plugins)
@@ -213,10 +237,13 @@ As discussed previously, Fastify offers a solid encapsulation model, to help you
 ```
 
 <a name="validate-data"></a>
+
 ### Validate your data
+
 Data validation is extremely important and is a core concept of the framework.<br>
 To validate incoming requests, Fastify uses [JSON Schema](http://json-schema.org/).
 Let's look at an example demonstrating validation for routes:
+
 ```js
 const opts = {
   schema: {
@@ -234,13 +261,17 @@ fastify.post('/', opts, async (request, reply) => {
   return { hello: 'world' }
 })
 ```
+
 This example shows how to pass an options object to the route, which accepts a `schema` key, that contains all of the schemas for route, `body`, `querystring`, `params` and `headers`.<br>
 Read [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) to learn more.
 
 <a name="serialize-data"></a>
+
 ### Serialize your data
+
 Fastify has first class support for JSON. It is extremely optimized to parse a JSON body and to serialize JSON output.<br>
 To speed up JSON serialization (yes, it is slow!) use the `response` key of the schema option like so:
+
 ```js
 const opts = {
   schema: {
@@ -259,21 +290,28 @@ fastify.get('/', opts, async (request, reply) => {
   return { hello: 'world' }
 })
 ```
+
 Simply by specifying a schema as shown, a speed up your of serialization by 2x or even 3x can be achieved. This also helps protect against leaking of sensitive data, since Fastify will serialize only the data present in the response schema.
 Read [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) to learn more.
 
 <a name="extend-server"></a>
+
 ### Extend your server
+
 Fastify is built to be extremely extensible and very minimal, We believe that a bare minimum framework is all that is necessary to make great applications possible.<br>
 In other words, Fastify is not a "batteries included" framework, and relies on an amazing [ecosystem](https://github.com/fastify/fastify/blob/master/docs/Ecosystem.md)!
 
 <a name="test-server"></a>
+
 ### Test your server
+
 Fastify does not offer a testing framework, but we do recommend a way to write your tests that uses the features and the architecture of Fastify.<br>
 Read the [testing](https://github.com/fastify/fastify/blob/master/docs/Testing.md) documentation to learn more!
 
 <a name="cli"></a>
+
 ### Run your server from CLI
+
 Fastify also has CLI integration thanks to
 [fastify-cli](https://github.com/fastify/fastify-cli).
 
@@ -286,6 +324,7 @@ npm i fastify-cli
 You can also install it globally with `-g`.
 
 Then, add the following lines to `package.json`:
+
 ```json
 {
   "scripts": {
@@ -295,11 +334,12 @@ Then, add the following lines to `package.json`:
 ```
 
 And create your server file(s):
+
 ```js
 // server.js
 'use strict'
 
-module.exports = async function (fastify, opts) {
+module.exports = async function(fastify, opts) {
   fastify.get('/', async (request, reply) => {
     return { hello: 'world' }
   })
@@ -307,13 +347,17 @@ module.exports = async function (fastify, opts) {
 ```
 
 Then run your server with:
+
 ```bash
 npm start
 ```
 
 <a name="slides"></a>
+
 ### Slides and Videos
+
 - Slides
+
   - [Take your HTTP server to ludicrous speed](https://mcollina.github.io/take-your-http-server-to-ludicrous-speed) by [@mcollina](https://github.com/mcollina)
   - [What if I told you that HTTP can be fast](https://delvedor.github.io/What-if-I-told-you-that-HTTP-can-be-fast) by [@delvedor](https://github.com/delvedor)
 

--- a/docs/HTTP2.md
+++ b/docs/HTTP2.md
@@ -12,8 +12,8 @@ _Fastify_, but Node's `req` and `res` can be access through our
 
 ### Secure (HTTPS)
 
-HTTP2 is supported in all modern browsers __only over a secure
-connection__:
+HTTP2 is supported in all modern browsers **only over a secure
+connection**:
 
 ```js
 'use strict'
@@ -28,7 +28,7 @@ const fastify = require('fastify')({
   }
 })
 
-fastify.get('/', function (request, reply) {
+fastify.get('/', function(request, reply) {
   reply.code(200).send({ hello: 'world' })
 })
 
@@ -55,7 +55,7 @@ const fastify = require('fastify')({
 })
 
 // this route can be accessed through both protocols
-fastify.get('/', function (request, reply) {
+fastify.get('/', function(request, reply) {
   reply.code(200).send({ hello: 'world' })
 })
 
@@ -80,7 +80,7 @@ const fastify = require('fastify')({
   http2: true
 })
 
-fastify.get('/', function (request, reply) {
+fastify.get('/', function(request, reply) {
   reply.code(200).send({ hello: 'world' })
 })
 
@@ -92,4 +92,3 @@ You can test your new server with:
 ```
 $ npx h2url http://localhost:3000
 ```
-

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -6,13 +6,15 @@ Hooks are registered with the `fastify.addHook` method and allow you to listen t
 
 ## Request/Response Hooks
 
-By using the hooks you can interact directly inside the lifecycle of Fastify. There are four different Hooks that you can use *(in order of execution)*:
+By using the hooks you can interact directly inside the lifecycle of Fastify. There are four different Hooks that you can use _(in order of execution)_:
+
 - `'onRequest'`
 - `'preHandler'`
 - `'onSend'`
 - `'onResponse'`
 
 Example:
+
 ```js
 fastify.addHook('onRequest', (req, res, next) => {
   // some code
@@ -34,7 +36,9 @@ fastify.addHook('onResponse', (res, next) => {
   next()
 })
 ```
+
 Or `async/await`
+
 ```js
 fastify.addHook('onRequest', async (req, res) => {
   // some code
@@ -66,7 +70,7 @@ fastify.addHook('onSend', async (request, reply, payload) => {
   return
 })
 
-fastify.addHook('onResponse', async (res) => {
+fastify.addHook('onResponse', async res => {
   // some code
   await asyncMethod()
   // error occurred
@@ -79,14 +83,14 @@ fastify.addHook('onResponse', async (res) => {
 
 **Notice:** the `next` callback is not available when using `async`/`await` or returning a `Promise`. If you do invoke a `next` callback in this situation unexpected behavior may occur, e.g. duplicate invocation of handlers.
 
-| Parameter   |  Description  |
-|-------------|-------------|
-| req |  Node.js [IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage) |
-| res | Node.js [ServerResponse](https://nodejs.org/api/http.html#http_class_http_serverresponse) |
-| request | Fastify [Request](https://github.com/fastify/fastify/blob/master/docs/Request.md) interface |
-| reply | Fastify [Reply](https://github.com/fastify/fastify/blob/master/docs/Reply.md) interface |
-| payload | The serialized payload |
-| next | Function to continue with the [lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md) |
+| Parameter | Description                                                                                                 |
+| --------- | ----------------------------------------------------------------------------------------------------------- |
+| req       | Node.js [IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage)                 |
+| res       | Node.js [ServerResponse](https://nodejs.org/api/http.html#http_class_http_serverresponse)                   |
+| request   | Fastify [Request](https://github.com/fastify/fastify/blob/master/docs/Request.md) interface                 |
+| reply     | Fastify [Reply](https://github.com/fastify/fastify/blob/master/docs/Reply.md) interface                     |
+| payload   | The serialized payload                                                                                      |
+| next      | Function to continue with the [lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md) |
 
 It is pretty easy to understand where each hook is executed by looking at the [lifecycle page](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md).<br>
 Hooks are affected by Fastify's encapsulation, and can thus be applied to selected routes. See the [Scopes](#scope) section for more information.
@@ -100,6 +104,7 @@ fastify.addHook('onRequest', (req, res, next) => {
 ```
 
 If you want to pass a custom error code to the user, just use `reply.code()`:
+
 ```js
 fastify.addHook('preHandler', (request, reply, next) => {
   reply.code(500)
@@ -107,7 +112,7 @@ fastify.addHook('preHandler', (request, reply, next) => {
 })
 ```
 
-*The error will be handled by [`Reply`](https://github.com/fastify/fastify/blob/master/docs/Reply.md#errors).*
+_The error will be handled by [`Reply`](https://github.com/fastify/fastify/blob/master/docs/Reply.md#errors)._
 
 Note that in the `'preHandler'` and `'onSend'` hook the request and reply objects are different from `'onRequest'`, because the two arguments are [`request`](https://github.com/fastify/fastify/blob/master/docs/Request.md) and [`reply`](https://github.com/fastify/fastify/blob/master/docs/Reply.md) core Fastify objects.
 
@@ -117,7 +122,7 @@ If you are using the `onSend` hook, you can change the payload. For example:
 
 ```js
 fastify.addHook('onSend', (request, reply, payload, next) => {
-  var err = null;
+  var err = null
   var newPayload = payload.replace('some-text', 'some-new-text')
   next(err, newPayload)
 })
@@ -144,6 +149,7 @@ fastify.addHook('onSend', (request, reply, payload, next) => {
 Note: If you change the payload, you may only change it to a `string`, a `Buffer`, a `stream`, or `null`.
 
 ### Respond to a request from a hook
+
 If needed, you can respond to a request before you reach the route handler. An example could be an authentication hook. If you are using `onRequest` or a middleware, use `res.end`. If you are using the `preHandler` hook, use `reply.send`.
 
 ```js
@@ -179,17 +185,20 @@ You are able to hook into the application-lifecycle as well. It's important to n
 **'onClose'**<br>
 Triggered when `fastify.close()` is invoked to stop the server. It is useful when [plugins](https://github.com/fastify/fastify/blob/master/docs/Plugins.md) need a "shutdown" event, such as a connection to a database.<br>
 The first argument is the Fastify instance, the second one the `done` callback.
+
 ```js
 fastify.addHook('onClose', (instance, done) => {
   // some code
   done()
 })
 ```
+
 <a name="on-route"></a>
 **'onRoute'**<br>
 Triggered when a new route is registered. Listeners are passed a `routeOptions` object as the sole parameter. The interface is synchronous, and, as such, the listeners do not get passed a callback.
+
 ```js
-fastify.addHook('onRoute', (routeOptions) => {
+fastify.addHook('onRoute', routeOptions => {
   // some code
   routeOptions.method
   routeOptions.schema
@@ -199,20 +208,26 @@ fastify.addHook('onRoute', (routeOptions) => {
   routeOptions.prefix
 })
 ```
+
 <a name="scope"></a>
+
 ### Scope
+
 Except for [Application Hooks](#application-hooks), all hooks are encapsulated. This means that you can decide where your hooks should run by using `register` as explained in the [plugins guide](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md). If you pass a function, that function is bound to the right Fastify context and from there you have full access to the Fastify API.
 
 ```js
-fastify.addHook('onRequest', function (req, res, next) {
+fastify.addHook('onRequest', function(req, res, next) {
   const self = this // Fastify context
   next()
 })
 ```
+
 Note: using an arrow function will break the binding of this to the Fastify instance.
 
 <a name="before-handler"></a>
+
 ### beforeHandler
+
 Despite the name, `beforeHandler` is not a standard hook like `preHandler`, but is a function that your register right in the route option that will be executed only in the specified route. Can be useful if you need to handle the authentication at route level instead of at hook level (`preHandler` for example), it could also be an array of functions.<br>
 **`beforeHandler` is executed always after the `preHandler` hook.**
 

--- a/docs/LTS.md
+++ b/docs/LTS.md
@@ -1,26 +1,28 @@
 <h1 align="center">Fastify</h1>
 
 <a name="lts"></a>
+
 ## Long Term Support
 
 Fastify's Long Term Support (LTS) is provided according the schedule laid
 out in this document:
 
-1. Major releases, "X" release of [semantic versioning][semver] X.Y.Z release
-versions, are supported for a minimum period of six months from their release
-date. The release date of any specific version can be found at
-[https://github.com/fastify/fastify/releases](https://github.com/fastify/fastify/releases).
+1.  Major releases, "X" release of [semantic versioning][semver] X.Y.Z release
+    versions, are supported for a minimum period of six months from their release
+    date. The release date of any specific version can be found at
+    [https://github.com/fastify/fastify/releases](https://github.com/fastify/fastify/releases).
 
-1. Major releases will receive security updates for an additional six months
-from the release of the next major release.
+1.  Major releases will receive security updates for an additional six months
+    from the release of the next major release.
 
 A "month" is to be a period of 30 consecutive days.
 
 [semver]: https://semver.org/
 
 <a name="lts-schedule"></a>
+
 ### Schedule
 
 | Version | Release Date | End Of LTS Date |
-|:--------|:-------------|:----------------|
+| :------ | :----------- | :-------------- |
 | 1.0.0   | 2018-03-06   | TBD             |

--- a/docs/Lifecycle.md
+++ b/docs/Lifecycle.md
@@ -1,8 +1,10 @@
 <h1 align="center">Fastify</h1>
 
 ## Lifecycle
+
 Following the schema of the internal lifecycle of Fastify.<br>
-On the right branch of every section there is the next phase of the lifecycle, on the left branch there is the corresponding error code that will be generated if the parent throws an error *(note that all the errors are automatically handled by Fastify)*.
+On the right branch of every section there is the next phase of the lifecycle, on the left branch there is the corresponding error code that will be generated if the parent throws an error _(note that all the errors are automatically handled by Fastify)_.
+
 ```
 Incoming Request
   │

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -18,7 +18,7 @@ const fastify = require('fastify')({
   logger: true
 })
 
-fastify.get('/', options, function (request, reply) {
+fastify.get('/', options, function(request, reply) {
   request.log.info('Some info about the current request')
   reply.send({ hello: 'world' })
 })
@@ -38,7 +38,7 @@ const fastify = require('fastify')({
   }
 })
 
-fastify.get('/', options, function (request, reply) {
+fastify.get('/', options, function(request, reply) {
   request.log.info('Some info about the current request')
   reply.send({ hello: 'world' })
 })
@@ -46,29 +46,33 @@ fastify.get('/', options, function (request, reply) {
 
 By default fastify adds an id to every request for easier tracking. If the "request-id" header is present its value is used, otherwise a new incremental id is generated.
 Additionally, `genReqId` option can be used for generating the request id by yourself. It will received the incoming request as a parameter.
+
 ```js
 let i = 0
 const fastify = require('fastify')({
   logger: {
-    genReqId: function (req) { return i++ }
+    genReqId: function(req) {
+      return i++
+    }
   }
 })
 ```
 
 The default logger is configured with a set of standard serializers that serialize objects with `req`, `res`, and `err` properties. This behavior can be customized by specifying custom serializers.
+
 ```js
 const fastify = require('fastify')({
   logger: {
     serializers: {
-      req: function (req) { 
-        return { url: req.url } 
+      req: function(req) {
+        return { url: req.url }
       }
     }
   }
 })
 ```
 
-*This option will be ignored by any logger other than Pino.*
+_This option will be ignored by any logger other than Pino._
 
 You can also supply your own logger instance. Instead of passing configuration options, simply pass the instance.
 The logger you supply must conform to the Pino interface; that is, it must have the following methods:
@@ -82,10 +86,12 @@ const fastify = require('fastify')({ logger: log })
 
 log.info('does not have request information')
 
-fastify.get('/', function (request, reply) {
-  request.log.info('includes request information, but is the same logger instance as `log`')
+fastify.get('/', function(request, reply) {
+  request.log.info(
+    'includes request information, but is the same logger instance as `log`'
+  )
   reply.send({ hello: 'world' })
 })
 ```
 
-*The logger instance for the current request is available in every part of the [lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md).*
+_The logger instance for the current request is available in every part of the [lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md)._

--- a/docs/Middlewares.md
+++ b/docs/Middlewares.md
@@ -4,12 +4,12 @@
 
 Fastify provides out of the box an asynchronous [middleware engine](https://github.com/fastify/middie) compatible with [Express](https://expressjs.com/) and [Restify](http://restify.com/) middlewares.
 
-*If you need a visual feedback to understand when the middlewares are executed take a look to the [lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md) page.*
+_If you need a visual feedback to understand when the middlewares are executed take a look to the [lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md) page._
 
 Fastify middlewares don't support the full syntax `middleware(err, req, res, next)`, because error handling is done inside Fastify.
 Furthermore methods added by Express and Restify to the enhanced versions of `req` and `res` are not supported in Fastify middlewares.
 
-Also, if you are using a middleware that bundles different, smaller middlewares, such as [*helmet*](https://helmetjs.github.io/), we recommend to use the single modules to get better performances.
+Also, if you are using a middleware that bundles different, smaller middlewares, such as [_helmet_](https://helmetjs.github.io/), we recommend to use the single modules to get better performances.
 
 ```js
 fastify.use(require('cors')())
@@ -21,7 +21,7 @@ fastify.use(require('ienoopen')())
 fastify.use(require('x-xss-protection')())
 ```
 
-or, in the specific case of *helmet*, you can use the [*fastify-helmet*](https://github.com/fastify/fastify-helmet) [plugin](Plugins.md), which is an optimized helmet integration for fastify:
+or, in the specific case of _helmet_, you can use the [_fastify-helmet_](https://github.com/fastify/fastify-helmet) [plugin](Plugins.md), which is an optimized helmet integration for fastify:
 
 ```js
 const fastify = require('fastify')()
@@ -32,13 +32,15 @@ fastify.register(helmet)
 
 Remember that middlewares can be encapsulated, this means that you can decide where your middlewares should run by using `register` as explained in the [plugins guide](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md).
 
-Fastify middlewares also do not expose the `send` method or other methods specific to the Fastify [Reply]('./Reply.md' "Reply") instance. This is because Fastify wraps the incoming `req` and `res` Node instances using the [Request](./Request.md "Request") and [Reply](./Reply.md "Reply") objects internally, but this is done after the middlewares phase. If you need to create a middleware you have to use the Node `req` and `res` instances. Otherwise, you can use the `preHandler` hook that has the [Request](./Request.md "Request") and [Reply](./Reply.md "Reply") Fastify instances. For more information, see [Hooks](./Hooks.md "Hooks").
+Fastify middlewares also do not expose the `send` method or other methods specific to the Fastify [Reply]('./Reply.md' 'Reply') instance. This is because Fastify wraps the incoming `req` and `res` Node instances using the [Request](./Request.md 'Request') and [Reply](./Reply.md 'Reply') objects internally, but this is done after the middlewares phase. If you need to create a middleware you have to use the Node `req` and `res` instances. Otherwise, you can use the `preHandler` hook that has the [Request](./Request.md 'Request') and [Reply](./Reply.md 'Reply') Fastify instances. For more information, see [Hooks](./Hooks.md 'Hooks').
 
 <a name="restrict-usage"></a>
+
 #### Restrict middleware execution to a certain path(s)
+
 If you need to run a middleware only under certain path(s), just pass the path as first parameter to `use` and you are done!
 
-*Note that this does not support routes with parameters, (eg: `/user/:id/comments`) and wildcard is not supported in multiple paths.*
+_Note that this does not support routes with parameters, (eg: `/user/:id/comments`) and wildcard is not supported in multiple paths._
 
 ```js
 const path = require('path')

--- a/docs/Plugins-Guide.md
+++ b/docs/Plugins-Guide.md
@@ -1,11 +1,13 @@
 <h1 align="center">Fastify</h1>
 
 # The hitchhiker's guide to plugins
+
 First of all, `DON'T PANIC`!
 
 Fastify was built from the beginning to be an extremely modular system. We built a powerful API that allows you to add methods and utilities to Fastify by creating a namespace. We built a system that creates an encapsulation model that allows you to split your application in multiple microservices at any moment, without the need to refactor the entire application.
 
 **Table of contents**
+
 - [Register](#register)
 - [Decorators](#decorators)
 - [Hooks](#hooks)
@@ -15,35 +17,38 @@ Fastify was built from the beginning to be an extremely modular system. We built
 - [Let's start!](#start)
 
 <a name="register"></a>
+
 ## Register
+
 As in JavaScript everything is an object, in Fastify everything is a plugin.<br>
 Your routes, your utilities and so on are all plugins. To add a new plugin, whatever its functionality is, in Fastify you have a nice and unique api to use: [`register`](https://github.com/fastify/fastify/blob/master/docs/Plugins.md).
+
 ```js
-fastify.register(
-  require('./my-plugin'),
-  { options }
-)
+fastify.register(require('./my-plugin'), { options })
 ```
+
 `register` creates a new Fastify context, this means that if you do any change to the Fastify instance, those changes will not be reflected in the context's ancestors. In other words, encapsulation!
 
-
-*Why is encapsulation important?*<br>
+_Why is encapsulation important?_<br>
 Well, let's say you are creating a new disruptive startup, what do you do? You create an api server with all your stuff, everything in the same place, a monolith!<br>
 Ok, you are growing very fast and you want to change your architecture and try microservices. Usually this implies a huge amount of work, because of cross dependencies and the lack of separation of concerns.<br>
 Fastify helps you a lot in this direction, because thanks to the encapsulation model it will completely avoid cross dependencies, and will help you structure your code in cohesive blocks.
 
-*Let's return to how to correctly use `register`.*<br>
+_Let's return to how to correctly use `register`._<br>
 As you probably know, the required plugins must expose a single function with the following signature
+
 ```js
-module.exports = function (fastify, options, next) {}
+module.exports = function(fastify, options, next) {}
 ```
+
 Where `fastify` is (pretty obvious) the encapsulated Fastify instance, `options` is the options object and `next` is the function you **must** call when you plugin is ready.
 
-Fastify's plugin model is fully reentrant and graph-based, it handles without any kind of problem asynchronous code and it guarantees the load order of the plugins, even the close order! *How?* Glad you asked, checkout [`avvio`](https://github.com/mcollina/avvio)! Fastify starts loading the plugin __after__ `.listen()`, `.inject()` or .ready()` are called.
+Fastify's plugin model is fully reentrant and graph-based, it handles without any kind of problem asynchronous code and it guarantees the load order of the plugins, even the close order! _How?_ Glad you asked, checkout [`avvio`](https://github.com/mcollina/avvio)! Fastify starts loading the plugin **after** `.listen()`, `.inject()` or .ready()` are called.
 
 Inside a plugin you can do whatever you want, register routes, utilities (we'll see this in a moment) and do nested registers, just remember to call `next` when everything is set up!
+
 ```js
-module.exports = function (fastify, options, next) {
+module.exports = function(fastify, options, next) {
   fastify.get('/plugin', (request, reply) => {
     reply.send({ hello: 'world' })
   })
@@ -55,27 +60,35 @@ module.exports = function (fastify, options, next) {
 Well, now you know how to use the `register` api and how it works, but how do we add new functionality to Fastify and even better, share them with other developers?
 
 <a name="decorators"></a>
+
 ## Decorators
+
 Okay, let's say that you wrote an utility that is so good that you decided to make it available along all your code. How would you do it? Probably something like the following:
+
 ```js
 // your-awesome-utility.js
-module.exports = function (a, b) {
+module.exports = function(a, b) {
   return a + b
 }
 ```
+
 ```js
 const util = require('./your-awesome-utility')
 console.log(util('that is ', ' awesome'))
 ```
+
 And now you will import your utility in every file you need it. (And don't forget that you will probably also need it in your test).
 
-Fastify offers you a way nicer and elegant way to do this, *decorators*.
+Fastify offers you a way nicer and elegant way to do this, _decorators_.
 Create a decorator is extremely easy, just use the [`decorate`](https://github.com/fastify/fastify/blob/master/docs/Decorators.md) api:
+
 ```js
 fastify.decorate('util', (a, b) => a + b)
 ```
+
 Now you can access your utility just by doing `fastify.util` whenever you need it, even inside your test.<br>
 And here's starts the magic; do you remember that few lines above we talked about encapsulation? Well, using `register` and `decorate` in conjunction enable exactly that, let me show you an example to clarify this:
+
 ```js
 fastify.register((instance, opts, next) => {
   instance.decorate('util', (a, b) => a + b)
@@ -90,8 +103,10 @@ fastify.register((instance, opts, next) => {
   next()
 })
 ```
+
 Inside the second register call `instance.util` will throw an error, because `util` exists only inside the first register context.<br>
 Let's step back for a moment and get deeper on this: when using the `register` api you will create a new context every time and this avoids situations like the one mentioned few line above. But pay attention, the encapsulation works only for the ancestors and the brothers, but not for the sons.
+
 ```js
 fastify.register((instance, opts, next) => {
   instance.decorate('util', (a, b) => a + b)
@@ -111,26 +126,28 @@ fastify.register((instance, opts, next) => {
   next()
 })
 ```
-*Take home message: if you need that an utility is available in every part of your application, pay attention that is declared at the root scope of your application. Otherwise you can use `fastify-plugin` utility as described [here](#distribution).*
+
+_Take home message: if you need that an utility is available in every part of your application, pay attention that is declared at the root scope of your application. Otherwise you can use `fastify-plugin` utility as described [here](#distribution)._
 
 `decorate` is not the unique api that you can use to extend the server functionalities, you can also use `decorateRequest` and `decorateReply`.
 
-*`decorateRequest` and `decorateReply`? Why do we need them if we already have `decorate`?*<br>
+_`decorateRequest` and `decorateReply`? Why do we need them if we already have `decorate`?_<br>
 Good question, we added them to make Fastify more developer-friendly. Let's see an example:
+
 ```js
 fastify.decorate('html', payload => {
   return generateHtml(payload)
 })
 
 fastify.get('/html', (request, reply) => {
-  reply
-    .type('text/html')
-    .send(fastify.html({ hello: 'world' }))
+  reply.type('text/html').send(fastify.html({ hello: 'world' }))
 })
 ```
+
 It works, but it can be way better!
+
 ```js
-fastify.decorateReply('html', function (payload) {
+fastify.decorateReply('html', function(payload) {
   this.type('text/html') // this is the 'Reply' object
   this.send(generateHtml(payload))
 })
@@ -141,6 +158,7 @@ fastify.get('/html', (request, reply) => {
 ```
 
 And in the same way you can do this for the `request` object:
+
 ```js
 fastify.decorate('getHeader', (req, header) => {
   return req.headers[header]
@@ -155,9 +173,11 @@ fastify.get('/happiness', (request, reply) => {
   reply.send({ happy: request.isHappy })
 })
 ```
+
 Again, it works, but it can be way better!
+
 ```js
-fastify.decorateRequest('setHeader', function (header) {
+fastify.decorateRequest('setHeader', function(header) {
   this.isHappy = this.headers[header]
 })
 
@@ -176,10 +196,15 @@ fastify.get('/happiness', (request, reply) => {
 We've seen how to extend server functionality and how handle the encapsulation system, but what if you need to add a function that must be executed every time that the server "[emits](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md)" an event?
 
 <a name="hooks"></a>
+
 ## Hooks
+
 You just built an amazing utility, but now you need to execute that for every request, this is what you will likely do:
+
 ```js
-fastify.decorate('util', (request, key, value) => { request.key = value })
+fastify.decorate('util', (request, key, value) => {
+  request.key = value
+})
 
 fastify.get('/plugin1', (request, reply) => {
   fastify.util(request, 'timestamp', new Date())
@@ -191,11 +216,15 @@ fastify.get('/plugin2', (request, reply) => {
   reply.send(request)
 })
 ```
+
 I think we all agree that this is terrible. Code repeat, awful readability and it cannot scale.
 
 So what can you do to avoid this annoying issue? Yes, you are right, use an [hook](https://github.com/fastify/fastify/blob/master/docs/Hooks.md)!<br>
+
 ```js
-fastify.decorate('util', (request, key, value) => { request.key = value })
+fastify.decorate('util', (request, key, value) => {
+  request.key = value
+})
 
 fastify.addHook('preHandler', (request, reply, done) => {
   fastify.util(request, 'timestamp', new Date())
@@ -210,12 +239,15 @@ fastify.get('/plugin2', (request, reply) => {
   reply.send(request)
 })
 ```
+
 Now for every request you will run your utility, it is obvious that you can register as many hooks as you need.<br>
-It can happen that you want a hook that must be executed just for a subset of routes, how can you do that?  Yep, encapsulation!
+It can happen that you want a hook that must be executed just for a subset of routes, how can you do that? Yep, encapsulation!
 
 ```js
 fastify.register((instance, opts, next) => {
-  instance.decorate('util', (request, key, value) => { request.key = value })
+  instance.decorate('util', (request, key, value) => {
+    request.key = value
+  })
 
   instance.addHook('preHandler', (request, reply, done) => {
     instance.util(request, 'timestamp', new Date())
@@ -233,76 +265,90 @@ fastify.get('/plugin2', (request, reply) => {
   reply.send(request)
 })
 ```
+
 Now your hook will run just for the first route!
 
-As you probably noticed at this time, `request` and `reply` are not the standard Nodejs *request* and *response* objects, but Fastify's objects.<br>
+As you probably noticed at this time, `request` and `reply` are not the standard Nodejs _request_ and _response_ objects, but Fastify's objects.<br>
 Let's say that you are arriving from a framework like Express or Restify, and you already have some Middleware that does exactly what you need, and you don't want to redo all the work.
 
 <a name="middlewares"></a>
+
 ## Middlewares
-Fastify [supports](https://github.com/fastify/fastify/blob/master/docs/Middlewares.md) out of the box Express/Restify/Connect middlewares, this means that you can just drop-in your old code and it will work! *(faster, by the way)*<br>
+
+Fastify [supports](https://github.com/fastify/fastify/blob/master/docs/Middlewares.md) out of the box Express/Restify/Connect middlewares, this means that you can just drop-in your old code and it will work! _(faster, by the way)_<br>
 How we can do that? Checkout our middlewares engine, [middie](https://github.com/fastify/middie).
+
 ```js
 const yourMiddleware = require('your-middleware')
 fastify.use(yourMiddleware)
 ```
 
 <a name="distribution"></a>
+
 ## How to handle encapsulation and distribution
+
 Perfect, now you know (almost) all the tools that you can use to extend Fastify. But probably there is something you noted when trying out your code.<br>
 How can you distribute your code?
 
-The preferred way to distribute a utility is to wrap all your code inside a `register`, in this way your plugin can support an asynchronous bootstrap *(since `decorate` is a synchronous api)*, in the case of a database connection for example.
+The preferred way to distribute a utility is to wrap all your code inside a `register`, in this way your plugin can support an asynchronous bootstrap _(since `decorate` is a synchronous api)_, in the case of a database connection for example.
 
-*Wait, what? Didn't you tell me that `register` creates an encapsulation and that what I create inside there will not be available outside?*<br>
+_Wait, what? Didn't you tell me that `register` creates an encapsulation and that what I create inside there will not be available outside?_<br>
 Yes, I said that. But what I didn't tell you, is that you can tell to Fastify to avoid this behavior, with the [`fastify-plugin`](https://github.com/fastify/fastify-plugin) module.
+
 ```js
 const fp = require('fastify-plugin')
 const dbClient = require('db-client')
 
-function dbPlugin (fastify, opts, next) {
-  dbClient.connect(opts.url, (err, conn) => {
-    fastify.decorate('db', conn)
-    next()
-  })
+function dbPlugin(fastify, opts, next) {
+  dbClient.connect(
+    opts.url,
+    (err, conn) => {
+      fastify.decorate('db', conn)
+      next()
+    }
+  )
 }
 
 module.exports = fp(dbPlugin)
 ```
+
 You can also tell to `fastify-plugin` to check the installed version of Fastify, in case of you need a specific api.
 
 <a name="handle-errors"></a>
+
 ## Handle errors
+
 It can happen that one of your plugins could fail during the startup. Maybe you expect it and you have a custom logic that will be triggered in that case. How can you do this?
 The `after` api is what you need. `after` simply registers a callback that will be executed just after a register, and it can take up to three parameters.<br>
 The callback changes based on the parameters your are giving:
 
-1. If no parameter is given to the callback and there is an error, that error will be passed to the next error handler.
-1. If one parameter is given to the callback, that parameter will be the error object.
-1. If two parameters are given to the callback, the first will be the error object, the second will be the done callback.
-1. If three parameters are given to the callback, the first will be the error object, the second will be the top level context unless you have specified both server and override, in that case the context will be what the override returns, and the third the done callback.
+1.  If no parameter is given to the callback and there is an error, that error will be passed to the next error handler.
+1.  If one parameter is given to the callback, that parameter will be the error object.
+1.  If two parameters are given to the callback, the first will be the error object, the second will be the done callback.
+1.  If three parameters are given to the callback, the first will be the error object, the second will be the top level context unless you have specified both server and override, in that case the context will be what the override returns, and the third the done callback.
 
 Let's see how to use it:
+
 ```js
-fastify
-  .register(require('./database-connector'))
-  .after(err => {
-    if (err) throw err
-  })
+fastify.register(require('./database-connector')).after(err => {
+  if (err) throw err
+})
 ```
 
 <a name="start"></a>
+
 ## Let's start!
-Awesome, now you know everything you need to know about Fastify and its plugin system to start building your first plugin, and please if you do, tell us! We will add it to the [*ecosystem*](https://github.com/fastify/fastify#ecosystem) section of our documentation!
+
+Awesome, now you know everything you need to know about Fastify and its plugin system to start building your first plugin, and please if you do, tell us! We will add it to the [_ecosystem_](https://github.com/fastify/fastify#ecosystem) section of our documentation!
 
 If you want to see some real world example, checkout:
+
 - [`point-of-view`](https://github.com/fastify/point-of-view)
-Templates rendering (*ejs, pug, handlebars, marko*) plugin support for Fastify.
+  Templates rendering (_ejs, pug, handlebars, marko_) plugin support for Fastify.
 - [`fastify-mongodb`](https://github.com/fastify/fastify-mongodb)
-Fastify MongoDB connection plugin, with this you can share the same MongoDb connection pool in every part of your server.
+  Fastify MongoDB connection plugin, with this you can share the same MongoDb connection pool in every part of your server.
 - [`fastify-multipart`](https://github.com/fastify/fastify-multipart)
-Multipart support for Fastify
+  Multipart support for Fastify
 - [`fastify-helmet`](https://github.com/fastify/fastify-helmet) Important security headers for Fastify
 
-
-*Do you feel it's missing something here? Let us know! :)*
+_Do you feel it's missing something here? Let us know! :)_

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -1,22 +1,26 @@
 <h1 align="center">Fastify</h1>
 
 ## Plugins
+
 Fastify allows the user to extend its functionalities with plugins.
 A plugin can be a set of routes, a server [decorator](https://github.com/fastify/fastify/blob/master/docs/Decorators.md) or whatever. The API that you will need to use one or more plugins, is `register`.<br>
 
-By default, `register` creates a *new scope*, this means that if you do some changes to the Fastify instance (via `decorate`), this change will not be reflected to the current context ancestors, but only to its sons. This feature allows us to achieve plugin *encapsulation* and *inheritance*, in this way we create a *direct acyclic graph* (DAG) and we will not have issues caused by cross dependencies.
+By default, `register` creates a _new scope_, this means that if you do some changes to the Fastify instance (via `decorate`), this change will not be reflected to the current context ancestors, but only to its sons. This feature allows us to achieve plugin _encapsulation_ and _inheritance_, in this way we create a _direct acyclic graph_ (DAG) and we will not have issues caused by cross dependencies.
 
 You already see in the [getting started](https://github.com/fastify/fastify/blob/master/docs/Getting-Started.md#register) section how using this API is pretty straightforward.
+
 ```
 fastify.register(plugin, [options])
 ```
 
 <a name="plugin-options"></a>
+
 ### Plugin Options
+
 The optional `options` parameter for `fastify.register` supports a predefined set of options that Fastify itself will use, except when the plugin has been wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This options object will also be passed to the plugin upon invocation, regardless of whether or not the plugin has been wrapped. The currently supported list of Fastify specific options is:
 
-+ [`logLevel`](https://github.com/fastify/fastify/blob/master/docs/Routes.md#custom-log-level)
-+ [`prefix`](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#route-prefixing-options)
+- [`logLevel`](https://github.com/fastify/fastify/blob/master/docs/Routes.md#custom-log-level)
+- [`prefix`](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#route-prefixing-options)
 
 It is possible that Fastify will directly support other options in the future. Thus, to avoid collisions, a plugin should consider namespacing its options. For example, a plugin `foo` might be registered like so:
 
@@ -41,21 +45,28 @@ fastify.register(require('fastify-foo'), {
 ```
 
 <a name="route-prefixing-option"></a>
+
 #### Route Prefixing option
+
 If you pass an option with the key `prefix` with a `string` value, Fastify will use it to prefix all the routes inside the register, for more info check [here](https://github.com/fastify/fastify/blob/master/docs/Routes.md#route-prefixing).<br>
 Be aware that if you use [`fastify-plugin`](https://github.com/fastify/fastify-plugin) this option won't work.
 
 <a name="error-handling"></a>
+
 #### Error handling
+
 The error handling is done by [avvio](https://github.com/mcollina/avvio#error-handling).<br>
 As general rule, it is highly recommended that you handle your errors in the `register`'s callback, otherwise the server will not start, and you will find the unhandled error in the `listen` callback.
 
 <a name="create-plugin"></a>
+
 ### Create a plugin
+
 Creating a plugin is very easy, you just need to create a function that takes three parameters, the `fastify` instance, an options object and the next callback.<br>
 Example:
+
 ```js
-module.exports = function (fastify, opts, next) {
+module.exports = function(fastify, opts, next) {
   fastify.decorate('utility', () => {})
 
   fastify.get('/', handler)
@@ -63,9 +74,11 @@ module.exports = function (fastify, opts, next) {
   next()
 }
 ```
+
 You can also use `register` inside another `register`:
+
 ```js
-module.exports = function (fastify, opts, next) {
+module.exports = function(fastify, opts, next) {
   fastify.decorate('utility', () => {})
 
   fastify.get('/', handler)
@@ -75,32 +88,39 @@ module.exports = function (fastify, opts, next) {
   next()
 }
 ```
+
 Sometimes, you will need to know when the server is about to close, for example because you must close a connection to a database. To know when this is going to happen, you can use the [`'onClose'`](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#on-close) hook.
 
 Do not forget that `register` will always create a new Fastify scope, if you don't need that, read the following section.
 
 <a name="handle-scope"></a>
+
 ### Handle the scope
-If you are using `register` only for extending the functionality of the server with  [`decorate`](https://github.com/fastify/fastify/blob/master/docs/Decorators.md), it is your responsibility to tell Fastify to not create a new scope, otherwise your changes will not be accessible by the user in the upper scope.
+
+If you are using `register` only for extending the functionality of the server with [`decorate`](https://github.com/fastify/fastify/blob/master/docs/Decorators.md), it is your responsibility to tell Fastify to not create a new scope, otherwise your changes will not be accessible by the user in the upper scope.
 
 You have two ways to tell Fastify to avoid the creation of a new context:
+
 - Use the [`fastify-plugin`](https://github.com/fastify/fastify-plugin) module
 - Use the `'skip-override'` hidden property
 
 We recommend to using the `fastify-plugin` module, because it solves this problem for you, and you can pass a version range of Fastify as a parameter that your plugin will support.
+
 ```js
 const fp = require('fastify-plugin')
 
-module.exports = fp(function (fastify, opts, next) {
+module.exports = fp(function(fastify, opts, next) {
   fastify.decorate('utility', () => {})
   next()
 }, '0.x')
 ```
+
 Check the [`fastify-plugin`](https://github.com/fastify/fastify-plugin) documentation to know more about how use this module.
 
 If you don't use the `fastify-plugin` module, you can use the `'skip-override'` hidden property, but we do not recommend it. If in the future the Fastify API changes it will be a your responsibility update the module, while if you use `fastify-plugin`, you can be sure about backwards compatibility.
+
 ```js
-function yourPlugin (fastify, opts, next) {
+function yourPlugin(fastify, opts, next) {
   fastify.decorate('utility', () => {})
   next()
 }

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -1,6 +1,7 @@
 <h1 align="center">Fastify</h1>
 
 ## Reply
+
 The second parameter of the handler function is `Reply`.
 Reply is a core Fastify object that exposes the following functions:
 
@@ -17,7 +18,7 @@ Reply is a core Fastify object that exposes the following functions:
 - `.res` - The [`http.ServerResponse`](https://nodejs.org/dist/latest/docs/api/http.html#http_class_http_serverresponse) from Node core.
 
 ```js
-fastify.get('/', options, function (request, reply) {
+fastify.get('/', options, function(request, reply) {
   // Your code
   reply
     .code(200)
@@ -29,34 +30,43 @@ fastify.get('/', options, function (request, reply) {
 Additionally, `Reply` provides access to the context of the request:
 
 ```js
-fastify.get('/', {config: {foo: 'bar'}}, function (request, reply) {
+fastify.get('/', { config: { foo: 'bar' } }, function(request, reply) {
   reply.send('handler config.foo = ' + reply.context.config.foo)
 })
 ```
 
 <a name="code"></a>
+
 ### .code(statusCode)
+
 If not set via `reply.code`, the resulting `statusCode` will be `200`.
 
 <a name="header"></a>
+
 ### .header(key, value)
+
 Sets a response header. If the value is omitted or undefined it is coerced
 to `''`.
 
 For more information, see [`http.ServerResponse#setHeader`](https://nodejs.org/dist/latest/docs/api/http.html#http_response_setheader_name_value).
 
 <a name="getHeader"></a>
+
 ### .getHeader(key)
+
 Retrieves the value of a previously set header.
+
 ```js
 reply.header('x-foo', 'foo')
 reply.getHeader('x-foo') // 'foo'
 ```
 
 <a name="getHeader"></a>
+
 ### .removeHeader(key)
 
 Removed the value of a previously set header.
+
 ```js
 reply.header('x-foo', 'foo')
 reply.removeHeader('x-foo')
@@ -64,18 +74,25 @@ reply.getHeader('x-foo') // undefined
 ```
 
 <a name="hasHeader"></a>
+
 ### .hasHeader(key)
+
 Returns a boolean indicating if the specified header has been set.
 
 <a name="redirect"></a>
+
 ### .redirect(dest)
+
 Redirects a request to the specified url, the status code is optional, default to `302`.
+
 ```js
 reply.redirect('/home')
 ```
 
 <a name="type"></a>
+
 ### .type(contentType, type)
+
 Sets the content type for the response.
 This is a shortcut for `reply.header('Content-Type', 'the/type')`.
 
@@ -84,7 +101,9 @@ reply.type('text/html')
 ```
 
 <a name="serializer"></a>
+
 ### .serializer(func)
+
 `.send()` will by default JSON-serialize any value that is not one of: `Buffer`, `stream`, `string`, `undefined`, `Error`. If you need to replace the default serializer with a custom serializer for a particular request, you can do so with the `.serializer()` utility. Be aware that if you are using a custom serializer, you must set a custom `'Content-Type'` header.
 
 ```js
@@ -104,32 +123,43 @@ reply
 See [`.send()`](#send) for more information on sending different types of values.
 
 <a name="send"></a>
+
 ### .send(data)
- As the name suggests, `.send()` is the function that sends the payload to the end user.
+
+As the name suggests, `.send()` is the function that sends the payload to the end user.
 
 <a name="send-object"></a>
+
 #### Objects
+
 As noted above, if you are sending JSON objects, `send` will serialize the object with [fast-json-stringify](https://www.npmjs.com/package/fast-json-stringify) if you set an output schema, otherwise `JSON.stringify()` will be used.
+
 ```js
-fastify.get('/json', options, function (request, reply) {
+fastify.get('/json', options, function(request, reply) {
   reply.send({ hello: 'world' })
 })
 ```
 
 <a name="send-string"></a>
+
 #### Strings
+
 If you pass a string to `send` without a `Content-Type`, it will be sent as `text/plain; charset=utf-8`. If you set the `Content-Type` header and pass a string to `send`, it will be serialized with the custom serializer if one is set, otherwise it will be sent unmodified (unless the `Content-Type` header is set to `application/json; charset=utf-8`, in which case it will be JSON-serialized like an object — see the section above).
+
 ```js
-fastify.get('/json', options, function (request, reply) {
+fastify.get('/json', options, function(request, reply) {
   reply.send('plain string')
 })
 ```
 
 <a name="send-streams"></a>
+
 #### Streams
-*send* can also handle streams out of the box, internally uses [pump](https://www.npmjs.com/package/pump) to avoid leaks of file descriptors. If you are sending a stream and you have not set a `'Content-Type'` header, *send* will set it at `'application/octet-stream'`.
+
+_send_ can also handle streams out of the box, internally uses [pump](https://www.npmjs.com/package/pump) to avoid leaks of file descriptors. If you are sending a stream and you have not set a `'Content-Type'` header, _send_ will set it at `'application/octet-stream'`.
+
 ```js
-fastify.get('/streams', function (request, reply) {
+fastify.get('/streams', function(request, reply) {
   const fs = require('fs')
   const stream = fs.createReadStream('some-file', 'utf8')
   reply.send(stream)
@@ -137,11 +167,14 @@ fastify.get('/streams', function (request, reply) {
 ```
 
 <a name="send-buffers"></a>
+
 #### Buffers
-If you are sending a buffer and you have not set a `'Content-Type'` header, *send* will set it to `'application/octet-stream'`.
+
+If you are sending a buffer and you have not set a `'Content-Type'` header, _send_ will set it to `'application/octet-stream'`.
+
 ```js
 const fs = require('fs')
-fastify.get('/streams', function (request, reply) {
+fastify.get('/streams', function(request, reply) {
   fs.readFile('some-file', (err, fileBuffer) => {
     reply.send(err || fileBuffer)
   })
@@ -149,22 +182,26 @@ fastify.get('/streams', function (request, reply) {
 ```
 
 <a name="errors"></a>
+
 #### Errors
-If you pass to *send* an object that is an instance of *Error*, Fastify will automatically create an error structured as the following:
+
+If you pass to _send_ an object that is an instance of _Error_, Fastify will automatically create an error structured as the following:
+
 ```js
 {
-  error: String        // the http error message
-  message: String      // the user error message
-  statusCode: Number   // the http status code
+  error: String // the http error message
+  message: String // the user error message
+  statusCode: Number // the http status code
 }
 ```
+
 You can add some custom property to the Error object, such as `code` and `headers`, that will be used to enhance the http response.<br>
-*Note: If you are passing an error to `send` and the statusCode is less than 400, Fastify will automatically set it at 500.*
+_Note: If you are passing an error to `send` and the statusCode is less than 400, Fastify will automatically set it at 500._
 
 Tip: you can simplify errors by using the [`http-errors`](https://npm.im/http-errors) module to generate errors:
 
 ```js
-fastify.get('/', function (request, reply) {
+fastify.get('/', function(request, reply) {
   reply.send(httpErrors.Gone())
 })
 ```
@@ -176,17 +213,19 @@ See [`server.setNotFoundHandler`](https://github.com/fastify/fastify/blob/master
 API to learn more about handling such cases:
 
 ```js
-fastify.setNotFoundHandler(function (request, reply) {
+fastify.setNotFoundHandler(function(request, reply) {
   reply.type('text/plain').send('a custom not found')
 })
 
-fastify.get('/', function (request, reply) {
+fastify.get('/', function(request, reply) {
   reply.send(new httpErrors.NotFound())
 })
 ```
 
 <a name="payload-type"></a>
+
 #### Type of the final payload
+
 The type of the sent payload (after serialization and going through any [`onSend` hooks](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#the-onsend-hook)) must be one of the following types, otherwise an error will be thrown:
 
 - `string`
@@ -196,18 +235,21 @@ The type of the sent payload (after serialization and going through any [`onSend
 - `null`
 
 <a name="async-await-promise"></a>
+
 #### Async-Await and Promises
+
 Fastify natively handles promises and supports async-await.<br>
-*Note that in the following examples we are not using reply.send.*
+_Note that in the following examples we are not using reply.send._
+
 ```js
-fastify.get('/promises', options, function (request, reply) {
-  return new Promise(function (resolve) {
+fastify.get('/promises', options, function(request, reply) {
+  return new Promise(function(resolve) {
     setTimeout(resolve, 200, { hello: 'world' })
   })
 })
 
-fastify.get('/async-await', options, async function (request, reply) {
-  var res = await new Promise(function (resolve) {
+fastify.get('/async-await', options, async function(request, reply) {
+  var res = await new Promise(function(resolve) {
     setTimeout(resolve, 200, { hello: 'world' })
   })
   return res

--- a/docs/Request.md
+++ b/docs/Request.md
@@ -1,18 +1,20 @@
 <h1 align="center">Fastify</h1>
 
 ## Request
+
 The first parameter of the handler function is `Request`.<br>
 Request is a core Fastify object containing the following fields:
+
 - `query` - the parsed querystring
 - `body` - the body
 - `params` - the params matching the URL
 - `headers` - the headers
-- `raw` - the incoming HTTP request from Node core *(you can use the alias `req`)*
+- `raw` - the incoming HTTP request from Node core _(you can use the alias `req`)_
 - `id` - the request id
 - `log` - the logger instance of the incoming request
 
 ```js
-fastify.post('/:params', options, function (request, reply) {
+fastify.post('/:params', options, function(request, reply) {
   console.log(request.body)
   console.log(request.query)
   console.log(request.params)

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -1,40 +1,45 @@
 <h1 align="center">Fastify</h1>
 
 ## Routes
+
 You have two ways to declare a route with Fastify, the shorthand method and the full declaration. Let's start with the second one:
 <a name="full-declaration"></a>
+
 ### Full declaration
+
 ```js
 fastify.route(options)
 ```
-* `method`: currently it supports `'DELETE'`, `'GET'`, `'HEAD'`, `'PATCH'`, `'POST'`, `'PUT'` and `'OPTIONS'`. It could also be an array of methods.
 
-* `url`: the path of the url to match this route (alias: `path`).
-* `schema`: an object containing the schemas for the request and response.
-They need to be in
+- `method`: currently it supports `'DELETE'`, `'GET'`, `'HEAD'`, `'PATCH'`, `'POST'`, `'PUT'` and `'OPTIONS'`. It could also be an array of methods.
+
+- `url`: the path of the url to match this route (alias: `path`).
+- `schema`: an object containing the schemas for the request and response.
+  They need to be in
   [JSON Schema](http://json-schema.org/) format, check [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) for more info.
 
-  * `body`: validates the body of the request if it is a POST or a
+  - `body`: validates the body of the request if it is a POST or a
     PUT.
-  * `querystring`: validates the querystring. This can be a complete JSON
-  Schema object, with the property `type` of `object` and `properties` object of parameters, or
-  simply the values of what would be contained in the `properties` object as shown below.
-  * `params`: validates the params.
-  * `response`: filter and generate a schema for the response, setting a
+  - `querystring`: validates the querystring. This can be a complete JSON
+    Schema object, with the property `type` of `object` and `properties` object of parameters, or
+    simply the values of what would be contained in the `properties` object as shown below.
+  - `params`: validates the params.
+  - `response`: filter and generate a schema for the response, setting a
     schema allows us to have 10-20% more throughput.
-* `beforeHandler(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#before-handler) called just before the request handler, useful if you need to perform authentication at route level for example, it could also be and array of functions.
-* `handler(request, reply)`: the function that will handle this request.
-* `schemaCompiler(schema)`: the function that build the schema for the validations. See [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-compiler)
-* `bodyLimit`: prevents the default JSON body parser from parsing request bodies larger than this number of bytes. Must be an integer. You may also set this option globally when first creating the Fastify instance with `fastify(options)`. Defaults to `1048576` (1 MiB).
-* `logLevel`: set log level for this route. See below.
-* `config`: object used to store custom configuration.
+
+- `beforeHandler(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#before-handler) called just before the request handler, useful if you need to perform authentication at route level for example, it could also be and array of functions.
+- `handler(request, reply)`: the function that will handle this request.
+- `schemaCompiler(schema)`: the function that build the schema for the validations. See [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-compiler)
+- `bodyLimit`: prevents the default JSON body parser from parsing request bodies larger than this number of bytes. Must be an integer. You may also set this option globally when first creating the Fastify instance with `fastify(options)`. Defaults to `1048576` (1 MiB).
+- `logLevel`: set log level for this route. See below.
+- `config`: object used to store custom configuration.
 
   `request` is defined in [Request](https://github.com/fastify/fastify/blob/master/docs/Request.md).
 
   `reply` is defined in [Reply](https://github.com/fastify/fastify/blob/master/docs/Reply.md).
 
-
 Example:
+
 ```js
 fastify.route({
   method: 'GET',
@@ -53,15 +58,17 @@ fastify.route({
       }
     }
   },
-  handler: function (request, reply) {
+  handler: function(request, reply) {
     reply.send({ hello: 'world' })
   }
 })
 ```
 
 <a name="shorthand-declaration"></a>
+
 ### Shorthand declaration
-The above route declaration is more *Hapi*-like, but if you prefer an *Express/Restify* approach, we support it as well:<br>
+
+The above route declaration is more _Hapi_-like, but if you prefer an _Express/Restify_ approach, we support it as well:<br>
 `fastify.get(path, [options], handler)`<br>
 `fastify.head(path, [options], handler)`<br>
 `fastify.post(path, [options], handler)`<br>
@@ -71,6 +78,7 @@ The above route declaration is more *Hapi*-like, but if you prefer an *Express/R
 `fastify.patch(path, [options], handler)`
 
 Example:
+
 ```js
 const opts = {
   schema: {
@@ -92,6 +100,7 @@ fastify.get('/', opts, (request, reply) => {
 `fastify.all(path, [options], handler)` will add the same handler to all the supported methods.
 
 The handler may also be supplied via the `options` object:
+
 ```js
 const opts = {
   schema: {
@@ -104,7 +113,7 @@ const opts = {
       }
     }
   },
-  handler (request, reply) {
+  handler(request, reply) {
     reply.send({ hello: 'world' })
   }
 }
@@ -114,10 +123,12 @@ fastify.get('/', opts)
 > Note: if the handler is specified in both the `options` and as the third parameter to the shortcut method then throws duplicate `handler` error.
 
 <a name="url-building"></a>
+
 ### Url building
+
 Fastify supports both static and dynamic urls.<br>
-To register a **parametric** path, use the *colon* before the parameter name. For **wildcard** use the *star*.
-*Remember that static routes are always checked before parametric and wildcard.*
+To register a **parametric** path, use the _colon_ before the parameter name. For **wildcard** use the _star_.
+_Remember that static routes are always checked before parametric and wildcard._
 
 ```js
 // parametric
@@ -129,61 +140,74 @@ fastify.get('/example/*', (request, reply) => {}))
 ```
 
 Regular expression routes are supported as well, but pay attention, RegExp are very expensive in term of performance!
+
 ```js
 // parametric with regexp
 fastify.get('/example/:file(^\\d+).png', (request, reply) => {}))
 ```
 
 It's possible to define more than one parameter within the same couple of slash ("/"). Such as:
+
 ```js
 fastify.get('/example/near/:lat-:lng/radius/:r', (request, reply) => {}))
 ```
-*Remember in this case to use the dash ("-") as parameters separator.*
+
+_Remember in this case to use the dash ("-") as parameters separator._
 
 Finally it's possible to have multiple parameters with RegExp.
+
 ```js
 fastify.get('/example/at/:hour(^\\d{2})h:minute(^\\d{2})m', (request, reply) => {}))
 ```
+
 In this case as parameter separator it's possible to use whatever character is not matched by the regular expression.
 
 Having a route with multiple parameters may affect negatively the performance, so prefer single parameter approach whenever possible, especially on routes which are on the hot path of your application.
 If you are interested in how we handle the routing, checkout [find-my-way](https://github.com/delvedor/find-my-way).
 
 <a name="async-await"></a>
+
 ### Async Await
+
 Are you an `async/await` user? We have you covered!
+
 ```js
-fastify.get('/', options, async function (request, reply) {
+fastify.get('/', options, async function(request, reply) {
   var data = await getData()
   var processed = await processData(data)
   return processed
 })
 ```
+
 **Warning:** You can't return `undefined`. For more details read [promise-resolution](#promise-resolution).
 
 As you can see we are not calling `reply.send` to send back the data to the user. You just need to return the body and you are done!
 
 If you need it you can also send back the data to the user with `reply.send`.
+
 ```js
-fastify.get('/', options, async function (request, reply) {
+fastify.get('/', options, async function(request, reply) {
   var data = await getData()
   var processed = await processData(data)
   reply.send(processed)
 })
 ```
+
 **Warning:**
-* If you use `return` and `reply.send` at the same time, the first one that happens takes precedence, the second value will be discarded, a *warn* log will also be emitted because you tried to send a response twice.
-* You can't return `undefined`. For more details read [promise-resolution](#promise-resolution).
+
+- If you use `return` and `reply.send` at the same time, the first one that happens takes precedence, the second value will be discarded, a _warn_ log will also be emitted because you tried to send a response twice.
+- You can't return `undefined`. For more details read [promise-resolution](#promise-resolution).
 
 <a name="promise-resolution"></a>
+
 ### Promise resolution
 
-If your handler is an `async` function or returns a promise, you should be aware of a special behaviour which is necessary to support the callback and promise control-flow. If the handler's promise is resolved with `undefined`, it will be ignored causing the request to hang and an *error* log to be emitted.
+If your handler is an `async` function or returns a promise, you should be aware of a special behaviour which is necessary to support the callback and promise control-flow. If the handler's promise is resolved with `undefined`, it will be ignored causing the request to hang and an _error_ log to be emitted.
 
-1. If you want to use `async/await` or promises but respond a value with `reply.send`:
+1.  If you want to use `async/await` or promises but respond a value with `reply.send`:
     - **Don't** `return` any value.
     - **Don't** forget to call `reply.send`.
-2. If you want to use `async/await` or promises:
+2.  If you want to use `async/await` or promises:
     - **Don't** use `reply.send`.
     - **Don't** return `undefined`.
 
@@ -192,9 +216,11 @@ In this way, we can support both `callback-style` and `async-await`, with the mi
 **Notice**: Every async function returns a promise by itself.
 
 <a name="route-prefixing"></a>
+
 ### Route Prefixing
+
 Sometimes you need to maintain two or more different versions of the same api, a classic approach is to prefix all the routes with the api version number, `/v1/user` for example.
-Fastify offers you a fast and smart way to create different version of the same api without changing all the route names by hand, *route prefixing*. Let's see how it works:
+Fastify offers you a fast and smart way to create different version of the same api without changing all the route names by hand, _route prefixing_. Let's see how it works:
 
 ```js
 // server.js
@@ -205,23 +231,27 @@ fastify.register(require('./routes/v2/users'), { prefix: '/v2' })
 
 fastify.listen(3000)
 ```
+
 ```js
 // routes/v1/users.js
-module.exports = function (fastify, opts, next) {
+module.exports = function(fastify, opts, next) {
   fastify.get('/user', handler_v1)
   next()
 }
 ```
+
 ```js
 // routes/v2/users.js
-module.exports = function (fastify, opts, next) {
+module.exports = function(fastify, opts, next) {
   fastify.get('/user', handler_v2)
   next()
 }
 ```
-Fastify will not complain because you are using the same name for two different routes, because at compilation time it will handle the prefix automatically *(this also means that the performance will not be affected at all!)*.
+
+Fastify will not complain because you are using the same name for two different routes, because at compilation time it will handle the prefix automatically _(this also means that the performance will not be affected at all!)_.
 
 Now your clients will have access to the following routes:
+
 - `/v1/user`
 - `/v2/user`
 
@@ -229,7 +259,9 @@ You can do this as many times as you want, it works also for nested `register` a
 Be aware that if you use [`fastify-plugin`](https://github.com/fastify/fastify-plugin) this option won't work.
 
 <a name="custom-log-level"></a>
+
 ### Custom Log Level
+
 It could happen that you need different log levels in your routes, with Fastify achieve this is very straightforward.<br/>
 You just need to pass the option `logLevel` to the plugin option or the route option with the [value](https://github.com/pinojs/pino/blob/master/docs/API.md#discussion-3) that you need.
 
@@ -244,24 +276,28 @@ fastify.register(require('./routes/events'), { logLevel: 'debug' })
 
 fastify.listen(3000)
 ```
+
 Or you can directly pass it to a route:
+
 ```js
 fastify.get('/', { logLevel: 'warn' }, (request, reply) => {
   reply.send({ hello: 'world' })
 })
 ```
-*Remember that the custom log level is applied only to the routes, and not to the global Fastify Logger, accessible with `fastify.log`*
 
+_Remember that the custom log level is applied only to the routes, and not to the global Fastify Logger, accessible with `fastify.log`_
 
 <a name="routes-config"></a>
+
 ### Config
+
 Registering a new handler, you can pass a configuration object to it and retrieve it in the handler.
 
 ```js
 // server.js
 const fastify = require('fastify')()
 
-function handler (req, reply) {
+function handler(req, reply) {
   reply.send(reply.context.config.output)
 }
 

--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -3,11 +3,15 @@
 ## Server Methods
 
 <a name="server"></a>
+
 #### server
+
 `fastify.server`: The Node core [server](https://nodejs.org/api/http.html#http_class_http_server) object as returned by the [**`Fastify factory function`**](https://github.com/fastify/fastify/blob/master/docs/Factory.md).
 
 <a name="after"></a>
+
 #### after
+
 Invoked when the current plugin and all the plugins
 that have been registered within it have finished loading.
 It is always executed before the method `fastify.ready`.
@@ -31,26 +35,35 @@ fastify
 ```
 
 <a name="ready"></a>
+
 #### ready
+
 Function called when all the plugins have been loaded.
 It takes an error parameter if something went wrong.
+
 ```js
 fastify.ready(err => {
   if (err) throw err
 })
 ```
+
 If it is called without any arguments, it will return a `Promise`:
 
 ```js
-fastify.ready().then(() => {
-  console.log('successfully booted!')
-}, (err) => {
-  console.log('an error happened', err)
-})
+fastify.ready().then(
+  () => {
+    console.log('successfully booted!')
+  },
+  err => {
+    console.log('an error happened', err)
+  }
+)
 ```
 
 <a name="listen"></a>
+
 #### listen
+
 Starts the server on the given port after all the plugins are loaded, internally waits for the `.ready()` event. The callback is the same as the Node core. By default, the server will listen on address `127.0.0.1` when no specific address is provided. If listening on any available interface is desired, then specifying `0.0.0.0` for the address will listen on all IPv4 address. Using `::` for the address will listen on all IPv6 addresses, and, depending on OS, may also listen on all IPv4 addresses. Be careful when deciding to listen on all interfaces; it comes with inherent [security risks](https://web.archive.org/web/20170831174611/https://snyk.io/blog/mongodb-hack-and-secure-defaults/).
 
 ```js
@@ -87,7 +100,8 @@ fastify.listen(3000, '127.0.0.1', 511, err => {
 If no callback is provided a Promise is returned:
 
 ```js
-fastify.listen(3000)
+fastify
+  .listen(3000)
   .then(() => console.log('Listening'))
   .catch(err => {
     console.log('Error starting server:', err)
@@ -98,7 +112,8 @@ fastify.listen(3000)
 Specifying an address without a callback is also supported:
 
 ```js
-fastify.listen(3000, '127.0.0.1')
+fastify
+  .listen(3000, '127.0.0.1')
   .then(() => console.log('Listening'))
   .catch(err => {
     console.log('Error starting server:', err)
@@ -109,7 +124,7 @@ fastify.listen(3000, '127.0.0.1')
 When deploying to a Docker, and potentially other, containers, it is advisable to listen on `0.0.0.0` because they do not default to exposing mapped ports to `127.0.0.1`:
 
 ```js
-fastify.listen(3000, '0.0.0.0', (err) => {
+fastify.listen(3000, '0.0.0.0', err => {
   if (err) {
     fastify.log.error(err)
     process.exit(1)
@@ -118,110 +133,144 @@ fastify.listen(3000, '0.0.0.0', (err) => {
 ```
 
 <a name="route"></a>
+
 #### route
+
 Method to add routes to the server, it also has shorthand functions, check [here](https://github.com/fastify/fastify/blob/master/docs/Routes.md).
 
 <a name="close"></a>
+
 #### close
+
 `fastify.close(callback)`: call this function to close the server instance and run the [`'onClose'`](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#on-close) hook.<br>
 Calling `close` will also cause the server to respond to every new incoming request with a `503` error and destroy that request.
 
 <a name="decorate"></a>
-#### decorate*
+
+#### decorate\*
+
 Function useful if you need to decorate the fastify instance, Reply or Request, check [here](https://github.com/fastify/fastify/blob/master/docs/Decorators.md).
 
 <a name="register"></a>
+
 #### register
+
 Fastify allows the user to extend its functionality with plugins.
 A plugin can be a set of routes, a server decorator or whatever, check [here](https://github.com/fastify/fastify/blob/master/docs/Plugins.md).
 
 <a name="use"></a>
+
 #### use
+
 Function to add middlewares to Fastify, check [here](https://github.com/fastify/fastify/blob/master/docs/Middlewares.md).
 
 <a name="addHook"></a>
+
 #### addHook
+
 Function to add a specific hook in the lifecycle of Fastify, check [here](https://github.com/fastify/fastify/blob/master/docs/Hooks.md).
 
 <a name="base-path"></a>
+
 #### basepath
+
 The full path that will be prefixed to a route.
 
 Example:
 
 ```js
-fastify.register(function (instance, opts, next) {
-  instance.get('/foo', function (request, reply) {
-    // Will log "basePath: /v1"
-    request.log.info('basePath: %s', instance.basePath)
-    reply.send({basePath: instance.basePath})
-  })
-
-  instance.register(function (instance, opts, next) {
-    instance.get('/bar', function (request, reply) {
-      // Will log "basePath: /v1/v2"
+fastify.register(
+  function(instance, opts, next) {
+    instance.get('/foo', function(request, reply) {
+      // Will log "basePath: /v1"
       request.log.info('basePath: %s', instance.basePath)
-      reply.send({basePath: instance.basePath})
+      reply.send({ basePath: instance.basePath })
     })
 
-    next()
-  }, { prefix: '/v2' })
+    instance.register(
+      function(instance, opts, next) {
+        instance.get('/bar', function(request, reply) {
+          // Will log "basePath: /v1/v2"
+          request.log.info('basePath: %s', instance.basePath)
+          reply.send({ basePath: instance.basePath })
+        })
 
-  next()
-}, { prefix: '/v1' })
+        next()
+      },
+      { prefix: '/v2' }
+    )
+
+    next()
+  },
+  { prefix: '/v1' }
+)
 ```
 
 <a name="log"></a>
+
 #### log
+
 The logger instance, check [here](https://github.com/fastify/fastify/blob/master/docs/Logging.md).
 
 <a name="inject"></a>
+
 #### inject
+
 Fake http injection (for testing purposes) [here](https://github.com/fastify/fastify/blob/master/docs/Testing.md#inject).
 
 <a name="add-schema"></a>
+
 #### addSchema
+
 `fastify.addSchema(schemaObj)`, adds a shared schema to the Fastify instance. This allows you to reuse it everywhere in your application just by writing the schema id that you need.<br/>
 To learn more, see [shared schema example](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#shared-schema) in the [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) documentation.
 
 <a name="set-schema-compiler"></a>
+
 #### setSchemaCompiler
+
 Set the schema compiler for all routes [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-compiler).
 
 <a name="set-not-found-handler"></a>
+
 #### setNotFoundHandler
 
 `fastify.setNotFoundHandler(handler(request, reply))`: set the 404 handler. This call is encapsulated by prefix, so different plugins can set different not found handlers if a different [`prefix` option](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#route-prefixing-option) is passed to `fastify.register()`. The handler is treated like a regular route handler so requests will go through the full [Fastify lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md#lifecycle).
 
 ```js
-fastify.setNotFoundHandler(function (request, reply) {
+fastify.setNotFoundHandler(function(request, reply) {
   // Default not found handler
 })
 
-fastify.register(function (instance, options, next) {
-  instance.setNotFoundHandler(function (request, reply) {
-    // Handle not found request to URLs that begin with '/v1'
-  })
-  next()
-}, { prefix: '/v1' })
+fastify.register(
+  function(instance, options, next) {
+    instance.setNotFoundHandler(function(request, reply) {
+      // Handle not found request to URLs that begin with '/v1'
+    })
+    next()
+  },
+  { prefix: '/v1' }
+)
 ```
 
 <a name="set-error-handler"></a>
+
 #### setErrorHandler
 
-`fastify.setErrorHandler(handler(error, request, reply))`: Set a function that will be called whenever an error happens. The handler is fully encapsulated, so different plugins can set different error handlers. *async-await* is supported as well.
+`fastify.setErrorHandler(handler(error, request, reply))`: Set a function that will be called whenever an error happens. The handler is fully encapsulated, so different plugins can set different error handlers. _async-await_ is supported as well.
 
 ```js
-fastify.setErrorHandler(function (error, request, reply) {
+fastify.setErrorHandler(function(error, request, reply) {
   // Send error response
 })
 ```
 
 <a name="print-routes"></a>
+
 #### printRoutes
 
 `fastify.printRoutes()`: Prints the representation of the internal radix tree used by the router, useful for debugging.<br/>
-*Remember to call it inside or after a `ready` call.*
+_Remember to call it inside or after a `ready` call._
 
 ```js
 fastify.get('/test', () => {})

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,22 +1,29 @@
 <h1 align="center">Fastify</h1>
 
 ## Testing
+
 Testing is one of the most important parts of developing an application. Fastify is very flexible when it comes to testing and is compatible with most testing frameworks (such as [Tap](https://www.npmjs.com/package/tap), which is used in the examples below).
 
 <a name="inject"></a>
+
 ### Testing with http injection
+
 Fastify comes with built-in support for fake http injection thanks to [`light-my-request`](https://github.com/fastify/light-my-request).
 
 To inject a fake http request, use the `inject` method:
+
 ```js
-fastify.inject({
-  method: String,
-  url: String,
-  payload: Object,
-  headers: Object
-}, (error, response) => {
-  // your tests
-})
+fastify.inject(
+  {
+    method: String,
+    url: String,
+    payload: Object,
+    headers: Object
+  },
+  (error, response) => {
+    // your tests
+  }
+)
 ```
 
 or in the promisified version
@@ -38,6 +45,7 @@ fastify
 ```
 
 Async await is supported as well!
+
 ```js
 try {
   const res = await fastify.inject({ method: String, url: String, payload: Object, headers: Object })
@@ -50,16 +58,17 @@ try {
 #### Example:
 
 **app.js**
+
 ```js
 const Fastify = require('fastify')
 
-function buildFastify () {
+function buildFastify() {
   const fastify = Fastify()
 
-  fastify.get('/', function (request, reply) {
+  fastify.get('/', function(request, reply) {
     reply.send({ hello: 'world' })
   })
-  
+
   return fastify
 }
 
@@ -67,32 +76,40 @@ module.exports = buildFastify
 ```
 
 **test.js**
+
 ```js
 const tap = require('tap')
 const buildFastify = require('./app')
 
 tap.test('GET `/` route', t => {
   t.plan(4)
-  
+
   const fastify = buildFastify()
-  
+
   // At the end of your tests it is highly recommended to call `.close()`
   // to ensure that all connections to external services get closed.
   t.tearDown(() => fastify.close())
 
-  fastify.inject({
-    method: 'GET',
-    url: '/'
-  }, (err, response) => {
-    t.error(err)
-    t.strictEqual(response.statusCode, 200)
-    t.strictEqual(response.headers['content-type'], 'application/json; charset=utf-8')
-    t.deepEqual(JSON.parse(response.payload), { hello: 'world' })
-  })
+  fastify.inject(
+    {
+      method: 'GET',
+      url: '/'
+    },
+    (err, response) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(
+        response.headers['content-type'],
+        'application/json; charset=utf-8'
+      )
+      t.deepEqual(JSON.parse(response.payload), { hello: 'world' })
+    }
+  )
 })
 ```
 
 ### Testing with a running server
+
 Fastify can also be tested after starting the server with `fastify.listen()` or after initializing routes and plugins with `fastify.ready()`.
 
 #### Example:
@@ -100,6 +117,7 @@ Fastify can also be tested after starting the server with `fastify.listen()` or 
 Uses **app.js** from the previous example.
 
 **test-listen.js** (testing with [`Request`](https://www.npmjs.com/package/request))
+
 ```js
 const tap = require('tap')
 const request = require('request')
@@ -107,40 +125,47 @@ const buildFastify = require('./app')
 
 tap.test('GET `/` route', t => {
   t.plan(5)
-  
+
   const fastify = buildFastify()
-  
+
   t.tearDown(() => fastify.close())
-  
-  fastify.listen(0, (err) => {
+
+  fastify.listen(0, err => {
     t.error(err)
-    
-    request({
-      method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port
-    }, (err, response, body) => {
-      t.error(err)
-      t.strictEqual(response.statusCode, 200)
-      t.strictEqual(response.headers['content-type'], 'application/json; charset=utf-8')
-      t.deepEqual(JSON.parse(body), { hello: 'world' })
-    })
+
+    request(
+      {
+        method: 'GET',
+        url: 'http://localhost:' + fastify.server.address().port
+      },
+      (err, response, body) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 200)
+        t.strictEqual(
+          response.headers['content-type'],
+          'application/json; charset=utf-8'
+        )
+        t.deepEqual(JSON.parse(body), { hello: 'world' })
+      }
+    )
   })
 })
 ```
 
 **test-ready.js** (testing with [`SuperTest`](https://www.npmjs.com/package/supertest))
+
 ```js
 const tap = require('tap')
 const supertest = require('supertest')
 const buildFastify = require('./app')
 
-tap.test('GET `/` route', async (t) => {
+tap.test('GET `/` route', async t => {
   const fastify = buildFastify()
 
   t.tearDown(() => fastify.close())
-  
+
   await fastify.ready()
-  
+
   const response = await supertest(fastify.server)
     .get('/')
     .expect(200)

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -1,17 +1,21 @@
 <h1 align="center">Fastify</h1>
 
 <a id="typescript"></a>
+
 ## TypeScript
+
 Fastify is shipped with the a typings file, but it still require to install `@types/node`, depending on the Node.js version that you are using.
 
 ## Types support
+
 We do care about the TypeScript community, but the framework is written in plain JavaScript and currently no one of the core team is a TypeScript user while only one of the collaborators is.
-We do our best to have the typing updated with the latest version of the API, but *it can happen* that the typings are not in sync.<br/>
+We do our best to have the typing updated with the latest version of the API, but _it can happen_ that the typings are not in sync.<br/>
 Luckly this is Open Source and you can contribute to fix them, we will be very happy to accept the fix and release it as soon as possible as a patch release. Checkout the [contributing](#contributing) rules!
 
 Plugins may or may not include typings. See [Plugin Types](#plugin-types) for more information.
 
 ## Example
+
 This example TypeScript app closely aligns with the JavaScript examples:
 
 ```ts
@@ -21,7 +25,11 @@ import { Server, IncomingMessage, ServerResponse } from 'http'
 // Create a http server. We pass the relevant typings for our http version used.
 // By passing types we get correctly typed access to the underlying http objects in routes.
 // If using http we'd pass <http2.Http2Server, http2.Http2ServerRequest, http2.Http2ServerResponse>
-const server: fastify.FastifyInstance<Server, IncomingMessage, ServerResponse> = fastify({})
+const server: fastify.FastifyInstance<
+  Server,
+  IncomingMessage,
+  ServerResponse
+> = fastify({})
 
 const opts: fastify.RouteShorthandOptions = {
   schema: {
@@ -45,7 +53,9 @@ server.get('/ping', opts, (request, reply) => {
 ```
 
 <a id="http-prototypes"></a>
+
 ## HTTP Prototypes
+
 By default, fastify will determine which version of http is being used based on the options you pass to it. If for any
 reason you need to override this you can do so as shown below:
 
@@ -55,37 +65,47 @@ interface CustomIncomingMessage extends http.IncomingMessage {
 }
 
 // Passing overrides for the http prototypes to fastify
-const server: fastify.FastifyInstance<http.Server, CustomIncomingMessage, http.ServerResponse> = fastify()
+const server: fastify.FastifyInstance<
+  http.Server,
+  CustomIncomingMessage,
+  http.ServerResponse
+> = fastify()
 
 server.get('/ping', (request, reply) => {
   // Access our custom method on the http prototype
   const clientDeviceType = request.raw.getClientDeviceType()
 
-  reply.send({ clientDeviceType: `you called this endpoint from a ${clientDeviceType}` })
+  reply.send({
+    clientDeviceType: `you called this endpoint from a ${clientDeviceType}`
+  })
 })
 ```
 
 In this example we pass a modified `http.IncomingMessage` interface since it has been extended elsewhere in our
 application.
 
-
 <a id="contributing"></a>
+
 ## Contributing
+
 TypeScript related changes can be considered to fall into one of two categories:
 
-* Core - The typings bundled with fastify
-* Plugins - Fastify ecosystem plugins
+- Core - The typings bundled with fastify
+- Plugins - Fastify ecosystem plugins
 
 Make sure to read our `CONTRIBUTING.md` file before getting started to make sure things go smoothly!
 
 <a id="core-types"></a>
+
 ### Core Types
+
 When updating core types you should make a PR to this repository. Ensure you:
 
-1. Update `examples/typescript-server.ts` to reflect the changes (if necessary)
-2. Update `test/types/index.ts` to validate changes work as expected
+1.  Update `examples/typescript-server.ts` to reflect the changes (if necessary)
+2.  Update `test/types/index.ts` to validate changes work as expected
 
 <a id="plugin-types"></a>
+
 ### Plugin Types
 
 Typings for plugins are hosted in DefinitelyTyped. This means when using plugins you should install like so:
@@ -97,7 +117,9 @@ npm install fastify-url-data @types/fastify-url-data
 After this you should be good to go. Some types might not be available yet, so don't be shy about contributing.
 
 <a id="authoring-plugin-types"></a>
+
 ### Authoring Plugin Types
+
 Typings for many plugins that extend the `FastifyRequest` and `FastifyReply` objects can be achieved as shown below.
 
 This code demonstrates adding types for `fastify-url-data` to your application.
@@ -106,23 +128,25 @@ This code demonstrates adding types for `fastify-url-data` to your application.
 // filename: custom-types.d.ts
 
 // Core typings and values
-import fastify = require('fastify');
+import fastify = require('fastify')
 
 // Extra types that will be used for plugin typings
-import { UrlObject } from 'url';
+import { UrlObject } from 'url'
 
 // Extend FastifyReply with the "fastify-url-data" plugin
 declare module 'fastify' {
   interface FastifyRequest {
-    urlData (): UrlObject
+    urlData(): UrlObject
   }
 }
 
-declare function urlData (): void
+declare function urlData(): void
 
-declare namespace urlData {}
+declare namespace urlData {
 
-export = urlData;
+}
+
+export = urlData
 ```
 
 Now you can use `fastify-url-data` like so:
@@ -133,7 +157,7 @@ import * as urlData from 'fastify-url-data'
 
 /// <reference types="./custom-types.d.ts"/>
 
-const server = fastify();
+const server = fastify()
 
 server.register(urlData)
 
@@ -143,7 +167,7 @@ server.get('/data', (request, reply) => {
   console.log(request.urlData().port)
   console.log(request.urlData().query)
 
-  reply.send({msg: 'ok'})
+  reply.send({ msg: 'ok' })
 })
 
 server.listen(3030)

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -1,17 +1,22 @@
 <h1 align="center">Fastify</h1>
 
 ## Validation and Serialization
+
 Fastify uses a schema-based approach, and even if it is not mandatory we recommend using [JSON Schema](http://json-schema.org/) to validate your routes and serialize your outputs. Internally, Fastify compiles the schema into a highly performant function.
 
 <a name="validation"></a>
+
 ### Validation
+
 The route validation internally relies upon [Ajv](https://www.npmjs.com/package/ajv), which is a high-performance JSON schema validator. Validating the input is very easy: just add the fields that you need inside the route schema, and you are done! The supported validations are:
+
 - `body`: validates the body of the request if it is a POST or a PUT.
 - `querystring`: validates the query string. This can be a complete JSON Schema object (with a `type` property of `'object'` and a `'properties'` object containing parameters) or a simpler variation in which the `type` and `properties` attributes are forgone and the query parameters are listed at the top level (see the example below).
 - `params`: validates the route params.
 - `headers`: validates the request headers.
 
 Example:
+
 ```js
 const schema = {
   body: {
@@ -46,11 +51,15 @@ const schema = {
 
 fastify.post('/the/url', { schema }, handler)
 ```
-*Note that Ajv will try to [coerce](https://github.com/epoberezkin/ajv#coercing-data-types) the values to the types specified in your schema `type` keywords, both to pass the validation and to use the correctly typed data afterwards.*
+
+_Note that Ajv will try to [coerce](https://github.com/epoberezkin/ajv#coercing-data-types) the values to the types specified in your schema `type` keywords, both to pass the validation and to use the correctly typed data afterwards._
 
 <a name="shared-schema"></a>
+
 #### Adding a shared schema
-Thanks to the `addSchema` API, you can add multiple schemas to the Fastify instance and then reuse them in multiple parts of your application. *(Note that this API is not encapsulated)*
+
+Thanks to the `addSchema` API, you can add multiple schemas to the Fastify instance and then reuse them in multiple parts of your application. _(Note that this API is not encapsulated)_
+
 ```js
 const fastify = require('fastify')()
 
@@ -71,7 +80,9 @@ fastify.route({
   handler: () => {}
 })
 ```
+
 You can use the shared schema everywhere, as top level schema or nested inside other schemas:
+
 ```js
 const fastify = require('fastify')()
 
@@ -100,6 +111,7 @@ fastify.route({
 ```
 
 <a name="schema-compiler"></a>
+
 #### Schema Compiler
 
 The `schemaCompiler` is a function that returns a function that validates the body, url parameters, headers, and query string. The default `schemaCompiler` returns a function that implements the `ajv` validation interface. Fastify uses it internally to speed the validation up.
@@ -115,7 +127,7 @@ const ajv = new Ajv({
   useDefaults: true,
   coerceTypes: true
 })
-fastify.setSchemaCompiler(function (schema) {
+fastify.setSchemaCompiler(function(schema) {
   return ajv.compile(schema)
 })
 ```
@@ -125,25 +137,35 @@ But maybe you want to change the validation library. Perhaps you like `Joi`. In 
 ```js
 const Joi = require('joi')
 
-fastify.post('/the/url', {
-  schema: {
-    body: Joi.object().keys({
-      hello: Joi.string().required()
-    }).required()
+fastify.post(
+  '/the/url',
+  {
+    schema: {
+      body: Joi.object()
+        .keys({
+          hello: Joi.string().required()
+        })
+        .required()
+    },
+    schemaCompiler: schema => data => Joi.validate(data, schema)
   },
-  schemaCompiler: schema => data => Joi.validate(data, schema)
-}, handler)
+  handler
+)
 ```
 
 In that case the function returned by `schemaCompiler` returns an object like:
-* `error`: filled with an instance of `Error` or a string that describes the validation error
-* `value`: the coerced value that passed the validation
+
+- `error`: filled with an instance of `Error` or a string that describes the validation error
+- `value`: the coerced value that passed the validation
 
 <a name="serialization"></a>
+
 ### Serialization
+
 Usually you will send your data to the clients via JSON, and Fastify has a powerful tool to help you, [fast-json-stringify](https://www.npmjs.com/package/fast-json-stringify), which is used if you have provided an output schema in the route options. We encourage you to use an output schema, as it will increase your throughput by 100-400% depending on your payload and will prevent accidental disclosure of sensitive information.
 
 Example:
+
 ```js
 const schema = {
   response: {
@@ -161,6 +183,7 @@ fastify.post('/the/url', { schema }, handler)
 ```
 
 As you can see, the response schema is based on the status code. If you want to use the same schema for multiple status codes, you can use `'2xx'`, for example:
+
 ```js
 const schema = {
   response: {
@@ -183,10 +206,12 @@ const schema = {
 fastify.post('/the/url', { schema }, handler)
 ```
 
-*If you need a custom serializer in a very specific part of your code, you can set one with `reply.serializer(...)`.*
+_If you need a custom serializer in a very specific part of your code, you can set one with `reply.serializer(...)`._
 
 <a name="resources"></a>
+
 ### Resources
+
 - [JSON Schema](http://json-schema.org/)
 - [Understanding JSON schema](https://spacetelescope.github.io/understanding-json-schema/)
 - [fast-json-stringify documentation](https://github.com/fastify/fast-json-stringify)

--- a/docs/Write-Plugin.md
+++ b/docs/Write-Plugin.md
@@ -1,12 +1,14 @@
 <h1 align="center">Fastify</h1>
 
 # How to write a good plugin
+
 First, thank you for deciding to write a plugin for Fastify. Fastify is a minimal framework and plugins are its strength, so thank you.<br>
 The core principles of Fastify are performance, low overhead and providing a good experience to our users. When writing a plugin, it is important to keep these principles in mind. Therefore, in this document we will analyze what characterizes a quality plugin.
 
-*Need some inspiration? You can use the label ["plugin suggestion"](https://github.com/fastify/fastify/issues?q=is%3Aissue+is%3Aopen+label%3A%22plugin+suggestion%22) in our issue tracker!*
+_Need some inspiration? You can use the label ["plugin suggestion"](https://github.com/fastify/fastify/issues?q=is%3Aissue+is%3Aopen+label%3A%22plugin+suggestion%22) in our issue tracker!_
 
 ## Code
+
 Fastify uses different techniques to optimize its code, many of them are documented in our Guides. We highly recommend you read [the hitchhiker's guide to plugins](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md) to discover all the APIs you can use to build your plugin and learn how use them.
 
 Have you got some question or are you seeking for a suggestion? We are more than happy to help you! Just open an issue in our [help repository](https://github.com/fastify/help).
@@ -14,8 +16,10 @@ Have you got some question or are you seeking for a suggestion? We are more than
 Once you submit a plugin to our [ecosystem list](https://github.com/fastify/fastify/blob/master/docs/Ecosystem.md), we will review your code and help you improve it if necessary.
 
 ## Documentation
+
 Documentation is extremely important. If your plugin is not well documented we will not accept it to the ecosystem list. Lack of quality documentation makes it more difficult for people to use your plugin, and will likely result in it going unused.<br>
 If you want to see some good examples on how to document a plugin take a look at:
+
 - [`fastify-caching`](https://github.com/fastify/fastify-caching)
 - [`fastify-compress`](https://github.com/fastify/fastify-compress)
 - [`fastify-cookie`](https://github.com/fastify/fastify-cookie)
@@ -23,36 +27,43 @@ If you want to see some good examples on how to document a plugin take a look at
 - [`under-pressure`](https://github.com/fastify/under-pressure)
 
 ## License
+
 You can license your plugin as you prefer, we do not enforce any kind of license.<br>
 We prefer the [MIT license](https://choosealicense.com/licenses/mit/) because we think it allows more people to use the code freely. For a list of alternative licenses see the [OSI list](https://opensource.org/licenses) or GitHub's [choosealicense.com](https://choosealicense.com/).
 
 ## Examples
+
 Always put an example file in your repository. Examples are very helpful for users and give a very fast way to test your plugin. Your users will be grateful.
 
 ## Test
+
 It is extremely important that a plugin is thoroughly tested to verify that is working properly.<br>
 A plugin without tests will not be accepted to the ecosystem list. A lack of tests does not inspire trust nor guarantee that the code will continue to work among different versions of its dependencies.
 
 We do not enforce any testing library. We use [`tap`](http://www.node-tap.org/) since it offers out of the box parallel testing and code coverage, but it is up to you to choose your library of preference.
 
 ## Code Linter
+
 It is not mandatory, but we highly recommend you use a code linter in your plugin. It will ensure a consistent code style and help you to avoid many errors.
 
 We use [`standard`](https://standardjs.com/) since it works without the need to configure it and is very easy integrate in a test suite.
 
 ## Continuous Integration
+
 It is not mandatory, but if you release your code as open source it helps to use Continuous Integration to ensure contributions do not break your plugin and to show that the plugin works as intended. [Travis](https://travis-ci.org/) is free for open source projects and easy to setup.<br>
 In addition you can enable services like [Greenkeeper](https://greenkeeper.io/), that will help you keep your dependencies up to date and discover if a new release of Fastify has some issues with your plugin.
 
 ## Let's start!
+
 Awesome, now you know everything you need to know about how to write a good plugin for Fastify!
 After you've built one (or more!) let us know! We will add it to the [ecosystem](https://github.com/fastify/fastify#ecosystem) section of our documentation!
 
 If you want to see some real world examples, checkout:
+
 - [`point-of-view`](https://github.com/fastify/point-of-view)
-Templates rendering (*ejs, pug, handlebars, marko*) plugin support for Fastify.
+  Templates rendering (_ejs, pug, handlebars, marko_) plugin support for Fastify.
 - [`fastify-mongodb`](https://github.com/fastify/fastify-mongodb)
-Fastify MongoDB connection plugin, with this you can share the same MongoDb connection pool in every part of your server.
+  Fastify MongoDB connection plugin, with this you can share the same MongoDb connection pool in every part of your server.
 - [`fastify-multipart`](https://github.com/fastify/fastify-multipart)
-Multipart support for Fastify.
+  Multipart support for Fastify.
 - [`fastify-helmet`](https://github.com/fastify/fastify-helmet) Important security headers for Fastify.

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "ienoopen": "^1.0.0",
     "joi": "~11.4.0",
     "pre-commit": "^1.2.2",
+    "prettier": "^1.13.5",
     "proxyquire": "^2.0.1",
     "pump": "^3.0.0",
     "semver": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "coverage": "npm run unit -- --cov --coverage-report=html",
     "coveralls": "npm run unit --  --cov",
     "bench": "branchcmp -r 2 -g -s \"npm run benchmark\"",
+    "format:md": "prettier --parser=markdown --single-quote --no-semi --trailing-comma none --write \"docs/**/*.md\"",
     "benchmark": "npx concurrently -k -s first \"node ./examples/simple.js\" \"npx autocannon -c 100 -d 5 -p 10 localhost:3000/\""
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "coverage": "npm run unit -- --cov --coverage-report=html",
     "coveralls": "npm run unit --  --cov",
     "bench": "branchcmp -r 2 -g -s \"npm run benchmark\"",
-    "format:md": "prettier --parser=markdown --single-quote --no-semi --trailing-comma none --write \"docs/**/*.md\"",
+    "format:docs": "prettier --parser=markdown --single-quote --no-semi --trailing-comma none --write \"docs/**/*.md\"",
     "benchmark": "npx concurrently -k -s first \"node ./examples/simple.js\" \"npx autocannon -c 100 -d 5 -p 10 localhost:3000/\""
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "coverage": "npm run unit -- --cov --coverage-report=html",
     "coveralls": "npm run unit --  --cov",
     "bench": "branchcmp -r 2 -g -s \"npm run benchmark\"",
-    "format:docs": "prettier --parser=markdown --single-quote --no-semi --trailing-comma none --write \"docs/**/*.md\"",
+    "format:docs": "prettier --single-quote --no-semi --trailing-comma none --write \"docs/**/*.md\"",
     "benchmark": "npx concurrently -k -s first \"node ./examples/simple.js\" \"npx autocannon -c 100 -d 5 -p 10 localhost:3000/\""
   },
   "repository": {


### PR DESCRIPTION
This PR will use https://github.com/prettier/prettier for markdown files only. It will format markdown and code snippets in a consistent way. The downside: It' not 100% standardjs compliant. It removes the space between function parentheses but I still like it because it's only for docs examples.

Just run

```
npm run format-docs
```

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
