### PR TITLE
Add license-checker on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ script:
 
 after_script:
   - ./tools/website.sh
+  - npm run license-checker
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ node_js:
 
 script:
   - npm run lint && npm run coveralls -- -c && npm run typescript
+  - npm run license-checker
 
 after_script:
   - ./tools/website.sh
-  - npm run license-checker
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -209,9 +209,8 @@ Past Sponsors:
 
 Licensed under [MIT](./LICENSE).
 
-The `fastify` CI guarantees that the accepted dependencies licenses are:
+`fastify` team cares about licence. We list all dependencies licences in order to stay as "open" as possibile:
 - MIT
 - ISC
 - BSD-3-Clause
 - BSD-2-Clause
-- Apache-2.0

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Past Sponsors:
 
 Licensed under [MIT](./LICENSE).
 
-`fastify` team cares about licence. We list all dependencies licences in order to stay as "open" as possibile:
+For your convenience, here is a list of all the licenses of our production dependencies:
 - MIT
 - ISC
 - BSD-3-Clause

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ fastify.get('/', (request, reply) => {
 })
 
 // Run the server!
-fastify.(3000, (err, address) => {
+fastify.listen(3000, (err, address) => {
   if (err) throw err
   fastify.log.info(`server listening on ${address}`)
 })
@@ -209,7 +209,7 @@ Past Sponsors:
 
 Licensed under [MIT](./LICENSE).
 
-The `fastify` CI guarantees the accepted dependencies licenses are:
+The `fastify` CI guarantees that the accepted dependencies licenses are:
 - MIT
 - ISC
 - BSD-3-Clause

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ fastify.get('/', (request, reply) => {
 })
 
 // Run the server!
-fastify.listen(3000, (err, address) => {
+fastify.(3000, (err, address) => {
   if (err) throw err
   fastify.log.info(`server listening on ${address}`)
 })
@@ -208,3 +208,10 @@ Past Sponsors:
 ## License
 
 Licensed under [MIT](./LICENSE).
+
+The `fastify` CI guarantees the accepted dependencies licenses are:
+- MIT
+- ISC
+- BSD-3-Clause
+- BSD-2-Clause
+- Apache-2.0

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "coveralls": "npm run unit -- --cov",
     "bench": "branchcmp -r 2 -g -s \"npm run benchmark\"",
     "benchmark": "npx concurrently -k -s first \"node ./examples/simple.js\" \"npx autocannon -c 100 -d 5 -p 10 localhost:3000/\"",
-    "license-checker": "license-checker --production"
+    "license-checker": "./tools/license-checker.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "coveralls": "npm run unit -- --cov",
     "bench": "branchcmp -r 2 -g -s \"npm run benchmark\"",
     "benchmark": "npx concurrently -k -s first \"node ./examples/simple.js\" \"npx autocannon -c 100 -d 5 -p 10 localhost:3000/\"",
-    "license-checker": "license-checker --production --onlyAllow='MIT;ISC;BSD-3-Clause;BSD-2-Clause'"
+    "license-checker": "license-checker --production --onlyAllow='MIT;ISC;BSD-3-Clause;BSD-2-Clause;Apache-2.0'"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "coveralls": "npm run unit -- --cov",
     "bench": "branchcmp -r 2 -g -s \"npm run benchmark\"",
     "benchmark": "npx concurrently -k -s first \"node ./examples/simple.js\" \"npx autocannon -c 100 -d 5 -p 10 localhost:3000/\"",
-    "license-checker": "./tools/license-checker.sh"
+    "license-checker": "license-checker --production --onlyAllow='MIT;ISC;BSD-3-Clause;BSD-2-Clause'"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "coverage": "npm run unit -- --cov --coverage-report=html",
     "coveralls": "npm run unit -- --cov",
     "bench": "branchcmp -r 2 -g -s \"npm run benchmark\"",
-    "benchmark": "npx concurrently -k -s first \"node ./examples/simple.js\" \"npx autocannon -c 100 -d 5 -p 10 localhost:3000/\""
+    "benchmark": "npx concurrently -k -s first \"node ./examples/simple.js\" \"npx autocannon -c 100 -d 5 -p 10 localhost:3000/\"",
+    "license-checker": "license-checker --production"
   },
   "repository": {
     "type": "git",
@@ -92,6 +93,7 @@
     "http-errors": "^1.7.1",
     "ienoopen": "^1.0.0",
     "joi": "~11.4.0",
+    "license-checker": "^24.1.0",
     "lolex": "^2.7.4",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "coveralls": "npm run unit -- --cov",
     "bench": "branchcmp -r 2 -g -s \"npm run benchmark\"",
     "benchmark": "npx concurrently -k -s first \"node ./examples/simple.js\" \"npx autocannon -c 100 -d 5 -p 10 localhost:3000/\"",
-    "license-checker": "license-checker --production --onlyAllow='MIT;ISC;BSD-3-Clause;BSD-2-Clause;Apache-2.0'"
+    "license-checker": "license-checker --production --onlyAllow='MIT;ISC;BSD-3-Clause;BSD-2-Clause'"
   },
   "repository": {
     "type": "git",

--- a/tools/license-checker.sh
+++ b/tools/license-checker.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 
-unknownLicenses=`license-checker --production --csv | grep -v '"MIT"' | grep -v '"ISC"' | grep -v '"BSD-3-Clause"' | grep -v '"BSD-2-Clauseii"'`
+unknownLicenses=`license-checker --production --csv | grep -v '"MIT"' | grep -v '"ISC"' | grep -v '"BSD-3-Clause"' | grep -v '"BSD-2-Clause"'`
 unknownLicenseCount=`echo "$unknownLicenses" | wc -l`
 
 if [ "$unknownLicenseCount" -eq 1 ]; then
@@ -9,5 +9,5 @@ if [ "$unknownLicenseCount" -eq 1 ]; then
 else
   echo 'Unknown License!'
   echo "$unknownLicenses"
-  echo 1
+  exit 1
 fi

--- a/tools/license-checker.sh
+++ b/tools/license-checker.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+
+unknownLicenses=`license-checker --production --csv | grep -v '"MIT"' | grep -v '"ISC"' | grep -v '"BSD-3-Clause"' | grep -v '"BSD-2-Clauseii"'`
+unknownLicenseCount=`echo "$unknownLicenses" | wc -l`
+
+if [ "$unknownLicenseCount" -eq 1 ]; then
+  echo 'Licenses are OK'
+else
+  echo 'Unknown License!'
+  echo "$unknownLicenses"
+  echo 1
+fi

--- a/tools/license-checker.sh
+++ b/tools/license-checker.sh
@@ -1,6 +1,0 @@
-#! /bin/bash
-
-set -e
-
-license-checker --production --onlyAllow='MIT;ISC;BSD-3-Clause;BSD-2-Clause'
-

--- a/tools/license-checker.sh
+++ b/tools/license-checker.sh
@@ -1,13 +1,6 @@
 #! /bin/bash
 
+set -e
 
-unknownLicenses=`license-checker --production --csv | grep -v '"MIT"' | grep -v '"ISC"' | grep -v '"BSD-3-Clause"' | grep -v '"BSD-2-Clause"'`
-unknownLicenseCount=`echo "$unknownLicenses" | wc -l`
+license-checker --production --onlyAllow='MIT;ISC;BSD-3-Clause;BSD-2-Clause'
 
-if [ "$unknownLicenseCount" -eq 1 ]; then
-  echo 'Licenses are OK'
-else
-  echo 'Unknown License!'
-  echo "$unknownLicenses"
-  exit 1
-fi


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

Fix https://github.com/fastify/fastify/issues/1356

The output si available here: https://travis-ci.org/fastify/fastify/jobs/472663107#L569
There's a summary also (see below).

Are there some cases on which the build fails? For example with Apache Licence?
The license is checker when the dependency is added but if the author doesn't make a breaking change on changing license, I'd like to have a check that fails.

For time being fastify has:
```
├─ MIT: 38
├─ ISC: 4
├─ BSD-3-Clause: 2
└─ BSD-2-Clause: 1
```