### PR TITLE
stricter typings in ServerOptions logger

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -8,6 +8,9 @@ import * as http from 'http'
 import * as http2 from 'http2'
 import * as https from 'https'
 
+import * as pino from 'pino'
+import { Stream } from 'stream'
+
 declare function fastify<
   HttpServer extends (http.Server | http2.Http2Server) = http.Server,
   HttpRequest extends (http.IncomingMessage | http2.Http2ServerRequest) = http.IncomingMessage,
@@ -66,6 +69,7 @@ declare namespace fastify {
     debug(obj: {}, msg?: string, ...args: any[]): void;
     trace(msg: string, ...args: any[]): void;
     trace(obj: {}, msg?: string, ...args: any[]): void;
+    child(...args: Parameters<pino.BaseLogger['child']>): Logger
   }
 
   type FastifyMiddleware<
@@ -183,7 +187,10 @@ declare namespace fastify {
     pluginTimeout?: number,
     disableRequestLogging?: boolean,
     onProtoPoisoning?: 'error' | 'remove' | 'ignore',
-    logger?: any,
+    logger?: boolean
+      | ({ level: keyof Logger, serializers?: typeof pino.stdSerializers }
+          & ({ file: string } | { stream: Stream }))
+      | Logger,
     trustProxy?: string | number | boolean | Array<string> | TrustProxyFunction,
     maxParamLength?: number,
     querystringParser?: (str: string) => { [key: string]: string | string[] },

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
   },
   "devDependencies": {
     "@types/node": "^11.9.3",
+    "@types/pino": "^5.8.7",
     "@typescript-eslint/eslint-plugin": "^1.4.2",
     "@typescript-eslint/parser": "^1.4.2",
     "JSONStream": "^1.3.5",


### PR DESCRIPTION
Hi. I'm using a custom logger in my project, and wanted to adapt it to match Fastify's/Pino's logger interface. I know Fastify validates the custom logger methods at runtime, but I wanted a type safe way to create a bridge between my logger and Fastify's logger interface, so I could have autocomplete in the function arguments, compiler warnings, etc...

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
