### PR TITLE
docs(Plugins): removed prefix from list with fastify-plugin

### DIFF
--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -16,6 +16,9 @@ fastify.register(plugin, [options])
 The optional `options` parameter for `fastify.register` supports a predefined set of options that Fastify itself will use, except when the plugin has been wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This options object will also be passed to the plugin upon invocation, regardless of whether or not the plugin has been wrapped. The currently supported list of Fastify specific options is:
 
 + [`logLevel`](https://github.com/fastify/fastify/blob/master/docs/Routes.md#custom-log-level)
++ [`prefix`](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#route-prefixing-options)
+
+**Note: Those options will be ignored when used with fastify-plugin**
 
 It is possible that Fastify will directly support other options in the future. Thus, to avoid collisions, a plugin should consider namespacing its options. For example, a plugin `foo` might be registered like so:
 

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -16,7 +16,6 @@ fastify.register(plugin, [options])
 The optional `options` parameter for `fastify.register` supports a predefined set of options that Fastify itself will use, except when the plugin has been wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This options object will also be passed to the plugin upon invocation, regardless of whether or not the plugin has been wrapped. The currently supported list of Fastify specific options is:
 
 + [`logLevel`](https://github.com/fastify/fastify/blob/master/docs/Routes.md#custom-log-level)
-+ [`prefix`](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#route-prefixing-options)
 
 It is possible that Fastify will directly support other options in the future. Thus, to avoid collisions, a plugin should consider namespacing its options. For example, a plugin `foo` might be registered like so:
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -18,6 +18,27 @@ test('require a plugin', t => {
   })
 })
 
+test('plugin metadata - ignore prefix', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  plugin[Symbol.for('skip-override')] = true
+  fastify.register(plugin, { prefix: 'foo' })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.equals(res.payload, 'hello')
+  })
+
+  function plugin (instance, opts, next) {
+    instance.get('/', async () => 'hello')
+    next()
+  }
+})
+
 test('fastify.register with fastify-plugin should not incapsulate his code', t => {
   t.plan(10)
   const fastify = Fastify()

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -28,13 +28,15 @@ test('plugin metadata - ignore prefix', t => {
   fastify.inject({
     method: 'GET',
     url: '/'
-  }, (err, res) => {
+  }, function (err, res) {
     t.error(err)
     t.equals(res.payload, 'hello')
   })
 
   function plugin (instance, opts, next) {
-    instance.get('/', async () => 'hello')
+    instance.get('/', function (request, reply) {
+      reply.send('hello')
+    })
     next()
   }
 })


### PR DESCRIPTION
reference: #1818 

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
