### PR TITLE
Lock tap-mocha-reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "split2": "^3.1.0",
     "standard": "^12.0.1",
     "tap": "^12.5.2",
-    "tap-mocha-reporter": "^3.0.7",
+    "tap-mocha-reporter": "3.0.7",
     "then-sleep": "^1.0.1",
     "typescript": "^3.3.3",
     "@types/node": "^11.9.3",


### PR DESCRIPTION
Locking this dependency (per #1458) since they dropped Node v6  support
