### PR TITLE
Fix Plugin type in fastify.d.ts

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -21,7 +21,10 @@ declare function fastify(opts?: fastify.ServerOptionsAsSecureHttp2): fastify.Fas
 // eslint-disable-next-line no-redeclare
 declare namespace fastify {
 
-  type Plugin < HttpServer, HttpRequest, HttpResponse, T > = (instance: FastifyInstance< HttpServer, HttpRequest, HttpResponse >, opts: T, callback: (err?: FastifyError) => void) => void
+  type Plugin<HttpServer, HttpRequest, HttpResponse, Options, PluginInstance extends Function = Function> =
+    PluginInstance extends () => Promise<void> ?
+      ((instance: FastifyInstance< HttpServer, HttpRequest, HttpResponse >, options: Options) => Promise<void>) :
+      (instance: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, options: Options, callback: (err?: FastifyError) => void) => void;
 
   type Middleware < HttpServer, HttpRequest, HttpResponse > = (this: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, req: HttpRequest, res: HttpResponse, callback: (err?: FastifyError) => void) => void
 
@@ -537,7 +540,7 @@ declare namespace fastify {
     /**
      * Registers a plugin
      */
-    register<T extends RegisterOptions<HttpServer, HttpRequest, HttpResponse>>(plugin: Plugin<HttpServer, HttpRequest, HttpResponse, T>, opts?: T): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    register<Options extends RegisterOptions<HttpServer, HttpRequest, HttpResponse>, PluginInstance extends Function>(plugin: Plugin<HttpServer, HttpRequest, HttpResponse, Options, PluginInstance>, options?: Options): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * `Register a callback that will be executed just after a register.

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -102,6 +102,20 @@ server.use('/', (req, res, next) => {
   console.log(`${req.method} ${req.url}`)
 })
 
+// Third party plugin
+// Also check if async functions are allowed to be passed to .register()
+// https://github.com/fastify/fastify/pull/1841
+// All function parameters should be inferrable and should not produce 'any'
+const thirdPartyPlugin: fastify.Plugin<http2.Http2SecureServer, http2.Http2ServerRequest, http2.Http2ServerResponse, {}> = (instance, options, callback) => {}
+const thirdPartyPluginAsync: fastify.Plugin<http2.Http2SecureServer, http2.Http2ServerRequest, http2.Http2ServerResponse, {}> = async (instance, options) => {}
+
+server.register(thirdPartyPlugin)
+server.register(thirdPartyPluginAsync)
+
+// Custom plugin
+server.register((instance, options, callback) => {})
+server.register(async (instance, options) => {})
+
 /**
  * Test various hooks and different signatures
  */


### PR DESCRIPTION
According to [avvio](https://github.com/mcollina/avvio/blob/3a386683994bfb274355edbb0d7d892e0e066e9a/plugin.js#L89) the `register()` function expects plugins to be either synchronous functions, asynchronous functions with a `callback` argument or asynchronous functions that return promises.

I stumbled upon this issue when using [apollo-server-fastify](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-server-fastify). The [`createHandler()`](https://github.com/apollographql/apollo-server/blob/2f4074252778e1946f5493513d249d26751036f2/packages/apollo-server-fastify/src/ApolloServer.ts#L82-L85) function returns an `async function` that's supposed be passed to `register` like this:

```js
server.register(apolloServer.createHandler());
```

TypeScript itself is fine with this because [it allows to assign an `async function` to a synchronous function type](http://www.typescriptlang.org/play/index.html#code/C4TwDgpgBAyiB2BjAYvKBeKAKAlBgfFAG4D2AlgCYDcAUDYifAM7BQBm8AXLAimpgEMmvbHnSEA3gF8qQA) which is debatable but probably another discussion 😉.

However, we're using [an ESLint rule](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-misused-promises.md) that checks for this case which is why I got an ESLint error in that line. I think it makes sense to document this kind of behavior in the typings although TypeScript itself allows to pass an async plugin to `register()`. What do you think?

I validated this change in my local setup and it seems to work.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
