### PR TITLE
fix inverted if-statement in example of serverless documentation

### DIFF
--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -35,7 +35,7 @@ function init() {
   return app;
 }
 
-if (require.main !== module) {
+if (require.main === module) {
   // called directly i.e. "node app"
   init().listen(3000, (err) => {
     if (err) console.error(err);


### PR DESCRIPTION
in one example of the serverless documentation: (require.main === module) was inverted.
The description of that example is fine and usage in another example of same document is also fine.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
