### PR TITLE
fix: don't add twice a json schema to an encapsulated object in tree

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -749,7 +749,9 @@ function build (options) {
   function addSchema (schema) {
     throwIfAlreadyStarted('Cannot call "addSchema" when fastify instance is already started!')
     this._schemas.add(schema)
-    this[childrenKey].forEach(child => child.addSchema(schema))
+    this[childrenKey]
+      .filter(child => !Object.is(this._schemas, child._schemas))
+      .forEach(child => child.addSchema(schema))
     return this
   }
 

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -648,8 +648,9 @@ test('a decorator should addSchema to all the encapsulated tree', t => {
   fastify.register(fp(decorator))
 
   fastify.register(function (instance, opts, next) {
-    instance.register(async (subInstance) => {
+    instance.register((subInstance, opts, next) => {
       subInstance.decoratorAddSchema()
+      next()
     })
     next()
   })

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -630,3 +630,29 @@ test('nested plugins can override things', t => {
     t.equal(fastify._Reply.prototype.test, rootFunc)
   })
 })
+
+test('a decorator should addSchema to all the encapsulated tree', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  const decorator = function (instance, opts, next) {
+    instance.decorate('decoratorAddSchema', function (whereAddTheSchema) {
+      instance.addSchema({
+        $id: 'schema',
+        type: 'string'
+      })
+    })
+    next()
+  }
+
+  fastify.register(fp(decorator))
+
+  fastify.register(function (instance, opts, next) {
+    instance.register(async (subInstance) => {
+      subInstance.decoratorAddSchema()
+    })
+    next()
+  })
+
+  fastify.ready(t.error)
+})


### PR DESCRIPTION
This fixes #1456 

I have to check if the problem needs to be ported to v2, I'll check later after your feedback 😃

Thanks

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
