### PR TITLE
Fix typo in Hooks.md

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -268,7 +268,7 @@ You are able to hook into the application-lifecycle as well. It's important to n
 
 - `'onClose'`
 - `'onRoute'`
-- `'onRegister''`
+- `'onRegister'`
 
 <a name="on-close"></a>
 **'onClose'**<br>


### PR DESCRIPTION
Hey guys!
Just fixed a small typo :)

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
