### PR TITLE
docs(reply): clarify settings headers

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -77,7 +77,7 @@ For more information, see [`http.ServerResponse#setHeader`](https://nodejs.org/d
 ### .getHeader(key)
 Retrieves the value of a previously set header.
 ```js
-reply.header('x-foo', 'foo')
+reply.header('x-foo', 'foo') // setHeader: key, value
 reply.getHeader('x-foo') // 'foo'
 ```
 


### PR DESCRIPTION
### Description:

I've had some issues drawing the connection from `header` to nodes-`setHeader`, especially as the link to node.js

So hopefully this small comment will make things more clear for people browsing the docs searching how to modify a header