### PR TITLE
fix: add querystringParser to ServerOptions

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -127,7 +127,7 @@ declare namespace fastify {
     logger?: pino.LoggerOptions | boolean,
     trustProxy?: string | number | boolean | Array<string> | TrustProxyFunction,
     maxParamLength?: number,
-    querystringParser?: (str: string) => { [key: string]: string | string[] | undefined },
+    querystringParser?: (str: string) => { [key: string]: string | string[] },
   }
   interface ServerOptionsAsSecure extends ServerOptions {
     https: http2.SecureServerOptions

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -127,6 +127,7 @@ declare namespace fastify {
     logger?: pino.LoggerOptions | boolean,
     trustProxy?: string | number | boolean | Array<string> | TrustProxyFunction,
     maxParamLength?: number,
+    querystringParser?: (str: string) => { [key: string]: string | string[] | undefined },
   }
   interface ServerOptionsAsSecure extends ServerOptions {
     https: http2.SecureServerOptions

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -50,7 +50,8 @@ const cors = require('cors')
   const otherServer = fastify({
     ignoreTrailingSlash: true,
     bodyLimit: 1000,
-    maxParamLength: 200
+    maxParamLength: 200,
+    querystringParser: (str: string) => ({ str: str, strArray: [str], notFound: undefined })
   })
 
   // custom types

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -51,7 +51,7 @@ const cors = require('cors')
     ignoreTrailingSlash: true,
     bodyLimit: 1000,
     maxParamLength: 200,
-    querystringParser: (str: string) => ({ str: str, strArray: [str], notFound: undefined })
+    querystringParser: (str: string) => ({ str: str, strArray: [str] })
   })
 
   // custom types


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
