### PR TITLE
Fix eslint "no-misused-promises" error in hooks

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -81,7 +81,7 @@ declare namespace fastify {
     req: FastifyRequest<HttpRequest, Query, Params, Headers, Body>,
     reply: FastifyReply<HttpResponse>,
     done: (err?: Error) => void,
-  ) => void
+  ) => void | Promise<any>
 
   type FastifyMiddlewareWithPayload<
   HttpServer = http.Server,
@@ -97,7 +97,7 @@ declare namespace fastify {
     reply: FastifyReply<HttpResponse>,
     payload: any,
     done: (err?: Error, value?: any) => void,
-  ) => void
+  ) => void | Promise<any>
 
   type RequestHandler<
   HttpRequest = http.IncomingMessage,

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -117,6 +117,18 @@ server.addHook('preHandler', function (req, reply, next) {
   }
 })
 
+server.addHook('preHandler', async function (req, reply) {
+  this.log.debug('`this` is not `any`')
+  if (req.body.error) {
+    throw new Error('testing if middleware errors can be passed')
+  } else {
+    // `stream` can be accessed correctly because `server` is an http2 server.
+    console.log('req stream', req.req.stream)
+    console.log('res stream', reply.res.stream)
+    reply.code(200).send('ok')
+  }
+})
+
 server.addHook('onRequest', function (req, reply, next) {
   this.log.debug('`this` is not `any`')
   console.log(`${req.raw.method} ${req.raw.url}`)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

Typescript eslint https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-misused-promises.md is reporting an error when creating an async/await hook function.

```js
server.addHook('preValidation', async (_request, _reply) => {
    await Promise.resolve();
    console.log('test');
});
```