### PR TITLE
Rewrite unnecessary lines in validation file

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -37,19 +37,14 @@ function build (context, compile, schemas) {
     // The header keys are case insensitive
     //  https://tools.ietf.org/html/rfc2616#section-4.2
     const headersSchemaLowerCase = {}
-    for (const k in headers) {
-      if (headers.hasOwnProperty(k) !== true) continue
-      headersSchemaLowerCase[k] = headers[k]
-    }
+    Object.keys(headers).forEach(k => { headersSchemaLowerCase[k] = headers[k] })
     if (headersSchemaLowerCase.required instanceof Array) {
       headersSchemaLowerCase.required = headersSchemaLowerCase.required.map(h => h.toLowerCase())
     }
     if (headers.properties) {
-      const properties = headers.properties
-      for (const k in properties) {
-        if (properties.hasOwnProperty(k) !== true) continue
-        headersSchemaLowerCase.properties[k.toLowerCase()] = properties[k]
-      }
+      Object.keys(headers.properties).forEach(k => {
+        headersSchemaLowerCase.properties[k.toLowerCase()] = headers.properties[k]
+      })
     }
     context[headersSchema] = compile(headersSchemaLowerCase)
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

Rewrites a vague code block to be more discrete. I think it would be better to use `Object.keys(headers).forEach(...)`. It also skips non-enumerable properties and imo is more readable than `for (var k in headers)` because `headers` can be misread as an array instead of the object it is.