### PR TITLE
Add test for content-type overriding inside a plugin

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -190,6 +190,7 @@ function getDefaultJsonParser (onProtoPoisoning) {
 
 function buildContentTypeParser (c) {
   const contentTypeParser = new ContentTypeParser()
+  contentTypeParser._defaultJsonParser = c._defaultJsonParser
   Object.assign(contentTypeParser.customParsers, c.customParsers)
   contentTypeParser.parserList = c.parserList.slice()
   return contentTypeParser

--- a/test/custom-parser.test.js
+++ b/test/custom-parser.test.js
@@ -537,6 +537,44 @@ test('Can override the default json parser', t => {
   })
 })
 
+test('Can override the default json parser in a plugin', t => {
+  t.plan(5)
+  const fastify = Fastify()
+
+  fastify.register((instance, opts, next) => {
+    instance.addContentTypeParser('application/json', function (req, done) {
+      t.ok('called')
+      jsonParser(req, function (err, body) {
+        done(err, body)
+      })
+    })
+
+    instance.post('/', (req, reply) => {
+      reply.send(req.body)
+    })
+
+    next()
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'POST',
+      url: 'http://localhost:' + fastify.server.address().port,
+      body: '{"hello":"world"}',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(body.toString(), '{"hello":"world"}')
+      fastify.close()
+    })
+  })
+})
+
 test('Can\'t override the json parser multiple times', t => {
   t.plan(1)
   const fastify = Fastify()


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

Latest minor broke our server, since it now generates new parser functions every time, the hasParser comparison fails. I only included a unit test so far to show the problem, I don't know how you want to address it so I'd happily take guidance on this one and make the changes, or feel free to merge the failing test and fix it if it's faster for you.