### PR TITLE
docs(Hooks): Add payload inside example to prevent bugs

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -339,7 +339,7 @@ Note: using an arrow function will break the binding of this to the Fastify inst
 
 <a name="route-hooks"></a>
 ## Route level hooks
-You can declare one or more custom `onRequest`, `preParsing`, `preValidation`, `preHandler` and `preSerialization` hook(s) that will be unique for the route.
+You can declare one or more custom `onRequest`, `preParsing`, `preValidation`, `preHandler` and `preSerialization` hook(s) that will be **unique** for the route.
 If you do so, those hooks always be executed as last hook in their category. <br/>
 This can be useful if you need to run the authentication, and the `preParsing` or `preValidation` hooks are exactly what you need for doing that.
 Multiple route-level hooks can also be specified as an array.
@@ -367,7 +367,7 @@ fastify.addHook('preHandler', (request, reply, done) => {
   done()
 })
 
-fastify.addHook('preSerialization', (request, reply, done) => {
+fastify.addHook('preSerialization', (request, reply, payload, done) => {
   // your code
   done()
 })
@@ -398,7 +398,7 @@ fastify.route({
   //   // this hook will always be executed after the shared `preHandler` hooks
   //   done()
   // }],
-  preSerialization: (request, reply, payload, next) => {
+  preSerialization: (request, reply, payload, done) => {
     // manipulate the payload
     next(null, payload)
   },


### PR DESCRIPTION
Based on #1593 

1) I noted that in some cases we use `next` and others `done`, can be interesting create a pattern.
2) Maybe create a section for each __hook__ sounds good for me, instead of showing the examples with all hooks.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
