### PR TITLE
update ajv and autocannon

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "@types/node": "^10.12.1",
     "JSONStream": "^1.3.5",
-    "autocannon": "^3.1.0",
+    "autocannon": "^3.2.0",
     "branch-comparer": "^0.4.0",
     "concurrently": "^4.0.0",
     "cors": "^2.8.4",
@@ -112,7 +112,7 @@
   "dependencies": {
     "@types/pino": "^4.16.0",
     "abstract-logging": "^1.0.0",
-    "ajv": "6.5.5",
+    "ajv": "^6.6.0",
     "avvio": "^6.0.0",
     "end-of-stream": "^1.4.1",
     "fast-json-stringify": "^1.9.1",


### PR DESCRIPTION
unpin ajv and use autocannon v3.2.0 which does not depend on the problematic table module. 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
