### PR TITLE
Take querystring parameters after last question mark

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -328,8 +328,9 @@ function buildRouting (options) {
       childLogger.info({ req }, 'incoming request')
     }
 
-    var queryPrefix = req.url.indexOf('?')
-    var query = querystringParser(queryPrefix > -1 ? req.url.slice(queryPrefix + 1) : '')
+    var url = req.url.replace(/\?{2,}/, '?')
+    var queryPrefix = url.indexOf('?')
+    var query = querystringParser(queryPrefix > -1 ? url.slice(queryPrefix + 1) : '')
     var request = new context.Request(params, req, query, req.headers, childLogger, ip, ips, hostname)
     var reply = new context.Reply(res, context, request, childLogger)
 

--- a/test/custom-querystring-parser.test.js
+++ b/test/custom-querystring-parser.test.js
@@ -120,6 +120,43 @@ test('Querystring without value', t => {
   })
 })
 
+test('Querystring after few question marks', t => {
+  t.plan(9)
+
+  const fastify = Fastify({
+    querystringParser: function (str) {
+      t.strictEqual(str, 'foo=bar')
+      return querystring.parse(str)
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    t.deepEqual(req.query, { foo: 'bar' })
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.listen(0, (err, address) => {
+    t.error(err)
+    t.tearDown(() => fastify.close())
+
+    sget({
+      method: 'GET',
+      url: `${address}??foo=bar`
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+    })
+
+    fastify.inject({
+      method: 'GET',
+      url: `${address}??foo=bar`
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+    })
+  })
+})
+
 test('Custom querystring parser should be a function', t => {
   t.plan(1)
 


### PR DESCRIPTION
Simple helper for inattentive developers.
If client send request to `/path??foo=bar`, **request.query** will contain **foo** property, not **?foo**

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
