### PR TITLE
Add toStrinTag to errors

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -95,6 +95,7 @@ function createError (code, message, statusCode = 500, Base = Error) {
     this.message = `${this.code}: ${this.message}`
     this.statusCode = statusCode || undefined
   }
+  FastifyError.prototype[Symbol.toStringTag] = 'Error'
 
   inherits(FastifyError, Base)
 

--- a/test/internals/errors.test.js
+++ b/test/internals/errors.test.js
@@ -94,3 +94,11 @@ test('Create error with different base', t => {
   t.equal(err.statusCode, 500)
   t.ok(err.stack)
 })
+
+test('Error has appropriate string tag', t => {
+  t.plan(1)
+  const NewError = createError('CODE', 'foo')
+  const err = new NewError()
+  const str = Object.prototype.toString.call(err)
+  t.equal(str, '[object Error]')
+})


### PR DESCRIPTION
This PR adds `Symbol.toStringTag` to Fastify error instances so silly packages like https://npm.im/lodash.iserror can figure out that they are instances of `Error`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
