### PR TITLE
Removes double call to afterRouteAdded when ignoreTrailingSlash === true

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -45,6 +45,7 @@ function buildRouting (options) {
   let modifyCoreObjects
   let genReqId
   let disableRequestLogging
+  let ignoreTrailingSlash
 
   let closing = false
 
@@ -65,6 +66,7 @@ function buildRouting (options) {
       modifyCoreObjects = options.modifyCoreObjects
       genReqId = options.genReqId
       disableRequestLogging = options.disableRequestLogging
+      ignoreTrailingSlash = options.ignoreTrailingSlash
     },
     routing: router.lookup.bind(router), // router func to find the right handler to call
     route, // configure a route in the fastify instance
@@ -142,7 +144,9 @@ function buildRouting (options) {
           case 'both':
           default:
             afterRouteAdded.call(this, '', notHandledErr, done)
-            afterRouteAdded.call(this, path, notHandledErr, done)
+            if (ignoreTrailingSlash !== true) {
+              afterRouteAdded.call(this, path, notHandledErr, done)
+            }
         }
       } else if (path[0] === '/' && prefix.endsWith('/')) {
         // Ensure that '/prefix/' + '/route' gets registered as '/prefix/route'

--- a/lib/route.js
+++ b/lib/route.js
@@ -144,6 +144,7 @@ function buildRouting (options) {
           case 'both':
           default:
             afterRouteAdded.call(this, '', notHandledErr, done)
+            // If ignoreTrailingSlash is set to true we need to add only the '' route to prevent adding an incomplete one.
             if (ignoreTrailingSlash !== true) {
               afterRouteAdded.call(this, path, notHandledErr, done)
             }

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -459,6 +459,37 @@ test('matches both /prefix and /prefix/  with a / route - prefixTrailingSlash: "
   })
 })
 
+test('returns 404 status code with /prefix/ and / route - prefixTrailingSlash: "both" (default), ignoreTrailingSlash: true', t => {
+  t.plan(2)
+  const fastify = Fastify({
+    ignoreTrailingSlash: true
+  })
+
+  fastify.register(function (fastify, opts, next) {
+    fastify.route({
+      method: 'GET',
+      url: '/',
+      handler: (req, reply) => {
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    next()
+  }, { prefix: '/prefix/' })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/prefix//'
+  }, (err, res) => {
+    t.error(err)
+    t.same(JSON.parse(res.payload), {
+      'error': 'Not Found',
+      'message': 'Not Found',
+      'statusCode': 404
+    })
+  })
+})
+
 test('matches only /prefix  with a / route - prefixTrailingSlash: "no-slash", ignoreTrailingSlash: false', t => {
   t.plan(4)
   const fastify = Fastify({


### PR DESCRIPTION
This PR fixes [1672](https://github.com/fastify/fastify/issues/1672) issue.

The real issue was that an incomplete route (`/prefix//`) was added if `ignoreTrailingSlash === true` and `prefixTrailingSlash: "both"` (default behaviour).  On `/prefix//` route call, the fastify server just crashed.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
