### PR TITLE
improve type annotations of `register` api

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -301,8 +301,8 @@ declare namespace fastify {
   /**
    * Register options
    */
-  interface RegisterOptions<HttpServer, HttpRequest, HttpResponse> {
-    [key: string]: any,
+   type RegisterOptions<HttpServer, HttpRequest, HttpResponse, T extends {}> = {
+   [ k in keyof T ]: T[k] } & {
     prefix?: string,
     logSerializers?: Object
   }
@@ -554,7 +554,7 @@ declare namespace fastify {
     /**
      * Registers a plugin
      */
-    register<Options extends RegisterOptions<HttpServer, HttpRequest, HttpResponse>, PluginInstance extends Function>(plugin: Plugin<HttpServer, HttpRequest, HttpResponse, Options, PluginInstance>, options?: Options): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+     register<Options extends RegisterOptions<HttpServer, HttpRequest, HttpResponse, any >, PluginInstance extends Function>(plugin: Plugin<HttpServer, HttpRequest, HttpResponse, Options, PluginInstance>, options?: Options): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * `Register a callback that will be executed just after a register.


### PR DESCRIPTION
Using generic paramaters so that when register plugin has proper type annotations, the linter can inference the second parameter of `register` function.

for example

![eg](https://user-images.githubusercontent.com/21005146/68645890-7bc32600-0554-11ea-8fc4-d62759887735.png)




<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
