### PR TITLE
Use .isFluentSchema instead of symbol to check for fluent-schema

### DIFF
--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const fastClone = require('rfdc')({ circles: false, proto: true })
+const kFluentSchema = Symbol.for('fluent-schema-object')
 
 const {
   codes: {
@@ -18,7 +19,7 @@ function Schemas () {
 }
 
 Schemas.prototype.add = function (inputSchema) {
-  var schema = fastClone(inputSchema.isFluentSchema
+  var schema = fastClone((inputSchema.isFluentSchema || inputSchema[kFluentSchema])
     ? inputSchema.valueOf()
     : inputSchema
   )

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const fastClone = require('rfdc')({ circles: false, proto: true })
-const kFluentSchema = Symbol.for('fluent-schema-object')
 
 const {
   codes: {
@@ -19,7 +18,7 @@ function Schemas () {
 }
 
 Schemas.prototype.add = function (inputSchema) {
-  var schema = fastClone(inputSchema[kFluentSchema]
+  var schema = fastClone(inputSchema.isFluentSchema
     ? inputSchema.valueOf()
     : inputSchema
   )

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -8,6 +8,7 @@ const querystringSchema = Symbol('querystring-schema')
 const paramsSchema = Symbol('params-schema')
 const responseSchema = Symbol('response-schema')
 const headersSchema = Symbol('headers-schema')
+const kFluentSchema = Symbol.for('fluent-schema-object')
 
 function getValidatorForStatusCodeSchema (statusCodeDefinition, externalSchema) {
   return fastJsonStringify(statusCodeDefinition, { schema: externalSchema })
@@ -69,14 +70,14 @@ function build (context, compile, schemas) {
 
 function generateFluentSchema (schema) {
   ;['params', 'body', 'querystring', 'query', 'headers'].forEach(key => {
-    if (schema[key] && schema[key].isFluentSchema) {
+    if (schema[key] && (schema[key].isFluentSchema || schema[key][kFluentSchema])) {
       schema[key] = schema[key].valueOf()
     }
   })
 
   if (schema.response) {
     Object.keys(schema.response).forEach(code => {
-      if (schema.response[code].isFluentSchema) {
+      if (schema.response[code].isFluentSchema || schema.response[code][kFluentSchema]) {
         schema.response[code] = schema.response[code].valueOf()
       }
     })

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -8,7 +8,6 @@ const querystringSchema = Symbol('querystring-schema')
 const paramsSchema = Symbol('params-schema')
 const responseSchema = Symbol('response-schema')
 const headersSchema = Symbol('headers-schema')
-const kFluentSchema = Symbol.for('fluent-schema-object')
 
 function getValidatorForStatusCodeSchema (statusCodeDefinition, externalSchema) {
   return fastJsonStringify(statusCodeDefinition, { schema: externalSchema })
@@ -70,14 +69,14 @@ function build (context, compile, schemas) {
 
 function generateFluentSchema (schema) {
   ;['params', 'body', 'querystring', 'query', 'headers'].forEach(key => {
-    if (schema[key] && schema[key][kFluentSchema]) {
+    if (schema[key] && schema[key].isFluentSchema) {
       schema[key] = schema[key].valueOf()
     }
   })
 
   if (schema.response) {
     Object.keys(schema.response).forEach(code => {
-      if (schema.response[code][kFluentSchema]) {
+      if (schema.response[code].isFluentSchema) {
         schema.response[code] = schema.response[code].valueOf()
       }
     })

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "eslint-import-resolver-node": "^0.3.2",
     "fast-json-body": "^1.1.0",
     "fastify-plugin": "^1.5.0",
-    "fluent-schema": "^0.7.3",
+    "fluent-schema": "^0.7.4",
     "form-data": "^2.5.0",
     "frameguard": "^3.0.0",
     "h2url": "^0.1.2",


### PR DESCRIPTION
See https://github.com/fastify/fluent-schema/pull/40

Note: users will need to update their dependency tree.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
