### PR TITLE
Minor host binding documentation rewrite

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -79,7 +79,7 @@ Fastify offers an easy platform that helps solve all of problems, and more.
 >
 > Similarly, specify `::1` to accept only local connections via IPv6. Or specify `::` to accept connections on all IPv6 addresses, and, if the operating system supports it, also on all IPv4 addresses.
 >
-> When deploying to a Docker, or other type of, container this would be the easiest method for exposing the application.
+> When deploying to a Docker (or other type of) container using `0.0.0.0` or `::` would be the easiest method for exposing the application.
 
 <a name="first-plugin"></a>
 ### Your first plugin


### PR DESCRIPTION
The previous version of the documentation didn’t make it clear that the correct approach in containerized environments is to bind to `::` or `0.0.0.0`.

#### Checklist

- [ ] ~~run `npm run test` and `npm run benchmark`~~ Not Applicable
- [ ] ~~tests and/or benchmarks are included~~ Not Applicable
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
