### PR TITLE
Updated find-my-way to v2

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -147,13 +147,12 @@ Internally Fastify uses the API of Node core http server, so if you are using a 
 
 By default, value equal to `true`, routes are registered as case sensitive. That is, `/foo` is not equivalent to `/Foo`. When set to `false`, routes are registered in a fashion such that `/foo` is equivalent to `/Foo` which is equivalent to `/FOO`.
 
-Setting `caseSensitive` to `false` will also result in
-all params (and all value matched by regexps) to be lowercased as well.
+By setting `caseSensitive` to `false`, all paths will be matched as lowercase, but the route parameters or wildcards will maintain their original letter casing.
 
 ```js
 fastify.get('/user/:username', (request, reply) => {
-  // Given the URL: /user/NodeJS
-  console.log(request.params.username) // -> 'nodejs'
+  // Given the URL: /USER/NodeJS
+  console.log(request.params.username) // -> 'NodeJS'
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "avvio": "^6.0.1",
     "bourne": "^1.1.1",
     "fast-json-stringify": "^1.11.0",
-    "find-my-way": "^1.18.0",
+    "find-my-way": "^2.0.0",
     "flatstr": "^1.0.9",
     "light-my-request": "^3.2.0",
     "middie": "^4.0.1",

--- a/test/case-insensitive.test.js
+++ b/test/case-insensitive.test.js
@@ -60,3 +60,61 @@ test('case insensitive inject', t => {
     })
   })
 })
+
+test('case insensitive (parametric)', t => {
+  t.plan(5)
+
+  const fastify = Fastify({
+    caseSensitive: false
+  })
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.get('/foo/:param', (req, reply) => {
+    t.strictEqual(req.params.param, 'bAr')
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port + '/FoO/bAr'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.deepEqual(JSON.parse(body), {
+        hello: 'world'
+      })
+    })
+  })
+})
+
+test('case insensitive (wildcard)', t => {
+  t.plan(5)
+
+  const fastify = Fastify({
+    caseSensitive: false
+  })
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.get('/foo/*', (req, reply) => {
+    t.strictEqual(req.params['*'], 'bAr/baZ')
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port + '/FoO/bAr/baZ'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.deepEqual(JSON.parse(body), {
+        hello: 'world'
+      })
+    })
+  })
+})


### PR DESCRIPTION
As titled, the behavior of `caseSensitive` has changed, I've added two more tests to verify that.

*This should not be backported to v1.*

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
