### PR TITLE
Change default plugin timeout to 10 seconds instead of 0

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -189,11 +189,11 @@ fastify.get('/', (request, reply) => {
 <a name="plugin-timeout"></a>
 ### `pluginTimeout`
 
-The maximum amount of time in milliseconds in which a plugin can load.
+The maximum amount of time in *milliseconds* in which a plugin can load.
 If not, [`ready`](https://github.com/fastify/fastify/blob/master/docs/Server.md#ready)
 will complete with an `Error` with code `'ERR_AVVIO_PLUGIN_TIMEOUT'`.
 
-+ Default: `0` (disabled)
++ Default: `10000`
 
 ## Instance
 

--- a/fastify.js
+++ b/fastify.js
@@ -97,7 +97,7 @@ function build (options) {
 
   const app = avvio(fastify, {
     autostart: false,
-    timeout: Number(options.pluginTimeout) || 0
+    timeout: Number(options.pluginTimeout) || 10000
   })
   // Override to allow the plugin incapsulation
   app.override = override

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "http-errors": "^1.6.3",
     "ienoopen": "^1.0.0",
     "joi": "~11.4.0",
+    "lolex": "^2.7.4",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.0.1",
     "pump": "^3.0.0",

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -5,6 +5,7 @@ const test = t.test
 const Fastify = require('..')
 const sget = require('simple-get').concat
 const fp = require('fastify-plugin')
+const lolex = require('lolex')
 
 test('require a plugin', t => {
   t.plan(1)
@@ -502,4 +503,22 @@ test('pluginTimeout', t => {
     t.ok(err)
     t.equal(err.code, 'ERR_AVVIO_PLUGIN_TIMEOUT')
   })
+})
+
+test('pluginTimeout default', t => {
+  t.plan(2)
+  const clock = lolex.install()
+
+  const fastify = Fastify()
+  fastify.register(function (app, opts, next) {
+    // default time elapsed without calling next
+    clock.tick(10000)
+  })
+
+  fastify.ready((err) => {
+    t.ok(err)
+    t.equal(err.code, 'ERR_AVVIO_PLUGIN_TIMEOUT')
+  })
+
+  t.tearDown(clock.uninstall)
 })


### PR DESCRIPTION
Fixes #1090 hopefully right this time 😄 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
