### PR TITLE
added generic Query, Params, Headers, and Body types

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -44,6 +44,122 @@ server.get('/ping', opts, (request, reply) => {
 })
 ```
 
+<a id="generic-parameters"></a>
+## Generic Parameters
+Since you can validate the querystring, params, body, and headers, you can also override the default types of those values on the request interface:
+
+```ts
+import * as fastify from 'fastify'
+
+const server = fastify({})
+
+interface Query {
+  foo?: number
+}
+
+interface Params {
+  bar?: string
+}
+
+interface Body {
+  baz?: string
+}
+
+interface Headers {
+  a?: string
+}
+
+const opts: fastify.RouteShorthandOptions = {
+  schema: {
+    querystring: {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'number'
+        }
+      }
+    },
+    params: {
+      type: 'object',
+      properties: {
+        bar: {
+          type: 'string'
+        }
+      }
+    },
+    body: {
+      type: 'object',
+      properties: {
+        baz: {
+          type: 'string'
+        }
+      }
+    },
+    headers: {
+      type: 'object',
+      properties: {
+        a: {
+          type: 'string'
+        }
+      }
+    }
+  }
+}
+
+server.get<Query, Params, Body, Headers>('/ping/:bar', opts, (request, reply) => {
+  console.log(request.query) // this is of type Query!
+  console.log(request.params) // this is of type Params!
+  console.log(request.body) // this is of type Body!
+  console.log(request.headers) // this is of type Headers!
+  reply.code(200).send({ pong: 'it worked!' })
+})
+```
+
+All generic types are optional, so you can also pass types for the parts you validate with schemas:
+
+```ts
+import * as fastify from 'fastify'
+
+const server = fastify({})
+
+interface Params {
+  bar?: string
+}
+
+const opts: fastify.RouteShorthandOptions = {
+  schema: {
+    params: {
+      type: 'object',
+      properties: {
+        bar: {
+          type: 'string'
+        }
+      }
+    },
+  }
+}
+
+server.get<fastify.DefaultQuery, Params, unknown>('/ping/:bar', opts, (request, reply) => {
+  console.log(request.query) // this is of type fastify.DefaultQuery!
+  console.log(request.params) // this is of type Params!
+  console.log(request.body) // this is of type unknown!
+  console.log(request.headers) // this is of type fastify.DefaultHeader because typescript will use the default type value!
+  reply.code(200).send({ pong: 'it worked!' })
+})
+
+// Given that you haven't validated the querystring, body, or headers, it would be best
+// to type those params as 'unknown'. However, it's up to you. The example below is the
+// best way to prevent you from shooting yourself in the foot. In other words, don't
+// use values you haven't validated.
+server.get<unknown, Params, unknown, unknown>('/ping/:bar', opts, (request, reply) => {
+  console.log(request.query) // this is of type unknown!
+  console.log(request.params) // this is of type Params!
+  console.log(request.body) // this is of type unknown!
+  console.log(request.headers) // this is of type unknown!
+  reply.code(200).send({ pong: 'it worked!' })
+})
+```
+
 <a id="http-prototypes"></a>
 ## HTTP Prototypes
 By default, fastify will determine which version of http is being used based on the options you pass to it. If for any

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -27,11 +27,39 @@ declare namespace fastify {
 
   type Middleware < HttpServer, HttpRequest, HttpResponse > = (this: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, req: HttpRequest, res: HttpResponse, callback: (err?: Error) => void) => void
 
+  type DefaultQuery = { [k: string]: any }
+  type DefaultParams = { [k: string]: any }
+  type DefaultHeaders = { [k: string]: any }
+  type DefaultBody = any
+
   type HTTPMethod = 'DELETE' | 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'OPTIONS'
 
-  type FastifyMiddleware < HttpServer, HttpRequest, HttpResponse > = (this: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, req: FastifyRequest<HttpRequest>, reply: FastifyReply<HttpResponse>, done: (err?: Error) => void) => void
+  type FastifyMiddleware<
+  HttpServer,
+  HttpRequest,
+  HttpResponse,
+  Query = DefaultQuery,
+  Params = DefaultParams,
+  Headers = DefaultHeaders,
+  Body = DefaultBody
+  > = (
+    this: FastifyInstance<HttpServer, HttpRequest, HttpResponse>,
+    req: FastifyRequest<HttpRequest, Query, Params, Headers, Body>,
+    reply: FastifyReply<HttpResponse>,
+    done: (err?: Error) => void,
+  ) => void
 
-  type RequestHandler < HttpRequest, HttpResponse > = (request: FastifyRequest<HttpRequest>, reply: FastifyReply<HttpResponse>) => void | Promise<any>
+  type RequestHandler<
+  HttpRequest,
+  HttpResponse,
+  Query = DefaultQuery,
+  Params = DefaultParams,
+  Headers = DefaultHeaders,
+  Body = DefaultBody
+  > = (
+    request: FastifyRequest<HttpRequest, Query, Params, Headers, Body>,
+    reply: FastifyReply<HttpResponse>,
+  ) => void | Promise<any>
 
   type SchemaCompiler = (schema: Object) => Function
 
@@ -45,28 +73,28 @@ declare namespace fastify {
   /**
    * fastify's wrapped version of node.js IncomingMessage
    */
-  interface FastifyRequest<HttpRequest> {
-    query: {
-      [key: string]: any
-    },
+  interface FastifyRequest<
+    HttpRequest,
+    Query = DefaultQuery,
+    Params = DefaultParams,
+    Headers = DefaultHeaders,
+    Body = DefaultBody
+  > {
+    query: Query
 
-    params: {
-      [key: string]: any
-    },
+    params: Params
 
-    headers: {
-      [key: string]: any
-    },
+    headers: Headers
 
-    body: any,
+    body: Body
 
-    id: any,
+    id: any
 
-    ip: string,
-    hostname: string,
+    ip: string
+    hostname: string
 
-    raw: HttpRequest,
-    req: HttpRequest,
+    raw: HttpRequest
+    req: HttpRequest
     log: pino.Logger
   }
 
@@ -123,22 +151,40 @@ declare namespace fastify {
   /**
    * Optional configuration parameters for the route being created
    */
-  interface RouteShorthandOptions<HttpServer = http.Server, HttpRequest = http.IncomingMessage, HttpResponse = http.ServerResponse> {
+  interface RouteShorthandOptions<
+    HttpServer = http.Server,
+    HttpRequest = http.IncomingMessage,
+    HttpResponse = http.ServerResponse,
+    Query = DefaultQuery,
+    Params = DefaultParams,
+    Headers = DefaultHeaders,
+    Body = DefaultBody
+  > {
     schema?: RouteSchema
-    beforeHandler?: FastifyMiddleware<HttpServer, HttpRequest, HttpResponse> | Array<FastifyMiddleware<HttpServer, HttpRequest, HttpResponse>>
+    beforeHandler?:
+      | FastifyMiddleware<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body>
+      | Array<FastifyMiddleware<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body>>
     schemaCompiler?: SchemaCompiler
-    bodyLimit?: number,
-    logLevel?: string,
+    bodyLimit?: number
+    logLevel?: string
     config?: any
   }
 
   /**
    * Route configuration options such as "url" and "method"
    */
-  interface RouteOptions<HttpServer, HttpRequest, HttpResponse> extends RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse> {
-    method: HTTPMethod|HTTPMethod[],
-    url: string,
-    handler: RequestHandler<HttpRequest, HttpResponse>
+  interface RouteOptions<
+    HttpServer,
+    HttpRequest,
+    HttpResponse,
+    Query = DefaultQuery,
+    Params = DefaultParams,
+    Headers = DefaultHeaders,
+    Body = DefaultBody
+  > extends RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body> {
+    method: HTTPMethod | HTTPMethod[]
+    url: string
+    handler: RequestHandler<HttpRequest, HttpResponse, Query, Params, Headers, Body>
   }
 
   /**
@@ -194,87 +240,145 @@ declare namespace fastify {
     /**
      * Adds a route to the server
      */
-    route(opts: RouteOptions<HttpServer, HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    route<Query = DefaultQuery, Params = DefaultParams, Headers = DefaultHeaders, Body = DefaultBody>(
+      opts: RouteOptions<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+    ): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Defines a GET route with the given mount path, options, and handler
      */
-    get(url: string, opts: RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse>, handler: RequestHandler<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    get<Query = DefaultQuery, Params = DefaultParams, Headers = DefaultHeaders, Body = DefaultBody>(
+      url: string,
+      opts: RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+      handler: RequestHandler<HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+    ): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Defines a GET route with the given mount path and handler
      */
-    get(url: string, handler: RequestHandler<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    get<Query = DefaultQuery, Params = DefaultParams, Headers = DefaultHeaders, Body = DefaultBody>(
+      url: string,
+      handler: RequestHandler<HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+    ): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Defines a PUT route with the given mount path, options, and handler
      */
-    put(url: string, opts: RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse>, handler: RequestHandler<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    put<Query = DefaultQuery, Params = DefaultParams, Headers = DefaultHeaders, Body = DefaultBody>(
+      url: string,
+      opts: RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+      handler: RequestHandler<HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+    ): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Defines a PUT route with the given mount path and handler
      */
-    put(url: string, handler: RequestHandler<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    put<Query = DefaultQuery, Params = DefaultParams, Headers = DefaultHeaders, Body = DefaultBody>(
+      url: string,
+      handler: RequestHandler<HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+    ): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Defines a PATCH route with the given mount path, options, and handler
      */
-    patch(url: string, opts: RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse>, handler: RequestHandler<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    patch<Query = DefaultQuery, Params = DefaultParams, Headers = DefaultHeaders, Body = DefaultBody>(
+      url: string,
+      opts: RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+      handler: RequestHandler<HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+    ): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Defines a PATCH route with the given mount path and handler
      */
-    patch(url: string, handler: RequestHandler<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    patch<Query = DefaultQuery, Params = DefaultParams, Headers = DefaultHeaders, Body = DefaultBody>(
+      url: string,
+      handler: RequestHandler<HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+    ): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Defines a POST route with the given mount path, options, and handler
      */
-    post(url: string, opts: RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse>, handler: RequestHandler<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    post<Query = DefaultQuery, Params = DefaultParams, Headers = DefaultHeaders, Body = DefaultBody>(
+      url: string,
+      opts: RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+      handler: RequestHandler<HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+    ): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Defines a POST route with the given mount path and handler
      */
-    post(url: string, handler: RequestHandler<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    post<Query = DefaultQuery, Params = DefaultParams, Headers = DefaultHeaders, Body = DefaultBody>(
+      url: string,
+      handler: RequestHandler<HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+    ): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Defines a HEAD route with the given mount path, options, and handler
      */
-    head(url: string, opts: RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse>, handler: RequestHandler<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    head<Query = DefaultQuery, Params = DefaultParams, Headers = DefaultHeaders, Body = DefaultBody>(
+      url: string,
+      opts: RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+      handler: RequestHandler<HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+    ): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Defines a HEAD route with the given mount path and handler
      */
-    head(url: string, handler: RequestHandler<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    head<Query = DefaultQuery, Params = DefaultParams, Headers = DefaultHeaders, Body = DefaultBody>(
+      url: string,
+      handler: RequestHandler<HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+    ): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Defines a DELETE route with the given mount path, options, and handler
      */
-    delete(url: string, opts: RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse>, handler: RequestHandler<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    delete<Query = DefaultQuery, Params = DefaultParams, Headers = DefaultHeaders, Body = DefaultBody>(
+      url: string,
+      opts: RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+      handler: RequestHandler<HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+    ): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Defines a DELETE route with the given mount path and handler
      */
-    delete(url: string, handler: RequestHandler<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    delete<Query = DefaultQuery, Params = DefaultParams, Headers = DefaultHeaders, Body = DefaultBody>(
+      url: string,
+      handler: RequestHandler<HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+    ): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Defines a OPTIONS route with the given mount path, options, and handler
      */
-    options(url: string, opts: RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse>, handler: RequestHandler<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    options<Query = DefaultQuery, Params = DefaultParams, Headers = DefaultHeaders, Body = DefaultBody>(
+      url: string,
+      opts: RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+      handler: RequestHandler<HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+    ): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Defines a OPTIONS route with the given mount path and handler
      */
-    options(url: string, handler: RequestHandler<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    options<Query = DefaultQuery, Params = DefaultParams, Headers = DefaultHeaders, Body = DefaultBody>(
+      url: string,
+      handler: RequestHandler<HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+    ): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Defines a route for all the supported methods with the given mount path, options, and handler
      */
-    all(url: string, opts: RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse>, handler: RequestHandler<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    all<Query = DefaultQuery, Params = DefaultParams, Headers = DefaultHeaders, Body = DefaultBody>(
+      url: string,
+      opts: RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+      handler: RequestHandler<HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+    ): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Defines a route for all the supported methods with the given mount path and handler
      */
-    all(url: string, handler: RequestHandler<HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    all<Query = DefaultQuery, Params = DefaultParams, Headers = DefaultHeaders, Body = DefaultBody>(
+      url: string,
+      handler: RequestHandler<HttpRequest, HttpResponse, Query, Params, Headers, Body>,
+    ): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Starts the server on the given port after all the plugins are loaded,

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -173,10 +173,10 @@ server
     reply.send(req.headers)
   })
   .get<{ foo: number }>('/req', function ({ query, headers }, reply) {
-    const foo: number = query.foo
+  const foo: number = query.foo
 
-    reply.send(headers)
-  })
+  reply.send(headers)
+})
   .get('/', opts, function (req, reply) {
     reply.header('Content-Type', 'application/json').code(200)
     reply.send({ hello: 'world' })
@@ -244,6 +244,45 @@ server
   .all('/all/with-opts', opts, function (req, reply) {
     reply.send(req.headers)
   })
+
+// Generics example
+interface Query {
+  foo: string
+  bar: number
+}
+
+interface Params {
+  foo: string
+}
+
+interface Headers {
+  'X-Access-Token': string
+}
+
+interface Body {
+  foo: {
+    bar: {
+      baz: number
+    }
+  }
+}
+
+// Query, Params, Headers, and Body can be provided as generics
+server.get<Query, Params, Headers, Body>('/', ({ query, params, headers, body }, reply) => {
+  const bar: number = query.bar
+  const foo: string = params.foo
+  const xAccessToken: string = headers['X-Access-Token']
+  const baz: number = body.foo.bar.baz
+
+  reply.send({ hello: 'world' })
+})
+
+// Default values are exported for each
+server.get<fastify.DefaultQuery, Params>('/', ({ params }, reply) => {
+  const foo: string = params.foo
+
+  reply.send({ hello: 'world' })
+})
 
 // Using decorate requires casting so the compiler knows about new properties
 server.decorate('utility', () => {})

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -172,6 +172,11 @@ server
   .get('/req', function (req, reply) {
     reply.send(req.headers)
   })
+  .get<{ foo: number }>('/req', function ({ query, headers }, reply) {
+    const foo: number = query.foo
+
+    reply.send(headers)
+  })
   .get('/', opts, function (req, reply) {
     reply.header('Content-Type', 'application/json').code(200)
     reply.send({ hello: 'world' })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

First off, this is a completely non-breaking change for typescript users. The main change here is that I converted the query, params, headers, and body types into generics that default to the existing type definitions. Since we can set the schema validators, I think it makes sense to also allow us to exactly type the pieces that can be validated since we will know exactly what their types should be. However, this should not be required which is why I defaulted these new generic types to their existing values, making this feature completely opt-in for typescript users.

Right now, overriding one of the generic types will be slightly verbose since typescript cannot infer generic parameters when one is overridden out of order, but generic parameter type inference is already on their roadmap for 3.2 (https://github.com/Microsoft/TypeScript/pull/26349). My opinion is that this should be merged now since it isn't breaking, and once 3.2 comes out, it will only be easier.