### PR TITLE
fix(types): Add missing child method to Logger interface

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -66,6 +66,7 @@ declare namespace fastify {
     debug(obj: {}, msg?: string, ...args: any[]): void;
     trace(msg: string, ...args: any[]): void;
     trace(obj: {}, msg?: string, ...args: any[]): void;
+    child(obj: {}): Logger;
   }
 
   type FastifyMiddleware<

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -604,6 +604,7 @@ server.log.trace('Should log trace message', [])
 server.log.trace({ log: 'object' }, 'Should log trace message', [])
 server.log.warn('Should log warn message', [])
 server.log.warn({ log: 'object' }, 'Should log warn message', [])
+server.log.child({ some: 'prop' })
 
 const server2 = fastify()
 server2.close().then(() => {})


### PR DESCRIPTION
Updates TypeScript definitions to include the child method in the Logger interface as discussed in https://github.com/fastify/fastify/issues/1715

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x]  commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
