### PR TITLE
Opts on register

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -299,19 +299,22 @@ fastify.register(async (instance, opts) => {
   instance.register(async (instance, opts) => {
     instance.data.push('world')
     console.log(instance.data) // ['hello', 'world']
-  })
-})
+  }, { prefix: '/hola' })
+}, { prefix: '/ciao' })
 
 fastify.register(async (instance, opts) => {
   console.log(instance.data) // []
-})
+}, { prefix: '/hello' })
 
-fastify.addHook('onRegister', (instance) => {
+fastify.addHook('onRegister', (instance, opts) => {
   // Create a new array from the old one
   // but without keeping the reference
   // allowing the user to have encapsulated
   // instances of the `data` property
   instance.data = instance.data.slice()
+
+  // the options of the new registered instance
+  console.log(opts.prefix)
 })
 ```
 

--- a/fastify.js
+++ b/fastify.js
@@ -491,7 +491,7 @@ function override (old, fn, opts) {
     instance[kFourOhFour].arrange404(instance)
   }
 
-  for (const hook of instance[kGlobalHooks].onRegister) hook.call(this, instance)
+  for (const hook of instance[kGlobalHooks].onRegister) hook.call(this, instance, opts)
 
   return instance
 }

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -2591,16 +2591,18 @@ test('preSerialization hooks should support encapsulation', t => {
 })
 
 test('onRegister hook should be called / 1', t => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
 
+  const pluginOpts = { prefix: 'hello', custom: 'world' }
   fastify.register((instance, opts, next) => {
     next()
-  })
+  }, pluginOpts)
 
-  fastify.addHook('onRegister', instance => {
+  fastify.addHook('onRegister', (instance, opts) => {
     // duck typing for the win!
     t.ok(instance.addHook)
+    t.deepEquals(opts, pluginOpts)
   })
 
   fastify.ready(err => {
@@ -2675,9 +2677,10 @@ test('onRegister hook should be called / 4', t => {
 
   fastify.register(plugin)
 
-  fastify.addHook('onRegister', instance => {
+  fastify.addHook('onRegister', (instance, opts) => {
     // duck typing for the win!
     t.ok(instance.addHook)
+    t.notOk(opts)
   })
 
   fastify.ready(err => {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -2673,7 +2673,7 @@ test('onRegister hook should be called / 3', t => {
 })
 
 test('onRegister hook should be called / 4', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
 
   function plugin (instance, opts, next) {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -2680,7 +2680,7 @@ test('onRegister hook should be called / 4', t => {
   fastify.addHook('onRegister', (instance, opts) => {
     // duck typing for the win!
     t.ok(instance.addHook)
-    t.notOk(opts)
+    t.deepEquals(opts, {})
   })
 
   fastify.ready(err => {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -2599,10 +2599,16 @@ test('onRegister hook should be called / 1', t => {
     next()
   }, pluginOpts)
 
+  let first = true
   fastify.addHook('onRegister', (instance, opts) => {
     // duck typing for the win!
     t.ok(instance.addHook)
-    t.deepEquals(opts, pluginOpts)
+    if (first) {
+      // the first call of the onRegister is the main fastify instance, not the registered ones
+      first = false
+    } else {
+      t.deepEquals(opts, pluginOpts)
+    }
   })
 
   fastify.ready(err => {


### PR DESCRIPTION
This change lets plugins' developers increase the feature they can develop with the `onRegister` plugin.

I'm working on a plugin that would use this feature and improve how the user writes tests.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
