### PR TITLE
Add support for decorating with a getter/setter object

### DIFF
--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -34,6 +34,22 @@ console.log(fastify.conf.db)
 
 Decorators are not *overwritable*. If you try to declare a decorator that was previously declared *(in other words, use the same name)*, `decorate` will throw an exception.
 
+Decorators accept special "getter/setter" objects. These objects have functions named `getter` and `setter` (though, the `setter` function is optional). This allows defining properties via decorators. For example:
+
+```js
+fastify.decorate('foo', {
+  getter () {
+    return 'a getter'
+  }
+})
+```
+
+Will define the `foo` property on the *Fastify* instance:
+
+```js
+console.log(fastify.foo) // 'a getter'
+```
+
 <a name="decorate-reply"></a>
 **decorateReply**
 As the name suggests, this API is needed if you want to add new methods to the `Reply` core object. Just call the `decorateReply` API and pass the name of the new property and its value:

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -9,6 +9,14 @@ function decorate (name, fn, dependencies) {
     checkDependencies(this, dependencies)
   }
 
+  if (fn.hasOwnProperty('getter') || fn.hasOwnProperty('setter')) {
+    Object.defineProperty(this, name, {
+      get: fn.getter,
+      set: fn.setter
+    })
+    return this
+  }
+
   this[name] = fn
   return this
 }

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -9,7 +9,7 @@ function decorate (name, fn, dependencies) {
     checkDependencies(this, dependencies)
   }
 
-  if (fn.hasOwnProperty('getter') || fn.hasOwnProperty('setter')) {
+  if (typeof fn.getter === 'function' || typeof fn.setter === 'function') {
     Object.defineProperty(this, name, {
       get: fn.getter,
       set: fn.setter

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -495,3 +495,23 @@ test('hasReplyDecorator', t => {
 
   t.end()
 })
+
+test('should register properties via getter/setter objects', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.register((instance, opts, next) => {
+    instance.decorate('test', {
+      getter () {
+        return 'a getter'
+      }
+    })
+    t.ok(instance.test)
+    t.is(instance.test, 'a getter')
+    next()
+  })
+
+  fastify.ready(() => {
+    t.notOk(fastify.test)
+  })
+})

--- a/test/internals/decorator.test.js
+++ b/test/internals/decorator.test.js
@@ -93,3 +93,28 @@ test('decorate should internally call checkDependencies', t => {
     t.is(e.message, 'Fastify decorator: missing dependency: \'test\'.')
   }
 })
+
+test('decorate should recognize getter/setter objects', t => {
+  t.plan(6)
+
+  const one = {}
+  decorator.add.call(one, 'foo', {
+    getter: () => this._a,
+    setter: (val) => {
+      t.pass()
+      this._a = val
+    }
+  })
+  t.is(one.hasOwnProperty('foo'), true)
+  t.is(one.foo, undefined)
+  one.foo = 'a'
+  t.is(one.foo, 'a')
+
+  // getter only
+  const two = {}
+  decorator.add.call(two, 'foo', {
+    getter: () => 'a getter'
+  })
+  t.is(two.hasOwnProperty('foo'), true)
+  t.is(two.foo, 'a getter')
+})


### PR DESCRIPTION
This PR adds support for defining properties via decoration. I recall an issue sometime ago asking for this feature, but I cannot find it. I personally encountered a need to do this earlier today. I think the proposed implementation is a fair compromise between a barebones decoration API and one that has checks for special supported features.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
