### PR TITLE
Better error message for empty body application/json

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -10,7 +10,8 @@ const {
     FST_ERR_CTP_INVALID_PARSE_TYPE,
     FST_ERR_CTP_BODY_TOO_LARGE,
     FST_ERR_CTP_INVALID_MEDIA_TYPE,
-    FST_ERR_CTP_INVALID_CONTENT_LENGTH
+    FST_ERR_CTP_INVALID_CONTENT_LENGTH,
+    FST_ERR_CTP_EMPTY_JSON_BODY
   }
 } = require('./errors')
 
@@ -178,6 +179,10 @@ function rawBody (request, reply, options, parser, done) {
 }
 
 function defaultJsonParser (req, body, done) {
+  if (body === '' || body == null) {
+    return done(new FST_ERR_CTP_EMPTY_JSON_BODY(), undefined)
+  }
+
   try {
     var json = JSON.parse(body)
   } catch (err) {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -20,6 +20,7 @@ createError('FST_ERR_CTP_INVALID_PARSE_TYPE', `The body parser can only parse yo
 createError('FST_ERR_CTP_BODY_TOO_LARGE', 'Request body is too large', 413, RangeError)
 createError('FST_ERR_CTP_INVALID_MEDIA_TYPE', `Unsupported Media Type: %s`, 415)
 createError('FST_ERR_CTP_INVALID_CONTENT_LENGTH', 'Request body size did not match Content-Length', 400, RangeError)
+createError('FST_ERR_CTP_EMPTY_JSON_BODY', `Body cannot be empty when content-type is set to 'application/json'`, 400)
 
 /**
  * decorate

--- a/test/post.test.js
+++ b/test/post.test.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const t = require('tap')
+const sget = require('simple-get').concat
+
 require('./helper').payloadMethod('post', t)
 require('./input-validation').payloadMethod('post', t)
 
@@ -21,5 +23,156 @@ t.test('cannot set schemaCompiler after binding', t => {
     } catch (e) {
       t.pass()
     }
+  })
+})
+
+t.test('should receive application/json content-type', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.post('/', function (req, reply) {
+    reply.code(200).send(req.body)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
+
+    sget({
+      method: 'POST',
+      body: {
+        key: 'value'
+      },
+      json: true,
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, res, body) => {
+      t.error(err)
+      t.strictDeepEqual(body, {
+        key: 'value'
+      })
+    })
+  })
+})
+
+t.test('should receive json body', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.post('/', function (req, reply) {
+    reply.code(200).send(req.body)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
+
+    sget({
+      method: 'POST',
+      body: {
+        key: 'value'
+      },
+      json: true,
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, res, body) => {
+      t.error(err)
+      t.strictDeepEqual(body, {
+        key: 'value'
+      })
+    })
+  })
+})
+
+t.test('should fail with empty body and application/json content-type', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.post('/', function (req, reply) {
+    reply.code(200).send('failed')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
+
+    sget({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, res, body) => {
+      t.error(err)
+      t.strictDeepEqual(JSON.parse(body.toString()), {
+        error: 'Bad Request',
+        code: 'FST_ERR_CTP_EMPTY_JSON_BODY',
+        message: `FST_ERR_CTP_EMPTY_JSON_BODY: Body cannot be empty when content-type is set to 'application/json'`,
+        statusCode: 400
+      })
+    })
+  })
+})
+
+t.test('should fail with null body and application/json content-type', t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.post('/', function (req, reply) {
+    reply.code(200).send('failed')
+  })
+
+  fastify.inject({
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    payload: null,
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.strictDeepEqual(JSON.parse(res.payload), {
+      error: 'Bad Request',
+      code: 'FST_ERR_CTP_EMPTY_JSON_BODY',
+      message: `FST_ERR_CTP_EMPTY_JSON_BODY: Body cannot be empty when content-type is set to 'application/json'`,
+      statusCode: 400
+    })
+  })
+})
+
+t.test('should fail with undefined body and application/json content-type', t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.post('/', function (req, reply) {
+    reply.code(200).send('failed')
+  })
+
+  fastify.inject({
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    payload: undefined,
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.strictDeepEqual(JSON.parse(res.payload), {
+      error: 'Bad Request',
+      code: 'FST_ERR_CTP_EMPTY_JSON_BODY',
+      message: `FST_ERR_CTP_EMPTY_JSON_BODY: Body cannot be empty when content-type is set to 'application/json'`,
+      statusCode: 400
+    })
   })
 })


### PR DESCRIPTION
Better error message for case #1251 

Another option is to check whether the body is > 2 bytes but I thought this way is more clear.

For custom json parser scenario, I guess it will up to the implementer to handle this?

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
