### PR TITLE
custom error handler can be able to handle contentTypeParser's errors

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -64,7 +64,9 @@ ContentTypeParser.prototype.getParser = function (contentType) {
 ContentTypeParser.prototype.run = function (contentType, handler, request, reply) {
   var parser = this.cache.get(contentType) || this.getParser(contentType)
   if (parser === undefined) {
-    reply.code(415).send(new Error('Unsupported Media Type: ' + contentType))
+    const err = new Error('Unsupported Media Type: ' + contentType)
+    err.statusCode = 415
+    reply.code(err.statusCode).send(err)
   } else {
     if (parser.asString === true || parser.asBuffer === true) {
       rawBody(
@@ -100,7 +102,9 @@ function rawBody (request, reply, options, parser, done) {
     : Number.parseInt(request.headers['content-length'], 10)
 
   if (contentLength > limit) {
-    reply.code(413).send(new Error('Request body is too large'))
+    const err = new Error('Request body is too large')
+    err.statusCode = 413
+    reply.code(err.statusCode).send(err)
     return
   }
 
@@ -123,7 +127,9 @@ function rawBody (request, reply, options, parser, done) {
       req.removeListener('data', onData)
       req.removeListener('end', onEnd)
       req.removeListener('error', onEnd)
-      reply.code(413).send(new Error('Request body is too large'))
+      const err = new Error('Request body is too large')
+      err.statusCode = 413
+      reply.code(err.statusCode).send(err)
       return
     }
 
@@ -140,7 +146,9 @@ function rawBody (request, reply, options, parser, done) {
     req.removeListener('error', onEnd)
 
     if (err !== undefined) {
-      reply.code(400).send(err)
+      const error = new Error(err.message)
+      error.statusCode = 400
+      reply.code(error.statusCode).send(error)
       return
     }
 
@@ -148,7 +156,9 @@ function rawBody (request, reply, options, parser, done) {
       receivedLength = Buffer.byteLength(body)
     }
     if (!Number.isNaN(contentLength) && receivedLength !== contentLength) {
-      reply.code(400).send(new Error('Request body size did not match Content-Length'))
+      const err = new Error('Request body size did not match Content-Length')
+      err.statusCode = 400
+      reply.code(err.statusCode).send(err)
       return
     }
 

--- a/test/content-length.test.js
+++ b/test/content-length.test.js
@@ -1,0 +1,141 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('..')
+
+test('default 413 with bodyLimit option', t => {
+  t.plan(4)
+
+  const fastify = Fastify({
+    bodyLimit: 10
+  })
+
+  fastify.post('/', function (req, reply) {
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    body: {
+      text: '12345678901234567890123456789012345678901234567890'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 413)
+    t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+    t.deepEqual(JSON.parse(res.payload), {
+      error: 'Payload Too Large',
+      message: 'Request body is too large',
+      statusCode: 413
+    })
+  })
+})
+
+test('default 413 with wrong content-length', t => {
+  t.plan(4)
+
+  const fastify = Fastify()
+
+  fastify.post('/', function (req, reply) {
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    headers: {
+      'content-length': 20
+    },
+    body: {
+      text: '12345678901234567890123456789012345678901234567890'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 400)
+    t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+    t.deepEqual(JSON.parse(res.payload), {
+      error: 'Bad Request',
+      message: 'Request body size did not match Content-Length',
+      statusCode: 400
+    })
+  })
+})
+
+test('custom 413 with bodyLimit option', t => {
+  t.plan(6)
+
+  const fastify = Fastify({
+    bodyLimit: 10
+  })
+
+  fastify.post('/', function (req, reply) {
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.setErrorHandler(function (err, request, reply) {
+    t.type(request, 'object')
+    t.type(request, fastify._Request)
+    reply
+      .code(err.statusCode)
+      .type('application/json; charset=utf-8')
+      .send(err)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    body: {
+      text: '12345678901234567890123456789012345678901234567890'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 413)
+    t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+    t.deepEqual(JSON.parse(res.payload), {
+      error: 'Payload Too Large',
+      message: 'Request body is too large',
+      statusCode: 413
+    })
+  })
+})
+
+test('custom 413 with wrong content-length', t => {
+  t.plan(6)
+
+  const fastify = Fastify()
+
+  fastify.post('/', function (req, reply) {
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.setErrorHandler(function (err, request, reply) {
+    t.type(request, 'object')
+    t.type(request, fastify._Request)
+    reply
+      .code(err.statusCode)
+      .type('application/json; charset=utf-8')
+      .send(err)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    headers: {
+      'content-length': 20
+    },
+    body: {
+      text: '12345678901234567890123456789012345678901234567890'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 400)
+    t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+    t.deepEqual(JSON.parse(res.payload), {
+      error: 'Bad Request',
+      message: 'Request body size did not match Content-Length',
+      statusCode: 400
+    })
+  })
+})

--- a/test/helper.js
+++ b/test/helper.js
@@ -3,9 +3,26 @@
 const sget = require('simple-get').concat
 const stream = require('stream')
 
-module.exports.payloadMethod = function (method, t) {
+/**
+ * @param method HTTP request method
+ * @param t tap instance
+ * @param isSetErrorHandler true: using setErrorHandler
+ */
+module.exports.payloadMethod = function (method, t, isSetErrorHandler = false) {
   const test = t.test
   const fastify = require('..')()
+
+  if (isSetErrorHandler) {
+    fastify.setErrorHandler(function (err, request, reply) {
+      t.type(request, 'object')
+      t.type(request, fastify._Request)
+      reply
+        .code(err.statusCode)
+        .type('application/json; charset=utf-8')
+        .send(err)
+    })
+  }
+
   const upMethod = method.toUpperCase()
   const loMethod = method.toLowerCase()
 

--- a/test/options.error-handler.test.js
+++ b/test/options.error-handler.test.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const t = require('tap')
+require('./helper').payloadMethod('options', t, true)
+require('./input-validation').payloadMethod('options', t)

--- a/test/patch.error-handler.test.js
+++ b/test/patch.error-handler.test.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const t = require('tap')
+require('./helper').payloadMethod('patch', t, true)
+require('./input-validation').payloadMethod('patch', t)

--- a/test/put.error-handler.test.js
+++ b/test/put.error-handler.test.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const t = require('tap')
+require('./helper').payloadMethod('put', t, true)
+require('./input-validation').payloadMethod('put', t)


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added - No documentation change.
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
