### PR TITLE
Added fastify-sentry to Community Plugins

### DIFF
--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -84,6 +84,7 @@ Plugins maintained by the fastify team are listed under [Core](#core) while plug
 - [`fastify-register-routes`](https://github.com/israeleriston/fastify-register-routes) Plugin to automatically load routes from a specified path and optionally limit loaded file names by a regular expression.
 - [`fastify-response-time`](https://github.com/lolo32/fastify-response-time) Add `X-Response-Time` header at each request for Fastify, in milliseconds.
 - [`fastify-rob-config`](https://github.com/jeromemacias/fastify-rob-config) Fastify Rob-Config integration.
+- [`fastify-sentry`](https://github.com/alex-ppg/fastify-sentry) Fastify plugin to add the Sentry SDK error handler to requests.
 - [`fastify-sequelize`](https://github.com/lyquocnam/fastify-sequelize) Fastify plugin work with Sequelize (adapter for NodeJS -> Sqlite, Mysql, Mssql, Postgres).
 - [`fastify-server-session`](https://github.com/jsumners/fastify-server-session) A session plugin with support for arbitrary backing caches via `fastify-caching`.
 - [`fastify-session`](https://github.com/SerayaEryn/fastify-session) a session plugin for Fastify.


### PR DESCRIPTION
Greetings everyone, 

I created this plugin that sets the error handler of `fastify` to forward errors to Sentry via their SDK and respond with a generic `500` error and `Internal Server Error` message. It also adds certain context parameters before reporting the error to Sentry, namely the `ip` and `path` of `req.raw` as a `User` context and `Tag` key-value respectively for more concise error grouping.

Once again, I recently required it for a project and thought that others might find it useful.

Thanks.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
