### PR TITLE
Added missing types for Server Options

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -184,6 +184,8 @@ declare namespace fastify {
     request: FastifyRequest
   }
   type TrustProxyFunction = (addr: string, index: number) => boolean
+  type ServerFactoryHandlerFunction = (request: http.IncomingMessage, response: http.ServerResponse) => void
+  type ServerFactoryFunction = (handler: ServerFactoryHandlerFunction, options: ServerOptions) => http.Server | http2.Http2Server
   interface ServerOptions {
     caseSensitive?: boolean,
     ignoreTrailingSlash?: boolean,
@@ -207,7 +209,10 @@ declare namespace fastify {
     },
     modifyCoreObjects?: boolean,
     return503OnClosing?: boolean,
-    genReqId?: () => number | string
+    genReqId?: () => number | string,
+    requestIdHeader?: string,
+    requestIdLogLabel?: string,
+    serverFactory?: ServerFactoryFunction
   }
   interface ServerOptionsAsSecure extends ServerOptions {
     https: http2.SecureServerOptions

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -184,7 +184,7 @@ declare namespace fastify {
     request: FastifyRequest
   }
   type TrustProxyFunction = (addr: string, index: number) => boolean
-  type ServerFactoryHandlerFunction = (request: http.IncomingMessage, response: http.ServerResponse) => void
+  type ServerFactoryHandlerFunction = (request: http.IncomingMessage | http2.Http2ServerRequest, response: http.ServerResponse | http2.Http2ServerResponse) => void
   type ServerFactoryFunction = (handler: ServerFactoryHandlerFunction, options: ServerOptions) => http.Server | http2.Http2Server
   interface ServerOptions {
     caseSensitive?: boolean,

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -81,6 +81,16 @@ const cors = require('cors')
     }
   })
 
+  // http2 server factory option
+  const otherHttp2Server = fastify({
+    serverFactory: (handler, options) => {
+      const server = http2.createServer((req, res) => {
+        handler(req, res)
+      })
+      return server
+    }
+  })
+
   // custom types
   interface CustomIncomingMessage extends http.IncomingMessage {
     getDeviceType: () => string;

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -70,6 +70,14 @@ const cors = require('cors')
         return Math.random().toString()
       }
       return Math.random()
+    },
+    requestIdHeader: 'request-id',
+    requestIdLogLabel: 'reqId',
+    serverFactory: (handler, options) => {
+      const server = http.createServer((req, res) => {
+        handler(req, res)
+      })
+      return server
     }
   })
 


### PR DESCRIPTION

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

Fixes: #1921 