### PR TITLE
Add method to get all shared schemas

### DIFF
--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -100,9 +100,9 @@ fastify.route({
 ```
 
 <a name="get-shared-schema"></a>
-#### Retrieving all shared schemas
+#### Retrieving a copy of all shared schemas
 
-The function `getAllSchemas` returns all shared schemas that were added by `addSchema` method.
+The function `getSchemas` returns all shared schemas that were added by `addSchema` method.
 
 <a name="schema-compiler"></a>
 #### Schema Compiler

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -99,6 +99,11 @@ fastify.route({
 })
 ```
 
+<a name="get-shared-schema"></a>
+#### Retreiving all shared schemas
+
+The function `getAllSchemas` returns all shared schemas that were added by `addSchema` method.
+
 <a name="schema-compiler"></a>
 #### Schema Compiler
 

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -100,7 +100,7 @@ fastify.route({
 ```
 
 <a name="get-shared-schema"></a>
-#### Retreiving all shared schemas
+#### Retrieving all shared schemas
 
 The function `getAllSchemas` returns all shared schemas that were added by `addSchema` method.
 

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -430,7 +430,7 @@ declare namespace fastify {
     /**
      * Get all shared schemas
      */
-    getAllSchemas(): Array<Object>
+    getAllSchemas(): {[shemaId: string]: Object}
 
     /**
      * Add a content type parser

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -428,6 +428,11 @@ declare namespace fastify {
     addSchema(schema: object): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
+     * Get all schemas
+     */
+    getAllSchemas(): Array<Object>
+
+    /**
      * Add a content type parser
      */
     addContentTypeParser(contentType: string, opts: {parseAs?: string, bodyLimit?: number} | AsyncContentTypeParser<HttpRequest> | ContentTypeParser<HttpRequest>, parser?: AsyncContentTypeParser<HttpRequest> | ContentTypeParser<HttpRequest>): void;

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -428,7 +428,7 @@ declare namespace fastify {
     addSchema(schema: object): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
-     * Get all schemas
+     * Get all shared schemas
      */
     getAllSchemas(): Array<Object>
 

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -430,7 +430,7 @@ declare namespace fastify {
     /**
      * Get all shared schemas
      */
-    getAllSchemas(): {[shemaId: string]: Object}
+    getSchemas(): {[shemaId: string]: Object}
 
     /**
      * Add a content type parser

--- a/fastify.js
+++ b/fastify.js
@@ -163,6 +163,7 @@ function build (options) {
 
   // schemas
   fastify.addSchema = addSchema
+  fastify.getAllSchemas = getAllSchemas
   fastify._schemas = new Schemas()
 
   const onRouteHooks = []
@@ -699,6 +700,10 @@ function build (options) {
     throwIfAlreadyStarted('Cannot call "addSchema" when fastify instance is already started!')
     this._schemas.add(name, schema)
     return this
+  }
+
+  function getAllSchemas () {
+    return this._schemas.getAllSchemas()
   }
 
   function addContentTypeParser (contentType, opts, parser) {

--- a/fastify.js
+++ b/fastify.js
@@ -163,8 +163,8 @@ function build (options) {
 
   // schemas
   fastify.addSchema = addSchema
-  fastify.getAllSchemas = getAllSchemas
   fastify._schemas = new Schemas()
+  fastify.getSchemas = fastify._schemas.getSchemas.bind(fastify._schemas)
 
   const onRouteHooks = []
 
@@ -700,10 +700,6 @@ function build (options) {
     throwIfAlreadyStarted('Cannot call "addSchema" when fastify instance is already started!')
     this._schemas.add(name, schema)
     return this
-  }
-
-  function getAllSchemas () {
-    return this._schemas.getAllSchemas()
   }
 
   function addContentTypeParser (contentType, opts, parser) {

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -78,8 +78,8 @@ Schemas.prototype.getSchemaAnyway = function (schema) {
   return schema
 }
 
-Schemas.prototype.getAllSchemas = function () {
-  return this.store
+Schemas.prototype.getSchemas = function () {
+  return Object.assign({}, this.store)
 }
 
 module.exports = Schemas

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -78,4 +78,8 @@ Schemas.prototype.getSchemaAnyway = function (schema) {
   return schema
 }
 
+Schemas.prototype.getAllSchemas = function () {
+  return this.store
+}
+
 module.exports = Schemas

--- a/test/shared-schemas.test.js
+++ b/test/shared-schemas.test.js
@@ -10,10 +10,10 @@ test('Should expose addSchema function', t => {
   t.is(typeof fastify.addSchema, 'function')
 })
 
-test('Should expose getAllSchemas function', t => {
+test('Should expose getSchemas function', t => {
   t.plan(1)
   const fastify = Fastify()
-  t.is(typeof fastify.getAllSchemas, 'function')
+  t.is(typeof fastify.getSchemas, 'function')
 })
 
 test('The schemas should be added to an internal store', t => {
@@ -25,14 +25,21 @@ test('The schemas should be added to an internal store', t => {
   t.deepEqual(fastify._schemas.store, { id: schema })
 })
 
-test('The schemas should be accessible via getAllSchemas', t => {
-  t.plan(2)
+test('The schemas should be accessible via getSchemas', t => {
+  t.plan(1)
   const fastify = Fastify()
 
-  const schema = { $id: 'id', my: 'schema' }
-  fastify.addSchema(schema)
-  t.deepEqual(fastify._schemas.getAllSchemas(), { id: schema })
-  t.deepEqual(fastify.getAllSchemas(), { id: schema })
+  const schemas = [
+    { $id: 'id', my: 'schema' },
+    { $id: 'abc', my: 'schema' },
+    { $id: 'bcd', my: 'schema', properties: {a: 'a', b: 1} }
+  ]
+  const expected = {}
+  schemas.forEach(function (schema) {
+    expected[schema.$id] = schema
+    fastify.addSchema(schema)
+  })
+  t.deepEqual(fastify.getSchemas(), expected)
 })
 
 test('Should throw if the $id property is missing', t => {

--- a/test/shared-schemas.test.js
+++ b/test/shared-schemas.test.js
@@ -10,6 +10,12 @@ test('Should expose addSchema function', t => {
   t.is(typeof fastify.addSchema, 'function')
 })
 
+test('Should expose getAllSchemas function', t => {
+  t.plan(1)
+  const fastify = Fastify()
+  t.is(typeof fastify.getAllSchemas, 'function')
+})
+
 test('The schemas should be added to an internal store', t => {
   t.plan(1)
   const fastify = Fastify()
@@ -17,6 +23,16 @@ test('The schemas should be added to an internal store', t => {
   const schema = { $id: 'id', my: 'schema' }
   fastify.addSchema(schema)
   t.deepEqual(fastify._schemas.store, { id: schema })
+})
+
+test('The schemas should be accessible via getAllChemas', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  const schema = { $id: 'id', my: 'schema' }
+  fastify.addSchema(schema)
+  t.deepEqual(fastify._schemas.getAllSchemas(), { id: schema })
+  t.deepEqual(fastify.getAllSchemas(), { id: schema })
 })
 
 test('Should throw if the $id property is missing', t => {

--- a/test/shared-schemas.test.js
+++ b/test/shared-schemas.test.js
@@ -25,7 +25,7 @@ test('The schemas should be added to an internal store', t => {
   t.deepEqual(fastify._schemas.store, { id: schema })
 })
 
-test('The schemas should be accessible via getAllChemas', t => {
+test('The schemas should be accessible via getAllSchemas', t => {
   t.plan(2)
   const fastify = Fastify()
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Added features

- Add method `getAllSchemas` that allows to retrieve fastify shared schemas.

#### Motivation

This PR is needed to implement support for creating swagger models from fastify shared schemas
https://github.com/fastify/fastify-swagger/pull/88

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
