### PR TITLE
Handle promises in the error handler with the same logic of normal handlers

### DIFF
--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -5,6 +5,7 @@ const urlUtil = require('url')
 const validation = require('./validation')
 const validateSchema = validation.validate
 const runHooks = require('./hookRunner').hookRunner
+const wrapThenable = require('./wrapThenable')
 
 function handleRequest (req, res, params, context) {
   var method = req.method
@@ -90,28 +91,7 @@ function preHandlerCallback (err, reply) {
 
   var result = reply.context.handler(reply.request, reply)
   if (result && typeof result.then === 'function') {
-    result
-      .then(function (payload) {
-        // this is for async functions that
-        // are using reply.send directly
-        if (payload !== undefined || (reply.res.statusCode === 204 && reply.sent === false)) {
-          // we use a try-catch internally to avoid adding a catch to another
-          // promise, increase promise perf by 10%
-          try {
-            reply.send(payload)
-          } catch (err) {
-            reply.sent = false
-            reply._isError = true
-            reply.send(err)
-          }
-        } else if (reply.sent === false) {
-          reply.res.log.error(new Error(`Promise may not be fulfilled with 'undefined' when statusCode is not 204`))
-        }
-      }, function (err) {
-        reply.sent = false
-        reply._isError = true
-        reply.send(err)
-      })
+    wrapThenable(result, reply)
   }
 }
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -9,6 +9,7 @@ const statusCodes = require('http').STATUS_CODES
 const flatstr = require('flatstr')
 const FJS = require('fast-json-stringify')
 const runHooks = require('./hookRunner').onSendHookRunner
+const wrapThenable = require('./wrapThenable')
 
 const serializeError = FJS({
   type: 'object',
@@ -306,9 +307,7 @@ function handleError (reply, error, cb) {
     reply._customError = true
     var result = customErrorHandler(error, reply.request, reply)
     if (result && typeof result.then === 'function') {
-      result
-        .then(payload => reply.send(payload))
-        .catch(err => reply.send(err))
+      wrapThenable(result, reply)
     }
     return
   }

--- a/lib/wrapThenable.js
+++ b/lib/wrapThenable.js
@@ -1,0 +1,27 @@
+'use strict'
+
+function wrapThenable (thenable, reply) {
+  thenable.then(function (payload) {
+    // this is for async functions that
+    // are using reply.send directly
+    if (payload !== undefined || (reply.res.statusCode === 204 && reply.sent === false)) {
+      // we use a try-catch internally to avoid adding a catch to another
+      // promise, increase promise perf by 10%
+      try {
+        reply.send(payload)
+      } catch (err) {
+        reply.sent = false
+        reply._isError = true
+        reply.send(err)
+      }
+    } else if (reply.sent === false) {
+      reply.res.log.error(new Error(`Promise may not be fulfilled with 'undefined' when statusCode is not 204`))
+    }
+  }, function (err) {
+    reply.sent = false
+    reply._isError = true
+    reply.send(err)
+  })
+}
+
+module.exports = wrapThenable


### PR DESCRIPTION
Turns out we were not really handling promises well in the error handler. This reuse the same logic of the main handlers. This problems does not apply to the 404 because they go through the normal path anyway.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
