### PR TITLE
Fix http2SecureServer test

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "node": ">=6"
   },
   "devDependencies": {
-    "@types/node": "^11.9.3",
+    "@types/node": "^11.13.12",
     "@typescript-eslint/eslint-plugin": "^1.4.2",
     "@typescript-eslint/parser": "^1.4.2",
     "JSONStream": "^1.3.5",
@@ -127,7 +127,7 @@
     "tap": "^12.5.2",
     "tap-mocha-reporter": "^3.0.7",
     "then-sleep": "^1.0.1",
-    "typescript": "^3.3.3333",
+    "typescript": "^3.5.1",
     "x-xss-protection": "^1.1.0"
   },
   "dependencies": {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -188,7 +188,7 @@ const schema: fastify.RouteSchema = {
   }
 }
 
-const opts: fastify.RouteShorthandOptions<http2.Http2Server, http2.Http2ServerRequest, http2.Http2ServerResponse> = {
+const opts: fastify.RouteShorthandOptions<http2.Http2SecureServer, http2.Http2ServerRequest, http2.Http2ServerResponse> = {
   schema,
   preValidation: [
     (request, reply, next) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

Ref #1678 all branches CI was failing most likely due to a type update in the @types/node library. I've tracked down the error and updated our tests so it passes. The commit should be added to 1.x and next as well (even though next will be getting the full TS refactor very soon).

Can land as a patch