### PR TITLE
fix(types): fix register options

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -280,7 +280,7 @@ declare namespace fastify {
   /**
    * Register options
    */
-  interface RegisterOptions<HttpServer, HttpRequest, HttpResponse> extends RouteShorthandOptions<HttpServer, HttpRequest, HttpResponse> {
+  interface RegisterOptions<HttpServer, HttpRequest, HttpResponse> {
     [key: string]: any,
     prefix?: string,
   }

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -308,7 +308,7 @@ server
       reply.send({ hello: 'world' })
     })
     done()
-  }, { prefix: 'v1', hello: 'world' })
+  }, { prefix: 'v1', hello: 'world', schema: 'any string' })
   .all('/all/no-opts', function (req, reply) {
     reply.send(req.headers)
   })


### PR DESCRIPTION
This PR fixes types for `register` method. For some reason it extended `RouteShorthandOptions` that contain some fields with declared types that can't be overridden. However any of those options are not directly used as plugin options. Such example could be find in https://github.com/mcollina/fastify-gql/pull/49 where `schema` should be string or graphql schema, however those type extension forcing it to be `RouteSchema`.

Also I left that options as "generic" for backward compatibility until major typescript refactoring will be merged https://github.com/fastify/fastify/pull/1569. There generic could be removed, cause it's not needed.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
