### PR TITLE
add FastifyReply#removeHeader method to fastify.d.ts

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -165,6 +165,7 @@ declare namespace fastify {
     headers(headers: { [key: string]: any }): FastifyReply<HttpResponse>
     getHeader(name: string): string | undefined
     hasHeader(name: string): boolean
+    removeHeader(name: string): FastifyReply<HttpResponse>
     callNotFound(): void
     getResponseTime(): number
     type(contentType: string): FastifyReply<HttpResponse>

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -667,5 +667,5 @@ const testReplyDecoration: TestReplyDecoration = function () {
 server4.decorateReply('test-request-accessible-from-reply', testReplyDecoration)
 
 server4.get('/', (req, reply) => {
-  reply.removeHeader('x-foo').removeHeader('x-bar')
+  reply.removeHeader('x-foo').removeHeader('x-bar').send({})
 })

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -665,3 +665,7 @@ const testReplyDecoration: TestReplyDecoration = function () {
   console.log('can access request from reply decorator', this.request.id)
 }
 server4.decorateReply('test-request-accessible-from-reply', testReplyDecoration)
+
+server4.get('/', (req, reply) => {
+  reply.removeHeader('x-foo').removeHeader('x-bar')
+})


### PR DESCRIPTION
This PR just adds the type declaration of `FastifyReply#removeHeader` into fastify.d.ts.

Implementation is there: [lib/reply.js#L150](https://github.com/fastify/fastify/blob/78c867f46ad17265f019dd8e84148a21bc4c33b6/lib/reply.js#L150)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
