### PR TITLE
Update default ajv instance to include all errors

### DIFF
--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -165,7 +165,8 @@ Fastify's [baseline ajv configuration](https://github.com/epoberezkin/ajv#option
 {
   removeAdditional: true, // remove additional properties
   useDefaults: true, // replace missing properties and items with the values from corresponding default keyword
-  coerceTypes: true  // change data type of data to match type keyword
+  coerceTypes: true, // change data type of data to match type keyword
+  allErrors: true    // check for all errors
 }
 ```
 
@@ -178,7 +179,8 @@ const ajv = new Ajv({
   // the fastify defaults (if needed)
   removeAdditional: true,
   useDefaults: true,
-  coerceTypes: true
+  coerceTypes: true,
+  allErrors: true
   // any other options
   // ...
 })

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -157,7 +157,8 @@ function buildSchemaCompiler () {
   const ajv = new Ajv({
     coerceTypes: true,
     useDefaults: true,
-    removeAdditional: true
+    removeAdditional: true,
+    allErrors: true
   })
 
   return ajv.compile.bind(ajv)

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -11,7 +11,7 @@ const schema = {
       name: { type: 'string' },
       work: { type: 'string' }
     },
-    required: ['name']
+    required: ['name', 'work']
   }
 }
 
@@ -27,7 +27,8 @@ test('should work with valid payload', t => {
   fastify.inject({
     method: 'POST',
     payload: {
-      name: 'michelangelo'
+      name: 'michelangelo',
+      work: 'sculptor, painter, architect and poet'
     },
     url: '/'
   }, (err, res) => {
@@ -57,7 +58,7 @@ test('should fail immediately with invalid payload', t => {
     t.deepEqual(JSON.parse(res.payload), {
       statusCode: 400,
       error: 'Bad Request',
-      message: "body should have required property 'name'"
+      message: "body should have required property 'name', body should have required property 'work'"
     })
     t.strictEqual(res.statusCode, 400)
   })
@@ -120,6 +121,13 @@ test('should be able to attach validation to request', t => {
       schemaPath: '#/required',
       params: { missingProperty: 'name' },
       message: 'should have required property \'name\''
+    },
+    {
+      keyword: 'required',
+      dataPath: '',
+      schemaPath: '#/required',
+      params: { missingProperty: 'work' },
+      message: 'should have required property \'work\''
     }])
     t.strictEqual(res.statusCode, 400)
   })
@@ -146,7 +154,7 @@ test('should respect when attachValidation is explicitly set to false', t => {
     t.deepEqual(JSON.parse(res.payload), {
       statusCode: 400,
       error: 'Bad Request',
-      message: "body should have required property 'name'"
+      message: "body should have required property 'name', body should have required property 'work'"
     })
     t.strictEqual(res.statusCode, 400)
   })
@@ -176,7 +184,7 @@ test('Attached validation error should take precendence over setErrorHandler', t
     url: '/'
   }, (err, res) => {
     t.error(err)
-    t.deepEqual(res.payload, "Attached: Error: body should have required property 'name'")
+    t.deepEqual(res.payload, "Attached: Error: body should have required property 'name', body should have required property 'work'")
     t.strictEqual(res.statusCode, 400)
   })
 })


### PR DESCRIPTION
Closes #1397 

Set `allErrors: true` in default AJV instance to catch all errors

#### Checklist

- [x] run `npm run test`
- [x]  run `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
