### PR TITLE
Update TypeScript to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "standard": "^11.0.1",
     "tap": "^12.0.0",
     "then-sleep": "^1.0.1",
-    "typescript": "^2.9.2",
+    "typescript": "^3.0.1",
     "typescript-eslint-parser": "^18.0.0",
     "x-xss-protection": "^1.1.0"
   },


### PR DESCRIPTION
This PR removes the following warning emitted during `npm test`:
```
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-eslint-parser.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: ~3.0.1

YOUR TYPESCRIPT VERSION: 2.9.2

Please only submit bug reports when using the officially supported version.

=============
```

#### Checklist

- [x] run `npm run test`
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
