### PR TITLE
Add type definition for genReqId option

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -205,7 +205,8 @@ declare namespace fastify {
       deriveVersion<Context>(req: Object, ctx?: Context) : String,
     },
     modifyCoreObjects?: boolean,
-    return503OnClosing?: boolean
+    return503OnClosing?: boolean,
+    genReqId?: () => number | string
   }
   interface ServerOptionsAsSecure extends ServerOptions {
     https: http2.SecureServerOptions

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -64,7 +64,13 @@ const cors = require('cors')
     maxParamLength: 200,
     querystringParser: (str: string) => ({ str: str, strArray: [str] }),
     modifyCoreObjects: true,
-    return503OnClosing: true
+    return503OnClosing: true,
+    genReqId: () => {
+      if (Math.random() > 0.5) {
+        return Math.random().toString()
+      }
+      return Math.random()
+    }
   })
 
   // custom types


### PR DESCRIPTION
Adds missing typescript definition for server option `genReqId`.

This missing definition required us to define it in our project to build successfully.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
