### PR TITLE
greenkeeper ignore @typescript-eslint/eslint-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,8 @@
       "joi",
       "@types/node",
       "tap",
-      "tap-mocha-reporter"
+      "tap-mocha-reporter",
+      "@typescript-eslint/eslint-plugin"
     ]
   },
   "standard": {


### PR DESCRIPTION
Closes #1798 
Node 6 no longer supported

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
