### PR TITLE
fix: premature close

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -353,14 +353,14 @@ function sendStream (payload, res, reply) {
       if (res.headersSent) {
         reply.log.warn({ err }, 'response terminated with an error with headers already sent')
       }
-      if (sourceOpen) {
-        if (payload.destroy) {
-          payload.destroy()
-        } else if (typeof payload.close === 'function') {
-          payload.close(noop)
-        } else if (typeof payload.abort === 'function') {
-          payload.abort()
-        }
+    }
+    if (sourceOpen) {
+      if (payload.destroy) {
+        payload.destroy()
+      } else if (typeof payload.close === 'function') {
+        payload.close(noop)
+      } else if (typeof payload.abort === 'function') {
+        payload.abort()
       }
     }
   })

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -140,7 +140,7 @@ test('onSend hook stream', t => {
 })
 
 test('Destroying streams prematurely', t => {
-  t.plan(5)
+  t.plan(6)
 
   let fastify = null
   const logStream = split(JSON.parse)
@@ -198,7 +198,7 @@ test('Destroying streams prematurely', t => {
 })
 
 test('Destroying streams prematurely should call close method', t => {
-  t.plan(6)
+  t.plan(7)
 
   let fastify = null
   const logStream = split(JSON.parse)
@@ -257,7 +257,7 @@ test('Destroying streams prematurely should call close method', t => {
 })
 
 test('Destroying streams prematurely should call abort method', t => {
-  t.plan(6)
+  t.plan(7)
 
   let fastify = null
   const logStream = split(JSON.parse)


### PR DESCRIPTION
Payload should be destroyed on premature close. 

Test counts corrected. Previously the count didn't actually correspond with the number of checks? Or am I counting wrong?

I'm not entirely sure about the change in `sendStream` but it makes sense to destroy the payload also in the error case, unless I'm missing something?

Refs: https://github.com/nodejs/node/pull/27984

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
