### PR TITLE
Don't change resolved schema

### DIFF
--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -39,7 +39,7 @@ Schemas.prototype.resolve = function (id) {
   if (this.store[id] === undefined) {
     throw new FST_ERR_SCH_NOT_PRESENT(id)
   }
-  return this.store[id]
+  return Object.assign({}, this.store[id])
 }
 
 Schemas.prototype.resolveRefs = function (routeSchemas, dontClearId) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify",
-  "version": "2.8.1",
+  "version": "2.8.0",
   "description": "Fast and low overhead web framework, for Node.js",
   "main": "fastify.js",
   "typings": "fastify.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Fast and low overhead web framework, for Node.js",
   "main": "fastify.js",
   "typings": "fastify.d.ts",

--- a/test/internals/schemas.test.js
+++ b/test/internals/schemas.test.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const test = require('tap').test
+const { Schemas } = require('../../lib/schemas')
+
+test('Should not change resolved schema', t => {
+  t.plan(4)
+
+  const schemas = new Schemas()
+  schemas.add({
+    $id: 'A',
+    field: 'value'
+  })
+  const schema = {
+    a: 'A#'
+  }
+  const resolvedSchema = schemas.resolveRefs(schema)
+
+  t.same(resolvedSchema.a, {
+    field: 'value'
+  })
+  t.same(resolvedSchema.$id, undefined)
+
+  schemas.getJsonSchemas()
+
+  t.same(resolvedSchema.a, {
+    field: 'value'
+  })
+  t.same(resolvedSchema.$id, undefined)
+})


### PR DESCRIPTION
Fixes bug with invalid schema. The reason is that calling `getJsonSchemas` changes `store[schemaKey]` (adds `$id` field). But `resolve` returns `this.store[id]` and returned object could be changed at next `getJsonSchemas` call. It affects plugins like [fastify-swagger](https://github.com/fastify/fastify-swagger)

Fixes #1871 

