### PR TITLE
Improve logger type declaration

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -8,7 +8,7 @@ import * as http from 'http'
 import * as http2 from 'http2'
 import * as https from 'https'
 import * as pino from 'pino'
-import * as Logger from './types/logger'
+import FastifyLoggerOptions from './types/logger'
 
 declare function fastify<
   HttpServer extends (http.Server | http2.Http2Server) = http.Server,
@@ -29,8 +29,7 @@ declare namespace fastify {
 
   type DefaultQuery = { [k: string]: any }
   type DefaultParams = { [k: string]: any }
-  // type DefaultHeaders = { [k: string]: any }
-  type DefaultHeaders = http.IncomingHttpHeaders | http.OutgoingHttpHeaders
+  type DefaultHeaders = { [k: string]: any }
   type DefaultBody = any
 
   type HTTPMethod = 'DELETE' | 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'OPTIONS'

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -7,6 +7,8 @@
 import * as http from 'http'
 import * as http2 from 'http2'
 import * as https from 'https'
+import * as pino from 'pino'
+import * as Logger from './types/logger'
 
 declare function fastify<
   HttpServer extends (http.Server | http2.Http2Server) = http.Server,
@@ -27,7 +29,8 @@ declare namespace fastify {
 
   type DefaultQuery = { [k: string]: any }
   type DefaultParams = { [k: string]: any }
-  type DefaultHeaders = { [k: string]: any }
+  // type DefaultHeaders = { [k: string]: any }
+  type DefaultHeaders = http.IncomingHttpHeaders | http.OutgoingHttpHeaders
   type DefaultBody = any
 
   type HTTPMethod = 'DELETE' | 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'OPTIONS'
@@ -181,7 +184,7 @@ declare namespace fastify {
     bodyLimit?: number,
     pluginTimeout?: number,
     onProtoPoisoning?: 'error' | 'remove' | 'ignore',
-    logger?: any,
+    logger?: boolean | pino.LoggerOptions | FastifyLoggerOptions,
     trustProxy?: string | number | boolean | Array<string> | TrustProxyFunction,
     maxParamLength?: number,
     querystringParser?: (str: string) => { [key: string]: string | string[] },

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
   },
   "devDependencies": {
     "@types/node": "^11.9.3",
+    "@types/pino": "^5.8.5",
     "@typescript-eslint/eslint-plugin": "^1.4.2",
     "@typescript-eslint/parser": "^1.4.2",
     "JSONStream": "^1.3.5",

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -1,0 +1,39 @@
+/// <reference types="node" />
+
+import * as http from 'http'
+import * as net from 'net'
+
+export default interface FastifyLoggerOptions<
+  HttpRequest extends http.IncomingMessage = http.IncomingMessage,
+  HttpResponse extends http.OutgoingMessage = http.OutgoingMessage
+> {
+  serializers: {
+    req: (req: HttpRequest) => {
+      method: HttpRequest['method'],
+      url: HttpRequest['url'],
+      version: http.IncomingHttpHeaders['accept-version'],
+      hostname: any, // not on http.IncomingMessage
+      remoteAddress: any, // not on http.IncomingMessage
+      remotePort: net.Socket['remotePort']
+    },
+    err: (err: Error) => {
+      type: string;
+      message: string;
+      stack: string;
+      [key: string]: any;
+    },
+    res: (res: HttpResponse) => {
+      statusCode: any // not on http.OutgoingMessage
+    }
+  };
+  info: WriteFn;
+  error: WriteFn;
+  debug: WriteFn;
+  fatal: WriteFn;
+  warn: WriteFn;
+  trace: WriteFn;
+  child: WriteFn;
+  genReqId?: string;
+}
+
+type WriteFn = (o: object) => void;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

Not complete yet. I want to add a standalone typescript test file that tests the logger types I've defined. I think using the atomic approach to types declarations and testing will be the best way of improving type support across the project. 

In this PR I have declared the types for the `fastify` instance `logger` option parameter. It was previously defined as `any`. I am not sure if this is considered breaking or not because:
- Non TS devs will not witness any change
- TS devs who were incorrectly defining logging options were not following the JS API.

Furthermore on that second bullet, I'd like to update the logging documentation to be more explicit about what options users have for logging
1. Boolean, defaults to pino with no special configuration
2. Pass an object with Pino options
3. Pass an object that implements a 'valid logger'

a 'valid logger' could be better documented as the current line (in reference to custom serializers)
> This option will be ignored by any logger other than Pino.
Is not entirely true because a correctly implemented custom logger (with all of the level methods) and a set of valid serializers will generated into a valid logger by the `createLogger` method.
