### PR TITLE
Hooks: throw on incorrect async function

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -25,11 +25,6 @@ const {
   kOptions,
   kGlobalHooks
 } = require('./lib/symbols.js')
-const {
-  codes: {
-    FST_ERR_HOOK_INVALID_FUNCTION
-  }
-} = require('./lib/errors')
 
 const { createServer } = require('./lib/server')
 const Reply = require('./lib/reply')
@@ -590,13 +585,14 @@ function build (options) {
   function addHook (name, fn) {
     throwIfAlreadyStarted('Cannot call "addHook" when fastify instance is already started!')
 
+    // TODO: v3 instead of log a warning, throw an error
     if (name === 'onSend' || name === 'preSerialization') {
       if (fn.constructor.name === 'AsyncFunction' && fn.length === 4) {
-        throw new FST_ERR_HOOK_INVALID_FUNCTION()
+        fastify.log.warn(`Async function has too many arguments. Async hooks should not use the 'next' argument.`)
       }
     } else {
       if (fn.constructor.name === 'AsyncFunction' && fn.length === 3) {
-        throw new FST_ERR_HOOK_INVALID_FUNCTION()
+        fastify.log.warn(`Async function has too many arguments. Async hooks should not use the 'next' argument.`)
       }
     }
 

--- a/fastify.js
+++ b/fastify.js
@@ -25,6 +25,11 @@ const {
   kOptions,
   kGlobalHooks
 } = require('./lib/symbols.js')
+const {
+  codes: {
+    FST_ERR_HOOK_INVALID_FUNCTION
+  }
+} = require('./lib/errors')
 
 const { createServer } = require('./lib/server')
 const Reply = require('./lib/reply')
@@ -584,6 +589,16 @@ function build (options) {
   // wrapper that we expose to the user for hooks handling
   function addHook (name, fn) {
     throwIfAlreadyStarted('Cannot call "addHook" when fastify instance is already started!')
+
+    if (name === 'onSend' || name === 'preSerialization') {
+      if (fn.constructor.name === 'AsyncFunction' && fn.length === 4) {
+        throw new FST_ERR_HOOK_INVALID_FUNCTION()
+      }
+    } else {
+      if (fn.constructor.name === 'AsyncFunction' && fn.length === 3) {
+        throw new FST_ERR_HOOK_INVALID_FUNCTION()
+      }
+    }
 
     if (name === 'onClose') {
       this[kHooks].validate(name, fn)

--- a/fastify.js
+++ b/fastify.js
@@ -588,11 +588,11 @@ function build (options) {
     // TODO: v3 instead of log a warning, throw an error
     if (name === 'onSend' || name === 'preSerialization') {
       if (fn.constructor.name === 'AsyncFunction' && fn.length === 4) {
-        fastify.log.warn(`Async function has too many arguments. Async hooks should not use the 'next' argument.`)
+        fastify.log.warn(`Async function has too many arguments. Async hooks should not use the 'next' argument.`, new Error().stack)
       }
     } else {
       if (fn.constructor.name === 'AsyncFunction' && fn.length === 3) {
-        fastify.log.warn(`Async function has too many arguments. Async hooks should not use the 'next' argument.`)
+        fastify.log.warn(`Async function has too many arguments. Async hooks should not use the 'next' argument.`, new Error().stack)
       }
     }
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -33,7 +33,6 @@ createError('FST_ERR_DEC_MISSING_DEPENDENCY', `The decorator is missing dependen
 */
 createError('FST_ERR_HOOK_INVALID_TYPE', `The hook name must be a string`, 500, TypeError)
 createError('FST_ERR_HOOK_INVALID_HANDLER', `The hook callback must be a function`, 500, TypeError)
-createError('FST_ERR_HOOK_INVALID_FUNCTION', `Async function has too many arguments. Async hooks should not use the `next` argument.`, 500, TypeError)
 
 /**
  * logger

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -33,7 +33,7 @@ createError('FST_ERR_DEC_MISSING_DEPENDENCY', `The decorator is missing dependen
 */
 createError('FST_ERR_HOOK_INVALID_TYPE', `The hook name must be a string`, 500, TypeError)
 createError('FST_ERR_HOOK_INVALID_HANDLER', `The hook callback must be a function`, 500, TypeError)
-createError('FST_ERR_HOOK_INVALID_FUNCTION', `You are using an async function with three arguments, 'next' is not needed.`, 500, TypeError)
+createError('FST_ERR_HOOK_INVALID_FUNCTION', `Async function has too many arguments. Async hooks should not use the `next` argument.`, 500, TypeError)
 
 /**
  * logger

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -33,6 +33,7 @@ createError('FST_ERR_DEC_MISSING_DEPENDENCY', `The decorator is missing dependen
 */
 createError('FST_ERR_HOOK_INVALID_TYPE', `The hook name must be a string`, 500, TypeError)
 createError('FST_ERR_HOOK_INVALID_HANDLER', `The hook callback must be a function`, 500, TypeError)
+createError('FST_ERR_HOOK_INVALID_FUNCTION', `You are using an async function with three arguments, 'next' is not needed.`, 500, TypeError)
 
 /**
  * logger

--- a/test/hooks-async.js
+++ b/test/hooks-async.js
@@ -433,7 +433,7 @@ function asyncHookTest (t) {
 
   test('Should throw if is an async function with `next`', t => {
     t.test('3 arguments', t => {
-      t.plan(2)
+      t.plan(3)
       const stream = split(JSON.parse)
       const fastify = Fastify({
         logger: { stream }
@@ -441,14 +441,15 @@ function asyncHookTest (t) {
 
       stream.on('data', line => {
         t.strictEqual(line.level, 40)
-        t.strictEqual(line.msg, `Async function has too many arguments. Async hooks should not use the 'next' argument.`)
+        t.true(line.msg.startsWith(`Async function has too many arguments. Async hooks should not use the 'next' argument.`))
+        t.true(/test\/hooks-async\.js/.test(line.msg))
       })
 
       fastify.addHook('onRequest', async (req, reply, next) => {})
     })
 
     t.test('4 arguments', t => {
-      t.plan(4)
+      t.plan(6)
       const stream = split(JSON.parse)
       const fastify = Fastify({
         logger: { stream }
@@ -456,7 +457,8 @@ function asyncHookTest (t) {
 
       stream.on('data', line => {
         t.strictEqual(line.level, 40)
-        t.strictEqual(line.msg, `Async function has too many arguments. Async hooks should not use the 'next' argument.`)
+        t.true(line.msg.startsWith(`Async function has too many arguments. Async hooks should not use the 'next' argument.`))
+        t.true(/test\/hooks-async\.js/.test(line.msg))
       })
 
       fastify.addHook('onSend', async (req, reply, payload, next) => {})

--- a/test/hooks-async.js
+++ b/test/hooks-async.js
@@ -431,7 +431,7 @@ function asyncHookTest (t) {
     })
   })
 
-  test('Should throw if is an async function with `next`', t => {
+  test('Should log a warning if is an async function with `next`', t => {
     t.test('3 arguments', t => {
       t.plan(3)
       const stream = split(JSON.parse)

--- a/test/hooks-async.js
+++ b/test/hooks-async.js
@@ -442,7 +442,7 @@ function asyncHookTest (t) {
       stream.on('data', line => {
         t.strictEqual(line.level, 40)
         t.true(line.msg.startsWith(`Async function has too many arguments. Async hooks should not use the 'next' argument.`))
-        t.true(/test\/hooks-async\.js/.test(line.msg))
+        t.true(/test(\\|\/)hooks-async\.js/.test(line.msg))
       })
 
       fastify.addHook('onRequest', async (req, reply, next) => {})

--- a/test/hooks-async.js
+++ b/test/hooks-async.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const split = require('split2')
 const sget = require('simple-get').concat
 const Fastify = require('..')
 const fs = require('fs')
@@ -431,34 +432,35 @@ function asyncHookTest (t) {
   })
 
   test('Should throw if is an async function with `next`', t => {
-    const fastify = Fastify()
-
     t.test('3 arguments', t => {
-      try {
-        fastify.addHook('onRequest', async (req, reply, next) => {})
-        t.fail('Should throw')
-      } catch (err) {
-        t.is(err.code, 'FST_ERR_HOOK_INVALID_FUNCTION')
-      }
-      t.end()
+      t.plan(2)
+      const stream = split(JSON.parse)
+      const fastify = Fastify({
+        logger: { stream }
+      })
+
+      stream.on('data', line => {
+        t.strictEqual(line.level, 40)
+        t.strictEqual(line.msg, `Async function has too many arguments. Async hooks should not use the 'next' argument.`)
+      })
+
+      fastify.addHook('onRequest', async (req, reply, next) => {})
     })
 
     t.test('4 arguments', t => {
-      try {
-        fastify.addHook('onSend', async (req, reply, payload, next) => {})
-        t.fail('Should throw')
-      } catch (err) {
-        t.is(err.code, 'FST_ERR_HOOK_INVALID_FUNCTION')
-      }
+      t.plan(4)
+      const stream = split(JSON.parse)
+      const fastify = Fastify({
+        logger: { stream }
+      })
 
-      try {
-        fastify.addHook('preSerialization', async (req, reply, payload, next) => {})
-        t.fail('Should throw')
-      } catch (err) {
-        t.is(err.code, 'FST_ERR_HOOK_INVALID_FUNCTION')
-      }
+      stream.on('data', line => {
+        t.strictEqual(line.level, 40)
+        t.strictEqual(line.msg, `Async function has too many arguments. Async hooks should not use the 'next' argument.`)
+      })
 
-      t.end()
+      fastify.addHook('onSend', async (req, reply, payload, next) => {})
+      fastify.addHook('preSerialization', async (req, reply, payload, next) => {})
     })
 
     t.end()

--- a/test/hooks-async.js
+++ b/test/hooks-async.js
@@ -429,6 +429,40 @@ function asyncHookTest (t) {
       t.is(res.statusCode, 200)
     })
   })
+
+  test('Should throw if is an async function with `next`', t => {
+    const fastify = Fastify()
+
+    t.test('3 arguments', t => {
+      try {
+        fastify.addHook('onRequest', async (req, reply, next) => {})
+        t.fail('Should throw')
+      } catch (err) {
+        t.ok(err.code, 'FST_ERR_HOOK_INVALID_FUNCTION')
+      }
+      t.end()
+    })
+
+    t.test('4 arguments', t => {
+      try {
+        fastify.addHook('onSend', async (req, reply, payload, next) => {})
+        t.fail('Should throw')
+      } catch (err) {
+        t.ok(err.code, 'FST_ERR_HOOK_INVALID_FUNCTION')
+      }
+
+      try {
+        fastify.addHook('preSerialization', async (req, reply, payload, next) => {})
+        t.fail('Should throw')
+      } catch (err) {
+        t.ok(err.code, 'FST_ERR_HOOK_INVALID_FUNCTION')
+      }
+
+      t.end()
+    })
+
+    t.end()
+  })
 }
 
 module.exports = asyncHookTest

--- a/test/hooks-async.js
+++ b/test/hooks-async.js
@@ -458,7 +458,7 @@ function asyncHookTest (t) {
       stream.on('data', line => {
         t.strictEqual(line.level, 40)
         t.true(line.msg.startsWith(`Async function has too many arguments. Async hooks should not use the 'next' argument.`))
-        t.true(/test\/hooks-async\.js/.test(line.msg))
+        t.true(/test(\\|\/)hooks-async\.js/.test(line.msg))
       })
 
       fastify.addHook('onSend', async (req, reply, payload, next) => {})

--- a/test/hooks-async.js
+++ b/test/hooks-async.js
@@ -438,7 +438,7 @@ function asyncHookTest (t) {
         fastify.addHook('onRequest', async (req, reply, next) => {})
         t.fail('Should throw')
       } catch (err) {
-        t.ok(err.code, 'FST_ERR_HOOK_INVALID_FUNCTION')
+        t.is(err.code, 'FST_ERR_HOOK_INVALID_FUNCTION')
       }
       t.end()
     })
@@ -448,14 +448,14 @@ function asyncHookTest (t) {
         fastify.addHook('onSend', async (req, reply, payload, next) => {})
         t.fail('Should throw')
       } catch (err) {
-        t.ok(err.code, 'FST_ERR_HOOK_INVALID_FUNCTION')
+        t.is(err.code, 'FST_ERR_HOOK_INVALID_FUNCTION')
       }
 
       try {
         fastify.addHook('preSerialization', async (req, reply, payload, next) => {})
         t.fail('Should throw')
       } catch (err) {
-        t.ok(err.code, 'FST_ERR_HOOK_INVALID_FUNCTION')
+        t.is(err.code, 'FST_ERR_HOOK_INVALID_FUNCTION')
       }
 
       t.end()


### PR DESCRIPTION
As titled.

> Wild idea: check at startup if is an async function and the arity, and if it is an async function with 3 arguments, throw an error.

Ref: https://github.com/fastify/fastify/issues/1593

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
