### PR TITLE
fix schema resolver for plain id

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -116,6 +116,7 @@ declare namespace fastify {
   ) => void | Promise<any>
 
   type SchemaCompiler = (schema: Object) => Function
+  type SchemaResolver = (ref: string) => Object
 
   type BodyParser<HttpRequest, RawBody extends string | Buffer> =
     | ((req: HttpRequest, rawBody: RawBody, done: (err: Error | null, body?: any) => void) => void)
@@ -679,6 +680,11 @@ declare namespace fastify {
      * Set the schema compiler for all routes.
      */
     setSchemaCompiler(schemaCompiler: SchemaCompiler): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+
+    /**
+     * Set the schema resolver to find the `$ref` schema object
+     */
+    setSchemaResolver(schemaResolver: SchemaResolver): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * Create a shared schema

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -107,7 +107,8 @@ Schemas.prototype.traverse = function (schema, refResolver) {
     } else if (key === '$ref' && refResolver) {
       const refValue = schema[key]
 
-      const refId = refValue.slice(0, refValue.indexOf('#'))
+      const framePos = refValue.indexOf('#')
+      const refId = framePos >= 0 ? refValue.slice(0, framePos) : refValue
       if (refId.length > 0 && !this.store[refId]) {
         const resolvedSchema = refResolver(refId)
         if (resolvedSchema) {

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "abstract-logging": "^1.0.0",
     "ajv": "^6.10.2",
     "avvio": "^6.2.2",
-    "fast-json-stringify": "^1.15.4",
+    "fast-json-stringify": "^1.15.5",
     "find-my-way": "^2.0.0",
     "flatstr": "^1.0.12",
     "light-my-request": "^3.4.1",

--- a/test/schemas.test.js
+++ b/test/schemas.test.js
@@ -283,6 +283,14 @@ test('$ref with a simple $id', t => {
       foo: { $ref: 'urn:schema:foo' }
     }
   })
+  ajv.addSchema({
+    $id: 'urn:schema:request',
+    type: 'object',
+    required: ['foo'],
+    properties: {
+      foo: { $ref: 'urn:schema:foo' }
+    }
+  })
 
   fastify.setSchemaCompiler(schema => ajv.compile(schema))
   fastify.setSchemaResolver((ref) => {
@@ -294,7 +302,7 @@ test('$ref with a simple $id', t => {
     method: 'POST',
     url: '/',
     schema: {
-      body: ajv.getSchema('urn:schema:response').schema,
+      body: ajv.getSchema('urn:schema:request').schema,
       response: {
         '2xx': ajv.getSchema('urn:schema:response').schema
       }

--- a/test/schemas.test.js
+++ b/test/schemas.test.js
@@ -294,10 +294,13 @@ test('$ref with a simple $id', t => {
     method: 'POST',
     url: '/',
     schema: {
-      body: ajv.getSchema('urn:schema:response').schema
+      body: ajv.getSchema('urn:schema:response').schema,
+      response: {
+        '2xx': ajv.getSchema('urn:schema:response').schema
+      }
     },
     handler (req, reply) {
-      reply.send({ foo: 'bar' })
+      reply.send({ foo: { foo: 'bar', bar: 'foo' } })
     }
   })
 
@@ -308,6 +311,6 @@ test('$ref with a simple $id', t => {
   }, (err, res) => {
     t.error(err)
     t.equals(res.statusCode, 200)
-    t.deepEquals(JSON.parse(res.payload), { foo: 'bar' })
+    t.deepEquals(JSON.parse(res.payload), { foo: { foo: 'bar' } })
   })
 })

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -558,6 +558,13 @@ server.setSchemaCompiler(function (schema: object) {
   return () => true
 })
 
+server.setSchemaResolver(function (ref: string) {
+  return {
+    $id: ref,
+    type: 'string'
+  }
+})
+
 server.addSchema({})
 
 server.addContentTypeParser('*', (req, done) => {


### PR DESCRIPTION
Fixes #1881 

This doesn't fix the case:

```
  fastify.route({
    method: 'POST',
    url: '/',
    schema: {
       response: {
         '2xx': ajv.getSchema('urn:schema:response').schema
       }
    },
    handler (req, reply) {
      reply.send({ foo: 'bar' })
    }
  })
```

I'm still investigating.

Meanwhile, @jsumners, if you would like to suggest more test it would be really helpful

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
