### PR TITLE
Add fastify-feature-flags plugin

### DIFF
--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -60,6 +60,7 @@ Plugins maintained by the fastify team are listed under [Core](#core) while plug
 - [`fastify-dynamodb`](https://github.com/matrus2/fastify-dynamodb) AWS DynamoDB plugin for Fastify. It exposes [AWS.DynamoDB.DocumentClient()](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html) object.
 - [`fastify-error-page`](https://github.com/hemerajs/fastify-error-page) Fastify plugin to print errors in structured HTML to the browser.
 - [`fastify-favicon`](https://github.com/smartiniOnGitHub/fastify-favicon) Fastify plugin to serve default favicon.
+- [`fastify-feature-flags`](https://gitlab.com/m03geek/fastify-feature-flags) Fastify feature flags plugin with multiple providers support (e.g. env, [config](http://lorenwest.github.io/node-config/), [unleash](https://unleash.github.io/)).
 - [`fastify-file-upload`](https://github.com/huangang/fastify-file-upload) Fastify plugin for uploading files.
 - [`fastify-firebase-auth`](https://github.com/oxsav/fastify-firebase-auth) Firebase Authentication for Fastify supporting all of the methods relating to the authentication API.
 - [`fastify-firestore`](https://github.com/now-ims/fastify-firestore) Fastify plugin for [Google Cloud Firestore](https://cloud.google.com/nodejs/docs/reference/firestore/0.13.x/).


### PR DESCRIPTION
Fastify-feature-flags plugin provides users simple interface to configure their features. It supports multiple providers starting from simple one - env provider, which reads configuration from env variables. Also it supports more enterprise-ready solutions like unleash - feature flags service that allows more complex configuration. Also it provides generic interface that could be extended in order to create new feature config providers.

This plugin could be useful for A-B testing, rolling releases of features, etc.