### PR TITLE
make sure app.prefix is always non-empty and ending with /.

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -360,21 +360,22 @@ Function to add a specific hook in the lifecycle of Fastify, check [here](https:
 
 <a name="prefix"></a>
 #### prefix
-The full path that will be prefixed to a route.
+The full path that will be prefixed to a route. It always ends with a
+`/`.
 
 Example:
 
 ```js
 fastify.register(function (instance, opts, next) {
   instance.get('/foo', function (request, reply) {
-    // Will log "prefix: /v1"
+    // Will log "prefix: /v1/"
     request.log.info('prefix: %s', instance.prefix)
     reply.send({ prefix: instance.prefix })
   })
 
   instance.register(function (instance, opts, next) {
     instance.get('/bar', function (request, reply) {
-      // Will log "prefix: /v1/v2"
+      // Will log "prefix: /v1/v2/"
       request.log.info('prefix: %s', instance.prefix)
       reply.send({ prefix: instance.prefix })
     })
@@ -384,6 +385,12 @@ fastify.register(function (instance, opts, next) {
 
   next()
 }, { prefix: '/v1' })
+
+fastify.get('/', function (request, reply) {
+  // Will log "prefix: /"
+  request.log.info('prefix: %s', instance.prefix)
+  reply.send({ prefix: instance.prefix })
+})
 ```
 
 <a name="log"></a>

--- a/fastify.js
+++ b/fastify.js
@@ -167,7 +167,7 @@ function build (options) {
   fastify.all = _all
   // extended route
   fastify.route = route
-  fastify[kRoutePrefix] = ''
+  fastify[kRoutePrefix] = '/'
   fastify[kLogLevel] = ''
 
   Object.defineProperty(fastify, 'prefix', {
@@ -486,6 +486,10 @@ function build (options) {
       pluginPrefix = '/' + pluginPrefix
     }
 
+    if (!pluginPrefix.endsWith('/')) {
+      pluginPrefix += '/'
+    }
+
     return instancePrefix + pluginPrefix
   }
 
@@ -574,10 +578,7 @@ function build (options) {
     _fastify.after(function afterRouteAdded (notHandledErr, done) {
       const prefix = _fastify[kRoutePrefix]
       var path = opts.url || opts.path
-      if (path === '/' && prefix.length > 0) {
-        // Ensure that '/prefix' + '/' gets registered as '/prefix'
-        path = ''
-      } else if (path[0] === '/' && prefix.endsWith('/')) {
+      if (path[0] === '/') {
         // Ensure that '/prefix/' + '/route' gets registered as '/prefix/route'
         path = path.slice(1)
       }
@@ -713,8 +714,7 @@ function build (options) {
   function use (url, fn) {
     throwIfAlreadyStarted('Cannot call "use" when fastify instance is already started!')
     if (typeof url === 'string') {
-      const prefix = this[kRoutePrefix]
-      url = prefix + (url === '/' && prefix.length > 0 ? '' : url)
+      url = buildRoutePrefix(this[kRoutePrefix], url)
     }
     return this.after((err, done) => {
       addMiddleware(this, [url, fn])
@@ -829,7 +829,7 @@ function build (options) {
     throwIfAlreadyStarted('Cannot call "setNotFoundHandler" when fastify instance is already started!')
 
     const _fastify = this
-    const prefix = this[kRoutePrefix] || '/'
+    const prefix = this[kRoutePrefix]
 
     if (this[kCanSetNotFoundHandler] === false) {
       throw new Error(`Not found handler already set for Fastify instance with prefix: '${prefix}'`)

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -205,7 +205,7 @@ test('setting a custom 404 handler multiple times is an error', t => {
         t.fail('setting multiple 404 handlers at the same prefix encapsulation level should throw')
       } catch (err) {
         t.type(err, Error)
-        t.strictEqual(err.message, 'Not found handler already set for Fastify instance with prefix: \'/prefix\'')
+        t.strictEqual(err.message, 'Not found handler already set for Fastify instance with prefix: \'/prefix/\'')
       }
 
       next()
@@ -255,7 +255,7 @@ test('setting a custom 404 handler multiple times is an error', t => {
           t.fail('setting multiple 404 handlers at the same prefix encapsulation level should throw')
         } catch (err) {
           t.type(err, Error)
-          t.strictEqual(err.message, 'Not found handler already set for Fastify instance with prefix: \'/prefix\'')
+          t.strictEqual(err.message, 'Not found handler already set for Fastify instance with prefix: \'/prefix/\'')
         }
         next()
       })
@@ -288,7 +288,7 @@ test('setting a custom 404 handler multiple times is an error', t => {
           t.fail('setting multiple 404 handlers at the same prefix encapsulation level should throw')
         } catch (err) {
           t.type(err, Error)
-          t.strictEqual(err.message, 'Not found handler already set for Fastify instance with prefix: \'/prefix\'')
+          t.strictEqual(err.message, 'Not found handler already set for Fastify instance with prefix: \'/prefix/\'')
         }
         next()
       })
@@ -375,7 +375,7 @@ test('encapsulated 404', t => {
       t.plan(3)
       sget({
         method: 'PUT',
-        url: 'http://localhost:' + fastify.server.address().port + '/test',
+        url: 'http://localhost:' + fastify.server.address().port + '/test/',
         body: JSON.stringify({ hello: 'world' }),
         headers: { 'Content-Type': 'application/json' }
       }, (err, response, body) => {
@@ -401,7 +401,7 @@ test('encapsulated 404', t => {
       t.plan(3)
       sget({
         method: 'PUT',
-        url: 'http://localhost:' + fastify.server.address().port + '/test2',
+        url: 'http://localhost:' + fastify.server.address().port + '/test2/',
         body: JSON.stringify({ hello: 'world' }),
         headers: { 'Content-Type': 'application/json' }
       }, (err, response, body) => {
@@ -791,7 +791,7 @@ test('run hooks and middleware with encapsulated 404', t => {
 
     sget({
       method: 'PUT',
-      url: 'http://localhost:' + fastify.server.address().port + '/test',
+      url: 'http://localhost:' + fastify.server.address().port + '/test/',
       body: JSON.stringify({ hello: 'world' }),
       headers: { 'Content-Type': 'application/json' }
     }, (err, response, body) => {
@@ -853,7 +853,7 @@ test('run middlewares with encapsulated 404', t => {
     })
 
     next()
-  }, { prefix: '/test' })
+  }, { prefix: '/test/' })
 
   t.tearDown(fastify.close.bind(fastify))
 
@@ -862,7 +862,7 @@ test('run middlewares with encapsulated 404', t => {
 
     sget({
       method: 'PUT',
-      url: 'http://localhost:' + fastify.server.address().port + '/test',
+      url: 'http://localhost:' + fastify.server.address().port + '/test/',
       body: JSON.stringify({ hello: 'world' }),
       headers: { 'Content-Type': 'application/json' }
     }, (err, response, body) => {

--- a/test/500s.test.js
+++ b/test/500s.test.js
@@ -86,7 +86,7 @@ test('encapsulated 500', t => {
 
   fastify.inject({
     method: 'GET',
-    url: '/test'
+    url: '/test/'
   }, (err, res) => {
     t.error(err)
     t.strictEqual(res.statusCode, 500)

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -430,7 +430,7 @@ test('onRoute hook should pass correct route with custom prefix', t => {
     t.strictEqual(route.method, 'GET')
     t.strictEqual(route.url, '/v1/foo')
     t.strictEqual(route.path, '/v1/foo')
-    t.strictEqual(route.prefix, '/v1')
+    t.strictEqual(route.prefix, '/v1/')
   })
 
   fastify.register((instance, opts, next) => {
@@ -438,7 +438,7 @@ test('onRoute hook should pass correct route with custom prefix', t => {
       t.strictEqual(route.method, 'GET')
       t.strictEqual(route.url, '/v1/foo')
       t.strictEqual(route.path, '/v1/foo')
-      t.strictEqual(route.prefix, '/v1')
+      t.strictEqual(route.prefix, '/v1/')
     })
     instance.get('/foo', opts, function (req, reply) {
       reply.send()

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -500,7 +500,7 @@ test('middlewares should support encapsulation with prefix', t => {
 
       sget({
         method: 'GET',
-        url: 'http://localhost:' + instance.server.address().port + '/local'
+        url: 'http://localhost:' + instance.server.address().port + '/local/'
       }, (err, response, body) => {
         t.error(err)
         t.strictEqual(response.statusCode, 500)

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -382,7 +382,7 @@ test('nested plugins', t => {
 
     sget({
       method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port + '/parent/child1'
+      url: 'http://localhost:' + fastify.server.address().port + '/parent/child1/'
     }, (err, response, body) => {
       t.error(err)
       t.deepEqual(body.toString(), 'I am child 1')
@@ -390,7 +390,7 @@ test('nested plugins', t => {
 
     sget({
       method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port + '/parent/child2'
+      url: 'http://localhost:' + fastify.server.address().port + '/parent/child2/'
     }, (err, response, body) => {
       t.error(err)
       t.deepEqual(body.toString(), 'I am child 2')


### PR DESCRIPTION
This fixes a long-standing issue with our plugin system that made it not
abide to the ignoreTrailingSlash flag. This change makes it consistent
so that a plugin with prefix /a/b/ will not respond to /a/b.

Consider the following examples.

In master:

```js
'use strict'

const fastify = require('fastify')()

fastify.register(function (instance, options, next) {
  // the route will be '/english'
  // note that '/english/' will be a 404
  instance.get('/', (req, reply) => {
    reply.send({ greet: 'hello' })
  })
  next()
}, { prefix: '/english' })

fastify.register(function (instance, options, next) {
  // the route will be '/italian'
  // note that '/italian/' will be a 404
  instance.get('/', (req, reply) => {
    reply.send({ greet: 'ciao' })
  })
  next()
}, { prefix: '/italian' })

fastify.listen(8000, function (err) {
  if (err) {
    throw err
  }
  console.log(`server listening on ${fastify.server.address().port}`)
})
```

In this branch:

```js
'use strict'

const fastify = require('fastify')()

fastify.register(function (instance, options, next) {
  // the route will be '/english/'
  instance.get('/', (req, reply) => {
    reply.send({ greet: 'hello' })
  })
  next()
}, { prefix: '/english' })

fastify.register(function (instance, options, next) {
  // the route will be '/italian/'
  instance.get('/', (req, reply) => {
    reply.send({ greet: 'ciao' })
  })
  next()
}, { prefix: '/italian' })

fastify.listen(8000, function (err) {
  if (err) {
    throw err
  }
  console.log(`server listening on ${fastify.server.address().port}`)
})
```

The `ignoreTrailingSlash` flag will also be correctly respected now.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
