### PR TITLE
fix listen ts types

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -272,7 +272,9 @@ declare namespace fastify {
     listen(port: number, callback: (err: Error, address: string) => void): void
     listen(port: number, address: string, callback: (err: Error, address: string) => void): void
     listen(port: number, address: string, backlog: number, callback: (err: Error, address: string) => void): void
+    listen(sockFile: string, callback: (err: Error, address: string) => void): void
     listen(port: number, address?: string, backlog?: number): Promise<string>
+    listen(sockFile: string): Promise<string>
 
     /**
      * Registers a listener function that is invoked when all the plugins have

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -269,15 +269,10 @@ declare namespace fastify {
      * internally waits for the .ready() event. The callback is the same as the
      * Node core.
      */
-    listen(port: number, hostname: string, callback?: (err: Error, address: string) => void): http.Server
-
-    /**
-     * Starts the server on the given port after all the plugins are loaded,
-     * internally waits for the .ready() event. The callback is the same as the
-     * Node core.
-     */
-    listen(port: number, callback?: (err: Error, address: string) => void): http.Server
-    listen(path: string, callback?: (err: Error, address: string) => void): http.Server
+    listen(port: number, callback: (err: Error, address: string) => void): void
+    listen(port: number, address: string, callback: (err: Error, address: string) => void): void
+    listen(port: number, address: string, backlog: number, callback: (err: Error, address: string) => void): void
+    listen(port: number, address?: string, backlog?: number): Promise<string>
 
     /**
      * Registers a listener function that is invoked when all the plugins have

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -35,11 +35,11 @@ test('listen accepts a port, address, and callback', t => {
   })
 })
 
-test('listen accepts a port and a callback with (err, address)', t => {
+test('listen accepts a port, address and a callback with (err, address)', t => {
   t.plan(2)
   const fastify = Fastify()
   t.tearDown(fastify.close.bind(fastify))
-  fastify.listen(0, (err, address) => {
+  fastify.listen(0, '127.0.0.1', (err, address) => {
     t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
     t.error(err)
   })
@@ -50,16 +50,6 @@ test('listen accepts a port, address, backlog and callback', t => {
   const fastify = Fastify()
   t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0, '127.0.0.1', 511, (err) => {
-    t.error(err)
-  })
-})
-
-test('listen accepts a port, address, backlog and callback with (err, address)', t => {
-  t.plan(2)
-  const fastify = Fastify()
-  t.tearDown(fastify.close.bind(fastify))
-  fastify.listen(0, '127.0.0.1', 511, (err, address) => {
-    t.is(address, 'http://127.0.0.1:' + fastify.server.address().port)
     t.error(err)
   })
 })

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -287,6 +287,10 @@ server.listen(3000, '127.0.0.1', 511, err => {
   if (err) throw err
 })
 
+server.listen('/tmp/sock', err => {
+  if (err) throw err
+})
+
 server.listen(3000)
   .then((address: string) => console.log(address))
 
@@ -294,6 +298,9 @@ server.listen(3000, '127.0.0.1')
   .then((address: string) => console.log(address))
 
 server.listen(3000, '127.0.0.1', 511)
+  .then((address: string) => console.log(address))
+
+server.listen('/tmp/sock')
   .then((address: string) => console.log(address))
 
 // http injections

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -279,6 +279,17 @@ server.listen(3000, err => {
   }
 })
 
+server.listen(3000, '127.0.0.1', err => {
+  if (err) throw err
+})
+
+server.listen(3000, '127.0.0.1', 511, err => {
+  if (err) throw err
+})
+
+server.listen(3000)
+  .then((address: string) => console.log(address))
+
 // http injections
 server.inject({ url: '/test' }, (err: Error, res: fastify.HTTPInjectResponse) => {
   server.log.debug(err)

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -290,6 +290,12 @@ server.listen(3000, '127.0.0.1', 511, err => {
 server.listen(3000)
   .then((address: string) => console.log(address))
 
+server.listen(3000, '127.0.0.1')
+  .then((address: string) => console.log(address))
+
+server.listen(3000, '127.0.0.1', 511)
+  .then((address: string) => console.log(address))
+
 // http injections
 server.inject({ url: '/test' }, (err: Error, res: fastify.HTTPInjectResponse) => {
   server.log.debug(err)


### PR DESCRIPTION

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

After check source code of `listen` method:
```
  function listen (port, address, backlog, cb) {
    /* Deal with listen (port, cb) */
    if (typeof address === 'function') {
      cb = address
      address = undefined
    }
    address = address || '127.0.0.1'

    /* Deal with listen (port, address, cb) */
    if (typeof backlog === 'function') {
      cb = backlog
      backlog = undefined
    }

    if (cb === undefined) return listenPromise(port, address, backlog)
...
```
We can use `listen` in six ways, correct me if I'm wrong.
* listen(port, cb)
* listen(port, address, cb)
* listen(port, address, backlog, cb)
* listen(port).then()
* listen(port, address).then()
* listen(port, address, backlog).then()
```

So I change the typings for the `listen` method according this.
