### PR TITLE
Improve default 404 route

### DIFF
--- a/lib/fourOhFour.js
+++ b/lib/fourOhFour.js
@@ -34,14 +34,7 @@ function fourOhFour (options) {
   // 404 router, used for handling encapsulated 404 handlers
   const router = FindMyWay({ defaultRoute: fourOhFourFallBack })
 
-  const fof = {
-    router,
-    setNotFoundHandler: setNotFoundHandler,
-    setContext: setContext,
-    arrange404: arrange404
-  }
-
-  return fof
+  return { router, setNotFoundHandler, setContext, arrange404 }
 
   function arrange404 (instance) {
     // Change the pointer of the fastify instance to itself, so register + prefix can add new 404 handler
@@ -49,8 +42,15 @@ function fourOhFour (options) {
     instance[kCanSetNotFoundHandler] = true
   }
 
-  function basic404 (req, reply) {
-    reply.code(404).send(new Error('Not Found'))
+  function basic404 (request, reply) {
+    const { url, method } = request.raw
+    const message = `Route ${method}:${url} not found`
+    request.log.info(message)
+    reply.code(404).send({
+      message,
+      error: 'Not Found',
+      statusCode: 404
+    })
   }
 
   function setContext (instance, context) {

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -979,7 +979,7 @@ test('log debug for 404', t => {
 
       const INFO_LEVEL = 30
       t.strictEqual(JSON.parse(logStream.logs[0]).msg, 'incoming request')
-      t.strictEqual(JSON.parse(logStream.logs[1]).msg, 'Not Found')
+      t.strictEqual(JSON.parse(logStream.logs[1]).msg, 'Route GET:/not-found not found')
       t.strictEqual(JSON.parse(logStream.logs[1]).level, INFO_LEVEL)
       t.strictEqual(JSON.parse(logStream.logs[2]).msg, 'request completed')
       t.strictEqual(logStream.logs.length, 3)

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -783,7 +783,11 @@ test('Should set a custom log level for a specific route', t => {
 test('The default 404 handler logs the incoming request', t => {
   t.plan(5)
 
-  const expectedMessages = ['incoming request', 'Not Found', 'request completed']
+  const expectedMessages = [
+    'incoming request',
+    'Route GET:/not-found not found',
+    'request completed'
+  ]
 
   const splitStream = split(JSON.parse)
   splitStream.on('data', (line) => {

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -484,7 +484,7 @@ test('returns 404 status code with /prefix/ and / route - prefixTrailingSlash: "
     t.error(err)
     t.same(JSON.parse(res.payload), {
       error: 'Not Found',
-      message: 'Not Found',
+      message: 'Route GET:/prefix// not found',
       statusCode: 404
     })
   })


### PR DESCRIPTION
This avoids creating an `Error` in the default 404 route and improves the log message by adding the method and url that has been called. 
Closes #1823

I did a benchmark run with the following command: 
```
npx concurrently -k -s first \"node ./examples/simple.js\" \"npx autocannon -c 100 -d 5 -p 10 localhost:3000/notfound\"
```

Results `master` branch:
```
[1] ┌─────────┬──────┬──────┬────────┬────────┬──────────┬─────────┬───────────┐
[1] │ Stat    │ 2.5% │ 50%  │ 97.5%  │ 99%    │ Avg      │ Stdev   │ Max       │
[1] ├─────────┼──────┼──────┼────────┼────────┼──────────┼─────────┼───────────┤
[1] │ Latency │ 0 ms │ 0 ms │ 159 ms │ 206 ms │ 16.17 ms │ 50.8 ms │ 759.36 ms │
[1] └─────────┴──────┴──────┴────────┴────────┴──────────┴─────────┴───────────┘
[1] ┌───────────┬────────┬────────┬─────────┬─────────┬─────────┬─────────┬────────┐
[1] │ Stat      │ 1%     │ 2.5%   │ 50%     │ 97.5%   │ Avg     │ Stdev   │ Min    │
[1] ├───────────┼────────┼────────┼─────────┼─────────┼─────────┼─────────┼────────┤
[1] │ Req/Sec   │ 3331   │ 3331   │ 6603    │ 6759    │ 5968.6  │ 1325.12 │ 3331   │
[1] ├───────────┼────────┼────────┼─────────┼─────────┼─────────┼─────────┼────────┤
[1] │ Bytes/Sec │ 713 kB │ 713 kB │ 1.41 MB │ 1.45 MB │ 1.28 MB │ 283 kB  │ 713 kB │
[1] └───────────┴────────┴────────┴─────────┴─────────┴─────────┴─────────┴────────┘
[1] 
[1] Req/Bytes counts sampled once per second.
[1] 
[1] 0 2xx responses, 29840 non 2xx responses
[1] 30k requests in 5.09s, 6.39 MB read
[1] 191 errors (0 timeouts)
```

Results `improve-default-404-route` branch:
```
[1] ┌─────────┬──────┬──────┬───────┬────────┬─────────┬──────────┬───────────┐
[1] │ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%    │ Avg     │ Stdev    │ Max       │
[1] ├─────────┼──────┼──────┼───────┼────────┼─────────┼──────────┼───────────┤
[1] │ Latency │ 0 ms │ 0 ms │ 91 ms │ 105 ms │ 8.59 ms │ 28.34 ms │ 544.59 ms │
[1] └─────────┴──────┴──────┴───────┴────────┴─────────┴──────────┴───────────┘
[1] ┌───────────┬─────────┬─────────┬─────────┬────────┬─────────┬─────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%  │ Avg     │ Stdev   │ Min     │
[1] ├───────────┼─────────┼─────────┼─────────┼────────┼─────────┼─────────┼─────────┤
[1] │ Req/Sec   │ 6063    │ 6063    │ 12111   │ 14519  │ 11247.6 │ 2858.52 │ 6062    │
[1] ├───────────┼─────────┼─────────┼─────────┼────────┼─────────┼─────────┼─────────┤
[1] │ Bytes/Sec │ 1.42 MB │ 1.42 MB │ 2.83 MB │ 3.4 MB │ 2.63 MB │ 669 kB  │ 1.42 MB │
[1] └───────────┴─────────┴─────────┴─────────┴────────┴─────────┴─────────┴─────────┘
[1] 
[1] Req/Bytes counts sampled once per second.
[1] 
[1] 0 2xx responses, 56231 non 2xx responses
[1] 56k requests in 5.11s, 13.2 MB read
[1] 250 errors (0 timeouts)
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
