### PR TITLE
Use secure-json-parse

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const lru = require('tiny-lru')
-const Bourne = require('bourne')
+const secureJson = require('secure-json-parse')
 const {
   kDefaultJsonParse,
   kContentTypeParser,
@@ -198,7 +198,7 @@ function getDefaultJsonParser (onProtoPoisoning) {
     }
 
     try {
-      var json = Bourne.parse(body, { protoAction: onProtoPoisoning })
+      var json = secureJson.parse(body, { protoAction: onProtoPoisoning })
     } catch (err) {
       err.statusCode = 400
       return done(err, undefined)

--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
     "abstract-logging": "^1.0.0",
     "ajv": "^6.9.2",
     "avvio": "^6.1.1",
-    "bourne": "^1.1.2",
     "fast-json-stringify": "^1.15.0",
     "find-my-way": "^2.0.0",
     "flatstr": "^1.0.9",
@@ -144,6 +143,7 @@
     "proxy-addr": "^2.0.4",
     "readable-stream": "^3.1.1",
     "rfdc": "^1.1.2",
+    "secure-json-parse": "^1.0.0",
     "tiny-lru": "^6.0.1"
   },
   "greenkeeper": {


### PR DESCRIPTION
As titled.
You can find the library code in https://github.com/fastify/secure-json-parse.

Main reasons:
- We need to support Node.js v6.
- The new Hapi licensing strategy may cause issues in the future.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)