### PR TITLE
Exclude tap-mocha-reporter from greenkeeper

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,8 @@
     "ignore": [
       "boom",
       "joi",
-      "@types/node"
+      "@types/node",
+      "tap-mocha-reporter"
     ]
   }
 }


### PR DESCRIPTION
 Locking this dependency, since they dropped support for Node v6.