### PR TITLE
Change the `next` to `done` inside documentation

### DIFF
--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -137,9 +137,9 @@ As an example let's add a user property to the `Request` object:
 fastify.decorateRequest('user', '')
 
 // Update our property
-fastify.addHook('preHandler', (req, reply, next) => {
+fastify.addHook('preHandler', (req, reply, done) => {
   req.user = 'Bob Dylan'
-  next()
+  done()
 })
 // And finally access it
 fastify.get('/', (req, reply) => {

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -18,44 +18,44 @@ By using the hooks you can interact directly inside the lifecycle of Fastify. Th
 
 Example:
 ```js
-fastify.addHook('onRequest', (request, reply, next) => {
+fastify.addHook('onRequest', (request, reply, done) => {
   // some code
-  next()
+  done()
 })
 
-fastify.addHook('preParsing', (request, reply, next) => {
+fastify.addHook('preParsing', (request, reply, done) => {
   // some code
-  next()
+  done()
 })
 
-fastify.addHook('preValidation', (request, reply, next) => {
+fastify.addHook('preValidation', (request, reply, done) => {
   // some code
-  next()
+  done()
 })
 
-fastify.addHook('preHandler', (request, reply, next) => {
+fastify.addHook('preHandler', (request, reply, done) => {
   // some code
-  next()
+  done()
 })
 
-fastify.addHook('preSerialization', (request, reply, payload, next) => {
+fastify.addHook('preSerialization', (request, reply, payload, done) => {
   // some code
-  next()
+  done()
 })
 
-fastify.addHook('onError', (request, reply, error, next) => {
+fastify.addHook('onError', (request, reply, error, done) => {
   // some code
-  next()
+  done()
 })
 
-fastify.addHook('onSend', (request, reply, payload, next) => {
+fastify.addHook('onSend', (request, reply, payload, done) => {
   // some code
-  next()
+  done()
 })
 
-fastify.addHook('onResponse', (request, reply, next) => {
+fastify.addHook('onResponse', (request, reply, done) => {
   // some code
-  next()
+  done()
 })
 ```
 Or `async/await`
@@ -136,29 +136,29 @@ fastify.addHook('onResponse', async (request, reply) => {
 })
 ```
 
-**Notice:** the `next` callback is not available when using `async`/`await` or returning a `Promise`. If you do invoke a `next` callback in this situation unexpected behavior may occur, e.g. duplicate invocation of handlers.
+**Notice:** the `done` callback is not available when using `async`/`await` or returning a `Promise`. If you do invoke a `done` callback in this situation unexpected behavior may occur, e.g. duplicate invocation of handlers.
 
 **Notice:** in the `onRequest` and `preValidation` hooks, `request.body` will always be `null`, because the body parsing happens before the `preHandler` hook.
 
 [Request](https://github.com/fastify/fastify/blob/master/docs/Request.md) and [Reply](https://github.com/fastify/fastify/blob/master/docs/Reply.md) are the core Fastify objects.<br/>
-`next` is the function to continue with the [lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md).
+`done` is the function to continue with the [lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md).
 
 It is pretty easy to understand where each hook is executed by looking at the [lifecycle page](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md).<br>
 Hooks are affected by Fastify's encapsulation, and can thus be applied to selected routes. See the [Scopes](#scope) section for more information.
 
-If you get an error during the execution of your hook, just pass it to `next()` and Fastify will automatically close the request and send the appropriate error code to the user.
+If you get an error during the execution of your hook, just pass it to `done()` and Fastify will automatically close the request and send the appropriate error code to the user.
 
 ```js
-fastify.addHook('onRequest', (request, reply, next) => {
-  next(new Error('some error'))
+fastify.addHook('onRequest', (request, reply, done) => {
+  done(new Error('some error'))
 })
 ```
 
 If you want to pass a custom error code to the user, just use `reply.code()`:
 ```js
-fastify.addHook('preHandler', (request, reply, next) => {
+fastify.addHook('preHandler', (request, reply, done) => {
   reply.code(400)
-  next(new Error('some error'))
+  done(new Error('some error'))
 })
 ```
 
@@ -169,13 +169,13 @@ fastify.addHook('preHandler', (request, reply, next) => {
 This hook is useful if you need to do some custom error logging or add some specific header in case of error.<br/>
 It is not intended for changing the error, and calling `reply.send` will throw an exception.<br/>
 This hook will be executed only after the `customErrorHandler` has been executed, and only if the `customErrorHandler` sends back an error to the user *(Note that the default `customErrorHandler` always send back the error to the user)*.<br/>
-**Notice:** unlike the other hooks, pass an error to the `next` function is not supported.
+**Notice:** unlike the other hooks, pass an error to the `done` function is not supported.
 
 ```js
-fastify.addHook('onError', (request, reply, error, next) => {
+fastify.addHook('onError', (request, reply, error, done) => {
   // apm stands for Application Performance Monitoring
   apm.sendError(error)
-  next()
+  done()
 })
 
 // Or async
@@ -190,10 +190,10 @@ fastify.addHook('onError', async (request, reply, error) => {
 If you are using the `preSerialization` hook, you can change (or replace) the payload before it is serialized. For example:
 
 ```js
-fastify.addHook('preSerialization', (request, reply, payload, next) => {
+fastify.addHook('preSerialization', (request, reply, payload, done) => {
   var err = null;
   var newPayload = {wrapped: payload }
-  next(err, newPayload)
+  done(err, newPayload)
 })
 
 // Or async
@@ -209,10 +209,10 @@ Note: the hook is NOT called if the payload is  a `string`, a `Buffer`, a `strea
 If you are using the `onSend` hook, you can change the payload. For example:
 
 ```js
-fastify.addHook('onSend', (request, reply, payload, next) => {
+fastify.addHook('onSend', (request, reply, payload, done) => {
   var err = null;
   var newPayload = payload.replace('some-text', 'some-new-text')
-  next(err, newPayload)
+  done(err, newPayload)
 })
 
 // Or async
@@ -225,10 +225,10 @@ fastify.addHook('onSend', async (request, reply, payload) => {
 You can also clear the payload to send a response with an empty body by replacing the payload with `null`:
 
 ```js
-fastify.addHook('onSend', (request, reply, payload, next) => {
+fastify.addHook('onSend', (request, reply, payload, done) => {
   reply.code(304)
   const newPayload = null
-  next(null, newPayload)
+  done(null, newPayload)
 })
 ```
 
@@ -243,7 +243,7 @@ The `onResponse` hook is executed when a response has been sent, so you will not
 If needed, you can respond to a request before you reach the route handler. An example could be an authentication hook. If you are using `onRequest` or `preHandler` use `reply.send`; if you are using a middleware, `res.end`.
 
 ```js
-fastify.addHook('onRequest', (request, reply, next) => {
+fastify.addHook('onRequest', (request, reply, done) => {
   reply.send('early response')
 })
 
@@ -256,7 +256,7 @@ fastify.addHook('preHandler', async (request, reply) => {
 If you want to respond with a stream, you should avoid using an `async` function for the hook. If you must use an `async` function, your code will need to follow the pattern in [test/hooks-async.js](https://github.com/fastify/fastify/blob/94ea67ef2d8dce8a955d510cd9081aabd036fa85/test/hooks-async.js#L269-L275).
 
 ```js
-fastify.addHook('onRequest', (request, reply, next) => {
+fastify.addHook('onRequest', (request, reply, done) => {
   const stream = fs.createReadStream('some-file', 'utf8')
   reply.send(stream)
 })
@@ -330,9 +330,9 @@ fastify.addHook('onRegister', (instance) => {
 Except for [Application Hooks](#application-hooks), all hooks are encapsulated. This means that you can decide where your hooks should run by using `register` as explained in the [plugins guide](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md). If you pass a function, that function is bound to the right Fastify context and from there you have full access to the Fastify API.
 
 ```js
-fastify.addHook('onRequest', function (request, reply, next) {
+fastify.addHook('onRequest', function (request, reply, done) {
   const self = this // Fastify context
-  next()
+  done()
 })
 ```
 Note: using an arrow function will break the binding of this to the Fastify instance.
@@ -398,9 +398,9 @@ fastify.route({
   //   // this hook will always be executed after the shared `preHandler` hooks
   //   done()
   // }],
-  preSerialization: (request, reply, payload, next) => {
+  preSerialization: (request, reply, payload, done) => {
     // manipulate the payload
-    next(null, payload)
+    done(null, payload)
   },
   handler: function (request, reply) {
     reply.send({ hello: 'world' })

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -106,11 +106,11 @@ const fastify = require('fastify')({
 See a approach to log `req.body`
 
 ```js
-app.addHook('preHandler', function (req, reply, next) {
+app.addHook('preHandler', function (req, reply, done) {
   if (req.body) {
     req.log.info({ body: req.body }, 'parsed body')
   }
-  next()
+  done()
 })
 ```
 

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -45,10 +45,10 @@ The `options` parameter can also be a `Function` which will be evaluated at the 
 ```js
 const fp = require('fastify-plugin')
 
-fastify.register(fp((fastify, opts, next) => {
+fastify.register(fp((fastify, opts, done) => {
   fastify.decorate('foo_bar', { hello: 'world' })
 
-  next()
+  done()
 }))
 
 // The opts argument of fastify-foo will be { hello: 'world' }
@@ -100,24 +100,24 @@ await fastify.listen(3000)
 Creating a plugin is very easy, you just need to create a function that takes three parameters, the `fastify` instance, an options object and the next callback.<br>
 Example:
 ```js
-module.exports = function (fastify, opts, next) {
+module.exports = function (fastify, opts, done) {
   fastify.decorate('utility', () => {})
 
   fastify.get('/', handler)
 
-  next()
+  done()
 }
 ```
 You can also use `register` inside another `register`:
 ```js
-module.exports = function (fastify, opts, next) {
+module.exports = function (fastify, opts, done) {
   fastify.decorate('utility', () => {})
 
   fastify.get('/', handler)
 
   fastify.register(require('./other-plugin'))
 
-  next()
+  done()
 }
 ```
 Sometimes, you will need to know when the server is about to close, for example because you must close a connection to a database. To know when this is going to happen, you can use the [`'onClose'`](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#on-close) hook.
@@ -136,18 +136,18 @@ We recommend to using the `fastify-plugin` module, because it solves this proble
 ```js
 const fp = require('fastify-plugin')
 
-module.exports = fp(function (fastify, opts, next) {
+module.exports = fp(function (fastify, opts, done) {
   fastify.decorate('utility', () => {})
-  next()
+  done()
 }, '0.x')
 ```
 Check the [`fastify-plugin`](https://github.com/fastify/fastify-plugin) documentation to know more about how use this module.
 
 If you don't use the `fastify-plugin` module, you can use the `'skip-override'` hidden property, but we do not recommend it. If in the future the Fastify API changes it will be a your responsibility update the module, while if you use `fastify-plugin`, you can be sure about backwards compatibility.
 ```js
-function yourPlugin (fastify, opts, next) {
+function yourPlugin (fastify, opts, done) {
   fastify.decorate('utility', () => {})
-  next()
+  done()
 }
 yourPlugin[Symbol.for('skip-override')] = true
 module.exports = yourPlugin

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -216,16 +216,16 @@ fastify.listen(3000)
 ```
 ```js
 // routes/v1/users.js
-module.exports = function (fastify, opts, next) {
+module.exports = function (fastify, opts, done) {
   fastify.get('/user', handler_v1)
-  next()
+  done()
 }
 ```
 ```js
 // routes/v2/users.js
-module.exports = function (fastify, opts, next) {
+module.exports = function (fastify, opts, done) {
   fastify.get('/user', handler_v2)
-  next()
+  done()
 }
 ```
 Fastify will not complain because you are using the same name for two different routes, because at compilation time it will handle the prefix automatically *(this also means that the performance will not be affected at all!)*.

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -150,14 +150,14 @@ custom `onRequest` and `onResponse` hooks.
 
 ```js
 // Examples of hooks to replicate the disabled functionality.
-fastify.addHook('onRequest', (req, reply, next) => {
+fastify.addHook('onRequest', (req, reply, done) => {
   req.log.info({ url: req.req.url, id: req.id }, 'received request')
-  next()
+  done()
 })
 
-fastify.addHook('onResponse', (req, reply, next) => {
+fastify.addHook('onResponse', (req, reply, done) => {
   req.log.info({ url: req.req.originalUrl, statusCode: res.res.statusCode }, 'request completed')
-  next()
+  done()
 })
 ```
 
@@ -368,16 +368,16 @@ It is always executed before the method `fastify.ready`.
 
 ```js
 fastify
-  .register((instance, opts, next) => {
+  .register((instance, opts, done) => {
     console.log('Current plugin')
-    next()
+    done()
   })
   .after(err => {
     console.log('After current plugin')
   })
-  .register((instance, opts, next) => {
+  .register((instance, opts, done) => {
     console.log('Next plugin')
-    next()
+    done()
   })
   .ready(err => {
     console.log('Everything has been loaded')
@@ -551,24 +551,24 @@ The full path that will be prefixed to a route.
 Example:
 
 ```js
-fastify.register(function (instance, opts, next) {
+fastify.register(function (instance, opts, done) {
   instance.get('/foo', function (request, reply) {
     // Will log "prefix: /v1"
     request.log.info('prefix: %s', instance.prefix)
     reply.send({ prefix: instance.prefix })
   })
 
-  instance.register(function (instance, opts, next) {
+  instance.register(function (instance, opts, done) {
     instance.get('/bar', function (request, reply) {
       // Will log "prefix: /v1/v2"
       request.log.info('prefix: %s', instance.prefix)
       reply.send({ prefix: instance.prefix })
     })
 
-    next()
+    done()
   }, { prefix: '/v2' })
 
-  next()
+  done()
 }, { prefix: '/v1' })
 ```
 
@@ -614,24 +614,24 @@ You can also register a [`preValidation`](https://www.fastify.io/docs/latest/Hoo
 
 ```js
 fastify.setNotFoundHandler({
-  preValidation: (req, reply, next) => {
+  preValidation: (req, reply, done) => {
     // your code
-    next()
+    done()
   },
-  preHandler: (req, reply, next) => {
+  preHandler: (req, reply, done) => {
     // your code
-    next()
+    done()
   }
 }, function (request, reply) {
     // Default not found handler with preValidation and preHandler hooks
 })
 
-fastify.register(function (instance, options, next) {
+fastify.register(function (instance, options, done) {
   instance.setNotFoundHandler(function (request, reply) {
     // Handle not found request without preValidation and preHandler hooks
     // to URLs that begin with '/v1'
   })
-  next()
+  done()
 }, { prefix: '/v1' })
 ```
 

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -156,7 +156,7 @@ fastify.route({
   handler: () => {}
 })
 
-fastify.register((instance, opts, next) => {
+fastify.register((instance, opts, done) => {
 
   /**
    * In children's scope can use schemas defined in upper scope like 'greetings'.
@@ -180,7 +180,7 @@ fastify.register((instance, opts, next) => {
     handler: () => {}
   })
 
-  next()
+  done()
 })
 ```
 
@@ -220,16 +220,16 @@ The function `getSchemas` returns the shared schemas available in the selected s
 fastify.addSchema({ $id: 'one', my: 'hello' })
 fastify.get('/', (request, reply) => { reply.send(fastify.getSchemas()) })
 
-fastify.register((instance, opts, next) => {
+fastify.register((instance, opts, done) => {
   instance.addSchema({ $id: 'two', my: 'ciao' })
   instance.get('/sub', (request, reply) => { reply.send(instance.getSchemas()) })
 
-  instance.register((subinstance, opts, next) => {
+  instance.register((subinstance, opts, done) => {
     subinstance.addSchema({ $id: 'three', my: 'hola' })
     subinstance.get('/deep', (request, reply) => { reply.send(subinstance.getSchemas()) })
-    next()
+    done()
   })
-  next()
+  done()
 })
 ```
 This example will returns:


### PR DESCRIPTION
## PR

Based on #1739 conversation, to add a pattern inside your plugins/routes/hooks.

We use `next` inside your `examples/*.js` and in our `tests/*.js`

Maybe another PR to adjust it?

Most of people that use Fastify, uses the pattern following `express`(next). Change it can cause some doubt, right?

Personally `done` sounds good for me.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
