### PR TITLE
log "premature close" stream errors as warnings

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -291,8 +291,7 @@ function sendStream (payload, res, reply) {
     sourceOpen = false
     if (err != null) {
       if (res.headersSent) {
-        // no "code" property, so match on "message"
-        var isPrematureClose = err.message === 'premature close'
+        var isPrematureClose = err.code && err.code === 'ERR_STREAM_PREMATURE_CLOSE'
         res.log[isPrematureClose ? 'warn' : 'error']({ err }, 'response terminated with an error with headers already sent')
         res.destroy()
       } else {
@@ -305,8 +304,7 @@ function sendStream (payload, res, reply) {
   eos(res, function (err) {
     if (err != null) {
       if (res.headersSent) {
-        // no "code" property, so match on "message"
-        var isPrematureClose = err.message === 'premature close'
+        var isPrematureClose = err.code && err.code === 'ERR_STREAM_PREMATURE_CLOSE'
         res.log[isPrematureClose ? 'warn' : 'error']({ err }, 'response terminated with an error with headers already sent')
       }
       if (sourceOpen) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -291,7 +291,9 @@ function sendStream (payload, res, reply) {
     sourceOpen = false
     if (err != null) {
       if (res.headersSent) {
-        res.log.error({ err }, 'response terminated with an error with headers already sent')
+        // no "code" property, so match on "message"
+        var isPrematureClose = err.message === 'premature close'
+        res.log[isPrematureClose ? 'warn' : 'error']({ err }, 'response terminated with an error with headers already sent')
         res.destroy()
       } else {
         onErrorHook(reply, err)
@@ -303,7 +305,9 @@ function sendStream (payload, res, reply) {
   eos(res, function (err) {
     if (err != null) {
       if (res.headersSent) {
-        res.log.error({ err }, 'response terminated with an error with headers already sent')
+        // no "code" property, so match on "message"
+        var isPrematureClose = err.message === 'premature close'
+        res.log[isPrematureClose ? 'warn' : 'error']({ err }, 'response terminated with an error with headers already sent')
       }
       if (sourceOpen) {
         if (payload.destroy) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -291,7 +291,7 @@ function sendStream (payload, res, reply) {
     sourceOpen = false
     if (err != null) {
       if (res.headersSent) {
-        var isPrematureClose = err.code && err.code === 'ERR_STREAM_PREMATURE_CLOSE'
+        var isPrematureClose = err.code === 'ERR_STREAM_PREMATURE_CLOSE'
         res.log[isPrematureClose ? 'warn' : 'error']({ err }, 'response terminated with an error with headers already sent')
         res.destroy()
       } else {
@@ -304,7 +304,7 @@ function sendStream (payload, res, reply) {
   eos(res, function (err) {
     if (err != null) {
       if (res.headersSent) {
-        var isPrematureClose = err.code && err.code === 'ERR_STREAM_PREMATURE_CLOSE'
+        var isPrematureClose = err.code === 'ERR_STREAM_PREMATURE_CLOSE'
         res.log[isPrematureClose ? 'warn' : 'error']({ err }, 'response terminated with an error with headers already sent')
       }
       if (sourceOpen) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const eos = require('end-of-stream')
+const eos = require('readable-stream').finished
 const statusCodes = require('http').STATUS_CODES
 const flatstr = require('flatstr')
 const FJS = require('fast-json-stringify')

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
     "abstract-logging": "^1.0.0",
     "ajv": "^6.6.0",
     "avvio": "^6.0.0",
-    "end-of-stream": "^1.4.1",
     "fast-json-stringify": "^1.9.1",
     "find-my-way": "^1.15.4",
     "flatstr": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "middie": "^4.0.0",
     "pino": "^5.0.0",
     "proxy-addr": "^2.0.3",
+    "readable-stream": "^3.1.1",
     "tiny-lru": "^5.0.1"
   },
   "greenkeeper": {

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -140,7 +140,7 @@ test('onSend hook stream', t => {
 })
 
 test('Destroying streams prematurely', t => {
-  t.plan(7)
+  t.plan(5)
 
   let fastify = null
   const logStream = split(JSON.parse)
@@ -161,10 +161,6 @@ test('Destroying streams prematurely', t => {
   logStream.once('data', line => {
     t.equal(line.level, 40)
     t.equal(line.err.message, 'premature close')
-    logStream.once('data', line => {
-      t.equal(line.level, 40)
-      t.equal(line.err.message, 'premature close')
-    })
   })
 
   fastify.get('/', function (request, reply) {

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -12,6 +12,7 @@ const errors = require('http-errors')
 const JSONStream = require('JSONStream')
 const send = require('send')
 const Readable = require('stream').Readable
+const split = require('split2')
 
 test('should respond with a stream', t => {
   t.plan(8)
@@ -139,11 +140,32 @@ test('onSend hook stream', t => {
 })
 
 test('Destroying streams prematurely', t => {
-  t.plan(3)
+  t.plan(7)
 
-  const fastify = Fastify()
+  let fastify = null
+  const logStream = split(JSON.parse)
+  try {
+    fastify = Fastify({
+      logger: {
+        stream: logStream,
+        level: 'warn'
+      }
+    })
+  } catch (e) {
+    t.fail()
+  }
   const stream = require('stream')
   const http = require('http')
+
+  // Test that "premature close" errors are logged with level warn
+  logStream.once('data', line => {
+    t.equal(line.level, 40)
+    t.equal(line.err.message, 'premature close')
+    logStream.once('data', line => {
+      t.equal(line.level, 40)
+      t.equal(line.err.message, 'premature close')
+    })
+  })
 
   fastify.get('/', function (request, reply) {
     t.pass('Received request')

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -140,7 +140,7 @@ test('onSend hook stream', t => {
 })
 
 test('Destroying streams prematurely', t => {
-  t.plan(5)
+  t.plan(4)
 
   let fastify = null
   const logStream = split(JSON.parse)
@@ -160,7 +160,6 @@ test('Destroying streams prematurely', t => {
   // Test that "premature close" errors are logged with level warn
   logStream.once('data', line => {
     t.equal(line.level, 40)
-    t.equal(line.err.message, 'premature close')
   })
 
   fastify.get('/', function (request, reply) {


### PR DESCRIPTION
This change logs "premature close" stream errors with log level `warn` instead of `error`, as discussed in #1406.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)