### PR TITLE
Enable nested plugins to override decorators

### DIFF
--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -1,7 +1,7 @@
 'use strict'
 
 function decorate (instance, name, fn, dependencies) {
-  if (checkExistence(instance, name)) {
+  if (instance.hasOwnProperty(name)) {
     throw new Error(`The decorator '${name}' has already been added!`)
   }
 

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -602,3 +602,21 @@ test('should register empty values', t => {
     t.notOk(fastify.test)
   })
 })
+
+test('nested plugins can override things', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  const rootFunc = () => {}
+  fastify.decorate('test', rootFunc)
+
+  fastify.register((instance, opts, next) => {
+    t.equal(instance.test, rootFunc)
+    const func = () => {}
+    instance.decorate('test', func)
+    t.equal(instance.test, func)
+    next()
+  })
+
+  fastify.ready()
+})

--- a/test/throw.test.js
+++ b/test/throw.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('tap')
 const Fastify = require('..')
 
 test('Fastify should throw on wrong options', t => {
@@ -101,7 +101,7 @@ test('Should throw on duplicate decorator', t => {
   }
 })
 
-test('Should throw on duplicate decorator encapsulation', t => {
+test('Should not throw on duplicate decorator encapsulation', t => {
   t.plan(1)
 
   const fastify = Fastify()
@@ -110,12 +110,9 @@ test('Should throw on duplicate decorator encapsulation', t => {
   fastify.decorate('foo2', foo2Obj)
 
   fastify.register(function (fastify, opts, next) {
-    try {
+    t.notThrow(() => {
       fastify.decorate('foo2', foo2Obj)
-      t.fail()
-    } catch (e) {
-      t.pass()
-    }
+    })
     next()
   })
 


### PR DESCRIPTION
This PR restores a functionality that we have lost in the last year (or even more). I would like for nested plugins to _override_ the decorators of their parent. I think this is a really powerful feature that enable some interesting encapsulation patterns.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
