### PR TITLE
Pass ip, ips, and hostname to Request object

### DIFF
--- a/docs/Request.md
+++ b/docs/Request.md
@@ -10,6 +10,9 @@ Request is a core Fastify object containing the following fields:
 - `raw` - the incoming HTTP request from Node core *(you can use the alias `req`)*
 - `id` - the request id
 - `log` - the logger instance of the incoming request
+- `ip` - the ip of the incoming request
+- `ips` - the ips from x-forwarder-for of the incoming request
+- `hostname` - the hostname of the incoming request
 
 ```js
 fastify.post('/:params', options, function (request, reply) {
@@ -19,6 +22,9 @@ fastify.post('/:params', options, function (request, reply) {
   console.log(request.headers)
   console.log(request.raw)
   console.log(request.id)
+  console.log(request.ip)
+  console.log(request.ips)
+  console.log(request.hostname)
   request.log.info('some info')
 })
 ```

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -262,13 +262,13 @@ const fastify = require('fastify')({
 })
 ```
 
-<a name="factory-add-properties-to-node-req"></a>
-### `addPropertiesToNodeReq`
+<a name="factory-modify-core-objects"></a>
+### `modifyCoreObjects`
 
-By enabling the `addPropertiesToNodeReq` option, Fastify will set `ip`, `ips`, and `hostname` to Node's request object. And set `log` to Node's request and response objects for logging. The consequence of enabling this option is these properties will be available in the `raw` object of Fastify's Request. For example, `ip`, `ips`, and `hostname` values can be accessed from raw `request`.
+By enabling the `modifyCoreObjects` option, Fastify will set `ip`, `ips`, and `hostname` to Node's request object. And set `log` to Node's request and response objects for logging. The consequence of enabling this option is these properties will be available in the `raw` object of Fastify's Request. For example, `ip`, `ips`, and `hostname` values can be accessed from raw `request`.
 
 ```js
