### PR TITLE
Added pluginTimeout option.

### DIFF
--- a/docs/Factory.md
+++ b/docs/Factory.md
@@ -185,3 +185,12 @@ fastify.get('/', (request, reply) => {
   console.log(request.raw.hostname)
 })
 ```
+
+<a name="plugin-timeout"></a>
+### `pluginTimeout`
+
+The maximum amount of time in milliseconds in which a plugin can load.
+If not, [`ready`](https://github.com/fastify/fastify/blob/master/docs/Server-Methods.md#ready)
+will complete with an `Error` with code `'ERR_AVVIO_PLUGIN_TIMEOUT'`.
+
++ Default: `0` (disabled)

--- a/fastify.js
+++ b/fastify.js
@@ -85,7 +85,8 @@ function build (options) {
   const onResponseCallback = hasLogger ? loggerUtils.onResponseCallback : noop
 
   const app = avvio(fastify, {
-    autostart: false
+    autostart: false,
+    timeout: Number(options.pluginTimeout) || 0
   })
   // Override to allow the plugin incapsulation
   app.override = override

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@types/pino": "^4.16.0",
     "abstract-logging": "^1.0.0",
     "ajv": "^6.5.2",
-    "avvio": "^5.6.0",
+    "avvio": "^5.8.0",
     "end-of-stream": "^1.4.1",
     "fast-json-stringify": "^1.5.4",
     "find-my-way": "^1.15.0",

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -489,3 +489,17 @@ test('plugin metadata - dependencies (nested)', t => {
     next()
   }
 })
+
+test('pluginTimeout', t => {
+  t.plan(2)
+  const fastify = Fastify({
+    pluginTimeout: 10
+  })
+  fastify.register(function (app, opts, next) {
+    // to no call next on purpose
+  })
+  fastify.ready((err) => {
+    t.ok(err)
+    t.equal(err.code, 'ERR_AVVIO_PLUGIN_TIMEOUT')
+  })
+})


### PR DESCRIPTION
I've seen some people complaining that debugging _what_ plugin did not start is very hard.
This fixed it by adding a `pluginTimeout` option to `Fastify`, the errors will contain the name of the plugin as guessed by avvio. 

#### Checklist 

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
