### PR TITLE
Custom querystring

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -211,6 +211,19 @@ will complete with an `Error` with code `'ERR_AVVIO_PLUGIN_TIMEOUT'`.
 
 + Default: `10000`
 
+<a name="factory-querystring-parser"></a>
+### `querystringParser`
+
+The default query string parser that Fastify uses is the Node.js's core `querystring` module.<br/>
+You can change this default setting by passing the option `querystringParser` and use a custom one, such as [`qs`](https://www.npmjs.com/package/qs).
+
+```js
+const qs = require('qs')
+const fastify = require('fastify')({
+  querystringParser: str => qs.parse(str)
+})
+```
+
 ## Instance
 
 ### Server Methods

--- a/fastify.js
+++ b/fastify.js
@@ -4,7 +4,7 @@ const FindMyWay = require('find-my-way')
 const Avvio = require('avvio')
 const http = require('http')
 const https = require('https')
-const urlUtil = require('url')
+const querystring = require('querystring')
 const Middie = require('middie')
 const lightMyRequest = require('light-my-request')
 const abstractLogging = require('abstract-logging')
@@ -86,6 +86,7 @@ function build (options) {
   })
 
   const requestIdHeader = options.requestIdHeader || 'request-id'
+  const querystringParser = options.querystringParser || querystring.parse
 
   let genReqId = options.genReqId || reqIdGenFactory(requestIdHeader)
 
@@ -293,7 +294,9 @@ function build (options) {
 
     req.log.info({ req }, 'incoming request')
 
-    var request = new context.Request(params, req, urlUtil.parse(req.url, true).query, req.headers, req.log)
+    var queryPrefix = req.url.indexOf('?')
+    var query = queryPrefix > -1 ? querystringParser(req.url.slice(queryPrefix + 1)) : {}
+    var request = new context.Request(params, req, query, req.headers, req.log)
     var reply = new context.Reply(res, context, request, res.log)
 
     if (hasLogger === true || context.onResponse !== null) {

--- a/fastify.js
+++ b/fastify.js
@@ -86,6 +86,9 @@ function build (options) {
   })
 
   const requestIdHeader = options.requestIdHeader || 'request-id'
+  if (options.querystringParser && typeof options.querystringParser !== 'function') {
+    throw new Error(`querystringParser option should be a function, instead got '${typeof options.querystringParser}'`)
+  }
   const querystringParser = options.querystringParser || querystring.parse
 
   let genReqId = options.genReqId || reqIdGenFactory(requestIdHeader)
@@ -295,7 +298,7 @@ function build (options) {
     req.log.info({ req }, 'incoming request')
 
     var queryPrefix = req.url.indexOf('?')
-    var query = queryPrefix > -1 ? querystringParser(req.url.slice(queryPrefix + 1)) : {}
+    var query = queryPrefix !== -1 ? querystringParser(req.url.slice(queryPrefix + 1)) : {}
     var request = new context.Request(params, req, query, req.headers, req.log)
     var reply = new context.Reply(res, context, request, res.log)
 

--- a/fastify.js
+++ b/fastify.js
@@ -298,7 +298,7 @@ function build (options) {
     req.log.info({ req }, 'incoming request')
 
     var queryPrefix = req.url.indexOf('?')
-    var query = queryPrefix !== -1 ? querystringParser(req.url.slice(queryPrefix + 1)) : {}
+    var query = querystringParser(queryPrefix > -1 ? req.url.slice(queryPrefix + 1) : '')
     var request = new context.Request(params, req, query, req.headers, req.log)
     var reply = new context.Reply(res, context, request, res.log)
 

--- a/test/custom-querystring-parser.test.js
+++ b/test/custom-querystring-parser.test.js
@@ -119,3 +119,19 @@ test('Querystring without value', t => {
     })
   })
 })
+
+test('Custom querystring parser should be a function', t => {
+  t.plan(1)
+
+  try {
+    Fastify({
+      querystringParser: 10
+    })
+    t.fail('Should throw')
+  } catch (err) {
+    t.strictEqual(
+      err.message,
+      `querystringParser option should be a function, instead got 'number'`
+    )
+  }
+})

--- a/test/custom-querystring-parser.test.js
+++ b/test/custom-querystring-parser.test.js
@@ -1,0 +1,121 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const querystring = require('querystring')
+const sget = require('simple-get').concat
+const Fastify = require('..')
+
+test('Custom querystring parser', t => {
+  t.plan(9)
+
+  const fastify = Fastify({
+    querystringParser: function (str) {
+      t.strictEqual(str, 'foo=bar&baz=faz')
+      return querystring.parse(str)
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    t.deepEqual(req.query, {
+      foo: 'bar',
+      baz: 'faz'
+    })
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.listen(0, (err, address) => {
+    t.error(err)
+    t.tearDown(() => fastify.close())
+
+    sget({
+      method: 'GET',
+      url: `${address}?foo=bar&baz=faz`
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+    })
+
+    fastify.inject({
+      method: 'GET',
+      url: `${address}?foo=bar&baz=faz`
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+    })
+  })
+})
+
+test('Custom querystring parser should not be called if there is nothing to parse', t => {
+  t.plan(5)
+
+  const fastify = Fastify({
+    querystringParser: function (str) {
+      t.fail('Should not be called')
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.listen(0, (err, address) => {
+    t.error(err)
+    t.tearDown(() => fastify.close())
+
+    sget({
+      method: 'GET',
+      url: address
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+    })
+
+    fastify.inject({
+      method: 'GET',
+      url: address
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+    })
+  })
+})
+
+test('Querystring without value', t => {
+  t.plan(9)
+
+  const fastify = Fastify({
+    querystringParser: function (str) {
+      t.strictEqual(str, 'foo')
+      return querystring.parse(str)
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    t.deepEqual(req.query, {
+      foo: ''
+    })
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.listen(0, (err, address) => {
+    t.error(err)
+    t.tearDown(() => fastify.close())
+
+    sget({
+      method: 'GET',
+      url: `${address}?foo`
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+    })
+
+    fastify.inject({
+      method: 'GET',
+      url: `${address}?foo`
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+    })
+  })
+})

--- a/test/custom-querystring-parser.test.js
+++ b/test/custom-querystring-parser.test.js
@@ -46,16 +46,18 @@ test('Custom querystring parser', t => {
   })
 })
 
-test('Custom querystring parser should not be called if there is nothing to parse', t => {
-  t.plan(5)
+test('Custom querystring parser should be called also if there is nothing to parse', t => {
+  t.plan(9)
 
   const fastify = Fastify({
     querystringParser: function (str) {
-      t.fail('Should not be called')
+      t.strictEqual(str, '')
+      return querystring.parse(str)
     }
   })
 
   fastify.get('/', (req, reply) => {
+    t.deepEqual(req.query, {})
     reply.send({ hello: 'world' })
   })
 
@@ -92,9 +94,7 @@ test('Querystring without value', t => {
   })
 
   fastify.get('/', (req, reply) => {
-    t.deepEqual(req.query, {
-      foo: ''
-    })
+    t.deepEqual(req.query, { foo: '' })
     reply.send({ hello: 'world' })
   })
 


### PR DESCRIPTION
Implementation of what has been proposed in https://github.com/fastify/fastify/issues/1268.

We are also dropping the use of `url.parse`, so this change will be flagged as `semver-major`.
With this change, the querystring parsing is twice faster than before 🚀 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
