### PR TITLE
Fix http2SecureServer test (1.x branch)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
     "node": ">=6"
   },
   "devDependencies": {
-    "@types/node": "^10.12.26",
     "JSONStream": "^1.3.3",
+    "@types/node": "^11.13.12",
     "autocannon": "^3.2.0",
     "branch-comparer": "^0.4.0",
     "concurrently": "^4.1.0",
@@ -104,10 +104,10 @@
     "serve-static": "^1.13.2",
     "simple-get": "^3.0.2",
     "snazzy": "^8.0.0",
+    "typescript": "^3.5.1",
     "split2": "^3.0.0",
     "standard": "^12.0.0",
     "tap": "^12.5.3",
-    "typescript": "^3.3.3",
     "typescript-eslint-parser": "^20.1.0",
     "x-xss-protection": "^1.1.0"
   },

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -164,7 +164,7 @@ const schema: fastify.RouteSchema = {
   }
 }
 
-const opts: fastify.RouteShorthandOptions<http2.Http2Server, http2.Http2ServerRequest, http2.Http2ServerResponse> = {
+const opts: fastify.RouteShorthandOptions<http2.Http2SecureServer, http2.Http2ServerRequest, http2.Http2ServerResponse> = {
   schema,
   beforeHandler: [
     (request, reply, next) => {
@@ -361,7 +361,7 @@ server.listen(3000, err => {
   if (err) throw err
   const address = server.server.address()
   if (typeof address === 'object') {
-    server.log.info(`server listening on ${address.port}`)
+    server.log.info(`server listening on ${address && address.port}`)
   } else {
     server.log.info(`server listening on ${address}`)
   }


### PR DESCRIPTION
Checklist

- [x] run npm run test and npm run benchmark
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows Code of conduct

Ref #1678 and #1681

all branches CI was failing most likely due to a type update in the @types/node library. I've tracked down the error and updated our tests so it passes.

This PR required an additional change to one of the lines due to 1.x being on an older tsc linting set up

Can land as a patch