### PR TITLE
Docs(typescript) and other typos

### DIFF
--- a/docs/Errors.md
+++ b/docs/Errors.md
@@ -79,7 +79,7 @@ The hook callback must be a function.
 <a name="FST_ERR_LOG_INVALID_DESTINATION"></a>
 #### FST_ERR_LOG_INVALID_DESTINATION
 
-Logger acceptes either a `'stream'` or a `'file'` as the destination.
+Logger accepts either a `'stream'` or a `'file'` as the destination.
 
 <a id="FST_ERR_REP_ALREADY_SENT"></a>
 ### FST_ERR_REP_ALREADY_SENT

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -104,7 +104,7 @@ are not present on the object, they will be added accordingly:
     for incoming requests. The default function generates sequential identifiers.
     * `level`: the minimum logging level. If not set, it will be set to `'info'`.
     * `serializers`: a hash of serialization functions. By default, serializers
-      are added for `req` (incoming request objects), `res` (outgoing repsonse
+      are added for `req` (incoming request objects), `res` (outgoing response
       objets), and `err` (standard `Error` objects). When a log method receives
       an object with any of these properties then the respective serializer will
       be used for that property. For example:

--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -93,7 +93,7 @@ An example deployable with [claudia.js](https://claudiajs.com/tutorials/serverle
 
 ## Google Cloud Run
 
-Unlike AWS Lambda or Google Cloud Functions, Google Cloud Run is a serverless **container** environment. It's primary purpose is to provide an infrastucture-abstracted environment to run arbitrary containers. As a result, Fastify can be deployed to Google Cloud Run with little-to-no code changes from the way you would write your Fastify app normally.
+Unlike AWS Lambda or Google Cloud Functions, Google Cloud Run is a serverless **container** environment. It's primary purpose is to provide an infrastructure-abstracted environment to run arbitrary containers. As a result, Fastify can be deployed to Google Cloud Run with little-to-no code changes from the way you would write your Fastify app normally.
 
 *Follow the steps below to deploy to Google Cloud Run if you are already familiar with gcloud or just follow their [quickstart](https://cloud.google.com/run/docs/quickstarts/build-and-deploy)*.
 

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -106,7 +106,7 @@ const opts: fastify.RouteShorthandOptions = {
   }
 }
 
-server.get<Query, Params, Body, Headers>('/ping/:bar', opts, (request, reply) => {
+server.get<Query, Params, Headers, Body>('/ping/:bar', opts, (request, reply) => {
   console.log(request.query) // this is of type Query!
   console.log(request.params) // this is of type Params!
   console.log(request.body) // this is of type Body!

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -7,7 +7,7 @@ Fastify is shipped with a typings file, but you may need to install `@types/node
 ## Types support
 We do care about the TypeScript community, and one of our core team members is currently reworking all types.
 We do our best to have the typings updated with the latest version of the API, but *it can happen* that the typings are not in sync.<br/>
-Luckly this is Open Source and you can contribute to fix them, we will be very happy to accept the fix and release it as soon as possible as a patch release. Checkout the [contributing](#contributing) rules!
+Luckily this is Open Source and you can contribute to fix them, we will be very happy to accept the fix and release it as soon as possible as a patch release. Checkout the [contributing](#contributing) rules!
 
 Plugins may or may not include typings. See [Plugin Types](#plugin-types) for more information.
 
@@ -204,7 +204,7 @@ When updating core types you should make a PR to this repository. Ensure you:
 <a id="plugin-types"></a>
 ### Plugin Types
 
-Plugins maintained by and orginized under the fastify organization on GitHub should ship with typings just like fastify itself does.
+Plugins maintained by and organized under the fastify organization on GitHub should ship with typings just like fastify itself does.
 Some plugins already include typings but many do not. We are happy to accept contributions to those plugins without any typings, see [fastify-cors](https://github.com/fastify/fastify-cors) for an example of a plugin that comes with it's own typings.
 
 Typings for third-party-plugins may either be included with the plugin or hosted on DefinitelyTyped. Remember, if you author a plugin to either include typings or publish them on DefinitelyTyped! Information  of how to install typings from DefinitelyTyped can be found [here](https://github.com/DefinitelyTyped/DefinitelyTyped#npm).


### PR DESCRIPTION
fix order of parameters in typescript docs according to type definitions https://github.com/andriyor/fastify/blob/124e7eea7af4048b008abf9c495bb581ec25061b/fastify.d.ts#L364
fix typos in the documentation

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
