### PR TITLE
fix(types): add missing Reply functions

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -111,6 +111,9 @@ declare namespace fastify {
     status: (statusCode: number) => FastifyReply<HttpResponse>
     header: (name: string, value: any) => FastifyReply<HttpResponse>
     headers: (headers: { [key: string]: any }) => FastifyReply<HttpResponse>
+    getHeader: (name: string) => string | undefined
+    hasHeader: (name: string) => boolean
+    callNotFound: () => void
     type: (contentType: string) => FastifyReply<HttpResponse>
     redirect: (statusCode: number, url: string) => FastifyReply<HttpResponse>
     serialize: (payload: any) => string


### PR DESCRIPTION
This PR adds missing function types for the Reply interface.
Matching public docs at https://www.fastify.io/docs/latest/Reply/

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
