### PR TITLE
Fix bug regarding Joi schemas (issue #1767)

### DIFF
--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -59,6 +59,9 @@ Schemas.prototype.resolveRefs = function (routeSchemas, dontClearId) {
     }
   }
 
+  // See issue https://github.com/fastify/fastify/issues/1767
+  const cachedSchema = Object.assign({}, routeSchemas)
+
   try {
     // this will work only for standard json schemas
     // other compilers such as Joi will fail
@@ -72,9 +75,13 @@ Schemas.prototype.resolveRefs = function (routeSchemas, dontClearId) {
       this.cleanId(routeSchemas)
     }
   } catch (err) {
-    // if we have failed because `resolve has thrown
+    // if we have failed because `resolve` has thrown
     // let's rethrow the error and let avvio handle it
     if (/FST_ERR_SCH_*/.test(err.code)) throw err
+
+    // otherwise, the schema must not be a JSON schema
+    // so we let the user configured schemaCompiler handle it
+    return cachedSchema
   }
 
   if (routeSchemas.headers) {


### PR DESCRIPTION
This PR reverts the change that caused Joi schemas to not validate correctly when being used as route schemas instead of JSON schemas. 

I need this fix in place to finish an update to Fastify v2. The sooner it can be released the better for me.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
