### PR TITLE
Log error after customErrorHandler #1072

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -287,12 +287,6 @@ function handleError (reply, error, cb) {
 
   res.statusCode = statusCode
 
-  if (statusCode >= 500) {
-    res.log.error({ req: reply.request.raw, res: res, err: error }, error && error.message)
-  } else if (statusCode >= 400) {
-    res.log.info({ res: res, err: error }, error && error.message)
-  }
-
   var customErrorHandler = reply.context.errorHandler
   if (customErrorHandler && reply._customError === false) {
     reply.sent = false
@@ -305,6 +299,12 @@ function handleError (reply, error, cb) {
         .catch(err => reply.send(err))
     }
     return
+  }
+
+  if (statusCode >= 500) {
+    res.log.error({ req: reply.request.raw, res: res, err: error }, error && error.message)
+  } else if (statusCode >= 400) {
+    res.log.info({ res: res, err: error }, error && error.message)
   }
 
   var payload = serializeError({

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -304,7 +304,7 @@ function handleError (reply, error, cb) {
   if (statusCode >= 500) {
     res.log.error({ req: reply.request.raw, res: res, err: error }, error && error.message)
   } else if (statusCode >= 400) {
-    res.log.info({ res: res, err: error }, error && error.message)
+    res.log.info({ req: reply.request.raw, res: res, err: error }, error && error.message)
   }
 
   var payload = serializeError({


### PR DESCRIPTION
Fixes #1072 
Error logging is performed only if there is no customErrorHandler or if has already been called. This allows the customErrorHandler to process and/or rethrow custom errors that are not supported by the built-in function and that would be incorrectly logged.
Moreover in case of log.info the request is also printed.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
