### PR TITLE
Backport sent fixes

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -2,7 +2,8 @@
 
 ## Reply
 The second parameter of the handler function is `Reply`.
-Reply is a core Fastify object that exposes the following functions:
+Reply is a core Fastify object that exposes the following functions
+and properties:
 
 - `.code(statusCode)` - Sets the status code.
 - `.status(statusCode)` - An alias for `.code(statusCode)`.
@@ -104,9 +105,35 @@ reply
 
 See [`.send()`](#send) for more information on sending different types of values.
 
+<a name="sent"></a>
+### .sent
+
+As the name suggests, `.sent` is a property to indicate if
+a response has been sent via `reply.send()`.
+
+In case a route handler is defined as an async function or it
+returns a promise, it is possible to set `reply.sent = true`
+to indicate that the automatic invocation of `reply.send()` once the
+handler promise resolve should be skipped. By setting `reply.sent =
+true`, an application claims full responsibility of the low-level
+request and response. Moreover, hooks will not be invoked.
+
+As an example:
+
+```js
+app.get('/', (req, reply) => {
+  reply.sent = true
+  reply.res.end('hello world')
+
+  return Promise.resolve('this will be skipped')
+})
+```
+
+If the handler rejects, the error will be logged.
+
 <a name="send"></a>
 ### .send(data)
- As the name suggests, `.send()` is the function that sends the payload to the end user.
+As the name suggests, `.send()` is the function that sends the payload to the end user.
 
 <a name="send-object"></a>
 #### Objects

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -44,8 +44,6 @@ Reply.prototype.send = function (payload) {
     return
   }
 
-  this.sent = true
-
   if (payload instanceof Error || this._isError === true) {
     handleError(this, payload, onSendHook)
     return
@@ -158,6 +156,7 @@ Reply.prototype.redirect = function (code, url) {
 }
 
 function onSendHook (reply, payload) {
+  reply.sent = true
   if (reply.context.onSend !== null) {
     runHooks(
       reply.context.onSend,
@@ -171,6 +170,7 @@ function onSendHook (reply, payload) {
 }
 
 function wrapOnSendEnd (err, reply, payload) {
+  reply.sent = true
   if (err) {
     handleError(reply, err)
   } else {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -29,17 +29,37 @@ var getHeader
 function Reply (res, context, request) {
   this.res = res
   this.context = context
-  this.sent = false
+  this._sent = false
   this._serializer = null
   this._customError = false
   this._isError = false
+  this._sentOverwritten = false
   this.request = request
   this._headers = {}
   this._hasStatusCode = false
 }
 
+Object.defineProperty(Reply.prototype, 'sent', {
+  enumerable: true,
+  get () {
+    return this._sent
+  },
+  set (value) {
+    if (value !== true) {
+      throw new Error('The only possible value for reply.sent is true.')
+    }
+
+    if (this._sent && value) {
+      throw new Error('Reply was already sent.')
+    }
+
+    this._sentOverwritten = true
+    this._sent = true
+  }
+})
+
 Reply.prototype.send = function (payload) {
-  if (this.sent) {
+  if (this._sent) {
     this.res.log.warn({ err: new Error('Reply already sent') }, 'Reply already sent')
     return
   }
@@ -156,7 +176,7 @@ Reply.prototype.redirect = function (code, url) {
 }
 
 function onSendHook (reply, payload) {
-  reply.sent = true
+  reply._sent = true
   if (reply.context.onSend !== null) {
     runHooks(
       reply.context.onSend,
@@ -170,7 +190,7 @@ function onSendHook (reply, payload) {
 }
 
 function wrapOnSendEnd (err, reply, payload) {
-  reply.sent = true
+  reply._sent = true
   if (err) {
     handleError(reply, err)
   } else {
@@ -183,7 +203,7 @@ function onSendEnd (reply, payload) {
   var statusCode = res.statusCode
 
   if (payload === undefined || payload === null) {
-    reply.sent = true
+    reply._sent = true
 
     // according to https://tools.ietf.org/html/rfc7230#section-3.3.2
     // we cannot send a content-length for 304 and 204, and all status code
@@ -211,7 +231,7 @@ function onSendEnd (reply, payload) {
     reply._headers['content-length'] = '' + Buffer.byteLength(payload)
   }
 
-  reply.sent = true
+  reply._sent = true
 
   res.writeHead(statusCode, reply._headers)
 
@@ -300,7 +320,7 @@ function handleError (reply, error, cb) {
 
   var customErrorHandler = reply.context.errorHandler
   if (customErrorHandler && reply._customError === false) {
-    reply.sent = false
+    reply._sent = false
     reply._isError = false
     reply._customError = true
     var result = customErrorHandler(error, reply.request, reply)
@@ -324,7 +344,7 @@ function handleError (reply, error, cb) {
   }
 
   reply._headers['content-length'] = '' + Buffer.byteLength(payload)
-  reply.sent = true
+  reply._sent = true
   res.writeHead(res.statusCode, reply._headers)
   res.end(payload)
 }
@@ -335,8 +355,9 @@ function buildReply (R) {
     this.context = context
     this._isError = false
     this._customError = false
-    this.sent = false
+    this._sent = false
     this._serializer = null
+    this._sentOverwritten = false
     this.request = request
     this._headers = {}
   }
@@ -345,7 +366,7 @@ function buildReply (R) {
 }
 
 function notFound (reply) {
-  reply.sent = false
+  reply._sent = false
   reply._isError = false
 
   if (reply.context._404Context === null) {

--- a/lib/wrapThenable.js
+++ b/lib/wrapThenable.js
@@ -2,23 +2,31 @@
 
 function wrapThenable (thenable, reply) {
   thenable.then(function (payload) {
+    if (reply._sentOverwritten === true) {
+      return
+    }
+
     // this is for async functions that
     // are using reply.send directly
-    if (payload !== undefined || (reply.res.statusCode === 204 && reply.sent === false)) {
+    if (payload !== undefined || (reply.res.statusCode === 204 && reply._sent === false)) {
       // we use a try-catch internally to avoid adding a catch to another
       // promise, increase promise perf by 10%
       try {
         reply.send(payload)
       } catch (err) {
-        reply.sent = false
+        reply._sent = false
         reply._isError = true
         reply.send(err)
       }
-    } else if (reply.sent === false) {
+    } else if (reply._sent === false) {
       reply.res.log.error({ err: new Error(`Promise may not be fulfilled with 'undefined' when statusCode is not 204`) }, `Promise may not be fulfilled with 'undefined' when statusCode is not 204`)
     }
   }, function (err) {
-    reply.sent = false
+    if (reply._sentOverwritten === true) {
+      reply.res.log.error({ err }, 'Promise errored, but reply.sent = true was set')
+      return
+    }
+    reply._sent = false
     reply._isError = true
     reply.send(err)
   })

--- a/test/skip-reply-send.js
+++ b/test/skip-reply-send.js
@@ -1,0 +1,98 @@
+'use strict'
+
+const { test } = require('tap')
+const split = require('split2')
+const Fastify = require('..')
+
+test('skip automatic reply.send() with reply.sent = true and a body', (t) => {
+  const stream = split(JSON.parse)
+  const app = Fastify({
+    logger: {
+      stream: stream
+    }
+  })
+
+  stream.on('data', (line) => {
+    t.notEqual(line.level, 40) // there are no errors
+    t.notEqual(line.level, 50) // there are no errors
+  })
+
+  app.get('/', (req, reply) => {
+    reply.sent = true
+    reply.res.end('hello world')
+
+    return Promise.resolve('this will be skipped')
+  })
+
+  return app.inject({
+    method: 'GET',
+    url: '/'
+  }).then((res) => {
+    t.equal(res.statusCode, 200)
+    t.equal(res.body, 'hello world')
+  })
+})
+
+test('skip automatic reply.send() with reply.sent = true and no body', (t) => {
+  const stream = split(JSON.parse)
+  const app = Fastify({
+    logger: {
+      stream: stream
+    }
+  })
+
+  stream.on('data', (line) => {
+    t.notEqual(line.level, 40) // there are no error
+    t.notEqual(line.level, 50) // there are no error
+  })
+
+  app.get('/', (req, reply) => {
+    reply.sent = true
+    reply.res.end('hello world')
+
+    return Promise.resolve()
+  })
+
+  return app.inject({
+    method: 'GET',
+    url: '/'
+  }).then((res) => {
+    t.equal(res.statusCode, 200)
+    t.equal(res.body, 'hello world')
+  })
+})
+
+test('skip automatic reply.send() with reply.sent = true and an error', (t) => {
+  const stream = split(JSON.parse)
+  const app = Fastify({
+    logger: {
+      stream: stream
+    }
+  })
+
+  let errorSeen = false
+
+  stream.on('data', (line) => {
+    if (line.level === 50) {
+      errorSeen = true
+      t.equal(line.err.message, 'kaboom')
+      t.equal(line.msg, 'Promise errored, but reply.sent = true was set')
+    }
+  })
+
+  app.get('/', (req, reply) => {
+    reply.sent = true
+    reply.res.end('hello world')
+
+    return Promise.reject(new Error('kaboom'))
+  })
+
+  return app.inject({
+    method: 'GET',
+    url: '/'
+  }).then((res) => {
+    t.equal(errorSeen, true)
+    t.equal(res.statusCode, 200)
+    t.equal(res.body, 'hello world')
+  })
+})

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -180,3 +180,67 @@ test('Attached validation error should take precendence over setErrorHandler', t
     t.strictEqual(res.statusCode, 400)
   })
 })
+
+test('should handle response validation error', t => {
+  t.plan(2)
+
+  const response = {
+    200: {
+      type: 'object',
+      required: ['name', 'work'],
+      properties: {
+        name: { type: 'string' },
+        work: { type: 'string' }
+      }
+    }
+  }
+
+  const fastify = Fastify()
+
+  fastify.get('/', { schema: { response } }, function (req, reply) {
+    try {
+      reply.code(200).send({ work: 'actor' })
+    } catch (error) {
+      reply.code(500).send(error)
+    }
+  })
+
+  fastify.inject({
+    method: 'GET',
+    payload: { },
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.payload, '{"statusCode":500,"error":"Internal Server Error","message":"name is required!"}')
+  })
+})
+
+test('should handle response validation error with promises', t => {
+  t.plan(2)
+
+  const response = {
+    200: {
+      type: 'object',
+      required: ['name', 'work'],
+      properties: {
+        name: { type: 'string' },
+        work: { type: 'string' }
+      }
+    }
+  }
+
+  const fastify = Fastify()
+
+  fastify.get('/', { schema: { response } }, function (req, reply) {
+    return Promise.resolve({ work: 'actor' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    payload: { },
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.payload, '{"statusCode":500,"error":"Internal Server Error","message":"name is required!"}')
+  })
+})


### PR DESCRIPTION
Backport of #1328 and #1330 to 1.x.
This needs to be landed manually to not lose commit history during squash.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
