### PR TITLE
Ajv update

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -378,7 +378,20 @@ If `false`, the server routes the incoming request as usual.
 
 Configure the ajv instance used by Fastify without providing a custom one.
 
-+ Default: `{ }`
++ Default:
+
+```js
+{
+  customOptions: {
+    removeAdditional: true,
+    useDefaults: true,
+    coerceTypes: true,
+    allErrors: true,
+    nullable: true
+  },
+  plugins: []
+}
+```
 
 ```js
 const fastify = require('fastify')({

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -373,6 +373,29 @@ If `false`, the server routes the incoming request as usual.
 
 + Default: `true`
 
+<a name="factory-ajv"></a>
+### `ajv`
+
+Configure the ajv instance used by Fastify without providing a custom one.
+
++ Default: `{ }`
+
+```js
+const fastify = require('fastify')({
+  ajv: {
+    customOptions: {
+      nullable: false // Refer to [ajv options](https://ajv.js.org/#options)
+    },
+    plugins: [
+      require('ajv-merge-patch')
+      [require('ajv-keywords'), 'instanceof'];
+      // Usage: [plugin, pluginOptions] - Plugin with options
+      // Usage: plugin - Plugin without options
+    ]
+  }
+})
+```
+
 ## Instance
 
 ### Server Methods

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -240,6 +240,77 @@ This example will returns:
 | /sub  | one, two        |
 | /deep | one, two, three |
 
+<a name="ajv-plugins"></a>
+#### Ajv Plugins
+
+You can provide a list of plugins you want to use with Ajv:
+
+> Refer to [`ajv options`](https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-ajv) to check plugins format
+
+```js
+const fastify = require('fastify')({
+  ajv: {
+    plugins: [
+      require('ajv-merge-patch')
+    ]
+  }
+})
+
+fastify.route({
+  method: 'POST',
+  url: '/',
+  schema: {
+    body: {
+      $patch: {
+        source: {
+          type: 'object',
+          properties: {
+            q: {
+              type: 'string'
+            }
+          }
+        },
+        with: [
+          {
+            op: 'add',
+            path: '/properties/q',
+            value: { type: 'number' }
+          }
+        ]
+      }
+    }
+  },
+  handler (req, reply) {
+    reply.send({ ok: 1 })
+  }
+})
+
+fastify.route({
+  method: 'POST',
+  url: '/',
+  schema: {
+    body: {
+      $merge: {
+        source: {
+          type: 'object',
+          properties: {
+            q: {
+              type: 'string'
+            }
+          }
+        },
+        with: {
+          required: ['q']
+        }
+      }
+    }
+  },
+  handler (req, reply) {
+    reply.send({ ok: 1 })
+  }
+})
+```
+
 <a name="schema-compiler"></a>
 #### Schema Compiler
 
@@ -257,7 +328,9 @@ Fastify's [baseline ajv configuration](https://github.com/epoberezkin/ajv#option
 }
 ```
 
