### PR TITLE
Add type definition for FastifyInstance.all

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -265,6 +265,16 @@ declare namespace fastify {
     options(url: string, handler: RequestHandler<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
+     * Defines a route for all the supported methods with the given mount path, options, and handler
+     */
+    all(url: string, opts: RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse>, handler: RequestHandler<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+
+    /**
+     * Defines a route for all the supported methods with the given mount path and handler
+     */
+    all(url: string, handler: RequestHandler<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+
+    /**
      * Starts the server on the given port after all the plugins are loaded,
      * internally waits for the .ready() event. The callback is the same as the
      * Node core.

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -233,6 +233,12 @@ server
     })
     done()
   }, { prefix: 'v1', hello: 'world' })
+  .all('/all/no-opts', function (req, reply) {
+    reply.send(req.headers)
+  })
+  .all('/all/with-opts', opts, function (req, reply) {
+    reply.send(req.headers)
+  })
 
 // Using decorate requires casting so the compiler knows about new properties
 server.decorate('utility', () => {})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

Added type definition for [`FastifyInstance.all`](https://github.com/fastify/fastify/blob/master/docs/Routes.md#shorthand-declaration).

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)