### PR TITLE
Fix missing object wrapper for errors in pino log

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -768,13 +768,13 @@ function build (options) {
     return this._contentTypeParser.hasParser(contentType)
   }
 
-  function handleClientError (e, socket) {
+  function handleClientError (err, socket) {
     const body = JSON.stringify({
       error: http.STATUS_CODES['400'],
       message: 'Client Error',
       statusCode: 400
     })
-    log.error(e, 'client error')
+    log.error({ err }, 'client error')
     socket.end(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n${body}`)
   }
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -42,7 +42,7 @@ function Reply (res, context, request) {
 
 Reply.prototype.send = function (payload) {
   if (this.sent) {
-    this.res.log.warn(new Error('Reply already sent'))
+    this.res.log.warn({ err: new Error('Reply already sent') }, 'Reply already sent')
     return
   }
 
@@ -228,7 +228,7 @@ function sendStream (payload, res, reply) {
     sourceOpen = false
     if (err) {
       if (res.headersSent) {
-        res.log.error(err, 'response terminated with an error with headers already sent')
+        res.log.error({ err }, 'response terminated with an error with headers already sent')
         res.destroy()
       } else {
         handleError(reply, err)
@@ -240,7 +240,7 @@ function sendStream (payload, res, reply) {
   eos(res, function (err) {
     if (err) {
       if (res.headersSent) {
-        res.log.error(err, 'response terminated with an error with headers already sent')
+        res.log.error({ err }, 'response terminated with an error with headers already sent')
       }
       if (sourceOpen) {
         if (payload.destroy) {

--- a/lib/wrapThenable.js
+++ b/lib/wrapThenable.js
@@ -15,7 +15,7 @@ function wrapThenable (thenable, reply) {
         reply.send(err)
       }
     } else if (reply.sent === false) {
-      reply.res.log.error(new Error(`Promise may not be fulfilled with 'undefined' when statusCode is not 204`))
+      reply.res.log.error({ err: new Error(`Promise may not be fulfilled with 'undefined' when statusCode is not 204`) }, `Promise may not be fulfilled with 'undefined' when statusCode is not 204`)
     }
   }, function (err) {
     reply.sent = false


### PR DESCRIPTION
log is a pino logger, the first argument is a mapping, so in order to give it an error object, we must give it an object with an `err` field, otherwise the error object itself is dissected as if it were a mapping.

This commit fixes places where this has been forgotten.
I only changed source files, not test files because it's not a big deal there.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

`npm run benchmark` exits this way on my machine, on my branch just like on master:
```
[0] {"level":30,"time":1537595975197,"msg":"request completed","pid":30338,"hostname":"Ofavre-Home-T5500","reqId":38361,"res":{"statusCode":200},"responseTime":0.18976199626922607,"v":1}
[0] {"level":50,"time":1537595975197,"msg":"client error","pid":30338,"hostname":"Ofavre-Home-T5500","type":"Error","stack":"Error: write EPIPE\n    at WriteWrap.afterWrite [as oncomplete] (net.js:835:14)","errno":"EPIPE","code":"EPIPE","syscall":"write","v":1}
[0] {"level":50,"time":1537595975198,"msg":"client error","pid":30338,"hostname":"Ofavre-Home-T5500","type":"Error","stack":"Error: read ECONNRESET\n    at TCP.onread (net.js:659:25)","errno":"ECONNRESET","code":"ECONNRESET","syscall":"read","v":1}
[0] node ./examples/simple.js exited with code SIGTERM
```
Benchmarking such a change makes no sense anyway.