### PR TITLE
Chore 404

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -74,6 +74,12 @@ function build (options) {
 
   // Instance Fastify components
   const { logger, hasLogger } = createLogger(options)
+
+  // Update the options with the fixed values
+  options.logger = logger
+  options.modifyCoreObjects = modifyCoreObjects
+  options.genReqId = genReqId
+
   // Default router
   const router = FindMyWay({
     defaultRoute: defaultRoute,
@@ -83,7 +89,7 @@ function build (options) {
     versioning: options.versioning
   })
   // 404 router, used for handling encapsulated 404 handlers
-  const fourOhFour = build404({ logger, modifyCoreObjects, genReqId })
+  const fourOhFour = build404(options)
 
   // HTTP server and its handler
   const httpHandler = router.lookup.bind(router)

--- a/fastify.js
+++ b/fastify.js
@@ -21,7 +21,6 @@ const {
   kMiddlewares,
   kCanSetNotFoundHandler,
   kFourOhFour,
-  kFourOhFourLevelInstance,
   kFourOhFourContext,
   kState,
   kOptions,
@@ -119,7 +118,6 @@ function build (options) {
     [kMiddlewares]: [],
     [kCanSetNotFoundHandler]: true,
     [kFourOhFour]: fourOhFour,
-    [kFourOhFourLevelInstance]: null,
     [kFourOhFourContext]: null,
     [kGlobalHooks]: {
       onRoute: [],
@@ -237,7 +235,7 @@ function build (options) {
 
   // Set the default 404 handler
   fastify.setNotFoundHandler()
-  fastify[kFourOhFourLevelInstance] = fastify
+  fastify[kFourOhFour].updateInstance.call(fastify, fastify)
 
   return fastify
 
@@ -719,7 +717,7 @@ function override (old, fn, opts) {
 
   if (opts.prefix) {
     instance[kCanSetNotFoundHandler] = true
-    instance[kFourOhFourLevelInstance] = instance
+    instance[kFourOhFour].updateInstance.call(instance, instance)
   }
 
   for (const hook of instance[kGlobalHooks].onRegister) hook.call(this, instance)

--- a/fastify.js
+++ b/fastify.js
@@ -527,9 +527,7 @@ function build (options) {
 
         // Must store the 404 Context in 'preReady' because it is only guaranteed to
         // be available after all of the plugins and routes have been loaded.
-        const _404Context = Object.assign({}, this[kFourOhFourContext])
-        _404Context.onSend = context.onSend
-        context[kFourOhFourContext] = _404Context
+        this[kFourOhFour].setContext.call(this, context)
       })
 
       done(notHandledErr)

--- a/fastify.js
+++ b/fastify.js
@@ -85,7 +85,7 @@ function build (options) {
     versioning: options.versioning
   })
   // 404 router, used for handling encapsulated 404 handlers
-  const fourOhFour = fourOhFourManager(fourOhFourFallBack)
+  const fourOhFour = fourOhFourManager(logger, modifyCoreObjects, genReqId)
 
   // HTTP server and its handler
   const httpHandler = router.lookup.bind(router)
@@ -625,28 +625,6 @@ function build (options) {
       req.headers['accept-version'] = undefined
     }
     fourOhFour.router.lookup(req, res)
-  }
-
-  function fourOhFourFallBack (req, res) {
-    // if this happen, we have a very bad bug
-    // we might want to do some hard debugging
-    // here, let's print out as much info as
-    // we can
-    req.id = genReqId(req)
-    req.originalUrl = req.url
-    var childLogger = logger.child({ reqId: req.id })
-    if (modifyCoreObjects) {
-      req.log = res.log = childLogger
-    }
-
-    childLogger.info({ req }, 'incoming request')
-
-    var request = new Request(null, req, null, req.headers, childLogger)
-    var reply = new Reply(res, { onSend: [], onError: [] }, request, childLogger)
-
-    request.log.warn('the default handler for 404 did not catch this, this is likely a fastify bug, please report it')
-    request.log.warn(fourOhFour.router.prettyPrint())
-    reply.code(404).send(new Error('Not Found'))
   }
 
   function setNotFoundHandler (opts, handler) {

--- a/fastify.js
+++ b/fastify.js
@@ -238,7 +238,7 @@ function build (options) {
 
   // Set the default 404 handler
   fastify.setNotFoundHandler()
-  fastify[kFourOhFour].arrange404(fastify)
+  fourOhFour.arrange404(fastify)
 
   return fastify
 
@@ -528,7 +528,7 @@ function build (options) {
 
         // Must store the 404 Context in 'preReady' because it is only guaranteed to
         // be available after all of the plugins and routes have been loaded.
-        this[kFourOhFour].setContext.call(this, context)
+        fourOhFour.setContext(this, context)
       })
 
       done(notHandledErr)
@@ -629,7 +629,7 @@ function build (options) {
   function setNotFoundHandler (opts, handler) {
     throwIfAlreadyStarted('Cannot call "setNotFoundHandler" when fastify instance is already started!')
 
-    this[kFourOhFour].setNotFoundHandler.call(this, opts, handler, avvio, routeHandler, buildMiddie)
+    fourOhFour.setNotFoundHandler.call(this, opts, handler, avvio, routeHandler, buildMiddie)
   }
 
   // wrapper that we expose to the user for schemas compiler handling

--- a/fastify.js
+++ b/fastify.js
@@ -42,6 +42,7 @@ const { createLogger } = require('./lib/logger')
 const pluginUtils = require('./lib/pluginUtils')
 const reqIdGenFactory = require('./lib/reqIdGenFactory')
 const build404 = require('./lib/fourOhFour')
+const { beforeHandlerWarning } = require('./lib/warnings')
 const getSecuredInitialConfig = require('./lib/initialConfigValidation')
 const { defaultInitOptions } = getSecuredInitialConfig
 
@@ -652,12 +653,6 @@ function build (options) {
     }
 
     return middie
-  }
-
-  function beforeHandlerWarning () {
-    if (beforeHandlerWarning.called) return
-    beforeHandlerWarning.called = true
-    process.emitWarning('The route option `beforeHandler` has been deprecated, use `preHandler` instead')
   }
 }
 

--- a/fastify.js
+++ b/fastify.js
@@ -232,7 +232,7 @@ function build (options) {
 
   // Set the default 404 handler
   fastify.setNotFoundHandler()
-  fastify[kFourOhFour].updateInstance(fastify)
+  fastify[kFourOhFour].arrange404(fastify)
 
   return fastify
 
@@ -707,7 +707,7 @@ function override (old, fn, opts) {
   instance[pluginUtils.registeredPlugins] = Object.create(instance[pluginUtils.registeredPlugins])
 
   if (opts.prefix) {
-    instance[kFourOhFour].updateInstance(instance)
+    instance[kFourOhFour].arrange404(instance)
   }
 
   for (const hook of instance[kGlobalHooks].onRegister) hook.call(this, instance)

--- a/lib/context.js
+++ b/lib/context.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const { kFourOhFourContext } = require('./symbols.js')
+
+// Objects that holds the context of every request
+// Every route holds an instance of this object.
+function Context (schema, handler, Reply, Request, contentTypeParser, config, errorHandler, bodyLimit, logLevel, attachValidation) {
+  this.schema = schema
+  this.handler = handler
+  this.Reply = Reply
+  this.Request = Request
+  this.contentTypeParser = contentTypeParser
+  this.onRequest = null
+  this.onSend = null
+  this.onError = null
+  this.preHandler = null
+  this.onResponse = null
+  this.config = config
+  this.errorHandler = errorHandler || defaultErrorHandler
+  this._middie = null
+  this._parserOptions = { limit: bodyLimit || null }
+  this.logLevel = logLevel
+  this[kFourOhFourContext] = null
+  this.attachValidation = attachValidation
+}
+
+function defaultErrorHandler (error, request, reply) {
+  var res = reply.res
+  if (res.statusCode >= 500) {
+    res.log.error({ req: reply.request.raw, res: res, err: error }, error && error.message)
+  } else if (res.statusCode >= 400) {
+    res.log.info({ res: res, err: error }, error && error.message)
+  }
+  reply.send(error)
+}
+
+module.exports = Context

--- a/lib/fourOhFour.js
+++ b/lib/fourOhFour.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const FindMyWay = require('find-my-way')
+
+const Reply = require('./reply')
+const Request = require('./request')
 const Context = require('./context')
 const {
   kRoutePrefix,
@@ -27,16 +30,16 @@ const {
   // kFourOhFourContext
 } = require('./symbols.js')
 
-function fourOhFour (fourOhFourFallBack) {
+function fourOhFour (logger, modifyCoreObjects, genReqId) {
   // 404 router, used for handling encapsulated 404 handlers
   const router = FindMyWay({ defaultRoute: fourOhFourFallBack })
 
-  const papi = {
+  const fof = {
     router,
     setNotFoundHandler: setNotFoundHandler
   }
 
-  return papi
+  return fof
 
   function basic404 (req, reply) {
     reply.code(404).send(new Error('Not Found'))
@@ -144,6 +147,28 @@ function fourOhFour (fourOhFourFallBack) {
 
     this[kFourOhFour].router.all(prefix + (prefix.endsWith('/') ? '*' : '/*'), routeHandler, context)
     this[kFourOhFour].router.all(prefix || '/', routeHandler, context)
+  }
+
+  function fourOhFourFallBack (req, res) {
+    // if this happen, we have a very bad bug
+    // we might want to do some hard debugging
+    // here, let's print out as much info as
+    // we can
+    req.id = genReqId(req)
+    req.originalUrl = req.url
+    var childLogger = logger.child({ reqId: req.id })
+    if (modifyCoreObjects) {
+      req.log = res.log = childLogger
+    }
+
+    childLogger.info({ req }, 'incoming request')
+
+    var request = new Request(null, req, null, req.headers, childLogger)
+    var reply = new Reply(res, { onSend: [], onError: [] }, request, childLogger)
+
+    request.log.warn('the default handler for 404 did not catch this, this is likely a fastify bug, please report it')
+    request.log.warn(router.prettyPrint())
+    reply.code(404).send(new Error('Not Found'))
   }
 }
 

--- a/lib/fourOhFour.js
+++ b/lib/fourOhFour.js
@@ -19,6 +19,7 @@ const {
   kMiddlewares,
   kHooks
 } = require('./symbols.js')
+const { beforeHandlerWarning } = require('./warnings')
 
 function fourOhFour ({ logger, modifyCoreObjects, genReqId }) {
   // 404 router, used for handling encapsulated 404 handlers
@@ -46,13 +47,6 @@ function fourOhFour ({ logger, modifyCoreObjects, genReqId }) {
     const _404Context = Object.assign({}, this[kFourOhFourContext])
     _404Context.onSend = context.onSend
     context[kFourOhFourContext] = _404Context
-  }
-
-  // TODO: remove duplicated
-  function beforeHandlerWarning () {
-    if (beforeHandlerWarning.called) return
-    beforeHandlerWarning.called = true
-    process.emitWarning('The route option `beforeHandler` has been deprecated, use `preHandler` instead')
   }
 
   function setNotFoundHandler (opts, handler, avvio, routeHandler, buildMiddie) {

--- a/lib/fourOhFour.js
+++ b/lib/fourOhFour.js
@@ -1,15 +1,23 @@
 'use strict'
 
 const FindMyWay = require('find-my-way')
-
+const Context = require('./context')
 const {
   kRoutePrefix,
   kCanSetNotFoundHandler,
-  kFourOhFourLevelInstance
+  kFourOhFourLevelInstance,
+  kReply,
+  kRequest,
+  kContentTypeParser,
+  kBodyLimit,
+  kLogLevel,
+  kFourOhFourContext,
+  kFourOhFour,
+  kMiddlewares,
   // kBodyLimit,
   // kRoutePrefix,
   // kLogLevel,
-  // kHooks,
+  kHooks
   // kContentTypeParser,
   // kReply,
   // kRequest,
@@ -34,13 +42,14 @@ function fourOhFour (fourOhFourFallBack) {
     reply.code(404).send(new Error('Not Found'))
   }
 
+  // TODO: remove duplicated
   function beforeHandlerWarning () {
     if (beforeHandlerWarning.called) return
     beforeHandlerWarning.called = true
     process.emitWarning('The route option `beforeHandler` has been deprecated, use `preHandler` instead')
   }
 
-  function setNotFoundHandler (opts, handler, _setNotFoundHandler) {
+  function setNotFoundHandler (opts, handler, avvio, routeHandler, buildMiddie) {
     const _fastify = this
     const prefix = this[kRoutePrefix] || '/'
 
@@ -84,9 +93,57 @@ function fourOhFour (fourOhFourFallBack) {
     }
 
     this.after((notHandledErr, done) => {
-      _setNotFoundHandler.call(this, prefix, opts, handler)
+      _setNotFoundHandler.call(this, prefix, opts, handler, avvio, routeHandler, buildMiddie)
       done(notHandledErr)
     })
+  }
+
+  function _setNotFoundHandler (prefix, opts, handler, avvio, routeHandler, buildMiddie) {
+    const context = new Context(
+      opts.schema,
+      handler,
+      this[kReply],
+      this[kRequest],
+      this[kContentTypeParser],
+      opts.config || {},
+      this._errorHandler,
+      this[kBodyLimit],
+      this[kLogLevel]
+    )
+
+    avvio.once('preReady', () => {
+      const context = this[kFourOhFourContext]
+
+      const onRequest = this[kHooks].onRequest
+      const preParsing = this[kHooks].preParsing.concat(opts.preParsing || [])
+      const preValidation = this[kHooks].preValidation.concat(opts.preValidation || [])
+      const preSerialization = this[kHooks].preSerialization.concat(opts.preSerialization || [])
+      const preHandler = this[kHooks].preHandler.concat(opts.beforeHandler || opts.preHandler || [])
+      const onSend = this[kHooks].onSend
+      const onError = this[kHooks].onError
+      const onResponse = this[kHooks].onResponse
+
+      context.onRequest = onRequest.length ? onRequest : null
+      context.preParsing = preParsing.length ? preParsing : null
+      context.preValidation = preValidation.length ? preValidation : null
+      context.preSerialization = preSerialization.length ? preSerialization : null
+      context.preHandler = preHandler.length ? preHandler : null
+      context.onSend = onSend.length ? onSend : null
+      context.onError = onError.length ? onError : null
+      context.onResponse = onResponse.length ? onResponse : null
+
+      context._middie = buildMiddie(this[kMiddlewares])
+    })
+
+    if (this[kFourOhFourContext] !== null && prefix === '/') {
+      Object.assign(this[kFourOhFourContext], context) // Replace the default 404 handler
+      return
+    }
+
+    this[kFourOhFourLevelInstance][kFourOhFourContext] = context
+
+    this[kFourOhFour].router.all(prefix + (prefix.endsWith('/') ? '*' : '/*'), routeHandler, context)
+    this[kFourOhFour].router.all(prefix || '/', routeHandler, context)
   }
 }
 

--- a/lib/fourOhFour.js
+++ b/lib/fourOhFour.js
@@ -1,0 +1,93 @@
+'use strict'
+
+const FindMyWay = require('find-my-way')
+
+const {
+  kRoutePrefix,
+  kCanSetNotFoundHandler,
+  kFourOhFourLevelInstance
+  // kBodyLimit,
+  // kRoutePrefix,
+  // kLogLevel,
+  // kHooks,
+  // kContentTypeParser,
+  // kReply,
+  // kRequest,
+  // kMiddlewares,
+  // kCanSetNotFoundHandler,
+  // kFourOhFourLevelInstance
+  // kFourOhFourContext
+} = require('./symbols.js')
+
+function fourOhFour (fourOhFourFallBack) {
+  // 404 router, used for handling encapsulated 404 handlers
+  const router = FindMyWay({ defaultRoute: fourOhFourFallBack })
+
+  const papi = {
+    router,
+    setNotFoundHandler: setNotFoundHandler
+  }
+
+  return papi
+
+  function basic404 (req, reply) {
+    reply.code(404).send(new Error('Not Found'))
+  }
+
+  function beforeHandlerWarning () {
+    if (beforeHandlerWarning.called) return
+    beforeHandlerWarning.called = true
+    process.emitWarning('The route option `beforeHandler` has been deprecated, use `preHandler` instead')
+  }
+
+  function setNotFoundHandler (opts, handler, _setNotFoundHandler) {
+    const _fastify = this
+    const prefix = this[kRoutePrefix] || '/'
+
+    if (this[kCanSetNotFoundHandler] === false) {
+      throw new Error(`Not found handler already set for Fastify instance with prefix: '${prefix}'`)
+    }
+
+    if (typeof opts === 'object') {
+      if (opts.preHandler == null && opts.beforeHandler != null) {
+        beforeHandlerWarning()
+        opts.preHandler = opts.beforeHandler
+      }
+      if (opts.preHandler) {
+        if (Array.isArray(opts.preHandler)) {
+          opts.preHandler = opts.preHandler.map(hook => hook.bind(_fastify))
+        } else {
+          opts.preHandler = opts.preHandler.bind(_fastify)
+        }
+      }
+
+      if (opts.preValidation) {
+        if (Array.isArray(opts.preValidation)) {
+          opts.preValidation = opts.preValidation.map(hook => hook.bind(_fastify))
+        } else {
+          opts.preValidation = opts.preValidation.bind(_fastify)
+        }
+      }
+    }
+
+    if (typeof opts === 'function') {
+      handler = opts
+      opts = undefined
+    }
+    opts = opts || {}
+
+    if (handler) {
+      this[kFourOhFourLevelInstance][kCanSetNotFoundHandler] = false
+      handler = handler.bind(this)
+    } else {
+      handler = basic404
+    }
+
+    this.after((notHandledErr, done) => {
+      _setNotFoundHandler.call(this, prefix, opts, handler)
+      done(notHandledErr)
+    })
+  }
+}
+
+module.exports = fourOhFour

--- a/lib/fourOhFour.js
+++ b/lib/fourOhFour.js
@@ -15,7 +15,6 @@ const {
   kBodyLimit,
   kLogLevel,
   kFourOhFourContext,
-  kFourOhFour,
   kMiddlewares,
   kHooks
 } = require('./symbols.js')
@@ -53,8 +52,8 @@ function fourOhFour (options) {
     reply.code(404).send(new Error('Not Found'))
   }
 
-  function setContext (context) {
-    const _404Context = Object.assign({}, this[kFourOhFourContext])
+  function setContext (instance, context) {
+    const _404Context = Object.assign({}, instance[kFourOhFourContext])
     _404Context.onSend = context.onSend
     context[kFourOhFourContext] = _404Context
   }
@@ -160,8 +159,8 @@ function fourOhFour (options) {
 
     this[kFourOhFourLevelInstance][kFourOhFourContext] = context
 
-    this[kFourOhFourLevelInstance][kFourOhFour].router.all(prefix + (prefix.endsWith('/') ? '*' : '/*'), routeHandler, context)
-    this[kFourOhFourLevelInstance][kFourOhFour].router.all(prefix || '/', routeHandler, context)
+    router.all(prefix + (prefix.endsWith('/') ? '*' : '/*'), routeHandler, context)
+    router.all(prefix || '/', routeHandler, context)
   }
 
   function fourOhFourFallBack (req, res) {

--- a/lib/fourOhFour.js
+++ b/lib/fourOhFour.js
@@ -28,7 +28,9 @@ const { beforeHandlerWarning } = require('./warnings')
  * kFourOhFour: the singleton instance of this 404 module
  * kFourOhFourContext: the context in the reply object where the handler will be executed
  */
-function fourOhFour ({ logger, modifyCoreObjects, genReqId }) {
+function fourOhFour (options) {
+  const { logger, modifyCoreObjects, genReqId } = options
+
   // 404 router, used for handling encapsulated 404 handlers
   const router = FindMyWay({ defaultRoute: fourOhFourFallBack })
 

--- a/lib/fourOhFour.js
+++ b/lib/fourOhFour.js
@@ -36,13 +36,20 @@ function fourOhFour (logger, modifyCoreObjects, genReqId) {
 
   const fof = {
     router,
-    setNotFoundHandler: setNotFoundHandler
+    setNotFoundHandler: setNotFoundHandler,
+    setContext: setContext
   }
 
   return fof
 
   function basic404 (req, reply) {
     reply.code(404).send(new Error('Not Found'))
+  }
+
+  function setContext (context) {
+    const _404Context = Object.assign({}, this[kFourOhFourContext])
+    _404Context.onSend = context.onSend
+    context[kFourOhFourContext] = _404Context
   }
 
   // TODO: remove duplicated

--- a/lib/fourOhFour.js
+++ b/lib/fourOhFour.js
@@ -17,17 +17,7 @@ const {
   kFourOhFourContext,
   kFourOhFour,
   kMiddlewares,
-  // kBodyLimit,
-  // kRoutePrefix,
-  // kLogLevel,
   kHooks
-  // kContentTypeParser,
-  // kReply,
-  // kRequest,
-  // kMiddlewares,
-  // kCanSetNotFoundHandler,
-  // kFourOhFourLevelInstance
-  // kFourOhFourContext
 } = require('./symbols.js')
 
 function fourOhFour (logger, modifyCoreObjects, genReqId) {
@@ -37,10 +27,15 @@ function fourOhFour (logger, modifyCoreObjects, genReqId) {
   const fof = {
     router,
     setNotFoundHandler: setNotFoundHandler,
-    setContext: setContext
+    setContext: setContext,
+    updateInstance: updateInstance
   }
 
   return fof
+
+  function updateInstance (instance) {
+    this[kFourOhFourLevelInstance] = instance
+  }
 
   function basic404 (req, reply) {
     reply.code(404).send(new Error('Not Found'))

--- a/lib/fourOhFour.js
+++ b/lib/fourOhFour.js
@@ -21,6 +21,13 @@ const {
 } = require('./symbols.js')
 const { beforeHandlerWarning } = require('./warnings')
 
+/**
+ * Each fastify instance have a:
+ * kFourOhFourLevelInstance: point to a fastify instance that has the 404 handler setted
+ * kCanSetNotFoundHandler: bool to track if the 404 handler has alredy been set
+ * kFourOhFour: the singleton instance of this 404 module
+ * kFourOhFourContext: the context in the reply object where the handler will be executed
+ */
 function fourOhFour ({ logger, modifyCoreObjects, genReqId }) {
   // 404 router, used for handling encapsulated 404 handlers
   const router = FindMyWay({ defaultRoute: fourOhFourFallBack })
@@ -29,12 +36,13 @@ function fourOhFour ({ logger, modifyCoreObjects, genReqId }) {
     router,
     setNotFoundHandler: setNotFoundHandler,
     setContext: setContext,
-    updateInstance: updateInstance
+    arrange404: arrange404
   }
 
   return fof
 
-  function updateInstance (instance) {
+  function arrange404 (instance) {
+    // Change the pointer of the fastify instance to itself, so register + prefix can add new 404 handler
     instance[kFourOhFourLevelInstance] = instance
     instance[kCanSetNotFoundHandler] = true
   }
@@ -150,8 +158,8 @@ function fourOhFour ({ logger, modifyCoreObjects, genReqId }) {
 
     this[kFourOhFourLevelInstance][kFourOhFourContext] = context
 
-    this[kFourOhFour].router.all(prefix + (prefix.endsWith('/') ? '*' : '/*'), routeHandler, context)
-    this[kFourOhFour].router.all(prefix || '/', routeHandler, context)
+    this[kFourOhFourLevelInstance][kFourOhFour].router.all(prefix + (prefix.endsWith('/') ? '*' : '/*'), routeHandler, context)
+    this[kFourOhFourLevelInstance][kFourOhFour].router.all(prefix || '/', routeHandler, context)
   }
 
   function fourOhFourFallBack (req, res) {

--- a/lib/fourOhFour.js
+++ b/lib/fourOhFour.js
@@ -20,7 +20,7 @@ const {
   kHooks
 } = require('./symbols.js')
 
-function fourOhFour (logger, modifyCoreObjects, genReqId) {
+function fourOhFour ({ logger, modifyCoreObjects, genReqId }) {
   // 404 router, used for handling encapsulated 404 handlers
   const router = FindMyWay({ defaultRoute: fourOhFourFallBack })
 
@@ -34,7 +34,8 @@ function fourOhFour (logger, modifyCoreObjects, genReqId) {
   return fof
 
   function updateInstance (instance) {
-    this[kFourOhFourLevelInstance] = instance
+    instance[kFourOhFourLevelInstance] = instance
+    instance[kCanSetNotFoundHandler] = true
   }
 
   function basic404 (req, reply) {
@@ -55,6 +56,14 @@ function fourOhFour (logger, modifyCoreObjects, genReqId) {
   }
 
   function setNotFoundHandler (opts, handler, avvio, routeHandler, buildMiddie) {
+    // First initialization of the fastify root instance
+    if (this[kCanSetNotFoundHandler] === undefined) {
+      this[kCanSetNotFoundHandler] = true
+    }
+    if (this[kFourOhFourContext] === undefined) {
+      this[kFourOhFourContext] = null
+    }
+
     const _fastify = this
     const prefix = this[kRoutePrefix] || '/'
 

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -12,6 +12,7 @@ const keys = {
   kRequest: Symbol('fastify.Request'),
   kMiddlewares: Symbol('fastify.middlewares'),
   kCanSetNotFoundHandler: Symbol('fastify.canSetNotFoundHandler'),
+  kFourOhFour: Symbol('fastify.404'),
   kFourOhFourLevelInstance: Symbol('fastify.404LogLevelInstance'),
   kFourOhFourContext: Symbol('fastify.404ContextKey'),
   kDefaultJsonParse: Symbol('fastify.defaultJSONParse'),

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports.beforeHandlerWarning = function beforeHandlerWarning () {
+  if (beforeHandlerWarning.called) return
+  beforeHandlerWarning.called = true
+  process.emitWarning('The route option `beforeHandler` has been deprecated, use `preHandler` instead')
+}


### PR DESCRIPTION
Relates to #1475 
Opening this draft to get little feedback: are ok to move all these functions?

For now, I have only moved the 404 functions from `fastify.js` to `fourOhFour.js` without editing too much the code (all works thanks to `.call(rightContext` )

I think I should extract also a `warning.js` that must emit the `process.emitWarning`

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
