### PR TITLE
Add test for checking multipart request using form-data module

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "eslint-plugin-typescript": "^0.12.0",
     "fast-json-body": "^1.1.0",
     "fastify-plugin": "^1.1.3",
+    "form-data": "^2.3.2",
     "frameguard": "^3.0.0",
     "h2url": "^0.1.2",
     "helmet": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "fast-json-stringify": "^1.5.4",
     "find-my-way": "^1.15.0",
     "flatstr": "^1.0.8",
-    "light-my-request": "^2.0.2",
+    "light-my-request": "^2.0.3",
     "middie": "^3.1.0",
     "pino": "^4.17.3",
     "tiny-lru": "^1.6.1"

--- a/test/inject.test.js
+++ b/test/inject.test.js
@@ -5,6 +5,7 @@ const test = t.test
 const Stream = require('stream')
 const util = require('util')
 const Fastify = require('..')
+const FormData = require('form-data')
 
 test('inject should exist', t => {
   t.plan(2)
@@ -320,6 +321,37 @@ test('should reject in error case', t => {
   })
     .catch(e => {
       t.strictEqual(e, error)
+    })
+})
+
+test('inject a multipart request using form-body', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  fastify.addContentTypeParser('*', function (req, done) {
+    var body = ''
+    req.raw.on('data', d => {
+      body += d
+    })
+    req.raw.on('end', () => {
+      req.body = body
+      done()
+    })
+  })
+  fastify.post('/', (req, reply) => {
+    reply.send(req.body)
+  })
+
+  const form = new FormData()
+  form.append('my_field', 'my value')
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: form
+  })
+    .then(response => {
+      t.equal(response.statusCode, 200)
     })
 })
 

--- a/test/inject.test.js
+++ b/test/inject.test.js
@@ -325,17 +325,16 @@ test('should reject in error case', t => {
 })
 
 test('inject a multipart request using form-body', t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
 
   fastify.addContentTypeParser('*', function (req, done) {
     var body = ''
-    req.raw.on('data', d => {
+    req.on('data', d => {
       body += d
     })
-    req.raw.on('end', () => {
-      req.body = body
-      done()
+    req.on('end', () => {
+      done(null, body)
     })
   })
   fastify.post('/', (req, reply) => {
@@ -352,6 +351,7 @@ test('inject a multipart request using form-body', t => {
   })
     .then(response => {
       t.equal(response.statusCode, 200)
+      t.ok(/Content-Disposition: form-data; name="my_field"/.test(response.payload))
     })
 })
 


### PR DESCRIPTION
The injection using `form-data` module doesn't work properly.

A test is added.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
