### PR TITLE
Docs: clarify error handling in non-async routes

### DIFF
--- a/docs/Errors.md
+++ b/docs/Errors.md
@@ -10,7 +10,8 @@ Uncaught errors are likely to cause memory leaks, file descriptor leaks and othe
 
 Fastify follows an all-or-nothing approach and aims to be lean and optimal as much as possible. Thus, the developer is responsible for making sure that the errors are handled properly. Most of the errors are usually a result of unexpected input data, so we recommend specifying a [JSON.schema validation](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) for your input data.
 
-Note that, while Fastify doesn't catch uncaught errors for you, if routes are declared as `async`, the error will safely be caught by the promise and routed to the default error handler of Fastify for a generic `Internal Server Error` response. For customizing this behaviour, you should use [setErrorHandler](https://github.com/fastify/fastify/blob/master/docs/Server.md#seterrorhandler).
+Note that Fastify doesn't catch uncaught errors within callback based routes for you, so any uncaught errors will result in a crash.
+If routes are declared as `async`though - the error will safely be caught by the promise and routed to the default error handler of Fastify for a generic `Internal Server Error` response. For customizing this behaviour, you should use [setErrorHandler](https://github.com/fastify/fastify/blob/master/docs/Server.md#seterrorhandler).
 
 <a name="fastify-error-codes"></a>
 ### Fastify Error Codes

--- a/docs/Errors.md
+++ b/docs/Errors.md
@@ -11,7 +11,7 @@ Uncaught errors are likely to cause memory leaks, file descriptor leaks and othe
 Fastify follows an all-or-nothing approach and aims to be lean and optimal as much as possible. Thus, the developer is responsible for making sure that the errors are handled properly. Most of the errors are usually a result of unexpected input data, so we recommend specifying a [JSON.schema validation](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) for your input data.
 
 Note that Fastify doesn't catch uncaught errors within callback based routes for you, so any uncaught errors will result in a crash.
-If routes are declared as `async`though - the error will safely be caught by the promise and routed to the default error handler of Fastify for a generic `Internal Server Error` response. For customizing this behaviour, you should use [setErrorHandler](https://github.com/fastify/fastify/blob/master/docs/Server.md#seterrorhandler).
+If routes are declared as `async` though - the error will safely be caught by the promise and routed to the default error handler of Fastify for a generic `Internal Server Error` response. For customizing this behavior, you should use [setErrorHandler](https://github.com/fastify/fastify/blob/master/docs/Server.md#seterrorhandler).
 
 <a name="fastify-error-codes"></a>
 ### Fastify Error Codes


### PR DESCRIPTION
Adjusted the docs on errors as discussed in #1514

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

