### PR TITLE
Add request property to reply documentation

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -43,7 +43,8 @@ and properties:
 - `.send(payload)` - Sends the payload to the user, could be a plain text, a buffer, JSON, stream, or an Error object.
 - `.sent` - A boolean value that you can use if you need to know if `send` has already been called.
 - `.res` - The [`http.ServerResponse`](https://nodejs.org/dist/latest/docs/api/http.html#http_class_http_serverresponse) from Node core.
-- `.log` - the logger instance of the incoming request
+- `.log` - The logger instance of the incoming request.
+- `.request` - The incoming request.
 
 ```js
 fastify.get('/', options, function (request, reply) {

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -176,6 +176,7 @@ declare namespace fastify {
     sent: boolean
     res: HttpResponse
     context: FastifyContext
+    request: FastifyRequest
   }
   type TrustProxyFunction = (addr: string, index: number) => boolean
   interface ServerOptions {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -645,3 +645,11 @@ server3.close(() => {})
     done()
   }
 }
+
+type TestReplyDecoration = (this: fastify.FastifyReply<http.ServerResponse>) => void
+
+const server4 = fastify()
+const testReplyDecoration: TestReplyDecoration = function () {
+  console.log('can access request from reply decorator', this.request.id)
+}
+server4.decorateReply('test-request-accessible-from-reply', testReplyDecoration)


### PR DESCRIPTION
Adds documentation and TypeScript type definition for property `reply.request`.

Additionally, adds missing punctuation mark in `.log` property description.

Relates to #1734 
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
