### PR TITLE
Feature: onRegister hook

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -296,7 +296,7 @@ fastify.addHook('onRoute', (routeOptions) => {
 ```
 <a name="on-register"></a>
 **'onRegister'**<br>
-Triggered when a new plugin function is registered, and a new encapsulation context is created, he hook will be executed **before** the plugin code.<br/>
+Triggered when a new plugin function is registered, and a new encapsulation context is created, the hook will be executed **before** the plugin code.<br/>
 This hook can be useful if you are developing a plugin that needs to know when a plugin context is formed, and you want to operate in that specific context.<br/>
 **Note:** This hook will not be called if a plugin is wrapped inside [`fastify-plugin`](https://github.com/fastify/fastify-plugin).
 ```js

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -296,8 +296,9 @@ fastify.addHook('onRoute', (routeOptions) => {
 ```
 <a name="on-register"></a>
 **'onRegister'**<br>
-Triggered when a new plugin function is registered, and a new encapsulation context is created.<br/>
-This hook can be useful if you are developing a plugin that needs to know when a plugin context is formed, and you want to operate in that specific context.
+Triggered when a new plugin function is registered, and a new encapsulation context is created, he hook will be executed **before** the plugin code.<br/>
+This hook can be useful if you are developing a plugin that needs to know when a plugin context is formed, and you want to operate in that specific context.<br/>
+**Note:** This hook will not be called if a plugin is wrapped inside [`fastify-plugin`](https://github.com/fastify/fastify-plugin).
 ```js
 fastify.decorate('data', [])
 
@@ -316,6 +317,10 @@ fastify.register(async (instance, opts) => {
 })
 
 fastify.addHook('onRegister', (instance) => {
+  // create a new array from the old one
+  // but without keeping the reference
+  // allowing the user to have encapsulated
+  // instances of the `data` property
   instance.data = instance.data.slice()
 })
 ```

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -268,7 +268,7 @@ You are able to hook into the application-lifecycle as well. It's important to n
 
 - `'onClose'`
 - `'onRoute'`
-- `'onPlugin''`
+- `'onRegister''`
 
 <a name="on-close"></a>
 **'onClose'**<br>
@@ -294,8 +294,8 @@ fastify.addHook('onRoute', (routeOptions) => {
   routeOptions.prefix
 })
 ```
-<a name="on-encapsulation"></a>
-**'onPlugin'**<br>
+<a name="on-register"></a>
+**'onRegister'**<br>
 Triggered when a new plugin function is registered, and a new encapsulation context is created.<br/>
 This hook can be useful if you are developing a plugin that needs to know when a plugin context is formed, and you want to operate in that specific context.
 ```js
@@ -315,7 +315,7 @@ fastify.register(async (instance, opts) => {
   console.log(instance.data) // []
 })
 
-fastify.addHook('onPlugin', (instance) => {
+fastify.addHook('onRegister', (instance) => {
   instance.data = instance.data.slice()
 })
 ```

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -268,7 +268,7 @@ You are able to hook into the application-lifecycle as well. It's important to n
 
 - `'onClose'`
 - `'onRoute'`
-- `'onEncapsulation''`
+- `'onPlugin''`
 
 <a name="on-close"></a>
 **'onClose'**<br>
@@ -295,9 +295,9 @@ fastify.addHook('onRoute', (routeOptions) => {
 })
 ```
 <a name="on-encapsulation"></a>
-**'onEncapsulation'**<br>
-Triggered when Fastify runs its internal logic that enables the encapsulation.<br/>
-This hook can be useful if you are developing a plugin that needs to use the encapsulation functionality of Fastify.
+**'onPlugin'**<br>
+Triggered when a new plugin function is registered, and a new encapsulation context is created.<br/>
+This hook can be useful if you are developing a plugin that needs to know when a plugin context is formed, and you want to operate in that specific context.
 ```js
 fastify.decorate('data', [])
 
@@ -315,7 +315,7 @@ fastify.register(async (instance, opts) => {
   console.log(instance.data) // []
 })
 
-fastify.addHook('onEncapsulation', (instance) => {
+fastify.addHook('onPlugin', (instance) => {
   instance.data = instance.data.slice()
 })
 ```

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -268,6 +268,7 @@ You are able to hook into the application-lifecycle as well. It's important to n
 
 - `'onClose'`
 - `'onRoute'`
+- `'onEncapsulation''`
 
 <a name="on-close"></a>
 **'onClose'**<br>
@@ -293,6 +294,32 @@ fastify.addHook('onRoute', (routeOptions) => {
   routeOptions.prefix
 })
 ```
+<a name="on-encapsulation"></a>
+**'onEncapsulation'**<br>
+Triggered when Fastify runs its internal logic that enables the encapsulation.<br/>
+This hook can be useful if you are developing a plugin that needs to use the encapsulation functionality of Fastify.
+```js
+fastify.decorate('data', [])
+
+fastify.register(async (instance, opts) => {
+  instance.data.push('hello')
+  console.log(instance.data) // ['hello']
+
+  instance.register(async (instance, opts) => {
+    instance.data.push('world')
+    console.log(instance.data) // ['hello', 'world']
+  })
+})
+
+fastify.register(async (instance, opts) => {
+  console.log(instance.data) // []
+})
+
+fastify.addHook('onEncapsulation', (instance) => {
+  instance.data = instance.data.slice()
+})
+```
+
 <a name="scope"></a>
 ### Scope
 Except for [Application Hooks](#application-hooks), all hooks are encapsulated. This means that you can decide where your hooks should run by using `register` as explained in the [plugins guide](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md). If you pass a function, that function is bound to the right Fastify context and from there you have full access to the Fastify API.

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -606,7 +606,7 @@ declare namespace fastify {
      * This hook can be useful if you are developing a plugin that needs to use the encapsulation functionality of Fastify.
      * The interface is synchronous, and, as such, the listeners do not get passed a callback.
      */
-    addHook(name: 'onPlugin', hook: (instance: FastifyInstance) => void): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    addHook(name: 'onRegister', hook: (instance: FastifyInstance) => void): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Useful for testing http requests without running a sever

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -602,11 +602,11 @@ declare namespace fastify {
     addHook(name: 'onRoute', hook: (opts: RouteOptions<HttpServer, HttpRequest, HttpResponse> & { path: string, prefix: string }) => void): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
-     * Adds a hook that is triggered when Fastify runs its internal logic that enables the encapsulation.
+     * Adds a hook that is triggered when Fastify a new plugin is being registered.
      * This hook can be useful if you are developing a plugin that needs to use the encapsulation functionality of Fastify.
      * The interface is synchronous, and, as such, the listeners do not get passed a callback.
      */
-    addHook(name: 'onEncapsulation', hook: (instance: FastifyInstance) => void): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    addHook(name: 'onPlugin', hook: (instance: FastifyInstance) => void): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Useful for testing http requests without running a sever

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -602,6 +602,13 @@ declare namespace fastify {
     addHook(name: 'onRoute', hook: (opts: RouteOptions<HttpServer, HttpRequest, HttpResponse> & { path: string, prefix: string }) => void): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
+     * Adds a hook that is triggered when Fastify runs its internal logic that enables the encapsulation.
+     * This hook can be useful if you are developing a plugin that needs to use the encapsulation functionality of Fastify.
+     * The interface is synchronous, and, as such, the listeners do not get passed a callback.
+     */
+    addHook(name: 'onEncapsulation', hook: (instance: FastifyInstance) => void): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+
+    /**
      * Useful for testing http requests without running a sever
      */
     inject(opts: HTTPInjectOptions | string, cb: (err: Error, res: HTTPInjectResponse) => void): void

--- a/fastify.js
+++ b/fastify.js
@@ -120,7 +120,7 @@ function build (options) {
     [kFourOhFourContext]: null,
     [kGlobalHooks]: {
       onRoute: [],
-      onEncapsulation: []
+      onPlugin: []
     },
     [pluginUtils.registeredPlugins]: [],
     // routes shorthand methods
@@ -593,9 +593,9 @@ function build (options) {
     } else if (name === 'onRoute') {
       this[kHooks].validate(name, fn)
       this[kGlobalHooks].onRoute.push(fn)
-    } else if (name === 'onEncapsulation') {
+    } else if (name === 'onPlugin') {
       this[kHooks].validate(name, fn)
-      this[kGlobalHooks].onEncapsulation.push(fn)
+      this[kGlobalHooks].onPlugin.push(fn)
     } else {
       this.after((err, done) => {
         _addHook.call(this, name, fn)
@@ -853,7 +853,7 @@ function override (old, fn, opts) {
     instance[kFourOhFourLevelInstance] = instance
   }
 
-  for (const hook of instance[kGlobalHooks].onEncapsulation) hook.call(this, instance)
+  for (const hook of instance[kGlobalHooks].onPlugin) hook.call(this, instance)
 
   return instance
 }

--- a/fastify.js
+++ b/fastify.js
@@ -120,7 +120,7 @@ function build (options) {
     [kFourOhFourContext]: null,
     [kGlobalHooks]: {
       onRoute: [],
-      onPlugin: []
+      onRegister: []
     },
     [pluginUtils.registeredPlugins]: [],
     // routes shorthand methods
@@ -593,9 +593,9 @@ function build (options) {
     } else if (name === 'onRoute') {
       this[kHooks].validate(name, fn)
       this[kGlobalHooks].onRoute.push(fn)
-    } else if (name === 'onPlugin') {
+    } else if (name === 'onRegister') {
       this[kHooks].validate(name, fn)
-      this[kGlobalHooks].onPlugin.push(fn)
+      this[kGlobalHooks].onRegister.push(fn)
     } else {
       this.after((err, done) => {
         _addHook.call(this, name, fn)
@@ -853,7 +853,7 @@ function override (old, fn, opts) {
     instance[kFourOhFourLevelInstance] = instance
   }
 
-  for (const hook of instance[kGlobalHooks].onPlugin) hook.call(this, instance)
+  for (const hook of instance[kGlobalHooks].onRegister) hook.call(this, instance)
 
   return instance
 }

--- a/fastify.js
+++ b/fastify.js
@@ -23,7 +23,8 @@ const {
   kFourOhFourLevelInstance,
   kFourOhFourContext,
   kState,
-  kOptions
+  kOptions,
+  kGlobalHooks
 } = require('./lib/symbols.js')
 
 const { createServer } = require('./lib/server')
@@ -94,7 +95,6 @@ function build (options) {
   const setupResponseListeners = Reply.setupResponseListeners
   const proxyFn = getTrustProxyFn(options)
   const schemas = new Schemas()
-  const onRouteHooks = []
 
   // Public API
   const fastify = {
@@ -118,6 +118,10 @@ function build (options) {
     [kCanSetNotFoundHandler]: true,
     [kFourOhFourLevelInstance]: null,
     [kFourOhFourContext]: null,
+    [kGlobalHooks]: {
+      onRoute: [],
+      onEncapsulation: []
+    },
     [pluginUtils.registeredPlugins]: [],
     // routes shorthand methods
     delete: function _delete (url, opts, handler) {
@@ -419,7 +423,7 @@ function build (options) {
       }
 
       // run 'onRoute' hooks
-      for (const hook of onRouteHooks) hook.call(this, opts)
+      for (const hook of this[kGlobalHooks].onRoute) hook.call(this, opts)
 
       const config = opts.config || {}
       config.url = url
@@ -588,7 +592,10 @@ function build (options) {
       this.onClose(fn)
     } else if (name === 'onRoute') {
       this[kHooks].validate(name, fn)
-      onRouteHooks.push(fn)
+      this[kGlobalHooks].onRoute.push(fn)
+    } else if (name === 'onEncapsulation') {
+      this[kHooks].validate(name, fn)
+      this[kGlobalHooks].onEncapsulation.push(fn)
     } else {
       this.after((err, done) => {
         _addHook.call(this, name, fn)
@@ -845,6 +852,8 @@ function override (old, fn, opts) {
     instance[kCanSetNotFoundHandler] = true
     instance[kFourOhFourLevelInstance] = instance
   }
+
+  for (const hook of instance[kGlobalHooks].onEncapsulation) hook.call(this, instance)
 
   return instance
 }

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -9,8 +9,9 @@ const supportedHooks = [
   'onResponse',
   'onSend',
   'onError',
-  // only for validation
+  // executed at start/close time
   'onRoute',
+  'onEncapsulation',
   'onClose'
 ]
 const {

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -11,7 +11,7 @@ const supportedHooks = [
   'onError',
   // executed at start/close time
   'onRoute',
-  'onPlugin',
+  'onRegister',
   'onClose'
 ]
 const {

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -11,7 +11,7 @@ const supportedHooks = [
   'onError',
   // executed at start/close time
   'onRoute',
-  'onEncapsulation',
+  'onPlugin',
   'onClose'
 ]
 const {

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -25,7 +25,8 @@ const keys = {
   kReplyErrorHandlerCalled: Symbol('fastify.reply.errorHandlerCalled'),
   kReplyIsRunningOnErrorHook: Symbol('fastify.reply.isRunningOnErrorHook'),
   kState: Symbol('fastify.state'),
-  kOptions: Symbol('fastify.options')
+  kOptions: Symbol('fastify.options'),
+  kGlobalHooks: Symbol('fastify.globalHooks')
 }
 
 module.exports = keys

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -2561,7 +2561,7 @@ test('preSerialization hooks should support encapsulation', t => {
   })
 })
 
-test('onPlugin hook should be called / 1', t => {
+test('onRegister hook should be called / 1', t => {
   t.plan(3)
   const fastify = Fastify()
 
@@ -2569,7 +2569,7 @@ test('onPlugin hook should be called / 1', t => {
     next()
   })
 
-  fastify.addHook('onPlugin', instance => {
+  fastify.addHook('onRegister', instance => {
     // duck typing for the win!
     t.ok(instance.addHook)
   })
@@ -2579,7 +2579,7 @@ test('onPlugin hook should be called / 1', t => {
   })
 })
 
-test('onPlugin hook should be called / 2', t => {
+test('onRegister hook should be called / 2', t => {
   t.plan(5)
   const fastify = Fastify()
 
@@ -2594,7 +2594,7 @@ test('onPlugin hook should be called / 2', t => {
     next()
   })
 
-  fastify.addHook('onPlugin', instance => {
+  fastify.addHook('onRegister', instance => {
     // duck typing for the win!
     t.ok(instance.addHook)
   })
@@ -2604,7 +2604,7 @@ test('onPlugin hook should be called / 2', t => {
   })
 })
 
-test('onPlugin hook should be called / 3', t => {
+test('onRegister hook should be called / 3', t => {
   t.plan(4)
   const fastify = Fastify()
 
@@ -2626,7 +2626,7 @@ test('onPlugin hook should be called / 3', t => {
     next()
   })
 
-  fastify.addHook('onPlugin', instance => {
+  fastify.addHook('onRegister', instance => {
     instance.data = instance.data.slice()
   })
 

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -2635,6 +2635,27 @@ test('onRegister hook should be called / 3', t => {
   })
 })
 
+test('onRegister hook should be called / 4', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  function plugin (instance, opts, next) {
+    next()
+  }
+  plugin[Symbol.for('skip-override')] = true
+
+  fastify.register(plugin)
+
+  fastify.addHook('onRegister', instance => {
+    // duck typing for the win!
+    t.ok(instance.addHook)
+  })
+
+  fastify.ready(err => {
+    t.error(err)
+  })
+})
+
 if (semver.gt(process.versions.node, '8.0.0')) {
   require('./hooks-async')(t)
 } else {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -2561,6 +2561,80 @@ test('preSerialization hooks should support encapsulation', t => {
   })
 })
 
+test('onEncapsulation hook should be called / 1', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.register((instance, opts, next) => {
+    next()
+  })
+
+  fastify.addHook('onEncapsulation', instance => {
+    // duck typing for the win!
+    t.ok(instance.addHook)
+  })
+
+  fastify.ready(err => {
+    t.error(err)
+  })
+})
+
+test('onEncapsulation hook should be called / 2', t => {
+  t.plan(5)
+  const fastify = Fastify()
+
+  fastify.register((instance, opts, next) => {
+    instance.register((instance, opts, next) => {
+      next()
+    })
+    next()
+  })
+
+  fastify.register((instance, opts, next) => {
+    next()
+  })
+
+  fastify.addHook('onEncapsulation', instance => {
+    // duck typing for the win!
+    t.ok(instance.addHook)
+  })
+
+  fastify.ready(err => {
+    t.error(err)
+  })
+})
+
+test('onEncapsulation hook should be called / 3', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.decorate('data', [])
+
+  fastify.register((instance, opts, next) => {
+    instance.data.push(1)
+    instance.register((instance, opts, next) => {
+      instance.data.push(2)
+      t.deepEqual(instance.data, [1, 2])
+      next()
+    })
+    t.deepEqual(instance.data, [1])
+    next()
+  })
+
+  fastify.register((instance, opts, next) => {
+    t.deepEqual(instance.data, [])
+    next()
+  })
+
+  fastify.addHook('onEncapsulation', instance => {
+    instance.data = instance.data.slice()
+  })
+
+  fastify.ready(err => {
+    t.error(err)
+  })
+})
+
 if (semver.gt(process.versions.node, '8.0.0')) {
   require('./hooks-async')(t)
 } else {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -2561,7 +2561,7 @@ test('preSerialization hooks should support encapsulation', t => {
   })
 })
 
-test('onEncapsulation hook should be called / 1', t => {
+test('onPlugin hook should be called / 1', t => {
   t.plan(3)
   const fastify = Fastify()
 
@@ -2569,7 +2569,7 @@ test('onEncapsulation hook should be called / 1', t => {
     next()
   })
 
-  fastify.addHook('onEncapsulation', instance => {
+  fastify.addHook('onPlugin', instance => {
     // duck typing for the win!
     t.ok(instance.addHook)
   })
@@ -2579,7 +2579,7 @@ test('onEncapsulation hook should be called / 1', t => {
   })
 })
 
-test('onEncapsulation hook should be called / 2', t => {
+test('onPlugin hook should be called / 2', t => {
   t.plan(5)
   const fastify = Fastify()
 
@@ -2594,7 +2594,7 @@ test('onEncapsulation hook should be called / 2', t => {
     next()
   })
 
-  fastify.addHook('onEncapsulation', instance => {
+  fastify.addHook('onPlugin', instance => {
     // duck typing for the win!
     t.ok(instance.addHook)
   })
@@ -2604,7 +2604,7 @@ test('onEncapsulation hook should be called / 2', t => {
   })
 })
 
-test('onEncapsulation hook should be called / 3', t => {
+test('onPlugin hook should be called / 3', t => {
   t.plan(4)
   const fastify = Fastify()
 
@@ -2626,7 +2626,7 @@ test('onEncapsulation hook should be called / 3', t => {
     next()
   })
 
-  fastify.addHook('onEncapsulation', instance => {
+  fastify.addHook('onPlugin', instance => {
     instance.data = instance.data.slice()
   })
 


### PR DESCRIPTION
This pr adds a brand new hook that will make super happy plugin developers!
It allows you to interact with Fastify encapsulation model and run your magic with it :)

Talk is cheap, here's the code:
```js
fastify.decorate('data', [])

fastify.register(async (instance, opts) => {
  instance.data.push('hello')
  console.log(instance.data) // ['hello']

  instance.register(async (instance, opts) => {
    instance.data.push('world')
    console.log(instance.data) // ['hello', 'world']
  })
})

fastify.register(async (instance, opts) => {
  console.log(instance.data) // []
})

fastify.addHook('onRegister', (instance) => {
  instance.data = instance.data.slice()
})
```

Feedbacks?

___

Edit: renamed `onEncapsulation` in `onPlugin`
Edit2: renamed `onPlugin` in `onRegister`

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
