### PR TITLE
fix: add middleware type for multiple paths

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -553,6 +553,11 @@ declare namespace fastify {
     use(path: string, middleware: Middleware<HttpServer, HttpRequest, HttpResponse>): void
 
     /**
+     * Apply the given middleware to routes matching the given multiple path
+     */
+    use(path: string[], middleware: Middleware<HttpServer, HttpRequest, HttpResponse>): void
+
+    /**
      * Registers a plugin
      */
     register<Options extends RegisterOptions<HttpServer, HttpRequest, HttpResponse>, PluginInstance extends Function>(plugin: Plugin<HttpServer, HttpRequest, HttpResponse, Options, PluginInstance>, options?: Options): FastifyInstance<HttpServer, HttpRequest, HttpResponse>

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -126,6 +126,11 @@ server.use('/', (req, res, next) => {
   console.log(`${req.method} ${req.url}`)
 })
 
+// Custom middleware with multiple paths
+server.use(['/foo', '/bar'], (req, res, next) => {
+  console.log(`${req.method} ${req.url}`)
+})
+
 // Third party plugin
 // Also check if async functions are allowed to be passed to .register()
 // https://github.com/fastify/fastify/pull/1841


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

Type changed only, Support multiple paths

```ts
    /**
     * Apply the given middleware to routes matching the given multiple path
     */
    use(path: string[], middleware: Middleware<HttpServer, HttpRequest, HttpResponse>): void
```
for example

```js
// Multiple paths
fastify.use(['/css', '/js'], serveStatic(path.join(__dirname, '/assets')))
```


#### Checklist

- [x] run `npm run test` and `npm run benchmark` (include lint)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
