### PR TITLE
greenkeeper ignore autocannon

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
   },
   "greenkeeper": {
     "ignore": [
+      "autocannon",
       "boom",
       "joi",
       "@types/node",


### PR DESCRIPTION
#### Checklist

autocannon dropped node 6 and we use it in our tests

Closes #1674 

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
