### PR TITLE
fix: premature close test

### DIFF
--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -140,7 +140,7 @@ test('onSend hook stream', t => {
 })
 
 test('Destroying streams prematurely', t => {
-  t.plan(5)
+  t.plan(6)
 
   let fastify = null
   const logStream = split(JSON.parse)
@@ -190,7 +190,9 @@ test('Destroying streams prematurely', t => {
       response.on('readable', function () {
         response.destroy()
       })
-      response.on('close', function () {
+
+      // Node bug? Node never emits 'close' here.
+      response.on('aborted', function () {
         t.pass('Response closed')
       })
     })
@@ -198,7 +200,7 @@ test('Destroying streams prematurely', t => {
 })
 
 test('Destroying streams prematurely should call close method', t => {
-  t.plan(6)
+  t.plan(7)
 
   let fastify = null
   const logStream = split(JSON.parse)
@@ -249,7 +251,8 @@ test('Destroying streams prematurely should call close method', t => {
       response.on('readable', function () {
         response.destroy()
       })
-      response.on('close', function () {
+      // Node bug? Node never emits 'close' here.
+      response.on('aborted', function () {
         t.pass('Response closed')
       })
     })
@@ -257,7 +260,7 @@ test('Destroying streams prematurely should call close method', t => {
 })
 
 test('Destroying streams prematurely should call abort method', t => {
-  t.plan(6)
+  t.plan(7)
 
   let fastify = null
   const logStream = split(JSON.parse)
@@ -309,7 +312,8 @@ test('Destroying streams prematurely should call abort method', t => {
       response.on('readable', function () {
         response.destroy()
       })
-      response.on('close', function () {
+      // Node bug? Node never emits 'close' here.
+      response.on('aborted', function () {
         t.pass('Response closed')
       })
     })


### PR DESCRIPTION
There was an incorrect test count on the premature close tests where it never actually tested whether `'close'` was emitted.

`'close'` is actually not emitted (Node bug?) and to fix these test we need to increment the test count and instead listen for `'aborted'`.

Refs: nodejs/node#27984

P.S. Sorry for the previous hasty PR. I've checked this properly now against both versions of Node.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
