### PR TITLE
move ECONNRESET log from error to debug

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -826,7 +826,13 @@ function build (options) {
       message: 'Client Error',
       statusCode: 400
     })
-    log.error({ err }, 'client error')
+    if(err.code == 'ECONNRESET') {
+      // chrome browser keep-alive socket connection
+      // so after 2 min of any https request server socket will timeout
+      log.debug({ err }, 'server socket timeout')
+    } else {
+      log.error({ err }, 'client error')
+    }
     socket.end(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n${body}`)
   }
 

--- a/fastify.js
+++ b/fastify.js
@@ -826,13 +826,7 @@ function build (options) {
       message: 'Client Error',
       statusCode: 400
     })
-    if(err.code == 'ECONNRESET') {
-      // chrome browser keep-alive socket connection
-      // so after 2 min of any https request server socket will timeout
-      log.debug({ err }, 'server socket timeout')
-    } else {
-      log.error({ err }, 'client error')
-    }
+    log.debug({ err }, 'client error')
     socket.end(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n${body}`)
   }
 


### PR DESCRIPTION
I'm new to js, github and this is my first PR, so feel fre to change anything.
Closes #[1361](https://github.com/fastify/fastify/issues/1361)

**Problem**
Google chrome browser keep-alive socket connection to server, so after 2 min of any https request, or if client will close browser window - server socket [will timeout](https://nodejs.org/api/http.html#http_server_settimeout_msecs_callback). 

After that error will be logged:
```
ERROR [2019-01-03 12:24:09.858 +0000] (11508 on PredatorRTW):
    msg: "client error"
    err: {
      "type": "Error",
      "message": "socket hang up",
      "stack":
          Error: socket hang up
              at TLSSocket.onSocketClose (_tls_wrap.js:737:23)
              at TLSSocket.emit (events.js:187:15)
              at _handle.close (net.js:616:12)
              at Socket.done (_tls_wrap.js:384:7)
              at Object.onceWrapper (events.js:273:13)
              at Socket.emit (events.js:182:13)
              at TCP._handle.close (net.js:616:12)
      "code": "ECONNRESET"
    }
```

**Proposal**
Errors should be something important and this one should be moved in less important category. As @mcollina suggested in previos conversation - into debug.

#### Checklist
- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
