### PR TITLE
fix: use reply instead of original res

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -27,9 +27,9 @@ function Context (schema, handler, Reply, Request, contentTypeParser, config, er
 function defaultErrorHandler (error, request, reply) {
   var res = reply.res
   if (res.statusCode >= 500) {
-    res.log.error({ req: reply.request.raw, res: res, err: error }, error && error.message)
+    reply.log.error({ req: reply.request.raw, res: res, err: error }, error && error.message)
   } else if (res.statusCode >= 400) {
-    res.log.info({ res: res, err: error }, error && error.message)
+    reply.log.info({ res: res, err: error }, error && error.message)
   }
   reply.send(error)
 }


### PR DESCRIPTION
If the `modifyCoreObject` option is false, the framework is incorrectly referencing `req.log` — which is not available. 

This PR changes the code to use `reply` instead of the raw response object coming from nodejs