### PR TITLE
Document `genReqId` being called even when 'request-id' header is supplied

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -179,9 +179,11 @@ Especially in distributed systems, you may want to override the default id gener
 ```js
 let i = 0
 const fastify = require('fastify')({
-  genReqId: function (req) { return i++ }
+  genReqId: function (req) { return req.headers['request-id'] || i++ }
 })
 ```
+
+**Note: genReqId will be called even when the 'request-id' header is supplied. It is possible to default to that value if provided before generating a new value, as per the example above.**
 
 <a name="factory-trust-proxy"></a>
 ### `trustProxy`


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] documentation is changed or added

This is a quickfix for documentation not describing how to use genReqId with the 'request-id' header is supplied.
