### PR TITLE
Improve support for Fluent Schema

### DIFF
--- a/docs/Fluent-Schema.md
+++ b/docs/Fluent-Schema.md
@@ -41,11 +41,12 @@ const paramsJsonSchema = S.object()
 const headersJsonSchema = S.object()
   .prop('x-foo', S.string().required())
 
+// note that there is no need to call `.valueOf()`!
 const schema = {
-  body: bodyJsonSchema.valueOf(),
-  querystring: queryStringJsonSchema.valueOf(), // (or) query: queryStringJsonSchema.valueOf()
-  params: paramsJsonSchema.valueOf(),
-  headers: headersJsonSchema.valueOf()
+  body: bodyJsonSchema,
+  querystring: queryStringJsonSchema, // (or) query: queryStringJsonSchema
+  params: paramsJsonSchema,
+  headers: headersJsonSchema
 }
 
 fastify.post('/the/url', { schema }, handler)
@@ -69,20 +70,17 @@ const addressSchema = S.object()
   .prop('country').required()
   .prop('city').required()
   .prop('zipcode').required()
-  .valueOf()
 
 const commonSchemas = S.object()
   .id('https://fastify/demo')
   .definition('addressSchema', addressSchema)
   .definition('otherSchema', otherSchema) // you can add any schemas you need
-  .valueOf()
 
 fastify.addSchema(commonSchemas)
 
 const bodyJsonSchema = S.object()
   .prop('residence', S.ref('https://fastify/demo#address')).required()
   .prop('office', S.ref('https://fastify/demo#/definitions/addressSchema')).required()
-  .valueOf()
 
 const schema = { body: bodyJsonSchema }
 

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const fastClone = require('rfdc')({ circles: false, proto: true })
+const kFluentSchema = Symbol.for('fluent-schema-object')
 
 const {
   codes: {
@@ -18,7 +19,10 @@ function Schemas () {
 }
 
 Schemas.prototype.add = function (inputSchema) {
-  const schema = fastClone(inputSchema)
+  var schema = fastClone(inputSchema[kFluentSchema]
+    ? inputSchema.valueOf()
+    : inputSchema
+  )
   const id = schema['$id']
   if (id === undefined) {
     throw new FST_ERR_SCH_MISSING_ID()

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -8,6 +8,7 @@ const querystringSchema = Symbol('querystring-schema')
 const paramsSchema = Symbol('params-schema')
 const responseSchema = Symbol('response-schema')
 const headersSchema = Symbol('headers-schema')
+const kFluentSchema = Symbol.for('fluent-schema-object')
 
 function getValidatorForStatusCodeSchema (statusCodeDefinition, externalSchema) {
   return fastJsonStringify(statusCodeDefinition, { schema: externalSchema })
@@ -26,6 +27,7 @@ function build (context, compile, schemas) {
     return
   }
 
+  generateFluentSchema(context.schema)
   context.schema = schemas.resolveRefs(context.schema)
 
   const headers = context.schema.headers
@@ -63,6 +65,36 @@ function build (context, compile, schemas) {
 
   if (context.schema.params) {
     context[paramsSchema] = compile(context.schema.params)
+  }
+}
+
+function generateFluentSchema (schema) {
+  if (schema.params && schema.params[kFluentSchema]) {
+    schema.params = schema.params.valueOf()
+  }
+
+  if (schema.body && schema.body[kFluentSchema]) {
+    schema.body = schema.body.valueOf()
+  }
+
+  if (schema.querystring && schema.querystring[kFluentSchema]) {
+    schema.querystring = schema.querystring.valueOf()
+  }
+
+  if (schema.query && schema.query[kFluentSchema]) {
+    schema.query = schema.query.valueOf()
+  }
+
+  if (schema.headers && schema.headers[kFluentSchema]) {
+    schema.headers = schema.headers.valueOf()
+  }
+
+  if (schema.response) {
+    Object.keys(schema.response).forEach(code => {
+      if (schema.response[code][kFluentSchema]) {
+        schema.response[code] = schema.response[code].valueOf()
+      }
+    })
   }
 }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -69,25 +69,11 @@ function build (context, compile, schemas) {
 }
 
 function generateFluentSchema (schema) {
-  if (schema.params && schema.params[kFluentSchema]) {
-    schema.params = schema.params.valueOf()
-  }
-
-  if (schema.body && schema.body[kFluentSchema]) {
-    schema.body = schema.body.valueOf()
-  }
-
-  if (schema.querystring && schema.querystring[kFluentSchema]) {
-    schema.querystring = schema.querystring.valueOf()
-  }
-
-  if (schema.query && schema.query[kFluentSchema]) {
-    schema.query = schema.query.valueOf()
-  }
-
-  if (schema.headers && schema.headers[kFluentSchema]) {
-    schema.headers = schema.headers.valueOf()
-  }
+  ;['params', 'body', 'querystring', 'query', 'headers'].forEach(key => {
+    if (schema[key] && schema[key][kFluentSchema]) {
+      schema[key] = schema[key].valueOf()
+    }
+  })
 
   if (schema.response) {
     Object.keys(schema.response).forEach(code => {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "eslint-import-resolver-node": "^0.3.2",
     "fast-json-body": "^1.1.0",
     "fastify-plugin": "^1.5.0",
-    "fluent-schema": "^0.7.0",
+    "fluent-schema": "^0.7.3",
     "form-data": "^2.3.3",
     "frameguard": "^3.0.0",
     "h2url": "^0.1.2",

--- a/test/fluent-schema.js
+++ b/test/fluent-schema.js
@@ -120,6 +120,60 @@ function fluentSchemaTest (t) {
 
     fastify.ready(t.error)
   })
+
+  test('Should call valueOf internally', t => {
+    t.plan(1)
+
+    const fastify = new Fastify()
+
+    const addressSchema = S.object()
+      .id('#address')
+      .prop('line1').required()
+      .prop('line2')
+      .prop('country').required()
+      .prop('city').required()
+      .prop('zipcode').required()
+
+    const commonSchemas = S.object()
+      .id('https://fastify/demo')
+      .definition('addressSchema', addressSchema)
+
+    fastify.addSchema(commonSchemas)
+
+    fastify.route({
+      method: 'POST',
+      url: '/query',
+      handler: () => {},
+      schema: {
+        query: S.object().prop('hello', S.string()).required(),
+        body: S.object().prop('hello', S.string()).required(),
+        params: S.object().prop('hello', S.string()).required(),
+        headers: S.object().prop('hello', S.string()).required(),
+        response: {
+          200: S.object().prop('hello', S.string()).required(),
+          201: S.object().prop('hello', S.string()).required()
+        }
+      }
+    })
+
+    fastify.route({
+      method: 'POST',
+      url: '/querystring',
+      handler: () => {},
+      schema: {
+        querystring: S.object().prop('hello', S.string()).required(),
+        body: S.object().prop('hello', S.string()).required(),
+        params: S.object().prop('hello', S.string()).required(),
+        headers: S.object().prop('hello', S.string()).required(),
+        response: {
+          200: S.object().prop('hello', S.string()).required(),
+          201: S.object().prop('hello', S.string()).required()
+        }
+      }
+    })
+
+    fastify.ready(t.error)
+  })
 }
 
 module.exports = fluentSchemaTest


### PR DESCRIPTION
Now Fastify can detect Fluent Schema objects and call internally `.valueOf`.
This vastly improves the user experience of validation handling.

Ref: https://github.com/fastify/fluent-schema/pull/38

/cc @aboutlo

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
