### PR TITLE
fix: if response.setHeader is used, will cause header write after send error

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -249,8 +249,10 @@ function sendStream (payload, res, reply) {
   // appropriately, e.g. a 404 for a missing file. So we cannot use
   // writeHead, and we need to resort to setHeader, which will trigger
   // a writeHead when there is data to send.
-  for (var key in reply._headers) {
-    res.setHeader(key, reply._headers[key])
+  if (!res.headersSent) {
+    for (var key in reply._headers) {
+      res.setHeader(key, reply._headers[key])
+    }
   }
   payload.pipe(res)
 }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -253,6 +253,8 @@ function sendStream (payload, res, reply) {
     for (var key in reply._headers) {
       res.setHeader(key, reply._headers[key])
     }
+  } else {
+    res.log.warn('response will send, but you shouldn\'t use res.writeHead in stream mode')
   }
   payload.pipe(res)
 }

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -293,6 +293,36 @@ test('buffer with content type should not send application/octet-stream', t => {
   })
 })
 
+test('stream using reply.res.writeHead should return customize headers', t => {
+  t.plan(4)
+
+  const fastify = require('../..')()
+  const fs = require('fs')
+  let stream = fs.createReadStream('/dev/null')
+  let buf = fs.readFileSync('/dev/null')
+
+  fastify.get('/', function (req, reply) {
+    reply.res.writeHead(200, {
+      location: '/'
+    })
+    reply.send(stream)
+    reply.res.end()
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.strictEqual(response.headers['location'], '/')
+      t.deepEqual(body, buf)
+      t.error(err)
+    })
+  })
+})
+
 test('plain string without content type should send a text/plain', t => {
   t.plan(4)
 

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -298,8 +298,9 @@ test('stream using reply.res.writeHead should return customize headers', t => {
 
   const fastify = require('../..')()
   const fs = require('fs')
+  const path = require('path')
 
-  let streamPath = process.platform === 'win32' ? 'nul' : '/dev/null'
+  let streamPath = path.join(process.cwd(), './package.json')
   let stream = fs.createReadStream(streamPath)
   let buf = fs.readFileSync(streamPath)
 
@@ -308,7 +309,6 @@ test('stream using reply.res.writeHead should return customize headers', t => {
       location: '/'
     })
     reply.send(stream)
-    reply.res.end()
   })
 
   fastify.listen(0, err => {

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -298,8 +298,10 @@ test('stream using reply.res.writeHead should return customize headers', t => {
 
   const fastify = require('../..')()
   const fs = require('fs')
-  let stream = fs.createReadStream('/dev/null')
-  let buf = fs.readFileSync('/dev/null')
+
+  let streamPath = process.platform === 'win32' ? 'nul' : '/dev/null'
+  let stream = fs.createReadStream(streamPath)
+  let buf = fs.readFileSync(streamPath)
 
   fastify.get('/', function (req, reply) {
     reply.res.writeHead(200, {

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -294,7 +294,7 @@ test('buffer with content type should not send application/octet-stream', t => {
 })
 
 test('stream using reply.res.writeHead should return customize headers', t => {
-  t.plan(4)
+  t.plan(5)
 
   const fastify = require('../..')()
   const fs = require('fs')
@@ -305,6 +305,9 @@ test('stream using reply.res.writeHead should return customize headers', t => {
   var buf = fs.readFileSync(streamPath)
 
   fastify.get('/', function (req, reply) {
+    reply.res.log.warn = function mockWarn (message) {
+      t.equal(message, 'response will send, but you shouldn\'t use res.writeHead in stream mode')
+    }
     reply.res.writeHead(200, {
       location: '/'
     })

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -300,9 +300,9 @@ test('stream using reply.res.writeHead should return customize headers', t => {
   const fs = require('fs')
   const path = require('path')
 
-  let streamPath = path.join(process.cwd(), './package.json')
-  let stream = fs.createReadStream(streamPath)
-  let buf = fs.readFileSync(streamPath)
+  var streamPath = path.join(__dirname, '..', '..', 'package.json')
+  var stream = fs.createReadStream(streamPath)
+  var buf = fs.readFileSync(streamPath)
 
   fastify.get('/', function (req, reply) {
     reply.res.writeHead(200, {


### PR DESCRIPTION
If use `reply.res.writeHead` before `reply.send(stream)`, it will cause `response.headersSent` to be true, and `res.setHeader` will throw a error.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
