### PR TITLE
Feature/better error management

### DIFF
--- a/docs/Errros.md
+++ b/docs/Errros.md
@@ -7,3 +7,83 @@
 ### FST_ERR_CTP_ALREADY_PRESENT
 
 The parser for this type was already registered.
+
+<a id="FST_ERR_CTP_INVALID_TYPE"></a>
+### FST_ERR_CTP_INVALID_TYPE
+
+The content type should be a string.
+
+<a id="FST_ERR_CTP_EMPTY_TYPE"></a>
+### FST_ERR_CTP_EMPTY_TYPE
+
+The content type cannot be an empty string.
+
+<a id="FST_ERR_CTP_INVALID_HANDLER"></a>
+### FST_ERR_CTP_INVALID_HANDLER
+
+The content type handler should be a function.
+
+<a id="FST_ERR_CTP_INVALID_PARSE_TYPE"></a>
+### FST_ERR_CTP_INVALID_PARSE_TYPE
+
+The provided parse type is not supported. Accepted values are 'string' or 'buffer'.
+
+<a id="FST_ERR_CTP_BODY_TOO_LARGE"></a>
+### FST_ERR_CTP_BODY_TOO_LARGE
+
+Request body is too large.
+
+<a id="FST_ERR_CTP_INVALID_MEDIA_TYPE"></a>
+### FST_ERR_CTP_INVALID_MEDIA_TYPE
+
+Received media type is not supported (i.e. there is no suitable content-type parser for it).
+
+<a id="FST_ERR_CTP_INVALID_CONTENT_LENGTH"></a>
+### FST_ERR_CTP_INVALID_CONTENT_LENGTH
+
+Request body size did not match Content-Length.
+
+<a id="FST_ERR_DEC_ALREADY_PRESENT"></a>
+### FST_ERR_DEC_ALREADY_PRESENT
+
+A decorator with the same name is already registered.
+
+<a id="FST_ERR_DEC_MISSING_DEPENDENCY"></a>
+### FST_ERR_DEC_MISSING_DEPENDENCY
+
+The decorator cannot be registered due to a missing dependency.
+
+<a id="FST_ERR_HOOK_INVALID_TYPE"></a>
+### FST_ERR_HOOK_INVALID_TYPE
+
+The hook name must be a string.
+
+<a id="FST_ERR_HOOK_INVALID_HANDLER"></a>
+### FST_ERR_HOOK_INVALID_HANDLER
+
+The hook callback must be a function.
+
+<a id="FST_ERR_LOG_INVALID_DESTINATION"></a>
+### FST_ERR_LOG_INVALID_DESTINATION
+
+Logger acceptes either a `stream` or a `file` as the destination.
+
+<a id="FST_ERR_REP_INVALID_PAYLOAD_TYPE"></a>
+### FST_ERR_REP_INVALID_PAYLOAD_TYPE
+
+Reply payload can either be a `string` or a `Buffer`.
+
+<a id="FST_ERR_SCH_MISSING_ID"></a>
+### FST_ERR_SCH_MISSING_ID
+
+The schema provided does not have `$id` property.
+
+<a id="FST_ERR_SCH_ALREADY_PRESENT"></a>
+### FST_ERR_SCH_ALREADY_PRESENT
+
+A schema with the same `id` already exists.
+
+<a id="FST_ERR_SCH_NOT_PRESENT"></a>
+### FST_ERR_SCH_NOT_PRESENT
+
+No schema with the provided `id` exists.

--- a/docs/Errros.md
+++ b/docs/Errros.md
@@ -1,0 +1,9 @@
+<h1 align="center">Fastify</h1>
+
+<a id="fastify-error-codes"></a>
+## Fastify Error Codes
+
+<a id="FST_ERR_CTP_ALREADY_PRESENT"></a>
+### FST_ERR_CTP_ALREADY_PRESENT
+
+The parser for this type was already registered.

--- a/docs/Errros.md
+++ b/docs/Errros.md
@@ -31,7 +31,7 @@ The provided parse type is not supported. Accepted values are 'string' or 'buffe
 <a id="FST_ERR_CTP_BODY_TOO_LARGE"></a>
 ### FST_ERR_CTP_BODY_TOO_LARGE
 
-Request body is too large.
+Request body is larger than the provided limit.
 
 <a id="FST_ERR_CTP_INVALID_MEDIA_TYPE"></a>
 ### FST_ERR_CTP_INVALID_MEDIA_TYPE

--- a/docs/Errros.md
+++ b/docs/Errros.md
@@ -71,7 +71,7 @@ Logger acceptes either a `'stream'` or a `'file'` as the destination.
 <a id="FST_ERR_REP_INVALID_PAYLOAD_TYPE"></a>
 ### FST_ERR_REP_INVALID_PAYLOAD_TYPE
 
-Reply payload can either be a `'string'` or a `'Buffer'`.
+Reply payload can either be a `string` or a `Buffer`.
 
 <a id="FST_ERR_SCH_MISSING_ID"></a>
 ### FST_ERR_SCH_MISSING_ID

--- a/docs/Errros.md
+++ b/docs/Errros.md
@@ -6,7 +6,7 @@
 <a id="FST_ERR_CTP_ALREADY_PRESENT"></a>
 ### FST_ERR_CTP_ALREADY_PRESENT
 
-The parser for this type was already registered.
+The parser for this content type was already registered.
 
 <a id="FST_ERR_CTP_INVALID_TYPE"></a>
 ### FST_ERR_CTP_INVALID_TYPE
@@ -21,7 +21,7 @@ The content type cannot be an empty string.
 <a id="FST_ERR_CTP_INVALID_HANDLER"></a>
 ### FST_ERR_CTP_INVALID_HANDLER
 
-The content type handler should be a function.
+An invalid handler was passed for the content type.
 
 <a id="FST_ERR_CTP_INVALID_PARSE_TYPE"></a>
 ### FST_ERR_CTP_INVALID_PARSE_TYPE

--- a/docs/Errros.md
+++ b/docs/Errros.md
@@ -26,7 +26,7 @@ An invalid handler was passed for the content type.
 <a id="FST_ERR_CTP_INVALID_PARSE_TYPE"></a>
 ### FST_ERR_CTP_INVALID_PARSE_TYPE
 
-The provided parse type is not supported. Accepted values are 'string' or 'buffer'.
+The provided parse type is not supported. Accepted values are `string` or `buffer`.
 
 <a id="FST_ERR_CTP_BODY_TOO_LARGE"></a>
 ### FST_ERR_CTP_BODY_TOO_LARGE
@@ -66,12 +66,12 @@ The hook callback must be a function.
 <a id="FST_ERR_LOG_INVALID_DESTINATION"></a>
 ### FST_ERR_LOG_INVALID_DESTINATION
 
-Logger acceptes either a `stream` or a `file` as the destination.
+Logger acceptes either a `'stream'` or a `'file'` as the destination.
 
 <a id="FST_ERR_REP_INVALID_PAYLOAD_TYPE"></a>
 ### FST_ERR_REP_INVALID_PAYLOAD_TYPE
 
-Reply payload can either be a `string` or a `Buffer`.
+Reply payload can either be a `'string'` or a `'Buffer'`.
 
 <a id="FST_ERR_SCH_MISSING_ID"></a>
 ### FST_ERR_SCH_MISSING_ID
@@ -81,9 +81,9 @@ The schema provided does not have `$id` property.
 <a id="FST_ERR_SCH_ALREADY_PRESENT"></a>
 ### FST_ERR_SCH_ALREADY_PRESENT
 
-A schema with the same `id` already exists.
+A schema with the same `$id` already exists.
 
 <a id="FST_ERR_SCH_NOT_PRESENT"></a>
 ### FST_ERR_SCH_NOT_PRESENT
 
-No schema with the provided `id` exists.
+No schema with the provided `$id` exists.

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -1,6 +1,18 @@
 'use strict'
 
 const lru = require('tiny-lru')
