### PR TITLE
Less flakyness maybe

### DIFF
--- a/test/http2/closing.js
+++ b/test/http2/closing.js
@@ -20,28 +20,27 @@ fastify.listen(0, err => {
   fastify.server.unref()
 
   test('http/2 request while fastify closing', t => {
-    t.plan(1)
-
     const url = `http://127.0.0.1:${fastify.server.address().port}`
-    http2.connect(url, function () {
+    const session = http2.connect(url, function () {
       this.request({
         ':method': 'GET',
         ':path': '/'
       }).on('response', headers => {
         t.strictEqual(headers[':status'], 503)
+        t.end()
         this.destroy()
       }).on('error', () => {
-        // This might happen instead of the 503,
-        // we don't have much to control what happens in
-        // this case. It might be a Node core fault
-        t.pass('connection errored')
-      })
-      this.on('error', () => {
         // Nothing to do here,
         // we are not interested in this error that might
         // happen or not
       })
       fastify.close()
+    })
+    session.on('error', () => {
+      // Nothing to do here,
+      // we are not interested in this error that might
+      // happen or not
+      t.end()
     })
   })
 })

--- a/test/http2/closing.js
+++ b/test/http2/closing.js
@@ -4,6 +4,7 @@ const t = require('tap')
 const test = t.test
 const Fastify = require('../..')
 const http2 = require('http2')
+const semver = require('semver')
 
 let fastify
 try {
@@ -19,7 +20,8 @@ fastify.listen(0, err => {
   t.error(err)
   fastify.server.unref()
 
-  test('http/2 request while fastify closing', t => {
+  // Skipped because there is likely a bug on Node 8.
+  test('http/2 request while fastify closing', { skip: semver.lt(process.versions.node, '10.15.0') }, t => {
     const url = `http://127.0.0.1:${fastify.server.address().port}`
     const session = http2.connect(url, function () {
       this.request({


### PR DESCRIPTION
I don't understand why the previous PR passed twice but it's still flaky from time to time.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
