### PR TITLE
Catches onRoute hooks errors

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -456,7 +456,14 @@ function build (options) {
       }
 
       // run 'onRoute' hooks
-      for (const hook of this[kGlobalHooks].onRoute) hook.call(this, opts)
+      for (const hook of this[kGlobalHooks].onRoute) {
+        try {
+          hook.call(this, opts)
+        } catch (error) {
+          done(error)
+          return
+        }
+      }
 
       const config = opts.config || {}
       config.url = url

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -564,6 +564,26 @@ test('onRoute hook should preserve handler function in options of shorthand rout
   })
 })
 
+test('onRoute hook that throws sholud be catched ', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.register((instance, opts, next) => {
+    instance.addHook('onRoute', () => {
+      t.pass()
+      throw new Error('snap')
+    })
+    instance.get('/', opts, function (req, reply) {
+      reply.send()
+    })
+    next()
+  })
+
+  fastify.ready(err => {
+    t.ok(err)
+  })
+})
+
 test('onResponse hook should log request error', t => {
   t.plan(4)
 

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -564,7 +564,7 @@ test('onRoute hook should preserve handler function in options of shorthand rout
   })
 })
 
-test('onRoute hook that throws sholud be catched ', t => {
+test('onRoute hook that throws should be caught ', t => {
   t.plan(2)
   const fastify = Fastify()
 

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -565,12 +565,11 @@ test('onRoute hook should preserve handler function in options of shorthand rout
 })
 
 test('onRoute hook that throws should be caught ', t => {
-  t.plan(2)
+  t.plan(1)
   const fastify = Fastify()
 
   fastify.register((instance, opts, next) => {
     instance.addHook('onRoute', () => {
-      t.pass()
       throw new Error('snap')
     })
     instance.get('/', opts, function (req, reply) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->
Working on https://github.com/fastify/fastify-websocket/pull/26 we discovered that if `onRoute` hook throws it is not caught anywhere. This PR fixes it.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
