### PR TITLE
Add option to match only prefix root with paths

### DIFF
--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -67,6 +67,7 @@ Plugins maintained by the fastify team are listed under [Core](#core) while plug
 - [`fastify-healthcheck`](https://github.com/smartiniOnGitHub/fastify-healthcheck) Fastify plugin to serve an health check route and a probe script.
 - [`fastify-hemera`](https://github.com/hemerajs/fastify-hemera) Fastify Hemera plugin, for writing reliable & fault-tolerant microservices with [nats.io](https://nats.io/).
 - [`fastify-http2https`](https://github.com/lolo32/fastify-http2https) Redirect HTTP requests to HTTPS, both using the same port number, or different response on HTTP and HTTPS.
+- [`fastify-influxdb`](https://github.com/alex-ppg/fastify-influxdb) Fastify InfluxDB plugin connecting to an InfluxDB instance via the Influx default package.
 - [`fastify-jwt-authz`](https://github.com/Ethan-Arrowood/fastify-jwt-authz) JWT user scope verifier.
 - [`fastify-jwt-webapp`](https://github.com/charlesread/fastify-jwt-webapp) JWT authentication for fastify-based web apps.
 - [`fastify-knexjs`](https://github.com/chapuletta/fastify-knexjs) Fastify plugin for support KnexJS Query Builder.

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -32,6 +32,7 @@ They need to be in
 * `logLevel`: set log level for this route. See below.
 * `config`: object used to store custom configuration.
 * `version`: a [semver](http://semver.org/) compatible string that defined the version of the endpoint. [Example](https://github.com/fastify/fastify/blob/versioned-routes/docs/Routes.md#version).
+* `prefixRootOnly`: when using a `/` url with a prefix, setting this option to true will register only `/prefix` without trailing slash. (Defaults to `false`)
 
   `request` is defined in [Request](https://github.com/fastify/fastify/blob/master/docs/Request.md).
 
@@ -239,6 +240,8 @@ The `/` route has a different behavior depending if the prefix ends with
 adding a `/` route will only match `/something/`. If we consider a
 prefix `/something`, adding a `/` route will match both `/something` 
 and `/something/`.
+
+Passing `prefixRootOnly: true` to the route options will match only `/something`.
 
 <a name="custom-log-level"></a>
 ### Custom Log Level

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -246,7 +246,7 @@ declare namespace fastify {
     bodyLimit?: number
     logLevel?: string
     config?: any
-    prefixTrailingSlash?: boolean
+    prefixTrailingSlash?: 'slash' | 'no-slash' | 'both'
   }
 
   /**

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -242,10 +242,11 @@ declare namespace fastify {
     preSerialization?:
       FastifyMiddlewareWithPayload<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body>
       | Array<FastifyMiddlewareWithPayload<HttpServer, HttpRequest, HttpResponse, Query, Params, Headers, Body>>
-  schemaCompiler?: SchemaCompiler
+    schemaCompiler?: SchemaCompiler
     bodyLimit?: number
     logLevel?: string
     config?: any
+    prefixRootOnly?: boolean
   }
 
   /**

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -246,7 +246,7 @@ declare namespace fastify {
     bodyLimit?: number
     logLevel?: string
     config?: any
-    prefixRootOnly?: boolean
+    prefixTrailingSlash?: boolean;
   }
 
   /**

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -246,7 +246,7 @@ declare namespace fastify {
     bodyLimit?: number
     logLevel?: string
     config?: any
-    prefixTrailingSlash?: boolean;
+    prefixTrailingSlash?: boolean
   }
 
   /**

--- a/fastify.js
+++ b/fastify.js
@@ -594,13 +594,17 @@ function build (options) {
     _fastify.after(function (notHandledErr, done) {
       var path = opts.url || opts.path
       if (path === '/' && prefix.length > 0) {
-        if (opts.prefixTrailingSlash === undefined) {
-          afterRouteAdded('', notHandledErr, done)
-          afterRouteAdded(path, notHandledErr, done)
-        } else if (!opts.prefixTrailingSlash) {
-          afterRouteAdded('', notHandledErr, done)
-        } else {
-          afterRouteAdded(path, notHandledErr, done)
+        switch (opts.prefixTrailingSlash) {
+          case 'slash':
+            afterRouteAdded(path, notHandledErr, done)
+            break
+          case 'no-slash':
+            afterRouteAdded('', notHandledErr, done)
+            break
+          case 'both':
+          default:
+            afterRouteAdded('', notHandledErr, done)
+            afterRouteAdded(path, notHandledErr, done)
         }
       } else if (path[0] === '/' && prefix.endsWith('/')) {
         // Ensure that '/prefix/' + '/route' gets registered as '/prefix/route'

--- a/fastify.js
+++ b/fastify.js
@@ -594,10 +594,12 @@ function build (options) {
     _fastify.after(function (notHandledErr, done) {
       var path = opts.url || opts.path
       if (path === '/' && prefix.length > 0) {
-        // Ensure that '/prefix' + '/' gets registered as '/prefix'
-        afterRouteAdded('', notHandledErr, done)
-
-        if (!opts.prefixRootOnly) {
+        if (opts.prefixTrailingSlash === undefined) {
+          afterRouteAdded('', notHandledErr, done)
+          afterRouteAdded(path, notHandledErr, done)
+        } else if (!opts.prefixTrailingSlash) {
+          afterRouteAdded('', notHandledErr, done)
+        } else {
           afterRouteAdded(path, notHandledErr, done)
         }
       } else if (path[0] === '/' && prefix.endsWith('/')) {

--- a/fastify.js
+++ b/fastify.js
@@ -596,12 +596,16 @@ function build (options) {
       if (path === '/' && prefix.length > 0) {
         // Ensure that '/prefix' + '/' gets registered as '/prefix'
         afterRouteAdded('', notHandledErr, done)
+
+        if (!opts.prefixRootOnly) {
+          afterRouteAdded(path, notHandledErr, done)
+        }
       } else if (path[0] === '/' && prefix.endsWith('/')) {
         // Ensure that '/prefix/' + '/route' gets registered as '/prefix/route'
-        path = path.slice(1)
+        afterRouteAdded(path.slice(1), notHandledErr, done)
+      } else {
+        afterRouteAdded(path, notHandledErr, done)
       }
-
-      afterRouteAdded(path, notHandledErr, done)
     })
 
     // chainable api

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -465,7 +465,7 @@ test('matches only /prefix  with a / route - prefixRootOnly: true, ignoreTrailin
       method: 'GET',
       url: '/',
       prefixRootOnly: true,
-      handler: ({ user }, reply) => {
+      handler: (req, reply) => {
         reply.send({ hello: 'world' })
       }
     })

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -453,3 +453,39 @@ test('matches both /prefix and /prefix/ with a / route - ignoreTrailingSlash: fa
     t.same(JSON.parse(res.payload), { hello: 'world' })
   })
 })
+
+test('matches only /prefix  with a / route - prefixRootOnly: true, ignoreTrailingSlash: false', t => {
+  t.plan(4)
+  const fastify = Fastify({
+    ignoreTrailingSlash: false
+  })
+
+  fastify.register(function (fastify, opts, next) {
+    fastify.route({
+      method: 'GET',
+      url: '/',
+      prefixRootOnly: true,
+      handler: async ({ user }, reply) => {
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    next()
+  }, { prefix: '/prefix' })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/prefix'
+  }, (err, res) => {
+    t.error(err)
+    t.same(JSON.parse(res.payload), { hello: 'world' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/prefix/'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(JSON.parse(res.payload).statusCode, 404)
+  })
+})

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -423,15 +423,20 @@ test('matches both /prefix and /prefix/ with a / route - ignoreTrailingSlash: tr
   })
 })
 
-test('matches both /prefix and /prefix/ with a / route with prefixTrailingSlash: undefined - ignoreTrailingSlash: false', t => {
+test('matches both /prefix and /prefix/  with a / route - prefixTrailingSlash: "both", ignoreTrailingSlash: false', t => {
   t.plan(4)
   const fastify = Fastify({
     ignoreTrailingSlash: false
   })
 
   fastify.register(function (fastify, opts, next) {
-    fastify.get('/', (req, reply) => {
-      reply.send({ hello: 'world' })
+    fastify.route({
+      method: 'GET',
+      url: '/',
+      prefixTrailingSlash: 'both',
+      handler: (req, reply) => {
+        reply.send({ hello: 'world' })
+      }
     })
 
     next()
@@ -454,7 +459,7 @@ test('matches both /prefix and /prefix/ with a / route with prefixTrailingSlash:
   })
 })
 
-test('matches only /prefix  with a / route - prefixTrailingSlash: false, ignoreTrailingSlash: false', t => {
+test('matches only /prefix  with a / route - prefixTrailingSlash: "no-slash", ignoreTrailingSlash: false', t => {
   t.plan(4)
   const fastify = Fastify({
     ignoreTrailingSlash: false
@@ -464,7 +469,7 @@ test('matches only /prefix  with a / route - prefixTrailingSlash: false, ignoreT
     fastify.route({
       method: 'GET',
       url: '/',
-      prefixTrailingSlash: false,
+      prefixTrailingSlash: 'no-slash',
       handler: (req, reply) => {
         reply.send({ hello: 'world' })
       }
@@ -490,7 +495,7 @@ test('matches only /prefix  with a / route - prefixTrailingSlash: false, ignoreT
   })
 })
 
-test('matches only /prefix/  with a / route - prefixTrailingSlash: true, ignoreTrailingSlash: false', t => {
+test('matches only /prefix/  with a / route - prefixTrailingSlash: "slash", ignoreTrailingSlash: false', t => {
   t.plan(4)
   const fastify = Fastify({
     ignoreTrailingSlash: false
@@ -500,7 +505,7 @@ test('matches only /prefix/  with a / route - prefixTrailingSlash: true, ignoreT
     fastify.route({
       method: 'GET',
       url: '/',
-      prefixTrailingSlash: true,
+      prefixTrailingSlash: 'slash',
       handler: (req, reply) => {
         reply.send({ hello: 'world' })
       }

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -465,7 +465,7 @@ test('matches only /prefix  with a / route - prefixRootOnly: true, ignoreTrailin
       method: 'GET',
       url: '/',
       prefixRootOnly: true,
-      handler: async ({ user }, reply) => {
+      handler: ({ user }, reply) => {
         reply.send({ hello: 'world' })
       }
     })

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -423,7 +423,7 @@ test('matches both /prefix and /prefix/ with a / route - ignoreTrailingSlash: tr
   })
 })
 
-test('matches both /prefix and /prefix/ with a / route - ignoreTrailingSlash: false', t => {
+test('matches both /prefix and /prefix/ with a / route with prefixTrailingSlash: undefined - ignoreTrailingSlash: false', t => {
   t.plan(4)
   const fastify = Fastify({
     ignoreTrailingSlash: false
@@ -454,7 +454,7 @@ test('matches both /prefix and /prefix/ with a / route - ignoreTrailingSlash: fa
   })
 })
 
-test('matches only /prefix  with a / route - prefixRootOnly: true, ignoreTrailingSlash: false', t => {
+test('matches only /prefix  with a / route - prefixTrailingSlash: false, ignoreTrailingSlash: false', t => {
   t.plan(4)
   const fastify = Fastify({
     ignoreTrailingSlash: false
@@ -464,7 +464,7 @@ test('matches only /prefix  with a / route - prefixRootOnly: true, ignoreTrailin
     fastify.route({
       method: 'GET',
       url: '/',
-      prefixRootOnly: true,
+      prefixTrailingSlash: false,
       handler: (req, reply) => {
         reply.send({ hello: 'world' })
       }
@@ -484,6 +484,42 @@ test('matches only /prefix  with a / route - prefixRootOnly: true, ignoreTrailin
   fastify.inject({
     method: 'GET',
     url: '/prefix/'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(JSON.parse(res.payload).statusCode, 404)
+  })
+})
+
+test('matches only /prefix/  with a / route - prefixTrailingSlash: true, ignoreTrailingSlash: false', t => {
+  t.plan(4)
+  const fastify = Fastify({
+    ignoreTrailingSlash: false
+  })
+
+  fastify.register(function (fastify, opts, next) {
+    fastify.route({
+      method: 'GET',
+      url: '/',
+      prefixTrailingSlash: true,
+      handler: (req, reply) => {
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    next()
+  }, { prefix: '/prefix' })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/prefix/'
+  }, (err, res) => {
+    t.error(err)
+    t.same(JSON.parse(res.payload), { hello: 'world' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/prefix'
   }, (err, res) => {
     t.error(err)
     t.equal(JSON.parse(res.payload).statusCode, 404)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->
Since 2.0 it is not possible to target only `/v1/test` with the multiple levels of nested prefixes. 

The code in this [sandbox](https://codesandbox.io/s/myxzv3m8ojl) would add only a single route `/v1/test` in v1. However in v2 it creates two routes `/v1/test` and `/v1/test/`.

This PR adds the option `prefixRootOnly` which behaves in the old way, adding only a single route.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
