### PR TITLE
update find-my-way to version 1.18.0;

### DIFF
--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -284,6 +284,7 @@ fastify.listen(3000)
 
 <a name="version"></a>
 ### Version
+#### Default
 If needed you can provide a version option, which will allow you to declare multiple versions of the same route. The versioning should follow the [semver](http://semver.org/) specification.<br/>
 Fastify will automatically detect the `Accept-Version` header and route the request accordingly (advanced ranges and pre-releases currently are not supported).<br/>
 *Be aware that using this feature will cause a degradation of the overall performances of the router.*
@@ -309,3 +310,5 @@ fastify.inject({
 ```
 If you declare multiple versions with the same major or minor, Fastify will always choose the highest compatible with the `Accept-Version` header value.<br/>
 If the request will not have the `Accept-Version` header, a 404 error will be returned.
+#### Custom
+It's possible to define a custom versioning logic. This can be done through the [`versioning`](https://github.com/fastify/fastify/blob/master/docs/Server.md#versioning) configuration, when creating a fastify server instance.

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -224,6 +224,32 @@ const fastify = require('fastify')({
 })
 ```
 
+<a name="versioning"></a>
+### `versioning`
+
+By default you can version your routes with [semver versioning](https://github.com/fastify/fastify/blob/master/docs/Routes.md#version), which is provided by `find-my-way`. There is still an option to provide custom versioning strategy. You can find more information in the [find-my-way](https://github.com/delvedor/find-my-way#versioned-routes) documentation.
+
+```js
+const versioning = {
+  storage: function () {
+    let versions = {}
+    return {
+      get: (version) => { return versions[version] || null },
+      set: (version, store) => { versions[version] = store },
+      del: (version) => { delete versions[version] },
+      empty: () => { versions = {} }
+    }
+  },
+  deriveVersion: (req, ctx) => {
+    return req.headers['accept']
+  }
+}
+
+const fastify = require('fastify')({
+  versioning
+})
+```
+
 ## Instance
 
 ### Server Methods
@@ -432,7 +458,7 @@ fastify.setNotFoundHandler({
   preHandler: (req, reply, next) => {
     // your code
     next()
-  }  
+  }
 }, function (request, reply) {
     // Default not found handler with preValidation and preHandler hooks
 })

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -167,6 +167,15 @@ declare namespace fastify {
     trustProxy?: string | number | boolean | Array<string> | TrustProxyFunction,
     maxParamLength?: number,
     querystringParser?: (str: string) => { [key: string]: string | string[] },
+    versioning? : {
+      storage() : {
+        get(version: String) : Function | null,
+        set(version: String, store: Function) : void,
+        del(version: String) : void,
+        empty() : void
+      },
+      deriveVersion<Context>(req: Object, ctx?: Context) : String,
+    }
   }
   interface ServerOptionsAsSecure extends ServerOptions {
     https: http2.SecureServerOptions

--- a/fastify.js
+++ b/fastify.js
@@ -86,7 +86,8 @@ function build (options) {
     defaultRoute: defaultRoute,
     ignoreTrailingSlash: options.ignoreTrailingSlash,
     maxParamLength: options.maxParamLength,
-    caseSensitive: options.caseSensitive
+    caseSensitive: options.caseSensitive,
+    versioning: options.versioning
   })
 
   const requestIdHeader = options.requestIdHeader || 'request-id'

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "ajv": "^6.6.0",
     "avvio": "^6.0.0",
     "fast-json-stringify": "^1.9.1",
-    "find-my-way": "^1.15.4",
+    "find-my-way": "^1.18.0",
     "flatstr": "^1.0.8",
     "light-my-request": "^3.0.0",
     "middie": "^4.0.0",


### PR DESCRIPTION
This PR makes it possible to use custom versioning feature from `find-my-way`.
Which was introduced in scope of this PR: https://github.com/delvedor/find-my-way/pull/107.