### PR TITLE
Prevent losing stacktrace onEnd

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -146,9 +146,7 @@ function rawBody (request, reply, options, parser, done) {
     req.removeListener('error', onEnd)
 
     if (err !== undefined) {
-      const error = new Error(err.message)
-      error.statusCode = 400
-      reply.code(error.statusCode).send(error)
+      reply.code(400).send(err)
       return
     }
 


### PR DESCRIPTION
Prevent losing stacktrace when onEnd is called in contentTypeParser

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
