### PR TITLE
Fix/add schema to validator

### DIFF
--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -313,8 +313,8 @@ in conjuction with the Fastify's shared schema, let you reuse all your schemas e
 | shared schema                     | ✔️ | ✔️ |
 | `$ref` to `$id`                   | ✔ | ✔️ |
 | `$ref` to `/definitions`          | ✔️ | ✔️ |
-| `$ref` to shared schema `$id`          | ❌ | ✔️ |
-| `$ref` to shared schema `/definitions` | ❌ | ✔️ |
+| `$ref` to shared schema `$id`          | ✔ | ✔️ |
+| `$ref` to shared schema `/definitions` | ✔ | ✔️ |
 
 #### Examples
 

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -51,6 +51,37 @@ fastify.post('/the/url', { schema }, handler)
 <a name="shared-schema"></a>
 #### Adding a shared schema
 Thanks to the `addSchema` API, you can add multiple schemas to the Fastify instance and then reuse them in multiple parts of your application. As usual, this API is encapsulated.
+
+There are two way to reuse your shared schema:
++ **`$ref-way`**: as described in the [standard](https://tools.ietf.org/html/draft-handrews-json-schema-01#section-8),
+you can refer to an external schema. To you it you have to `addSchema` with a valid `$id` absolute URI.
+
+```js
+fastify.addSchema({
+  $id: 'http://example.com/common.json',
+  type: 'object',
+  properties: {
+    hello: { type: 'string' }
+  }
+})
+
+fastify.route({
+  method: 'POST',
+  url: '/',
+  schema: {
+    body: {
+      type: 'array',
+      items: { $ref: 'http://example.com/common.json#/properties/hello' }
+    }
+  },
+  handler: () => {}
+})
+```
+
++ **`replace-way`**: this is a Fastify utils that let you to substitute some fields with a shared schema.
+To use it you have to `addSchema` with an `$id` with a relative URI fragment: a simple string that apply only
+to alphanumeric chars `[A-Za-z0-9]`.
+
 ```js
 const fastify = require('fastify')()
 

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -52,9 +52,9 @@ fastify.post('/the/url', { schema }, handler)
 #### Adding a shared schema
 Thanks to the `addSchema` API, you can add multiple schemas to the Fastify instance and then reuse them in multiple parts of your application. As usual, this API is encapsulated.
 
-There are two way to reuse your shared schema:
+There are two ways to reuse your shared schemas:
 + **`$ref-way`**: as described in the [standard](https://tools.ietf.org/html/draft-handrews-json-schema-01#section-8),
-you can refer to an external schema. To you it you have to `addSchema` with a valid `$id` absolute URI.
+you can refer to an external schema. To use it you have to `addSchema` with a valid `$id` absolute URI.
 
 ```js
 fastify.addSchema({
@@ -78,9 +78,9 @@ fastify.route({
 })
 ```
 
-+ **`replace-way`**: this is a Fastify utils that let you to substitute some fields with a shared schema.
-To use it you have to `addSchema` with an `$id` with a relative URI fragment: a simple string that apply only
-to alphanumeric chars `[A-Za-z0-9]`.
++ **`replace-way`**: this is a Fastify utility that lets you to substitute some fields with a shared schema.
+To use it you have to `addSchema` with an `$id` having a relative URI fragment which is a simple string that
+applies only to alphanumeric chars `[A-Za-z0-9]`.
 
 ```js
 const fastify = require('fastify')()

--- a/fastify.js
+++ b/fastify.js
@@ -635,8 +635,8 @@ function build (options) {
       )
 
       try {
-        if (_fastify._schemaCompiler === undefined) {
-          const externalSchemas = _fastify[kSchemas].getJsonSchemas(false)
+        if (opts.schemaCompiler === undefined && _fastify._schemaCompiler === undefined) {
+          const externalSchemas = _fastify[kSchemas].getJsonSchemas({ onlyAbsoluteUri: true })
           _fastify.setSchemaCompiler(buildSchemaCompiler(externalSchemas))
         }
 

--- a/fastify.js
+++ b/fastify.js
@@ -212,7 +212,6 @@ function build (options) {
   fastify[kContentTypeParser] = new ContentTypeParser(fastify[kBodyLimit], options.onProtoPoisoning)
 
   fastify.setSchemaCompiler = setSchemaCompiler
-  fastify.setSchemaCompiler(buildSchemaCompiler())
 
   // plugin
   fastify.register = fastify.use
@@ -636,6 +635,11 @@ function build (options) {
       )
 
       try {
+        if (_fastify._schemaCompiler === undefined) {
+          const externalSchemas = _fastify[kSchemas].getJsonSchemas(false)
+          _fastify.setSchemaCompiler(buildSchemaCompiler(externalSchemas))
+        }
+
         buildSchema(context, opts.schemaCompiler || _fastify._schemaCompiler, _fastify[kSchemas])
       } catch (error) {
         done(error)

--- a/fastify.js
+++ b/fastify.js
@@ -635,7 +635,7 @@ function build (options) {
       )
 
       try {
-        if (opts.schemaCompiler === undefined && _fastify._schemaCompiler === undefined) {
+        if (opts.schemaCompiler == null && _fastify._schemaCompiler == null) {
           const externalSchemas = _fastify[kSchemas].getJsonSchemas({ onlyAbsoluteUri: true })
           _fastify.setSchemaCompiler(buildSchemaCompiler(externalSchemas))
         }

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -107,17 +107,21 @@ Schemas.prototype.getSchemas = function () {
   return Object.assign({}, this.store)
 }
 
-Schemas.prototype.getJsonSchemas = function (sharedSchema = true) {
+Schemas.prototype.getJsonSchemas = function (options) {
   const store = this.getSchemas()
-  return Object.keys(store).map(schemaKey => {
-    // if the shared-schema has been used, the $id field has been removed
+  const schemasArray = Object.keys(store).map(schemaKey => {
+    // if the shared-schema "replace-way" has been used, the $id field has been removed
     if (store[schemaKey]['$id'] === undefined) {
       store[schemaKey]['$id'] = schemaKey
     }
     return store[schemaKey]
-  }).filter(_ => {
-    return sharedSchema || !/^\w*$/g.test(_.$id)
   })
+
+  if (options && options.onlyAbsoluteUri === true) {
+    // the caller want only absolute URI (without the shared schema - "replace-way" usage)
+    return schemasArray.filter(_ => !/^\w*$/g.test(_.$id))
+  }
+  return schemasArray
 }
 
 function buildSchemas (s) {

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -107,16 +107,23 @@ Schemas.prototype.getSchemas = function () {
   return Object.assign({}, this.store)
 }
 
-function buildSchemas (s) {
-  const schema = new Schemas()
-  const store = s.getSchemas()
-  Object.keys(store).forEach(schemaKey => {
+Schemas.prototype.getJsonSchemas = function (sharedSchema = true) {
+  const store = this.getSchemas()
+  return Object.keys(store).map(schemaKey => {
     // if the shared-schema has been used, the $id field has been removed
     if (store[schemaKey]['$id'] === undefined) {
       store[schemaKey]['$id'] = schemaKey
     }
-    schema.add(store[schemaKey])
+    return store[schemaKey]
+  }).filter(_ => {
+    return sharedSchema || !/^\w*$/g.test(_.$id)
   })
+}
+
+function buildSchemas (s) {
+  const schema = new Schemas()
+  const schemas = s.getJsonSchemas()
+  schemas.forEach(_ => schema.add(_))
   return schema
 }
 

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -118,7 +118,7 @@ Schemas.prototype.getJsonSchemas = function (options) {
   })
 
   if (options && options.onlyAbsoluteUri === true) {
-    // the caller want only absolute URI (without the shared schema - "replace-way" usage)
+    // the caller wants only the absolute URI (without the shared schema - "replace-way" usage)
     return schemasArray.filter(_ => !/^\w*$/g.test(_.$id))
   }
   return schemasArray
@@ -126,8 +126,7 @@ Schemas.prototype.getJsonSchemas = function (options) {
 
 function buildSchemas (s) {
   const schema = new Schemas()
-  const schemas = s.getJsonSchemas()
-  schemas.forEach(_ => schema.add(_))
+  s.getJsonSchemas().forEach(_ => schema.add(_))
   return schema
 }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -144,7 +144,7 @@ function schemaErrorsText (errors, dataVar) {
   return text.slice(0, -separator.length)
 }
 
-function buildSchemaCompiler () {
+function buildSchemaCompiler (externalSchemas) {
   // This instance of Ajv is private
   // it should not be customized or used
   const ajv = new Ajv({
@@ -153,6 +153,10 @@ function buildSchemaCompiler () {
     removeAdditional: true,
     allErrors: true
   })
+
+  if (Array.isArray(externalSchemas)) {
+    externalSchemas.forEach(s => ajv.addSchema(s))
+  }
 
   return ajv.compile.bind(ajv)
 }


### PR DESCRIPTION
Hi, this fixes #1441 

I have changed how the schema compiler is built, adding to it all the shared schema to support the `$ref` keyword.
I had also the necessity to distinguish between the custom fastify function of the shared schema and the usage of the shared schema to add external schemas.
These two features can coexist but they need to have different names to clarify that they are different.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
