### PR TITLE
better typing for headers object

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -316,7 +316,7 @@ declare namespace fastify {
       req: NodeJS.ReadableStream,
       res: http.ServerResponse
     },
-    headers: Record<string,string>,
+    headers: Record<string, string>,
     statusCode: number,
     statusMessage: string,
     payload: string,

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -316,7 +316,7 @@ declare namespace fastify {
       req: NodeJS.ReadableStream,
       res: http.ServerResponse
     },
-    headers: object,
+    headers: Record<string,string>,
     statusCode: number,
     statusMessage: string,
     payload: string,


### PR DESCRIPTION
using "object" forces manual casting to do string index lookups on headers object