### PR TITLE
Added support for onConstructorPoisoning

### DIFF
--- a/build/build-validation.js
+++ b/build/build-validation.js
@@ -15,9 +15,12 @@ const ajv = new Ajv({
 const defaultInitOptions = {
   bodyLimit: 1024 * 1024, // 1 MiB
   caseSensitive: true,
+  disableRequestLogging: false,
   ignoreTrailingSlash: false,
   maxParamLength: 100,
   onProtoPoisoning: 'error',
+  // TODO v3: default should be 'error'
+  onConstructorPoisoning: 'ignore',
   pluginTimeout: 10000,
   requestIdHeader: 'request-id',
   requestIdLogLabel: 'reqId'
@@ -62,8 +65,13 @@ const schema = {
       then: { setDefaultValue: true }
     },
     ignoreTrailingSlash: { type: 'boolean', default: defaultInitOptions.ignoreTrailingSlash },
+    disableRequestLogging: {
+      type: 'boolean',
+      default: false
+    },
     maxParamLength: { type: 'integer', default: defaultInitOptions.maxParamLength },
     onProtoPoisoning: { type: 'string', default: defaultInitOptions.onProtoPoisoning },
+    onConstructorPoisoning: { type: 'string', default: defaultInitOptions.onConstructorPoisoning },
     pluginTimeout: { type: 'integer', default: defaultInitOptions.pluginTimeout },
     requestIdHeader: { type: 'string', default: defaultInitOptions.requestIdHeader },
     requestIdLogLabel: { type: 'string', default: defaultInitOptions.requestIdLogLabel }

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -75,13 +75,26 @@ Defines the maximum payload, in bytes, the server is allowed to accept.
 
 Defines what action the framework must take when parsing a JSON object
 with `__proto__`. This functionality is provided by
-[bourne](https://github.com/hapijs/bourne).
+[secure-json-parse](https://github.com/fastify/secure-json-parse).
 See https://hueniverse.com/a-tale-of-prototype-poisoning-2610fa170061
 for more details about prototype poisoning attacks.
 
 Possible values are `'error'`, `'remove'` and `'ignore'`.
 
 + Default: `'error'`
+
+<a name="factory-on-constructor-poisoning"></a>
+### `onConstructorPoisoning`
+
+Defines what action the framework must take when parsing a JSON object
+with `constructor`. This functionality is provided by
+[secure-json-parse](https://github.com/fastify/secure-json-parse).
+See https://hueniverse.com/a-tale-of-prototype-poisoning-2610fa170061
+for more details about prototype poisoning attacks.
+
+Possible values are `'error'`, `'remove'` and `'ignore'`.
+
++ Default: `'ignore'`
 
 <a name="factory-logger"></a>
 ### `logger`

--- a/fastify.js
+++ b/fastify.js
@@ -123,7 +123,11 @@ function build (options) {
     [kSchemaCompiler]: null,
     [kSchemaResolver]: null,
     [kReplySerializerDefault]: null,
-    [kContentTypeParser]: new ContentTypeParser(bodyLimit, (options.onProtoPoisoning || defaultInitOptions.onProtoPoisoning)),
+    [kContentTypeParser]: new ContentTypeParser(
+      bodyLimit,
+      (options.onProtoPoisoning || defaultInitOptions.onProtoPoisoning),
+      (options.onConstructorPoisoning || defaultInitOptions.onConstructorPoisoning)
+    ),
     [kReply]: Reply.buildReply(Reply),
     [kRequest]: Request.buildRequest(Request),
     [kMiddlewares]: [],

--- a/lib/configValidator.js
+++ b/lib/configValidator.js
@@ -14,10 +14,11 @@ var validate = (function() {
     if ((data && typeof data === "object" && !Array.isArray(data))) {
       if (data.bodyLimit === undefined) data.bodyLimit = 1048576;
       if (data.caseSensitive === undefined) data.caseSensitive = true;
-      if (data.disableRequestLogging === undefined) data.disableRequestLogging = false;
       if (data.ignoreTrailingSlash === undefined) data.ignoreTrailingSlash = false;
+      if (data.disableRequestLogging === undefined) data.disableRequestLogging = false;
       if (data.maxParamLength === undefined) data.maxParamLength = 100;
       if (data.onProtoPoisoning === undefined) data.onProtoPoisoning = "error";
+      if (data.onConstructorPoisoning === undefined) data.onConstructorPoisoning = "ignore";
       if (data.pluginTimeout === undefined) data.pluginTimeout = 10000;
       if (data.requestIdHeader === undefined) data.requestIdHeader = "request-id";
       if (data.requestIdLogLabel === undefined) data.requestIdLogLabel = "reqId";
@@ -321,80 +322,81 @@ var validate = (function() {
                 }
                 var valid1 = errors === errs_1;
                 if (valid1) {
-                  var data1 = data.maxParamLength;
+                  var data1 = data.disableRequestLogging;
                   var errs_1 = errors;
-                  if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
+                  if (typeof data1 !== "boolean") {
                     var dataType1 = typeof data1;
                     var coerced1 = undefined;
-                    if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
+                    if (data1 === 'false' || data1 === 0 || data1 === null) coerced1 = false;
+                    else if (data1 === 'true' || data1 === 1) coerced1 = true;
                     if (coerced1 === undefined) {
                       validate.errors = [{
                         keyword: 'type',
-                        dataPath: (dataPath || '') + '.maxParamLength',
-                        schemaPath: '#/properties/maxParamLength/type',
+                        dataPath: (dataPath || '') + '.disableRequestLogging',
+                        schemaPath: '#/properties/disableRequestLogging/type',
                         params: {
-                          type: 'integer'
+                          type: 'boolean'
                         },
-                        message: 'should be integer'
+                        message: 'should be boolean'
                       }];
                       return false;
                     } else {
                       data1 = coerced1;
-                      data['maxParamLength'] = coerced1;
+                      data['disableRequestLogging'] = coerced1;
                     }
                   }
                   var valid1 = errors === errs_1;
                   if (valid1) {
-                    var data1 = data.onProtoPoisoning;
+                    var data1 = data.maxParamLength;
                     var errs_1 = errors;
-                    if (typeof data1 !== "string") {
+                    if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
                       var dataType1 = typeof data1;
                       var coerced1 = undefined;
-                      if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
-                      else if (data1 === null) coerced1 = '';
+                      if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
                       if (coerced1 === undefined) {
                         validate.errors = [{
                           keyword: 'type',
-                          dataPath: (dataPath || '') + '.onProtoPoisoning',
-                          schemaPath: '#/properties/onProtoPoisoning/type',
+                          dataPath: (dataPath || '') + '.maxParamLength',
+                          schemaPath: '#/properties/maxParamLength/type',
                           params: {
-                            type: 'string'
+                            type: 'integer'
                           },
-                          message: 'should be string'
+                          message: 'should be integer'
                         }];
                         return false;
                       } else {
                         data1 = coerced1;
-                        data['onProtoPoisoning'] = coerced1;
+                        data['maxParamLength'] = coerced1;
                       }
                     }
                     var valid1 = errors === errs_1;
                     if (valid1) {
-                      var data1 = data.pluginTimeout;
+                      var data1 = data.onProtoPoisoning;
                       var errs_1 = errors;
-                      if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
+                      if (typeof data1 !== "string") {
                         var dataType1 = typeof data1;
                         var coerced1 = undefined;
-                        if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
+                        if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
+                        else if (data1 === null) coerced1 = '';
                         if (coerced1 === undefined) {
                           validate.errors = [{
                             keyword: 'type',
-                            dataPath: (dataPath || '') + '.pluginTimeout',
-                            schemaPath: '#/properties/pluginTimeout/type',
+                            dataPath: (dataPath || '') + '.onProtoPoisoning',
+                            schemaPath: '#/properties/onProtoPoisoning/type',
                             params: {
-                              type: 'integer'
+                              type: 'string'
                             },
-                            message: 'should be integer'
+                            message: 'should be string'
                           }];
                           return false;
                         } else {
                           data1 = coerced1;
-                          data['pluginTimeout'] = coerced1;
+                          data['onProtoPoisoning'] = coerced1;
                         }
                       }
                       var valid1 = errors === errs_1;
                       if (valid1) {
-                        var data1 = data.requestIdHeader;
+                        var data1 = data.onConstructorPoisoning;
                         var errs_1 = errors;
                         if (typeof data1 !== "string") {
                           var dataType1 = typeof data1;
@@ -404,8 +406,8 @@ var validate = (function() {
                           if (coerced1 === undefined) {
                             validate.errors = [{
                               keyword: 'type',
-                              dataPath: (dataPath || '') + '.requestIdHeader',
-                              schemaPath: '#/properties/requestIdHeader/type',
+                              dataPath: (dataPath || '') + '.onConstructorPoisoning',
+                              schemaPath: '#/properties/onConstructorPoisoning/type',
                               params: {
                                 type: 'string'
                               },
@@ -414,35 +416,86 @@ var validate = (function() {
                             return false;
                           } else {
                             data1 = coerced1;
-                            data['requestIdHeader'] = coerced1;
+                            data['onConstructorPoisoning'] = coerced1;
                           }
                         }
                         var valid1 = errors === errs_1;
                         if (valid1) {
-                          var data1 = data.requestIdLogLabel;
+                          var data1 = data.pluginTimeout;
                           var errs_1 = errors;
-                          if (typeof data1 !== "string") {
+                          if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
                             var dataType1 = typeof data1;
                             var coerced1 = undefined;
-                            if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
-                            else if (data1 === null) coerced1 = '';
+                            if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
                             if (coerced1 === undefined) {
                               validate.errors = [{
                                 keyword: 'type',
-                                dataPath: (dataPath || '') + '.requestIdLogLabel',
-                                schemaPath: '#/properties/requestIdLogLabel/type',
+                                dataPath: (dataPath || '') + '.pluginTimeout',
+                                schemaPath: '#/properties/pluginTimeout/type',
                                 params: {
-                                  type: 'string'
+                                  type: 'integer'
                                 },
-                                message: 'should be string'
+                                message: 'should be integer'
                               }];
                               return false;
                             } else {
                               data1 = coerced1;
-                              data['requestIdLogLabel'] = coerced1;
+                              data['pluginTimeout'] = coerced1;
                             }
                           }
                           var valid1 = errors === errs_1;
+                          if (valid1) {
+                            var data1 = data.requestIdHeader;
+                            var errs_1 = errors;
+                            if (typeof data1 !== "string") {
+                              var dataType1 = typeof data1;
+                              var coerced1 = undefined;
+                              if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
+                              else if (data1 === null) coerced1 = '';
+                              if (coerced1 === undefined) {
+                                validate.errors = [{
+                                  keyword: 'type',
+                                  dataPath: (dataPath || '') + '.requestIdHeader',
+                                  schemaPath: '#/properties/requestIdHeader/type',
+                                  params: {
+                                    type: 'string'
+                                  },
+                                  message: 'should be string'
+                                }];
+                                return false;
+                              } else {
+                                data1 = coerced1;
+                                data['requestIdHeader'] = coerced1;
+                              }
+                            }
+                            var valid1 = errors === errs_1;
+                            if (valid1) {
+                              var data1 = data.requestIdLogLabel;
+                              var errs_1 = errors;
+                              if (typeof data1 !== "string") {
+                                var dataType1 = typeof data1;
+                                var coerced1 = undefined;
+                                if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
+                                else if (data1 === null) coerced1 = '';
+                                if (coerced1 === undefined) {
+                                  validate.errors = [{
+                                    keyword: 'type',
+                                    dataPath: (dataPath || '') + '.requestIdLogLabel',
+                                    schemaPath: '#/properties/requestIdLogLabel/type',
+                                    params: {
+                                      type: 'string'
+                                    },
+                                    message: 'should be string'
+                                  }];
+                                  return false;
+                                } else {
+                                  data1 = coerced1;
+                                  data['requestIdLogLabel'] = coerced1;
+                                }
+                              }
+                              var valid1 = errors === errs_1;
+                            }
+                          }
                         }
                       }
                     }
@@ -507,11 +560,11 @@ validate.schema = {
         "setDefaultValue": true
       }
     },
-    "disableRequestLogging": {
+    "ignoreTrailingSlash": {
       "type": "boolean",
       "default": false
     },
-    "ignoreTrailingSlash": {
+    "disableRequestLogging": {
       "type": "boolean",
       "default": false
     },
@@ -522,6 +575,10 @@ validate.schema = {
     "onProtoPoisoning": {
       "type": "string",
       "default": "error"
+    },
+    "onConstructorPoisoning": {
+      "type": "string",
+      "default": "ignore"
     },
     "pluginTimeout": {
       "type": "integer",
@@ -545,14 +602,4 @@ function customRule0 (schemaParamValue, validatedParamValue, validationSchemaObj
   return true
 }
 
-module.exports.defaultInitOptions = {
-  "bodyLimit":1048576,
-  "caseSensitive":true,
-  "disableRequestLogging": false,
-  "ignoreTrailingSlash":false,
-  "maxParamLength":100,
-  "onProtoPoisoning":"error",
-  "pluginTimeout":10000,
-  "requestIdHeader":"request-id",
-  "requestIdLogLabel":"reqId"
-}
+module.exports.defaultInitOptions = {"bodyLimit":1048576,"caseSensitive":true,"disableRequestLogging":false,"ignoreTrailingSlash":false,"maxParamLength":100,"onProtoPoisoning":"error","onConstructorPoisoning":"ignore","pluginTimeout":10000,"requestIdHeader":"request-id","requestIdLogLabel":"reqId"}

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -22,8 +22,8 @@ const {
   }
 } = require('./errors')
 
-function ContentTypeParser (bodyLimit, onProtoPoisoning) {
-  this[kDefaultJsonParse] = getDefaultJsonParser(onProtoPoisoning)
+function ContentTypeParser (bodyLimit, onProtoPoisoning, onConstructorPoisoning) {
+  this[kDefaultJsonParse] = getDefaultJsonParser(onProtoPoisoning, onConstructorPoisoning)
   this.customParsers = {}
   this.customParsers['application/json'] = new Parser(true, false, bodyLimit, this[kDefaultJsonParse])
   this.customParsers['text/plain'] = new Parser(true, false, bodyLimit, defaultPlainTextParser)
@@ -189,7 +189,7 @@ function rawBody (request, reply, options, parser, done) {
   }
 }
 
-function getDefaultJsonParser (onProtoPoisoning) {
+function getDefaultJsonParser (onProtoPoisoning, onConstructorPoisoning) {
   return defaultJsonParser
 
   function defaultJsonParser (req, body, done) {
@@ -198,7 +198,7 @@ function getDefaultJsonParser (onProtoPoisoning) {
     }
 
     try {
-      var json = secureJson.parse(body, { protoAction: onProtoPoisoning })
+      var json = secureJson.parse(body, { protoAction: onProtoPoisoning, constructorAction: onConstructorPoisoning })
     } catch (err) {
       err.statusCode = 400
       return done(err, undefined)

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "proxy-addr": "^2.0.4",
     "readable-stream": "^3.1.1",
     "rfdc": "^1.1.2",
-    "secure-json-parse": "^1.0.0",
+    "secure-json-parse": "^2.0.0",
     "tiny-lru": "^7.0.0"
   },
   "greenkeeper": {

--- a/test/internals/initialConfig.test.js
+++ b/test/internals/initialConfig.test.js
@@ -25,6 +25,7 @@ test('without options passed to Fastify, initialConfig should expose default val
     ignoreTrailingSlash: false,
     maxParamLength: 100,
     onProtoPoisoning: 'error',
+    onConstructorPoisoning: 'ignore',
     pluginTimeout: 10000,
     requestIdHeader: 'request-id',
     requestIdLogLabel: 'reqId'
@@ -228,6 +229,7 @@ test('Should not have issues when passing stream options to Pino.js', t => {
       ignoreTrailingSlash: true,
       maxParamLength: 100,
       onProtoPoisoning: 'error',
+      onConstructorPoisoning: 'ignore',
       pluginTimeout: 10000,
       requestIdHeader: 'request-id',
       requestIdLogLabel: 'reqId'

--- a/test/proto-poisoning.test.js
+++ b/test/proto-poisoning.test.js
@@ -81,3 +81,79 @@ test('proto-poisoning ignore', t => {
     })
   })
 })
+
+test('constructor-poisoning ignore (default in v2)', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.post('/', (request, reply) => {
+    reply.send('ok')
+  })
+
+  fastify.listen(0, function (err) {
+    t.error(err)
+
+    sget({
+      method: 'POST',
+      url: 'http://localhost:' + fastify.server.address().port,
+      headers: { 'Content-Type': 'application/json' },
+      body: '{ "constructor": { "prototype": { "foo": "bar" } } }'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+    })
+  })
+})
+
+test('constructor-poisoning error', t => {
+  t.plan(3)
+
+  const fastify = Fastify({ onConstructorPoisoning: 'error' })
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.post('/', (request, reply) => {
+    t.fail('handler should not be called')
+  })
+
+  fastify.listen(0, function (err) {
+    t.error(err)
+
+    sget({
+      method: 'POST',
+      url: 'http://localhost:' + fastify.server.address().port,
+      headers: { 'Content-Type': 'application/json' },
+      body: '{ "constructor": { "prototype": { "foo": "bar" } } }'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 400)
+    })
+  })
+})
+
+test('constructor-poisoning remove', t => {
+  t.plan(4)
+
+  const fastify = Fastify({ onProtoPoisoning: 'remove' })
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.post('/', (request, reply) => {
+    t.equal(undefined, Object.assign({}, request.body).foo)
+    reply.send({ ok: true })
+  })
+
+  fastify.listen(0, function (err) {
+    t.error(err)
+
+    sget({
+      method: 'POST',
+      url: 'http://localhost:' + fastify.server.address().port,
+      headers: { 'Content-Type': 'application/json' },
+      body: '{ "constructor": { "prototype": { "foo": "bar" } } }'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+    })
+  })
+})


### PR DESCRIPTION
As titled, see https://github.com/fastify/secure-json-parse/pull/4 for discussion.
I've also fixed a validation leftover from https://github.com/fastify/fastify/pull/1629.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
