### PR TITLE
Configure request id header key

### DIFF
--- a/docs/Factory.md
+++ b/docs/Factory.md
@@ -147,3 +147,10 @@ fastify.get('/user/:username', (request, reply) => {
 
 Please note this setting this option to `false` goes against
 [RFC3986](https://tools.ietf.org/html/rfc3986#section-6.2.2.1).
+
+<a name="factory-request-id-header"></a>
+### `requestIdHeader`
+
+The header name used to know the request id. See [the request id](./Logging.md#logging-request-id) section.
+
++ Default: `'request-id'`

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -44,7 +44,8 @@ fastify.get('/', options, function (request, reply) {
 })
 ```
 
-By default fastify adds an id to every request for easier tracking. If the "request-id" header is present its value is used, otherwise a new incremental id is generated.
+<a name="logging-request-id" />
+By default fastify adds an id to every request for easier tracking. If the "request-id" header is present its value is used, otherwise a new incremental id is generated. See Fastify Factory [`requestIdHeader`](./Factory.md#factory-request-id-header) options for customizing that header name.
 Additionally, `genReqId` option can be used for generating the request id by yourself. It will received the incoming request as a parameter.
 ```js
 let i = 0
@@ -60,8 +61,8 @@ The default logger is configured with a set of standard serializers that seriali
 const fastify = require('fastify')({
   logger: {
     serializers: {
-      req: function (req) { 
-        return { url: req.url } 
+      req: function (req) {
+        return { url: req.url }
       }
     }
   }

--- a/fastify.js
+++ b/fastify.js
@@ -70,13 +70,13 @@ function build (options) {
     caseSensitive: options.caseSensitive
   })
 
-  const requestIdHeaderKey = options.requestIdHeaderKey || 'request-id'
+  const requestIdHeader = options.requestIdHeader || 'request-id'
 
   fastify.printRoutes = router.prettyPrint.bind(router)
 
   // logger utils
   const customGenReqId = options.logger ? options.logger.genReqId : null
-  const genReqId = customGenReqId || loggerUtils.reqIdGenFactory(requestIdHeaderKey)
+  const genReqId = customGenReqId || loggerUtils.reqIdGenFactory(requestIdHeader)
   const now = loggerUtils.now
   const onResponseIterator = loggerUtils.onResponseIterator
   const onResponseCallback = hasLogger ? loggerUtils.onResponseCallback : noop

--- a/fastify.js
+++ b/fastify.js
@@ -70,11 +70,13 @@ function build (options) {
     caseSensitive: options.caseSensitive
   })
 
+  const requestIdHeaderKey = options.requestIdHeaderKey || 'request-id'
+
   fastify.printRoutes = router.prettyPrint.bind(router)
 
   // logger utils
   const customGenReqId = options.logger ? options.logger.genReqId : null
-  const genReqId = customGenReqId || loggerUtils.reqIdGenFactory()
+  const genReqId = customGenReqId || loggerUtils.reqIdGenFactory(requestIdHeaderKey)
   const now = loggerUtils.now
   const onResponseIterator = loggerUtils.onResponseIterator
   const onResponseCallback = hasLogger ? loggerUtils.onResponseCallback : noop

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -29,11 +29,11 @@ function createLogger (opts, stream) {
   return logger
 }
 
-function reqIdGenFactory () {
+function reqIdGenFactory (requestIdHeaderKey) {
   var maxInt = 2147483647
   var nextReqId = 0
   return function genReqId (req) {
-    return req.headers['request-id'] || (nextReqId = (nextReqId + 1) & maxInt)
+    return req.headers[requestIdHeaderKey] || (nextReqId = (nextReqId + 1) & maxInt)
   }
 }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -29,11 +29,11 @@ function createLogger (opts, stream) {
   return logger
 }
 
-function reqIdGenFactory (requestIdHeaderKey) {
+function reqIdGenFactory (requestIdHeader) {
   var maxInt = 2147483647
   var nextReqId = 0
   return function genReqId (req) {
-    return req.headers[requestIdHeaderKey] || (nextReqId = (nextReqId + 1) & maxInt)
+    return req.headers[requestIdHeader] || (nextReqId = (nextReqId + 1) & maxInt)
   }
 }
 

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -273,6 +273,51 @@ test('The logger should accept a custom genReqId function', t => {
   })
 })
 
+test('The request id header key can be customized', t => {
+  t.plan(9)
+  const REQUEST_ID = '42'
+
+  const stream = split(JSON.parse)
+  const fastify = Fastify({
+    logger: { stream: stream, level: 'info' },
+    requestIdHeaderKey: 'my-custom-request-id'
+  })
+  t.tearDown(() => fastify.close())
+
+  fastify.get('/', (req, reply) => {
+    t.equal(req.raw.id, REQUEST_ID)
+    req.log.info('some log message')
+    reply.send({ id: req.raw.id })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      'my-custom-request-id': REQUEST_ID
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.equal(payload.id, REQUEST_ID)
+
+    stream.once('data', line => {
+      t.equal(line.reqId, REQUEST_ID)
+      t.equal(line.msg, 'incoming request', 'message is set')
+
+      stream.once('data', line => {
+        t.equal(line.reqId, REQUEST_ID)
+        t.equal(line.msg, 'some log message', 'message is set')
+
+        stream.once('data', line => {
+          t.equal(line.reqId, REQUEST_ID)
+          t.equal(line.msg, 'request completed', 'message is set')
+        })
+      })
+    })
+  })
+})
+
 t.test('The logger should accept custom serializer', t => {
   t.plan(9)
 

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -280,7 +280,7 @@ test('The request id header key can be customized', t => {
   const stream = split(JSON.parse)
   const fastify = Fastify({
     logger: { stream: stream, level: 'info' },
-    requestIdHeaderKey: 'my-custom-request-id'
+    requestIdHeader: 'my-custom-request-id'
   })
   t.tearDown(() => fastify.close())
 


### PR DESCRIPTION
Add `requestIdHeaderKey` to fastify configuration in order to support the request id header key customization.

I should update the documentation accordingly too.

The benchmark doesn't reveal changes.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
