### PR TITLE
onClose should support promise/async functions

### DIFF
--- a/test/close.test.js
+++ b/test/close.test.js
@@ -23,6 +23,25 @@ test('close callback', t => {
   })
 })
 
+test('close promise', t => {
+  t.plan(4)
+  const fastify = Fastify()
+  fastify.addHook('onClose', onClose)
+  function onClose (instance) {
+    t.type(fastify, instance)
+    return Promise.resolve()
+  }
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    fastify.close((err) => {
+      t.error(err)
+      t.ok('close callback')
+    })
+  })
+})
+
 test('inside register', t => {
   t.plan(5)
   const fastify = Fastify()


### PR DESCRIPTION
Adding a test to demonstrate a possible regression on the onClose hook. It seems like fastify@1 supported async handlers/promises.

Any hints on how to fix this? Is this intended behaviour? Is it a bug in avvio or fastify?

Ref: https://github.com/fastify/fastify-mongodb/pull/67

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
