### PR TITLE
Add plugin name in case of dependency error

### DIFF
--- a/lib/pluginUtils.js
+++ b/lib/pluginUtils.js
@@ -26,7 +26,7 @@ function checkDependencies (fn) {
   dependencies.forEach(dependency => {
     assert(
       this[registeredPlugins].indexOf(dependency) > -1,
-      `The dependency '${dependency}' is not registered`
+      `The dependency '${dependency}' of plugin '${meta.name}' is not registered`
     )
   })
 }

--- a/test/internals/plugin.test.js
+++ b/test/internals/plugin.test.js
@@ -106,6 +106,7 @@ test('checkDependencies should check if the given dependency is present in the i
   t.plan(1)
 
   fn[Symbol.for('plugin-meta')] = {
+    name: 'test-plugin',
     dependencies: ['plugin']
   }
 
@@ -116,7 +117,7 @@ test('checkDependencies should check if the given dependency is present in the i
     pluginUtils.checkDependencies.call(context, fn)
     t.fail('should throw')
   } catch (err) {
-    t.is(err.message, `The dependency 'plugin' is not registered`)
+    t.is(err.message, `The dependency 'plugin' of plugin 'test-plugin' is not registered`)
   }
 
   function fn () {}


### PR DESCRIPTION
In case of a dependency error, it can be hard to find the plugin responsible. This PR adds the plugin name to the error for easier debug.

`The dependency 'dep-plugin' is not registered` 
is changed to `The dependency 'dep-plugin' of plugin 'my-plugin' is not registered`

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
