### PR TITLE
use a cache for Ajv compiled schemas

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -252,6 +252,9 @@ function build (options) {
   fastify.setNotFoundHandler()
   fourOhFour.arrange404(fastify)
 
+  const schemaCache = new Map()
+  schemaCache.put = schemaCache.set
+
   return fastify
 
   // HTTP request entry point, the routing has already been executed
@@ -473,7 +476,7 @@ function build (options) {
         try {
           if (opts.schemaCompiler == null && this[kSchemaCompiler] == null) {
             const externalSchemas = this[kSchemas].getJsonSchemas({ onlyAbsoluteUri: true })
-            this.setSchemaCompiler(buildSchemaCompiler(externalSchemas))
+            this.setSchemaCompiler(buildSchemaCompiler(externalSchemas, schemaCache))
           }
 
           buildSchema(context, opts.schemaCompiler || this[kSchemaCompiler], this[kSchemas])

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -144,14 +144,15 @@ function schemaErrorsText (errors, dataVar) {
   return text.slice(0, -separator.length)
 }
 
-function buildSchemaCompiler (externalSchemas) {
+function buildSchemaCompiler (externalSchemas, cache) {
   // This instance of Ajv is private
   // it should not be customized or used
   const ajv = new Ajv({
     coerceTypes: true,
     useDefaults: true,
     removeAdditional: true,
-    allErrors: true
+    allErrors: true,
+    cache
   })
 
   if (Array.isArray(externalSchemas)) {


### PR DESCRIPTION
Adding a shared cache between all Ajv instances is going to speed up
external schemas compilation.

See #1597 for more details

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
