### PR TITLE
onRoute and onRegister are now encapsulated

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -23,7 +23,6 @@ const {
   kFourOhFour,
   kState,
   kOptions,
-  kGlobalHooks,
   kPluginNameChain
 } = require('./lib/symbols.js')
 
@@ -151,10 +150,6 @@ function build (options) {
     [kRequest]: Request.buildRequest(Request),
     [kMiddlewares]: [],
     [kFourOhFour]: fourOhFour,
-    [kGlobalHooks]: {
-      onRoute: [],
-      onRegister: []
-    },
     [pluginUtils.registeredPlugins]: [],
     [kPluginNameChain]: [],
     // routes shorthand methods
@@ -380,12 +375,6 @@ function build (options) {
     if (name === 'onClose') {
       this[kHooks].validate(name, fn)
       this.onClose(fn)
-    } else if (name === 'onRoute') {
-      this[kHooks].validate(name, fn)
-      this[kGlobalHooks].onRoute.push(fn)
-    } else if (name === 'onRegister') {
-      this[kHooks].validate(name, fn)
-      this[kGlobalHooks].onRegister.push(fn)
     } else {
       this.after((err, done) => {
         _addHook.call(this, name, fn)
@@ -507,7 +496,7 @@ function override (old, fn, opts) {
     instance[kFourOhFour].arrange404(instance)
   }
 
-  for (const hook of instance[kGlobalHooks].onRegister) hook.call(this, instance, opts)
+  for (const hook of instance[kHooks].onRegister) hook.call(this, instance, opts)
 
   return instance
 }

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -30,6 +30,8 @@ function Hooks () {
   this.onResponse = []
   this.onSend = []
   this.onError = []
+  this.onRoute = []
+  this.onRegister = []
 }
 
 Hooks.prototype.validate = function (hook, fn) {
@@ -55,6 +57,8 @@ function buildHooks (h) {
   hooks.onSend = h.onSend.slice()
   hooks.onResponse = h.onResponse.slice()
   hooks.onError = h.onError.slice()
+  hooks.onRoute = h.onRoute.slice()
+  hooks.onRegister = h.onRegister.slice()
   return hooks
 }
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -33,7 +33,6 @@ const {
   kReplySerializerDefault,
   kRequest,
   kMiddlewares,
-  kGlobalHooks,
   kDisableRequestLogging
 } = require('./symbols.js')
 
@@ -191,7 +190,7 @@ function buildRouting (options) {
       }
 
       // run 'onRoute' hooks
-      for (const hook of this[kGlobalHooks].onRoute) {
+      for (const hook of this[kHooks].onRoute) {
         try {
           hook.call(this, opts)
         } catch (error) {

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -31,7 +31,6 @@ const keys = {
   kReplyIsRunningOnErrorHook: Symbol('fastify.reply.isRunningOnErrorHook'),
   kState: Symbol('fastify.state'),
   kOptions: Symbol('fastify.options'),
-  kGlobalHooks: Symbol('fastify.globalHooks'),
   kDisableRequestLogging: Symbol('fastify.disableRequestLogging'),
   kPluginNameChain: Symbol('fastify.pluginNameChain')
 }


### PR DESCRIPTION
Back in https://github.com/fastify/fastify/pull/642 we have decided to not encapsulate `onRoute` and `onRegister`, almost two years after, the use of this hooks in our plugins has changed, and make this two hooks encapsulated is now the right choice.

Unfortunately, doing so will introduce a breaking change, since the behavior of those hooks will change slightly.

**`onRoute`**
The hook will be called asynchronously, in v1/v2 it's called as soon as a route is registered. This means that if you want to use it, you should register this hook as soon as possible in your code.

**`onRegister`**
Same as the `onRoute` hook, the only difference is that now the very first call will no longer be the framework itself, but the first registered plugin.

Fixes: #1970

I'll keep this as a draft pr until https://github.com/fastify/fastify/pull/1954 is merged, then I'll rebase on `next`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
