### PR TITLE
Better error message for empty body application/json

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -173,6 +173,12 @@ function rawBody (request, reply, options, parser, done) {
 }
 
 function defaultJsonParser (req, body, done) {
+  if (body === '' || body == null) {
+    const err = new Error(`Body cannot be empty when content-type is set to 'application/json'`)
+    err.statusCode = 400
+    return done(err, undefined)
+  }
+
   try {
     var json = JSON.parse(body)
   } catch (err) {

--- a/test/post.test.js
+++ b/test/post.test.js
@@ -23,3 +23,77 @@ t.test('cannot set schemaCompiler after binding', t => {
     }
   })
 })
+
+t.test('should error with empty body and application/json content-type', t => {
+  t.plan(4)
+
+  const fastify = Fastify()
+
+  fastify.post('/', function (req, reply) {
+    reply.code(200).send(req.body.name)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.is(payload.error, `Bad Request`)
+    t.is(payload.message, `Body cannot be empty when content-type is set to 'application/json'`)
+    t.strictEqual(res.statusCode, 400)
+  })
+})
+
+t.test('should error with null body and application/json content-type', t => {
+  t.plan(4)
+
+  const fastify = Fastify()
+
+  fastify.post('/', function (req, reply) {
+    reply.code(200).send(req.body.name)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    payload: null,
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.is(payload.error, `Bad Request`)
+    t.is(payload.message, `Body cannot be empty when content-type is set to 'application/json'`)
+    t.strictEqual(res.statusCode, 400)
+  })
+})
+
+t.test('should error with undefined body and application/json content-type', t => {
+  t.plan(4)
+
+  const fastify = Fastify()
+
+  fastify.post('/', function (req, reply) {
+    reply.code(200).send(req.body.name)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    payload: undefined,
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.is(payload.error, `Bad Request`)
+    t.is(payload.message, `Body cannot be empty when content-type is set to 'application/json'`)
+    t.strictEqual(res.statusCode, 400)
+  })
+})


### PR DESCRIPTION
Better error message for case #1251 

Another option is to check whether the body is > 2 bytes but I thought this way is more clear.

For custom json parser scenario, I guess it will up to the implementer to handle this?

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
