### PR TITLE
chore: pin ajv to 6.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   "dependencies": {
     "@types/pino": "^4.16.0",
     "abstract-logging": "^1.0.0",
-    "ajv": "^6.5.4",
+    "ajv": "6.5.5",
     "avvio": "^6.0.0",
     "end-of-stream": "^1.4.1",
     "fast-json-stringify": "^1.9.1",


### PR DESCRIPTION
Needed because of #1281 and https://github.com/epoberezkin/ajv/issues/889.