### PR TITLE
feat: add pluginTimeout options in d.ts

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -179,6 +179,7 @@ declare namespace fastify {
   interface ServerOptions {
     ignoreTrailingSlash?: boolean,
     bodyLimit?: number,
+    pluginTimeout?: number,
     onProtoPoisoning?: 'error' | 'remove' | 'ignore',
     logger?: any,
     trustProxy?: string | number | boolean | Array<string> | TrustProxyFunction,


### PR DESCRIPTION
```
 import * as fastify from 'fastify';
 const fastifyApp = fastify({
    pluginTimeout: 900000,
 });
```
to fix 
`Object literal may only specify known properties, and 'pluginTimeout' does not exist in type'.`