### PR TITLE
Fix support for latest Joi

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -28,10 +28,14 @@ function build (context, compile, schemas) {
 
   context.schema = schemas.resolveRefs(context.schema)
 
-  if (context.schema.headers) {
+  const headers = context.schema.headers
+
+  if (headers && headers.constructor !== Object) {
+    // do not mess with non-literals, e.g. Joi schemas
+    context[headersSchema] = compile(headers)
+  } else if (headers) {
     // The header keys are case insensitive
     //  https://tools.ietf.org/html/rfc2616#section-4.2
-    const headers = context.schema.headers
     const headersSchemaLowerCase = {}
     for (const k in headers) {
       if (headers.hasOwnProperty(k) !== true) continue


### PR DESCRIPTION
I have not added any unit test because we cannot really test latest joi as it requires Node 8+. It works on my machine.

cc @cemremengu 

Fixes #1158.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
