### PR TITLE
Remove/Merge redundant decorate functions

### DIFF
--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -14,15 +14,14 @@ function decorate (instance, name, fn, dependencies) {
       get: fn.getter,
       set: fn.setter
     })
-    return instance
+  } else {
+    instance[name] = fn
   }
-
-  instance[name] = fn
-  return instance
 }
 
 function decorateFastify (name, fn, dependencies) {
-  return decorate(this, name, fn, dependencies)
+  decorate(this, name, fn, dependencies)
+  return this
 }
 
 function checkExistence (instance, name) {
@@ -53,11 +52,13 @@ function checkDependencies (instance, deps) {
 }
 
 function decorateReply (name, fn, dependencies) {
-  return decorate(this._Reply.prototype, name, fn, dependencies)
+  decorate(this._Reply.prototype, name, fn, dependencies)
+  return this
 }
 
 function decorateRequest (name, fn, dependencies) {
-  return decorate(this._Request.prototype, name, fn, dependencies)
+  decorate(this._Request.prototype, name, fn, dependencies)
+  return this
 }
 
 module.exports = {

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -25,22 +25,19 @@ function decorateFastify (name, fn, dependencies) {
 }
 
 function checkExistence (instance, name) {
-  if (!name) {
-    name = instance
-    instance = this
+  if (name) {
+    return name in instance
   }
 
-  const prototype = instance.prototype || instance
-
-  return name in instance || name in prototype
+  return instance in this
 }
 
 function checkRequestExistence (name) {
-  return checkExistence(this._Request, name)
+  return checkExistence(this._Request.prototype, name)
 }
 
 function checkReplyExistence (name) {
-  return checkExistence(this._Reply, name)
+  return checkExistence(this._Reply.prototype, name)
 }
 
 function checkDependencies (instance, deps) {

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -1,24 +1,28 @@
 'use strict'
 
-function decorate (name, fn, dependencies) {
-  if (checkExistence(this, name)) {
-    throw new Error(`The decorator '${name}' has been already added!`)
+function decorate (instance, name, fn, dependencies) {
+  if (checkExistence(instance, name)) {
+    throw new Error(`The decorator '${name}' has already been added!`)
   }
 
   if (dependencies) {
-    checkDependencies(this, dependencies)
+    checkDependencies(instance, dependencies)
   }
 
   if (fn && (typeof fn.getter === 'function' || typeof fn.setter === 'function')) {
-    Object.defineProperty(this, name, {
+    Object.defineProperty(instance, name, {
       get: fn.getter,
       set: fn.setter
     })
-    return this
+    return instance
   }
 
-  this[name] = fn
-  return this
+  instance[name] = fn
+  return instance
+}
+
+function decorateFastify (name, fn, dependencies) {
+  return decorate(this, name, fn, dependencies)
 }
 
 function checkExistence (instance, name) {
@@ -26,19 +30,18 @@ function checkExistence (instance, name) {
     name = instance
     instance = this
   }
-  return name in instance
+
+  const prototype = instance.prototype || instance
+
+  return name in instance || name in prototype
 }
 
 function checkRequestExistence (name) {
-  return checkExistenceInPrototype(this._Request, name)
+  return checkExistence(this._Request, name)
 }
 
 function checkReplyExistence (name) {
-  return checkExistenceInPrototype(this._Reply, name)
-}
-
-function checkExistenceInPrototype (klass, name) {
-  return name in klass.prototype
+  return checkExistence(this._Reply, name)
 }
 
 function checkDependencies (instance, deps) {
@@ -50,49 +53,15 @@ function checkDependencies (instance, deps) {
 }
 
 function decorateReply (name, fn, dependencies) {
-  if (checkExistenceInPrototype(this._Reply, name)) {
-    throw new Error(`The decorator '${name}' has been already added to Reply!`)
-  }
-
-  if (dependencies) {
-    checkDependencies(this._Reply, dependencies)
-  }
-
-  if (fn && (typeof fn.getter === 'function' || typeof fn.setter === 'function')) {
-    Object.defineProperty(this._Reply.prototype, name, {
-      get: fn.getter,
-      set: fn.setter
-    })
-    return this
-  }
-
-  this._Reply.prototype[name] = fn
-  return this
+  return decorate(this._Reply.prototype, name, fn, dependencies)
 }
 
 function decorateRequest (name, fn, dependencies) {
-  if (checkExistenceInPrototype(this._Request, name)) {
-    throw new Error(`The decorator '${name}' has been already added to Request!`)
-  }
-
-  if (dependencies) {
-    checkDependencies(this._Request, dependencies)
-  }
-
-  if (fn && (typeof fn.getter === 'function' || typeof fn.setter === 'function')) {
-    Object.defineProperty(this._Request.prototype, name, {
-      get: fn.getter,
-      set: fn.setter
-    })
-    return this
-  }
-
-  this._Request.prototype[name] = fn
-  return this
+  return decorate(this._Request.prototype, name, fn, dependencies)
 }
 
 module.exports = {
-  add: decorate,
+  add: decorateFastify,
   exist: checkExistence,
   existRequest: checkRequestExistence,
   existReply: checkReplyExistence,

--- a/test/throw.test.js
+++ b/test/throw.test.js
@@ -133,7 +133,7 @@ test('Should throw on duplicate request decorator', t => {
     fastify.decorateRequest('foo', fooObj)
     t.fail()
   } catch (e) {
-    t.ok(/has been already added/.test(e.message))
+    t.ok(/has already been added/.test(e.message))
   }
 })
 
@@ -162,7 +162,7 @@ test('Should throw on duplicate reply decorator', t => {
     fastify.decorateReply('foo', fooObj)
     t.fail()
   } catch (e) {
-    t.ok(/has been already added/.test(e.message))
+    t.ok(/has already been added/.test(e.message))
   }
 })
 


### PR DESCRIPTION
Addresses #1116 

One downside is that decorate has now a generic message instead of `already added to Reply/Request`

also not sure if the dependency check of `request.prototype` and `reply.prototype` is valid but I assumed there is a test for it.

#### Checklist

- [x] run `npm run test`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
