### PR TITLE
Reply status code

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -75,7 +75,7 @@ If not set via `reply.code`, the resulting `statusCode` will be `200`.
 
 <a name="statusCode"></a>
 ### .statusCode
-This property read and set the HTTP status code. It is an alias for `reply.code()` when used as a set.
+This property reads and sets the HTTP status code. It is an alias for `reply.code()` when used as a setter.
 ```js
 if (reply.statusCode >= 299) {
   reply.statusCode = 500

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -4,6 +4,7 @@
 - [Reply](#reply)
   - [Introduction](#introduction)
   - [.code(statusCode)](#codestatuscode)
+  - [.statusCode](#statusCode)
   - [.header(key, value)](#headerkey-value)
   - [.headers(object)](#headersobject)
   - [.getHeader(key)](#getheaderkey)
@@ -33,6 +34,7 @@ and properties:
 
 - `.code(statusCode)` - Sets the status code.
 - `.status(statusCode)` - An alias for `.code(statusCode)`.
+- `.statusCode` - Read and set the HTTP status code.
 - `.header(name, value)` - Sets a response header.
 - `.headers(object)` - Sets all the keys of the object as a response headers.
 - `.getHeader(name)` - Retrieve value of already set header.
@@ -70,6 +72,15 @@ fastify.get('/', {config: {foo: 'bar'}}, function (request, reply) {
 <a name="code"></a>
 ### .code(statusCode)
 If not set via `reply.code`, the resulting `statusCode` will be `200`.
+
+<a name="statusCode"></a>
+### .statusCode
+This property read and set the HTTP status code. It is an alias for `reply.code()` when used as a set.
+```js
+if (reply.statusCode >= 299) {
+  reply.statusCode = 500
+}
+```
 
 <a name="header"></a>
 ### .header(key, value)

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -86,6 +86,15 @@ Object.defineProperty(Reply.prototype, 'sent', {
   }
 })
 
+Object.defineProperty(Reply.prototype, 'statusCode', {
+  get () {
+    return this.res.statusCode
+  },
+  set (value) {
+    this.code(value)
+  }
+})
+
 Reply.prototype.send = function (payload) {
   if (this[kReplyIsRunningOnErrorHook] === true) {
     throw new FST_ERR_SEND_INSIDE_ONERR()

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -924,6 +924,23 @@ test('.status() is an alias for .code()', t => {
   })
 })
 
+test('.statusCode is getter and setter', t => {
+  t.plan(4)
+  const fastify = require('../..')()
+
+  fastify.get('/', function (req, reply) {
+    t.ok(reply.statusCode, 200, 'default status value')
+    reply.statusCode = 418
+    t.ok(reply.statusCode, 418)
+    reply.send()
+  })
+
+  fastify.inject('/', (err, res) => {
+    t.error(err)
+    t.is(res.statusCode, 418)
+  })
+})
+
 test('reply.header setting multiple cookies as multiple Set-Cookie headers', t => {
   t.plan(7)
 


### PR DESCRIPTION
The necessity is for this use case:

https://github.com/fastify/fastify-reply-from/blob/master/index.js#L119-L121

It is not possible for the user to access the status code set by plugins and not exposed.
In this way, the user can have control every time.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
