### PR TITLE
Plugin double prefix

### DIFF
--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -230,6 +230,14 @@ Now your clients will have access to the following routes:
 You can do this as many times as you want, it works also for nested `register` and routes parameter are supported as well.
 Be aware that if you use [`fastify-plugin`](https://github.com/fastify/fastify-plugin) this option won't work.
 
+#### Handling of / route inside prefixed plugins
+
+The `/` route has a different behavior depending if the prefix ends with
+`/` or not. As an example, if we consider a prefix `/something/`,
+adding a `/` route will only match `/something/`. If we consider a
+prefix `/something`, adding a `/` route will match both `/something` 
+and `/something/`.
+
 <a name="custom-log-level"></a>
 ### Custom Log Level
 It could happen that you need different log levels in your routes, with Fastify achieve this is very straightforward.<br/>

--- a/fastify.js
+++ b/fastify.js
@@ -571,16 +571,25 @@ function build (options) {
 
     validateBodyLimitOption(opts.bodyLimit)
 
-    _fastify.after(function afterRouteAdded (notHandledErr, done) {
-      const prefix = _fastify[kRoutePrefix]
+    const prefix = _fastify[kRoutePrefix]
+
+    _fastify.after(function (notHandledErr, done) {
       var path = opts.url || opts.path
       if (path === '/' && prefix.length > 0) {
         // Ensure that '/prefix' + '/' gets registered as '/prefix'
-        path = ''
+        afterRouteAdded('', notHandledErr, done)
       } else if (path[0] === '/' && prefix.endsWith('/')) {
         // Ensure that '/prefix/' + '/route' gets registered as '/prefix/route'
         path = path.slice(1)
       }
+
+      afterRouteAdded(path, notHandledErr, done)
+    })
+
+    // chainable api
+    return _fastify
+
+    function afterRouteAdded (path, notHandledErr, done) {
       const url = prefix + path
 
       opts.url = url
@@ -668,10 +677,7 @@ function build (options) {
       })
 
       done(notHandledErr)
-    })
-
-    // chainable api
-    return _fastify
+    }
   }
 
   function Context (schema, handler, Reply, Request, contentTypeParser, config, errorHandler, bodyLimit, logLevel) {

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -362,3 +362,32 @@ test('matches both /prefix and /prefix/ with a / route', t => {
     t.same(JSON.parse(res.payload), { hello: 'world' })
   })
 })
+
+test('prefix "/prefix/" does not match "/prefix" with a / route', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.register(function (fastify, opts, next) {
+    fastify.get('/', (req, reply) => {
+      reply.send({ hello: 'world' })
+    })
+
+    next()
+  }, { prefix: '/prefix/' })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/prefix'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 404)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/prefix/'
+  }, (err, res) => {
+    t.error(err)
+    t.same(JSON.parse(res.payload), { hello: 'world' })
+  })
+})

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -391,3 +391,65 @@ test('prefix "/prefix/" does not match "/prefix" with a / route', t => {
     t.same(JSON.parse(res.payload), { hello: 'world' })
   })
 })
+
+test('matches both /prefix and /prefix/ with a / route - ignoreTrailingSlash: true', t => {
+  t.plan(4)
+  const fastify = Fastify({
+    ignoreTrailingSlash: true
+  })
+
+  fastify.register(function (fastify, opts, next) {
+    fastify.get('/', (req, reply) => {
+      reply.send({ hello: 'world' })
+    })
+
+    next()
+  }, { prefix: '/prefix' })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/prefix'
+  }, (err, res) => {
+    t.error(err)
+    t.same(JSON.parse(res.payload), { hello: 'world' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/prefix/'
+  }, (err, res) => {
+    t.error(err)
+    t.same(JSON.parse(res.payload), { hello: 'world' })
+  })
+})
+
+test('matches both /prefix and /prefix/ with a / route - ignoreTrailingSlash: false', t => {
+  t.plan(4)
+  const fastify = Fastify({
+    ignoreTrailingSlash: true
+  })
+
+  fastify.register(function (fastify, opts, next) {
+    fastify.get('/', (req, reply) => {
+      reply.send({ hello: 'world' })
+    })
+
+    next()
+  }, { prefix: '/prefix' })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/prefix'
+  }, (err, res) => {
+    t.error(err)
+    t.same(JSON.parse(res.payload), { hello: 'world' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/prefix/'
+  }, (err, res) => {
+    t.error(err)
+    t.same(JSON.parse(res.payload), { hello: 'world' })
+  })
+})

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -426,7 +426,7 @@ test('matches both /prefix and /prefix/ with a / route - ignoreTrailingSlash: tr
 test('matches both /prefix and /prefix/ with a / route - ignoreTrailingSlash: false', t => {
   t.plan(4)
   const fastify = Fastify({
-    ignoreTrailingSlash: true
+    ignoreTrailingSlash: false
   })
 
   fastify.register(function (fastify, opts, next) {

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -333,3 +333,32 @@ test('Can retrieve prefix within encapsulated instances', t => {
     t.is(res.payload, '/v1/v2')
   })
 })
+
+test('matches both /prefix and /prefix/ with a / route', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.register(function (fastify, opts, next) {
+    fastify.get('/', (req, reply) => {
+      reply.send({ hello: 'world' })
+    })
+
+    next()
+  }, { prefix: '/prefix' })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/prefix'
+  }, (err, res) => {
+    t.error(err)
+    t.same(JSON.parse(res.payload), { hello: 'world' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/prefix/'
+  }, (err, res) => {
+    t.error(err)
+    t.same(JSON.parse(res.payload), { hello: 'world' })
+  })
+})


### PR DESCRIPTION
This is an alternative to #1225 that creates much less breakage. Basically I'm registering two routes, one with and one without the ending slash. I'm up for adding a flag that have the more strict behavior that #1225 defines, if you think it's needed.

```js
'use strict'

const fastify = require('fastify')()

fastify.register(function (instance, options, next) {
  // the route will be called for both '/english/' and '/english'
  instance.get('/', (req, reply) => {
    reply.send({ greet: 'hello' })
  })
  next()
}, { prefix: '/english' })

fastify.register(function (instance, options, next) {
  // the handler will be called for both '/italian/' and '/italian'
  instance.get('/', (req, reply) => {
    reply.send({ greet: 'ciao' })
  })
  next()
}, { prefix: '/italian' })

fastify.listen(8000, function (err) {
  if (err) {
    throw err
  }
  console.log(`server listening on ${fastify.server.address().port}`)
})
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
