### PR TITLE
doc fix: add .headers to reply docs

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -5,6 +5,7 @@
   - [Introduction](#introduction)
   - [.code(statusCode)](#codestatuscode)
   - [.header(key, value)](#headerkey-value)
+  - [.headers(object)](#headersobject)
   - [.getHeader(key)](#getheaderkey)
   - [.removeHeader(key)](#removeheaderkey)
   - [.hasHeader(key)](#hasheaderkey)
@@ -33,6 +34,7 @@ and properties:
 - `.code(statusCode)` - Sets the status code.
 - `.status(statusCode)` - An alias for `.code(statusCode)`.
 - `.header(name, value)` - Sets a response header.
+- `.headers(object)` - Sets all the keys of the object as a response headers.
 - `.getHeader(name)` - Retrieve value of already set header.
 - `.removeHeader(key)` - Remove the value of a previously set header.
 - `.hasHeader(name)` - Determine if a header has been set.
@@ -75,6 +77,16 @@ Sets a response header. If the value is omitted or undefined it is coerced
 to `''`.
 
 For more information, see [`http.ServerResponse#setHeader`](https://nodejs.org/dist/latest/docs/api/http.html#http_response_setheader_name_value).
+
+<a name="headers"></a>
+### .headers(object)
+Sets all the keys of the object as response headers. [`.header`](#headerkey-value) will be called under the hood.
+```js
+reply.headers({
+  'x-foo': 'foo',
+  'x-bar': 'bar'
+})
+```
 
 <a name="getHeader"></a>
 ### .getHeader(key)


### PR DESCRIPTION

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
