### PR TITLE
feature: custom serializator

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -585,6 +585,18 @@ Fake http injection (for testing purposes) [here](https://github.com/fastify/fas
 `fastify.addSchema(schemaObj)`, adds a shared schema to the Fastify instance. This allows you to reuse it everywhere in your application just by writing the schema id that you need.<br/>
 To learn more, see [shared schema example](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#shared-schema) in the [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) documentation.
 
+<a name="set-reply-serializer"></a>
+#### setReplySerializer
+Set the reply serializer for all the routes. This will used as default if a [Reply.serializer(func)](https://github.com/fastify/fastify/blob/master/docs/Reply.md#serializerfunc) has not been set. The handler is fully encapsulated, so different plugins can set different error handlers.
+Note: the function parameter is called only for status `2xx`. Checkout the [`setErrorHandler`](https://github.com/fastify/fastify/blob/master/docs/Server.md#seterrorhandler) for errors.
+
+```js
+fastify.setReplySerializer(function (payload, statusCode){
+  // serialize the payload with a sync function
+  return `my serialized ${statusCode} content: ${payload}`
+})
+```
+
 <a name="set-schema-compiler"></a>
 #### setSchemaCompiler
 Set the schema compiler for all routes [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-compiler).

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -661,6 +661,11 @@ declare namespace fastify {
     setErrorHandler(handler: (error: FastifyError, request: FastifyRequest<HttpRequest>, reply: FastifyReply<HttpResponse>) => void): void
 
     /**
+     * Set a function that will be called whenever an error happens
+     */
+    setReplySerializer(handler: (payload: string | object | Buffer | NodeJS.ReadableStream, statusCode: number) => string): void
+
+    /**
      * Set the schema compiler for all routes.
      */
     setSchemaCompiler(schemaCompiler: SchemaCompiler): FastifyInstance<HttpServer, HttpRequest, HttpResponse>

--- a/fastify.js
+++ b/fastify.js
@@ -13,6 +13,7 @@ const {
   kHooks,
   kSchemas,
   kSchemaCompiler,
+  kReplySerializerDefault,
   kContentTypeParser,
   kReply,
   kRequest,
@@ -118,6 +119,7 @@ function build (options) {
     [kHooks]: new Hooks(),
     [kSchemas]: schemas,
     [kSchemaCompiler]: null,
+    [kReplySerializerDefault]: null,
     [kContentTypeParser]: new ContentTypeParser(bodyLimit, (options.onProtoPoisoning || defaultInitOptions.onProtoPoisoning)),
     [kReply]: Reply.buildReply(Reply),
     [kRequest]: Request.buildRequest(Request),
@@ -167,6 +169,7 @@ function build (options) {
     addSchema: addSchema,
     getSchemas: schemas.getSchemas.bind(schemas),
     setSchemaCompiler: setSchemaCompiler,
+    setReplySerializer: setReplySerializer,
     // custom parsers
     addContentTypeParser: ContentTypeParser.helpers.addContentTypeParser,
     hasContentTypeParser: ContentTypeParser.helpers.hasContentTypeParser,
@@ -387,6 +390,13 @@ function build (options) {
     throwIfAlreadyStarted('Cannot call "setSchemaCompiler" when fastify instance is already started!')
 
     this[kSchemaCompiler] = schemaCompiler
+    return this
+  }
+
+  function setReplySerializer (replySerializer) {
+    throwIfAlreadyStarted('Cannot call "setReplySerializer" when fastify instance is already started!')
+
+    this[kReplySerializerDefault] = replySerializer
     return this
   }
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const { kFourOhFourContext } = require('./symbols.js')
+const { kFourOhFourContext, kReplySerializerDefault } = require('./symbols.js')
 
 // Objects that holds the context of every request
 // Every route holds an instance of this object.
-function Context (schema, handler, Reply, Request, contentTypeParser, config, errorHandler, bodyLimit, logLevel, attachValidation) {
+function Context (schema, handler, Reply, Request, contentTypeParser, config, errorHandler, bodyLimit, logLevel, attachValidation, replySerializer) {
   this.schema = schema
   this.handler = handler
   this.Reply = Reply
@@ -22,6 +22,7 @@ function Context (schema, handler, Reply, Request, contentTypeParser, config, er
   this.logLevel = logLevel
   this[kFourOhFourContext] = null
   this.attachValidation = attachValidation
+  this[kReplySerializerDefault] = replySerializer
 }
 
 function defaultErrorHandler (error, request, reply) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -11,6 +11,7 @@ const {
   kReplySentOverwritten,
   kReplyStartTime,
   kReplySerializer,
+  kReplySerializerDefault,
   kReplyIsError,
   kReplyHeaders,
   kReplyHasStatusCode,
@@ -195,7 +196,11 @@ Reply.prototype.serialize = function (payload) {
   if (this[kReplySerializer] !== null) {
     return this[kReplySerializer](payload)
   } else {
-    return serialize(this.context, payload, this.res.statusCode)
+    if (this.context && this.context[kReplySerializerDefault]) {
+      return this.context[kReplySerializerDefault](payload)
+    } else {
+      return serialize(this.context, payload, this.res.statusCode)
+    }
   }
 }
 
@@ -252,7 +257,12 @@ function preserializeHookEnd (err, request, reply, payload) {
     return
   }
 
-  payload = serialize(reply.context, payload, reply.res.statusCode)
+  if (reply.context && reply.context[kReplySerializerDefault]) {
+    payload = reply.context[kReplySerializerDefault](payload)
+  } else {
+    payload = serialize(reply.context, payload, reply.res.statusCode)
+  }
+
   flatstr(payload)
 
   onSendHook(reply, payload)

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -197,7 +197,7 @@ Reply.prototype.serialize = function (payload) {
     return this[kReplySerializer](payload)
   } else {
     if (this.context && this.context[kReplySerializerDefault]) {
-      return this.context[kReplySerializerDefault](payload)
+      return this.context[kReplySerializerDefault](payload, this.res.statusCode)
     } else {
       return serialize(this.context, payload, this.res.statusCode)
     }
@@ -258,7 +258,7 @@ function preserializeHookEnd (err, request, reply, payload) {
   }
 
   if (reply.context && reply.context[kReplySerializerDefault]) {
-    payload = reply.context[kReplySerializerDefault](payload)
+    payload = reply.context[kReplySerializerDefault](payload, reply.res.statusCode)
   } else {
     payload = serialize(reply.context, payload, reply.res.statusCode)
   }

--- a/lib/route.js
+++ b/lib/route.js
@@ -19,6 +19,7 @@ const {
   kSchemaCompiler,
   kContentTypeParser,
   kReply,
+  kReplySerializerDefault,
   kRequest,
   kMiddlewares,
   kGlobalHooks,
@@ -195,7 +196,8 @@ function buildRouting (options) {
         this._errorHandler,
         opts.bodyLimit,
         opts.logLevel,
-        opts.attachValidation
+        opts.attachValidation,
+        this[kReplySerializerDefault]
       )
 
       // TODO this needs to be refactored so that buildSchemaCompiler is

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -8,6 +8,7 @@ const keys = {
   kHooks: Symbol('fastify.hooks'),
   kSchemas: Symbol('fastify.schemas'),
   kSchemaCompiler: Symbol('fastify.schemaCompiler'),
+  kReplySerializerDefault: Symbol('fastify.replySerializerDefault'),
   kContentTypeParser: Symbol('fastify.contentTypeParser'),
   kReply: Symbol('fastify.Reply'),
   kRequest: Symbol('fastify.Request'),

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -1215,7 +1215,8 @@ test('cannot set the replySerializer when the server is running', t => {
 })
 
 test('reply should not call the custom serializer for errors and not found', t => {
-  t.plan(15)
+  t.plan(9)
+
   const fastify = require('../..')()
   fastify.setReplySerializer((payload, statusCode) => {
     t.deepEqual(payload, { foo: 'bar' })

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -1005,3 +1005,29 @@ test('reply.getResponseTime() should return a number greater than 0 after the ti
 
   fastify.inject({ method: 'GET', url: '/' })
 })
+
+test('reply should use the custom serializer', t => {
+  t.plan(3)
+  const fastify = require('../..')()
+  fastify.setReplySerializer((payload) => {
+    t.deepEqual(payload, { foo: 'bar' })
+    payload.foo = 'bar bar'
+    return JSON.stringify(payload)
+  })
+
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    handler: (req, reply) => {
+      reply.send({ foo: 'bar' })
+    }
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.payload, '{"foo":"bar bar"}')
+  })
+})

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -445,6 +445,13 @@ server.setErrorHandler((err, request, reply) => {
   }
 })
 
+server.setReplySerializer((payload, statusCode) => {
+  if (statusCode === 201) {
+    return `Created ${payload}`
+  }
+  return JSON.stringify(payload)
+})
+
 server.listen(3000, err => {
   if (err) throw err
   const address = server.server.address()


### PR DESCRIPTION
Closes #961 

Hi, I would like to share my first idea to implement a "default serializer" for a fastify (encapsulated) context.

There will be a new method to add a sync function:

```
  // The sync function API is the same as `reply.serializer()`.
  fastify.setReplySerializer((payload) => {
    payload.foo = 'bar bar'
    return JSON.stringify(payload)
  })
```

Anyway, I would also add to the signature the response code since it could be useful.

The workflow will be:

1. use the reply.serializer if any
1. use the fastify.setReplySerializer if any
1. use the (actual) default validation.serialize

The main issue I found is that the:
- [`validation.serialize`](https://github.com/fastify/fastify/blob/901911c553bea62a21799ec7df34d5e36d2bacd0/lib/validation.js#L106) has a completely different signature

so it could be a breaking change trying to standardise and remove the static `validation.serialize` function and use it as a parameter (unless to put some `if`s).

This PR is not complete (missing many tests, not sure of the symbol name also 😅) but I wanted to check the effort and the feasibility.

Let me know what you think about it 👍

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
