### PR TITLE
Establish reply.sent = true as a proper way to skip async/await handling

### DIFF
--- a/docs/Errors.md
+++ b/docs/Errors.md
@@ -80,6 +80,11 @@ The hook callback must be a function.
 
 Logger acceptes either a `'stream'` or a `'file'` as the destination.
 
+<a id="FST_ERR_REP_ALREADY_SENT"></a>
+### FST_ERR_REP_ALREADY_SENT
+
+A response was already sent.
+
 <a name="FST_ERR_REP_INVALID_PAYLOAD_TYPE"></a>
 #### FST_ERR_REP_INVALID_PAYLOAD_TYPE
 

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -2,7 +2,8 @@
 
 ## Reply
 The second parameter of the handler function is `Reply`.
-Reply is a core Fastify object that exposes the following functions:
+Reply is a core Fastify object that exposes the following functions
+and properties:
 
 - `.code(statusCode)` - Sets the status code.
 - `.status(statusCode)` - An alias for `.code(statusCode)`.
@@ -112,9 +113,35 @@ reply
 
 See [`.send()`](#send) for more information on sending different types of values.
 
+<a name="sent"></a>
+### .sent
+
+As the name suggests, `.sent` is a property to indicate if
+a response has been sent via `reply.send()`.
+
+In case a route handler is defined as an async function or it
+returns a promise, it is possible to set `reply.sent = true`
+to indicate that the automatic invocation of `reply.send()` once the
+handler promise resolve should be skipped. By setting `reply.sent =
+true`, an application claims full responsibility of the low-level
+request and response. Moreover, hooks will not be invoked.
+
+As an example:
+
+```js
+app.get('/', (req, reply) => {
+  reply.sent = true
+  reply.res.end('hello world')
+
+  return Promise.resolve('this will be skipped')
+})
+```
+
+If the handler rejects, the error will be logged.
+
 <a name="send"></a>
 ### .send(data)
- As the name suggests, `.send()` is the function that sends the payload to the end user.
+As the name suggests, `.send()` is the function that sends the payload to the end user.
 
 <a name="send-object"></a>
 #### Objects

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -43,6 +43,8 @@ createError('FST_ERR_LOG_INVALID_DESTINATION', `Cannot specify both logger.strea
  * reply
 */
 createError('FST_ERR_REP_INVALID_PAYLOAD_TYPE', `Attempted to send payload of invalid type '%s'. Expected a string or Buffer.`, 500, TypeError)
+createError('FST_ERR_REP_ALREADY_SENT', 'Reply was already sent.')
+createError('FST_ERR_REP_SENT_VALUE', 'The only possible value for reply.sent is true.')
 
 /**
  * schemas

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -7,6 +7,8 @@ const FJS = require('fast-json-stringify')
 const {
   kFourOhFourContext,
   kReplyErrorHandlerCalled,
+  kReplySent,
+  kReplySentOverwritten,
   kReplyStartTime,
   kReplySerializer,
   kReplyIsError,
@@ -39,7 +41,9 @@ const CONTENT_TYPE = {
 }
 const {
   codes: {
-    FST_ERR_REP_INVALID_PAYLOAD_TYPE
+    FST_ERR_REP_INVALID_PAYLOAD_TYPE,
+    FST_ERR_REP_ALREADY_SENT,
+    FST_ERR_REP_SENT_VALUE
   }
 } = require('./errors')
 
@@ -48,7 +52,7 @@ var getHeader
 function Reply (res, context, request, log) {
   this.res = res
   this.context = context
-  this.sent = false
+  this[kReplySent] = false
   this[kReplySerializer] = null
   this[kReplyErrorHandlerCalled] = false
   this[kReplyIsError] = false
@@ -60,13 +64,32 @@ function Reply (res, context, request, log) {
   this.log = log
 }
 
+Object.defineProperty(Reply.prototype, 'sent', {
+  enumerable: true,
+  get () {
+    return this[kReplySent]
+  },
+  set (value) {
+    if (value !== true) {
+      throw new FST_ERR_REP_SENT_VALUE()
+    }
+
+    if (this[kReplySent] && value) {
+      throw new FST_ERR_REP_ALREADY_SENT()
+    }
+
+    this[kReplySentOverwritten] = true
+    this[kReplySent] = true
+  }
+})
+
 Reply.prototype.send = function (payload) {
   if (this[kReplyIsRunningOnErrorHook] === true) {
     throw new Error('You cannot use `send` inside the `onError` hook')
   }
 
-  if (this.sent) {
-    this.res.log.warn({ err: new Error('Reply already sent') }, 'Reply already sent')
+  if (this[kReplySent]) {
+    this.res.log.warn({ err: new FST_ERR_REP_ALREADY_SENT() }, 'Reply already sent')
     return
   }
 
@@ -190,7 +213,7 @@ Reply.prototype.callNotFound = function () {
 }
 
 function onSendHook (reply, payload) {
-  reply.sent = true
+  reply[kReplySent] = true
   if (reply.context.onSend !== null) {
     onSendHookRunner(
       reply.context.onSend,
@@ -217,7 +240,7 @@ function onSendEnd (reply, payload) {
   var statusCode = res.statusCode
 
   if (payload === undefined || payload === null) {
-    reply.sent = true
+    reply[kReplySent] = true
 
     // according to https://tools.ietf.org/html/rfc7230#section-3.3.2
     // we cannot send a content-length for 304 and 204, and all status code
@@ -245,7 +268,7 @@ function onSendEnd (reply, payload) {
     reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)
   }
 
-  reply.sent = true
+  reply[kReplySent] = true
 
   res.writeHead(statusCode, reply[kReplyHeaders])
 
@@ -301,7 +324,7 @@ function sendStream (payload, res, reply) {
 }
 
 function onErrorHook (reply, error, cb) {
-  reply.sent = true
+  reply[kReplySent] = true
   if (reply.context.onError !== null && reply[kReplyErrorHandlerCalled] === true) {
     reply[kReplyIsRunningOnErrorHook] = true
     onSendHookRunner(
@@ -337,7 +360,7 @@ function handleError (reply, error, cb) {
 
   var errorHandler = reply.context.errorHandler
   if (errorHandler && reply[kReplyErrorHandlerCalled] === false) {
-    reply.sent = false
+    reply[kReplySent] = false
     reply[kReplyIsError] = false
     reply[kReplyErrorHandlerCalled] = true
     var result = errorHandler(error, reply.request, reply)
@@ -362,7 +385,7 @@ function handleError (reply, error, cb) {
   }
 
   reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)
-  reply.sent = true
+  reply[kReplySent] = true
   res.writeHead(res.statusCode, reply[kReplyHeaders])
   res.end(payload)
 }
@@ -425,7 +448,8 @@ function buildReply (R) {
     this.context = context
     this[kReplyIsError] = false
     this[kReplyErrorHandlerCalled] = false
-    this.sent = false
+    this[kReplySent] = false
+    this[kReplySentOverwritten] = false
     this[kReplySerializer] = null
     this.request = request
     this[kReplyHeaders] = {}
@@ -437,7 +461,7 @@ function buildReply (R) {
 }
 
 function notFound (reply) {
-  reply.sent = false
+  reply[kReplySent] = false
   reply[kReplyIsError] = false
 
   if (reply.context[kFourOhFourContext] === null) {

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -18,6 +18,8 @@ const keys = {
   kReplyIsError: Symbol('fastify.reply.isError'),
   kReplyHeaders: Symbol('fastify.reply.headers'),
   kReplyHasStatusCode: Symbol('fastify.reply.hasStatusCode'),
+  kReplySent: Symbol('fastify.reply.sent'),
+  kReplySentOverwritten: Symbol('fastify.reply.sentOverwritten'),
   kReplyStartTime: Symbol('fastify.reply.startTime'),
   kReplyErrorHandlerCalled: Symbol('fastify.reply.errorHandlerCalled'),
   kReplyIsRunningOnErrorHook: Symbol('fastify.reply.isRunningOnErrorHook')

--- a/lib/wrapThenable.js
+++ b/lib/wrapThenable.js
@@ -1,25 +1,38 @@
 'use strict'
-const { kReplyIsError } = require('./symbols')
+
+const {
+  kReplyIsError,
+  kReplySent,
+  kReplySentOverwritten
+} = require('./symbols')
 
 function wrapThenable (thenable, reply) {
   thenable.then(function (payload) {
+    if (reply[kReplySentOverwritten] === true) {
+      return
+    }
+
     // this is for async functions that
     // are using reply.send directly
-    if (payload !== undefined || (reply.res.statusCode === 204 && reply.sent === false)) {
+    if (payload !== undefined || (reply.res.statusCode === 204 && reply[kReplySent] === false)) {
       // we use a try-catch internally to avoid adding a catch to another
       // promise, increase promise perf by 10%
       try {
         reply.send(payload)
       } catch (err) {
-        reply.sent = false
+        reply[kReplySent] = false
         reply[kReplyIsError] = true
         reply.send(err)
       }
-    } else if (reply.sent === false) {
+    } else if (reply[kReplySent] === false) {
       reply.res.log.error({ err: new Error(`Promise may not be fulfilled with 'undefined' when statusCode is not 204`) }, `Promise may not be fulfilled with 'undefined' when statusCode is not 204`)
     }
   }, function (err) {
-    reply.sent = false
+    if (reply[kReplySentOverwritten] === true) {
+      reply.res.log.error({ err }, 'Promise errored, but reply.sent = true was set')
+      return
+    }
+    reply[kReplySent] = false
     reply[kReplyIsError] = true
     reply.send(err)
   })

--- a/test/skip-reply-send.js
+++ b/test/skip-reply-send.js
@@ -1,0 +1,98 @@
+'use strict'
+
+const { test } = require('tap')
+const split = require('split2')
+const Fastify = require('..')
+
+test('skip automatic reply.send() with reply.sent = true and a body', (t) => {
+  const stream = split(JSON.parse)
+  const app = Fastify({
+    logger: {
+      stream: stream
+    }
+  })
+
+  stream.on('data', (line) => {
+    t.notEqual(line.level, 40) // there are no errors
+    t.notEqual(line.level, 50) // there are no errors
+  })
+
+  app.get('/', (req, reply) => {
+    reply.sent = true
+    reply.res.end('hello world')
+
+    return Promise.resolve('this will be skipped')
+  })
+
+  return app.inject({
+    method: 'GET',
+    url: '/'
+  }).then((res) => {
+    t.equal(res.statusCode, 200)
+    t.equal(res.body, 'hello world')
+  })
+})
+
+test('skip automatic reply.send() with reply.sent = true and no body', (t) => {
+  const stream = split(JSON.parse)
+  const app = Fastify({
+    logger: {
+      stream: stream
+    }
+  })
+
+  stream.on('data', (line) => {
+    t.notEqual(line.level, 40) // there are no error
+    t.notEqual(line.level, 50) // there are no error
+  })
+
+  app.get('/', (req, reply) => {
+    reply.sent = true
+    reply.res.end('hello world')
+
+    return Promise.resolve()
+  })
+
+  return app.inject({
+    method: 'GET',
+    url: '/'
+  }).then((res) => {
+    t.equal(res.statusCode, 200)
+    t.equal(res.body, 'hello world')
+  })
+})
+
+test('skip automatic reply.send() with reply.sent = true and an error', (t) => {
+  const stream = split(JSON.parse)
+  const app = Fastify({
+    logger: {
+      stream: stream
+    }
+  })
+
+  let errorSeen = false
+
+  stream.on('data', (line) => {
+    if (line.level === 50) {
+      errorSeen = true
+      t.equal(line.err.message, 'kaboom')
+      t.equal(line.msg, 'Promise errored, but reply.sent = true was set')
+    }
+  })
+
+  app.get('/', (req, reply) => {
+    reply.sent = true
+    reply.res.end('hello world')
+
+    return Promise.reject(new Error('kaboom'))
+  })
+
+  return app.inject({
+    method: 'GET',
+    url: '/'
+  }).then((res) => {
+    t.equal(errorSeen, true)
+    t.equal(res.statusCode, 200)
+    t.equal(res.body, 'hello world')
+  })
+})


### PR DESCRIPTION
Fixes https://github.com/fastify/fastify/issues/1330

To avoid conflicts, this is based on https://github.com/fastify/fastify/pull/1328, and it will need to be rebased once that lands.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
