### PR TITLE
Set log level to warn for all sendStream errors

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -291,8 +291,7 @@ function sendStream (payload, res, reply) {
     sourceOpen = false
     if (err != null) {
       if (res.headersSent) {
-        var isPrematureClose = err.code === 'ERR_STREAM_PREMATURE_CLOSE'
-        res.log[isPrematureClose ? 'warn' : 'error']({ err }, 'response terminated with an error with headers already sent')
+        res.log.warn({ err }, 'response terminated with an error with headers already sent')
         res.destroy()
       } else {
         onErrorHook(reply, err)
@@ -304,8 +303,7 @@ function sendStream (payload, res, reply) {
   eos(res, function (err) {
     if (err != null) {
       if (res.headersSent) {
-        var isPrematureClose = err.code === 'ERR_STREAM_PREMATURE_CLOSE'
-        res.log[isPrematureClose ? 'warn' : 'error']({ err }, 'response terminated with an error with headers already sent')
+        res.log.warn({ err }, 'response terminated with an error with headers already sent')
       }
       if (sourceOpen) {
         if (payload.destroy) {


### PR DESCRIPTION
I think the list in #1407 will only grow in time so we should probably just emit a warning for all problems.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
