### PR TITLE
Fix broken link to Server#listen docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ For more information, see the [Fastify CLI documentation](https://github.com/fas
 #### Note
 
 `.listen` binds to the local host, `localhost`, interface by default (`127.0.0.1` or `::1`, depending on the operating system configuration).
-See [the documentation](https://github.com/fastify/fastify/blob/master/docs/Server-Methods.md#listen) for more information.
+See [the documentation](https://github.com/fastify/fastify/blob/master/docs/Server.md#listen) for more information.
 
 ### Core features
 


### PR DESCRIPTION
fix broken link to Server#listen docs

- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)