### PR TITLE
Update copyright year to 2019

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016-2018 The Fastify Team
+Copyright (c) 2016-2019 The Fastify Team
 
 The Fastify team members are listed at https://github.com/fastify/fastify#team
 and in the README file.


### PR DESCRIPTION
Backporting to 1.x
