### PR TITLE
fix: #1353 ignore evaluation of $schema field in json-schema

### DIFF
--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -72,7 +72,7 @@ Schemas.prototype.resolveRefs = function (routeSchemas) {
 
 Schemas.prototype.traverse = function (schema) {
   for (var key in schema) {
-    if (typeof schema[key] === 'string' && schema[key].slice(-1) === '#') {
+    if (typeof schema[key] === 'string' && key !== '$schema' && schema[key].slice(-1) === '#') {
       schema[key] = this.resolve(schema[key].slice(0, -1))
     }
 

--- a/test/input-validation.test.js
+++ b/test/input-validation.test.js
@@ -2,10 +2,11 @@
 
 const t = require('tap')
 const test = t.test
-const fastify = require('..')()
+const Fastify = require('..')
 
 test('case insensitive header validation', t => {
   t.plan(2)
+  const fastify = Fastify()
   fastify.route({
     method: 'GET',
     url: '/',
@@ -31,5 +32,38 @@ test('case insensitive header validation', t => {
   }, (err, res) => {
     t.error(err)
     t.equal(res.payload, 'Baz')
+  })
+})
+
+test('not evaluate json-schema $schema keyword', t => {
+  t.plan(2)
+  const fastify = Fastify()
+  fastify.route({
+    method: 'POST',
+    url: '/',
+    handler: (req, reply) => {
+      reply.code(200).send(req.body.hello)
+    },
+    schema: {
+      body: {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: {
+          hello: {
+            type: 'string'
+          }
+        }
+      }
+    }
+  })
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    body: {
+      hello: 'world'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.payload, 'world')
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

Hi,
this is the fix for #1353 issue, where `$schema` field is ignored and it is not `resolve`d.
I checked that there aren't other fields like that, and I didn't notice them.

I have run also benchmark (with some problems 😅), but looking the code I think that this change impact only the startup time right?
Do you need this fix starting from branch `1.x` also?

Thank you

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

---
Running banchmarks I get these error after some succesfull run, but maybe could be caused by PC?

```
{"level":50,"time":1545772614031,"msg":"client error","pid":14584,"hostname":"EOMM-XPS","err":{"type":"Error","message":"write ECANCELED","stack":"Error: write ECANCELED\n    at _errnoException (util.js:992:11)\n    at WriteWrap.afterWrite [as oncomplete] (net.js:864:14)","code":"ECANCELED","errno":"ECANCELED","syscall":"write"},"v":1}
```