### PR TITLE
Update route generics to use object instead

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -61,7 +61,7 @@ export type FastifyServerOptions<
 type TrustProxyFunction = (address: string, hop: number) => boolean
 
 /* Export all additional types */
-export { FastifyRequest } from './types/request'
+export { FastifyRequest, RequestGenericInterface } from './types/request'
 export { FastifyReply } from './types/reply'
 export { FastifyPlugin, FastifyPluginOptions } from './types/plugin'
 export { FastifyInstance } from './types/instance'

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -73,7 +73,7 @@ export { RegisterOptions } from './types/register'
 export { FastifyBodyParser, FastifyContentTypeParser, AddContentTypeParser, hasContentTypeParser } from './types/content-type-parser'
 export { FastifyError, ValidationResult } from './types/error'
 export { FastifySchema, FastifySchemaCompiler } from './types/schema'
-export { HTTPMethods, RawServerBase, RawRequestDefaultExpression, RawReplyDefaultExpression, RawServerDefault } from './types/utils'
+export { HTTPMethods, RawServerBase, RawRequestDefaultExpression, RawReplyDefaultExpression, RawServerDefault, ContextConfigDefault, RequestBodyDefault, RequestQuerystringDefault, RequestParamsDefault, RequestHeadersDefault } from './types/utils'
 export { onCloseHookHandler, onRouteHookHandler, onRequestHookHandler, onSendHookHandler, onErrorHookHandler, preHandlerHookHandler, preParsingHookHandler, preSerializationHookHandler, preValidationHookHandler, AddHook, addHookHandler } from './types/hooks'
 export { FastifyServerFactory, FastifyServerFactoryHandler } from './types/serverFactory'
 export { fastify }

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "tap": "^14.4.1",
     "tap-mocha-reporter": "^4.0.1",
     "then-sleep": "^1.0.1",
-    "tsd": "^0.7.3",
+    "tsd": "^0.11.0",
     "typescript": "^3.5.2",
     "x-xss-protection": "^1.2.0"
   },

--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -1,6 +1,7 @@
 import fastify, { FastifyInstance, FastifyRequest, FastifyReply, RouteHandlerMethod, RequestGenericInterface } from '../../fastify'
 import { expectType, expectError } from 'tsd'
 import { HTTPMethods } from '../../types/utils'
