### PR TITLE
InitialConfig

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -293,7 +293,10 @@ function build (options) {
       }
       res.writeHead(503, headers)
       res.end('{"error":"Service Unavailable","message":"Service Unavailable","statusCode":503}')
-      setImmediate(() => req.destroy())
+      if (req.httpVersionMajor !== 2) {
+        // This is not needed in HTTP/2
+        setImmediate(() => req.destroy())
+      }
       return
     }
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,10 @@
       "url": "https://loige.co"
     },
     {
+      "name": "Cemre Mengu",
+      "email": "cemremengu@gmail.com"
+    },
+    {
       "name": "Evan Shortiss",
       "email": "evanshortiss@gmail.com"
     },

--- a/test/http2/closing.js
+++ b/test/http2/closing.js
@@ -4,6 +4,7 @@ const t = require('tap')
 const test = t.test
 const Fastify = require('../..')
 const http2 = require('http2')
+const semver = require('semver')
 
 let fastify
 try {
@@ -19,29 +20,29 @@ fastify.listen(0, err => {
   t.error(err)
   fastify.server.unref()
 
-  test('http/2 request while fastify closing', t => {
-    t.plan(1)
-
+  // Skipped because there is likely a bug on Node 8.
+  test('http/2 request while fastify closing', { skip: semver.lt(process.versions.node, '10.15.0') }, t => {
     const url = `http://127.0.0.1:${fastify.server.address().port}`
-    http2.connect(url, function () {
+    const session = http2.connect(url, function () {
       this.request({
         ':method': 'GET',
         ':path': '/'
       }).on('response', headers => {
         t.strictEqual(headers[':status'], 503)
+        t.end()
         this.destroy()
       }).on('error', () => {
-        // This might happen instead of the 503,
-        // we don't have much to control what happens in
-        // this case. It might be a Node core fault
-        t.pass('connection errored')
-      })
-      this.on('error', () => {
         // Nothing to do here,
         // we are not interested in this error that might
         // happen or not
       })
       fastify.close()
+    })
+    session.on('error', () => {
+      // Nothing to do here,
+      // we are not interested in this error that might
+      // happen or not
+      t.end()
     })
   })
 })

--- a/test/http2/closing.js
+++ b/test/http2/closing.js
@@ -22,7 +22,7 @@ fastify.listen(0, err => {
   test('http/2 request while fastify closing', t => {
     t.plan(1)
 
-    const url = `http://localhost:${fastify.server.address().port}`
+    const url = `http://127.0.0.1:${fastify.server.address().port}`
     http2.connect(url, function () {
       fastify.close()
       this.request({
@@ -31,6 +31,16 @@ fastify.listen(0, err => {
       }).on('response', headers => {
         t.strictEqual(headers[':status'], 503)
         this.destroy()
+      }).on('error', () => {
+        // This might happen instead of the 503,
+        // we don't have much to control what happens in
+        // this case. It might be a Node core fault
+        t.pass('connection errored')
+      })
+      this.on('error', () => {
+        // Nothing to do here,
+        // we are not interested in this error that might
+        // happen or not
       })
     })
   })

--- a/test/http2/closing.js
+++ b/test/http2/closing.js
@@ -24,7 +24,6 @@ fastify.listen(0, err => {
 
     const url = `http://127.0.0.1:${fastify.server.address().port}`
     http2.connect(url, function () {
-      fastify.close()
       this.request({
         ':method': 'GET',
         ':path': '/'
@@ -42,6 +41,7 @@ fastify.listen(0, err => {
         // we are not interested in this error that might
         // happen or not
       })
+      fastify.close()
     })
   })
 })

--- a/test/internals/initialConfig.test.js
+++ b/test/internals/initialConfig.test.js
@@ -1,0 +1,123 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('../..')
+const fs = require('fs')
+const path = require('path')
+const http = require('http')
+const pino = require('pino')
+
+test('Fastify.initialConfig is an object', t => {
+  t.plan(1)
+  t.type(Fastify().initialConfig, 'object')
+})
+
+test('without options passed to Fastify initialConfig is an empty object', t => {
+  t.plan(1)
+  t.deepEquals(Fastify().initialConfig, {})
+})
+
+test('Fastify.initialConfig should expose all options', t => {
+  t.plan(17)
+
+  const serverFactory = (handler, opts) => {
+    const server = http.createServer((req, res) => {
+      handler(req, res)
+    })
+
+    return server
+  }
+
+  const versioning = {
+    storage: function () {
+      let versions = {}
+      return {
+        get: (version) => { return versions[version] || null },
+        set: (version, store) => { versions[version] = store },
+        del: (version) => { delete versions[version] },
+        empty: () => { versions = {} }
+      }
+    },
+    deriveVersion: (req, ctx) => {
+      return req.headers['accept']
+    }
+  }
+
+  let options = {
+    http2: true,
+    https: {
+      key: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.key')),
+      cert: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.cert'))
+    },
+    ignoreTrailingSlash: true,
+    maxParamLength: 200,
+    bodyLimit: 1049600,
+    onProtoPoisoning: 'remove',
+    logger: true,
+    serverFactory,
+    caseSensitive: true,
+    requestIdHeader: 'request-id-alt',
+    trustProxy: '127.0.0.1,192.168.1.1/24',
+    pluginTimeout: 20000
+  }
+
+  const app = Fastify(options)
+  t.strictEqual(app.initialConfig.http2, true)
+  t.strictEqual(app.initialConfig.https, true)
+  t.strictEqual(app.initialConfig.ignoreTrailingSlash, true)
+  t.strictEqual(app.initialConfig.maxParamLength, 200)
+  t.strictEqual(app.initialConfig.bodyLimit, 1049600)
+  t.strictEqual(app.initialConfig.onProtoPoisoning, 'remove')
+  t.deepEqual(app.initialConfig.logger, { level: 'info' })
+  t.strictEqual(app.initialConfig.serverFactory, true)
+  t.strictEqual(app.initialConfig.caseSensitive, true)
+  t.strictEqual(app.initialConfig.requestIdHeader, 'request-id-alt')
+  t.strictEqual(app.initialConfig.trustProxy, '127.0.0.1,192.168.1.1/24')
+  t.strictEqual(app.initialConfig.pluginTimeout, 20000)
+
+  let customOptions = {
+    querystringParser: str => str,
+    genReqId: function (req) {
+      let i = 0
+      return i++
+    },
+    logger: pino({ level: 'info' }),
+    versioning,
+    trustProxy: function myTrustFn (address, hop) {
+      return address === '1.2.3.4' || hop === 1
+    }
+  }
+
+  const fatify = Fastify(customOptions)
+
+  // obfuscated options:
+  t.strictEqual(fatify.initialConfig.genReqId, 'custom')
+  t.strictEqual(fatify.initialConfig.querystringParser, 'custom')
+  t.strictEqual(fatify.initialConfig.logger, 'custom')
+  t.strictEqual(fatify.initialConfig.versioning, 'custom')
+  t.strictEqual(fatify.initialConfig.trustProxy, 'custom')
+})
+
+test('Should throw if you try to modify Fastify.initialConfig', t => {
+  t.plan(1)
+
+  const fastify = Fastify({ logger: true })
+  try {
+    fastify.initialConfig.logger = false
+    t.fail()
+  } catch (error) {
+    t.pass()
+  }
+})
+
+test('We must avoid shallow freezing and ensure that the whole object is freezed', t => {
+  t.plan(1)
+
+  const fastify = Fastify({ logger: true })
+  try {
+    fastify.initialConfig.logger.level = 'error'
+    t.fail()
+  } catch (error) {
+    t.pass()
+  }
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->
Address https://github.com/fastify/fastify/issues/1444

Currently `initialConfig` exposes an object that can have those properties:
```js
{
  http2, // show http2: true/false if explicitly passed.
  https, // show https: true or https: { allowHTTP1: true/false } if explicitly passed.
  ignoreTrailingSlash, // show ignoreTrailingSlash: true/false if explicitly passed.
  maxParamLength,
  bodyLimit,
  onProtoPoisoning,
  logger, // show logger: 'custom' if an instance is passed or logger: false/ { level }
  serverFactory, // show serverFactory: true if detected
  caseSensitive,
  requestIdHeader,
  genReqId, // show genReqId: 'custom' if a function is passed
  trustProxy, // show trustProxy: 'custom' if a function is passed
  pluginTimeout,
  querystringParser // show querystringParser: 'custom' if a function is passed
}
```
I have chosen to display a `custom` string when a custom function is explicitly passed to certain properties. And to avoid any security breach I filtered critical information (such as certificates, for example), i tried to avoid shallow freeze, so `initialConfig` is completely frozen and read-only.

Maybe some properties exposed here are not relevant and should to be removed, but for this first draft I tried to include all user customable options.

What do you think about this approach ?  If you have suggestions I am completely open, and when we reach a consensus I will write the documentation and a fastify 1.x backport too ^^

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
