### PR TITLE
Resolves issue #936

### DIFF
--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -38,10 +38,16 @@ function handleRequest (req, res, params, context) {
   }
 
   if (method === 'OPTIONS' || method === 'DELETE') {
-    if (contentType === undefined) {
-      handler(reply)
-    } else {
+    if (
+      contentType !== undefined &&
+      (
+        headers['transfer-encoding'] !== undefined ||
+        headers['content-length'] !== undefined
+      )
+    ) {
       context.contentTypeParser.run(contentType, handler, request, reply)
+    } else {
+      handler(reply)
     }
     return
   }

--- a/test/custom-parser.test.js
+++ b/test/custom-parser.test.js
@@ -638,7 +638,7 @@ test('Should get the body as buffer', t => {
 })
 
 test('Should parse empty bodies as a string', t => {
-  t.plan(5)
+  t.plan(9)
   const fastify = Fastify()
 
   fastify.addContentTypeParser('text/plain', { parseAs: 'string' }, (req, body, done) => {
@@ -647,7 +647,7 @@ test('Should parse empty bodies as a string', t => {
   })
 
   fastify.route({
-    method: ['POST'],
+    method: ['POST', 'DELETE'],
     url: '/',
     handler (request, reply) {
       reply.send(request.body)
@@ -664,6 +664,20 @@ test('Should parse empty bodies as a string', t => {
       body: '',
       headers: {
         'Content-Type': 'text/plain'
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(body.toString(), '')
+    })
+
+    sget({
+      method: 'DELETE',
+      url: 'http://localhost:' + fastify.server.address().port,
+      body: '',
+      headers: {
+        'Content-Type': 'text/plain',
+        'Content-Length': '0'
       }
     }, (err, response, body) => {
       t.error(err)

--- a/test/custom-parser.test.js
+++ b/test/custom-parser.test.js
@@ -638,7 +638,7 @@ test('Should get the body as buffer', t => {
 })
 
 test('Should parse empty bodies as a string', t => {
-  t.plan(9)
+  t.plan(5)
   const fastify = Fastify()
 
   fastify.addContentTypeParser('text/plain', { parseAs: 'string' }, (req, body, done) => {
@@ -647,7 +647,7 @@ test('Should parse empty bodies as a string', t => {
   })
 
   fastify.route({
-    method: ['POST', 'DELETE'],
+    method: ['POST'],
     url: '/',
     handler (request, reply) {
       reply.send(request.body)
@@ -660,19 +660,6 @@ test('Should parse empty bodies as a string', t => {
 
     sget({
       method: 'POST',
-      url: 'http://localhost:' + fastify.server.address().port,
-      body: '',
-      headers: {
-        'Content-Type': 'text/plain'
-      }
-    }, (err, response, body) => {
-      t.error(err)
-      t.strictEqual(response.statusCode, 200)
-      t.strictEqual(body.toString(), '')
-    })
-
-    sget({
-      method: 'DELETE',
       url: 'http://localhost:' + fastify.server.address().port,
       body: '',
       headers: {

--- a/test/delete.test.js
+++ b/test/delete.test.js
@@ -296,3 +296,23 @@ fastify.listen(0, err => {
     })
   })
 })
+
+// https://github.com/fastify/fastify/issues/936
+test('shorthand - delete with application/json Content-Type header and without body', t => {
+  t.plan(4)
+  const fastify = require('..')()
+  fastify.delete('/', {}, (req, reply) => {
+    t.equal(req.body, null)
+    reply.send(req.body)
+  })
+  fastify.inject({
+    method: 'DELETE',
+    url: '/',
+    headers: { 'Content-Type': 'application/json' },
+    body: null
+  }, (err, response) => {
+    t.error(err)
+    t.strictEqual(response.statusCode, 200)
+    t.deepEqual(JSON.parse(response.payload), null)
+  })
+})

--- a/test/helper.js
+++ b/test/helper.js
@@ -239,8 +239,10 @@ module.exports.payloadMethod = function (method, t) {
       sget({
         method: upMethod,
         url: 'http://localhost:' + fastify.server.address().port,
-        body: '',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': '0'
+        },
         timeout: 500
       }, (err, response, body) => {
         t.error(err)

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -183,8 +183,8 @@ test('request should be defined in onSend Hook on options request with content t
       }
     }, (err, response, body) => {
       t.error(err)
-      // a 415 error is expected because of missing content type parser
-      t.strictEqual(response.statusCode, 415)
+      // Body parsing skipped, so no body sent
+      t.strictEqual(response.statusCode, 200)
     })
   })
 })


### PR DESCRIPTION
The original discussion is #936.

#895 made possible to accept request without body and with valid `Content-Type` header **other than** `application/json`.

This change makes possible to do the same if the request method is `DELETE` and the `Content-Type` header is `application/json`.

The PR also separates how we handle the `OPTIONS` and `DELETE` methods based on https://github.com/fastify/fastify/issues/936#issuecomment-397460128.

Best of my knowledge these two RFC paragraph are the closest to our use case, but none of them regulates it explicitly:
*From [RFC 7231 Section 3.1.1.5](https://tools.ietf.org/html/rfc7231#section-3.1.1.5)*
> A sender that generates a message containing a payload body SHOULD
> generate a Content-Type header field in that message unless the
> intended media type of the enclosed representation is unknown to the sender.

*From [RFC  7231 Section 4.3.5](https://tools.ietf.org/html/rfc7231#section-4.3.5)*
> A payload within a DELETE request message has no defined semantics;
> sending a payload body on a DELETE request might cause some existing
> implementations to reject the request.
</details>


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
