### PR TITLE
docs(Hooks): modify description for Request/Reply hooks and the content

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -4,7 +4,7 @@
 
 Hooks are registered with the `fastify.addHook` method and allow you to listen to specific events in the application or request/response lifecycle. You have to register a hook before the event is triggered otherwise the event is lost.
 
-By using the hooks you can interact directly inside the lifecycle of Fastify. There are seven different Hooks that you can use *(in order of execution)*:
+By using the hooks you can interact directly inside the lifecycle of Fastify. There are Request/Reply hooks and application hooks:
 
 - [Request/Reply Hooks](#requestreply-hooks)
   - [onRequest](#onRequest)
@@ -29,6 +29,8 @@ By using the hooks you can interact directly inside the lifecycle of Fastify. Th
 
 It is pretty easy to understand where each hook is executed by looking at the [lifecycle page](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md).<br>
 Hooks are affected by Fastify's encapsulation, and can thus be applied to selected routes. See the [Scopes](#scope) section for more information.
+
+There are eight different hooks that you can use in Request/Reply *(in order of execution)*:
 
 ### onRequest
 ```js


### PR DESCRIPTION
1. move L7 to L33, for it is a description for Request/Reply hooks.
2. change the number of Request/Reply hooks from seven to eight.
3. add a description for different types of hooks in L7.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
