### PR TITLE
Docs: Update Server#logger to discuss custom logger option

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -116,6 +116,27 @@ are not present on the object, they will be added accordingly:
         ```
       Any user supplied serializer will override the default serializer of the
       corresponding property.
++ `loggerInstance`: a custom logger instance. The logger must conform to the Pino 
+interface by having the following methods: `info`, `error`, `debug`, `fatal`, `warn`, `trace`, `child`. For example:
+  ```js
+  const pino = require('pino')();
+  
+  const customLogger = {
+    info: function (o, ...n) {},
+    warn: function (o, ...n) {},
+    error: function (o, ...n) {},
+    fatal: function (o, ...n) {},
+    trace: function (o, ...n) {},
+    debug: function (o, ...n) {},
+    child: function() {
+      const child = Object.create(this);
+      child.pino = pino.child(...arguments);
+      return child;
+    },
+  };
+  
+  const fastify = require('fastify')({logger: customLogger});
+  ```
 
 <a name="custom-http-server"></a>
 ### `serverFactory`


### PR DESCRIPTION
Added a fourth option under server logging discussing a custom logger. Closes #1542.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
