### PR TITLE
Update onRoute documentation for plugin authors.

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -291,7 +291,7 @@ If you are authoring a plugin and you need to customize application routes, like
 fastify.addHook('onRoute', (routeOptions) => {
   routeOptions.preSerialization = function (request, reply, payload, done) {
     // Your code
-    done()
+    done(null, payload)
   })
 })
 ```
@@ -375,7 +375,7 @@ fastify.addHook('preHandler', (request, reply, done) => {
 
 fastify.addHook('preSerialization', (request, reply, payload, done) => {
   // Your code
-  done()
+  done(null, payload)
 })
 
 fastify.route({

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -289,15 +289,12 @@ If you are authoring a plugin and you need to customize application routes, like
 
 ```js
 fastify.addHook('onRoute', (routeOptions) => {
-  // Can be undefined or an array of functions.
-  if(!routeOptions.preSerialization) {
-    routeOptions.preSerialization = []
-  }
-  
-  routeOptions.preSerialization.push(function (request, reply, payload, done) {
+  function onPreSerialization(request, reply, payload, done) {
     // Your code
     done(null, payload)
-  }))
+  }
+  
+  routeOptions.preSerialization = [...routeOptions.preSerialization, onPreSerialization]
 })
 ```
 

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -289,10 +289,15 @@ If you are authoring a plugin and you need to customize application routes, like
 
 ```js
 fastify.addHook('onRoute', (routeOptions) => {
-  routeOptions.preSerialization = function (request, reply, payload, done) {
+  // Can be undefined or an array of functions.
+  if(!routeOptions.preSerialization) {
+    routeOptions.preSerialization = []
+  }
+  
+  routeOptions.preSerialization.push(function (request, reply, payload, done) {
     // Your code
     done(null, payload)
-  })
+  }))
 })
 ```
 

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -287,6 +287,15 @@ fastify.addHook('onRoute', (routeOptions) => {
 
 If you are authoring a plugin and you need to customize application routes, like modifying the options or adding new route hooks, this is the right place.
 
+```js
+fastify.addHook('onRoute', (routeOptions) => {
+  routeOptions.preSerialization = function (request, reply, payload, done) {
+    // Your code
+    done()
+  })
+})
+```
+
 <a name="on-register"></a>
 ### onRegister
 Triggered when a new plugin is registered and a new encapsulation context is created. The hook will be executed **before** the registered code.<br/>
@@ -400,7 +409,7 @@ fastify.route({
   //   done()
   // }],
   preSerialization: (request, reply, payload, done) => {
-    // Manipulate the payload
+    // This hook will always be executed after the shared `preSerialization` hooks
     done(null, payload)
   },
   handler: function (request, reply) {

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -284,6 +284,9 @@ fastify.addHook('onRoute', (routeOptions) => {
   routeOptions.prefix
 })
 ```
+
+If you are authoring a plugin and you need to customize application routes, like modifying the options or adding new route hooks, this is the right place.
+
 <a name="on-register"></a>
 ### onRegister
 Triggered when a new plugin is registered and a new encapsulation context is created. The hook will be executed **before** the registered code.<br/>


### PR DESCRIPTION
Hi!
While working on a custom plugin I had problem understanding how to access route options in a `preSerialization` hook.
After talking to @mcollina I realize that adding a new hook (by setting `route.preSerialization`) from within a `onRoute` is perfectly legit and actually the intended way to go.

This documentation PR aims to makes this aspect more explicit.
Hope this helps!

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
