### PR TITLE
fix the logic of convert chunk segement into string

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -108,6 +108,10 @@ function rawBody (request, reply, options, parser, done) {
   var body = asString === true ? '' : []
   var req = request.raw
 
+  if (asString === true) {
+    req.setEncoding('utf8')
+  }
+
   req.on('data', onData)
   req.on('end', onEnd)
   req.on('error', onEnd)
@@ -124,7 +128,7 @@ function rawBody (request, reply, options, parser, done) {
     }
 
     if (asString === true) {
-      body += chunk.toString()
+      body += chunk
     } else {
       body.push(chunk)
     }

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -186,3 +186,4 @@ function Parser (asString, asBuffer, bodyLimit, fn) {
 
 module.exports = ContentTypeParser
 module.exports.buildContentTypeParser = buildContentTypeParser
+module.exports[Symbol.for('internals')] = { rawBody }

--- a/test/helper.js
+++ b/test/helper.js
@@ -267,7 +267,7 @@ module.exports.payloadMethod = function (method, t) {
 
       // Node errors for OPTIONS requests with a stream body and no Content-Length header
       if (upMethod !== 'OPTIONS') {
-        var chunk = Buffer.allocUnsafe(1024 * 1024 + 1)
+        var chunk = Buffer.alloc(1024 * 1024 + 1, 0)
         const largeStream = new stream.Readable({
           read () {
             this.push(chunk)

--- a/test/internals/contentTypeParser.test.js
+++ b/test/internals/contentTypeParser.test.js
@@ -1,0 +1,50 @@
+/* eslint-disable no-useless-return */
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const { Readable } = require('stream')
+const internals = require('../../lib/contentTypeParser')[Symbol.for('internals')]
+const Request = require('../../lib/request')
+const Reply = require('../../lib/reply')
+
+test('rawBody function', t => {
+  t.plan(1)
+  const body = Buffer.from('你好 世界')
+  const parser = {
+    asString: true,
+    asBuffer: false,
+    fn (req, bodyInString) {
+      t.equal(bodyInString, body.toString())
+    }
+  }
+  const res = {}
+  res.end = () => {
+    return
+  }
+  res.writeHead = () => {
+    return
+  }
+  res.log = { error: () => {}, info: () => {} }
+  const context = {
+    Reply: Reply,
+    Request: Request,
+    preHandler: [],
+    onSend: [],
+    _parserOptions: {
+      limit: 1024
+    }
+  }
+  const rs = new Readable()
+  rs._read = function () {}
+  const request = new Request('params', rs, 'query', 'headers', 'log')
+  const reply = new Reply(res, context, {})
+  internals.rawBody(
+    request,
+    reply,
+    reply.context._parserOptions,
+    parser
+  )
+  rs.emit('data', body)
+  rs.emit('end')
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

#### The bug

Currently we have this logic for the `asString` type parser's `onData` callback:
```js
body += chunk.toString()
```
This may cause the body string to be wrong because some character may have multi length buffer, for example chinese character:
```js
console.log(Buffer.from('啊')) // <Buffer e5 95 8a>
```
Since a multi length buffer may be cut into two chunks, `chunk.toString()` will make a broken string with symbol `&#65533`.

#### The fix

Just concat chunks in the callback and convert the whole buffer into string when transfer end.

#### The test

I'm not sure whether we can control the chunk size and then we could give a test to reproduce the bug. But if not, it seems hard to make a solid end to end test.
