### PR TITLE
Fixes #1043

### DIFF
--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -79,6 +79,7 @@ Schemas.prototype.cleanId = function (schema) {
 }
 
 Schemas.prototype.getSchemaAnyway = function (schema) {
+  if (schema.oneOf || schema.allOf || schema.anyOf) return schema
   if (!schema.type || !schema.properties) {
     return {
       type: 'object',

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -34,6 +34,7 @@ Schemas.prototype.resolveRefs = function (routeSchemas) {
     // this will work only for standard json schemas
     // other compilers such as Joi will fail
     this.traverse(routeSchemas)
+    this.cleanId(routeSchemas)
   } catch (err) {
     // if we have failed because `resolve has thrown
     // let's rethrow the error and let avvio handle it
@@ -64,6 +65,15 @@ Schemas.prototype.traverse = function (schema) {
 
     if (schema[key] !== null && typeof schema[key] === 'object') {
       this.traverse(schema[key])
+    }
+  }
+}
+
+Schemas.prototype.cleanId = function (schema) {
+  for (var key in schema) {
+    if (key === '$id') delete schema[key]
+    if (schema[key] !== null && typeof schema[key] === 'object') {
+      this.cleanId(schema[key])
     }
   }
 }

--- a/test/shared-schemas.test.js
+++ b/test/shared-schemas.test.js
@@ -377,3 +377,67 @@ test('Use the same schema id in diferent places', t => {
     t.error(err)
   })
 })
+
+// https://github.com/fastify/fastify/issues/1043
+test('The schema resolver should clean the $id key before passing it to the compiler', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  fastify.addSchema({
+    $id: 'first',
+    type: 'object',
+    properties: {
+      first: {
+        type: 'number'
+      }
+    }
+  })
+
+  fastify.addSchema({
+    $id: 'second',
+    type: 'object',
+    allOf: [
+      {
+        type: 'object',
+        properties: {
+          second: {
+            type: 'number'
+          }
+        }
+      },
+      'first#'
+    ]
+  })
+
+  fastify.route({
+    url: '/',
+    method: 'GET',
+    schema: {
+      description: `get`,
+      body: 'second#',
+      response: {
+        200: 'second#'
+      }
+    },
+    handler: (request, reply) => {
+      reply.send({ hello: 'world' })
+    }
+  })
+
+  fastify.route({
+    url: '/',
+    method: 'PATCH',
+    schema: {
+      description: `patch`,
+      body: 'first#',
+      response: {
+        200: 'first#'
+      }
+    },
+    handler: (request, reply) => {
+      reply.send({ hello: 'world' })
+    }
+  })
+
+  fastify.ready(t.error)
+})

--- a/test/shared-schemas.test.js
+++ b/test/shared-schemas.test.js
@@ -441,3 +441,42 @@ test('The schema resolver should clean the $id key before passing it to the comp
 
   fastify.ready(t.error)
 })
+
+test('Get schema anyway should not add `properties` if *Of is present', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  fastify.addSchema({
+    $id: 'first',
+    type: 'object',
+    properties: {
+      first: { type: 'number' }
+    }
+  })
+
+  fastify.addSchema({
+    $id: 'second',
+    type: 'object',
+    allOf: [
+      {
+        type: 'object',
+        properties: {
+          second: { type: 'number' }
+        }
+      },
+      'first#'
+    ]
+  })
+
+  fastify.route({
+    url: '/',
+    method: 'GET',
+    schema: {
+      querystring: 'second#',
+      response: { 200: 'second#' }
+    },
+    handler: () => {}
+  })
+
+  fastify.ready(t.error)
+})

--- a/test/shared-schemas.test.js
+++ b/test/shared-schemas.test.js
@@ -442,7 +442,7 @@ test('The schema resolver should clean the $id key before passing it to the comp
   fastify.ready(t.error)
 })
 
-test('Get schema anyway should not add `properties` if *Of is present', t => {
+test('Get schema anyway should not add `properties` if allOf is present', t => {
   t.plan(1)
   const fastify = Fastify()
 
@@ -458,6 +458,84 @@ test('Get schema anyway should not add `properties` if *Of is present', t => {
     $id: 'second',
     type: 'object',
     allOf: [
+      {
+        type: 'object',
+        properties: {
+          second: { type: 'number' }
+        }
+      },
+      'first#'
+    ]
+  })
+
+  fastify.route({
+    url: '/',
+    method: 'GET',
+    schema: {
+      querystring: 'second#',
+      response: { 200: 'second#' }
+    },
+    handler: () => {}
+  })
+
+  fastify.ready(t.error)
+})
+
+test('Get schema anyway should not add `properties` if oneOf is present', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  fastify.addSchema({
+    $id: 'first',
+    type: 'object',
+    properties: {
+      first: { type: 'number' }
+    }
+  })
+
+  fastify.addSchema({
+    $id: 'second',
+    type: 'object',
+    oneOf: [
+      {
+        type: 'object',
+        properties: {
+          second: { type: 'number' }
+        }
+      },
+      'first#'
+    ]
+  })
+
+  fastify.route({
+    url: '/',
+    method: 'GET',
+    schema: {
+      querystring: 'second#',
+      response: { 200: 'second#' }
+    },
+    handler: () => {}
+  })
+
+  fastify.ready(t.error)
+})
+
+test('Get schema anyway should not add `properties` if anyOf is present', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  fastify.addSchema({
+    $id: 'first',
+    type: 'object',
+    properties: {
+      first: { type: 'number' }
+    }
+  })
+
+  fastify.addSchema({
+    $id: 'second',
+    type: 'object',
+    anyOf: [
       {
         type: 'object',
         properties: {


### PR DESCRIPTION
As titled.
The issue was caused by using the same `$id` key multiple times and `Ajv` was complaining about that (probably because of the cache).
Since we are using a custom schema resolver and only the full final object is passed to the compiler there is no need to also pass the `$id` key.

cc @SkeLLLa 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
