### PR TITLE
fix: json schema $ref with $id set in definitions

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -800,10 +800,10 @@ function build (options) {
     instance[kChildren].forEach(child => _addHook(child, name, fn))
   }
 
-  function addSchema (name, schema) {
+  function addSchema (schema) {
     throwIfAlreadyStarted('Cannot call "addSchema" when fastify instance is already started!')
-    this[kSchemas].add(name, schema)
-    this[kChildren].forEach(child => child.addSchema(name, schema))
+    this[kSchemas].add(schema)
+    this[kChildren].forEach(child => child.addSchema(schema))
     return this
   }
 

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -8,6 +8,8 @@ const {
   }
 } = require('./errors')
 
+const URI_NAME_FRAGMENT = /^#[A-Za-z]{1}[\w-:.]{0,}$/
+
 function Schemas () {
   this.store = {}
 }
@@ -80,7 +82,9 @@ Schemas.prototype.traverse = function (schema) {
 
 Schemas.prototype.cleanId = function (schema) {
   for (var key in schema) {
-    if (key === '$id') delete schema[key]
+    if (key === '$id' && !URI_NAME_FRAGMENT.test(schema[key])) {
+      delete schema[key]
+    }
     if (schema[key] !== null && typeof schema[key] === 'object') {
       this.cleanId(schema[key])
     }

--- a/test/shared-schemas.test.js
+++ b/test/shared-schemas.test.js
@@ -441,6 +441,47 @@ test('Use the same schema id in diferent places', t => {
   })
 })
 
+test('Use shared schema and $ref with $id', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  fastify.addSchema({
+    $id: 'test',
+    type: 'object',
+    properties: {
+      id: { type: 'number' }
+    }
+  })
+
+  const body = {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    $id: 'http://foo/user',
+    type: 'object',
+    definitions: {
+      address: {
+        $id: '#address',
+        type: 'object',
+        properties: {
+          city: { 'type': 'string' }
+        }
+      }
+    },
+    properties: {
+      test: 'test#',
+      address: { $ref: '#address' }
+    }
+  }
+
+  fastify.route({
+    method: 'POST',
+    url: '/',
+    schema: { body },
+    handler: () => {}
+  })
+
+  fastify.ready(t.error)
+})
+
 // https://github.com/fastify/fastify/issues/1043
 test('The schema resolver should clean the $id key before passing it to the compiler', t => {
   t.plan(1)

--- a/test/shared-schemas.test.js
+++ b/test/shared-schemas.test.js
@@ -442,7 +442,7 @@ test('Use the same schema id in diferent places', t => {
 })
 
 test('Use shared schema and $ref with $id', t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
 
   fastify.addSchema({
@@ -475,11 +475,29 @@ test('Use shared schema and $ref with $id', t => {
   fastify.route({
     method: 'POST',
     url: '/',
-    schema: { body },
-    handler: () => {}
+    schema: {
+      body,
+      response: {
+        200: 'test#'
+      }
+    },
+    handler: (req, reply) => {
+      reply.send(req.body.test)
+    }
   })
 
-  fastify.ready(t.error)
+  const id = Date.now()
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: {
+      address: { city: 'New Node' },
+      test: { id }
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.deepEqual(JSON.parse(res.payload), { id })
+  })
 })
 
 // https://github.com/fastify/fastify/issues/1043


### PR DESCRIPTION
This fixes #1419 

The pattern used in the code has been written reading the actual [draft standard](https://tools.ietf.org/html/draft-handrews-json-schema-01#section-8.2.3):

>    To specify such a subschema identifier, the "$id" keyword is set to a
>    URI reference with a plain name fragment (not a JSON Pointer
>    fragment).  This value MUST begin with the number sign that specifies
>    a fragment ("#"), then a letter ([A-Za-z]), followed by any number of
>    letters, digits ([0-9]), hyphens ("-"), underscores ("_"), colons
>    (":"), or periods (".").

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
