### PR TITLE
minor docs update for https typings

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -21,6 +21,7 @@ import { Server, IncomingMessage, ServerResponse } from 'http'
 // Create a http server. We pass the relevant typings for our http version used.
 // By passing types we get correctly typed access to the underlying http objects in routes.
 // If using http2 we'd pass <http2.Http2Server, http2.Http2ServerRequest, http2.Http2ServerResponse>
+// For https pass http2.Http2SecureServer or http.SecureServer instead of Server.
 const server: fastify.FastifyInstance<Server, IncomingMessage, ServerResponse> = fastify({})
 
 const opts: fastify.RouteShorthandOptions = {


### PR DESCRIPTION
Added docs comment for correct use of typings for https server:
"// For https pass http2.Http2SecureServer or http.SecureServer instead of Server."

