### PR TITLE
Attach validation result to request

### DIFF
--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -22,7 +22,7 @@ They need to be in
   * `params`: validates the params.
   * `response`: filter and generate a schema for the response, setting a
     schema allows us to have 10-20% more throughput.
-* `attachValidation`: attach validation result to request, if there is a schema validation error, instead of sending back the error immediately.
+* `attachValidation`: attach `validationError` to request, if there is a schema validation error, instead of sending the error to the error handler.
 * `beforeHandler(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#before-handler) called just before the request handler, useful if you need to perform authentication at route level for example, it could also be and array of functions.
 * `handler(request, reply)`: the function that will handle this request.
 * `schemaCompiler(schema)`: the function that build the schema for the validations. See [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-compiler)

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -22,6 +22,7 @@ They need to be in
   * `params`: validates the params.
   * `response`: filter and generate a schema for the response, setting a
     schema allows us to have 10-20% more throughput.
+* `attachValidation`: attach validation result to request, if there is a schema validation error, instead of sending back the error immediately.
 * `beforeHandler(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#before-handler) called just before the request handler, useful if you need to perform authentication at route level for example, it could also be and array of functions.
 * `handler(request, reply)`: the function that will handle this request.
 * `schemaCompiler(schema)`: the function that build the schema for the validations. See [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-compiler)

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -227,6 +227,19 @@ and fail to satisfy it, the route will immediately return a response with the fo
 }
 ```
 
+If you want to handle errors inside the route, you can specify the `attachValidation` option for your route. If there is a validation error, the `validation` property of the request will contain the `Error` object and the raw validation result as shown below
+
+```js
+const fastify = Fastify()
+
+fastify.post('/', { schema, attachValidation: true }, function (req, reply) {
+  if (req.validation) {
+    // `req.validation.validation` contains the raw validation result
+    reply.code(400).send(req.validation)
+  }
+})
+```
+
 You can also use [setErrorHandler](https://www.fastify.io/docs/latest/Server/#seterrorhandler) to define a custom response for validation errors such as
 
 ```js

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -227,15 +227,15 @@ and fail to satisfy it, the route will immediately return a response with the fo
 }
 ```
 
-If you want to handle errors inside the route, you can specify the `attachValidation` option for your route. If there is a validation error, the `validation` property of the request will contain the `Error` object and the raw validation result as shown below
+If you want to handle errors inside the route, you can specify the `attachValidation` option for your route. If there is a validation error, the `validationError` property of the request will contain the `Error` object with the raw `validation` result as shown below
 
 ```js
 const fastify = Fastify()
 
 fastify.post('/', { schema, attachValidation: true }, function (req, reply) {
   if (req.validation) {
-    // `req.validation.validation` contains the raw validation result
-    reply.code(400).send(req.validation)
+    // `req.validationError.validation` contains the raw validation error
+    reply.code(400).send(req.validationError)
   }
 })
 ```

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -166,6 +166,7 @@ declare namespace fastify {
     Body = DefaultBody
   > {
     schema?: RouteSchema
+    attachValidation?: boolean
     beforeHandler?:
       | FastifyMiddleware<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body>
       | Array<FastifyMiddleware<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body>>

--- a/fastify.js
+++ b/fastify.js
@@ -589,6 +589,10 @@ function build (options) {
       opts.prefix = prefix
       opts.logLevel = opts.logLevel || _fastify._logLevel
 
+      if (opts.attachValidation == null) {
+        opts.attachValidation = false
+      }
+
       // run 'onRoute' hooks
       for (var h of onRouteHooks) {
         h.call(_fastify, opts)
@@ -606,7 +610,8 @@ function build (options) {
         config,
         _fastify._errorHandler,
         opts.bodyLimit,
-        opts.logLevel
+        opts.logLevel,
+        opts.attachValidation
       )
 
       try {
@@ -663,7 +668,7 @@ function build (options) {
     return _fastify
   }
 
-  function Context (schema, handler, Reply, Request, contentTypeParser, config, errorHandler, bodyLimit, logLevel) {
+  function Context (schema, handler, Reply, Request, contentTypeParser, config, errorHandler, bodyLimit, logLevel, attachValidation) {
     this.schema = schema
     this.handler = handler
     this.Reply = Reply
@@ -681,6 +686,7 @@ function build (options) {
     }
     this.logLevel = logLevel
     this._404Context = null
+    this.attachValidation = attachValidation
   }
 
   function inject (opts, cb) {

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -59,8 +59,12 @@ function handleRequest (req, res, params, context) {
 function handler (reply) {
   var result = validateSchema(reply.context, reply.request)
   if (result) {
-    reply.code(400).send(result)
-    return
+    if (reply.context.attachValidation === false) {
+      reply.code(400).send(result)
+      return
+    } else {
+      reply.request.validation = result.validation
+    }
   }
 
   // preHandler hook

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -63,7 +63,7 @@ function handler (reply) {
       reply.code(400).send(result)
       return
     } else {
-      reply.request.validation = result.validation
+      reply.request.validation = result.message
     }
   }
 

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -64,7 +64,7 @@ function handler (reply) {
       return
     }
 
-    reply.request.validation = result.message
+    reply.request.validation = result
   }
 
   // preHandler hook

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -64,7 +64,7 @@ function handler (reply) {
       return
     }
 
-    reply.request.validation = result
+    reply.request.validationError = result
   }
 
   // preHandler hook

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -62,9 +62,9 @@ function handler (reply) {
     if (reply.context.attachValidation === false) {
       reply.code(400).send(result)
       return
-    } else {
-      reply.request.validation = result.message
     }
+
+    reply.request.validation = result.message
   }
 
   // preHandler hook

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -58,7 +58,8 @@ test('handler function - invalid schema', t => {
     Reply: Reply,
     Request: Request,
     preHandler: [],
-    onSend: []
+    onSend: [],
+    attachValidation: false
   }
   const schemas = new Schemas()
   buildSchema(context, schemaCompiler, schemas)

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -101,7 +101,7 @@ test('should be able to attach validation to request', t => {
   const fastify = Fastify()
 
   fastify.post('/', { schema, attachValidation: true }, function (req, reply) {
-    reply.code(400).send(req.validation)
+    reply.code(400).send('Attached: ' + req.validation)
   })
 
   fastify.inject({
@@ -112,7 +112,7 @@ test('should be able to attach validation to request', t => {
     url: '/'
   }, (err, res) => {
     t.error(err)
-    t.deepEqual(res.payload, "body should have required property 'name'")
+    t.deepEqual(res.payload, "Attached: body should have required property 'name'")
     t.strictEqual(res.statusCode, 400)
   })
 })

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -1,0 +1,128 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('..')
+const test = t.test
+
+const schema = {
+  body: {
+    type: 'object',
+    properties: {
+      name: { type: 'string' }
+    },
+    required: ['name']
+  }
+}
+
+test('should work with valid payload', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  fastify.post('/', { schema }, function (req, reply) {
+    reply.code(200).send(req.body.name)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    payload: {
+      name: 'michelangelo'
+    },
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.deepEqual(res.payload, 'michelangelo')
+    t.strictEqual(res.statusCode, 200)
+  })
+})
+
+test('should fail immediately with invalid payload', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  fastify.post('/', { schema }, function (req, reply) {
+    reply.code(200).send(req.body.name)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    payload: {
+      hello: 'michelangelo'
+    },
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.deepEqual(JSON.parse(res.payload), {
+      statusCode: 400,
+      error: 'Bad Request',
+      message: "body should have required property 'name'"
+    })
+    t.strictEqual(res.statusCode, 400)
+  })
+})
+
+test('should be able to use setErrorHandler specify custom validation error', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  fastify.post('/', { schema }, function (req, reply) {
+    reply.code(200).send(req.body.name)
+  })
+
+  fastify.setErrorHandler(function (error, request, reply) {
+    if (error.validation) {
+      reply.status(422).send(new Error('validation failed'))
+    }
+  })
+
+  fastify.inject({
+    method: 'POST',
+    payload: {
+      hello: 'michelangelo'
+    },
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.deepEqual(JSON.parse(res.payload), {
+      statusCode: 422,
+      error: 'Unprocessable Entity',
+      message: 'validation failed'
+    })
+    t.strictEqual(res.statusCode, 422)
+  })
+})
+
+test('should be able to attach validation to request', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  fastify.post('/', { schema, attachValidation: true }, function (req, reply) {
+    reply.code(400).send(req.validation)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    payload: {
+      hello: 'michelangelo'
+    },
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.deepEqual(JSON.parse(res.payload), [
+      {
+        keyword: 'required',
+        dataPath: '',
+        schemaPath: '#/required',
+        params: {
+          missingProperty: 'name'
+        },
+        message: 'should have required property \'name\''
+      }
+    ]
+    )
+    t.strictEqual(res.statusCode, 400)
+  })
+})

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -8,7 +8,8 @@ const schema = {
   body: {
     type: 'object',
     properties: {
-      name: { type: 'string' }
+      name: { type: 'string' },
+      work: { type: 'string' }
     },
     required: ['name']
   }
@@ -111,18 +112,7 @@ test('should be able to attach validation to request', t => {
     url: '/'
   }, (err, res) => {
     t.error(err)
-    t.deepEqual(JSON.parse(res.payload), [
-      {
-        keyword: 'required',
-        dataPath: '',
-        schemaPath: '#/required',
-        params: {
-          missingProperty: 'name'
-        },
-        message: 'should have required property \'name\''
-      }
-    ]
-    )
+    t.deepEqual(res.payload, "body should have required property 'name'")
     t.strictEqual(res.statusCode, 400)
   })
 })

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -101,7 +101,7 @@ test('should be able to attach validation to request', t => {
   const fastify = Fastify()
 
   fastify.post('/', { schema, attachValidation: true }, function (req, reply) {
-    reply.code(400).send('Attached: ' + req.validation)
+    reply.code(400).send(req.validation.validation)
   })
 
   fastify.inject({
@@ -112,7 +112,14 @@ test('should be able to attach validation to request', t => {
     url: '/'
   }, (err, res) => {
     t.error(err)
-    t.deepEqual(res.payload, "Attached: body should have required property 'name'")
+
+    t.deepEqual(JSON.parse(res.payload), [{
+      keyword: 'required',
+      dataPath: '',
+      schemaPath: '#/required',
+      params: { missingProperty: 'name' },
+      message: 'should have required property \'name\''
+    }])
     t.strictEqual(res.statusCode, 400)
   })
 })
@@ -140,7 +147,7 @@ test('Attached validation error should take precendence over setErrorHandler', t
     url: '/'
   }, (err, res) => {
     t.error(err)
-    t.deepEqual(res.payload, "Attached: body should have required property 'name'")
+    t.deepEqual(res.payload, "Attached: Error: body should have required property 'name'")
     t.strictEqual(res.statusCode, 400)
   })
 })

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -102,7 +102,7 @@ test('should be able to attach validation to request', t => {
   const fastify = Fastify()
 
   fastify.post('/', { schema, attachValidation: true }, function (req, reply) {
-    reply.code(400).send(req.validation.validation)
+    reply.code(400).send(req.validationError.validation)
   })
 
   fastify.inject({
@@ -132,7 +132,7 @@ test('should respect when attachValidation is explicitly set to false', t => {
 
   fastify.post('/', { schema, attachValidation: false }, function (req, reply) {
     t.fail('should not be here')
-    reply.code(200).send(req.validation.validation)
+    reply.code(200).send(req.validationError.validation)
   })
 
   fastify.inject({
@@ -158,7 +158,7 @@ test('Attached validation error should take precendence over setErrorHandler', t
   const fastify = Fastify()
 
   fastify.post('/', { schema, attachValidation: true }, function (req, reply) {
-    reply.code(400).send('Attached: ' + req.validation)
+    reply.code(400).send('Attached: ' + req.validationError)
   })
 
   fastify.setErrorHandler(function (error, request, reply) {


### PR DESCRIPTION
Attempts to provide a solution for #1202 

Here is the original `gitter` chat:

![47423754-8286cb80-d78e-11e8-860f-aeaffd4f8f39](https://user-images.githubusercontent.com/1297759/47574915-6c713a80-d949-11e8-8b27-2d9a41fdbbac.png)

The OP wanted to have functionality similar to `express-validator` which is attaching validation result to request. 

~~However, I wanted to provide a more reusable and less distruptive/polluting way to the main content of request. Instead of filling a request body with validation checks, it makes sense for me to provide an external function for overriding what we already do.~~

~~I also thought putting `wrapValidationError` inside the schema object itself but then decided it will pollute the main information in schema definitions.~~

I will update the docs as well if you think this solves the problem here @fastify/fastify 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
