### PR TITLE
Listen to localhost instead of 127.0.0.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ For more information, see the [Fastify CLI documentation](https://github.com/fas
 
 #### Note
 
-`.listen` binds to the local host, `127.0.0.1`, interface by default. See [the documentation](https://github.com/fastify/fastify/blob/master/docs/Server-Methods.md#listen) for more information.
+`.listen` binds to the local host, `localhost`, interface by default (`127.0.0.1` or `::1`, depending on the operating system configuration).
+See [the documentation](https://github.com/fastify/fastify/blob/master/docs/Server-Methods.md#listen) for more information.
 
 ### Core features
 

--- a/docs/Server-Methods.md
+++ b/docs/Server-Methods.md
@@ -51,7 +51,7 @@ fastify.ready().then(() => {
 
 <a name="listen"></a>
 #### listen
-Starts the server on the given port after all the plugins are loaded, internally waits for the `.ready()` event. The callback is the same as the Node core. By default, the server will listen on address `127.0.0.1` when no specific address is provided. If listening on any available interface is desired, then specifying `0.0.0.0` for the address will listen on all IPv4 address. Using `::` for the address will listen on all IPv6 addresses, and, depending on OS, may also listen on all IPv4 addresses. Be careful when deciding to listen on all interfaces; it comes with inherent [security risks](https://web.archive.org/web/20170831174611/https://snyk.io/blog/mongodb-hack-and-secure-defaults/).
+Starts the server on the given port after all the plugins are loaded, internally waits for the `.ready()` event. The callback is the same as the Node core. By default, the server will listen on the address resolved by `localhost` when no specific address is provided (`127.0.0.1` or `::1` depending on the operating system). If listening on any available interface is desired, then specifying `0.0.0.0` for the address will listen on all IPv4 address. Using `::` for the address will listen on all IPv6 addresses, and, depending on OS, may also listen on all IPv4 addresses. Be careful when deciding to listen on all interfaces; it comes with inherent [security risks](https://web.archive.org/web/20170831174611/https://snyk.io/blog/mongodb-hack-and-secure-defaults/).
 
 ```js
 fastify.listen(3000, (err, address) => {
@@ -106,7 +106,7 @@ fastify.listen(3000, '127.0.0.1')
   })
 ```
 
-When deploying to a Docker, and potentially other, containers, it is advisable to listen on `0.0.0.0` because they do not default to exposing mapped ports to `127.0.0.1`:
+When deploying to a Docker, and potentially other, containers, it is advisable to listen on `0.0.0.0` because they do not default to exposing mapped ports to `localhost`:
 
 ```js
 fastify.listen(3000, '0.0.0.0', (err, address) => {

--- a/fastify.js
+++ b/fastify.js
@@ -271,6 +271,7 @@ function build (options) {
   function listenPromise (port, address, backlog) {
     // This will listen to what localhost is.
     // It can be 127.0.0.1 or ::1, depending on the operating system.
+    // Fixes https://github.com/fastify/fastify/issues/1022.
     address = address || 'localhost'
 
     if (listening) {

--- a/fastify.js
+++ b/fastify.js
@@ -269,7 +269,9 @@ function build (options) {
   }
 
   function listenPromise (port, address, backlog) {
-    address = address || '127.0.0.1'
+    // This will listen to what localhost is.
+    // It can be 127.0.0.1 or ::1, depending on the operating system.
+    address = address || 'localhost'
 
     if (listening) {
       return Promise.reject(new Error('Fastify is already listening'))


### PR DESCRIPTION
On some systems (Win 10), localhost resolves to ::1 first, creating
a sub-par development experience when connecting to localhost by
introducing a 300-500ms delay on connection.

Fixes https://github.com/fastify/fastify/issues/1022.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
