### PR TITLE
WIP: onError hook

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -10,6 +10,7 @@ By using the hooks you can interact directly inside the lifecycle of Fastify. Th
 - `'onRequest'`
 - `'preValidation'`
 - `'preHandler'`
+- `'onError'`
 - `'onSend'`
 - `'onResponse'`
 
@@ -26,6 +27,11 @@ fastify.addHook('preValidation', (request, reply, next) => {
 })
 
 fastify.addHook('preHandler', (request, reply, next) => {
+  // some code
+  next()
+})
+
+fastify.addHook('onError', (request, reply, error, next) => {
   // some code
   next()
 })
@@ -70,6 +76,11 @@ fastify.addHook('preHandler', async (request, reply) => {
     throw new Error('some errors occurred.')
   }
   return
+})
+
+fastify.addHook('onError', async (request, reply, error) => {
+  // useful for custom error logging
+  // you should not use this hook to update the error
 })
 
 fastify.addHook('onSend', async (request, reply, payload) => {
@@ -120,6 +131,27 @@ fastify.addHook('preHandler', (request, reply, next) => {
 ```
 
 *The error will be handled by [`Reply`](https://github.com/fastify/fastify/blob/master/docs/Reply.md#errors).*
+
+#### The `onError` Hook
+
+This hook is useful if you need to do some custom error logging or add some specific header in case of error.<br/>
+It is not intended for changing the error, and calling `reply.send` will throw an exception.<br/>
+This hook will be executed only after the `customErrorHandler` has been executed.<br/>
+**Notice:** unlike the other hooks, pass an error to the `next` function is not supported.
+
+```js
+fastify.addHook('onError', (request, reply, error, next) => {
+  // apm stands for Application Performance Monitoring
+  apm.sendError(error)
+  next()
+})
+
+// Or async
+fastify.addHook('onError', async (request, reply, error) => {
+  // apm stands for Application Performance Monitoring
+  apm.sendError(error)
+})
+```
 
 #### The `onSend` Hook
 

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -136,7 +136,7 @@ fastify.addHook('preHandler', (request, reply, next) => {
 
 This hook is useful if you need to do some custom error logging or add some specific header in case of error.<br/>
 It is not intended for changing the error, and calling `reply.send` will throw an exception.<br/>
-This hook will be executed only after the `customErrorHandler` has been executed.<br/>
+This hook will be executed only after the `customErrorHandler` has been executed, and only if the `customErrorHandler` sends back and error to the user *(Note that the default `customErrorHandler` always send back the error to the user)*.<br/>
 **Notice:** unlike the other hooks, pass an error to the `next` function is not supported.
 
 ```js

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -499,6 +499,11 @@ declare namespace fastify {
      */
     addHook(name: 'onSend', hook: (this: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, req: FastifyRequest<HttpRequest>, reply: FastifyReply<HttpResponse>, payload: any, done: (err?: Error, value?: any) => void) => void): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
+    /**
+     * Hook that is fired if `reply.send` is invoked with an Error
+     */
+    addHook(name: 'onError', hook: (this: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, req: FastifyRequest<HttpRequest>, reply: FastifyReply<HttpResponse>, error: Error, done: () => void) => void): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+
      /**
      * Hook that is called when a response is about to be sent to a client
      */

--- a/fastify.js
+++ b/fastify.js
@@ -649,6 +649,7 @@ function build (options) {
         const onRequest = _fastify[kHooks].onRequest
         const onResponse = _fastify[kHooks].onResponse
         const onSend = _fastify[kHooks].onSend
+        const onError = _fastify[kHooks].onError
         const preValidation = _fastify[kHooks].preValidation.concat(opts.preValidation || [])
         const preHandler = _fastify[kHooks].preHandler.concat(opts.preHandler || [])
 
@@ -656,6 +657,7 @@ function build (options) {
         context.preValidation = preValidation.length ? preValidation : null
         context.preHandler = preHandler.length ? preHandler : null
         context.onSend = onSend.length ? onSend : null
+        context.onError = onError.length ? onError : null
         context.onResponse = onResponse.length ? onResponse : null
 
         context._middie = buildMiddie(_fastify[kMiddlewares])
@@ -692,6 +694,7 @@ function build (options) {
     this.contentTypeParser = contentTypeParser
     this.onRequest = null
     this.onSend = null
+    this.onError = null
     this.preHandler = null
     this.onResponse = null
     this.config = config
@@ -828,7 +831,7 @@ function build (options) {
     req.log.info({ req }, 'incoming request')
 
     var request = new Request(null, req, null, req.headers, req.log)
-    var reply = new Reply(res, { onSend: [] }, request, res.log)
+    var reply = new Reply(res, { onSend: [], onError: [] }, request, res.log)
 
     request.log.warn('the default handler for 404 did not catch this, this is likely a fastify bug, please report it')
     request.log.warn(fourOhFour.prettyPrint())
@@ -906,12 +909,14 @@ function build (options) {
       const preValidation = this[kHooks].preValidation.concat(opts.preValidation || [])
       const preHandler = this[kHooks].preHandler.concat(opts.beforeHandler || opts.preHandler || [])
       const onSend = this[kHooks].onSend
+      const onError = this[kHooks].onError
       const onResponse = this[kHooks].onResponse
 
       context.onRequest = onRequest.length ? onRequest : null
       context.preValidation = preValidation.length ? preValidation : null
       context.preHandler = preHandler.length ? preHandler : null
       context.onSend = onSend.length ? onSend : null
+      context.onError = onError.length ? onError : null
       context.onResponse = onResponse.length ? onResponse : null
 
       context._middie = buildMiddie(this[kMiddlewares])

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -6,6 +6,7 @@ const supportedHooks = [
   'preHandler',
   'onResponse',
   'onSend',
+  'onError',
   // only for validation
   'onRoute',
   'onClose'
@@ -23,6 +24,7 @@ function Hooks () {
   this.preHandler = []
   this.onResponse = []
   this.onSend = []
+  this.onError = []
 }
 
 Hooks.prototype.validate = function (hook, fn) {
@@ -45,6 +47,7 @@ function buildHooks (h) {
   hooks.preHandler = h.preHandler.slice()
   hooks.onSend = h.onSend.slice()
   hooks.onResponse = h.onResponse.slice()
+  hooks.onError = h.onError.slice()
   return hooks
 }
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -47,7 +47,7 @@ function Reply (res, context, request, log) {
   this._serializer = null
   this._errorHandlerCalled = false
   this._isError = false
-  this._isRunningOnErroHook = false
+  this._isRunningOnErrorHook = false
   this.request = request
   this._headers = {}
   this._hasStatusCode = false
@@ -56,7 +56,7 @@ function Reply (res, context, request, log) {
 }
 
 Reply.prototype.send = function (payload) {
-  if (this._isRunningOnErroHook === true) {
+  if (this._isRunningOnErrorHook === true) {
     throw new Error('You cannot use `send` inside the `onError` hook')
   }
 
@@ -298,7 +298,7 @@ function sendStream (payload, res, reply) {
 
 function onErrorHook (reply, error, cb) {
   if (reply.context.onError !== null && reply._errorHandlerCalled === true) {
-    reply._isRunningOnErroHook = true
+    reply._isRunningOnErrorHook = true
     onSendHookRunner(
       reply.context.onError,
       reply.request,
@@ -312,7 +312,7 @@ function onErrorHook (reply, error, cb) {
 }
 
 function handleError (reply, error, cb) {
-  reply._isRunningOnErroHook = false
+  reply._isRunningOnErrorHook = false
   var res = reply.res
   var statusCode = res.statusCode
   statusCode = (statusCode >= 400) ? statusCode : 500

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -47,6 +47,7 @@ function Reply (res, context, request, log) {
   this._serializer = null
   this._errorHandlerCalled = false
   this._isError = false
+  this._isRunningOnErroHook = false
   this.request = request
   this._headers = {}
   this._hasStatusCode = false
@@ -55,6 +56,10 @@ function Reply (res, context, request, log) {
 }
 
 Reply.prototype.send = function (payload) {
+  if (this._isRunningOnErroHook === true) {
+    throw new Error('You cannot use `send` inside the `onError` hook')
+  }
+
   if (this.sent) {
     this.res.log.warn({ err: new Error('Reply already sent') }, 'Reply already sent')
     return
@@ -63,7 +68,7 @@ Reply.prototype.send = function (payload) {
   this.sent = true
 
   if (payload instanceof Error || this._isError === true) {
-    handleError(this, payload, onSendHook)
+    onErrorHook(this, payload, onSendHook)
     return
   }
 
@@ -197,7 +202,7 @@ function onSendHook (reply, payload) {
 
 function wrapOnSendEnd (err, request, reply, payload) {
   if (err != null) {
-    handleError(reply, err)
+    onErrorHook(reply, err)
   } else {
     onSendEnd(reply, payload)
   }
@@ -254,7 +259,7 @@ function sendStream (payload, res, reply) {
         res.log.error({ err }, 'response terminated with an error with headers already sent')
         res.destroy()
       } else {
-        handleError(reply, err)
+        onErrorHook(reply, err)
       }
     }
     // there is nothing to do if there is not an error
@@ -291,7 +296,23 @@ function sendStream (payload, res, reply) {
   payload.pipe(res)
 }
 
+function onErrorHook (reply, error, cb) {
+  if (reply.context.onError !== null && reply._errorHandlerCalled === true) {
+    reply._isRunningOnErroHook = true
+    onSendHookRunner(
+      reply.context.onError,
+      reply.request,
+      reply,
+      error,
+      () => handleError(reply, error, cb)
+    )
+  } else {
+    handleError(reply, error, cb)
+  }
+}
+
 function handleError (reply, error, cb) {
+  reply._isRunningOnErroHook = false
   var res = reply.res
   var statusCode = res.statusCode
   statusCode = (statusCode >= 400) ? statusCode : 500

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -61,7 +61,8 @@ test('handler function - invalid schema', t => {
     Reply: Reply,
     Request: Request,
     preHandler: [],
-    onSend: []
+    onSend: [],
+    onError: []
   }
   const schemas = new Schemas()
   buildSchema(context, schemaCompiler, schemas)
@@ -90,7 +91,8 @@ test('handler function - reply', t => {
     Reply: Reply,
     Request: Request,
     preHandler: [],
-    onSend: []
+    onSend: [],
+    onError: []
   }
   buildSchema(context, schemaCompiler)
   internals.handler({}, new Reply(res, context, {}))

--- a/test/internals/hooks.test.js
+++ b/test/internals/hooks.test.js
@@ -7,7 +7,7 @@ const { Hooks } = require('../../lib/hooks')
 const noop = () => {}
 
 test('hooks should have 4 array with the registered hooks', t => {
-  t.plan(6)
+  t.plan(7)
   const hooks = new Hooks()
   t.is(typeof hooks, 'object')
   t.ok(Array.isArray(hooks.onRequest))
@@ -15,10 +15,11 @@ test('hooks should have 4 array with the registered hooks', t => {
   t.ok(Array.isArray(hooks.preValidation))
   t.ok(Array.isArray(hooks.preHandler))
   t.ok(Array.isArray(hooks.onResponse))
+  t.ok(Array.isArray(hooks.onError))
 })
 
 test('hooks.add should add a hook to the given hook', t => {
-  t.plan(10)
+  t.plan(12)
   const hooks = new Hooks()
   hooks.add('onRequest', noop)
   t.is(hooks.onRequest.length, 1)
@@ -39,6 +40,10 @@ test('hooks.add should add a hook to the given hook', t => {
   hooks.add('onSend', noop)
   t.is(hooks.onSend.length, 1)
   t.is(typeof hooks.onSend[0], 'function')
+
+  hooks.add('onError', noop)
+  t.is(hooks.onError.length, 1)
+  t.is(typeof hooks.onError[0], 'function')
 })
 
 test('hooks should throw on unexisting handler', t => {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -116,6 +116,12 @@ server.addHook('onSend', function (req, reply, payload, next) {
   next()
 })
 
+server.addHook('onError', function (req, reply, error, next) {
+  this.log.debug('`this` is not `any`')
+  console.log(`${req.req.method} ${req.req.url}`)
+  next()
+})
+
 server.addHook('onClose', (instance, done) => {
   done()
 })


### PR DESCRIPTION
Hi all!
This is an initial implementation of what discussed in https://github.com/fastify/fastify/issues/1224.

The documentation/typings are still missing, once we finalize the API and how it works, I'll add them.

Features:
- The `onError` hook lives inside the standard request pipeline and is executed every time `reply.send` is invoked with an Error object (but only after the `customErrorHandler` has finished its execution, in `next` we always have a default);
- `reply.send` will throw if called inside the `onError` hook;
- Changing headers is allowed.

Note:
- If you pass an error to the `next` function inside the `onError` hook, that error will be swallowed.

Feedbacks are welcome!

cc @watson 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