-const fastify = Fastify({ addPropertiesToNodeReq: true })
+const fastify = Fastify({ modifyCoreObjects: true })
 
 fastify.get('/', (request, reply) => {
   console.log(request.raw.ip)

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -262,6 +262,26 @@ const fastify = require('fastify')({
 })
 ```
 
+<a name="factory-add-properties-to-node-req"></a>
+### `addPropertiesToNodeReq`
+
+By enabling the `addPropertiesToNodeReq` option, Fastify will set `ip`, `ips`, and `hostname` to Node's request object. And set `log` to Node's request and response objects for logging. The consequence of enabling this option is these properties will be available in the `raw` object of Fastify's Request. For example, `ip`, `ips`, and `hostname` values can be accessed from raw `request`.
+
+```js
+const fastify = Fastify({ addPropertiesToNodeReq: true })
+
+fastify.get('/', (request, reply) => {
+  console.log(request.raw.ip)
+  console.log(request.raw.ips)
+  console.log(request.raw.hostname)
+})
+```
+
++ Default: `false`
++ `true/false`: add properties `ip`, `ips`, `hostname`, and `log` to Node's request object and only `log` to Node's response object  (`true`) or leave Node's request and response objects alone (`false`).
+
+
+
 ## Instance
 
 ### Server Methods

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -193,7 +193,7 @@ declare namespace fastify {
       },
       deriveVersion<Context>(req: Object, ctx?: Context) : String,
     },
-    modifyCoreObjects: boolean
+    modifyCoreObjects?: boolean
   }
   interface ServerOptionsAsSecure extends ServerOptions {
     https: http2.SecureServerOptions

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -192,7 +192,8 @@ declare namespace fastify {
         empty() : void
       },
       deriveVersion<Context>(req: Object, ctx?: Context) : String,
-    }
+    },
+    modifyCoreObjects: boolean
   }
   interface ServerOptionsAsSecure extends ServerOptions {
     https: http2.SecureServerOptions

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -146,6 +146,7 @@ declare namespace fastify {
     id: any
 
     ip: string
+    ips: any
     hostname: string
 
     raw: HttpRequest

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -146,7 +146,7 @@ declare namespace fastify {
     id: any
 
     ip: string
-    ips: any
+    ips: string[]
     hostname: string
 
     raw: HttpRequest

--- a/fastify.js
+++ b/fastify.js
@@ -62,7 +62,7 @@ function build (options) {
   }
 
   const trustProxy = options.trustProxy
-  const optAddToNodeReq = options.addPropertiesToNodeReq === true
+  const modifyCoreObjects = options.modifyCoreObjects === true
 
   var log
   var hasLogger = true
@@ -305,7 +305,7 @@ function build (options) {
     var logger = log.child({ reqId: req.id, level: context.logLevel })
 
     // added hostname, ip, and ips back to the Node req object to maintain backward compatibility
-    if (optAddToNodeReq) {
+    if (modifyCoreObjects) {
       req.hostname = hostname
       req.ip = ip
       req.ips = ips
@@ -886,7 +886,7 @@ function build (options) {
     req.id = genReqId(req)
 
     var logger = log.child({ reqId: req.id })
-    if (optAddToNodeReq) {
+    if (modifyCoreObjects) {
       req.log = res.log = logger
     }
 

--- a/fastify.js
+++ b/fastify.js
@@ -294,7 +294,7 @@ function build (options) {
     if (trustProxy) {
       ip = proxyAddr(req, proxyFn)
       ips = proxyAddr.all(req, proxyFn)
-      if (ip !== undefined) {
+      if (ip !== undefined && req.headers['x-forwarded-host']) {
         hostname = req.headers['x-forwarded-host']
       }
     }

--- a/fastify.js
+++ b/fastify.js
@@ -271,17 +271,11 @@ function build (options) {
   }
 
   function _handleTrustProxy (req) {
-    var ip = proxyAddr(req, proxyFn)
-    var ips = proxyAddr.all(req, proxyFn)
-    var hostname
-    if (ip !== undefined) {
-      hostname = req.headers['x-forwarded-host']
-    }
-    return { ip: ip, ips: ips, hostname: hostname }
+    return { ip: proxyAddr(req, proxyFn), ips: proxyAddr.all(req, proxyFn), get hostname () { return this.ip !== undefined ? req.headers['x-forwarded-host'] : req.hostname } }
   }
 
   function _ipAsRemoteAddress (req) {
-    return { ip: req.connection.remoteAddress }
+    return { ip: req.connection.remoteAddress, ips: undefined, hostname: undefined }
   }
 
   function routeHandler (req, res, params, context) {
@@ -301,8 +295,7 @@ function build (options) {
 
     req.id = genReqId(req)
     var trustProxyResult = handleTrustProxy(req)
-    var hostname = trustProxyResult.hostname || req.hostname || req.headers['host']
-    // req.hostname = req.hostname || req.headers['host']
+    var hostname = trustProxyResult.hostname || req.headers['host']
     req.log = res.log = log.child({ reqId: req.id, level: context.logLevel })
     req.originalUrl = req.url
 

--- a/fastify.js
+++ b/fastify.js
@@ -271,7 +271,8 @@ function build (options) {
   }
 
   function _handleTrustProxy (req) {
-    return { ip: proxyAddr(req, proxyFn), ips: proxyAddr.all(req, proxyFn), get hostname () { return this.ip !== undefined ? req.headers['x-forwarded-host'] : req.hostname } }
+    var ip = proxyAddr(req, proxyFn)
+    return { ip: ip, ips: proxyAddr.all(req, proxyFn), hostname: ip !== undefined ? req.headers['x-forwarded-host'] : undefined }
   }
 
   function _ipAsRemoteAddress (req) {

--- a/fastify.js
+++ b/fastify.js
@@ -299,6 +299,7 @@ function build (options) {
       }
     }
 
+    // added hostname, ip, and ips back to the Node req object to maintain backward compatibility
     req.hostname = hostname
     req.ip = ip
     req.ips = ips

--- a/fastify.js
+++ b/fastify.js
@@ -299,6 +299,10 @@ function build (options) {
       }
     }
 
+    req.hostname = hostname
+    req.ip = ip
+    req.ips = ips
+
     req.log = res.log = log.child({ reqId: req.id, level: context.logLevel })
     req.originalUrl = req.url
 

--- a/fastify.js
+++ b/fastify.js
@@ -61,6 +61,8 @@ function build (options) {
     throw new TypeError('Options must be an object')
   }
 
+  const trustProxy = options.trustProxy
+
   var log
   var hasLogger = true
   if (isValidLogger(options.logger)) {
@@ -249,24 +251,23 @@ function build (options) {
   return fastify
 
   function getTrustProxyFn () {
-    const tp = options.trustProxy
-    if (typeof tp === 'function') {
-      return tp
+    if (typeof trustProxy === 'function') {
+      return trustProxy
     }
-    if (tp === true) {
+    if (trustProxy === true) {
       // Support plain true/false
       return function () { return true }
     }
-    if (typeof tp === 'number') {
+    if (typeof trustProxy === 'number') {
       // Support trusting hop count
-      return function (a, i) { return i < tp }
+      return function (a, i) { return i < trustProxy }
     }
-    if (typeof tp === 'string') {
+    if (typeof trustProxy === 'string') {
       // Support comma-separated tps
-      const vals = tp.split(',').map(it => it.trim())
+      const vals = trustProxy.split(',').map(it => it.trim())
       return proxyAddr.compile(vals)
     }
-    return proxyAddr.compile(tp || [])
+    return proxyAddr.compile(trustProxy || [])
   }
 
   function routeHandler (req, res, params, context) {
@@ -290,7 +291,7 @@ function build (options) {
     var ip = req.connection.remoteAddress
     var ips
 
-    if (options.trustProxy) {
+    if (trustProxy) {
       ip = proxyAddr(req, proxyFn)
       ips = proxyAddr.all(req, proxyFn)
       if (ip !== undefined) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -90,7 +90,7 @@ Reply.prototype.send = function (payload) {
   }
 
   if (this[kReplySent]) {
-    this.res.log.warn({ err: new FST_ERR_REP_ALREADY_SENT() }, 'Reply already sent')
+    this.log.warn({ err: new FST_ERR_REP_ALREADY_SENT() }, 'Reply already sent')
     return
   }
 
@@ -318,7 +318,7 @@ function sendStream (payload, res, reply) {
     sourceOpen = false
     if (err != null) {
       if (res.headersSent) {
-        res.log.warn({ err }, 'response terminated with an error with headers already sent')
+        reply.log.warn({ err }, 'response terminated with an error with headers already sent')
         res.destroy()
       } else {
         onErrorHook(reply, err)
@@ -330,7 +330,7 @@ function sendStream (payload, res, reply) {
   eos(res, function (err) {
     if (err != null) {
       if (res.headersSent) {
-        res.log.warn({ err }, 'response terminated with an error with headers already sent')
+        reply.log.warn({ err }, 'response terminated with an error with headers already sent')
       }
       if (sourceOpen) {
         if (payload.destroy) {
@@ -353,7 +353,7 @@ function sendStream (payload, res, reply) {
       res.setHeader(key, reply[kReplyHeaders][key])
     }
   } else {
-    res.log.warn('response will send, but you shouldn\'t use res.writeHead in stream mode')
+    reply.log.warn('response will send, but you shouldn\'t use res.writeHead in stream mode')
   }
   payload.pipe(res)
 }
@@ -500,7 +500,7 @@ function notFound (reply) {
   reply[kReplyIsError] = false
 
   if (reply.context[kFourOhFourContext] === null) {
-    reply.res.log.warn('Trying to send a NotFound error inside a 404 handler. Sending basic 404 response.')
+    reply.log.warn('Trying to send a NotFound error inside a 404 handler. Sending basic 404 response.')
     reply.code(404).send('404 Not Found')
     return
   }

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,22 +1,28 @@
 'use strict'
 
-function Request (params, req, query, headers, log) {
+function Request (params, req, query, headers, log, ip, ips, hostname) {
   this.params = params
   this.raw = req
   this.query = query
   this.headers = headers
   this.log = log
   this.body = null
+  this.ip = ip
+  this.ips = ips
+  this.hostname = hostname
 }
 
 function buildRequest (R) {
-  function _Request (params, req, query, headers, log) {
+  function _Request (params, req, query, headers, log, ip, ips, hostname) {
     this.params = params
     this.raw = req
     this.query = query
     this.headers = headers
     this.log = log
     this.body = null
+    this.ip = ip
+    this.ips = ips
+    this.hostname = hostname
   }
   _Request.prototype = new R()
 

--- a/lib/wrapThenable.js
+++ b/lib/wrapThenable.js
@@ -31,11 +31,11 @@ function wrapThenable (thenable, reply) {
         reply.send(err)
       }
     } else if (reply[kReplySent] === false) {
-      reply.res.log.error({ err: new FST_ERR_PROMISE_NOT_FULLFILLED() }, `Promise may not be fulfilled with 'undefined' when statusCode is not 204`)
+      reply.log.error({ err: new FST_ERR_PROMISE_NOT_FULLFILLED() }, `Promise may not be fulfilled with 'undefined' when statusCode is not 204`)
     }
   }, function (err) {
     if (reply[kReplySentOverwritten] === true) {
-      reply.res.log.error({ err }, 'Promise errored, but reply.sent = true was set')
+      reply.log.error({ err }, 'Promise errored, but reply.sent = true was set')
       return
     }
     reply[kReplySent] = false

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -401,7 +401,7 @@ test('stream using reply.res.writeHead should return customize headers', t => {
   var buf = fs.readFileSync(streamPath)
 
   fastify.get('/', function (req, reply) {
-    reply.res.log.warn = function mockWarn (message) {
+    reply.log.warn = function mockWarn (message) {
       t.equal(message, 'response will send, but you shouldn\'t use res.writeHead in stream mode')
     }
     reply.res.writeHead(200, {

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -615,7 +615,7 @@ test('Should set the log level for the customized 500 handler', t => {
     })
 
     instance.setErrorHandler(function (e, request, reply) {
-      reply.res.log.fatal('Hello')
+      reply.log.fatal('Hello')
       reply.code(500).send()
     })
     next()

--- a/test/trust-proxy.test.js
+++ b/test/trust-proxy.test.js
@@ -18,7 +18,7 @@ const sgetForwardedRequest = (app, forHeader, path) => {
 
 const testRequestValues = (t, req, options) => {
   if (options.ip) {
-    if (options.addPropertiesToNodeReq) {
+    if (options.modifyCoreObjects) {
       t.ok(req.raw.ip, 'ip is defined')
       t.equal(req.raw.ip, options.ip, 'gets ip from x-forwarder-for')
     }
@@ -26,7 +26,7 @@ const testRequestValues = (t, req, options) => {
     t.equal(req.ip, options.ip, 'gets ip from x-forwarder-for')
   }
   if (options.hostname) {
-    if (options.addPropertiesToNodeReq) {
+    if (options.modifyCoreObjects) {
       t.ok(req.raw.hostname, 'hostname is defined')
       t.equal(req.raw.hostname, options.hostname, 'gets hostname from x-forwarded-host')
     }
@@ -34,7 +34,7 @@ const testRequestValues = (t, req, options) => {
     t.equal(req.hostname, options.hostname, 'gets hostname from x-forwarded-host')
   }
   if (options.ips) {
-    if (options.addPropertiesToNodeReq) {
+    if (options.modifyCoreObjects) {
       t.deepEqual(req.raw.ips, options.ips, 'gets ips from x-forwarder-for')
     }
     t.deepEqual(req.ips, options.ips, 'gets ips from x-forwarder-for')
@@ -43,18 +43,18 @@ const testRequestValues = (t, req, options) => {
 
 test('trust proxy, add properties to node req', (t) => {
   t.plan(15)
-  const addPropertiesToNodeReq = true
+  const modifyCoreObjects = true
   const app = fastify({
     trustProxy: true,
-    addPropertiesToNodeReq
+    modifyCoreObjects
   })
   app.get('/trustproxy', function (req, reply) {
-    testRequestValues(t, req, { ip: '1.1.1.1', hostname: 'example.com', addPropertiesToNodeReq })
+    testRequestValues(t, req, { ip: '1.1.1.1', hostname: 'example.com', modifyCoreObjects })
     reply.code(200).send({ ip: req.ip, hostname: req.hostname })
   })
 
   app.get('/trustproxychain', function (req, reply) {
-    testRequestValues(t, req, { ip: '2.2.2.2', ips: ['127.0.0.1', '1.1.1.1', '2.2.2.2'], addPropertiesToNodeReq })
+    testRequestValues(t, req, { ip: '2.2.2.2', ips: ['127.0.0.1', '1.1.1.1', '2.2.2.2'], modifyCoreObjects })
     reply.code(200).send({ ip: req.ip, hostname: req.hostname })
   })
 

--- a/test/trust-proxy.test.js
+++ b/test/trust-proxy.test.js
@@ -18,25 +18,58 @@ const sgetForwardedRequest = (app, forHeader, path) => {
 
 const testRequestValues = (t, req, options) => {
   if (options.ip) {
-    t.ok(req.raw.ip, 'ip is defined')
-    t.equal(req.raw.ip, options.ip, 'gets ip from x-forwarder-for')
+    if (options.addPropertiesToNodeReq) {
+      t.ok(req.raw.ip, 'ip is defined')
+      t.equal(req.raw.ip, options.ip, 'gets ip from x-forwarder-for')
+    }
     t.ok(req.ip, 'ip is defined')
     t.equal(req.ip, options.ip, 'gets ip from x-forwarder-for')
   }
   if (options.hostname) {
-    t.ok(req.raw.hostname, 'hostname is defined')
-    t.equal(req.raw.hostname, options.hostname, 'gets hostname from x-forwarded-host')
+    if (options.addPropertiesToNodeReq) {
+      t.ok(req.raw.hostname, 'hostname is defined')
+      t.equal(req.raw.hostname, options.hostname, 'gets hostname from x-forwarded-host')
+    }
     t.ok(req.hostname, 'hostname is defined')
     t.equal(req.hostname, options.hostname, 'gets hostname from x-forwarded-host')
   }
   if (options.ips) {
-    t.deepEqual(req.raw.ips, options.ips, 'gets ips from x-forwarder-for')
+    if (options.addPropertiesToNodeReq) {
+      t.deepEqual(req.raw.ips, options.ips, 'gets ips from x-forwarder-for')
+    }
     t.deepEqual(req.ips, options.ips, 'gets ips from x-forwarder-for')
   }
 }
 
-test('trust proxy', (t) => {
+test('trust proxy, add properties to node req', (t) => {
   t.plan(15)
+  const addPropertiesToNodeReq = true
+  const app = fastify({
+    trustProxy: true,
+    addPropertiesToNodeReq
+  })
+  app.get('/trustproxy', function (req, reply) {
+    testRequestValues(t, req, { ip: '1.1.1.1', hostname: 'example.com', addPropertiesToNodeReq })
+    reply.code(200).send({ ip: req.ip, hostname: req.hostname })
+  })
+
+  app.get('/trustproxychain', function (req, reply) {
+    testRequestValues(t, req, { ip: '2.2.2.2', ips: ['127.0.0.1', '1.1.1.1', '2.2.2.2'], addPropertiesToNodeReq })
+    reply.code(200).send({ ip: req.ip, hostname: req.hostname })
+  })
+
+  t.tearDown(app.close.bind(app))
+
+  app.listen(0, (err) => {
+    app.server.unref()
+    t.error(err)
+    sgetForwardedRequest(app, '1.1.1.1', '/trustproxy')
+    sgetForwardedRequest(app, '2.2.2.2, 1.1.1.1', '/trustproxychain')
+  })
+})
+
+test('trust proxy, not add properties to node req', (t) => {
+  t.plan(8)
   const app = fastify({
     trustProxy: true
   })
@@ -61,7 +94,7 @@ test('trust proxy', (t) => {
 })
 
 test('trust proxy chain', (t) => {
-  t.plan(5)
+  t.plan(3)
   const app = fastify({
     trustProxy: ['127.0.0.1', '192.168.1.1']
   })
@@ -81,7 +114,7 @@ test('trust proxy chain', (t) => {
 })
 
 test('trust proxy function', (t) => {
-  t.plan(5)
+  t.plan(3)
   const app = fastify({
     trustProxy: (address) => address === '127.0.0.1'
   })
@@ -100,7 +133,7 @@ test('trust proxy function', (t) => {
 })
 
 test('trust proxy number', (t) => {
-  t.plan(7)
+  t.plan(4)
   const app = fastify({
     trustProxy: 1
   })
@@ -119,7 +152,7 @@ test('trust proxy number', (t) => {
 })
 
 test('trust proxy IP addresses', (t) => {
-  t.plan(7)
+  t.plan(4)
   const app = fastify({
     trustProxy: '127.0.0.1, 2.2.2.2'
   })

--- a/test/trust-proxy.test.js
+++ b/test/trust-proxy.test.js
@@ -18,15 +18,15 @@ const sgetForwardedRequest = (app, forHeader, path) => {
 
 const testRequestValues = (t, req, options) => {
   if (options.ip) {
-    t.ok(req.raw.ip, 'ip is defined')
-    t.equal(req.raw.ip, options.ip, 'gets ip from x-forwarder-for')
+    t.ok(req.ip, 'ip is defined')
+    t.equal(req.ip, options.ip, 'gets ip from x-forwarder-for')
   }
   if (options.hostname) {
-    t.ok(req.raw.hostname, 'hostname is defined')
-    t.equal(req.raw.hostname, options.hostname, 'gets hostname from x-forwarded-host')
+    t.ok(req.hostname, 'hostname is defined')
+    t.equal(req.hostname, options.hostname, 'gets hostname from x-forwarded-host')
   }
   if (options.ips) {
-    t.deepEqual(req.raw.ips, options.ips, 'gets ips from x-forwarder-for')
+    t.deepEqual(req.ips, options.ips, 'gets ips from x-forwarder-for')
   }
 }
 

--- a/test/trust-proxy.test.js
+++ b/test/trust-proxy.test.js
@@ -18,20 +18,25 @@ const sgetForwardedRequest = (app, forHeader, path) => {
 
 const testRequestValues = (t, req, options) => {
   if (options.ip) {
+    t.ok(req.raw.ip, 'ip is defined')
+    t.equal(req.raw.ip, options.ip, 'gets ip from x-forwarder-for')
     t.ok(req.ip, 'ip is defined')
     t.equal(req.ip, options.ip, 'gets ip from x-forwarder-for')
   }
   if (options.hostname) {
+    t.ok(req.raw.hostname, 'hostname is defined')
+    t.equal(req.raw.hostname, options.hostname, 'gets hostname from x-forwarded-host')
     t.ok(req.hostname, 'hostname is defined')
     t.equal(req.hostname, options.hostname, 'gets hostname from x-forwarded-host')
   }
   if (options.ips) {
+    t.deepEqual(req.raw.ips, options.ips, 'gets ips from x-forwarder-for')
     t.deepEqual(req.ips, options.ips, 'gets ips from x-forwarder-for')
   }
 }
 
 test('trust proxy', (t) => {
-  t.plan(8)
+  t.plan(15)
   const app = fastify({
     trustProxy: true
   })
@@ -56,7 +61,7 @@ test('trust proxy', (t) => {
 })
 
 test('trust proxy chain', (t) => {
-  t.plan(3)
+  t.plan(5)
   const app = fastify({
     trustProxy: ['127.0.0.1', '192.168.1.1']
   })
@@ -76,7 +81,7 @@ test('trust proxy chain', (t) => {
 })
 
 test('trust proxy function', (t) => {
-  t.plan(3)
+  t.plan(5)
   const app = fastify({
     trustProxy: (address) => address === '127.0.0.1'
   })
@@ -95,7 +100,7 @@ test('trust proxy function', (t) => {
 })
 
 test('trust proxy number', (t) => {
-  t.plan(4)
+  t.plan(7)
   const app = fastify({
     trustProxy: 1
   })
@@ -114,7 +119,7 @@ test('trust proxy number', (t) => {
 })
 
 test('trust proxy IP addresses', (t) => {
-  t.plan(4)
+  t.plan(7)
   const app = fastify({
     trustProxy: '127.0.0.1, 2.2.2.2'
   })

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -61,7 +61,8 @@ const cors = require('cors')
     ignoreTrailingSlash: true,
     bodyLimit: 1000,
     maxParamLength: 200,
-    querystringParser: (str: string) => ({ str: str, strArray: [str] })
+    querystringParser: (str: string) => ({ str: str, strArray: [str] }),
+    modifyCoreObjects: true
   })
 
   // custom types

--- a/test/wrapThenable.test.js
+++ b/test/wrapThenable.test.js
@@ -17,7 +17,7 @@ test('should reject immediately when reply[kReplySentOverwritten] is true', t =>
   t.plan(1)
   const reply = { res: {} }
   reply[kReplySentOverwritten] = true
-  reply.res.log = {
+  reply.log = {
     error: ({ err }) => {
       t.strictEqual(err.message, 'Reply sent already')
     }


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

Add ip, ips, and hostname in `Request` object. Related to @delvedor's feedback at https://github.com/fastify/fastify/pull/1086#discussion_r211718687. All credits go to @nwoltman . Without his guidance, the work won't be possible. 

[benchmarks](https://gist.github.com/shwei/390c850ebc7a52650de5e33481f5fce3#file-fastify-3dc46f3-tables-comparing-master-vs-pass-ip-to-request-constructor-branches-L1)