### PR TITLE
Update Server.md

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -230,7 +230,7 @@ Especially in distributed systems, you may want to override the default id gener
 ```js
 let i = 0
 const fastify = require('fastify')({
-  genReqId: function (req) { return req.headers['request-id'] || i++ }
+  genReqId: function (req) { return i++ }
 })
 ```
 


### PR DESCRIPTION
In the genReqId sention, it is mentioned in note, that the provided function for it will not be called if the "request-id" header is available. Hence, I think in the mentioned example, it should only return "i++" instead of "req.headers['request-id'] || i++"' as here the header here will not be present always.