### PR TITLE
Fix/pkg manager ci

### DIFF
--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run tests
         run: |
-          npm run test
+          pnpm run test
 
   yarn:
     runs-on: ${{ matrix.os }}
@@ -54,4 +54,4 @@ jobs:
 
       - name: Run tests
         run: |
-          npm run test
+          yarn run test

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         # Maintenance and active LTS
-        node-version: [8.x 10.x]
+        node-version: [8.x, 10.x]
         os: [ubuntu-16.04]
 
     steps:

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -17,14 +17,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Use Node.js ${{ matrix.node-version }} in ${{ matrix.os }}
 
+      - name: Use Node.js
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Install with pnpm
         uses: znck/pnpm@v0.1.0-alpha.1
+        with:
+          args: install
 
       - name: Run tests
         run: |
@@ -41,9 +43,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Use Node.js ${{ matrix.node-version }} in ${{ matrix.os }}
 
-      - uses: actions/setup-node@v1
+      - name: Use Node.js
+        uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/package.json
+++ b/package.json
@@ -89,8 +89,8 @@
   },
   "devDependencies": {
     "@types/node": "^11.13.19",
-    "@typescript-eslint/eslint-plugin": "^1.13.0",
-    "@typescript-eslint/parser": "^2.0.0",
+    "@typescript-eslint/eslint-plugin": "^2.3.0",
+    "@typescript-eslint/parser": "^2.3.0",
     "JSONStream": "^1.3.5",
     "ajv-pack": "^0.3.1",
     "autocannon": "^3.2.0",
@@ -99,6 +99,7 @@
     "cors": "^2.8.5",
     "coveralls": "^3.0.6",
     "dns-prefetch-control": "^0.2.0",
+    "eslint": "^6.4.0",
     "eslint-import-resolver-node": "^0.3.2",
     "fast-json-body": "^1.1.0",
     "fastify-plugin": "^1.5.0",
@@ -127,7 +128,7 @@
     "tap": "^12.5.2",
     "tap-mocha-reporter": "^3.0.7",
     "then-sleep": "^1.0.1",
-    "typescript": "^3.5.3",
+    "typescript": "^3.6.3",
     "x-xss-protection": "^1.1.0"
   },
   "dependencies": {


### PR DESCRIPTION
There is an [error](https://github.com/fastify/fastify/runs/230154822) with pnpm regarding typescript-eslint. Its required to install `eslint` as dev dep

```
 WARN  @typescript-eslint/eslint-plugin: @typescript-eslint/experimental-utils@1.13.0 requires a peer of eslint@* but none was installed.
```

I could reproduce the error with NPM by upgrading to the latest versions.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
