### PR TITLE
change default host address 127.0.0.1

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -308,7 +308,7 @@ function build (options) {
       cb = address
       address = undefined
     }
-    address = address || '127.0.0.1'
+    address = address || '0.0.0.0'
 
     /* Deal with listen (port, address, cb) */
     if (typeof backlog === 'function') {

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -11,7 +11,7 @@ test('listen accepts a port and a callback', t => {
   const fastify = Fastify()
   fastify.listen(0, (err) => {
     fastify.server.unref()
-    t.is(fastify.server.address().address, '127.0.0.1')
+    t.is(fastify.server.address().address, '0.0.0.0')
     t.error(err)
     t.pass()
     fastify.close()
@@ -119,7 +119,7 @@ test('listen without callback', t => {
   const fastify = Fastify()
   fastify.listen(0)
     .then(() => {
-      t.is(fastify.server.address().address, '127.0.0.1')
+      t.is(fastify.server.address().address, '0.0.0.0')
       fastify.close()
       t.end()
     })


### PR DESCRIPTION
Two reasons for this change:

1. Node default use '0.0.0.0' when run function `serveer.listen`, change from '127.0.0.1' to '0.0.0.0' to be better compatible. https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback

2. Cloud environment like cloud foundry (which I'm using right now) can't detect a server running with '127.0.0.1' but can detect a server running with '0.0.0.0'. Details between these: https://superuser.com/questions/949428/whats-the-difference-between-127-0-0-1-and-0-0-0-0


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
