### PR TITLE
Test coverage further improvement

### DIFF
--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -2,6 +2,7 @@
 
 const t = require('tap')
 const test = t.test
+const handleRequest = require('../../lib/handleRequest')
 const internals = require('../../lib/handleRequest')[Symbol.for('internals')]
 const Request = require('../../lib/request')
 const Reply = require('../../lib/reply')
@@ -34,6 +35,14 @@ test('Request object', t => {
   t.equal(req.headers, 'headers')
   t.equal(req.log, 'log')
   t.strictDeepEqual(req.body, null)
+})
+
+test('handleRequest function - sent reply', t => {
+  t.plan(1)
+  const request = {}
+  const reply = { sent: true }
+  const res = handleRequest(null, request, reply)
+  t.equal(res, undefined)
 })
 
 test('handler function - invalid schema', t => {

--- a/test/wrapThenable.test.js
+++ b/test/wrapThenable.test.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const { kReplySentOverwritten } = require('../lib/symbols')
+const wrapThenable = require('../lib/wrapThenable')
+
+test('should resolve immediately when reply.sentOverwritten is true', t => {
+  t.plan(1)
+  const reply = {}
+  reply[kReplySentOverwritten] = true
+  const thenable = Promise.resolve()
+  wrapThenable(thenable, reply)
+  t.pass()
+})
+
+test('should reject immediately when reply.sentOverwritten is true', t => {
+  t.plan(1)
+  const reply = { res: {} }
+  reply[kReplySentOverwritten] = true
+  reply.res.log = {
+    error: () => { }
+  }
+
+  const thenable = Promise.reject(new Error('Reply sent already'))
+  wrapThenable(thenable, reply)
+  t.pass()
+})

--- a/test/wrapThenable.test.js
+++ b/test/wrapThenable.test.js
@@ -5,7 +5,7 @@ const test = t.test
 const { kReplySentOverwritten } = require('../lib/symbols')
 const wrapThenable = require('../lib/wrapThenable')
 
-test('should resolve immediately when reply.sentOverwritten is true', t => {
+test('should resolve immediately when reply[kReplySentOverwritten] is true', t => {
   t.plan(1)
   const reply = {}
   reply[kReplySentOverwritten] = true

--- a/test/wrapThenable.test.js
+++ b/test/wrapThenable.test.js
@@ -6,23 +6,23 @@ const { kReplySentOverwritten } = require('../lib/symbols')
 const wrapThenable = require('../lib/wrapThenable')
 
 test('should resolve immediately when reply[kReplySentOverwritten] is true', t => {
-  t.plan(1)
   const reply = {}
   reply[kReplySentOverwritten] = true
   const thenable = Promise.resolve()
   wrapThenable(thenable, reply)
-  t.pass()
+  t.end()
 })
 
-test('should reject immediately when reply.sentOverwritten is true', t => {
+test('should reject immediately when reply[kReplySentOverwritten] is true', t => {
   t.plan(1)
   const reply = { res: {} }
   reply[kReplySentOverwritten] = true
   reply.res.log = {
-    error: () => { }
+    error: ({ err }) => {
+      t.strictEqual(err.message, 'Reply sent already')
+    }
   }
 
   const thenable = Promise.reject(new Error('Reply sent already'))
   wrapThenable(thenable, reply)
-  t.pass()
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

In continuation of the effort to increase the code coverage (#1335 ). 
- 1st commit: Having doubt about how I imported ../../lib/handleRequest again [here](https://github.com/flickz/fastify/blob/fix/improve-test-coverage/test/internals/handleRequest.test.js#L5) but couldn't figure out alternative way to do it. But let me know if you think there's another way I could have done it better.
- 2nd commit: Spent a lot of time trying to come with a test description :smile: but will really appreciate a better way to describe the test.

cc @Ethan-Arrowood 