### PR TITLE
Add test for retuning sock file path on listen

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -342,14 +342,15 @@ function build (options) {
   }
 
   function logServerAddress (address, isHttps) {
-    if (typeof address === 'object') {
+    const isUnixSocket = typeof address === 'string'
+    if (!isUnixSocket) {
       if (address.address.indexOf(':') === -1) {
         address = address.address + ':' + address.port
       } else {
         address = '[' + address.address + ']:' + address.port
       }
     }
-    address = 'http' + (isHttps ? 's' : '') + '://' + address
+    address = (isUnixSocket ? '' : ('http' + (isHttps ? 's' : '') + '://')) + address
     fastify.log.info('Server listening at ' + address)
     return address
   }

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -169,16 +169,19 @@ test('listen twice on the same port callback with (err, address)', t => {
 // https://nodejs.org/api/net.html#net_ipc_support
 if (os.platform() !== 'win32') {
   test('listen on socket', t => {
-    t.plan(2)
+    t.plan(3)
     const fastify = Fastify()
+    t.tearDown(fastify.close.bind(fastify))
+
     const sockFile = path.join(os.tmpdir(), 'server.sock')
     try {
       fs.unlinkSync(sockFile)
     } catch (e) { }
-    fastify.listen(sockFile, (err) => {
+
+    fastify.listen(sockFile, (err, address) => {
       t.error(err)
       t.equal(sockFile, fastify.server.address())
-      fastify.close()
+      t.equal(address, sockFile)
     })
   })
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

Continuing https://github.com/fastify/fastify/pull/964.
Add test and a fix for returning the sock path.

The `address` is the sock path and it is not prefixed with the protocol

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
