### PR TITLE
feat: allow listen() to be called without a port

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -314,6 +314,8 @@ fastify.listen(3000, '0.0.0.0', (err, address) => {
 })
 ```
 
+If the `port` is omitted (or is set to zero), a random available port is automatically chosen (later available via `fastify.server.address().port`).
+
 <a name="route"></a>
 #### route
 Method to add routes to the server, it also has shorthand functions, check [here](https://github.com/fastify/fastify/blob/master/docs/Routes.md).

--- a/fastify.js
+++ b/fastify.js
@@ -338,6 +338,12 @@ function build (options) {
   }
 
   function listen (port, address, backlog, cb) {
+    /* Deal with listen (cb) */
+    if (typeof port === 'function') {
+      cb = port
+      port = 0
+    }
+
     /* Deal with listen (port, cb) */
     if (typeof address === 'function') {
       cb = address

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -6,6 +6,16 @@ const fs = require('fs')
 const test = require('tap').test
 const Fastify = require('..')
 
+test('listen accepts a callback', t => {
+  t.plan(2)
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+  fastify.listen((err) => {
+    t.is(fastify.server.address().address, '127.0.0.1')
+    t.error(err)
+  })
+})
+
 test('listen accepts a port and a callback', t => {
   t.plan(2)
   const fastify = Fastify()
@@ -176,11 +186,21 @@ if (os.platform() !== 'win32') {
   })
 }
 
-test('listen without callback', t => {
+test('listen without callback (port zero)', t => {
   t.plan(1)
   const fastify = Fastify()
   t.tearDown(fastify.close.bind(fastify))
   fastify.listen(0)
+    .then(() => {
+      t.is(fastify.server.address().address, '127.0.0.1')
+    })
+})
+
+test('listen without callback (port not given)', t => {
+  t.plan(1)
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+  fastify.listen()
     .then(() => {
       t.is(fastify.server.address().address, '127.0.0.1')
     })


### PR DESCRIPTION
This aligns with Node core api where calling `server.listen(callback)` is allowed. Without this fastify just hangs forever.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
