### PR TITLE
Feature/#713 beforeHandler for setNotFoundHandler

### DIFF
--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -193,14 +193,22 @@ Set the schema compiler for all routes [here](https://github.com/fastify/fastify
 
 `fastify.setNotFoundHandler(handler(request, reply))`: set the 404 handler. This call is encapsulated by prefix, so different plugins can set different not found handlers if a different [`prefix` option](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#route-prefixing-option) is passed to `fastify.register()`. The handler is treated like a regular route handler so requests will go through the full [Fastify lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md#lifecycle).
 
+You can also register [beforeHandler](https://www.fastify.io/docs/latest/Hooks/#beforehandler) hook for the 404 handler. 
+
 ```js
-fastify.setNotFoundHandler(function (request, reply) {
-  // Default not found handler
+fastify.setNotFoundHandler({
+  beforeHandler: (req, reply, next) => {
+    req.body.beforeHandler = true
+    next()
+  }  
+}, function (request, reply) {
+    // Default not found handler with beforeHandler hook
 })
 
 fastify.register(function (instance, options, next) {
   instance.setNotFoundHandler(function (request, reply) {
-    // Handle not found request to URLs that begin with '/v1'
+    // Handle not found request without beforeHandler hook
+    // to URLs that begin with '/v1'
   })
   next()
 }, { prefix: '/v1' })

--- a/fastify.js
+++ b/fastify.js
@@ -773,10 +773,21 @@ function build (options) {
   function setNotFoundHandler (opts, handler) {
     throwIfAlreadyStarted('Cannot call "setNotFoundHandler" when fastify instance is already started!')
 
+    const _fastify = this
     const prefix = this._routePrefix || '/'
 
     if (this._canSetNotFoundHandler === false) {
       throw new Error(`Not found handler already set for Fastify instance with prefix: '${prefix}'`)
+    }
+
+    if (typeof opts === 'object' && opts.beforeHandler) {
+      if (Array.isArray(opts.beforeHandler)) {
+        opts.beforeHandler.forEach((h, i) => {
+          opts.beforeHandler[i] = h.bind(_fastify)
+        })
+      } else {
+        opts.beforeHandler = opts.beforeHandler.bind(_fastify)
+      }
     }
 
     if (typeof opts === 'function') {
@@ -815,7 +826,7 @@ function build (options) {
       const context = this._404Context
 
       const onRequest = this._hooks.onRequest
-      const preHandler = this._hooks.preHandler
+      const preHandler = this._hooks.preHandler.concat(opts.beforeHandler || [])
       const onSend = this._hooks.onSend
       const onResponse = this._hooks.onResponse
 


### PR DESCRIPTION
Hi! This is the first attempt to implement `beforeHandler` for custom `notFoundHandler`.
The original discussion is #713.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

#### Benchmark:
**Machine:** QEMU Virtual CPU version (cpu64-rhel6) 2.9Ghz 1 core | 1GB DDR3 2000Mhz

| Variant            |  Requests/sec (error) | diff |
| :----------------- | :------------------------- | :----------: |
| master with custom 404 | 6.600 | --- |
| custom 404 wo beforeHandler | 6.400 | ~= |
| custom 404 with beforeHandler | 5.400 | ~15% |