-This baseline configuration cannot be modified. If you want to change or set additional config options, you will need to create your own instance and override the existing one like:
+This baseline configuration can be modified by providing [`ajv.customOptions`](https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-ajv) to your Fastify factory.
+
+If you want to change or set additional config options, you will need to create your own instance and override the existing one like:
 
 ```js
 const fastify = require('fastify')()

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -4,6 +4,7 @@
 
 /// <reference types="node" />
 
+import * as ajv from 'ajv'
 import * as http from 'http'
 import * as http2 from 'http2'
 import * as https from 'https'
@@ -186,6 +187,7 @@ declare namespace fastify {
   type TrustProxyFunction = (addr: string, index: number) => boolean
   type ServerFactoryHandlerFunction = (request: http.IncomingMessage | http2.Http2ServerRequest, response: http.ServerResponse | http2.Http2ServerResponse) => void
   type ServerFactoryFunction = (handler: ServerFactoryHandlerFunction, options: ServerOptions) => http.Server | http2.Http2Server
+
   interface ServerOptions {
     caseSensitive?: boolean,
     ignoreTrailingSlash?: boolean,
@@ -212,7 +214,11 @@ declare namespace fastify {
     genReqId?: () => number | string,
     requestIdHeader?: string,
     requestIdLogLabel?: string,
-    serverFactory?: ServerFactoryFunction
+    serverFactory?: ServerFactoryFunction,
+    ajv?: {
+      customOptions?: ajv.Options,
+      plugins?: Array<Array<String>|String>
+    }
   }
   interface ServerOptionsAsSecure extends ServerOptions {
     https: http2.SecureServerOptions

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -217,7 +217,7 @@ declare namespace fastify {
     serverFactory?: ServerFactoryFunction,
     ajv?: {
       customOptions?: ajv.Options,
-      plugins?: Array<Array<String>|String>
+      plugins?: Array<Array<any>|String>
     }
   }
   interface ServerOptionsAsSecure extends ServerOptions {

--- a/fastify.js
+++ b/fastify.js
@@ -69,6 +69,8 @@ function build (options) {
   const requestIdLogLabel = options.requestIdLogLabel || 'reqId'
   const bodyLimit = options.bodyLimit || defaultInitOptions.bodyLimit
   const disableRequestLogging = options.disableRequestLogging || false
+  const ajvOptions = options.ajvOptions || {}
+  const ajvUseMergeAndPatch = options.ajvUseMergeAndPatch || false
 
   // Instance Fastify components
   const { logger, hasLogger } = createLogger(options)
@@ -82,6 +84,8 @@ function build (options) {
   options.requestIdLogLabel = requestIdLogLabel
   options.modifyCoreObjects = modifyCoreObjects
   options.disableRequestLogging = disableRequestLogging
+  options.ajvOptions = ajvOptions
+  options.ajvUseMergeAndPatch = ajvUseMergeAndPatch
 
   // Default router
   const router = buildRouting({

--- a/fastify.js
+++ b/fastify.js
@@ -71,12 +71,19 @@ function build (options) {
   const disableRequestLogging = options.disableRequestLogging || false
   const ajvOptions = Object.assign({
     customOptions: {},
-    useMergeAndPatch: false
+    plugins: []
   }, options.ajv)
 
-  if (ajvOptions && typeof ajvOptions.customOptions !== 'object') {
+  // Ajv options
+  if (!ajvOptions.customOptions || Object.prototype.toString.call(ajvOptions.customOptions) !== '[object Object]') {
     throw new Error(`ajv.customOptions option should be an object, instead got '${typeof ajvOptions.customOptions}'`)
   }
+  if (!ajvOptions.plugins || !Array.isArray(ajvOptions.plugins)) {
+    throw new Error(`ajv.plugins option should be an array, instead got '${typeof ajvOptions.customOptions}'`)
+  }
+  ajvOptions.plugins = ajvOptions.plugins.map(plugin => {
+    return Array.isArray(plugin) ? plugin : [plugin]
+  })
 
   // Instance Fastify components
   const { logger, hasLogger } = createLogger(options)

--- a/fastify.js
+++ b/fastify.js
@@ -69,8 +69,14 @@ function build (options) {
   const requestIdLogLabel = options.requestIdLogLabel || 'reqId'
   const bodyLimit = options.bodyLimit || defaultInitOptions.bodyLimit
   const disableRequestLogging = options.disableRequestLogging || false
-  const ajvOptions = options.ajvOptions || {}
-  const ajvUseMergeAndPatch = options.ajvUseMergeAndPatch || false
+  const ajvOptions = Object.assign({
+    customOptions: {},
+    useMergeAndPatch: false
+  }, options.ajv)
+
+  if (ajvOptions && typeof ajvOptions.customOptions !== 'object') {
+    throw new Error(`ajv.customOptions option should be an object, instead got '${typeof ajvOptions.customOptions}'`)
+  }
 
   // Instance Fastify components
   const { logger, hasLogger } = createLogger(options)
@@ -84,8 +90,7 @@ function build (options) {
   options.requestIdLogLabel = requestIdLogLabel
   options.modifyCoreObjects = modifyCoreObjects
   options.disableRequestLogging = disableRequestLogging
-  options.ajvOptions = ajvOptions
-  options.ajvUseMergeAndPatch = ajvUseMergeAndPatch
+  options.ajv = ajvOptions
 
   // Default router
   const router = buildRouting({

--- a/lib/route.js
+++ b/lib/route.js
@@ -230,7 +230,7 @@ function buildRouting (options) {
         try {
           if (opts.schemaCompiler == null && this[kSchemaCompiler] == null) {
             const externalSchemas = this[kSchemas].getJsonSchemas({ onlyAbsoluteUri: true })
-            this.setSchemaCompiler(buildSchemaCompiler(externalSchemas, this[kOptions].ajvOptions, { useMergeAndPatch: this[kOptions].ajvUseMergeAndPatch }, schemaCache))
+            this.setSchemaCompiler(buildSchemaCompiler(externalSchemas, this[kOptions].ajv, schemaCache))
           }
 
           buildSchema(context, opts.schemaCompiler || this[kSchemaCompiler], this[kSchemas], this[kSchemaResolver])

--- a/lib/route.js
+++ b/lib/route.js
@@ -25,6 +25,7 @@ const {
   kLogSerializers,
   kHooks,
   kSchemas,
+  kOptions,
   kSchemaCompiler,
   kSchemaResolver,
   kContentTypeParser,
@@ -229,7 +230,7 @@ function buildRouting (options) {
         try {
           if (opts.schemaCompiler == null && this[kSchemaCompiler] == null) {
             const externalSchemas = this[kSchemas].getJsonSchemas({ onlyAbsoluteUri: true })
-            this.setSchemaCompiler(buildSchemaCompiler(externalSchemas, schemaCache))
+            this.setSchemaCompiler(buildSchemaCompiler(externalSchemas, this[kOptions].ajvOptions, { useMergeAndPatch: this[kOptions].ajvUseMergeAndPatch }, schemaCache))
           }
 
           buildSchema(context, opts.schemaCompiler || this[kSchemaCompiler], this[kSchemas], this[kSchemaResolver])

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -135,7 +135,7 @@ Schemas.prototype.cleanId = function (schema) {
 }
 
 Schemas.prototype.getSchemaAnyway = function (schema) {
-  if (schema.oneOf || schema.allOf || schema.anyOf) return schema
+  if (schema.oneOf || schema.allOf || schema.anyOf || schema.$merge || schema.$patch) return schema
   if (!schema.type || !schema.properties) {
     return {
       type: 'object',

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -2,6 +2,7 @@
 
 const fastJsonStringify = require('fast-json-stringify')
 const Ajv = require('ajv')
+const ajvMergePatch = require('ajv-merge-patch')
 
 const bodySchema = Symbol('body-schema')
 const querystringSchema = Symbol('querystring-schema')
@@ -163,17 +164,20 @@ function schemaErrorsText (errors, dataVar) {
   return text.slice(0, -separator.length)
 }
 
-function buildSchemaCompiler (externalSchemas, cache) {
+function buildSchemaCompiler (externalSchemas, options, moreOptions, cache) {
   // This instance of Ajv is private
   // it should not be customized or used
-  const ajv = new Ajv({
+  const ajv = new Ajv(Object.assign({
     coerceTypes: true,
     useDefaults: true,
     removeAdditional: true,
     allErrors: true,
-    nullable: true,
-    cache
-  })
+    nullable: true
+  }, options, { cache }))
+
+  if (moreOptions.useMergeAndPatch) {
+    ajvMergePatch(ajv)
+  }
 
   if (Array.isArray(externalSchemas)) {
     externalSchemas.forEach(s => ajv.addSchema(s))

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -164,7 +164,7 @@ function schemaErrorsText (errors, dataVar) {
   return text.slice(0, -separator.length)
 }
 
-function buildSchemaCompiler (externalSchemas, options, moreOptions, cache) {
+function buildSchemaCompiler (externalSchemas, options, cache) {
   // This instance of Ajv is private
   // it should not be customized or used
   const ajv = new Ajv(Object.assign({
@@ -173,9 +173,9 @@ function buildSchemaCompiler (externalSchemas, options, moreOptions, cache) {
     removeAdditional: true,
     allErrors: true,
     nullable: true
-  }, options, { cache }))
+  }, options.customOptions, { cache }))
 
-  if (moreOptions.useMergeAndPatch) {
+  if (options.useMergeAndPatch) {
     ajvMergePatch(ajv)
   }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -2,7 +2,6 @@
 
 const fastJsonStringify = require('fast-json-stringify')
 const Ajv = require('ajv')
-const ajvMergePatch = require('ajv-merge-patch')
 
 const bodySchema = Symbol('body-schema')
 const querystringSchema = Symbol('querystring-schema')
@@ -175,8 +174,10 @@ function buildSchemaCompiler (externalSchemas, options, cache) {
     nullable: true
   }, options.customOptions, { cache }))
 
-  if (options.useMergeAndPatch) {
-    ajvMergePatch(ajv)
+  if (options.plugins && options.plugins.length > 0) {
+    options.plugins.forEach(plugin => {
+      plugin[0](ajv, plugin[1])
+    })
   }
 
   if (Array.isArray(externalSchemas)) {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -175,9 +175,9 @@ function buildSchemaCompiler (externalSchemas, options, cache) {
   }, options.customOptions, { cache }))
 
   if (options.plugins && options.plugins.length > 0) {
-    options.plugins.forEach(plugin => {
+    for (const plugin of options.plugins) {
       plugin[0](ajv, plugin[1])
-    })
+    }
   }
 
   if (Array.isArray(externalSchemas)) {

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
   "dependencies": {
     "abstract-logging": "^2.0.0",
     "ajv": "^6.10.2",
+    "ajv-merge-patch": "^4.1.0",
     "avvio": "^6.2.2",
     "fast-json-stringify": "^1.15.5",
     "find-my-way": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@typescript-eslint/eslint-plugin": "^2.3.0",
     "@typescript-eslint/parser": "^2.3.0",
     "JSONStream": "^1.3.5",
+    "ajv-merge-patch": "^4.1.0",
     "ajv-pack": "^0.3.1",
     "autocannon": "^3.2.0",
     "branch-comparer": "^0.4.0",
@@ -138,7 +139,6 @@
   "dependencies": {
     "abstract-logging": "^2.0.0",
     "ajv": "^6.10.2",
-    "ajv-merge-patch": "^4.1.0",
     "avvio": "^6.2.2",
     "fast-json-stringify": "^1.15.5",
     "find-my-way": "^2.2.0",

--- a/test/fastify-instance.test.js
+++ b/test/fastify-instance.test.js
@@ -3,8 +3,38 @@
 const t = require('tap')
 const test = t.test
 const Fastify = require('..')
+const {
+  kOptions
+} = require('../lib/symbols')
 
 test('root fastify instance is an object', t => {
   t.plan(1)
   t.type(Fastify(), 'object')
+})
+
+test('fastify instance should contains ajv options', t => {
+  t.plan(1)
+  const fastify = Fastify({
+    ajv: {
+      customOptions: {
+        nullable: false
+      },
+      useMergeAndPatch: true
+    }
+  })
+  t.same(fastify[kOptions].ajv, {
+    customOptions: {
+      nullable: false
+    },
+    useMergeAndPatch: true
+  })
+})
+
+test('fastify instance get invalid ajv options', t => {
+  t.plan(1)
+  t.throw(() => Fastify({
+    ajv: {
+      customOptions: 8
+    }
+  }))
 })

--- a/test/fastify-instance.test.js
+++ b/test/fastify-instance.test.js
@@ -18,15 +18,14 @@ test('fastify instance should contains ajv options', t => {
     ajv: {
       customOptions: {
         nullable: false
-      },
-      useMergeAndPatch: true
+      }
     }
   })
   t.same(fastify[kOptions].ajv, {
     customOptions: {
       nullable: false
     },
-    useMergeAndPatch: true
+    plugins: []
   })
 })
 

--- a/test/input-validation.test.js
+++ b/test/input-validation.test.js
@@ -67,3 +67,124 @@ test('not evaluate json-schema $schema keyword', t => {
     t.equal(res.payload, 'world')
   })
 })
+
+test('Should handle $merge keywords in body', t => {
+  t.plan(5)
+  const fastify = Fastify({
+    ajv: {
+      useMergeAndPatch: true
+    }
+  })
+
+  fastify.route({
+    method: 'POST',
+    url: '/',
+    schema: {
+      body: {
+        $merge: {
+          source: {
+            type: 'object',
+            properties: {
+              q: {
+                type: 'string'
+              }
+            }
+          },
+          with: {
+            required: ['q']
+          }
+        }
+      }
+    },
+    handler (req, reply) {
+      reply.send({ ok: 1 })
+    }
+  })
+
+  fastify.ready(err => {
+    t.error(err)
+
+    fastify.inject({
+      method: 'POST',
+      url: '/'
+    }, (err, res) => {
+      t.error(err)
+      t.equals(res.statusCode, 400)
+    })
+
+    fastify.inject({
+      method: 'POST',
+      url: '/',
+      body: {
+        q: 'foo'
+      }
+    }, (err, res) => {
+      t.error(err)
+      t.equals(res.statusCode, 200)
+    })
+  })
+})
+
+test('Should handle $patch keywords in body', t => {
+  t.plan(5)
+  const fastify = Fastify({
+    ajv: {
+      useMergeAndPatch: true
+    }
+  })
+
+  fastify.route({
+    method: 'POST',
+    url: '/',
+    schema: {
+      body: {
+        $patch: {
+          source: {
+            type: 'object',
+            properties: {
+              q: {
+                type: 'string'
+              }
+            }
+          },
+          with: [
+            {
+              op: 'add',
+              path: '/properties/q',
+              value: { type: 'number' }
+            }
+          ]
+        }
+      }
+    },
+    handler (req, reply) {
+      reply.send({ ok: 1 })
+    }
+  })
+
+  fastify.ready(err => {
+    t.error(err)
+
+    fastify.inject({
+      method: 'POST',
+      url: '/',
+      body: {
+        q: 'foo'
+      }
+    }, (err, res) => {
+      t.error(err)
+      t.equals(res.statusCode, 400)
+    })
+
+    fastify.inject({
+      method: 'POST',
+      url: '/',
+      body: {
+        q: 10
+      }
+    }, (err, res) => {
+      t.error(err)
+      t.equals(res.statusCode, 200)
+    })
+  })
+})

--- a/test/input-validation.test.js
+++ b/test/input-validation.test.js
@@ -3,6 +3,7 @@
 const t = require('tap')
 const test = t.test
 const Fastify = require('..')
+const ajvMergePatch = require('ajv-merge-patch')
 
 test('case insensitive header validation', t => {
   t.plan(2)
@@ -72,7 +73,9 @@ test('Should handle $merge keywords in body', t => {
   t.plan(5)
   const fastify = Fastify({
     ajv: {
-      useMergeAndPatch: true
+      plugins: [
+        ajvMergePatch
+      ]
     }
   })
 
@@ -129,7 +132,9 @@ test('Should handle $patch keywords in body', t => {
   t.plan(5)
   const fastify = Fastify({
     ajv: {
-      useMergeAndPatch: true
+      plugins: [
+        ajvMergePatch
+      ]
     }
   })
 

--- a/test/schemas.test.js
+++ b/test/schemas.test.js
@@ -4,6 +4,7 @@ const t = require('tap')
 const test = t.test
 const Fastify = require('..')
 
+const ajvMergePatch = require('ajv-merge-patch')
 const AJV = require('ajv')
 const fastClone = require('rfdc')({ circles: false, proto: true })
 
@@ -327,7 +328,9 @@ test('Should handle root $merge keywords in header', t => {
   t.plan(5)
   const fastify = Fastify({
     ajv: {
-      useMergeAndPatch: true
+      plugins: [
+        ajvMergePatch
+      ]
     }
   })
 
@@ -384,7 +387,9 @@ test('Should handle root $patch keywords in header', t => {
   t.plan(5)
   const fastify = Fastify({
     ajv: {
-      useMergeAndPatch: true
+      plugins: [
+        ajvMergePatch
+      ]
     }
   })
 


### PR DESCRIPTION
- Implement support for custom Ajv options without breaking encapsulation when creating custom Ajv instance.
- Implement support for ajv plugins

```js
const fastify = require('fastify')({
  ajv: {
    customOptions: {
      nullable: false // Refer to [ajv options](https://ajv.js.org/#options)
    },
    plugins: [
      require('ajv-merge-patch')
      [require('ajv-keywords'), 'instanceof'];
      // Usage: [plugin, pluginOptions] - Plugin with options
      // Usage: plugin - Plugin without options
    ]
  }
})
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
