### PR TITLE
Test: After can access to decorations registered into plugin

### DIFF
--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -660,3 +660,53 @@ test('a decorator should addSchema to all the encapsulated tree', t => {
 
   fastify.ready(t.error)
 })
+
+test('after can access to a decorated instance and previous plugin decoration', t => {
+  t.plan(11)
+  const TEST_VALUE = {}
+  const OTHER_TEST_VALUE = {}
+  const NEW_TEST_VALUE = {}
+
+  const fastify = Fastify()
+
+  fastify.register(fp(function (instance, options, next) {
+    instance.decorate('test', TEST_VALUE)
+
+    next()
+  }))
+    .after(function (err, instance, done) {
+      t.error(err)
+      t.equal(instance.test, TEST_VALUE)
+
+      instance.decorate('test2', OTHER_TEST_VALUE)
+      done()
+    })
+
+  fastify.register(fp(function (instance, options, next) {
+    t.equal(instance.test, TEST_VALUE)
+    t.equal(instance.test2, OTHER_TEST_VALUE)
+
+    instance.decorate('test3', NEW_TEST_VALUE)
+
+    next()
+  }))
+    .after(function (err, instance, done) {
+      t.error(err)
+      t.equal(instance.test, TEST_VALUE)
+      t.equal(instance.test2, OTHER_TEST_VALUE)
+      t.equal(instance.test3, NEW_TEST_VALUE)
+
+      done()
+    })
+
+  fastify.get('/', function (req, res) {
+    t.equal(this.test, TEST_VALUE)
+    t.equal(this.test2, OTHER_TEST_VALUE)
+    res.send({})
+  })
+
+  fastify.inject('/')
+    .then(response => {
+      t.equal(response.statusCode, 200)
+    })
+})

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -689,15 +689,14 @@ test('after can access to a decorated instance and previous plugin decoration', 
     instance.decorate('test3', NEW_TEST_VALUE)
 
     next()
-  }))
-    .after(function (err, instance, done) {
-      t.error(err)
-      t.equal(instance.test, TEST_VALUE)
-      t.equal(instance.test2, OTHER_TEST_VALUE)
-      t.equal(instance.test3, NEW_TEST_VALUE)
+  })).after(function (err, instance, done) {
+    t.error(err)
+    t.equal(instance.test, TEST_VALUE)
+    t.equal(instance.test2, OTHER_TEST_VALUE)
+    t.equal(instance.test3, NEW_TEST_VALUE)
 
-      done()
-    })
+    done()
+  })
 
   fastify.get('/', function (req, res) {
     t.equal(this.test, TEST_VALUE)

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -673,14 +673,13 @@ test('after can access to a decorated instance and previous plugin decoration', 
     instance.decorate('test', TEST_VALUE)
 
     next()
-  }))
-    .after(function (err, instance, done) {
-      t.error(err)
-      t.equal(instance.test, TEST_VALUE)
+  })).after(function (err, instance, done) {
+    t.error(err)
+    t.equal(instance.test, TEST_VALUE)
 
-      instance.decorate('test2', OTHER_TEST_VALUE)
-      done()
-    })
+    instance.decorate('test2', OTHER_TEST_VALUE)
+    done()
+  })
 
   fastify.register(fp(function (instance, options, next) {
     t.equal(instance.test, TEST_VALUE)


### PR DESCRIPTION
Add test for documenting behaviour "After can access to decorations registered into plugin"

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
