### PR TITLE
Fix warning for onError hook

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -344,7 +344,7 @@ function build (options) {
     throwIfAlreadyStarted('Cannot call "addHook" when fastify instance is already started!')
 
     // TODO: v3 instead of log a warning, throw an error
-    if (name === 'onSend' || name === 'preSerialization') {
+    if (name === 'onSend' || name === 'preSerialization' || name === 'onError') {
       if (fn.constructor.name === 'AsyncFunction' && fn.length === 4) {
         fastify.log.warn("Async function has too many arguments. Async hooks should not use the 'next' argument.", new Error().stack)
       }

--- a/test/hooks-async.js
+++ b/test/hooks-async.js
@@ -528,7 +528,7 @@ function asyncHookTest (t) {
     })
 
     t.test('4 arguments', t => {
-      t.plan(6)
+      t.plan(9)
       const stream = split(JSON.parse)
       const fastify = Fastify({
         logger: { stream }
@@ -542,6 +542,7 @@ function asyncHookTest (t) {
 
       fastify.addHook('onSend', async (req, reply, payload, next) => {})
       fastify.addHook('preSerialization', async (req, reply, payload, next) => {})
+      fastify.addHook('onError', async (req, reply, error, next) => {})
     })
 
     t.end()


### PR DESCRIPTION
The onError hook has 3 parameters (request, reply, error) and it's currently triggering a warning saying that it has too many arguments.
This change adds `onError` the same condition branch as `onSend` and `preSerialization`.

#### Checklist
- [X] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct]