### PR TITLE
Fixed typos

### DIFF
--- a/docs/Plugins-Guide.md
+++ b/docs/Plugins-Guide.md
@@ -37,7 +37,7 @@ As you probably know, the required plugins must expose a single function with th
 ```js
 module.exports = function (fastify, options, next) {}
 ```
-Where `fastify` is (pretty obvious) the encapsulated Fastify instance, `options` is the options object and `next` is the function you **must** call when you plugin is ready.
+Where `fastify` is (pretty obvious) the encapsulated Fastify instance, `options` is the options object and `next` is the function you **must** call when your plugin is ready.
 
 Fastify's plugin model is fully reentrant and graph-based, it handles without any kind of problem asynchronous code and it guarantees the load order of the plugins, even the close order! *How?* Glad you asked, checkout [`avvio`](https://github.com/mcollina/avvio)! Fastify starts loading the plugin __after__ `.listen()`, `.inject()` or `.ready()` are called.
 


### PR DESCRIPTION
Fixed typos in this sentence:

> Where `fastify` is (pretty obvious) the encapsulated Fastify instance, `options` is the options object and `next` is the function you **must** call when you plugin is ready.

I think that instead of `... call when you plugin is ready` it could be `... call when your plugin is ready`.