### PR TITLE
Fix decorate{Request, Reply} not recognizing getter/setter config

### DIFF
--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -58,6 +58,14 @@ function decorateReply (name, fn, dependencies) {
     checkDependencies(this._Reply, dependencies)
   }
 
+  if (fn && (typeof fn.getter === 'function' || typeof fn.setter === 'function')) {
+    Object.defineProperty(this._Reply.prototype, name, {
+      get: fn.getter,
+      set: fn.setter
+    })
+    return this
+  }
+
   this._Reply.prototype[name] = fn
   return this
 }
@@ -69,6 +77,14 @@ function decorateRequest (name, fn, dependencies) {
 
   if (dependencies) {
     checkDependencies(this._Request, dependencies)
+  }
+
+  if (fn && (typeof fn.getter === 'function' || typeof fn.setter === 'function')) {
+    Object.defineProperty(this._Request.prototype, name, {
+      get: fn.getter,
+      set: fn.setter
+    })
+    return this
   }
 
   this._Request.prototype[name] = fn

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -516,6 +516,78 @@ test('should register properties via getter/setter objects', t => {
   })
 })
 
+test('decorateRequest should work with getter/setter', t => {
+  t.plan(5)
+  const fastify = Fastify()
+
+  fastify.register((instance, opts, next) => {
+    instance.decorateRequest('test', {
+      getter () {
+        return 'a getter'
+      }
+    })
+
+    instance.get('/req-decorated-get-set', (req, res) => {
+      res.send({test: req.test})
+    })
+
+    next()
+  })
+
+  fastify.get('/not-decorated', (req, res) => {
+    t.notOk(req.test)
+    res.send()
+  })
+
+  fastify.ready(() => {
+    fastify.inject({url: '/req-decorated-get-set'}, (err, res) => {
+      t.error(err)
+      t.deepEqual(JSON.parse(res.payload), {test: 'a getter'})
+    })
+
+    fastify.inject({url: '/not-decorated'}, (err, res) => {
+      t.error(err)
+      t.pass()
+    })
+  })
+})
+
+test('decorateReply should work with getter/setter', t => {
+  t.plan(5)
+  const fastify = Fastify()
+
+  fastify.register((instance, opts, next) => {
+    instance.decorateReply('test', {
+      getter () {
+        return 'a getter'
+      }
+    })
+
+    instance.get('/res-decorated-get-set', (req, res) => {
+      res.send({test: res.test})
+    })
+
+    next()
+  })
+
+  fastify.get('/not-decorated', (req, res) => {
+    t.notOk(res.test)
+    res.send()
+  })
+
+  fastify.ready(() => {
+    fastify.inject({url: '/res-decorated-get-set'}, (err, res) => {
+      t.error(err)
+      t.deepEqual(JSON.parse(res.payload), {test: 'a getter'})
+    })
+
+    fastify.inject({url: '/not-decorated'}, (err, res) => {
+      t.error(err)
+      t.pass()
+    })
+  })
+})
+
 test('should register empty values', t => {
   t.plan(2)
   const fastify = Fastify()


### PR DESCRIPTION
When I implemented #987 I was unaware that we had special internal functions for decorating the request and reply prototypes. I thought all decorations filtered through this function:

https://github.com/fastify/fastify/blob/d99cd61f246b9d505ae0e0a26819008b65a5afe1/lib/decorate.js#L3-L22

But that isn't the case. That function is essentially duplicated twice: once for request and once for reply. This PR fixes a problem where `instance.decorateRequest` and `instance.decorateReply` do not recognize the getter/setter config like they should be.

I think this code duplication should be removed in a future PR so that this sort of situation does not arise again.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
