### PR TITLE
add: schemaCompiler property

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -528,8 +528,7 @@ Set the schema compiler for all routes [here](https://github.com/fastify/fastify
 
 <a name="schema-compiler"></a>
 #### schemaCompiler
-This property can be used to set the schema compiler, it is a shortcut for the `setSchemaCompiler` method,
-and get the schema compiler back for all routes.
+This property can be used to set the schema compiler, it is a shortcut for the `setSchemaCompiler` method, and get the schema compiler back for all routes.
 
 <a name="set-not-found-handler"></a>
 #### setNotFoundHandler

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -528,7 +528,8 @@ Set the schema compiler for all routes [here](https://github.com/fastify/fastify
 
 <a name="schema-compiler"></a>
 #### schemaCompiler
-Get the schema compiler for all routes if one has been settled.
+This property can be used to set the schema compiler, it is a shortcut for the `setSchemaCompiler` method,
+and get the schema compiler back for all routes.
 
 <a name="set-not-found-handler"></a>
 #### setNotFoundHandler

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -491,6 +491,10 @@ To learn more, see [shared schema example](https://github.com/fastify/fastify/bl
 #### setSchemaCompiler
 Set the schema compiler for all routes [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-compiler).
 
+<a name="schema-compiler"></a>
+#### schemaCompiler
+Get the schema compiler for all routes if one has been settled.
+
 <a name="set-not-found-handler"></a>
 #### setNotFoundHandler
 

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -248,6 +248,10 @@ const ajv = new Ajv({
 fastify.setSchemaCompiler(function (schema) {
   return ajv.compile(schema)
 })
+
+// -------
+// Alternatively, you can set the schema compiler using the setter property:
+fastify.schemaCompiler = function (schema) { return ajv.compile(schema) })
 ```
 
 But maybe you want to change the validation library. Perhaps you like `Joi`. In this case, you can use it to validate the url parameters, body, and query string!

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -628,6 +628,11 @@ declare namespace fastify {
     setSchemaCompiler(schemaCompiler: SchemaCompiler): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
+     * Get the schema compiler
+     */
+    getSchemaCompiler(): SchemaCompiler
+
+    /**
      * Create a shared schema
      */
     addSchema(schema: object): FastifyInstance<HttpServer, HttpRequest, HttpResponse>

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -318,6 +318,7 @@ declare namespace fastify {
   interface FastifyInstance<HttpServer = http.Server, HttpRequest = http.IncomingMessage, HttpResponse = http.ServerResponse> {
     server: HttpServer
     log: Logger
+    schemaCompiler: SchemaCompiler
 
     /**
      * Adds a route to the server
@@ -626,11 +627,6 @@ declare namespace fastify {
      * Set the schema compiler for all routes.
      */
     setSchemaCompiler(schemaCompiler: SchemaCompiler): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
-
-    /**
-     * Get the schema compiler
-     */
-    getSchemaCompiler(): SchemaCompiler
 
     /**
      * Create a shared schema

--- a/fastify.js
+++ b/fastify.js
@@ -154,6 +154,7 @@ function build (options) {
     addSchema: addSchema,
     getSchemas: schemas.getSchemas.bind(schemas),
     setSchemaCompiler: setSchemaCompiler,
+    getSchemaCompiler: getSchemaCompiler,
     // custom parsers
     addContentTypeParser: ContentTypeParser.helpers.addContentTypeParser,
     hasContentTypeParser: ContentTypeParser.helpers.hasContentTypeParser,
@@ -761,6 +762,10 @@ function build (options) {
 
     this._schemaCompiler = schemaCompiler
     return this
+  }
+
+  function getSchemaCompiler () {
+    return this._schemaCompiler
   }
 
   // wrapper that we expose to the user for configure the custom error handler

--- a/fastify.js
+++ b/fastify.js
@@ -15,6 +15,7 @@ const {
   kLogLevel,
   kHooks,
   kSchemas,
+  kSchemaCompiler,
   kContentTypeParser,
   kReply,
   kRequest,
@@ -111,6 +112,7 @@ function build (options) {
     [kLogLevel]: '',
     [kHooks]: new Hooks(),
     [kSchemas]: schemas,
+    [kSchemaCompiler]: null,
     [kContentTypeParser]: new ContentTypeParser(bodyLimit, options.onProtoPoisoning),
     [kReply]: Reply.buildReply(Reply),
     [kRequest]: Request.buildRequest(Request),
@@ -186,7 +188,7 @@ function build (options) {
 
   Object.defineProperty(fastify, 'schemaCompiler', {
     get: function () {
-      return this._schemaCompiler
+      return this[kSchemaCompiler]
     },
     set: function (schemaCompiler) {
       this.setSchemaCompiler(schemaCompiler)
@@ -447,12 +449,12 @@ function build (options) {
       )
 
       try {
-        if (opts.schemaCompiler == null && this._schemaCompiler == null) {
+        if (opts.schemaCompiler == null && this[kSchemaCompiler] == null) {
           const externalSchemas = this[kSchemas].getJsonSchemas({ onlyAbsoluteUri: true })
           this.setSchemaCompiler(buildSchemaCompiler(externalSchemas))
         }
 
-        buildSchema(context, opts.schemaCompiler || this._schemaCompiler, this[kSchemas])
+        buildSchema(context, opts.schemaCompiler || this[kSchemaCompiler], this[kSchemas])
       } catch (error) {
         done(error)
         return
@@ -768,7 +770,7 @@ function build (options) {
   function setSchemaCompiler (schemaCompiler) {
     throwIfAlreadyStarted('Cannot call "setSchemaCompiler" when fastify instance is already started!')
 
-    this._schemaCompiler = schemaCompiler
+    this[kSchemaCompiler] = schemaCompiler
     return this
   }
 

--- a/fastify.js
+++ b/fastify.js
@@ -154,7 +154,6 @@ function build (options) {
     addSchema: addSchema,
     getSchemas: schemas.getSchemas.bind(schemas),
     setSchemaCompiler: setSchemaCompiler,
-    getSchemaCompiler: getSchemaCompiler,
     // custom parsers
     addContentTypeParser: ContentTypeParser.helpers.addContentTypeParser,
     hasContentTypeParser: ContentTypeParser.helpers.hasContentTypeParser,
@@ -184,6 +183,15 @@ function build (options) {
     setNotFoundHandler: setNotFoundHandler,
     setErrorHandler: setErrorHandler
   }
+
+  Object.defineProperty(fastify, 'schemaCompiler', {
+    get: function () {
+      return this._schemaCompiler
+    },
+    set: function (schemaCompiler) {
+      this.setSchemaCompiler(schemaCompiler)
+    }
+  })
 
   Object.defineProperty(fastify, 'prefix', {
     get: function () {
@@ -762,10 +770,6 @@ function build (options) {
 
     this._schemaCompiler = schemaCompiler
     return this
-  }
-
-  function getSchemaCompiler () {
-    return this._schemaCompiler
   }
 
   // wrapper that we expose to the user for configure the custom error handler

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -7,6 +7,7 @@ const keys = {
   kLogLevel: Symbol('fastify.logLevel'),
   kHooks: Symbol('fastify.hooks'),
   kSchemas: Symbol('fastify.schemas'),
+  kSchemaCompiler: Symbol('fastify.schemaCompiler'),
   kContentTypeParser: Symbol('fastify.contentTypeParser'),
   kReply: Symbol('fastify.Reply'),
   kRequest: Symbol('fastify.Request'),

--- a/test/post.test.js
+++ b/test/post.test.js
@@ -23,3 +23,15 @@ t.test('cannot set schemaCompiler after binding', t => {
     }
   })
 })
+
+t.test('get schemaCompiler after set schemaCompiler', t => {
+  t.plan(2)
+  const mySchemaCompiler = () => { }
+
+  const fastify = Fastify()
+  fastify.setSchemaCompiler(mySchemaCompiler)
+  const sc = fastify.getSchemaCompiler()
+
+  t.ok(Object.is(mySchemaCompiler, sc))
+  fastify.ready(t.error)
+})

--- a/test/post.test.js
+++ b/test/post.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const t = require('tap')
+const Joi = require('joi')
 require('./helper').payloadMethod('post', t)
 require('./input-validation').payloadMethod('post', t)
 
@@ -64,4 +65,33 @@ t.test('get schemaCompiler after setSchemaCompiler', t => {
 
   t.ok(Object.is(mySchemaCompiler, sc))
   fastify.ready(t.error)
+})
+
+t.test('get schemaCompiler is empty for schemaCompilere settle on routes', t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  const body = Joi.object().keys({
+    name: Joi.string(),
+    work: Joi.string()
+  }).required()
+
+  const schemaCompiler = schema => data => Joi.validate(data, schema)
+
+  fastify.post('/', {
+    schema: { body },
+    schemaCompiler
+  }, function (req, reply) {
+    reply.send('ok')
+  })
+
+  fastify.inject({
+    method: 'POST',
+    payload: {},
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(fastify.schemaCompiler, null)
+  })
 })

--- a/test/post.test.js
+++ b/test/post.test.js
@@ -6,7 +6,7 @@ require('./input-validation').payloadMethod('post', t)
 
 const Fastify = require('..')
 
-t.test('cannot set schemaCompiler after binding', t => {
+t.test('cannot call setSchemaCompiler after binding', t => {
   t.plan(2)
 
   const fastify = Fastify()
@@ -24,13 +24,43 @@ t.test('cannot set schemaCompiler after binding', t => {
   })
 })
 
+t.test('cannot set schemaCompiler after binding', t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    try {
+      fastify.schemaCompiler = () => { }
+      t.fail()
+    } catch (e) {
+      t.pass()
+    }
+  })
+})
+
 t.test('get schemaCompiler after set schemaCompiler', t => {
   t.plan(2)
   const mySchemaCompiler = () => { }
 
   const fastify = Fastify()
+  fastify.schemaCompiler = mySchemaCompiler
+  const sc = fastify.schemaCompiler
+
+  t.ok(Object.is(mySchemaCompiler, sc))
+  fastify.ready(t.error)
+})
+
+t.test('get schemaCompiler after setSchemaCompiler', t => {
+  t.plan(2)
+  const mySchemaCompiler = () => { }
+
+  const fastify = Fastify()
   fastify.setSchemaCompiler(mySchemaCompiler)
-  const sc = fastify.getSchemaCompiler()
+  const sc = fastify.schemaCompiler
 
   t.ok(Object.is(mySchemaCompiler, sc))
   fastify.ready(t.error)


### PR DESCRIPTION
Hi,
I would like to add a `getSchemaCompiler` method in order to get returned the function used by the `validation.js` to build the validation function.
That `this._schemaCompiler` have all the JSON schemas of the fastify instance and could let the devs to add some feature validation using the schemas they already set plus the resolved shared-schema.

I'm adding this method in order to solve issue #1376 
I have already build a plugin that accomplishes that task but it works only thanks to this line:

https://github.com/Eomm/fastify-schema-constraint/blob/dbec55b3da4dc88d8c4a1a7c1d337396cc4e9757/plugin.js#L84

I think that could give some new flexibility to the community 👍

Let me know what you think about this PR.
I'm not sure if there could be some side effect I don't spot

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
