### PR TITLE
Docs/Add standard json schema examples

### DIFF
--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -24,10 +24,7 @@ const bodyJsonSchema = {
       maxItems: 3,
       items: { type: 'integer' }
     },
-    nullableKey: {
-      nullable: true,
-      type: 'number'
-    },
+    nullableKey: { type: ['number', 'null'] },
     multipleTypesKey: { type: ['boolean', 'number'] },
     multipleRestrictedTypesKey: {
       oneOf: [

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -279,9 +279,47 @@ fastify.setErrorHandler(function (error, request, reply) {
 })
 ```
 
+<a name="json_schema_example"></a>
+### JSON Schema
+To define [JSON Schema](http://json-schema.org/) in a easier way, you can use [fluent-schema](https://github.com/fastify/fluent-schema)
+and pass the generated schema as configuration for fastify.
+
+Examples:
+```js
+const { FluentSchema, FORMATS } = require('fluent-schema')
+
+const subSchema = FluentSchema().prop('nick', stringMaxLength)
+const stringMaxLength = FluentSchema().asString().maxLength(5)
+
+const jsonSchema = FluentSchema()
+  .prop('someKey', FluentSchema().asString())
+  .prop('someObject', subSchema)
+  .prop('someOtherKey', FluentSchema().asNumber())
+  .prop('requiredKey', FluentSchema().asArray().minItems(3).items(FluentSchema().asInteger()))
+  .required()
+  .prop('nullableKey')
+  .oneOf([FluentSchema().asString(), FluentSchema().asNull()])
+  .prop('multipleTypesKey')
+  .oneOf([FluentSchema().asBoolean(), FluentSchema().asNumber(), stringMaxLength])
+  .prop('multipleRestrictedTypesKey')
+  .oneOf([stringMaxLength, FluentSchema().asNumber().minimum(10)])
+  .prop('enumKey', FluentSchema().enum(['John', 'Foo']))
+  .prop('dateKey', FluentSchema().asString().format(FORMATS.DATE))
+
+const schema = { 
+  body: jsonSchema.valueOf(), 
+  params: jsonSchema.valueOf() 
+}
+
+fastify.post('/the/url', { schema }, (request, reply) => {
+  reply.send({ hello: 'world' })
+})
+```
+
 <a name="resources"></a>
 ### Resources
 - [JSON Schema](http://json-schema.org/)
 - [Understanding JSON schema](https://spacetelescope.github.io/understanding-json-schema/)
 - [fast-json-stringify documentation](https://github.com/fastify/fast-json-stringify)
+- [fluent-schema documentation](https://github.com/fastify/fluent-schema)
 - [Ajv documentation](https://github.com/epoberezkin/ajv/blob/master/README.md)

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -16,9 +16,33 @@ Example:
 const schema = {
   body: {
     type: 'object',
-    properties: {
+    required: ['requiredKey'],
+      properties: {
       someKey: { type: 'string' },
-      someOtherKey: { type: 'number' }
+      someOtherKey: { type: 'number' },
+      requiredKey: {
+        type: 'array',
+        maxItems: 3,
+        items: { type: 'integer' }
+      },
+      nullableKey: {
+        nullable: true,
+        type: 'number'
+      },
+      multipleTypesKey: { type: ['boolean', 'number'] },
+      multipleRestrictedTypesKey: {
+        oneOf: [
+          { type: 'string', maxLength: 5 },
+          { type: 'number', minimum: 10 }
+        ]
+      },
+      enumKey: {
+        type: 'string',
+        enum: ['John', 'Foo']
+      },
+      notTypeKey: {
+        not: { type: 'array' }
+      }
     }
   },
 

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -279,47 +279,9 @@ fastify.setErrorHandler(function (error, request, reply) {
 })
 ```
 
-<a name="json_schema_example"></a>
-### JSON Schema
-To define [JSON Schema](http://json-schema.org/) in a easier way, you can use [fluent-schema](https://github.com/fastify/fluent-schema)
-and pass the generated schema as configuration for fastify.
-
-Examples:
-```js
-const { FluentSchema, FORMATS } = require('fluent-schema')
-
-const subSchema = FluentSchema().prop('nick', stringMaxLength)
-const stringMaxLength = FluentSchema().asString().maxLength(5)
-
-const jsonSchema = FluentSchema()
-  .prop('someKey', FluentSchema().asString())
-  .prop('someObject', subSchema)
-  .prop('someOtherKey', FluentSchema().asNumber())
-  .prop('requiredKey', FluentSchema().asArray().minItems(3).items(FluentSchema().asInteger()))
-  .required()
-  .prop('nullableKey')
-  .oneOf([FluentSchema().asString(), FluentSchema().asNull()])
-  .prop('multipleTypesKey')
-  .oneOf([FluentSchema().asBoolean(), FluentSchema().asNumber(), stringMaxLength])
-  .prop('multipleRestrictedTypesKey')
-  .oneOf([stringMaxLength, FluentSchema().asNumber().minimum(10)])
-  .prop('enumKey', FluentSchema().enum(['John', 'Foo']))
-  .prop('dateKey', FluentSchema().asString().format(FORMATS.DATE))
-
-const schema = { 
-  body: jsonSchema.valueOf(), 
-  params: jsonSchema.valueOf() 
-}
-
-fastify.post('/the/url', { schema }, (request, reply) => {
-  reply.send({ hello: 'world' })
-})
-```
-
 <a name="resources"></a>
 ### Resources
 - [JSON Schema](http://json-schema.org/)
 - [Understanding JSON schema](https://spacetelescope.github.io/understanding-json-schema/)
 - [fast-json-stringify documentation](https://github.com/fastify/fast-json-stringify)
-- [fluent-schema documentation](https://github.com/fastify/fluent-schema)
 - [Ajv documentation](https://github.com/epoberezkin/ajv/blob/master/README.md)

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -13,59 +13,67 @@ The route validation internally relies upon [Ajv](https://www.npmjs.com/package/
 
 Example:
 ```js
-const schema = {
-  body: {
-    type: 'object',
-    required: ['requiredKey'],
-      properties: {
-      someKey: { type: 'string' },
-      someOtherKey: { type: 'number' },
-      requiredKey: {
-        type: 'array',
-        maxItems: 3,
-        items: { type: 'integer' }
-      },
-      nullableKey: {
-        nullable: true,
-        type: 'number'
-      },
-      multipleTypesKey: { type: ['boolean', 'number'] },
-      multipleRestrictedTypesKey: {
-        oneOf: [
-          { type: 'string', maxLength: 5 },
-          { type: 'number', minimum: 10 }
-        ]
-      },
-      enumKey: {
-        type: 'string',
-        enum: ['John', 'Foo']
-      },
-      notTypeKey: {
-        not: { type: 'array' }
-      }
-    }
-  },
-
-  querystring: {
-    name: { type: 'string' },
-    excitement: { type: 'integer' }
-  },
-
-  params: {
-    type: 'object',
-    properties: {
-      par1: { type: 'string' },
-      par2: { type: 'number' }
-    }
-  },
-
-  headers: {
-    type: 'object',
-    properties: {
-      'x-foo': { type: 'string' }
+const bodyJsonSchema = {
+  type: 'object',
+  required: ['requiredKey'],
+  properties: {
+    someKey: { type: 'string' },
+    someOtherKey: { type: 'number' },
+    requiredKey: {
+      type: 'array',
+      maxItems: 3,
+      items: { type: 'integer' }
     },
-    required: ['x-foo']
+    nullableKey: {
+      nullable: true,
+      type: 'number'
+    },
+    multipleTypesKey: { type: ['boolean', 'number'] },
+    multipleRestrictedTypesKey: {
+      oneOf: [
+        { type: 'string', maxLength: 5 },
+        { type: 'number', minimum: 10 }
+      ]
+    },
+    enumKey: {
+      type: 'string',
+      enum: ['John', 'Foo']
+    },
+    notTypeKey: {
+      not: { type: 'array' }
+    }
   }
+}
+
+const queryStringJsonSchema = {
+  name: { type: 'string' },
+  excitement: { type: 'integer' }
+}
+
+const paramsJsonSchema = {
+  type: 'object',
+  properties: {
+    par1: { type: 'string' },
+    par2: { type: 'number' }
+  }
+}
+
+const headersJsonSchema = {
+  type: 'object',
+  properties: {
+    'x-foo': { type: 'string' }
+  },
+  required: ['x-foo']
+}
+
+const schema = {
+  body: bodyJsonSchema,
+
+  querystring: queryStringJsonSchema,
+
+  params: paramsJsonSchema,
+
+  headers: headersJsonSchema
 }
 
 fastify.post('/the/url', { schema }, handler)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

Hi,
I'm opening this PR to get some feedback about this changing for issue #1329 .

I have written a "big" example with fluent schema because I think that put many little examples could be too broad and more confusing.

I have split the first example to view better the four main parameters of schema validation input (`body, querystring, params and headers`).

There are some questions I would like to expose you:
- `fluent-schema` has started a [big refactor](https://github.com/fastify/fluent-schema/issues/22) for the v1 release, so I will update docs when it will be released
- the `definitions` and `$ref` tags, as discussed in other issues like #1351 is supported by `fluent-schema` but not in fastify: should we implement that function or add a disclaimer in docs?

Let me know what do you think and what I should I do 😄 
Thank you

PS: next days I will not have the PC so I'll continue with this PR at starts of January 💪 
