### PR TITLE
Fix X-Forwarded-Host HTTP header is always trusted

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -294,7 +294,7 @@ function buildRouting (options) {
     if (trustProxy) {
       ip = proxyAddr(req, proxyFn)
       ips = proxyAddr.all(req, proxyFn)
-      if (ip !== undefined && req.headers['x-forwarded-host']) {
+      if (proxyFn(req.connection.remoteAddress, 0) && req.headers['x-forwarded-host']) {
         hostname = req.headers['x-forwarded-host']
       }
     }

--- a/test/trust-proxy.test.js
+++ b/test/trust-proxy.test.js
@@ -169,3 +169,22 @@ test('trust proxy IP addresses', (t) => {
     sgetForwardedRequest(app, '3.3.3.3, 2.2.2.2, 1.1.1.1', '/trustproxyipaddrs')
   })
 })
+
+test('validation trust proxy chain', (t) => {
+  t.plan(5)
+  const app = fastify({
+    trustProxy: ['2.2.2.2', '1.1.1.1']
+  })
+  app.get('/trustproxyipvalidation', function (req, reply) {
+    testRequestValues(t, req, { ip: '127.0.0.1', hostname: req.headers.host })
+    reply.code(200).send({ ip: req.ip, hostname: req.hostname })
+  })
+
+  t.tearDown(app.close.bind(app))
+
+  app.listen(0, (err) => {
+    app.server.unref()
+    t.error(err)
+    sgetForwardedRequest(app, '1.1.1.1', '/trustproxyipvalidation')
+  })
+})


### PR DESCRIPTION
[#1817](https://github.com/fastify/fastify/issues/1817)
its gonna to work but i think proxyFn should be get from different section 
For easily used on fly for example exposed protocol [#1805](https://github.com/fastify/fastify/pull/1805)