### PR TITLE
add tap into greenkeeper ignore list

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
       "boom",
       "joi",
       "@types/node",
+      "tap",
       "tap-mocha-reporter"
     ]
   },


### PR DESCRIPTION
As discussed in [PR-1618](https://github.com/fastify/fastify/pull/1618), this is the change for adding Tap to GreenKeeper ignore list.

Bye
