### PR TITLE
Documentation update for avvio PR 82

### DIFF
--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -78,6 +78,7 @@ Plugins maintained by the fastify team are listed under [Core](#core) while plug
 - [`fastify-markdown`](https://github.com/freezestudio/fastify-markdown) Plugin to markdown support.
 - [`fastify-metrics`](https://gitlab.com/m03geek/fastify-metrics) Plugin for exporting [Prometheus](https://prometheus.io) metrics.
 - [`fastify-mongo-memory`](https://github.com/chapuletta/fastify-mongo-memory) Fastify MongoDB in Memory Plugin for testing support.
+- [`fastify-mongoose-driver`](https://github.com/alex-ppg/fastify-mongoose) Fastify Mongoose plugin that connects to a MongoDB via the Mongoose plugin with support for Models.
 - [`fastify-nats`](https://github.com/mahmed8003/fastify-nats) Plugin to share [NATS](http://nats.io) client across Fastify.
 - [`fastify-no-icon`](https://github.com/jsumners/fastify-no-icon) Plugin to eliminate thrown errors for `/favicon.ico` requests.
 - [`fastify-nodemailer`](https://github.com/lependu/fastify-nodemailer) Plugin to share [nodemailer](http://nodemailer.com) transporter across Fastify.

--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -78,7 +78,6 @@ Plugins maintained by the fastify team are listed under [Core](#core) while plug
 - [`fastify-markdown`](https://github.com/freezestudio/fastify-markdown) Plugin to markdown support.
 - [`fastify-metrics`](https://gitlab.com/m03geek/fastify-metrics) Plugin for exporting [Prometheus](https://prometheus.io) metrics.
 - [`fastify-mongo-memory`](https://github.com/chapuletta/fastify-mongo-memory) Fastify MongoDB in Memory Plugin for testing support.
-- [`fastify-mongoose-driver`](https://github.com/alex-ppg/fastify-mongoose) Fastify Mongoose plugin that connects to a MongoDB via the Mongoose plugin with support for Models.
 - [`fastify-nats`](https://github.com/mahmed8003/fastify-nats) Plugin to share [NATS](http://nats.io) client across Fastify.
 - [`fastify-no-icon`](https://github.com/jsumners/fastify-no-icon) Plugin to eliminate thrown errors for `/favicon.ico` requests.
 - [`fastify-nodemailer`](https://github.com/lependu/fastify-nodemailer) Plugin to share [nodemailer](http://nodemailer.com) transporter across Fastify.

--- a/docs/Plugins-Guide.md
+++ b/docs/Plugins-Guide.md
@@ -291,7 +291,7 @@ fastify.register(require('your-plugin'), parent => {
   return { connection: parent.db, otherOption: 'foo-bar' }
 })
 ```
-In the above example, the `parent` variable of the function passed in as the second argument of `register` is a reference to the **external fastify instance** that the plugin was registered at. This means that we are able to access any variables that were injected by preceding plugins in the order of declaration.
+In the above example, the `parent` variable of the function passed in as the second argument of `register` is a copy of the **external fastify instance** that the plugin was registered at. This means that we are able to access any variables that were injected by preceding plugins in the order of declaration.
 
 <a name="handle-errors"></a>
 ## Handle errors

--- a/docs/Plugins-Guide.md
+++ b/docs/Plugins-Guide.md
@@ -271,11 +271,11 @@ module.exports = fp(dbPlugin)
 ```
 You can also tell to `fastify-plugin` to check the installed version of Fastify, in case of you need a specific api.
 
-As we mentioned earlier, Fastify starts loading its plugins __after__ `.listen()`, `.inject()` or `.ready()` are called and as such, __after__ they have been declared. This means that, even though the plugin may inject variables to the global scope via `decorate`, the decorated variables will not be accessible before calling `.listen()`, `.inject()` or `.ready()`.
+As we mentioned earlier, Fastify starts loading its plugins __after__ `.listen()`, `.inject()` or `.ready()` are called and as such, __after__ they have been declared. This means that, even though the plugin may inject variables to the external fastify instance via [`decorate`](https://github.com/fastify/fastify/blob/master/docs/Decorators.md), the decorated variables will not be accessible before calling `.listen()`, `.inject()` or `.ready()`.
 
 In case you rely on a variable injected by a preceding plugin and want to pass that in the `options` argument of `register`, you can do so by using a function instead of an object:
 ```js
-const fastify = require('fastify')
+const fastify = require('fastify')()
 const fp = require('fastify-plugin')
 const dbClient = require('db-client')
 
@@ -291,7 +291,7 @@ fastify.register(require('your-plugin'), parent => {
   return { connection: parent.db, otherOption: 'foo-bar' }
 })
 ```
-In the above example, the `parent` variable of the function passed in as the second argument of `register` refers to the latest state of the **global fastify instance**. This means that we are able to access any variables that were injected by preceding plugins in the order of declaration.
+In the above example, the `parent` variable of the function passed in as the second argument of `register` is a reference to the **external fastify instance** that the plugin was registered at. This means that we are able to access any variables that were injected by preceding plugins in the order of declaration.
 
 <a name="handle-errors"></a>
 ## Handle errors

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -57,7 +57,7 @@ fastify.register(require('fastify-foo'), parent => parent.foo_bar)
 
 The fastify instance passed on to the function is the latest state of the **external fastify instance** the plugin was declared on, allowing access to variables injected via [`decorate`](https://github.com/fastify/fastify/blob/master/docs/Decorators.md) by preceding plugins according to the **order of registration**. This is useful in case a plugin depends on changes made to the Fastify instance by a preceding plugin f.e. utilizing an existing database connection to wrap around it.
 
-Keep in mind that the fastify instance passed on to the function is the same as the one that will be passed in to the plugin, a copy of the external fastify instance rather than a reference. Any usage of the instance will behave the same as it would if called within the plugin's function i.e. if `decorate` is called, the decorated variables will be available within the plugin's function.
+Keep in mind that the fastify instance passed on to the function is the same as the one that will be passed in to the plugin, a copy of the external fastify instance rather than a reference. Any usage of the instance will behave the same as it would if called within the plugin's function i.e. if `decorate` is called, the decorated variables will be available within the plugin's function unless it was wrapped with [`fastify-plugin`](https://github.com/fastify/fastify-plugin).
 
 <a name="route-prefixing-option"></a>
 #### Route Prefixing option

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -40,6 +40,21 @@ fastify.register(require('fastify-foo'), {
 })
 ```
 
+Functions in the `options` parameter are also supported and will be evaluated at the time the plugin is registered while giving access to the fastify instance via the first positional argument:
+
+```js
+fastify.register((fastify, opts, next) => {
+  fastify.decorate('foo_bar', { hello: 'world' })
+
+  next()
+})
+
+// The opts argument of fastify-foo will be { hello: 'world' }
+fastify.register(require('fastify-foo'), parent => parent.foo_bar)
+```
+
+The fastify instance passed on to the function is the latest state of the **global fastify instance** allowing access to variables injected via `decorate` by preceding plugins according to the **order of registration**. This is useful in case a plugin depends on changes made to the Fastify instance by a preceding plugin f.e. utilizing an existing database connection to wrap around it.
+
 <a name="route-prefixing-option"></a>
 #### Route Prefixing option
 If you pass an option with the key `prefix` with a `string` value, Fastify will use it to prefix all the routes inside the register, for more info check [here](https://github.com/fastify/fastify/blob/master/docs/Routes.md#route-prefixing).<br>

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -53,7 +53,7 @@ fastify.register((fastify, opts, next) => {
 fastify.register(require('fastify-foo'), parent => parent.foo_bar)
 ```
 
-The fastify instance passed on to the function is the latest state of the **global fastify instance** allowing access to variables injected via `decorate` by preceding plugins according to the **order of registration**. This is useful in case a plugin depends on changes made to the Fastify instance by a preceding plugin f.e. utilizing an existing database connection to wrap around it.
+The fastify instance passed on to the function is the latest state of the **external fastify instance** the plugin was declared on, allowing access to variables injected via [`decorate`](https://github.com/fastify/fastify/blob/master/docs/Decorators.md) by preceding plugins according to the **order of registration**. This is useful in case a plugin depends on changes made to the Fastify instance by a preceding plugin f.e. utilizing an existing database connection to wrap around it.
 
 <a name="route-prefixing-option"></a>
 #### Route Prefixing option

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -43,17 +43,21 @@ fastify.register(require('fastify-foo'), {
 The `options` parameter can also be a `Function` which will be evaluated at the time the plugin is registered while giving access to the fastify instance via the first positional argument:
 
 ```js
-fastify.register((fastify, opts, next) => {
+const fp = require('fastify-plugin')
+
+fastify.register(fp((fastify, opts, next) => {
   fastify.decorate('foo_bar', { hello: 'world' })
 
   next()
-})
+}))
 
 // The opts argument of fastify-foo will be { hello: 'world' }
 fastify.register(require('fastify-foo'), parent => parent.foo_bar)
 ```
 
 The fastify instance passed on to the function is the latest state of the **external fastify instance** the plugin was declared on, allowing access to variables injected via [`decorate`](https://github.com/fastify/fastify/blob/master/docs/Decorators.md) by preceding plugins according to the **order of registration**. This is useful in case a plugin depends on changes made to the Fastify instance by a preceding plugin f.e. utilizing an existing database connection to wrap around it.
+
+Keep in mind that the fastify instance passed on to the function is the same as the one that will be passed in to the plugin, a copy of the external fastify instance rather than a reference. Any usage of the instance will behave the same as it would if called within the plugin's function i.e. if `decorate` is called, the decorated variables will be available within the plugin's function.
 
 <a name="route-prefixing-option"></a>
 #### Route Prefixing option

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -40,7 +40,7 @@ fastify.register(require('fastify-foo'), {
 })
 ```
 
-Functions in the `options` parameter are also supported and will be evaluated at the time the plugin is registered while giving access to the fastify instance via the first positional argument:
+The `options` parameter can also be a `Function` which will be evaluated at the time the plugin is registered while giving access to the fastify instance via the first positional argument:
 
 ```js
 fastify.register((fastify, opts, next) => {

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
   "dependencies": {
     "abstract-logging": "^1.0.0",
     "ajv": "^6.9.1",
-    "avvio": "^6.0.1",
+    "avvio": "^6.1.1",
     "bourne": "^1.1.2",
     "fast-json-stringify": "^1.11.0",
     "find-my-way": "^2.0.0",

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -100,17 +100,17 @@ test('fastify.register with fastify-plugin should provide access to external fas
       n()
     }), p => p.decorate('test_2', () => {}))
 
+    instance.register((i, o, n) => n(), p => p.get('/', (req, reply) => {
+      t.ok(instance.test)
+      reply.send({ hello: 'world' })
+    }))
+
     t.notOk(instance.test)
     t.notOk(instance.test_2)
 
     // the decoration is added at the end
     instance.after(() => {
       t.ok(instance.test)
-    })
-
-    instance.get('/', (req, reply) => {
-      t.ok(instance.test)
-      reply.send({ hello: 'world' })
     })
 
     next()

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -100,8 +100,11 @@ test('fastify.register with fastify-plugin should provide access to external fas
       n()
     }), p => p.decorate('test_2', () => {}))
 
-    instance.register((i, o, n) => n(), p => p.get('/', (req, reply) => {
-      t.ok(instance.test)
+    instance.register((i, o, n) => {
+      i.decorate('test_2', () => {})
+      n()
+    }, p => p.get('/', (req, reply) => {
+      t.ok(instance.test_2)
       reply.send({ hello: 'world' })
     }))
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -82,7 +82,6 @@ test('fastify.register with fastify-plugin should provide access to external fas
 
     instance.register((i, o, n) => {
       i.decorate('test_2', () => {})
-      t.ok(i.test)
       n()
     })
 
@@ -98,14 +97,14 @@ test('fastify.register with fastify-plugin should provide access to external fas
     instance.register(fp((i, o, n) => {
       t.ok(i.test_2)
       n()
-    }), p => p.decorate('test_2', () => {}))
+    }), p => p.decorate('test_2', () => 'hello'))
 
     instance.register((i, o, n) => {
-      i.decorate('test_2', () => {})
+      i.decorate('test_2', () => 'world')
       n()
     }, p => p.get('/', (req, reply) => {
-      t.ok(instance.test_2)
-      reply.send({ hello: 'world' })
+      t.ok(p.test_2)
+      reply.send({ hello: p.test_2() })
     }))
 
     t.notOk(instance.test)
@@ -114,6 +113,7 @@ test('fastify.register with fastify-plugin should provide access to external fas
     // the decoration is added at the end
     instance.after(() => {
       t.ok(instance.test)
+      t.strictEqual(instance.test_2(), 'hello')
     })
 
     next()

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -63,7 +63,7 @@ test('fastify.register with fastify-plugin should not incapsulate his code', t =
 })
 
 test('fastify.register with fastify-plugin should provide access to external fastify instance if opts argument is a function', t => {
-  t.plan(16)
+  t.plan(20)
   const fastify = Fastify()
 
   fastify.register((instance, opts, next) => {
@@ -88,7 +88,20 @@ test('fastify.register with fastify-plugin should provide access to external fas
 
     instance.register((i, o, n) => n(), p => t.notOk(p.test_2))
 
+    instance.register((i, o, n) => {
+      t.ok(i.test_2)
+      n()
+    }, p => p.decorate('test_2', () => {}))
+
+    instance.register((i, o, n) => n(), p => t.notOk(p.test_2))
+
+    instance.register(fp((i, o, n) => {
+      t.ok(i.test_2)
+      n()
+    }), p => p.decorate('test_2', () => {}))
+
     t.notOk(instance.test)
+    t.notOk(instance.test_2)
 
     // the decoration is added at the end
     instance.after(() => {


### PR DESCRIPTION
Hey everyone,

You can find some updated documentation to reflect the changes made to the plugin registration API for the `options` parameter. It refers to the avvio [PR82](https://github.com/mcollina/avvio/pull/82). I believe it is clear enough but contributions are more than welcome!

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
