### PR TITLE
Add test for content-type overriding inside a plugin (#1434)

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -210,6 +210,7 @@ function defaultPlainTextParser (req, body, done) {
 
 function buildContentTypeParser (c) {
   const contentTypeParser = new ContentTypeParser()
+  contentTypeParser[kDefaultJsonParse] = c[kDefaultJsonParse]
   Object.assign(contentTypeParser.customParsers, c.customParsers)
   contentTypeParser.parserList = c.parserList.slice()
   return contentTypeParser


### PR DESCRIPTION
Forward port of #1434 from `1.x`.

cc @marsup