+const {
+  codes: {
+    FST_ERR_CTP_INVALID_TYPE,
+    FST_ERR_CTP_EMPTY_TYPE,
+    FST_ERR_CTP_ALREADY_PRESENT,
+    FST_ERR_CTP_INVALID_HANDLER,
+    FST_ERR_CTP_INVALID_PARSE_TYPE,
+    FST_ERR_CTP_BODY_TOO_LARGE,
+    FST_ERR_CTP_INVALID_MEDIA_TYPE,
+    FST_ERR_CTP_INVALID_CONTENT_LENGTH
+  }
+} = require('./errors')
 
 function ContentTypeParser (bodyLimit) {
   this.customParsers = {}
@@ -10,17 +22,17 @@ function ContentTypeParser (bodyLimit) {
 }
 
 ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
-  if (typeof contentType !== 'string') throw new Error('The content type should be a string')
-  if (contentType.length === 0) throw new Error('The content type cannot be an empty string')
-  if (typeof parserFn !== 'function') throw new Error('The content type handler should be a function')
+  if (typeof contentType !== 'string') throw new FST_ERR_CTP_INVALID_TYPE()
+  if (contentType.length === 0) throw new FST_ERR_CTP_EMPTY_TYPE()
+  if (typeof parserFn !== 'function') throw new FST_ERR_CTP_INVALID_HANDLER()
 
   if (this.hasParser(contentType)) {
-    throw new Error(`Content type parser '${contentType}' already present.`)
+    throw new FST_ERR_CTP_ALREADY_PRESENT(contentType)
   }
 
   if (opts.parseAs !== undefined) {
     if (opts.parseAs !== 'string' && opts.parseAs !== 'buffer') {
-      throw new Error(`The body parser can only parse your data as 'string' or 'buffer', you asked '${opts.parseAs}' which is not supported.`)
+      throw new FST_ERR_CTP_INVALID_PARSE_TYPE(opts.parseAs)
     }
   }
 
@@ -64,7 +76,7 @@ ContentTypeParser.prototype.getParser = function (contentType) {
 ContentTypeParser.prototype.run = function (contentType, handler, request, reply) {
   var parser = this.cache.get(contentType) || this.getParser(contentType)
   if (parser === undefined) {
-    reply.code(415).send(new Error('Unsupported Media Type: ' + contentType))
+    reply.send(new FST_ERR_CTP_INVALID_MEDIA_TYPE(contentType))
   } else {
     if (parser.asString === true || parser.asBuffer === true) {
       rawBody(
@@ -100,7 +112,7 @@ function rawBody (request, reply, options, parser, done) {
     : Number.parseInt(request.headers['content-length'], 10)
 
   if (contentLength > limit) {
-    reply.code(413).send(new Error('Request body is too large'))
+    reply.send(new FST_ERR_CTP_BODY_TOO_LARGE())
     return
   }
 
@@ -119,7 +131,7 @@ function rawBody (request, reply, options, parser, done) {
       req.removeListener('data', onData)
       req.removeListener('end', onEnd)
       req.removeListener('error', onEnd)
-      reply.code(413).send(new Error('Request body is too large'))
+      reply.send(new FST_ERR_CTP_BODY_TOO_LARGE())
       return
     }
 
@@ -141,7 +153,7 @@ function rawBody (request, reply, options, parser, done) {
     }
 
     if (!Number.isNaN(contentLength) && receivedLength !== contentLength) {
-      reply.code(400).send(new Error('Request body size did not match Content-Length'))
+      reply.send(new FST_ERR_CTP_INVALID_CONTENT_LENGTH())
       return
     }
 

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -5,9 +5,16 @@ const {
   kRequest
 } = require('./symbols.js')
 
+const {
+  codes: {
+    FST_ERR_DEC_ALREADY_EXISTS,
+    FST_ERR_DEC_MISSING_DEPENDENCY
+  }
+} = require('./errors')
+
 function decorate (instance, name, fn, dependencies) {
   if (checkExistence(instance, name)) {
-    throw new Error(`The decorator '${name}' has already been added!`)
+    throw new FST_ERR_DEC_ALREADY_EXISTS(name)
   }
 
   if (dependencies) {
@@ -48,7 +55,7 @@ function checkReplyExistence (name) {
 function checkDependencies (instance, deps) {
   for (var i = 0; i < deps.length; i++) {
     if (!checkExistence(instance, deps[i])) {
-      throw new Error(`Fastify decorator: missing dependency: '${deps[i]}'.`)
+      throw new FST_ERR_DEC_MISSING_DEPENDENCY(deps[i])
     }
   }
 }

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -7,14 +7,14 @@ const {
 
 const {
   codes: {
-    FST_ERR_DEC_ALREADY_EXISTS,
+    FST_ERR_DEC_ALREADY_PRESENT,
     FST_ERR_DEC_MISSING_DEPENDENCY
   }
 } = require('./errors')
 
 function decorate (instance, name, fn, dependencies) {
   if (checkExistence(instance, name)) {
-    throw new FST_ERR_DEC_ALREADY_EXISTS(name)
+    throw new FST_ERR_DEC_ALREADY_PRESENT(name)
   }
 
   if (dependencies) {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -43,6 +43,13 @@ createError('FST_ERR_LOG_INVALID_DESTINATION', `Cannot specify both logger.strea
 */
 createError('FST_ERR_REP_INVALID_PAYLOAD_TYPE', `Attempted to send payload of invalid type '%s'. Expected a string or Buffer.`, 500, TypeError)
 
+/**
+ * schemas
+*/
+createError('FST_ERR_SCH_MISSING_ID', `Missing schema $id property`)
+createError('FST_ERR_SCH_ALREADY_PRESENT', `Schema with id '%s' already declared!`)
+createError('FST_ERR_SCH_NOT_PRESENT', `Schema with id '%s' does not exist!`)
+
 function createError (code, message, statusCode = 500, Base = Error) {
   if (!code) throw new Error('Fastify error code must not be empty')
   if (!message) throw new Error('Fastify error message must not be empty')

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -21,6 +21,12 @@ createError('FST_ERR_CTP_BODY_TOO_LARGE', 'Request body is too large', 413, Rang
 createError('FST_ERR_CTP_INVALID_MEDIA_TYPE', `Unsupported Media Type: %s`, 415)
 createError('FST_ERR_CTP_INVALID_CONTENT_LENGTH', 'Request body size did not match Content-Length', 400, RangeError)
 
+/**
+ * decorate
+*/
+createError('FST_ERR_DEC_ALREADY_EXISTS', `The decorator '%s' has already been added!`)
+createError('FST_ERR_DEC_MISSING_DEPENDENCY', `The decorator is missing dependency '%s'.`)
+
 function createError (code, message, statusCode = 500, Base = Error) {
   if (!code) throw new Error('Fastify error code must not be empty')
   if (!message) throw new Error('Fastify error message must not be empty')

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const { inherits, format } = require('util')
+const codes = {}
+
+/**
+ * Basic
+ */
+
+createError('FST_ERR_NOT_FOUND', `Not Found`, 404)
+
+/**
+ * ContentTypeParser
+*/
+createError('FST_ERR_CTP_ALREADY_PRESENT', `Content type parser '%s' already present.`)
+createError('FST_ERR_CTP_INVALID_TYPE', 'The content type should be a string', 500, TypeError)
+createError('FST_ERR_CTP_EMPTY_TYPE', 'The content type cannot be an empty string', 500, TypeError)
+createError('FST_ERR_CTP_INVALID_HANDLER', 'The content type handler should be a function', 500, TypeError)
+createError('FST_ERR_CTP_INVALID_PARSE_TYPE', `The body parser can only parse your data as 'string' or 'buffer', you asked '%s' which is not supported.`, 500, TypeError)
+createError('FST_ERR_CTP_BODY_TOO_LARGE', 'Request body is too large', 413, RangeError)
+createError('FST_ERR_CTP_INVALID_MEDIA_TYPE', `Unsupported Media Type: %s`, 415)
+createError('FST_ERR_CTP_INVALID_CONTENT_LENGTH', 'Request body size did not match Content-Length', 400, RangeError)
+
+function createError (code, message, statusCode = 500, Base = Error) {
+  if (!code) throw new Error('Fastify error code must not be empty')
+  if (!message) throw new Error('Fastify error message must not be empty')
+
+  code = code.toUpperCase()
+
+  function FastifyError (a, b, c) {
+    Error.captureStackTrace(this, FastifyError)
+    this.name = `FastifyError [${code}]`
+    this.code = code
+
+    // more performant than spread (...) operator
+    if (a && b && c) {
+      this.message = format(message, a, b, c)
+    } else if (a && b) {
+      this.message = format(message, a, b)
+    } else if (a) {
+      this.message = format(message, a)
+    } else {
+      this.message = message
+    }
+
+    this.message = `${this.code}: ${this.message}`
+    this.statusCode = statusCode || undefined
+  }
+
+  inherits(FastifyError, Base)
+
+  codes[code] = FastifyError
+
+  return codes[code]
+}
+
+module.exports = { codes, createError }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -33,6 +33,11 @@ createError('FST_ERR_DEC_MISSING_DEPENDENCY', `The decorator is missing dependen
 createError('FST_ERR_HOOK_INVALID_TYPE', `The hook name must be a string`, 500, TypeError)
 createError('FST_ERR_HOOK_INVALID_HANDLER', `The hook callback must be a function`, 500, TypeError)
 
+/**
+ * logger
+*/
+createError('FST_ERR_LOG_INVALID_DESTINATION', `Cannot specify both logger.stream and logger.file options`)
+
 function createError (code, message, statusCode = 500, Base = Error) {
   if (!code) throw new Error('Fastify error code must not be empty')
   if (!message) throw new Error('Fastify error message must not be empty')

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -27,6 +27,12 @@ createError('FST_ERR_CTP_INVALID_CONTENT_LENGTH', 'Request body size did not mat
 createError('FST_ERR_DEC_ALREADY_EXISTS', `The decorator '%s' has already been added!`)
 createError('FST_ERR_DEC_MISSING_DEPENDENCY', `The decorator is missing dependency '%s'.`)
 
+/**
+ * hooks
+*/
+createError('FST_ERR_HOOK_INVALID_TYPE', `The hook name must be a string`, 500, TypeError)
+createError('FST_ERR_HOOK_INVALID_HANDLER', `The hook callback must be a function`, 500, TypeError)
+
 function createError (code, message, statusCode = 500, Base = Error) {
   if (!code) throw new Error('Fastify error code must not be empty')
   if (!message) throw new Error('Fastify error message must not be empty')

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -38,6 +38,11 @@ createError('FST_ERR_HOOK_INVALID_HANDLER', `The hook callback must be a functio
 */
 createError('FST_ERR_LOG_INVALID_DESTINATION', `Cannot specify both logger.stream and logger.file options`)
 
+/**
+ * reply
+*/
+createError('FST_ERR_REP_INVALID_PAYLOAD_TYPE', `Attempted to send payload of invalid type '%s'. Expected a string or Buffer.`, 500, TypeError)
+
 function createError (code, message, statusCode = 500, Base = Error) {
   if (!code) throw new Error('Fastify error code must not be empty')
   if (!message) throw new Error('Fastify error message must not be empty')

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -24,7 +24,7 @@ createError('FST_ERR_CTP_INVALID_CONTENT_LENGTH', 'Request body size did not mat
 /**
  * decorate
 */
-createError('FST_ERR_DEC_ALREADY_EXISTS', `The decorator '%s' has already been added!`)
+createError('FST_ERR_DEC_ALREADY_PRESENT', `The decorator '%s' has already been added!`)
 createError('FST_ERR_DEC_MISSING_DEPENDENCY', `The decorator is missing dependency '%s'.`)
 
 /**

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -9,6 +9,12 @@ const supportedHooks = [
   'onRoute',
   'onClose'
 ]
+const {
+  codes: {
+    FST_ERR_HOOK_INVALID_TYPE,
+    FST_ERR_HOOK_INVALID_HANDLER
+  }
+} = require('./errors')
 
 function Hooks () {
   this.onRequest = []
@@ -18,8 +24,8 @@ function Hooks () {
 }
 
 Hooks.prototype.validate = function (hook, fn) {
-  if (typeof hook !== 'string') throw new TypeError('The hook name must be a string')
-  if (typeof fn !== 'function') throw new TypeError('The hook callback must be a function')
+  if (typeof hook !== 'string') throw new FST_ERR_HOOK_INVALID_TYPE()
+  if (typeof fn !== 'function') throw new FST_ERR_HOOK_INVALID_HANDLER()
   if (supportedHooks.indexOf(hook) === -1) {
     throw new Error(`${hook} hook not supported!`)
   }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -8,13 +8,18 @@
 
 const pino = require('pino')
 const { serializersSym } = pino.symbols
+const {
+  codes: {
+    FST_ERR_LOG_INVALID_DESTINATION
+  }
+} = require('./errors')
 
 function createLogger (opts, stream) {
   stream = stream || opts.stream
   delete opts.stream
 
   if (stream && opts.file) {
-    throw new Error('cannot specify both logger.stream and logger.file options')
+    throw new FST_ERR_LOG_INVALID_DESTINATION()
   } else if (opts.file) {
     // we do not have stream
     stream = pino.destination(opts.file)

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -21,6 +21,7 @@ const serializeError = FJS({
   type: 'object',
   properties: {
     statusCode: { type: 'number' },
+    code: { type: 'string' },
     error: { type: 'string' },
     message: { type: 'string' }
   }
@@ -319,6 +320,7 @@ function handleError (reply, error, cb) {
 
   var payload = serializeError({
     error: statusCodes[statusCode + ''],
+    code: error.code,
     message: error ? error.message : '',
     statusCode: statusCode
   })

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -32,6 +32,11 @@ const CONTENT_TYPE = {
   PLAIN: 'text/plain; charset=utf-8',
   OCTET: 'application/octet-stream'
 }
+const {
+  codes: {
+    FST_ERR_REP_INVALID_PAYLOAD_TYPE
+  }
+} = require('./errors')
 
 var getHeader
 
@@ -220,7 +225,7 @@ function onSendEnd (reply, payload) {
   }
 
   if (typeof payload !== 'string' && !Buffer.isBuffer(payload)) {
-    throw new TypeError(`Attempted to send payload of invalid type '${typeof payload}'. Expected a string or Buffer.`)
+    throw new FST_ERR_REP_INVALID_PAYLOAD_TYPE(typeof payload)
   }
 
   if (!reply._headers['content-length']) {
@@ -421,7 +426,7 @@ function notFound (reply) {
   reply.context.handler(reply.request, reply)
 }
 
-function noop () {}
+function noop () { }
 
 function getHeaderProper (reply, key) {
   key = key.toLowerCase()

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -426,7 +426,7 @@ function notFound (reply) {
   reply.context.handler(reply.request, reply)
 }
 
-function noop () { }
+function noop () {}
 
 function getHeaderProper (reply, key) {
   key = key.toLowerCase()

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -1,5 +1,13 @@
 'use strict'
 
+const {
+  codes: {
+    FST_ERR_SCH_MISSING_ID,
+    FST_ERR_SCH_ALREADY_PRESENT,
+    FST_ERR_SCH_NOT_PRESENT
+  }
+} = require('./errors')
+
 function Schemas () {
   this.store = {}
 }
@@ -7,11 +15,11 @@ function Schemas () {
 Schemas.prototype.add = function (schema) {
   const id = schema['$id']
   if (id === undefined) {
-    throw new Error('Missing schema $id property')
+    throw new FST_ERR_SCH_MISSING_ID()
   }
 
   if (this.store[id] !== undefined) {
-    throw new Error(`Schema with id '${id}' already declared!`)
+    throw new FST_ERR_SCH_ALREADY_PRESENT(id)
   }
 
   this.store[id] = schema
@@ -19,9 +27,7 @@ Schemas.prototype.add = function (schema) {
 
 Schemas.prototype.resolve = function (id) {
   if (this.store[id] === undefined) {
-    const error = new Error(`Schema with id '${id}' does not exist!`)
-    error.code = 404
-    throw error
+    throw new FST_ERR_SCH_NOT_PRESENT(id)
   }
   return this.store[id]
 }
@@ -38,7 +44,7 @@ Schemas.prototype.resolveRefs = function (routeSchemas) {
   } catch (err) {
     // if we have failed because `resolve has thrown
     // let's rethrow the error and let avvio handle it
-    if (err.code === 404) throw err
+    if (/FST_ERR_SCH_*/.test(err.code)) throw err
     return swapSchema
   }
 

--- a/test/custom-parser.test.js
+++ b/test/custom-parser.test.js
@@ -6,16 +6,6 @@ const test = t.test
 const semver = require('semver')
 const sget = require('simple-get').concat
 const Fastify = require('..')
-const {
-  codes: {
-    FST_ERR_CTP_INVALID_TYPE,
-    FST_ERR_CTP_EMPTY_TYPE,
-    FST_ERR_CTP_ALREADY_PRESENT,
-    FST_ERR_CTP_INVALID_HANDLER,
-    FST_ERR_CTP_INVALID_PARSE_TYPE,
-    FST_ERR_CTP_BODY_TOO_LARGE
-  }
-} = require('./../lib/errors')
 
 const jsonParser = require('fast-json-body')
 if (semver.gt(process.versions.node, '8.0.0')) {
@@ -226,11 +216,11 @@ test('contentTypeParser should support encapsulation', t => {
   const fastify = Fastify()
 
   fastify.register((instance, opts, next) => {
-    instance.addContentTypeParser('application/jsoff', () => {})
+    instance.addContentTypeParser('application/jsoff', () => { })
     t.ok(instance.hasContentTypeParser('application/jsoff'))
 
     instance.register((instance, opts, next) => {
-      instance.addContentTypeParser('application/ffosj', () => {})
+      instance.addContentTypeParser('application/ffosj', () => { })
       t.ok(instance.hasContentTypeParser('application/jsoff'))
       t.ok(instance.hasContentTypeParser('application/ffosj'))
       next()
@@ -320,10 +310,10 @@ test('the content type should be a string', t => {
   const fastify = Fastify()
 
   try {
-    fastify.addContentTypeParser(null, () => {})
+    fastify.addContentTypeParser(null, () => { })
     t.fail()
   } catch (err) {
-    t.is(err.message, new FST_ERR_CTP_INVALID_TYPE().message)
+    t.is(err.message, 'FST_ERR_CTP_INVALID_TYPE: The content type should be a string')
   }
 })
 
@@ -332,10 +322,10 @@ test('the content type cannot be an empty string', t => {
   const fastify = Fastify()
 
   try {
-    fastify.addContentTypeParser('', () => {})
+    fastify.addContentTypeParser('', () => { })
     t.fail()
   } catch (err) {
-    t.is(err.message, new FST_ERR_CTP_EMPTY_TYPE().message)
+    t.is(err.message, 'FST_ERR_CTP_EMPTY_TYPE: The content type cannot be an empty string')
   }
 })
 
@@ -347,7 +337,7 @@ test('the content type handler should be a function', t => {
     fastify.addContentTypeParser('aaa', null)
     t.fail()
   } catch (err) {
-    t.is(err.message, new FST_ERR_CTP_INVALID_HANDLER().message)
+    t.is(err.message, 'FST_ERR_CTP_INVALID_HANDLER: The content type handler should be a function')
   }
 })
 
@@ -506,7 +496,7 @@ test('cannot add custom parser after binding', t => {
     t.error(err)
 
     try {
-      fastify.addContentTypeParser('*', () => {})
+      fastify.addContentTypeParser('*', () => { })
       t.fail()
     } catch (e) {
       t.pass()
@@ -566,7 +556,7 @@ test('Can\'t override the json parser multiple times', t => {
       })
     })
   } catch (err) {
-    t.is(err.message, new FST_ERR_CTP_ALREADY_PRESENT('application/json').message)
+    t.is(err.message, 'FST_ERR_CTP_ALREADY_PRESENT: Content type parser \'application/json\' already present.')
   }
 })
 
@@ -770,10 +760,10 @@ test('Wrong parseAs parameter', t => {
   const fastify = Fastify()
 
   try {
-    fastify.addContentTypeParser('application/json', { parseAs: 'fireworks' }, () => {})
+    fastify.addContentTypeParser('application/json', { parseAs: 'fireworks' }, () => { })
     t.fail('should throw')
   } catch (err) {
-    t.is(err.message, new FST_ERR_CTP_INVALID_PARSE_TYPE('fireworks').message)
+    t.is(err.message, `FST_ERR_CTP_INVALID_PARSE_TYPE: The body parser can only parse your data as 'string' or 'buffer', you asked 'fireworks' which is not supported.`)
   }
 })
 
@@ -807,12 +797,11 @@ test('Should allow defining the bodyLimit per parser', t => {
       }
     }, (err, response, body) => {
       t.error(err)
-      const expectedError = new FST_ERR_CTP_BODY_TOO_LARGE()
       t.strictDeepEqual(JSON.parse(body.toString()), {
-        statusCode: expectedError.statusCode,
-        code: expectedError.code,
+        statusCode: 413,
+        code: 'FST_ERR_CTP_BODY_TOO_LARGE',
         error: 'Payload Too Large',
-        message: expectedError.message
+        message: 'FST_ERR_CTP_BODY_TOO_LARGE: Request body is too large'
       })
       fastify.close()
     })
@@ -847,12 +836,11 @@ test('route bodyLimit should take precedence over a custom parser bodyLimit', t 
       headers: { 'Content-Type': 'x/foo' }
     }, (err, response, body) => {
       t.error(err)
-      const expectedError = new FST_ERR_CTP_BODY_TOO_LARGE()
       t.strictDeepEqual(JSON.parse(body.toString()), {
-        statusCode: expectedError.statusCode,
-        code: expectedError.code,
+        statusCode: 413,
+        code: 'FST_ERR_CTP_BODY_TOO_LARGE',
         error: 'Payload Too Large',
-        message: expectedError.message
+        message: 'FST_ERR_CTP_BODY_TOO_LARGE: Request body is too large'
       })
       fastify.close()
     })

--- a/test/custom-parser.test.js
+++ b/test/custom-parser.test.js
@@ -216,11 +216,11 @@ test('contentTypeParser should support encapsulation', t => {
   const fastify = Fastify()
 
   fastify.register((instance, opts, next) => {
-    instance.addContentTypeParser('application/jsoff', () => { })
+    instance.addContentTypeParser('application/jsoff', () => {})
     t.ok(instance.hasContentTypeParser('application/jsoff'))
 
     instance.register((instance, opts, next) => {
-      instance.addContentTypeParser('application/ffosj', () => { })
+      instance.addContentTypeParser('application/ffosj', () => {})
       t.ok(instance.hasContentTypeParser('application/jsoff'))
       t.ok(instance.hasContentTypeParser('application/ffosj'))
       next()
@@ -310,7 +310,7 @@ test('the content type should be a string', t => {
   const fastify = Fastify()
 
   try {
-    fastify.addContentTypeParser(null, () => { })
+    fastify.addContentTypeParser(null, () => {})
     t.fail()
   } catch (err) {
     t.is(err.message, 'FST_ERR_CTP_INVALID_TYPE: The content type should be a string')
@@ -322,7 +322,7 @@ test('the content type cannot be an empty string', t => {
   const fastify = Fastify()
 
   try {
-    fastify.addContentTypeParser('', () => { })
+    fastify.addContentTypeParser('', () => {})
     t.fail()
   } catch (err) {
     t.is(err.message, 'FST_ERR_CTP_EMPTY_TYPE: The content type cannot be an empty string')
@@ -496,7 +496,7 @@ test('cannot add custom parser after binding', t => {
     t.error(err)
 
     try {
-      fastify.addContentTypeParser('*', () => { })
+      fastify.addContentTypeParser('*', () => {})
       t.fail()
     } catch (e) {
       t.pass()
@@ -760,7 +760,7 @@ test('Wrong parseAs parameter', t => {
   const fastify = Fastify()
 
   try {
-    fastify.addContentTypeParser('application/json', { parseAs: 'fireworks' }, () => { })
+    fastify.addContentTypeParser('application/json', { parseAs: 'fireworks' }, () => {})
     t.fail('should throw')
   } catch (err) {
     t.is(err.message, `FST_ERR_CTP_INVALID_PARSE_TYPE: The body parser can only parse your data as 'string' or 'buffer', you asked 'fireworks' which is not supported.`)

--- a/test/custom-parser.test.js
+++ b/test/custom-parser.test.js
@@ -810,6 +810,7 @@ test('Should allow defining the bodyLimit per parser', t => {
       const expectedError = new FST_ERR_CTP_BODY_TOO_LARGE()
       t.strictDeepEqual(JSON.parse(body.toString()), {
         statusCode: expectedError.statusCode,
+        code: expectedError.code,
         error: 'Payload Too Large',
         message: expectedError.message
       })
@@ -849,6 +850,7 @@ test('route bodyLimit should take precedence over a custom parser bodyLimit', t 
       const expectedError = new FST_ERR_CTP_BODY_TOO_LARGE()
       t.strictDeepEqual(JSON.parse(body.toString()), {
         statusCode: expectedError.statusCode,
+        code: expectedError.code,
         error: 'Payload Too Large',
         message: expectedError.message
       })

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -19,7 +19,7 @@ test('server methods should be incapsulated via .register', t => {
   const fastify = Fastify()
 
   fastify.register((instance, opts, next) => {
-    instance.decorate('test', () => {})
+    instance.decorate('test', () => { })
     t.ok(instance.test)
     next()
   })
@@ -34,7 +34,7 @@ test('hasServerMethod should check if the given method already exist', t => {
   const fastify = Fastify()
 
   fastify.register((instance, opts, next) => {
-    instance.decorate('test', () => {})
+    instance.decorate('test', () => { })
     t.ok(instance.hasDecorator('test'))
     next()
   })
@@ -50,10 +50,10 @@ test('decorate should throw if a declared dependency is not present', t => {
 
   fastify.register((instance, opts, next) => {
     try {
-      instance.decorate('test', () => {}, ['dependency'])
+      instance.decorate('test', () => { }, ['dependency'])
       t.fail()
     } catch (e) {
-      t.is(e.message, 'Fastify decorator: missing dependency: \'dependency\'.')
+      t.is(e.message, 'FST_ERR_DEC_MISSING_DEPENDENCY: The decorator is missing dependency \'dependency\'.')
     }
     next()
   })

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -19,7 +19,7 @@ test('server methods should be incapsulated via .register', t => {
   const fastify = Fastify()
 
   fastify.register((instance, opts, next) => {
-    instance.decorate('test', () => { })
+    instance.decorate('test', () => {})
     t.ok(instance.test)
     next()
   })
@@ -34,7 +34,7 @@ test('hasServerMethod should check if the given method already exist', t => {
   const fastify = Fastify()
 
   fastify.register((instance, opts, next) => {
-    instance.decorate('test', () => { })
+    instance.decorate('test', () => {})
     t.ok(instance.hasDecorator('test'))
     next()
   })
@@ -50,7 +50,7 @@ test('decorate should throw if a declared dependency is not present', t => {
 
   fastify.register((instance, opts, next) => {
     try {
-      instance.decorate('test', () => { }, ['dependency'])
+      instance.decorate('test', () => {}, ['dependency'])
       t.fail()
     } catch (e) {
       t.is(e.message, 'FST_ERR_DEC_MISSING_DEPENDENCY: The decorator is missing dependency \'dependency\'.')

--- a/test/internals/decorator.test.js
+++ b/test/internals/decorator.test.js
@@ -9,11 +9,11 @@ test('decorate should add the given method to its instance', t => {
   function build () {
     server.add = decorator.add
     return server
-    function server () {}
+    function server () { }
   }
 
   const server = build()
-  server.add('test', () => {})
+  server.add('test', () => { })
   t.ok(server.test)
 })
 
@@ -22,14 +22,14 @@ test('decorate is chainable', t => {
   function build () {
     server.add = decorator.add
     return server
-    function server () {}
+    function server () { }
   }
 
   const server = build()
   server
-    .add('test1', () => {})
-    .add('test2', () => {})
-    .add('test3', () => {})
+    .add('test1', () => { })
+    .add('test2', () => { })
+    .add('test3', () => { })
 
   t.ok(server.test1)
   t.ok(server.test2)
@@ -38,7 +38,7 @@ test('decorate is chainable', t => {
 
 test('checkExistence should check if a property is part of the given instance', t => {
   t.plan(1)
-  const instance = { test: () => {} }
+  const instance = { test: () => { } }
   t.ok(decorator.exist(instance, 'test'))
 })
 
@@ -48,18 +48,18 @@ test('checkExistence should find the instance if not given', t => {
     server.add = decorator.add
     server.check = decorator.exist
     return server
-    function server () {}
+    function server () { }
   }
 
   const server = build()
-  server.add('test', () => {})
+  server.add('test', () => { })
   t.ok(server.check('test'))
 })
 
 test('checkExistence should check the prototype as well', t => {
   t.plan(1)
-  function Instance () {}
-  Instance.prototype.test = () => {}
+  function Instance () { }
+  Instance.prototype.test = () => { }
 
   const instance = new Instance()
   t.ok(decorator.exist(instance, 'test'))
@@ -72,7 +72,7 @@ test('checkDependencies should throw if a dependency is not present', t => {
     decorator.dependencies(instance, ['test'])
     t.fail()
   } catch (e) {
-    t.is(e.message, 'Fastify decorator: missing dependency: \'test\'.')
+    t.is(e.message, 'FST_ERR_DEC_MISSING_DEPENDENCY: The decorator is missing dependency \'test\'.')
   }
 })
 
@@ -81,16 +81,16 @@ test('decorate should internally call checkDependencies', t => {
   function build () {
     server.add = decorator.add
     return server
-    function server () {}
+    function server () { }
   }
 
   const server = build()
 
   try {
-    server.add('method', () => {}, ['test'])
+    server.add('method', () => { }, ['test'])
     t.fail()
   } catch (e) {
-    t.is(e.message, 'Fastify decorator: missing dependency: \'test\'.')
+    t.is(e.message, 'FST_ERR_DEC_MISSING_DEPENDENCY: The decorator is missing dependency \'test\'.')
   }
 })
 

--- a/test/internals/decorator.test.js
+++ b/test/internals/decorator.test.js
@@ -9,11 +9,11 @@ test('decorate should add the given method to its instance', t => {
   function build () {
     server.add = decorator.add
     return server
-    function server () { }
+    function server () {}
   }
 
   const server = build()
-  server.add('test', () => { })
+  server.add('test', () => {})
   t.ok(server.test)
 })
 
@@ -22,14 +22,14 @@ test('decorate is chainable', t => {
   function build () {
     server.add = decorator.add
     return server
-    function server () { }
+    function server () {}
   }
 
   const server = build()
   server
-    .add('test1', () => { })
-    .add('test2', () => { })
-    .add('test3', () => { })
+    .add('test1', () => {})
+    .add('test2', () => {})
+    .add('test3', () => {})
 
   t.ok(server.test1)
   t.ok(server.test2)
@@ -38,7 +38,7 @@ test('decorate is chainable', t => {
 
 test('checkExistence should check if a property is part of the given instance', t => {
   t.plan(1)
-  const instance = { test: () => { } }
+  const instance = { test: () => {} }
   t.ok(decorator.exist(instance, 'test'))
 })
 
@@ -48,48 +48,50 @@ test('checkExistence should find the instance if not given', t => {
     server.add = decorator.add
     server.check = decorator.exist
     return server
-    function server () { }
+    function server () {}
   }
 
   const server = build()
-  server.add('test', () => { })
+  server.add('test', () => {})
   t.ok(server.check('test'))
 })
 
 test('checkExistence should check the prototype as well', t => {
   t.plan(1)
-  function Instance () { }
-  Instance.prototype.test = () => { }
+  function Instance () {}
+  Instance.prototype.test = () => {}
 
   const instance = new Instance()
   t.ok(decorator.exist(instance, 'test'))
 })
 
 test('checkDependencies should throw if a dependency is not present', t => {
-  t.plan(1)
+  t.plan(2)
   const instance = {}
   try {
     decorator.dependencies(instance, ['test'])
     t.fail()
   } catch (e) {
+    t.is(e.code, 'FST_ERR_DEC_MISSING_DEPENDENCY')
     t.is(e.message, 'FST_ERR_DEC_MISSING_DEPENDENCY: The decorator is missing dependency \'test\'.')
   }
 })
 
 test('decorate should internally call checkDependencies', t => {
-  t.plan(1)
+  t.plan(2)
   function build () {
     server.add = decorator.add
     return server
-    function server () { }
+    function server () {}
   }
 
   const server = build()
 
   try {
-    server.add('method', () => { }, ['test'])
+    server.add('method', () => {}, ['test'])
     t.fail()
   } catch (e) {
+    t.is(e.code, 'FST_ERR_DEC_MISSING_DEPENDENCY')
     t.is(e.message, 'FST_ERR_DEC_MISSING_DEPENDENCY: The decorator is missing dependency \'test\'.')
   }
 })

--- a/test/internals/errors.test.js
+++ b/test/internals/errors.test.js
@@ -1,0 +1,96 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const { createError } = require('../../lib/errors')
+
+test('Create error with zero parameter', t => {
+  t.plan(6)
+  const NewError = createError('CODE', 'Not available')
+  const err = new NewError()
+  t.type(err, Error)
+  t.equal(err.name, 'FastifyError [CODE]')
+  t.equal(err.message, 'CODE: Not available')
+  t.equal(err.code, 'CODE')
+  t.equal(err.statusCode, 500)
+  t.ok(err.stack)
+})
+
+test('Create error with 1 parameter', t => {
+  t.plan(6)
+  const NewError = createError('CODE', 'hey %s')
+  const err = new NewError('alice')
+  t.type(err, Error)
+  t.equal(err.name, 'FastifyError [CODE]')
+  t.equal(err.message, 'CODE: hey alice')
+  t.equal(err.code, 'CODE')
+  t.equal(err.statusCode, 500)
+  t.ok(err.stack)
+})
+
+test('Create error with 2 parameters', t => {
+  t.plan(6)
+  const NewError = createError('CODE', 'hey %s, I like your %s')
+  const err = new NewError('alice', 'attitude')
+  t.type(err, Error)
+  t.equal(err.name, 'FastifyError [CODE]')
+  t.equal(err.message, 'CODE: hey alice, I like your attitude')
+  t.equal(err.code, 'CODE')
+  t.equal(err.statusCode, 500)
+  t.ok(err.stack)
+})
+
+test('Create error with 3 parameters', t => {
+  t.plan(6)
+  const NewError = createError('CODE', 'hey %s, I like your %s %s')
+  const err = new NewError('alice', 'attitude', 'see you')
+  t.type(err, Error)
+  t.equal(err.name, 'FastifyError [CODE]')
+  t.equal(err.message, 'CODE: hey alice, I like your attitude see you')
+  t.equal(err.code, 'CODE')
+  t.equal(err.statusCode, 500)
+  t.ok(err.stack)
+})
+
+test('Create error with no statusCode property', t => {
+  t.plan(6)
+  const NewError = createError('CODE', 'hey %s', 0)
+  const err = new NewError('dude')
+  t.type(err, Error)
+  t.equal(err.name, 'FastifyError [CODE]')
+  t.equal(err.message, 'CODE: hey dude')
+  t.equal(err.code, 'CODE')
+  t.notOk(err.statusCode)
+  t.ok(err.stack)
+})
+
+test('Should throw when error code has no fastify code', t => {
+  t.plan(1)
+  try {
+    createError()
+  } catch (err) {
+    t.equal(err.message, 'Fastify error code must not be empty')
+  }
+})
+
+test('Should throw when error code has no message', t => {
+  t.plan(1)
+  try {
+    createError('code')
+  } catch (err) {
+    t.equal(err.message, `Fastify error message must not be empty`)
+  }
+})
+
+test('Create error with different base', t => {
+  t.plan(7)
+  const NewError = createError('CODE', 'hey %s', 500, TypeError)
+  const err = new NewError('dude')
+  t.type(err, Error)
+  t.type(err, TypeError)
+  t.equal(err.name, 'FastifyError [CODE]')
+  t.equal(err.message, 'CODE: hey dude')
+  t.equal(err.code, 'CODE')
+  t.equal(err.statusCode, 500)
+  t.ok(err.stack)
+})

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -47,7 +47,7 @@ test('handler function - invalid schema', t => {
   res.writeHead = () => {
     return
   }
-  res.log = { error: () => { }, info: () => { } }
+  res.log = { error: () => {}, info: () => {} }
   const context = {
     schema: {
       body: {
@@ -57,7 +57,7 @@ test('handler function - invalid schema', t => {
         }
       }
     },
-    handler: () => { },
+    handler: () => {},
     Reply: Reply,
     Request: Request,
     preHandler: [],

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -47,7 +47,7 @@ test('handler function - invalid schema', t => {
   res.writeHead = () => {
     return
   }
-  res.log = { error: () => {}, info: () => {} }
+  res.log = { error: () => { }, info: () => { } }
   const context = {
     schema: {
       body: {
@@ -57,7 +57,7 @@ test('handler function - invalid schema', t => {
         }
       }
     },
-    handler: () => {},
+    handler: () => { },
     Reply: Reply,
     Request: Request,
     preHandler: [],
@@ -206,9 +206,10 @@ test('request should respond with an error if an unserialized payload is sent in
   }, (err, res) => {
     t.error(err)
     t.strictEqual(res.statusCode, 500)
-    t.deepEqual(JSON.parse(res.payload), {
+    t.strictDeepEqual(JSON.parse(res.payload), {
       error: 'Internal Server Error',
-      message: 'Attempted to send payload of invalid type \'object\'. Expected a string or Buffer.',
+      code: 'FST_ERR_REP_INVALID_PAYLOAD_TYPE',
+      message: 'FST_ERR_REP_INVALID_PAYLOAD_TYPE: Attempted to send payload of invalid type \'object\'. Expected a string or Buffer.',
       statusCode: 500
     })
   })

--- a/test/internals/hooks.test.js
+++ b/test/internals/hooks.test.js
@@ -4,7 +4,7 @@ const t = require('tap')
 const test = t.test
 
 const { Hooks } = require('../../lib/hooks')
-const noop = () => { }
+const noop = () => {}
 
 test('hooks should have 4 array with the registered hooks', t => {
   t.plan(5)
@@ -49,11 +49,12 @@ test('hooks should throw on unexisting handler', t => {
 
 test('should throw on wrong parameters', t => {
   const hooks = new Hooks()
-  t.plan(2)
+  t.plan(4)
   try {
     hooks.add(null, noop)
     t.fail()
   } catch (e) {
+    t.is(e.code, 'FST_ERR_HOOK_INVALID_TYPE')
     t.is(e.message, 'FST_ERR_HOOK_INVALID_TYPE: The hook name must be a string')
   }
 
@@ -61,6 +62,7 @@ test('should throw on wrong parameters', t => {
     hooks.add('', null)
     t.fail()
   } catch (e) {
+    t.is(e.code, 'FST_ERR_HOOK_INVALID_HANDLER')
     t.is(e.message, 'FST_ERR_HOOK_INVALID_HANDLER: The hook callback must be a function')
   }
 })

--- a/test/internals/hooks.test.js
+++ b/test/internals/hooks.test.js
@@ -4,7 +4,7 @@ const t = require('tap')
 const test = t.test
 
 const { Hooks } = require('../../lib/hooks')
-const noop = () => {}
+const noop = () => { }
 
 test('hooks should have 4 array with the registered hooks', t => {
   t.plan(5)
@@ -54,13 +54,13 @@ test('should throw on wrong parameters', t => {
     hooks.add(null, noop)
     t.fail()
   } catch (e) {
-    t.is(e.message, 'The hook name must be a string')
+    t.is(e.message, 'FST_ERR_HOOK_INVALID_TYPE: The hook name must be a string')
   }
 
   try {
     hooks.add('', null)
     t.fail()
   } catch (e) {
-    t.is(e.message, 'The hook callback must be a function')
+    t.is(e.message, 'FST_ERR_HOOK_INVALID_HANDLER: The hook callback must be a function')
   }
 })

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -22,7 +22,7 @@ test('fastify.register with fastify-plugin should not incapsulate his code', t =
 
   fastify.register((instance, opts, next) => {
     instance.register(fp((i, o, n) => {
-      i.decorate('test', () => { })
+      i.decorate('test', () => {})
       t.ok(i.test)
       n()
     }))
@@ -133,14 +133,14 @@ test('check dependencies - should not throw', t => {
 
   fastify.register((instance, opts, next) => {
     instance.register(fp((i, o, n) => {
-      i.decorate('test', () => { })
+      i.decorate('test', () => {})
       t.ok(i.test)
       n()
     }))
 
     instance.register(fp((i, o, n) => {
       try {
-        i.decorate('otherTest', () => { }, ['test'])
+        i.decorate('otherTest', () => {}, ['test'])
         t.ok(i.test)
         t.ok(i.otherTest)
         n()
@@ -180,22 +180,23 @@ test('check dependencies - should not throw', t => {
 })
 
 test('check dependencies - should throw', t => {
-  t.plan(11)
+  t.plan(12)
   const fastify = Fastify()
 
   fastify.register((instance, opts, next) => {
     instance.register(fp((i, o, n) => {
       try {
-        i.decorate('otherTest', () => { }, ['test'])
+        i.decorate('otherTest', () => {}, ['test'])
         t.fail()
       } catch (e) {
+        t.is(e.code, 'FST_ERR_DEC_MISSING_DEPENDENCY')
         t.is(e.message, 'FST_ERR_DEC_MISSING_DEPENDENCY: The decorator is missing dependency \'test\'.')
       }
       n()
     }))
 
     instance.register(fp((i, o, n) => {
-      i.decorate('test', () => { })
+      i.decorate('test', () => {})
       t.ok(i.test)
       t.notOk(i.otherTest)
       n()

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -22,7 +22,7 @@ test('fastify.register with fastify-plugin should not incapsulate his code', t =
 
   fastify.register((instance, opts, next) => {
     instance.register(fp((i, o, n) => {
-      i.decorate('test', () => {})
+      i.decorate('test', () => { })
       t.ok(i.test)
       n()
     }))
@@ -133,14 +133,14 @@ test('check dependencies - should not throw', t => {
 
   fastify.register((instance, opts, next) => {
     instance.register(fp((i, o, n) => {
-      i.decorate('test', () => {})
+      i.decorate('test', () => { })
       t.ok(i.test)
       n()
     }))
 
     instance.register(fp((i, o, n) => {
       try {
-        i.decorate('otherTest', () => {}, ['test'])
+        i.decorate('otherTest', () => { }, ['test'])
         t.ok(i.test)
         t.ok(i.otherTest)
         n()
@@ -186,16 +186,16 @@ test('check dependencies - should throw', t => {
   fastify.register((instance, opts, next) => {
     instance.register(fp((i, o, n) => {
       try {
-        i.decorate('otherTest', () => {}, ['test'])
+        i.decorate('otherTest', () => { }, ['test'])
         t.fail()
       } catch (e) {
-        t.is(e.message, 'Fastify decorator: missing dependency: \'test\'.')
+        t.is(e.message, 'FST_ERR_DEC_MISSING_DEPENDENCY: The decorator is missing dependency \'test\'.')
       }
       n()
     }))
 
     instance.register(fp((i, o, n) => {
-      i.decorate('test', () => {})
+      i.decorate('test', () => { })
       t.ok(i.test)
       t.notOk(i.otherTest)
       n()

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -53,7 +53,7 @@ test('preHandler hook error handling with external code', t => {
     done(err)
   })
 
-  fastify.get('/', () => { })
+  fastify.get('/', () => {})
 
   fastify.inject({
     method: 'GET',
@@ -82,7 +82,7 @@ test('onRequest hook error handling with external done', t => {
     done(err)
   })
 
-  fastify.get('/', () => { })
+  fastify.get('/', () => {})
 
   fastify.inject({
     method: 'GET',
@@ -350,7 +350,7 @@ test('should set the status code and the headers from the error object (from cus
 
 // Issue 595 https://github.com/fastify/fastify/issues/595
 test('\'*\' should throw an error due to serializer can not handle the payload type', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
 
   fastify.get('/', (req, reply) => {
@@ -359,7 +359,8 @@ test('\'*\' should throw an error due to serializer can not handle the payload t
       reply.send({})
     } catch (err) {
       t.type(err, TypeError)
-      t.strictEqual(err.message, "FST_ERR_REP_INVALID_PAYLOAD_TYPE: Attempted to send payload of invalid type 'object'. Expected a string or Buffer.")
+      t.is(err.code, 'FST_ERR_REP_INVALID_PAYLOAD_TYPE')
+      t.is(err.message, "FST_ERR_REP_INVALID_PAYLOAD_TYPE: Attempted to send payload of invalid type 'object'. Expected a string or Buffer.")
     }
   })
 
@@ -372,7 +373,7 @@ test('\'*\' should throw an error due to serializer can not handle the payload t
 })
 
 test('should throw an error if the custom serializer does not serialize the payload to a valid type', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
 
   fastify.get('/', (req, reply) => {
@@ -383,7 +384,8 @@ test('should throw an error if the custom serializer does not serialize the payl
         .send({})
     } catch (err) {
       t.type(err, TypeError)
-      t.strictEqual(err.message, "FST_ERR_REP_INVALID_PAYLOAD_TYPE: Attempted to send payload of invalid type 'object'. Expected a string or Buffer.")
+      t.is(err.code, 'FST_ERR_REP_INVALID_PAYLOAD_TYPE')
+      t.is(err.message, "FST_ERR_REP_INVALID_PAYLOAD_TYPE: Attempted to send payload of invalid type 'object'. Expected a string or Buffer.")
     }
   })
 

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -53,7 +53,7 @@ test('preHandler hook error handling with external code', t => {
     done(err)
   })
 
-  fastify.get('/', () => {})
+  fastify.get('/', () => { })
 
   fastify.inject({
     method: 'GET',
@@ -82,7 +82,7 @@ test('onRequest hook error handling with external done', t => {
     done(err)
   })
 
-  fastify.get('/', () => {})
+  fastify.get('/', () => { })
 
   fastify.inject({
     method: 'GET',
@@ -359,7 +359,7 @@ test('\'*\' should throw an error due to serializer can not handle the payload t
       reply.send({})
     } catch (err) {
       t.type(err, TypeError)
-      t.strictEqual(err.message, "Attempted to send payload of invalid type 'object'. Expected a string or Buffer.")
+      t.strictEqual(err.message, "FST_ERR_REP_INVALID_PAYLOAD_TYPE: Attempted to send payload of invalid type 'object'. Expected a string or Buffer.")
     }
   })
 
@@ -383,7 +383,7 @@ test('should throw an error if the custom serializer does not serialize the payl
         .send({})
     } catch (err) {
       t.type(err, TypeError)
-      t.strictEqual(err.message, "Attempted to send payload of invalid type 'object'. Expected a string or Buffer.")
+      t.strictEqual(err.message, "FST_ERR_REP_INVALID_PAYLOAD_TYPE: Attempted to send payload of invalid type 'object'. Expected a string or Buffer.")
     }
   })
 

--- a/test/shared-schemas.test.js
+++ b/test/shared-schemas.test.js
@@ -44,30 +44,32 @@ test('The schemas should be accessible via getSchemas', t => {
 })
 
 test('Should throw if the $id property is missing', t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
 
   try {
     fastify.addSchema({ type: 'string' })
   } catch (err) {
+    t.is(err.code, 'FST_ERR_SCH_MISSING_ID')
     t.is(err.message, 'FST_ERR_SCH_MISSING_ID: Missing schema $id property')
   }
 })
 
 test('Cannot add multiple times the same id', t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
 
   fastify.addSchema({ $id: 'id' })
   try {
     fastify.addSchema({ $id: 'id' })
   } catch (err) {
+    t.is(err.code, 'FST_ERR_SCH_ALREADY_PRESENT')
     t.is(err.message, 'FST_ERR_SCH_ALREADY_PRESENT: Schema with id \'id\' already declared!')
   }
 })
 
 test('Should throw of the schema does not exists', t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
 
   fastify.route({
@@ -82,6 +84,7 @@ test('Should throw of the schema does not exists', t => {
   })
 
   fastify.ready(err => {
+    t.is(err.code, 'FST_ERR_SCH_NOT_PRESENT')
     t.is(err.message, 'FST_ERR_SCH_NOT_PRESENT: Schema with id \'test\' does not exist!')
   })
 })
@@ -359,7 +362,7 @@ test('Use the same schema id in diferent places', t => {
         }
       }
     },
-    handler: () => { }
+    handler: () => {}
   })
 
   fastify.route({
@@ -371,7 +374,7 @@ test('Use the same schema id in diferent places', t => {
         200: 'test#'
       }
     },
-    handler: () => { }
+    handler: () => {}
   })
 
   fastify.ready(err => {
@@ -476,7 +479,7 @@ test('Get schema anyway should not add `properties` if allOf is present', t => {
       querystring: 'second#',
       response: { 200: 'second#' }
     },
-    handler: () => { }
+    handler: () => {}
   })
 
   fastify.ready(t.error)
@@ -515,7 +518,7 @@ test('Get schema anyway should not add `properties` if oneOf is present', t => {
       querystring: 'second#',
       response: { 200: 'second#' }
     },
-    handler: () => { }
+    handler: () => {}
   })
 
   fastify.ready(t.error)
@@ -554,7 +557,7 @@ test('Get schema anyway should not add `properties` if anyOf is present', t => {
       querystring: 'second#',
       response: { 200: 'second#' }
     },
-    handler: () => { }
+    handler: () => {}
   })
 
   fastify.ready(t.error)

--- a/test/shared-schemas.test.js
+++ b/test/shared-schemas.test.js
@@ -50,7 +50,7 @@ test('Should throw if the $id property is missing', t => {
   try {
     fastify.addSchema({ type: 'string' })
   } catch (err) {
-    t.is(err.message, 'Missing schema $id property')
+    t.is(err.message, 'FST_ERR_SCH_MISSING_ID: Missing schema $id property')
   }
 })
 
@@ -62,7 +62,7 @@ test('Cannot add multiple times the same id', t => {
   try {
     fastify.addSchema({ $id: 'id' })
   } catch (err) {
-    t.is(err.message, 'Schema with id \'id\' already declared!')
+    t.is(err.message, 'FST_ERR_SCH_ALREADY_PRESENT: Schema with id \'id\' already declared!')
   }
 })
 
@@ -82,7 +82,7 @@ test('Should throw of the schema does not exists', t => {
   })
 
   fastify.ready(err => {
-    t.is(err.message, 'Schema with id \'test\' does not exist!')
+    t.is(err.message, 'FST_ERR_SCH_NOT_PRESENT: Schema with id \'test\' does not exist!')
   })
 })
 
@@ -359,7 +359,7 @@ test('Use the same schema id in diferent places', t => {
         }
       }
     },
-    handler: () => {}
+    handler: () => { }
   })
 
   fastify.route({
@@ -371,7 +371,7 @@ test('Use the same schema id in diferent places', t => {
         200: 'test#'
       }
     },
-    handler: () => {}
+    handler: () => { }
   })
 
   fastify.ready(err => {
@@ -476,7 +476,7 @@ test('Get schema anyway should not add `properties` if allOf is present', t => {
       querystring: 'second#',
       response: { 200: 'second#' }
     },
-    handler: () => {}
+    handler: () => { }
   })
 
   fastify.ready(t.error)
@@ -515,7 +515,7 @@ test('Get schema anyway should not add `properties` if oneOf is present', t => {
       querystring: 'second#',
       response: { 200: 'second#' }
     },
-    handler: () => {}
+    handler: () => { }
   })
 
   fastify.ready(t.error)
@@ -554,7 +554,7 @@ test('Get schema anyway should not add `properties` if anyOf is present', t => {
       querystring: 'second#',
       response: { 200: 'second#' }
     },
-    handler: () => {}
+    handler: () => { }
   })
 
   fastify.ready(t.error)

--- a/test/throw.test.js
+++ b/test/throw.test.js
@@ -17,8 +17,8 @@ test('Fastify should throw on wrong options', t => {
 test('Fastify should throw on multiple assignment to the same route', t => {
   t.plan(1)
   const fastify = Fastify()
-  fastify.get('/', () => { })
-  fastify.get('/', () => { })
+  fastify.get('/', () => {})
+  fastify.get('/', () => {})
 
   fastify.ready(err => {
     t.is(err.message, "Method 'GET' already declared for route '/'")
@@ -33,7 +33,7 @@ test('Should throw on unsupported method', t => {
       method: 'TROLL',
       url: '/',
       schema: {},
-      handler: function (req, reply) { }
+      handler: function (req, reply) {}
     })
     t.fail()
   } catch (e) {
@@ -63,7 +63,7 @@ test('Should throw if one method is unsupported', t => {
       method: ['GET', 'TROLL'],
       url: '/',
       schema: {},
-      handler: function (req, reply) { }
+      handler: function (req, reply) {}
     })
     t.fail()
   } catch (e) {
@@ -123,7 +123,7 @@ test('Should throw on duplicate decorator encapsulation', t => {
 })
 
 test('Should throw on duplicate request decorator', t => {
-  t.plan(1)
+  t.plan(2)
 
   const fooObj = {}
   const fastify = Fastify()
@@ -133,12 +133,13 @@ test('Should throw on duplicate request decorator', t => {
     fastify.decorateRequest('foo', fooObj)
     t.fail()
   } catch (e) {
-    t.ok(/has already been added/.test(e.message))
+    t.is(e.code, 'FST_ERR_DEC_ALREADY_PRESENT')
+    t.is(e.message, `FST_ERR_DEC_ALREADY_PRESENT: The decorator 'foo' has already been added!`)
   }
 })
 
 test('Should throw if request decorator dependencies are not met', t => {
-  t.plan(1)
+  t.plan(2)
 
   const fastify = Fastify()
   const fooObj = {}
@@ -147,7 +148,8 @@ test('Should throw if request decorator dependencies are not met', t => {
     fastify.decorateRequest('bar', fooObj, ['world'])
     t.fail()
   } catch (e) {
-    t.ok(/FST_ERR_DEC_MISSING_DEPENDENCY/.test(e.message))
+    t.is(e.code, 'FST_ERR_DEC_MISSING_DEPENDENCY')
+    t.is(e.message, `FST_ERR_DEC_MISSING_DEPENDENCY: The decorator is missing dependency 'world'.`)
   }
 })
 
@@ -268,35 +270,35 @@ test('Should throw if there is handler function as the third parameter to the sh
   const fastify = Fastify()
 
   try {
-    fastify.get('/foo/1', '', (req, res) => { })
+    fastify.get('/foo/1', '', (req, res) => {})
     t.fail()
   } catch (e) {
     t.pass()
   }
 
   try {
-    fastify.get('/foo/2', 1, (req, res) => { })
+    fastify.get('/foo/2', 1, (req, res) => {})
     t.fail()
   } catch (e) {
     t.pass()
   }
 
   try {
-    fastify.get('/foo/3', [], (req, res) => { })
+    fastify.get('/foo/3', [], (req, res) => {})
     t.fail()
   } catch (e) {
     t.pass()
   }
 
   try {
-    fastify.get('/foo/4', undefined, (req, res) => { })
+    fastify.get('/foo/4', undefined, (req, res) => {})
     t.fail()
   } catch (e) {
     t.pass()
   }
 
   try {
-    fastify.get('/foo/5', null, (req, res) => { })
+    fastify.get('/foo/5', null, (req, res) => {})
     t.fail()
   } catch (e) {
     t.pass()
@@ -310,8 +312,8 @@ test('Should throw if found duplicate handler as the third parameter to the shor
 
   try {
     fastify.get('/foo/abc', {
-      handler: (req, res) => { }
-    }, (req, res) => { })
+      handler: (req, res) => {}
+    }, (req, res) => {})
     t.fail()
   } catch (e) {
     t.pass()

--- a/test/throw.test.js
+++ b/test/throw.test.js
@@ -17,8 +17,8 @@ test('Fastify should throw on wrong options', t => {
 test('Fastify should throw on multiple assignment to the same route', t => {
   t.plan(1)
   const fastify = Fastify()
-  fastify.get('/', () => {})
-  fastify.get('/', () => {})
+  fastify.get('/', () => { })
+  fastify.get('/', () => { })
 
   fastify.ready(err => {
     t.is(err.message, "Method 'GET' already declared for route '/'")
@@ -33,7 +33,7 @@ test('Should throw on unsupported method', t => {
       method: 'TROLL',
       url: '/',
       schema: {},
-      handler: function (req, reply) {}
+      handler: function (req, reply) { }
     })
     t.fail()
   } catch (e) {
@@ -63,7 +63,7 @@ test('Should throw if one method is unsupported', t => {
       method: ['GET', 'TROLL'],
       url: '/',
       schema: {},
-      handler: function (req, reply) {}
+      handler: function (req, reply) { }
     })
     t.fail()
   } catch (e) {
@@ -147,7 +147,7 @@ test('Should throw if request decorator dependencies are not met', t => {
     fastify.decorateRequest('bar', fooObj, ['world'])
     t.fail()
   } catch (e) {
-    t.ok(/missing dependency/.test(e.message))
+    t.ok(/FST_ERR_DEC_MISSING_DEPENDENCY/.test(e.message))
   }
 })
 
@@ -268,35 +268,35 @@ test('Should throw if there is handler function as the third parameter to the sh
   const fastify = Fastify()
 
   try {
-    fastify.get('/foo/1', '', (req, res) => {})
+    fastify.get('/foo/1', '', (req, res) => { })
     t.fail()
   } catch (e) {
     t.pass()
   }
 
   try {
-    fastify.get('/foo/2', 1, (req, res) => {})
+    fastify.get('/foo/2', 1, (req, res) => { })
     t.fail()
   } catch (e) {
     t.pass()
   }
 
   try {
-    fastify.get('/foo/3', [], (req, res) => {})
+    fastify.get('/foo/3', [], (req, res) => { })
     t.fail()
   } catch (e) {
     t.pass()
   }
 
   try {
-    fastify.get('/foo/4', undefined, (req, res) => {})
+    fastify.get('/foo/4', undefined, (req, res) => { })
     t.fail()
   } catch (e) {
     t.pass()
   }
 
   try {
-    fastify.get('/foo/5', null, (req, res) => {})
+    fastify.get('/foo/5', null, (req, res) => { })
     t.fail()
   } catch (e) {
     t.pass()
@@ -310,8 +310,8 @@ test('Should throw if found duplicate handler as the third parameter to the shor
 
   try {
     fastify.get('/foo/abc', {
-      handler: (req, res) => {}
-    }, (req, res) => {})
+      handler: (req, res) => { }
+    }, (req, res) => { })
     t.fail()
   } catch (e) {
     t.pass()


### PR DESCRIPTION
This is a first draft of introducing error codes to fastify. It only handles the codes for the contentTypeParser.

# TODO

* [x] Create error codes for all others
* [x] Document the error codes

Previous PR: https://github.com/fastify/fastify/pull/957

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)