### PR TITLE
Set UTF8 charset for default 404 and 500 responses

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -313,7 +313,7 @@ function handleError (reply, error, cb) {
     statusCode: statusCode
   })
   flatstr(payload)
-  reply._headers['content-type'] = 'application/json'
+  reply._headers['content-type'] = 'application/json; charset=utf-8'
 
   if (cb) {
     cb(reply, payload)

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -24,7 +24,7 @@ test('default 404', t => {
     t.error(err)
 
     test('unsupported method', t => {
-      t.plan(2)
+      t.plan(3)
       sget({
         method: 'PUT',
         url: 'http://localhost:' + fastify.server.address().port,
@@ -33,11 +33,12 @@ test('default 404', t => {
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
+        t.strictEqual(response.headers['content-type'], 'application/json; charset=utf-8')
       })
     })
 
     test('unsupported route', t => {
-      t.plan(2)
+      t.plan(3)
       sget({
         method: 'GET',
         url: 'http://localhost:' + fastify.server.address().port + '/notSupported',
@@ -46,6 +47,7 @@ test('default 404', t => {
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 404)
+        t.strictEqual(response.headers['content-type'], 'application/json; charset=utf-8')
       })
     })
   })

--- a/test/500s.test.js
+++ b/test/500s.test.js
@@ -19,7 +19,7 @@ test('default 500', t => {
   }, (err, res) => {
     t.error(err)
     t.strictEqual(res.statusCode, 500)
-    t.strictEqual(res.headers['content-type'], 'application/json')
+    t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
     t.deepEqual(JSON.parse(res.payload), {
       error: 'Internal Server Error',
       message: 'kaboom',
@@ -99,7 +99,7 @@ test('encapsulated 500', t => {
   }, (err, res) => {
     t.error(err)
     t.strictEqual(res.statusCode, 500)
-    t.strictEqual(res.headers['content-type'], 'application/json')
+    t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
     t.deepEqual(JSON.parse(res.payload), {
       error: 'Internal Server Error',
       message: 'kaboom',

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -603,7 +603,7 @@ test('reply.send(new NotFound()) should invoke the 404 handler', t => {
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 404)
-      t.strictEqual(response.headers['content-type'], 'application/json')
+      t.strictEqual(response.headers['content-type'], 'application/json; charset=utf-8')
       t.deepEqual(JSON.parse(body.toString()), {
         statusCode: 404,
         error: 'Not Found',

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -30,7 +30,7 @@ function helper (code) {
     }, (error, res) => {
       t.error(error)
       t.strictEqual(res.statusCode, Number(code))
-      t.equal(res.headers['content-type'], 'application/json')
+      t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
       t.deepEqual(
         {
           error: statusCodes[code],

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -223,7 +223,7 @@ test('return a 404 if the stream emits a 404 error', t => {
 
     sget(`http://localhost:${port}`, function (err, response) {
       t.error(err)
-      t.strictEqual(response.headers['content-type'], 'application/json')
+      t.strictEqual(response.headers['content-type'], 'application/json; charset=utf-8')
       t.strictEqual(response.statusCode, 404)
     })
   })


### PR DESCRIPTION
As I have been making tests for my application, I noticed that default 404 and 500 messages set `content-type` header to only `application/json`, omitting the `charset=utf-8` part.

This seems odd to me, so I propose this pull request.

(possibly linked to #913)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
