### PR TITLE
Updated reply.redirect declaration

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -142,18 +142,19 @@ declare namespace fastify {
    * Response object that is used to build and send a http response
    */
   interface FastifyReply<HttpResponse> {
-    code: (statusCode: number) => FastifyReply<HttpResponse>
-    status: (statusCode: number) => FastifyReply<HttpResponse>
-    header: (name: string, value: any) => FastifyReply<HttpResponse>
-    headers: (headers: { [key: string]: any }) => FastifyReply<HttpResponse>
-    getHeader: (name: string) => string | undefined
-    hasHeader: (name: string) => boolean
-    callNotFound: () => void
-    type: (contentType: string) => FastifyReply<HttpResponse>
-    redirect: (statusCode: number, url: string) => FastifyReply<HttpResponse>
-    serialize: (payload: any) => string
-    serializer: (fn: Function) => FastifyReply<HttpResponse>
-    send: (payload?: any) => FastifyReply<HttpResponse>
+    code(statusCode: number): FastifyReply<HttpResponse>
+    status(statusCode: number): FastifyReply<HttpResponse>
+    header(name: string, value: any): FastifyReply<HttpResponse>
+    headers(headers: { [key: string]: any }): FastifyReply<HttpResponse>
+    getHeader(name: string): string | undefined
+    hasHeader(name: string): boolean
+    callNotFound(): void
+    type(contentType: string): FastifyReply<HttpResponse>
+    redirect(url: string): FastifyReply<HttpResponse>
+    redirect(statusCode: number, url: string): FastifyReply<HttpResponse>
+    serialize(payload: any): string
+    serializer(fn: Function): FastifyReply<HttpResponse>
+    send(payload?: any): FastifyReply<HttpResponse>
     sent: boolean
     res: HttpResponse
     context: FastifyContext

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -233,6 +233,10 @@ server
     const stream = fs.createReadStream(process.cwd() + '/examples/plugin.js', 'utf8')
     reply.code(200).send(stream)
   })
+  .get('/redirect', function (req, reply) {
+    reply.redirect('/other')
+    reply.redirect(301, '/something')
+  })
   .post('/', opts, function (req, reply) {
     reply
       .headers({ 'Content-Type': 'application/json' })


### PR DESCRIPTION
I had to update the `Reply` definition because with the previous syntax was not possible to define function overloads.
Closes https://github.com/fastify/fastify/pull/1341.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
