### PR TITLE
docs: fix a broken anchor tag in Logging page

### DIFF
--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -55,7 +55,7 @@ const fastify = require('fastify')({
 })
 ```
 
-<a name="logging-request-id" />
+<a name="logging-request-id"></a>
 
 By default fastify adds an id to every request for easier tracking. If the "request-id" header is present its value is used, otherwise a new incremental id is generated. See Fastify Factory [`requestIdHeader`](https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-request-id-header) and Fastify Factory [`genReqId`](https://github.com/fastify/fastify/blob/master/docs/Server.md#gen-request-id) for customization options.
 


### PR DESCRIPTION
An anchor tag is broken in this page.
https://www.fastify.io/docs/latest/Logging/

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
