### PR TITLE
Fix the default for the modifyCoreObjects option

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -18,6 +18,7 @@ and properties:
 - `.send(payload)` - Sends the payload to the user, could be a plain text, a buffer, JSON, stream, or an Error object.
 - `.sent` - A boolean value that you can use if you need to know if `send` has already been called.
 - `.res` - The [`http.ServerResponse`](https://nodejs.org/dist/latest/docs/api/http.html#http_class_http_serverresponse) from Node core.
+- `.log` - the logger instance of the incoming request
 
 ```js
 fastify.get('/', options, function (request, reply) {

--- a/docs/Request.md
+++ b/docs/Request.md
@@ -10,8 +10,8 @@ Request is a core Fastify object containing the following fields:
 - `raw` - the incoming HTTP request from Node core *(you can use the alias `req`)*
 - `id` - the request id
 - `log` - the logger instance of the incoming request
-- `ip` - the ip of the incoming request
-- `ips` - the ips from x-forwarder-for of the incoming request
+- `ip` - the IP address of the incoming request
+- `ips` - an array of the IP addresses in the `X-Forwarded-For` header of the incoming request (only when the [`trustProxy`](ttps://github.com/fastify/fastify/blob/master/docs/Server.md#factory-trust-proxy) option is enabled)
 - `hostname` - the hostname of the incoming request
 
 ```js

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -205,12 +205,13 @@ const fastify = Fastify({ trustProxy: true })
 
 For more examples refer to [proxy-addr](https://www.npmjs.com/package/proxy-addr) package.
 
-You may also access `ip` and `hostname` values from raw `request`.
+You may access the `ip`, `ips`, and `hostname` values on the [`request`](https://github.com/fastify/fastify/blob/master/docs/Request.md) object.
 
 ```js
 fastify.get('/', (request, reply) => {
-  console.log(request.raw.ip)
-  console.log(request.raw.hostname)
+  console.log(request.ip)
+  console.log(request.ips)
+  console.log(request.hostname)
 })
 ```
 
@@ -265,22 +266,35 @@ const fastify = require('fastify')({
 <a name="factory-modify-core-objects"></a>
 ### `modifyCoreObjects`
 
-By enabling the `modifyCoreObjects` option, Fastify will set `ip`, `ips`, and `hostname` to Node's request object. And set `log` to Node's request and response objects for logging. The consequence of enabling this option is these properties will be available in the `raw` object of Fastify's Request. For example, `ip`, `ips`, and `hostname` values can be accessed from raw `request`.
++ Default: `true`
+
+By default, Fastify will add the `ip`, `ips`, `hostname`, and `log` [`Request`](https://github.com/fastify/fastify/blob/master/docs/Request.md) properties to Node's raw request object and the `log` property to Node's raw response object. Set to `false` to prevent these properties from being added to the Node core objects.
 
 ```js
-const fastify = Fastify({ modifyCoreObjects: true })
+const fastify = Fastify({ modifyCoreObjects: true }) // the default
 
 fastify.get('/', (request, reply) => {
   console.log(request.raw.ip)
   console.log(request.raw.ips)
   console.log(request.raw.hostname)
+  request.raw.log('Hello')
+  reply.res.log('World')
 })
 ```
 
-+ Default: `false`
-+ `true/false`: add properties `ip`, `ips`, `hostname`, and `log` to Node's request object and only `log` to Node's response object  (`true`) or leave Node's request and response objects alone (`false`).
+**Note that these properties are deprecated and will be removed in the next major version of Fastify along with this option.** It is recommended to use the same properties on Fastify's [`Request`](https://github.com/fastify/fastify/blob/master/docs/Request.md) and [`Reply`](https://github.com/fastify/fastify/blob/master/docs/Reply.md) objects instead.
 
+```js
+const fastify = Fastify({ modifyCoreObjects: false }) 
 
+fastify.get('/', (request, reply) => {
+  console.log(request.ip)
+  console.log(request.ips)
+  console.log(request.hostname)
+  request.log('Hello')
+  reply.log('World')
+})
+```
 
 ## Instance
 

--- a/fastify.js
+++ b/fastify.js
@@ -62,7 +62,7 @@ function build (options) {
   }
 
   const trustProxy = options.trustProxy
-  const modifyCoreObjects = options.modifyCoreObjects === true
+  const modifyCoreObjects = options.modifyCoreObjects !== false
 
   var log
   var hasLogger = true

--- a/test/trust-proxy.test.js
+++ b/test/trust-proxy.test.js
@@ -20,10 +20,10 @@ const testRequestValues = (t, req, options) => {
   if (options.ip) {
     if (options.modifyCoreObjects) {
       t.ok(req.raw.ip, 'ip is defined')
-      t.equal(req.raw.ip, options.ip, 'gets ip from x-forwarder-for')
+      t.equal(req.raw.ip, options.ip, 'gets ip from x-forwarded-for')
     }
     t.ok(req.ip, 'ip is defined')
-    t.equal(req.ip, options.ip, 'gets ip from x-forwarder-for')
+    t.equal(req.ip, options.ip, 'gets ip from x-forwarded-for')
   }
   if (options.hostname) {
     if (options.modifyCoreObjects) {
@@ -35,9 +35,9 @@ const testRequestValues = (t, req, options) => {
   }
   if (options.ips) {
     if (options.modifyCoreObjects) {
-      t.deepEqual(req.raw.ips, options.ips, 'gets ips from x-forwarder-for')
+      t.deepEqual(req.raw.ips, options.ips, 'gets ips from x-forwarded-for')
     }
-    t.deepEqual(req.ips, options.ips, 'gets ips from x-forwarder-for')
+    t.deepEqual(req.ips, options.ips, 'gets ips from x-forwarded-for')
   }
 }
 


### PR DESCRIPTION
To maintain backwards compatibility with Fastify v2, the default value for the new `modifyCoreObjects` option should be `true`.

This PR also updates the relevant documentation to be clearer about how the properties should be accessed and it also fixes some typos.

This is a followup to #1476.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
