### PR TITLE
Move all _ prefixed properties to Symbols

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -8,7 +8,7 @@ const flatstr = require('flatstr')
 const FJS = require('fast-json-stringify')
 const {
   kFourOhFourContext,
-  kErrorHandlerCalled,
+  kReplyErrorHandlerCalled,
   kReplyStartTime,
   kReplySerializer,
   kReplyIsError,
@@ -51,7 +51,7 @@ function Reply (res, context, request, log) {
   this.context = context
   this.sent = false
   this[kReplySerializer] = null
-  this[kErrorHandlerCalled] = false
+  this[kReplyErrorHandlerCalled] = false
   this[kReplyIsError] = false
   this.request = request
   this[kReplyHeaders] = {}
@@ -316,10 +316,10 @@ function handleError (reply, error, cb) {
   res.statusCode = statusCode
 
   var errorHandler = reply.context.errorHandler
-  if (errorHandler && reply[kErrorHandlerCalled] === false) {
+  if (errorHandler && reply[kReplyErrorHandlerCalled] === false) {
     reply.sent = false
     reply[kReplyIsError] = false
-    reply[kErrorHandlerCalled] = true
+    reply[kReplyErrorHandlerCalled] = true
     var result = errorHandler(error, reply.request, reply)
     if (result && typeof result.then === 'function') {
       wrapThenable(result, reply)
@@ -404,7 +404,7 @@ function buildReply (R) {
     this.res = res
     this.context = context
     this[kReplyIsError] = false
-    this[kErrorHandlerCalled] = false
+    this[kReplyErrorHandlerCalled] = false
     this.sent = false
     this[kReplySerializer] = null
     this.request = request

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -9,11 +9,11 @@ const FJS = require('fast-json-stringify')
 const {
   kFourOhFourContext,
   kErrorHandlerCalled,
-  kStartTime,
-  kSerializer,
-  kIsError,
-  kHeaders,
-  kHasStatusCode
+  kReplyStartTime,
+  kReplySerializer,
+  kReplyIsError,
+  kReplyHeaders,
+  kReplyHasStatusCode
 } = require('./symbols.js')
 const { hookRunner, onSendHookRunner } = require('./hooks')
 const validation = require('./validation')
@@ -50,13 +50,13 @@ function Reply (res, context, request, log) {
   this.res = res
   this.context = context
   this.sent = false
-  this[kSerializer] = null
+  this[kReplySerializer] = null
   this[kErrorHandlerCalled] = false
-  this[kIsError] = false
+  this[kReplyIsError] = false
   this.request = request
-  this[kHeaders] = {}
-  this[kHasStatusCode] = false
-  this[kStartTime] = undefined
+  this[kReplyHeaders] = {}
+  this[kReplyHasStatusCode] = false
+  this[kReplyStartTime] = undefined
   this.log = log
 }
 
@@ -68,7 +68,7 @@ Reply.prototype.send = function (payload) {
 
   this.sent = true
 
-  if (payload instanceof Error || this[kIsError] === true) {
+  if (payload instanceof Error || this[kReplyIsError] === true) {
     handleError(this, payload, onSendHook)
     return
   }
@@ -84,24 +84,24 @@ Reply.prototype.send = function (payload) {
   if (payload !== null) {
     if (Buffer.isBuffer(payload) || typeof payload.pipe === 'function') {
       if (hasContentType === false) {
-        this[kHeaders]['content-type'] = CONTENT_TYPE.OCTET
+        this[kReplyHeaders]['content-type'] = CONTENT_TYPE.OCTET
       }
       onSendHook(this, payload)
       return
     }
 
     if (hasContentType === false && typeof payload === 'string') {
-      this[kHeaders]['content-type'] = CONTENT_TYPE.PLAIN
+      this[kReplyHeaders]['content-type'] = CONTENT_TYPE.PLAIN
       onSendHook(this, payload)
       return
     }
   }
 
-  if (this[kSerializer] !== null) {
-    payload = this[kSerializer](payload)
+  if (this[kReplySerializer] !== null) {
+    payload = this[kReplySerializer](payload)
   } else if (hasContentType === false || contentType.indexOf('application/json') > -1) {
     if (hasContentType === false || contentType.indexOf('charset') === -1) {
-      this[kHeaders]['content-type'] = CONTENT_TYPE.JSON
+      this[kReplyHeaders]['content-type'] = CONTENT_TYPE.JSON
     }
     payload = serialize(this.context, payload, this.res.statusCode)
     flatstr(payload)
@@ -115,13 +115,13 @@ Reply.prototype.getHeader = function (key) {
 }
 
 Reply.prototype.hasHeader = function (key) {
-  return this[kHeaders][key.toLowerCase()] !== undefined
+  return this[kReplyHeaders][key.toLowerCase()] !== undefined
 }
 
 Reply.prototype.removeHeader = function (key) {
   // Node.js does not like headers with keys set to undefined,
   // so we have to delete the key.
-  delete this[kHeaders][key.toLowerCase()]
+  delete this[kReplyHeaders][key.toLowerCase()]
   return this
 }
 
@@ -131,11 +131,11 @@ Reply.prototype.header = function (key, value) {
   // default the value to ''
   value = value === undefined ? '' : value
 
-  if (this[kHeaders][_key] && _key === 'set-cookie') {
+  if (this[kReplyHeaders][_key] && _key === 'set-cookie') {
     // https://tools.ietf.org/html/rfc7230#section-3.2.2
-    this[kHeaders][_key] = [this[kHeaders][_key]].concat(value)
+    this[kReplyHeaders][_key] = [this[kReplyHeaders][_key]].concat(value)
   } else {
-    this[kHeaders][_key] = value
+    this[kReplyHeaders][_key] = value
   }
   return this
 }
@@ -150,34 +150,34 @@ Reply.prototype.headers = function (headers) {
 
 Reply.prototype.code = function (code) {
   this.res.statusCode = code
-  this[kHasStatusCode] = true
+  this[kReplyHasStatusCode] = true
   return this
 }
 
 Reply.prototype.status = Reply.prototype.code
 
 Reply.prototype.serialize = function (payload) {
-  if (this[kSerializer] !== null) {
-    return this[kSerializer](payload)
+  if (this[kReplySerializer] !== null) {
+    return this[kReplySerializer](payload)
   } else {
     return serialize(this.context, payload, this.res.statusCode)
   }
 }
 
 Reply.prototype.serializer = function (fn) {
-  this[kSerializer] = fn
+  this[kReplySerializer] = fn
   return this
 }
 
 Reply.prototype.type = function (type) {
-  this[kHeaders]['content-type'] = type
+  this[kReplyHeaders]['content-type'] = type
   return this
 }
 
 Reply.prototype.redirect = function (code, url) {
   if (typeof code === 'string') {
     url = code
-    code = this[kHasStatusCode] ? this.res.statusCode : 302
+    code = this[kReplyHasStatusCode] ? this.res.statusCode : 302
   }
 
   this.header('location', url).code(code).send()
@@ -220,10 +220,10 @@ function onSendEnd (reply, payload) {
     // we cannot send a content-length for 304 and 204, and all status code
     // < 200.
     if (statusCode >= 200 && statusCode !== 204 && statusCode !== 304) {
-      reply[kHeaders]['content-length'] = '0'
+      reply[kReplyHeaders]['content-length'] = '0'
     }
 
-    res.writeHead(statusCode, reply[kHeaders])
+    res.writeHead(statusCode, reply[kReplyHeaders])
     // avoid ArgumentsAdaptorTrampoline from V8
     res.end(null, null, null)
     return
@@ -238,13 +238,13 @@ function onSendEnd (reply, payload) {
     throw new FST_ERR_REP_INVALID_PAYLOAD_TYPE(typeof payload)
   }
 
-  if (!reply[kHeaders]['content-length']) {
-    reply[kHeaders]['content-length'] = '' + Buffer.byteLength(payload)
+  if (!reply[kReplyHeaders]['content-length']) {
+    reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)
   }
 
   reply.sent = true
 
-  res.writeHead(statusCode, reply[kHeaders])
+  res.writeHead(statusCode, reply[kReplyHeaders])
 
   // avoid ArgumentsAdaptorTrampoline from V8
   res.end(payload, null, null)
@@ -288,8 +288,8 @@ function sendStream (payload, res, reply) {
   // writeHead, and we need to resort to setHeader, which will trigger
   // a writeHead when there is data to send.
   if (!res.headersSent) {
-    for (var key in reply[kHeaders]) {
-      res.setHeader(key, reply[kHeaders][key])
+    for (var key in reply[kReplyHeaders]) {
+      res.setHeader(key, reply[kReplyHeaders][key])
     }
   } else {
     res.log.warn('response will send, but you shouldn\'t use res.writeHead in stream mode')
@@ -318,7 +318,7 @@ function handleError (reply, error, cb) {
   var errorHandler = reply.context.errorHandler
   if (errorHandler && reply[kErrorHandlerCalled] === false) {
     reply.sent = false
-    reply[kIsError] = false
+    reply[kReplyIsError] = false
     reply[kErrorHandlerCalled] = true
     var result = errorHandler(error, reply.request, reply)
     if (result && typeof result.then === 'function') {
@@ -334,16 +334,16 @@ function handleError (reply, error, cb) {
     statusCode: statusCode
   })
   flatstr(payload)
-  reply[kHeaders]['content-type'] = CONTENT_TYPE.JSON
+  reply[kReplyHeaders]['content-type'] = CONTENT_TYPE.JSON
 
   if (cb) {
     cb(reply, payload)
     return
   }
 
-  reply[kHeaders]['content-length'] = '' + Buffer.byteLength(payload)
+  reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)
   reply.sent = true
-  res.writeHead(res.statusCode, reply[kHeaders])
+  res.writeHead(res.statusCode, reply[kReplyHeaders])
   res.end(payload)
 }
 
@@ -403,13 +403,13 @@ function buildReply (R) {
   function _Reply (res, context, request, log) {
     this.res = res
     this.context = context
-    this[kIsError] = false
+    this[kReplyIsError] = false
     this[kErrorHandlerCalled] = false
     this.sent = false
-    this[kSerializer] = null
+    this[kReplySerializer] = null
     this.request = request
-    this[kHeaders] = {}
-    this[kStartTime] = undefined
+    this[kReplyHeaders] = {}
+    this[kReplyStartTime] = undefined
     this.log = log
   }
   _Reply.prototype = new R()
@@ -418,7 +418,7 @@ function buildReply (R) {
 
 function notFound (reply) {
   reply.sent = false
-  reply[kIsError] = false
+  reply[kReplyIsError] = false
 
   if (reply.context[kFourOhFourContext] === null) {
     reply.res.log.warn('Trying to send a NotFound error inside a 404 handler. Sending basic 404 response.')
@@ -435,7 +435,7 @@ function noop () {}
 function getHeaderProper (reply, key) {
   key = key.toLowerCase()
   var res = reply.res
-  var value = reply[kHeaders][key]
+  var value = reply[kReplyHeaders][key]
   if (value === undefined && res.hasHeader(key)) {
     value = res.getHeader(key)
   }
@@ -445,7 +445,7 @@ function getHeaderProper (reply, key) {
 function getHeaderFallback (reply, key) {
   key = key.toLowerCase()
   var res = reply.res
-  var value = reply[kHeaders][key]
+  var value = reply[kReplyHeaders][key]
   if (value === undefined) {
     value = res.getHeader(key)
   }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -7,7 +7,13 @@ const statusCodes = require('http').STATUS_CODES
 const flatstr = require('flatstr')
 const FJS = require('fast-json-stringify')
 const {
-  kFourOhFourContext
+  kFourOhFourContext,
+  kErrorHandlerCalled,
+  kStartTime,
+  kSerializer,
+  kIsError,
+  kHeaders,
+  kHasStatusCode
 } = require('./symbols.js')
 const { hookRunner, onSendHookRunner } = require('./hooks')
 const validation = require('./validation')
@@ -44,13 +50,13 @@ function Reply (res, context, request, log) {
   this.res = res
   this.context = context
   this.sent = false
-  this._serializer = null
-  this._errorHandlerCalled = false
-  this._isError = false
+  this[kSerializer] = null
+  this[kErrorHandlerCalled] = false
+  this[kIsError] = false
   this.request = request
-  this._headers = {}
-  this._hasStatusCode = false
-  this._startTime = undefined
+  this[kHeaders] = {}
+  this[kHasStatusCode] = false
+  this[kStartTime] = undefined
   this.log = log
 }
 
@@ -62,7 +68,7 @@ Reply.prototype.send = function (payload) {
 
   this.sent = true
 
-  if (payload instanceof Error || this._isError === true) {
+  if (payload instanceof Error || this[kIsError] === true) {
     handleError(this, payload, onSendHook)
     return
   }
@@ -78,24 +84,24 @@ Reply.prototype.send = function (payload) {
   if (payload !== null) {
     if (Buffer.isBuffer(payload) || typeof payload.pipe === 'function') {
       if (hasContentType === false) {
-        this._headers['content-type'] = CONTENT_TYPE.OCTET
+        this[kHeaders]['content-type'] = CONTENT_TYPE.OCTET
       }
       onSendHook(this, payload)
       return
     }
 
     if (hasContentType === false && typeof payload === 'string') {
-      this._headers['content-type'] = CONTENT_TYPE.PLAIN
+      this[kHeaders]['content-type'] = CONTENT_TYPE.PLAIN
       onSendHook(this, payload)
       return
     }
   }
 
-  if (this._serializer !== null) {
-    payload = this._serializer(payload)
+  if (this[kSerializer] !== null) {
+    payload = this[kSerializer](payload)
   } else if (hasContentType === false || contentType.indexOf('application/json') > -1) {
     if (hasContentType === false || contentType.indexOf('charset') === -1) {
-      this._headers['content-type'] = CONTENT_TYPE.JSON
+      this[kHeaders]['content-type'] = CONTENT_TYPE.JSON
     }
     payload = serialize(this.context, payload, this.res.statusCode)
     flatstr(payload)
@@ -109,13 +115,13 @@ Reply.prototype.getHeader = function (key) {
 }
 
 Reply.prototype.hasHeader = function (key) {
-  return this._headers[key.toLowerCase()] !== undefined
+  return this[kHeaders][key.toLowerCase()] !== undefined
 }
 
 Reply.prototype.removeHeader = function (key) {
   // Node.js does not like headers with keys set to undefined,
   // so we have to delete the key.
-  delete this._headers[key.toLowerCase()]
+  delete this[kHeaders][key.toLowerCase()]
   return this
 }
 
@@ -125,11 +131,11 @@ Reply.prototype.header = function (key, value) {
   // default the value to ''
   value = value === undefined ? '' : value
 
-  if (this._headers[_key] && _key === 'set-cookie') {
+  if (this[kHeaders][_key] && _key === 'set-cookie') {
     // https://tools.ietf.org/html/rfc7230#section-3.2.2
-    this._headers[_key] = [this._headers[_key]].concat(value)
+    this[kHeaders][_key] = [this[kHeaders][_key]].concat(value)
   } else {
-    this._headers[_key] = value
+    this[kHeaders][_key] = value
   }
   return this
 }
@@ -144,34 +150,34 @@ Reply.prototype.headers = function (headers) {
 
 Reply.prototype.code = function (code) {
   this.res.statusCode = code
-  this._hasStatusCode = true
+  this[kHasStatusCode] = true
   return this
 }
 
 Reply.prototype.status = Reply.prototype.code
 
 Reply.prototype.serialize = function (payload) {
-  if (this._serializer !== null) {
-    return this._serializer(payload)
+  if (this[kSerializer] !== null) {
+    return this[kSerializer](payload)
   } else {
     return serialize(this.context, payload, this.res.statusCode)
   }
 }
 
 Reply.prototype.serializer = function (fn) {
-  this._serializer = fn
+  this[kSerializer] = fn
   return this
 }
 
 Reply.prototype.type = function (type) {
-  this._headers['content-type'] = type
+  this[kHeaders]['content-type'] = type
   return this
 }
 
 Reply.prototype.redirect = function (code, url) {
   if (typeof code === 'string') {
     url = code
-    code = this._hasStatusCode ? this.res.statusCode : 302
+    code = this[kHasStatusCode] ? this.res.statusCode : 302
   }
 
   this.header('location', url).code(code).send()
@@ -214,10 +220,10 @@ function onSendEnd (reply, payload) {
     // we cannot send a content-length for 304 and 204, and all status code
     // < 200.
     if (statusCode >= 200 && statusCode !== 204 && statusCode !== 304) {
-      reply._headers['content-length'] = '0'
+      reply[kHeaders]['content-length'] = '0'
     }
 
-    res.writeHead(statusCode, reply._headers)
+    res.writeHead(statusCode, reply[kHeaders])
     // avoid ArgumentsAdaptorTrampoline from V8
     res.end(null, null, null)
     return
@@ -232,13 +238,13 @@ function onSendEnd (reply, payload) {
     throw new FST_ERR_REP_INVALID_PAYLOAD_TYPE(typeof payload)
   }
 
-  if (!reply._headers['content-length']) {
-    reply._headers['content-length'] = '' + Buffer.byteLength(payload)
+  if (!reply[kHeaders]['content-length']) {
+    reply[kHeaders]['content-length'] = '' + Buffer.byteLength(payload)
   }
 
   reply.sent = true
 
-  res.writeHead(statusCode, reply._headers)
+  res.writeHead(statusCode, reply[kHeaders])
 
   // avoid ArgumentsAdaptorTrampoline from V8
   res.end(payload, null, null)
@@ -282,8 +288,8 @@ function sendStream (payload, res, reply) {
   // writeHead, and we need to resort to setHeader, which will trigger
   // a writeHead when there is data to send.
   if (!res.headersSent) {
-    for (var key in reply._headers) {
-      res.setHeader(key, reply._headers[key])
+    for (var key in reply[kHeaders]) {
+      res.setHeader(key, reply[kHeaders][key])
     }
   } else {
     res.log.warn('response will send, but you shouldn\'t use res.writeHead in stream mode')
@@ -310,10 +316,10 @@ function handleError (reply, error, cb) {
   res.statusCode = statusCode
 
   var errorHandler = reply.context.errorHandler
-  if (errorHandler && reply._errorHandlerCalled === false) {
+  if (errorHandler && reply[kErrorHandlerCalled] === false) {
     reply.sent = false
-    reply._isError = false
-    reply._errorHandlerCalled = true
+    reply[kIsError] = false
+    reply[kErrorHandlerCalled] = true
     var result = errorHandler(error, reply.request, reply)
     if (result && typeof result.then === 'function') {
       wrapThenable(result, reply)
@@ -328,16 +334,16 @@ function handleError (reply, error, cb) {
     statusCode: statusCode
   })
   flatstr(payload)
-  reply._headers['content-type'] = CONTENT_TYPE.JSON
+  reply[kHeaders]['content-type'] = CONTENT_TYPE.JSON
 
   if (cb) {
     cb(reply, payload)
     return
   }
 
-  reply._headers['content-length'] = '' + Buffer.byteLength(payload)
+  reply[kHeaders]['content-length'] = '' + Buffer.byteLength(payload)
   reply.sent = true
-  res.writeHead(res.statusCode, reply._headers)
+  res.writeHead(res.statusCode, reply[kHeaders])
   res.end(payload)
 }
 
@@ -397,13 +403,13 @@ function buildReply (R) {
   function _Reply (res, context, request, log) {
     this.res = res
     this.context = context
-    this._isError = false
-    this._errorHandlerCalled = false
+    this[kIsError] = false
+    this[kErrorHandlerCalled] = false
     this.sent = false
-    this._serializer = null
+    this[kSerializer] = null
     this.request = request
-    this._headers = {}
-    this._startTime = undefined
+    this[kHeaders] = {}
+    this[kStartTime] = undefined
     this.log = log
   }
   _Reply.prototype = new R()
@@ -412,7 +418,7 @@ function buildReply (R) {
 
 function notFound (reply) {
   reply.sent = false
-  reply._isError = false
+  reply[kIsError] = false
 
   if (reply.context[kFourOhFourContext] === null) {
     reply.res.log.warn('Trying to send a NotFound error inside a 404 handler. Sending basic 404 response.')
@@ -429,7 +435,7 @@ function noop () {}
 function getHeaderProper (reply, key) {
   key = key.toLowerCase()
   var res = reply.res
-  var value = reply._headers[key]
+  var value = reply[kHeaders][key]
   if (value === undefined && res.hasHeader(key)) {
     value = res.getHeader(key)
   }
@@ -439,7 +445,7 @@ function getHeaderProper (reply, key) {
 function getHeaderFallback (reply, key) {
   key = key.toLowerCase()
   var res = reply.res
-  var value = reply._headers[key]
+  var value = reply[kHeaders][key]
   if (value === undefined) {
     value = res.getHeader(key)
   }

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -13,7 +13,12 @@ const keys = {
   kMiddlewares: Symbol('fastify.middlewares'),
   kCanSetNotFoundHandler: Symbol('fastify.canSetNotFoundHandler'),
   kFourOhFourLevelInstance: Symbol('fastify.404LogLevelInstance'),
-  kFourOhFourContext: Symbol('fastify.404ContextKey')
+  kFourOhFourContext: Symbol('fastify.404ContextKey'),
+  kSerializer: Symbol('reply.Serializer'),
+  kIsError: Symbol('reply.isError'),
+  kHeaders: Symbol('reply.headers'),
+  kHasStatusCode: Symbol('reply.hasStatusCode'),
+  kStartTime: Symbol('reply.errorHandlerCalled')
 }
 
 module.exports = keys

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -14,7 +14,7 @@ const keys = {
   kCanSetNotFoundHandler: Symbol('fastify.canSetNotFoundHandler'),
   kFourOhFourLevelInstance: Symbol('fastify.404LogLevelInstance'),
   kFourOhFourContext: Symbol('fastify.404ContextKey'),
-  kReplySerializer: Symbol('reply.Serializer'),
+  kReplySerializer: Symbol('reply.serializer'),
   kReplyIsError: Symbol('reply.isError'),
   kReplyHeaders: Symbol('reply.headers'),
   kReplyHasStatusCode: Symbol('reply.hasStatusCode'),

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -18,7 +18,8 @@ const keys = {
   kReplyIsError: Symbol('reply.isError'),
   kReplyHeaders: Symbol('reply.headers'),
   kReplyHasStatusCode: Symbol('reply.hasStatusCode'),
-  kReplyStartTime: Symbol('reply.errorHandlerCalled')
+  kReplyStartTime: Symbol('reply.startTime'),
+  kReplyErrorHandlerCalled: Symbol('reply.errorHandlerCalled')
 }
 
 module.exports = keys

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -14,12 +14,12 @@ const keys = {
   kCanSetNotFoundHandler: Symbol('fastify.canSetNotFoundHandler'),
   kFourOhFourLevelInstance: Symbol('fastify.404LogLevelInstance'),
   kFourOhFourContext: Symbol('fastify.404ContextKey'),
-  kReplySerializer: Symbol('reply.serializer'),
-  kReplyIsError: Symbol('reply.isError'),
-  kReplyHeaders: Symbol('reply.headers'),
-  kReplyHasStatusCode: Symbol('reply.hasStatusCode'),
-  kReplyStartTime: Symbol('reply.startTime'),
-  kReplyErrorHandlerCalled: Symbol('reply.errorHandlerCalled')
+  kReplySerializer: Symbol('fastify.reply.serializer'),
+  kReplyIsError: Symbol('fastify.reply.isError'),
+  kReplyHeaders: Symbol('fastify.reply.headers'),
+  kReplyHasStatusCode: Symbol('fastify.reply.hasStatusCode'),
+  kReplyStartTime: Symbol('fastify.reply.startTime'),
+  kReplyErrorHandlerCalled: Symbol('fastify.reply.errorHandlerCalled')
 }
 
 module.exports = keys

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -14,11 +14,11 @@ const keys = {
   kCanSetNotFoundHandler: Symbol('fastify.canSetNotFoundHandler'),
   kFourOhFourLevelInstance: Symbol('fastify.404LogLevelInstance'),
   kFourOhFourContext: Symbol('fastify.404ContextKey'),
-  kSerializer: Symbol('reply.Serializer'),
-  kIsError: Symbol('reply.isError'),
-  kHeaders: Symbol('reply.headers'),
-  kHasStatusCode: Symbol('reply.hasStatusCode'),
-  kStartTime: Symbol('reply.errorHandlerCalled')
+  kReplySerializer: Symbol('reply.Serializer'),
+  kReplyIsError: Symbol('reply.isError'),
+  kReplyHeaders: Symbol('reply.headers'),
+  kReplyHasStatusCode: Symbol('reply.hasStatusCode'),
+  kReplyStartTime: Symbol('reply.errorHandlerCalled')
 }
 
 module.exports = keys

--- a/lib/wrapThenable.js
+++ b/lib/wrapThenable.js
@@ -1,5 +1,5 @@
 'use strict'
-const { kIsError } = require('./symbols')
+const { kReplyIsError } = require('./symbols')
 
 function wrapThenable (thenable, reply) {
   thenable.then(function (payload) {
@@ -12,7 +12,7 @@ function wrapThenable (thenable, reply) {
         reply.send(payload)
       } catch (err) {
         reply.sent = false
-        reply[kIsError] = true
+        reply[kReplyIsError] = true
         reply.send(err)
       }
     } else if (reply.sent === false) {
@@ -20,7 +20,7 @@ function wrapThenable (thenable, reply) {
     }
   }, function (err) {
     reply.sent = false
-    reply[kIsError] = true
+    reply[kReplyIsError] = true
     reply.send(err)
   })
 }

--- a/lib/wrapThenable.js
+++ b/lib/wrapThenable.js
@@ -1,4 +1,5 @@
 'use strict'
+const { kIsError } = require('./symbols')
 
 function wrapThenable (thenable, reply) {
   thenable.then(function (payload) {
@@ -11,7 +12,7 @@ function wrapThenable (thenable, reply) {
         reply.send(payload)
       } catch (err) {
         reply.sent = false
-        reply._isError = true
+        reply[kIsError] = true
         reply.send(err)
       }
     } else if (reply.sent === false) {
@@ -19,7 +20,7 @@ function wrapThenable (thenable, reply) {
     }
   }, function (err) {
     reply.sent = false
-    reply._isError = true
+    reply[kIsError] = true
     reply.send(err)
   })
 }

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -727,7 +727,7 @@ test('onSend hook is called after payload is serialized and headers are set', t 
 
     instance.addHook('onSend', function (request, reply, payload, next) {
       t.deepEqual(JSON.parse(payload), thePayload)
-      t.strictEqual(reply._headers['content-type'], 'application/json; charset=utf-8')
+      t.strictEqual(reply[symbols.kHeaders]['content-type'], 'application/json; charset=utf-8')
       next()
     })
 
@@ -741,7 +741,7 @@ test('onSend hook is called after payload is serialized and headers are set', t 
   fastify.register((instance, opts, next) => {
     instance.addHook('onSend', function (request, reply, payload, next) {
       t.strictEqual(payload, 'some text')
-      t.strictEqual(reply._headers['content-type'], 'text/plain; charset=utf-8')
+      t.strictEqual(reply[symbols.kHeaders]['content-type'], 'text/plain; charset=utf-8')
       next()
     })
 
@@ -757,7 +757,7 @@ test('onSend hook is called after payload is serialized and headers are set', t 
 
     instance.addHook('onSend', function (request, reply, payload, next) {
       t.strictEqual(payload, thePayload)
-      t.strictEqual(reply._headers['content-type'], 'application/octet-stream')
+      t.strictEqual(reply[symbols.kHeaders]['content-type'], 'application/octet-stream')
       next()
     })
 
@@ -779,7 +779,7 @@ test('onSend hook is called after payload is serialized and headers are set', t 
 
     instance.addHook('onSend', function (request, reply, payload, next) {
       t.strictEqual(payload, thePayload)
-      t.strictEqual(reply._headers['content-type'], 'application/octet-stream')
+      t.strictEqual(reply[symbols.kHeaders]['content-type'], 'application/octet-stream')
       next()
     })
 
@@ -795,7 +795,7 @@ test('onSend hook is called after payload is serialized and headers are set', t 
 
     instance.addHook('onSend', function (request, reply, payload, next) {
       t.strictEqual(payload, serializedPayload)
-      t.strictEqual(reply._headers['content-type'], 'text/custom')
+      t.strictEqual(reply[symbols.kHeaders]['content-type'], 'text/custom')
       next()
     })
 
@@ -1784,7 +1784,7 @@ test('If the content type has been set inside an hook it should not be changed',
   })
 
   fastify.get('/', (request, reply) => {
-    t.ok(reply._headers['content-type'])
+    t.ok(reply[symbols.kHeaders]['content-type'])
     reply.send('hello')
   })
 

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -727,7 +727,7 @@ test('onSend hook is called after payload is serialized and headers are set', t 
 
     instance.addHook('onSend', function (request, reply, payload, next) {
       t.deepEqual(JSON.parse(payload), thePayload)
-      t.strictEqual(reply[symbols.kHeaders]['content-type'], 'application/json; charset=utf-8')
+      t.strictEqual(reply[symbols.kReplyHeaders]['content-type'], 'application/json; charset=utf-8')
       next()
     })
 
@@ -741,7 +741,7 @@ test('onSend hook is called after payload is serialized and headers are set', t 
   fastify.register((instance, opts, next) => {
     instance.addHook('onSend', function (request, reply, payload, next) {
       t.strictEqual(payload, 'some text')
-      t.strictEqual(reply[symbols.kHeaders]['content-type'], 'text/plain; charset=utf-8')
+      t.strictEqual(reply[symbols.kReplyHeaders]['content-type'], 'text/plain; charset=utf-8')
       next()
     })
 
@@ -757,7 +757,7 @@ test('onSend hook is called after payload is serialized and headers are set', t 
 
     instance.addHook('onSend', function (request, reply, payload, next) {
       t.strictEqual(payload, thePayload)
-      t.strictEqual(reply[symbols.kHeaders]['content-type'], 'application/octet-stream')
+      t.strictEqual(reply[symbols.kReplyHeaders]['content-type'], 'application/octet-stream')
       next()
     })
 
@@ -779,7 +779,7 @@ test('onSend hook is called after payload is serialized and headers are set', t 
 
     instance.addHook('onSend', function (request, reply, payload, next) {
       t.strictEqual(payload, thePayload)
-      t.strictEqual(reply[symbols.kHeaders]['content-type'], 'application/octet-stream')
+      t.strictEqual(reply[symbols.kReplyHeaders]['content-type'], 'application/octet-stream')
       next()
     })
 
@@ -795,7 +795,7 @@ test('onSend hook is called after payload is serialized and headers are set', t 
 
     instance.addHook('onSend', function (request, reply, payload, next) {
       t.strictEqual(payload, serializedPayload)
-      t.strictEqual(reply[symbols.kHeaders]['content-type'], 'text/custom')
+      t.strictEqual(reply[symbols.kReplyHeaders]['content-type'], 'text/custom')
       next()
     })
 
@@ -1784,7 +1784,7 @@ test('If the content type has been set inside an hook it should not be changed',
   })
 
   fastify.get('/', (request, reply) => {
-    t.ok(reply[symbols.kHeaders]['content-type'])
+    t.ok(reply[symbols.kReplyHeaders]['content-type'])
     reply.send('hello')
   })
 

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -8,9 +8,9 @@ const NotFound = require('http-errors').NotFound
 const Reply = require('../../lib/reply')
 const {
   kErrorHandlerCalled,
-  kHeaders,
-  kSerializer,
-  kIsError
+  kReplyHeaders,
+  kReplySerializer,
+  kReplyIsError
 } = require('../../lib/symbols')
 
 test('Once called, Reply should return an object with methods', t => {
@@ -20,14 +20,14 @@ test('Once called, Reply should return an object with methods', t => {
   function request () {}
   const reply = new Reply(response, context, request)
   t.is(typeof reply, 'object')
-  t.is(typeof reply[kIsError], 'boolean')
+  t.is(typeof reply[kReplyIsError], 'boolean')
   t.is(typeof reply[kErrorHandlerCalled], 'boolean')
   t.is(typeof reply.send, 'function')
   t.is(typeof reply.code, 'function')
   t.is(typeof reply.status, 'function')
   t.is(typeof reply.header, 'function')
   t.is(typeof reply.serialize, 'function')
-  t.is(typeof reply[kHeaders], 'object')
+  t.is(typeof reply[kReplyHeaders], 'object')
   t.strictEqual(reply.res, response)
   t.strictEqual(reply.context, context)
   t.strictEqual(reply.request, request)
@@ -48,9 +48,9 @@ test('reply.send throw with circular JSON', t => {
 test('reply.serializer should set a custom serializer', t => {
   t.plan(2)
   const reply = new Reply(null, null, null)
-  t.equal(reply[kSerializer], null)
+  t.equal(reply[kReplySerializer], null)
   reply.serializer('serializer')
-  t.equal(reply[kSerializer], 'serializer')
+  t.equal(reply[kReplySerializer], 'serializer')
 })
 
 test('reply.serialize should serialize payload', t => {

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -7,7 +7,7 @@ const http = require('http')
 const NotFound = require('http-errors').NotFound
 const Reply = require('../../lib/reply')
 const {
-  kErrorHandlerCalled,
+  kReplyErrorHandlerCalled,
   kReplyHeaders,
   kReplySerializer,
   kReplyIsError
@@ -21,7 +21,7 @@ test('Once called, Reply should return an object with methods', t => {
   const reply = new Reply(response, context, request)
   t.is(typeof reply, 'object')
   t.is(typeof reply[kReplyIsError], 'boolean')
-  t.is(typeof reply[kErrorHandlerCalled], 'boolean')
+  t.is(typeof reply[kReplyErrorHandlerCalled], 'boolean')
   t.is(typeof reply.send, 'function')
   t.is(typeof reply.code, 'function')
   t.is(typeof reply.status, 'function')

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -6,6 +6,12 @@ const sget = require('simple-get').concat
 const http = require('http')
 const NotFound = require('http-errors').NotFound
 const Reply = require('../../lib/reply')
+const {
+  kErrorHandlerCalled,
+  kHeaders,
+  kSerializer,
+  kIsError
+} = require('../../lib/symbols')
 
 test('Once called, Reply should return an object with methods', t => {
   t.plan(12)
@@ -14,14 +20,14 @@ test('Once called, Reply should return an object with methods', t => {
   function request () {}
   const reply = new Reply(response, context, request)
   t.is(typeof reply, 'object')
-  t.is(typeof reply._isError, 'boolean')
-  t.is(typeof reply._errorHandlerCalled, 'boolean')
+  t.is(typeof reply[kIsError], 'boolean')
+  t.is(typeof reply[kErrorHandlerCalled], 'boolean')
   t.is(typeof reply.send, 'function')
   t.is(typeof reply.code, 'function')
   t.is(typeof reply.status, 'function')
   t.is(typeof reply.header, 'function')
   t.is(typeof reply.serialize, 'function')
-  t.is(typeof reply._headers, 'object')
+  t.is(typeof reply[kHeaders], 'object')
   t.strictEqual(reply.res, response)
   t.strictEqual(reply.context, context)
   t.strictEqual(reply.request, request)
@@ -42,9 +48,9 @@ test('reply.send throw with circular JSON', t => {
 test('reply.serializer should set a custom serializer', t => {
   t.plan(2)
   const reply = new Reply(null, null, null)
-  t.equal(reply._serializer, null)
+  t.equal(reply[kSerializer], null)
   reply.serializer('serializer')
-  t.equal(reply._serializer, 'serializer')
+  t.equal(reply[kSerializer], 'serializer')
 })
 
 test('reply.serialize should serialize payload', t => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->
I moved _prefixed properties in Reply.js to symbols.
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
