### PR TITLE
typings: fix allowHTTP1 flag for http2 servers

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -129,7 +129,7 @@ declare namespace fastify {
     maxParamLength?: number,
   }
   interface ServerOptionsAsSecure extends ServerOptions {
-    https: tls.TlsOptions
+    https: http2.SecureServerOptions
   }
   interface ServerOptionsAsHttp extends ServerOptions {
     http2?: false

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -31,6 +31,14 @@ const cors = require('cors')
       key: readFileSync('path/to/key.pem')
     }
   })
+  const h2AllowH1SecureServer = fastify({
+    http2: true,
+    https: {
+      allowHTTP1: true,
+      cert: readFileSync('path/to/cert.pem'),
+      key: readFileSync('path/to/key.pem')
+    }
+  })
   // logger true
   const logAllServer = fastify({ logger: true })
   logAllServer.addHook('onRequest', (req, res, next) => {


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

This PR just fixes the typings of the https property in `ServerOptionsAsSecure`. I added a scenario. to the typescript test file.