+import * as http from 'http'
 
 /*
  * Testing Fastify HTTP Routes and Route Shorthands.
@@ -54,7 +55,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
     expectType<BodyType>(req.body)
     expectType<QuerystringType>(req.query)
     expectType<ParamsType>(req.params)
-    expectType<HeadersType>(req.headers)
+    expectType<http.IncomingHttpHeaders & HeadersType>(req.headers)
     expectType<string>(res.context.config.foo)
     expectType<number>(res.context.config.bar)
   })
@@ -67,7 +68,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<BodyType>(req.body)
       expectType<QuerystringType>(req.query)
       expectType<ParamsType>(req.params)
-      expectType<HeadersType>(req.headers)
+      expectType<http.IncomingHttpHeaders & HeadersType>(req.headers)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
     },
@@ -75,7 +76,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<BodyType>(req.body)
       expectType<QuerystringType>(req.query)
       expectType<ParamsType>(req.params)
-      expectType<HeadersType>(req.headers)
+      expectType<http.IncomingHttpHeaders & HeadersType>(req.headers)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
     },
@@ -83,7 +84,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<BodyType>(req.body)
       expectType<QuerystringType>(req.query)
       expectType<ParamsType>(req.params)
-      expectType<HeadersType>(req.headers)
+      expectType<http.IncomingHttpHeaders & HeadersType>(req.headers)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
     },
@@ -91,7 +92,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<BodyType>(req.body)
       expectType<QuerystringType>(req.query)
       expectType<ParamsType>(req.params)
-      expectType<HeadersType>(req.headers)
+      expectType<http.IncomingHttpHeaders & HeadersType>(req.headers)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
     }

--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -1,4 +1,4 @@
-import fastify, { FastifyInstance, FastifyRequest, FastifyReply, RouteHandlerMethod, RequestGenericInterface } from '../../fastify'
+import fastify, { FastifyInstance, FastifyRequest, FastifyReply, RouteHandlerMethod } from '../../fastify'
 import { expectType, expectError } from 'tsd'
 import { HTTPMethods } from '../../types/utils'
 import * as http from 'http'
@@ -34,28 +34,28 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
   expectType<FastifyInstance>(fastify()[lowerCaseMethod]('/', {}, routeHandler))
   expectType<FastifyInstance>(fastify()[lowerCaseMethod]('/', { handler: routeHandler }))
 
-  type BodyType = { prop: string }
-  type QuerystringType = { prop: number }
-  type ParamsType = { prop: boolean }
-  type HeadersType = { prop: string }
+  interface BodyInterface { prop: string }
+  interface QuerystringInterface { prop: number }
+  interface ParamsInterface { prop: boolean }
+  interface HeadersInterface { prop: string }
 
   interface ContextConfigType {
     foo: string;
     bar: number;
   }
 
-  type RouteGeneric = {
-    Body: BodyType, 
-    Querystring: QuerystringType, 
-    Params: ParamsType,
-    Headers: HeadersType
+  interface RouteGeneric {
+    Body: BodyInterface;
+    Querystring: QuerystringInterface;
+    Params: ParamsInterface;
+    Headers: HeadersInterface;
   }
 
   fastify()[lowerCaseMethod]<RouteGeneric, ContextConfigType>('/', { config: { foo: 'bar', bar: 100 } }, (req, res) => {
-    expectType<BodyType>(req.body)
-    expectType<QuerystringType>(req.query)
-    expectType<ParamsType>(req.params)
-    expectType<http.IncomingHttpHeaders & HeadersType>(req.headers)
+    expectType<BodyInterface>(req.body)
+    expectType<QuerystringInterface>(req.query)
+    expectType<ParamsInterface>(req.params)
+    expectType<http.IncomingHttpHeaders & HeadersInterface>(req.headers)
     expectType<string>(res.context.config.foo)
     expectType<number>(res.context.config.bar)
   })
@@ -65,34 +65,34 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
     method: method as HTTPMethods,
     config: { foo: 'bar', bar: 100 },
     preHandler: (req, res) => {
-      expectType<BodyType>(req.body)
-      expectType<QuerystringType>(req.query)
-      expectType<ParamsType>(req.params)
-      expectType<http.IncomingHttpHeaders & HeadersType>(req.headers)
+      expectType<BodyInterface>(req.body)
+      expectType<QuerystringInterface>(req.query)
+      expectType<ParamsInterface>(req.params)
+      expectType<http.IncomingHttpHeaders & HeadersInterface>(req.headers)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
     },
     preValidation: (req, res) => {
-      expectType<BodyType>(req.body)
-      expectType<QuerystringType>(req.query)
-      expectType<ParamsType>(req.params)
-      expectType<http.IncomingHttpHeaders & HeadersType>(req.headers)
+      expectType<BodyInterface>(req.body)
+      expectType<QuerystringInterface>(req.query)
+      expectType<ParamsInterface>(req.params)
+      expectType<http.IncomingHttpHeaders & HeadersInterface>(req.headers)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
     },
     preSerialization: (req, res) => {
-      expectType<BodyType>(req.body)
-      expectType<QuerystringType>(req.query)
-      expectType<ParamsType>(req.params)
-      expectType<http.IncomingHttpHeaders & HeadersType>(req.headers)
+      expectType<BodyInterface>(req.body)
+      expectType<QuerystringInterface>(req.query)
+      expectType<ParamsInterface>(req.params)
+      expectType<http.IncomingHttpHeaders & HeadersInterface>(req.headers)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
     },
     handler: (req, res) => {
-      expectType<BodyType>(req.body)
-      expectType<QuerystringType>(req.query)
-      expectType<ParamsType>(req.params)
-      expectType<http.IncomingHttpHeaders & HeadersType>(req.headers)
+      expectType<BodyInterface>(req.body)
+      expectType<QuerystringInterface>(req.query)
+      expectType<ParamsInterface>(req.params)
+      expectType<http.IncomingHttpHeaders & HeadersInterface>(req.headers)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
     }

--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -1,4 +1,4 @@
-import fastify, { FastifyInstance, FastifyRequest, FastifyReply, RouteHandlerMethod } from '../../fastify'
+import fastify, { FastifyInstance, FastifyRequest, FastifyReply, RouteHandlerMethod, RequestGenericInterface } from '../../fastify'
 import { expectType, expectError } from 'tsd'
 import { HTTPMethods } from '../../types/utils'
 
@@ -33,15 +33,24 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
   expectType<FastifyInstance>(fastify()[lowerCaseMethod]('/', {}, routeHandler))
   expectType<FastifyInstance>(fastify()[lowerCaseMethod]('/', { handler: routeHandler }))
 
-  type BodyType = void
-  type QuerystringType = void
-  type ParamsType = void
-  type HeadersType = void
+  type BodyType = { prop: string }
+  type QuerystringType = { prop: number }
+  type ParamsType = { prop: boolean }
+  type HeadersType = { prop: string }
+
   interface ContextConfigType {
     foo: string;
     bar: number;
   }
-  fastify()[lowerCaseMethod]<BodyType, QuerystringType, ParamsType, HeadersType, ContextConfigType>('/', { config: { foo: 'bar', bar: 100 } }, (req, res) => {
+
+  type RouteGeneric = {
+    Body: BodyType, 
+    Querystring: QuerystringType, 
+    Params: ParamsType,
+    Headers: HeadersType
+  }
+
+  fastify()[lowerCaseMethod]<RouteGeneric, ContextConfigType>('/', { config: { foo: 'bar', bar: 100 } }, (req, res) => {
     expectType<BodyType>(req.body)
     expectType<QuerystringType>(req.query)
     expectType<ParamsType>(req.params)
@@ -50,7 +59,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
     expectType<number>(res.context.config.bar)
   })
 
-  fastify().route<BodyType, QuerystringType, ParamsType, HeadersType, ContextConfigType>({
+  fastify().route<RouteGeneric, ContextConfigType>({
     url: '/',
     method: method as HTTPMethods,
     config: { foo: 'bar', bar: 100 },

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -1,7 +1,7 @@
 import { InjectOptions, InjectPayload } from 'light-my-request'
 import { RouteOptions, RouteShorthandMethod } from './route'
 import { FastifySchema, FastifySchemaCompiler } from './schema'
-import { RawServerBase, RawRequestDefaultExpression, RawServerDefault, RawReplyDefaultExpression, ContextConfigDefault, RequestBodyDefault, RequestQuerystringDefault, RequestParamsDefault, RequestHeadersDefault } from './utils'
+import { RawServerBase, RawRequestDefaultExpression, RawServerDefault, RawReplyDefaultExpression, ContextConfigDefault } from './utils'
 import { FastifyLoggerOptions } from './logger'
 import { FastifyRegister } from './register'
 import { AddHook } from './hooks'

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -5,7 +5,7 @@ import { RawServerBase, RawRequestDefaultExpression, RawServerDefault, RawReplyD
 import { FastifyLoggerOptions } from './logger'
 import { FastifyRegister } from './register'
 import { AddHook } from './hooks'
-import { FastifyRequest } from './request'
+import { FastifyRequest, RequestGenericInterface } from './request'
 import { FastifyReply } from './reply'
 import { FastifyError } from './error'
 import { AddContentTypeParser, hasContentTypeParser } from './content-type-parser'
@@ -54,12 +54,9 @@ export interface FastifyInstance<
   use: FastifyRegister<RawServer, RawRequest, RawReply>;
 
   route<
-    RequestBody = RequestBodyDefault,
-    RequestQuerystring = RequestQuerystringDefault,
-    RequestParams = RequestParamsDefault,
-    RequestHeaders = RequestHeadersDefault,
+    RequestGeneric extends RequestGenericInterface = RequestGenericInterface,
     ContextConfig = ContextConfigDefault
-  >(opts: RouteOptions<RawServer, RawRequest, RawReply, RequestBody, RequestQuerystring, RequestParams, RequestHeaders, ContextConfig>): FastifyInstance<RawServer, RawRequest, RawReply>;
+  >(opts: RouteOptions<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>): FastifyInstance<RawServer, RawRequest, RawReply>;
 
   // Would love to implement something like the following:
   // [key in RouteMethodsLower]: RouteShorthandMethod<RawServer, RawRequest, RawReply> | RouteShorthandMethodWithOptions<RawServer, RawRequest, RawReply>,

--- a/types/middleware.d.ts
+++ b/types/middleware.d.ts
@@ -1,8 +1,8 @@
-import { FastifyRequest } from './request'
+import { FastifyRequest, RequestGenericInterface } from './request'
 import { FastifyReply } from './reply'
 import { FastifyError } from './error'
-import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, RequestBodyDefault, RequestQuerystringDefault, RequestParamsDefault, RequestHeadersDefault, ContextConfigDefault } from './utils'
-import { RequestGenericInterface } from './request'
+import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, ContextConfigDefault } from './utils'
+
 /**
  * Fastify Middleware
  *

--- a/types/middleware.d.ts
+++ b/types/middleware.d.ts
@@ -2,7 +2,7 @@ import { FastifyRequest } from './request'
 import { FastifyReply } from './reply'
 import { FastifyError } from './error'
 import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, RequestBodyDefault, RequestQuerystringDefault, RequestParamsDefault, RequestHeadersDefault, ContextConfigDefault } from './utils'
-
+import { RequestGenericInterface } from './request'
 /**
  * Fastify Middleware
  *
@@ -12,14 +12,11 @@ export interface FastifyMiddleware<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
-  RequestBody = RequestBodyDefault,
-  RequestQuerystring = RequestQuerystringDefault,
-  RequestParams = RequestParamsDefault,
-  RequestHeaders = RequestHeadersDefault,
+  RequestGeneric extends RequestGenericInterface = RequestGenericInterface,
   ContextConfig = ContextConfigDefault
 > {
   (
-    request: FastifyRequest<RawServer, RawRequest, RequestBody, RequestQuerystring, RequestParams, RequestHeaders>,
+    request: FastifyRequest<RawServer, RawRequest, RequestGeneric>,
     reply: FastifyReply<RawServer, RawReply, ContextConfig>,
     done: (err?: FastifyError) => void
   ): void;
@@ -34,14 +31,11 @@ export interface FastifyMiddlewareWithPayload<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
-  RequestBody = RequestBodyDefault,
-  RequestQuerystring = RequestQuerystringDefault,
-  RequestParams = RequestParamsDefault,
-  RequestHeaders = RequestHeadersDefault,
+  RequestGeneric extends RequestGenericInterface = RequestGenericInterface,
   ContextConfig = ContextConfigDefault
 > {
   (
-    request: FastifyRequest<RawServer, RawRequest, RequestBody, RequestQuerystring, RequestParams, RequestHeaders>,
+    request: FastifyRequest<RawServer, RawRequest, RequestGeneric>,
     reply: FastifyReply<RawServer, RawReply, ContextConfig>,
     payload: any,
     done: (err?: FastifyError, value?: any) => void

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -1,6 +1,13 @@
 import { FastifyLoggerOptions } from './logger'
 import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RequestBodyDefault, RequestQuerystringDefault, RequestParamsDefault, RequestHeadersDefault } from './utils'
 
+export interface RequestGenericInterface {
+  Body?: RequestBodyDefault,
+  Querystring?: RequestQuerystringDefault,
+  Params?: RequestParamsDefault,
+  Headers?: RequestHeadersDefault
+}
+
 /**
  * FastifyRequest is an instance of the standard http or http2 request objects.
  * It defaults to http.IncomingMessage, and it also extends the relative request object.
@@ -8,16 +15,13 @@ import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RequestBo
 export type FastifyRequest<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
-  RequestBody = RequestBodyDefault,
-  RequestQuerystring = RequestQuerystringDefault,
-  RequestParams = RequestParamsDefault,
-  RequestHeaders = RequestHeadersDefault
+  RequestGeneric extends RequestGenericInterface = RequestGenericInterface
 > = RawRequest & {
-  body: RequestBody;
+  body: RequestGeneric['Body'];
   id: any;
   log: FastifyLoggerOptions<RawServer>;
-  params: RequestParams;
-  query: RequestQuerystring;
+  params: RequestGeneric['Params'];
+  query: RequestGeneric['Querystring'];
   raw: RawRequest;
-  headers: RawRequest['headers'] & RequestHeaders; // this enables the developer to extend the existing http(s|2) headers list
+  headers: RawRequest['headers'] & RequestGeneric['Headers']; // this enables the developer to extend the existing http(s|2) headers list
 }

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -2,10 +2,10 @@ import { FastifyLoggerOptions } from './logger'
 import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RequestBodyDefault, RequestQuerystringDefault, RequestParamsDefault, RequestHeadersDefault } from './utils'
 
 export interface RequestGenericInterface {
-  Body?: RequestBodyDefault,
-  Querystring?: RequestQuerystringDefault,
-  Params?: RequestParamsDefault,
-  Headers?: RequestHeadersDefault
+  Body?: RequestBodyDefault;
+  Querystring?: RequestQuerystringDefault;
+  Params?: RequestParamsDefault;
+  Headers?: RequestHeadersDefault;
 }
 
 /**

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from './instance'
 import { FastifyMiddleware, FastifyMiddlewareWithPayload } from './middleware'
-import { FastifyRequest } from './request'
+import { FastifyRequest, RequestGenericInterface } from './request'
 import { FastifyReply } from './reply'
 import { FastifySchema, FastifySchemaCompiler } from './schema'
 import { HTTPMethods, RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, RequestBodyDefault, RequestQuerystringDefault, RequestParamsDefault, RequestHeadersDefault, ContextConfigDefault } from './utils'
@@ -14,10 +14,10 @@ export interface RouteShorthandMethod<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
 > {
-  <RequestBody, RequestQuerystring, RequestParams, RequestHeaders, ContextConfig>(
+  <RequestGeneric extends RequestGenericInterface, ContextConfig>(
     path: string,
-    opts: RouteShorthandOptions<RawServer, RawRequest, RawReply, RequestBody, RequestQuerystring, RequestParams, RequestHeaders, ContextConfig>,
-    handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RequestBody, RequestQuerystring, RequestParams, RequestHeaders, ContextConfig>
+    opts: RouteShorthandOptions<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>,
+    handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>
   ): FastifyInstance<RawServer, RawRequest, RawReply>;
 }
 
@@ -29,9 +29,9 @@ export interface RouteShorthandMethod<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
 > {
-  <RequestBody, RequestQuerystring, RequestParams, RequestHeaders, ContextConfig>(
+  <RequestGeneric extends RequestGenericInterface, ContextConfig>(
     path: string,
-    handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RequestBody, RequestQuerystring, RequestParams, RequestHeaders, ContextConfig>
+    handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>
   ): FastifyInstance<RawServer, RawRequest, RawReply>;
 }
 
@@ -43,9 +43,9 @@ export interface RouteShorthandMethod<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
 > {
-  <RequestBody, RequestQuerystring, RequestParams, RequestHeaders, ContextConfig>(
+  <RequestGeneric extends RequestGenericInterface, ContextConfig>(
     path: string,
-    opts: RouteShorthandOptionsWithHandler<RawServer, RawRequest, RawReply, RequestBody, RequestQuerystring, RequestParams, RequestHeaders, ContextConfig>
+    opts: RouteShorthandOptionsWithHandler<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>
   ): FastifyInstance<RawServer, RawRequest, RawReply>;
 }
 
@@ -56,17 +56,14 @@ export interface RouteShorthandOptions<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
-  RequestBody = RequestBodyDefault,
-  RequestQuerystring = RequestQuerystringDefault,
-  RequestParams = RequestParamsDefault,
-  RequestHeaders = RequestHeadersDefault,
+  RequestGeneric extends RequestGenericInterface = RequestGenericInterface,
   ContextConfig = ContextConfigDefault
 > {
   schema?: FastifySchema;
   attachValidation?: boolean;
-  preValidation?: FastifyMiddleware<RawServer, RawRequest, RawReply, RequestBody, RequestQuerystring, RequestParams, RequestHeaders, ContextConfig> | FastifyMiddleware<RawServer, RawRequest, RawReply, RequestBody, RequestQuerystring, RequestParams, RequestHeaders, ContextConfig>[];
-  preHandler?: FastifyMiddleware<RawServer, RawRequest, RawReply, RequestBody, RequestQuerystring, RequestParams, RequestHeaders, ContextConfig> | FastifyMiddleware<RawServer, RawRequest, RawReply, RequestBody, RequestQuerystring, RequestParams, RequestHeaders, ContextConfig>[];
-  preSerialization?: FastifyMiddlewareWithPayload<RawServer, RawRequest, RawReply, RequestBody, RequestQuerystring, RequestParams, RequestHeaders, ContextConfig> | FastifyMiddlewareWithPayload<RawServer, RawRequest, RawReply, RequestBody, RequestQuerystring, RequestParams, RequestHeaders, ContextConfig>[];
+  preValidation?: FastifyMiddleware<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig> | FastifyMiddleware<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>[];
+  preHandler?: FastifyMiddleware<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig> | FastifyMiddleware<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>[];
+  preSerialization?: FastifyMiddlewareWithPayload<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig> | FastifyMiddlewareWithPayload<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>[];
   schemaCompiler?: FastifySchemaCompiler;
   bodyLimit?: number;
   logLevel?: LogLevels;
@@ -82,15 +79,12 @@ export interface RouteOptions<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
-  RequestBody = RequestBodyDefault,
-  RequestQuerystring = RequestQuerystringDefault,
-  RequestParams = RequestParamsDefault,
-  RequestHeaders = RequestHeadersDefault,
+  RequestGeneric extends RequestGenericInterface = RequestGenericInterface,
   ContextConfig = ContextConfigDefault
-> extends RouteShorthandOptions<RawServer, RawRequest, RawReply, RequestBody, RequestQuerystring, RequestParams, RequestHeaders, ContextConfig> {
+> extends RouteShorthandOptions<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig> {
   method: HTTPMethods | HTTPMethods[];
   url: string;
-  handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RequestBody, RequestQuerystring, RequestParams, RequestHeaders, ContextConfig>;
+  handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>;
 }
 
 /**
@@ -100,13 +94,10 @@ export interface RouteShorthandOptionsWithHandler<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
-  RequestBody = RequestBodyDefault,
-  RequestQuerystring = RequestQuerystringDefault,
-  RequestParams = RequestParamsDefault,
-  RequestHeaders = RequestHeadersDefault,
+  RequestGeneric extends RequestGenericInterface = RequestGenericInterface,
   ContextConfig = ContextConfigDefault
-> extends RouteShorthandOptions<RawServer, RawRequest, RawReply, RequestBody, RequestQuerystring, RequestParams, RequestHeaders, ContextConfig> {
-  handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RequestBody, RequestQuerystring, RequestParams, RequestHeaders, ContextConfig>;
+> extends RouteShorthandOptions<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig> {
+  handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>;
 }
 
 /**
@@ -116,12 +107,9 @@ export type RouteHandlerMethod<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
-  RequestBody = RequestBodyDefault,
-  RequestQuerystring = RequestQuerystringDefault,
-  RequestParams = RequestParamsDefault,
-  RequestHeaders = RequestHeadersDefault,
+  RequestGeneric extends RequestGenericInterface = RequestGenericInterface,
   ContextConfig = ContextConfigDefault
 > = (
-  request: FastifyRequest<RawServer, RawRequest, RequestBody, RequestQuerystring, RequestParams, RequestHeaders>,
+  request: FastifyRequest<RawServer, RawRequest, RequestGeneric>,
   reply: FastifyReply<RawServer, RawReply, ContextConfig>
 ) => void | Promise<any>

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -3,7 +3,7 @@ import { FastifyMiddleware, FastifyMiddlewareWithPayload } from './middleware'
 import { FastifyRequest, RequestGenericInterface } from './request'
 import { FastifyReply } from './reply'
 import { FastifySchema, FastifySchemaCompiler } from './schema'
-import { HTTPMethods, RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, RequestBodyDefault, RequestQuerystringDefault, RequestParamsDefault, RequestHeadersDefault, ContextConfigDefault } from './utils'
+import { HTTPMethods, RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, ContextConfigDefault } from './utils'
 import { LogLevels } from './logger'
 
 /**

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -14,7 +14,7 @@ export interface RouteShorthandMethod<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
 > {
-  <RequestGeneric extends RequestGenericInterface, ContextConfig>(
+  <RequestGeneric extends RequestGenericInterface = RequestGenericInterface, ContextConfig = ContextConfigDefault>(
     path: string,
     opts: RouteShorthandOptions<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>,
     handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>
@@ -29,7 +29,7 @@ export interface RouteShorthandMethod<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
 > {
-  <RequestGeneric extends RequestGenericInterface, ContextConfig>(
+  <RequestGeneric extends RequestGenericInterface = RequestGenericInterface, ContextConfig = ContextConfigDefault>(
     path: string,
     handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>
   ): FastifyInstance<RawServer, RawRequest, RawReply>;
@@ -43,7 +43,7 @@ export interface RouteShorthandMethod<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
 > {
-  <RequestGeneric extends RequestGenericInterface, ContextConfig>(
+  <RequestGeneric extends RequestGenericInterface = RequestGenericInterface, ContextConfig = ContextConfigDefault>(
     path: string,
     opts: RouteShorthandOptionsWithHandler<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>
   ): FastifyInstance<RawServer, RawRequest, RawReply>;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark` _(tests failing due to tsd - https://github.com/SamVerschueren/tsd/issues/59)_
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added _(docs in progress see branch [typescript-docs](https://github.com/Ethan-Arrowood/fastify/blob/typescript-docs/docs/TypeScript.md))_
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

While working on the new documentation I realized that when defining generic properties for routes can be extremely repetitive, and exhaustive when only defining one of the 4 available generics (Body, Querystring, Params, Headers). For example:
```typescript
import fastify, { 
  RouteShorthandOptions, 
  RequestBodyDefault, 
  RequestParamsDefault, 
  RequestHeadersDefault } from 'fastify'

const server = fastify()

type QuerystringType = {
  username: string,
  password: number
}

server.get<
  RequestBodyDefault,
  QuerystringType,
  RequestParamsDefault, 
  RequestHeadersDefault
>('/auth', async (request, reply) => {
  const { username, password } = request.query
  return `logged in!`
}) 
```

In this example we only need to modify the `Querystring` generic, but are required to pass in the preceding `Body` generic and the remaining `Params`, `Headers`, and `Context` generics.

This PR merges the 4 generics related to the `request` object into a single generic property `RequestGeneric`, allowing the developer to specify only the properties necessary using named properties. Thus, simplifying the previous example into:

```typescript
import fastify from 'fastify'

const server = fastify()

type QuerystringType = {
  username: string,
  password: number
}

server.get<{ Querystring: QuerystringType }>('/auth', async (request, reply) => {
  const { username, password } = request.query
  return `logged in!`
}) 
```

Something going on in the [tsd]() library we're using to test the type definitions is causing a previously passing test to fail so I have an issue opened to resolve that. We can consider this PR blocked until that is fixed.