### PR TITLE
feat: Added preSerialization hook and route option.

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -11,6 +11,7 @@ By using the hooks you can interact directly inside the lifecycle of Fastify. Th
 - `'preParsing'`
 - `'preValidation'`
 - `'preHandler'`
+- `'preSerialization'`
 - `'onError'`
 - `'onSend'`
 - `'onResponse'`
@@ -33,6 +34,11 @@ fastify.addHook('preValidation', (request, reply, next) => {
 })
 
 fastify.addHook('preHandler', (request, reply, next) => {
+  // some code
+  next()
+})
+
+fastify.addHook('preSerialization', (request, reply, payload, next) => {
   // some code
   next()
 })
@@ -92,6 +98,16 @@ fastify.addHook('preHandler', async (request, reply) => {
     throw new Error('some errors occurred.')
   }
   return
+})
+
+fastify.addHook('preSerialization', async (request, reply, payload) => {
+  // some code
+  await asyncMethod()
+  // error occurred
+  if (err) {
+    throw new Error('some errors occurred.')
+  }
+  return payload
 })
 
 fastify.addHook('onError', async (request, reply, error) => {
@@ -168,6 +184,25 @@ fastify.addHook('onError', async (request, reply, error) => {
   apm.sendError(error)
 })
 ```
+
+#### The `preSerialization` Hook
+
+If you are using the `preSerialization` hook, you can change (or replace) the payload before it is serialized. For example:
+
+```js
+fastify.addHook('preSerialization', (request, reply, payload, next) => {
+  var err = null;
+  var newPayload = {wrapped: payload }
+  next(err, newPayload)
+})
+
+// Or async
+fastify.addHook('onSend', async (request, reply, payload) => {
+  return {wrapped: payload }
+})
+```
+
+Note: the hook is NOT called if the payload is  a `string`, a `Buffer`, a `stream`, or `null`.
 
 #### The `onSend` Hook
 

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -197,7 +197,7 @@ fastify.addHook('preSerialization', (request, reply, payload, next) => {
 })
 
 // Or async
-fastify.addHook('onSend', async (request, reply, payload) => {
+fastify.addHook('preSerialization', async (request, reply, payload) => {
   return {wrapped: payload }
 })
 ```

--- a/docs/Lifecycle.md
+++ b/docs/Lifecycle.md
@@ -28,9 +28,11 @@ Incoming Request
                                                           │
                                                           └─▶ Reply
                                                                 │
-                                                                └─▶ onSend Hook
-                                                                       │
-                                                             4**/5** ◀─┴─▶ Outgoing Response
-                                                                             │
-                                                                           └─▶ onResponse Hook
+                                                      4**/5** ◀─┴─▶ preSerialization Hook
+                                                                      │
+                                                                      └─▶ onSend Hook
+                                                                            │
+                                                                  4**/5** ◀─┴─▶ Outgoing Response
+                                                                                  │
+                                                                                  └─▶ onResponse Hook
 ```

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -23,9 +23,9 @@ They need to be in
   * `response`: filter and generate a schema for the response, setting a
     schema allows us to have 10-20% more throughput.
 * `attachValidation`: attach `validationError` to request, if there is a schema validation error, instead of sending the error to the error handler.
-* `preValidation(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#route-hooks) called after the shared `preValidation` hooks, useful if you need to perform authentication at route level for example, it could also be and array of functions.
-* `preHandler(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#route-hooks) called just before the request handler, it could also be and array of functions.
-* `preSerialization(request, reply, payload, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#route-hooks) called just before the serialization, it could also be and array of functions.
+* `preValidation(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#route-hooks) called after the shared `preValidation` hooks, useful if you need to perform authentication at route level for example, it could also be an array of functions.
+* `preHandler(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#route-hooks) called just before the request handler, it could also be an array of functions.
+* `preSerialization(request, reply, payload, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#route-hooks) called just before the serialization, it could also be an array of functions.
 * `handler(request, reply)`: the function that will handle this request.
 * `schemaCompiler(schema)`: the function that build the schema for the validations. See [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-compiler)
 * `bodyLimit`: prevents the default JSON body parser from parsing request bodies larger than this number of bytes. Must be an integer. You may also set this option globally when first creating the Fastify instance with `fastify(options)`. Defaults to `1048576` (1 MiB).

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -25,6 +25,7 @@ They need to be in
 * `attachValidation`: attach `validationError` to request, if there is a schema validation error, instead of sending the error to the error handler.
 * `preValidation(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#route-hooks) called after the shared `preValidation` hooks, useful if you need to perform authentication at route level for example, it could also be and array of functions.
 * `preHandler(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#route-hooks) called just before the request handler, it could also be and array of functions.
+* `preSerialization(request, reply, payload, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#route-hooks) called just before the serialization, it could also be and array of functions.
 * `handler(request, reply)`: the function that will handle this request.
 * `schemaCompiler(schema)`: the function that build the schema for the validations. See [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-compiler)
 * `bodyLimit`: prevents the default JSON body parser from parsing request bodies larger than this number of bytes. Must be an integer. You may also set this option globally when first creating the Fastify instance with `fastify(options)`. Defaults to `1048576` (1 MiB).

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -4,10 +4,9 @@
 
 /// <reference types="node" />
 
-import * as http from 'http'
-import * as http2 from 'http2'
-import * as https from 'https'
-import * as tls from 'tls'
+import * as http from 'http';
+import * as http2 from 'http2';
+import * as https from 'https';
 
 declare function fastify<
   HttpServer extends (http.Server | http2.Http2Server) = http.Server,
@@ -528,6 +527,12 @@ declare namespace fastify {
      * Add a hook that is triggered after the onRequest, middlewares, and body parsing, but before the validation
      */
     addHook(name: 'preValidation', hook: FastifyMiddleware<HttpServer, HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+
+    /**
+     * Hook that is fired after a request is processed, but before the response is serialized
+     * hook
+     */
+    addHook(name: 'preSerialization', hook: (this: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, req: FastifyRequest<HttpRequest>, reply: FastifyReply<HttpResponse>, payload: any, done: (err?: Error, value?: any) => void) => void): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Hook that is fired before a request is processed, but after the "preValidation"

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -4,9 +4,9 @@
 
 /// <reference types="node" />
 
-import * as http from 'http';
-import * as http2 from 'http2';
-import * as https from 'https';
+import * as http from 'http'
+import * as http2 from 'http2'
+import * as https from 'https'
 
 declare function fastify<
   HttpServer extends (http.Server | http2.Http2Server) = http.Server,
@@ -81,6 +81,22 @@ declare namespace fastify {
     req: FastifyRequest<HttpRequest, Query, Params, Headers, Body>,
     reply: FastifyReply<HttpResponse>,
     done: (err?: Error) => void,
+  ) => void
+
+  type FastifyMiddlewareWithPayload<
+  HttpServer,
+  HttpRequest,
+  HttpResponse,
+  Query = DefaultQuery,
+  Params = DefaultParams,
+  Headers = DefaultHeaders,
+  Body = DefaultBody
+  > = (
+    this: FastifyInstance<HttpServer, HttpRequest, HttpResponse>,
+    req: FastifyRequest<HttpRequest, Query, Params, Headers, Body>,
+    reply: FastifyReply<HttpResponse>,
+    payload: any,
+    done: (err?: Error, value?: any) => void,
   ) => void
 
   type RequestHandler<
@@ -213,7 +229,10 @@ declare namespace fastify {
     preHandler?:
       | FastifyMiddleware<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body>
       | Array<FastifyMiddleware<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body>>
-    schemaCompiler?: SchemaCompiler
+    preSerialization?:
+      FastifyMiddlewareWithPayload<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body>
+      | Array<FastifyMiddlewareWithPayload<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body>>
+  schemaCompiler?: SchemaCompiler
     bodyLimit?: number
     logLevel?: string
     config?: any

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -551,7 +551,7 @@ declare namespace fastify {
      * Hook that is fired after a request is processed, but before the response is serialized
      * hook
      */
-    addHook(name: 'preSerialization', hook: (this: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, req: FastifyRequest<HttpRequest>, reply: FastifyReply<HttpResponse>, payload: any, done: (err?: Error, value?: any) => void) => void): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    addHook(name: 'preSerialization', hook: FastifyMiddlewareWithPayload<HttpServer, HttpRequest, HttpResponse>): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Hook that is fired before a request is processed, but after the "preValidation"

--- a/fastify.js
+++ b/fastify.js
@@ -687,11 +687,13 @@ function build (options) {
         const onError = _fastify[kHooks].onError
         const preParsing = _fastify[kHooks].preParsing.concat(opts.preParsing || [])
         const preValidation = _fastify[kHooks].preValidation.concat(opts.preValidation || [])
+        const preSerialization = _fastify[kHooks].preSerialization.concat(opts.preSerialization || [])
         const preHandler = _fastify[kHooks].preHandler.concat(opts.preHandler || [])
 
         context.onRequest = onRequest.length ? onRequest : null
         context.preParsing = preParsing.length ? preParsing : null
         context.preValidation = preValidation.length ? preValidation : null
+        context.preSerialization = preSerialization.length ? preSerialization : null
         context.preHandler = preHandler.length ? preHandler : null
         context.onSend = onSend.length ? onSend : null
         context.onError = onError.length ? onError : null
@@ -944,6 +946,7 @@ function build (options) {
       const onRequest = this[kHooks].onRequest
       const preParsing = this[kHooks].preParsing.concat(opts.preParsing || [])
       const preValidation = this[kHooks].preValidation.concat(opts.preValidation || [])
+      const preSerialization = this[kHooks].preSerialization.concat(opts.preSerialization || [])
       const preHandler = this[kHooks].preHandler.concat(opts.beforeHandler || opts.preHandler || [])
       const onSend = this[kHooks].onSend
       const onError = this[kHooks].onError
@@ -952,6 +955,7 @@ function build (options) {
       context.onRequest = onRequest.length ? onRequest : null
       context.preParsing = preParsing.length ? preParsing : null
       context.preValidation = preValidation.length ? preValidation : null
+      context.preSerialization = preSerialization.length ? preSerialization : null
       context.preHandler = preHandler.length ? preHandler : null
       context.onSend = onSend.length ? onSend : null
       context.onError = onError.length ? onError : null

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -4,6 +4,7 @@ const supportedHooks = [
   'onRequest',
   'preParsing',
   'preValidation',
+  'preSerialization',
   'preHandler',
   'onResponse',
   'onSend',
@@ -23,6 +24,7 @@ function Hooks () {
   this.onRequest = []
   this.preParsing = []
   this.preValidation = []
+  this.preSerialization = []
   this.preHandler = []
   this.onResponse = []
   this.onSend = []
@@ -47,6 +49,7 @@ function buildHooks (h) {
   hooks.onRequest = h.onRequest.slice()
   hooks.preParsing = h.preParsing.slice()
   hooks.preValidation = h.preValidation.slice()
+  hooks.preSerialization = h.preSerialization.slice()
   hooks.preHandler = h.preHandler.slice()
   hooks.onSend = h.onSend.slice()
   hooks.onResponse = h.onResponse.slice()

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -129,8 +129,9 @@ Reply.prototype.send = function (payload) {
     if (hasContentType === false || contentType.indexOf('charset') === -1) {
       this[kReplyHeaders]['content-type'] = CONTENT_TYPE.JSON
     }
-    payload = serialize(this.context, payload, this.res.statusCode)
-    flatstr(payload)
+
+    preserializeHook(this, payload)
+    return
   }
 
   onSendHook(this, payload)
@@ -218,6 +219,32 @@ Reply.prototype.redirect = function (code, url) {
 
 Reply.prototype.callNotFound = function () {
   notFound(this)
+}
+
+function preserializeHook (reply, payload) {
+  if (reply.context.preSerialization !== null) {
+    onSendHookRunner(
+      reply.context.preSerialization,
+      reply.request,
+      reply,
+      payload,
+      preserializeHookEnd
+    )
+  } else {
+    preserializeHookEnd(null, reply.request, reply, payload)
+  }
+}
+
+function preserializeHookEnd (err, request, reply, payload) {
+  if (err != null) {
+    onErrorHook(reply, err)
+    return
+  }
+
+  payload = serialize(reply.context, payload, reply.res.statusCode)
+  flatstr(payload)
+
+  onSendHook(reply, payload)
 }
 
 function onSendHook (reply, payload) {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -54,6 +54,8 @@ const cors = require('cors')
     next()
   })
 
+  logAllServer.addHook('preSerialization', async (req, reply, payload, next) => payload)
+
   // other simple options
   const otherServer = fastify({
     ignoreTrailingSlash: true,
@@ -125,6 +127,12 @@ server.addHook('onResponse', function (req, reply, next) {
     console.log('response is finished after 100ms?', reply.res.finished)
     next()
   }, 100)
+})
+
+server.addHook('preSerialization', function (req, reply, payload, next) {
+  this.log.debug('`this` is not `any`')
+  console.log(`${req.req.method} ${req.req.url}`)
+  next(undefined, payload)
 })
 
 server.addHook('onSend', function (req, reply, payload, next) {


### PR DESCRIPTION
I've added preSerialization hook and route option. This fixes #1369.
One use-case for this is to being able to intercept serialization error before fast-json-stringify (which would hide all information since the error thrown has no context).

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
