### PR TITLE
Ensure that header properties are not duplicated in schema

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -44,6 +44,7 @@ function build (context, compile, schemas) {
       headersSchemaLowerCase.required = headersSchemaLowerCase.required.map(h => h.toLowerCase())
     }
     if (headers.properties) {
+      headersSchemaLowerCase.properties = {}
       Object.keys(headers.properties).forEach(k => {
         headersSchemaLowerCase.properties[k.toLowerCase()] = headers.properties[k]
       })

--- a/test/internals/validation.test.js
+++ b/test/internals/validation.test.js
@@ -226,3 +226,21 @@ test('build schema - headers are not lowercased in case of custom object', t => 
     return () => {}
   }, new Schemas())
 })
+
+test('build schema - uppercased headers are not included', t => {
+  t.plan(1)
+  const opts = {
+    schema: {
+      headers: {
+        type: 'object',
+        properties: {
+          'Content-Type': { type: 'string' }
+        }
+      }
+    }
+  }
+  validation.build(opts, schema => {
+    t.notOk('Content-Type' in schema.properties, 'uppercase does not exist')
+    return () => {}
+  }, new Schemas())
+})


### PR DESCRIPTION
Originally reported this issue in fastify-swagger (https://github.com/fastify/fastify-swagger/issues/197), but my investigation lead me to fastify itself.

The issue was that header properties were being duplicated with both upper and lowercase, which caused issues like the one above with fastify-swagger.

I've included a test exemplifying the issue, which passes on this branch and would fail on the master branch.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

#### Test results
```
test/404s.test.js ................................. 257/257
test/500s.test.js ................................... 29/29
test/async-await.test.js ............................ 63/63
test/bodyLimit.test.js ................................ 5/5
test/case-insensitive.test.js ....................... 18/18
test/chainable.test.js ................................ 3/3
(node:23006) Warning: Using 'genReqId' in logger options is deprecated. Use fastify options instead. See: https://www.fastify.io/docs/latest/Server/#gen-request-id
(node:23006) Warning: basePath is deprecated. Use prefix instead. See: https://www.fastify.io/docs/latest/Server/#prefix
(node:23006) Warning: The route option `beforeHandler` has been deprecated, use `preHandler` instead
test/close-pipelining.test.js ....................... 24/24
test/close.test.js .................................. 32/32
test/content-length.test.js ......................... 16/16
test/context-config.test.js ........................... 9/9
test/custom-http-server.test.js ....................... 6/6
test/custom-parser.test.js ........................ 152/152
test/custom-querystring-parser.test.js .............. 28/28
test/decorator.test.js ............................ 119/119
test/delete.test.js ................................. 43/43
test/emit-warning.test.js ............................. 3/3
test/error-in-post.test.js ............................ 1/1 893ms
test/fastify-instance.test.js ......................... 1/1 710ms
test/fluent-schema.test.js ............................ 4/4 1s
test/genReqId.test.js ................................. 4/4
test/get.test.js .................................... 53/53
test/handler-context.test.js .......................... 9/9
test/head.test.js ................................... 17/17
test/hooks.test.js ................................ 572/572
test/inject.test.js ................................. 58/58
test/input-validation.test.js ......................... 4/4
test/listen.test.js ................................. 48/48
test/logger.test.js ............................... 226/226
test/middleware.test.js ........................... 138/138
test/nullable-validation.test.js ...................... 3/3 868ms
test/options.error-handler.test.js .................. 73/73
test/options.test.js ................................ 63/63
test/output-validation.test.js ...................... 24/24
test/patch.error-handler.test.js .................... 98/98
test/patch.test.js .................................. 74/74
test/plugin.test.js ................................. 99/99
test/post.test.js ................................... 84/84
test/pretty-print.test.js ............................. 8/8
test/promises.test.js ............................... 10/10
test/proto-poisoning.test.js ........................ 11/11
test/put.error-handler.test.js ...................... 98/98
test/put.test.js .................................... 74/74
test/register.test.js ............................... 20/20
test/reply-error.test.js .......................... 245/245
test/request-error.test.js .......................... 10/10
(node:23036) Warning: The route option `beforeHandler` has been deprecated, use `preHandler` instead
test/route-hooks.test.js .......................... 124/124
test/route-prefix.test.js ........................... 62/62
test/route.test.js .................................. 31/31
test/router-options.test.js ........................... 8/8
test/shared-schemas.test.js ......................... 62/62
test/stream.test.js ................................. 56/56
test/throw.test.js .................................. 31/31
test/trust-proxy.test.js ............................ 37/37
(node:23047) ExperimentalWarning: The http2 module is an experimental API.
test/validation-error-handling.test.js .............. 28/28
test/versioned-routes.test.js ....................... 59/59
test/wrapThenable.test.js ............................. 2/2
test/http2/http2.test.js ............................ 33/35
  Skipped: 2
    return 200
    return 200

test/https/custom-https-server.test.js ................ 6/6
test/https/https.test.js .............................. 7/7
test/internals/all.test.js .......................... 14/14
test/internals/contentTypeParser.test.js .............. 2/2 546ms
test/internals/decorator.test.js .................... 17/17
test/internals/errors.test.js ....................... 40/40
test/internals/handleRequest.test.js ................ 41/41
test/internals/hookRunner.test.js ................... 82/82
test/internals/hooks.test.js ........................ 27/27
test/internals/initialConfig.test.js ................ 59/59
test/internals/logger.test.js ....................... 39/39
test/internals/plugin.test.js ......................... 7/7
test/internals/reply.test.js ...................... 202/202
test/internals/validation.test.js ................... 25/25
total ........................................... 4037/4039

  4037 passing (18s)
  2 pending
```

##### Benchmark results
```
 → npm run benchmark                                                                                                                             [git:bugfig/dont-duplicate-headers]

> fastify@2.7.1 benchmark /Users/JKJones1/Documents/Projects/fastify
> npx concurrently -k -s first "node ./examples/simple.js" "npx autocannon -c 100 -d 5 -p 10 localhost:3000/"

[1] Running 5s test @ http://localhost:3000/
[1] 100 connections with 10 pipelining factor
[1] 
[0] {"level":30,"time":1565921216757,"pid":23081,"hostname":"Jemars-MacBook-Pro-2.local","msg":"Server listening at http://127.0.0.1:3000","v":1}
[0] {"level":30,"time":1565921216758,"pid":23081,"hostname":"Jemars-MacBook-Pro-2.local","msg":"server listening on http://127.0.0.1:3000","v":1}
[1] ┌─────────┬──────┬──────┬────────┬────────┬──────────┬──────────┬───────────┐
[1] │ Stat    │ 2.5% │ 50%  │ 97.5%  │ 99%    │ Avg      │ Stdev    │ Max       │
[1] ├─────────┼──────┼──────┼────────┼────────┼──────────┼──────────┼───────────┤
[1] │ Latency │ 0 ms │ 0 ms │ 230 ms │ 370 ms │ 24.44 ms │ 77.72 ms │ 732.57 ms │
[1] └─────────┴──────┴──────┴────────┴────────┴──────────┴──────────┴───────────┘
[1] ┌───────────┬─────────┬─────────┬─────────┬─────────┬────────┬─────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg    │ Stdev   │ Min     │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼────────┼─────────┼─────────┤
[1] │ Req/Sec   │ 3101    │ 3101    │ 3921    │ 4711    │ 4001   │ 594.5   │ 3101    │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼────────┼─────────┼─────────┤
[1] │ Bytes/Sec │ 6.28 MB │ 6.28 MB │ 7.94 MB │ 9.55 MB │ 8.1 MB │ 1.21 MB │ 6.28 MB │
[1] └───────────┴─────────┴─────────┴─────────┴─────────┴────────┴─────────┴─────────┘
[1] 
[1] Req/Bytes counts sampled once per second.
[1] 
[1] 20k requests in 5.07s, 40.5 MB read
[1] npx autocannon -c 100 -d 5 -p 10 localhost:3000/ exited with code 0
--> Sending SIGTERM to other processes..
[0] node ./examples/simple.js exited with code SIGTERM

```