### PR TITLE
Refactor content type strings

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -19,6 +19,12 @@ const serializeError = FJS({
   }
 })
 
+const CONTENT_TYPE = {
+  JSON: 'application/json; charset=utf-8',
+  PLAIN: 'text/plain; charset=utf-8',
+  OCTET: 'application/octet-stream'
+}
+
 var getHeader
 
 function Reply (res, context, request) {
@@ -57,14 +63,14 @@ Reply.prototype.send = function (payload) {
   if (payload !== null) {
     if (Buffer.isBuffer(payload) || typeof payload.pipe === 'function') {
       if (hasContentType === false) {
-        this._headers['content-type'] = 'application/octet-stream'
+        this._headers['content-type'] = CONTENT_TYPE.OCTET
       }
       onSendHook(this, payload)
       return
     }
 
     if (hasContentType === false && typeof payload === 'string') {
-      this._headers['content-type'] = 'text/plain; charset=utf-8'
+      this._headers['content-type'] = CONTENT_TYPE.PLAIN
       onSendHook(this, payload)
       return
     }
@@ -74,7 +80,7 @@ Reply.prototype.send = function (payload) {
     payload = this._serializer(payload)
   } else if (hasContentType === false || contentType.indexOf('application/json') > -1) {
     if (hasContentType === false || contentType.indexOf('charset') === -1) {
-      this._headers['content-type'] = 'application/json; charset=utf-8'
+      this._headers['content-type'] = CONTENT_TYPE.JSON
     }
     payload = serialize(this.context, payload, this.res.statusCode)
     flatstr(payload)
@@ -313,7 +319,7 @@ function handleError (reply, error, cb) {
     statusCode: statusCode
   })
   flatstr(payload)
-  reply._headers['content-type'] = 'application/json; charset=utf-8'
+  reply._headers['content-type'] = CONTENT_TYPE.JSON
 
   if (cb) {
     cb(reply, payload)


### PR DESCRIPTION
Use the same content type string in all `reply.js` file.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
