### PR TITLE
Remove `then-sleep`

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "split2": "^3.0.0",
     "standard": "^12.0.0",
     "tap": "^12.0.0",
-    "then-sleep": "^1.0.1",
     "typescript": "^3.0.1",
     "typescript-eslint-parser": "^20.0.0",
     "x-xss-protection": "^1.1.0"

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -2,10 +2,10 @@
 
 const sget = require('simple-get').concat
 const Fastify = require('..')
-const sleep = require('then-sleep')
 const split = require('split2')
 const pino = require('pino')
 const statusCodes = require('http').STATUS_CODES
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 const opts = {
   schema: {

--- a/test/hooks-async.js
+++ b/test/hooks-async.js
@@ -1,9 +1,9 @@
 'use strict'
 
 const sget = require('simple-get').concat
-const sleep = require('then-sleep')
 const Fastify = require('..')
 const fs = require('fs')
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 function asyncHookTest (t) {
   const test = t.test


### PR DESCRIPTION
Remove devDependency `then-sleep` since it's updated 3 years ago (ok theres not much maintenance needed maybe for it), can be achieved natively in one line and gives deprecation error:

`native-or-bluebird is deprecated. please switch to any-promise`

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
