### PR TITLE
fix citgm failure closes #1708

### DIFF
--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -188,10 +188,11 @@ if (os.platform() !== 'win32') {
   test('listen on socket', t => {
     t.plan(4)
     const fastify = Fastify()
-    t.tearDown(fastify.close.bind(fastify))
-
     const socketFileName = Date.now().toString().concat('.sock')
     const sockFile = path.join(os.tmpdir(), socketFileName)
+
+    t.tearDown(fastify.close.bind(t.equal(fs.existsSync(sockFile), false)))
+
     try {
       fs.unlinkSync(sockFile)
     } catch (e) { }
@@ -200,10 +201,6 @@ if (os.platform() !== 'win32') {
       t.error(err)
       t.equal(sockFile, fastify.server.address())
       t.equal(address, sockFile)
-
-      fastify.close(() => {
-        t.equal(fs.existsSync(sockFile), false)
-      })
     })
   })
 }

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -186,11 +186,12 @@ test('listen twice on the same port callback with (err, address)', t => {
 // https://nodejs.org/api/net.html#net_ipc_support
 if (os.platform() !== 'win32') {
   test('listen on socket', t => {
-    t.plan(3)
+    t.plan(4)
     const fastify = Fastify()
     t.tearDown(fastify.close.bind(fastify))
 
-    const sockFile = path.join(os.tmpdir(), 'server.sock')
+    const socketFileName = Date.now().toString().concat('.sock')
+    const sockFile = path.join(os.tmpdir(), socketFileName)
     try {
       fs.unlinkSync(sockFile)
     } catch (e) { }
@@ -199,6 +200,10 @@ if (os.platform() !== 'win32') {
       t.error(err)
       t.equal(sockFile, fastify.server.address())
       t.equal(address, sockFile)
+
+      fastify.close(() => {
+        t.equal(fs.existsSync(sockFile), false)
+      })
     })
   })
 }


### PR DESCRIPTION
closes #1708

I've renamed the `server.sock` file in `(current timestamp).sock`. After `fastify.close` I made sure that the file was removed. I hope it is correct.

####  #Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
