### PR TITLE
Add .status() alias for .code()

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -5,7 +5,7 @@ The second parameter of the handler function is `Reply`.
 Reply is a core Fastify object that exposes the following functions:
 
 - `.code(statusCode)` - Sets the status code.
-- `.status(statusCode`)` - An alias for `.code(statusCode)`.
+- `.status(statusCode)` - An alias for `.code(statusCode)`.
 - `.header(name, value)` - Sets a response header.
 - `.getHeader(name)` - Retrieve value of already set header.
 - `.hasHeader(name)` = Determine if a header has been set.

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -5,7 +5,7 @@ The second parameter of the handler function is `Reply`.
 Reply is a core Fastify object that exposes the following functions:
 
 - `.code(statusCode)` - Sets the status code.
-- `.status(statusCod`)` - An alias for `.code(statusCode)`.
+- `.status(statusCode`)` - An alias for `.code(statusCode)`.
 - `.header(name, value)` - Sets a response header.
 - `.getHeader(name)` - Retrieve value of already set header.
 - `.hasHeader(name)` = Determine if a header has been set.

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -5,6 +5,7 @@ The second parameter of the handler function is `Reply`.
 Reply is a core Fastify object that exposes the following functions:
 
 - `.code(statusCode)` - Sets the status code.
+- `.status(statusCod`)` - An alias for `.code(statusCode)`.
 - `.header(name, value)` - Sets a response header.
 - `.getHeader(name)` - Retrieve value of already set header.
 - `.hasHeader(name)` = Determine if a header has been set.

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -71,6 +71,7 @@ declare namespace fastify {
    */
   interface FastifyReply<HttpResponse> {
     code: (statusCode: number) => FastifyReply<HttpResponse>
+    status: (statusCode: number) => FastifyReply<HttpResponse>
     header: (name: string, value: any) => FastifyReply<HttpResponse>
     headers: (headers: { [key: string]: any }) => FastifyReply<HttpResponse>
     type: (contentType: string) => FastifyReply<HttpResponse>

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -125,6 +125,8 @@ Reply.prototype.code = function (code) {
   return this
 }
 
+Reply.prototype.status = Reply.prototype.code
+
 Reply.prototype.serialize = function (payload) {
   return serialize(this.context, payload, this.res.statusCode)
 }

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -18,7 +18,7 @@ test('Once called, Reply should return an object with methods', t => {
   t.is(typeof reply._customError, 'boolean')
   t.is(typeof reply.send, 'function')
   t.is(typeof reply.code, 'function')
-  t.is(typeof reply.code, 'function')
+  t.is(typeof reply.status, 'function')
   t.is(typeof reply.header, 'function')
   t.is(typeof reply.serialize, 'function')
   t.is(typeof reply._headers, 'object')

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -18,6 +18,7 @@ test('Once called, Reply should return an object with methods', t => {
   t.is(typeof reply._customError, 'boolean')
   t.is(typeof reply.send, 'function')
   t.is(typeof reply.code, 'function')
+  t.is(typeof reply.code, 'function')
   t.is(typeof reply.header, 'function')
   t.is(typeof reply.serialize, 'function')
   t.is(typeof reply._headers, 'object')
@@ -784,5 +785,19 @@ test('Content type and charset set previously', t => {
   fastify.inject('/', (err, res) => {
     t.error(err)
     t.is(res.headers['content-type'], 'application/json; charset=utf-16')
+  })
+})
+
+test('.status() is an alias for .code()', t => {
+  t.plan(2)
+  const fastify = require('../..')()
+
+  fastify.get('/', function (req, reply) {
+    reply.status(418).send()
+  })
+
+  fastify.inject('/', (err, res) => {
+    t.error(err)
+    t.is(res.statusCode, 418)
   })
 })

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -8,7 +8,7 @@ const NotFound = require('http-errors').NotFound
 const Reply = require('../../lib/reply')
 
 test('Once called, Reply should return an object with methods', t => {
-  t.plan(11)
+  t.plan(12)
   const response = { res: 'res' }
   function context () {}
   function request () {}


### PR DESCRIPTION
This PR adds a `.status()` alias on the `Reply` object that maps to the `.code()` method. Using `status()` is more familiar to some people because it's the leading word of what is actually being set: the status code. In particular, it's more familiar to people coming from Express; see https://expressjs.com/en/4x/api.html#res.status .

Note: the test I added passes when I run `node test/internals/reply.test.js`. Trying to run `npm test` results in some TypeScript nonsense:

```sh
[jsumners@morla] ~/Projects/fastify <git:(status-code *)>
% npm test                                                                                                                   [s:1 l:8140]

> fastify@1.6.0 test /Users/jsumners/Projects/fastify
> npm run lint && npm run unit && npm run typescript


> fastify@1.6.0 lint /Users/jsumners/Projects/fastify
> standard | snazzy && npm run lint:typescript


> fastify@1.6.0 lint:typescript /Users/jsumners/Projects/fastify
> standard --parser typescript-eslint-parser --plugin typescript test/types/*.ts fastify.d.ts

standard: Use JavaScript Standard Style (https://standardjs.com)
  /Users/jsumners/Projects/fastify/fastify.d.ts:1:1: Resolve error: unable to load resolver "node".
  /Users/jsumners/Projects/fastify/test/types/index.ts:1:1: Resolve error: unable to load resolver "node".
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! fastify@1.6.0 lint:typescript: `standard --parser typescript-eslint-parser --plugin typescript test/types/*.ts fastify.d.ts`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the fastify@1.6.0 lint:typescript script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/jsumners/.npm/_logs/2018-06-19T00_01_15_829Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! fastify@1.6.0 lint: `standard | snazzy && npm run lint:typescript`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the fastify@1.6.0 lint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/jsumners/.npm/_logs/2018-06-19T00_01_15_865Z-debug.log
npm ERR! Test failed.  See above for more details.
```

#### Checklist

- [ ] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
