### PR TITLE
Switch to husky from pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
     "bench": "branchcmp -r 2 -g -s \"npm run benchmark\"",
     "benchmark": "npx concurrently -k -s first \"node ./examples/simple.js\" \"npx autocannon -c 100 -d 5 -p 10 localhost:3000/\""
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm test"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fastify/fastify.git"
@@ -90,9 +95,9 @@
     "hide-powered-by": "^1.0.0",
     "hsts": "^2.1.0",
     "http-errors": "^1.7.1",
+    "husky": "^1.2.0",
     "ienoopen": "^1.0.0",
     "joi": "~11.4.0",
-    "pre-commit": "^1.2.2",
     "proxyquire": "^2.0.1",
     "pump": "^3.0.0",
     "semver": "^5.5.0",


### PR DESCRIPTION
This PR switches the module that handles pre-commit hooks from [`pre-commit`](https://npm.im/pre-commit) to [`husky`](https://npm.im/husky). The reason for this is because the `pre-commit` package seems to be abandoned. The last publish for `pre-commit` was two years ago and I have had an [issue](https://github.com/observing/pre-commit/issues/121) and [pull request](https://github.com/observing/pre-commit/pull/122) outstanding since February and March, respectively. The project continues to receive new issues without any response.

**NOTE:** you must remove `.git/hooks/pre-commit` prior to installing `husky` or its hook will not be installed. There does not seem to be a way to force the overwrite.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
