### PR TITLE
Add tests to cover handleRequest

### DIFF
--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -7,10 +7,7 @@ const wrapThenable = require('./wrapThenable')
 
 function handleRequest (err, request, reply) {
   if (reply.sent === true) return
-  if (err != null) {
-    reply.send(err)
-    return
-  }
+  if (err != null) return reply.send(err)
 
   var method = request.raw.method
   var headers = request.headers

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -7,7 +7,10 @@ const wrapThenable = require('./wrapThenable')
 
 function handleRequest (err, request, reply) {
   if (reply.sent === true) return
-  if (err != null) return reply.send(err)
+  if (err != null) {
+    reply.send(err)
+    return
+  }
 
   var method = request.raw.method
   var headers = request.headers

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -45,6 +45,14 @@ test('handleRequest function - sent reply', t => {
   t.equal(res, undefined)
 })
 
+test('handleRequest function - invoke with error', t => {
+  t.plan(1)
+  const request = {}
+  const reply = {}
+  reply.send = (err) => t.is(err.message, 'Kaboom')
+  handleRequest(new Error('Kaboom'), request, reply)
+})
+
 test('handler function - invalid schema', t => {
   t.plan(2)
   const res = {}
@@ -97,6 +105,30 @@ test('handler function - reply', t => {
     Reply: Reply,
     Request: Request,
     preValidation: [],
+    preHandler: [],
+    onSend: [],
+    onError: []
+  }
+  buildSchema(context, schemaCompiler)
+  internals.handler({}, new Reply(res, context, {}))
+})
+
+test('handler function - preValidationCallback with finished response', t => {
+  t.plan(0)
+  const res = {}
+  res.finished = true
+  res.end = () => {
+    t.fail()
+  }
+  res.writeHead = () => {}
+  const context = {
+    handler: (req, reply) => {
+      t.fail()
+      reply.send(undefined)
+    },
+    Reply: Reply,
+    Request: Request,
+    preValidation: null,
     preHandler: [],
     onSend: [],
     onError: []


### PR DESCRIPTION
Add tests to exercise more lines. `preValidationCallback with finished response` test is a bit synthetic but it gets the work done.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
