### PR TITLE
fix/schema error text

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -139,7 +139,7 @@ function schemaErrorsText (errors, dataVar) {
   var separator = ', '
   for (var i = 0; i < errors.length; i++) {
     var e = errors[i]
-    text += dataVar + e.dataPath + ' ' + e.message + separator
+    text += dataVar + (e.dataPath || '') + ' ' + e.message + separator
   }
   return text.slice(0, -separator.length)
 }


### PR DESCRIPTION
Closes #1512 

The checks on the error messages are too strict?
I think that in this way we could find regression in case of an update of those modules, do you agree?

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
