### PR TITLE
after should not cause inject() to be called

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -688,12 +688,8 @@ function build (options) {
         return lightMyRequest(httpHandler, opts, cb)
       })
     } else {
-      return new Promise((resolve, reject) => {
-        this.ready(err => {
-          if (err) return reject(err)
-          resolve()
-        })
-      }).then(() => lightMyRequest(httpHandler, opts))
+      return this.ready()
+        .then(() => lightMyRequest(httpHandler, opts))
     }
   }
 

--- a/test/inject.test.js
+++ b/test/inject.test.js
@@ -370,3 +370,24 @@ function getStream () {
 
   return new Read()
 }
+
+test('should error the promise if ready errors', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.register((instance, opts) => {
+    return Promise.reject(new Error('kaboom'))
+  }).after(function () {
+    t.pass('after is called')
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }).then(() => {
+    t.fail('this should not be called')
+  }).catch(err => {
+    t.ok(err)
+    t.strictequal(err.message, 'kaboom')
+  })
+})


### PR DESCRIPTION
This was fixed by https://github.com/mcollina/avvio/pull/74.

Should we also update the docs about calling `after()` without a error parameter?

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
