### PR TITLE
Add option to disable request start and end logging

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -148,6 +148,19 @@ custom `onRequest` and `onResponse` hooks.
 
 + Default: `false`
 
+```js
+// Examples of hooks to replicate the disabled functionality.
+fastify.addHook('onRequest', (req, reply, next) => {
+  req.log.info({ url: req.req.url, id: req.id }, 'received request')
+  next()
+})
+
+fastify.addHook('onResponse', (req, reply, next) => {
+  req.log.info({ url: req.req.originalUrl, statusCode: res.res.statusCode }, 'request completed')
+  next()
+})
+```
+
 <a name="custom-http-server"></a>
 ### `serverFactory`
 You can pass a custom http server to Fastify by using the `serverFactory` option.<br/>

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -116,11 +116,11 @@ are not present on the object, they will be added accordingly:
         ```
       Any user supplied serializer will override the default serializer of the
       corresponding property.
-+ `loggerInstance`: a custom logger instance. The logger must conform to the Pino 
++ `loggerInstance`: a custom logger instance. The logger must conform to the Pino
 interface by having the following methods: `info`, `error`, `debug`, `fatal`, `warn`, `trace`, `child`. For example:
   ```js
   const pino = require('pino')();
-  
+
   const customLogger = {
     info: function (o, ...n) {},
     warn: function (o, ...n) {},
@@ -134,9 +134,19 @@ interface by having the following methods: `info`, `error`, `debug`, `fatal`, `w
       return child;
     },
   };
-  
+
   const fastify = require('fastify')({logger: customLogger});
   ```
+
+<a name="factory-disable-request-logging"></a>
+### `disableRequestLogging`
+By default, when logging is enabled, Fastify will issue an `info` level log
+message when a request is received and when the response for that request has
+been sent. By setting this option to `true`, these log messages will be disabled.
+This allows for more flexible request start and end logging by attaching
+custom `onRequest` and `onResponse` hooks.
+
++ Default: `false`
 
 <a name="custom-http-server"></a>
 ### `serverFactory`

--- a/lib/configValidator.js
+++ b/lib/configValidator.js
@@ -14,6 +14,7 @@ var validate = (function() {
     if ((data && typeof data === "object" && !Array.isArray(data))) {
       if (data.bodyLimit === undefined) data.bodyLimit = 1048576;
       if (data.caseSensitive === undefined) data.caseSensitive = true;
+      if (data.disableRequestLogging === undefined) data.disableRequestLogging = false;
       if (data.ignoreTrailingSlash === undefined) data.ignoreTrailingSlash = false;
       if (data.maxParamLength === undefined) data.maxParamLength = 100;
       if (data.onProtoPoisoning === undefined) data.onProtoPoisoning = "error";
@@ -506,6 +507,10 @@ validate.schema = {
         "setDefaultValue": true
       }
     },
+    "disableRequestLogging": {
+      "type": "boolean",
+      "default": false
+    },
     "ignoreTrailingSlash": {
       "type": "boolean",
       "default": false
@@ -540,4 +545,14 @@ function customRule0 (schemaParamValue, validatedParamValue, validationSchemaObj
   return true
 }
 
-module.exports.defaultInitOptions = {"bodyLimit":1048576,"caseSensitive":true,"ignoreTrailingSlash":false,"maxParamLength":100,"onProtoPoisoning":"error","pluginTimeout":10000,"requestIdHeader":"request-id","requestIdLogLabel":"reqId"}
+module.exports.defaultInitOptions = {
+  "bodyLimit":1048576,
+  "caseSensitive":true,
+  "disableRequestLogging": false,
+  "ignoreTrailingSlash":false,
+  "maxParamLength":100,
+  "onProtoPoisoning":"error",
+  "pluginTimeout":10000,
+  "requestIdHeader":"request-id",
+  "requestIdLogLabel":"reqId"
+}

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -14,7 +14,8 @@ const {
   kReplyIsError,
   kReplyHeaders,
   kReplyHasStatusCode,
-  kReplyIsRunningOnErrorHook
+  kReplyIsRunningOnErrorHook,
+  kDisableRequestLogging
 } = require('./symbols.js')
 const { hookRunner, onSendHookRunner } = require('./hooks')
 const validation = require('./validation')
@@ -456,6 +457,9 @@ function onResponseIterator (fn, request, reply, next) {
 }
 
 function onResponseCallback (err, request, reply) {
+  if (reply.log[kDisableRequestLogging]) {
+    return
+  }
   var responseTime = 0
 
   if (reply[kReplyStartTime] !== undefined) {

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -28,7 +28,8 @@ const keys = {
   kReplyIsRunningOnErrorHook: Symbol('fastify.reply.isRunningOnErrorHook'),
   kState: Symbol('fastify.state'),
   kOptions: Symbol('fastify.options'),
-  kGlobalHooks: Symbol('fastify.globalHooks')
+  kGlobalHooks: Symbol('fastify.globalHooks'),
+  kDisableRequestLogging: Symbol('fastify.disableRequestLogging')
 }
 
 module.exports = keys

--- a/test/internals/initialConfig.test.js
+++ b/test/internals/initialConfig.test.js
@@ -21,6 +21,7 @@ test('without options passed to Fastify, initialConfig should expose default val
   const fastifyDefaultOptions = {
     bodyLimit: 1024 * 1024,
     caseSensitive: true,
+    disableRequestLogging: false,
     ignoreTrailingSlash: false,
     maxParamLength: 100,
     onProtoPoisoning: 'error',
@@ -223,6 +224,7 @@ test('Should not have issues when passing stream options to Pino.js', t => {
     t.deepEqual(fastify.initialConfig, {
       bodyLimit: 1024 * 1024,
       caseSensitive: true,
+      disableRequestLogging: false,
       ignoreTrailingSlash: true,
       maxParamLength: 100,
       onProtoPoisoning: 'error',


### PR DESCRIPTION
This addresses issue #1624. Instead of attempting to pass along a limited set of information such that it can be logged at the end of the request, which would lead to a never ending "I need this info there" path, this PR adds an option to disable the initial and final request logs. The result is you can attach your own `onRequest` and `onResponse` hooks to log the information you need and not get double log messages due to the enforced logging in Fastify.

#### Checklist

- [x] run `npm run test` ~and `npm run benchmark`~
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
