### PR TITLE
Updated addHook to throw instead of logging

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -366,14 +366,13 @@ function build (options) {
   function addHook (name, fn) {
     throwIfAlreadyStarted('Cannot call "addHook" when fastify instance is already started!')
 
-    // TODO: v3 instead of log a warning, throw an error
     if (name === 'onSend' || name === 'preSerialization' || name === 'onError') {
       if (fn.constructor.name === 'AsyncFunction' && fn.length === 4) {
-        fastify.log.warn("Async function has too many arguments. Async hooks should not use the 'next' argument.", new Error().stack)
+        throw new Error("Async function has too many arguments. Async hooks should not use the 'next' argument.")
       }
     } else {
       if (fn.constructor.name === 'AsyncFunction' && fn.length === 3) {
-        fastify.log.warn("Async function has too many arguments. Async hooks should not use the 'next' argument.", new Error().stack)
+        throw new Error("Async function has too many arguments. Async hooks should not use the 'next' argument.")
       }
     }
 

--- a/test/hooks-async.js
+++ b/test/hooks-async.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const split = require('split2')
 const sget = require('simple-get').concat
 const Fastify = require('..')
 const fs = require('fs')
@@ -510,39 +509,26 @@ function asyncHookTest (t) {
     })
   })
 
-  test('Should log a warning if is an async function with `next`', t => {
+  test('Should throw an error if is an async function with `next`', t => {
+    const expectedError = {
+      message: /^Async function has too many arguments. Async hooks should not use the 'next' argument./,
+      stack: /test(\\|\/)hooks-async\.js/m
+    }
+
     t.test('3 arguments', t => {
-      t.plan(3)
-      const stream = split(JSON.parse)
-      const fastify = Fastify({
-        logger: { stream }
-      })
+      t.plan(1)
+      const fastify = Fastify({})
 
-      stream.on('data', line => {
-        t.strictEqual(line.level, 40)
-        t.true(line.msg.startsWith("Async function has too many arguments. Async hooks should not use the 'next' argument."))
-        t.true(/test(\\|\/)hooks-async\.js/.test(line.msg))
-      })
-
-      fastify.addHook('onRequest', async (req, reply, next) => {})
+      t.throws(() => fastify.addHook('onRequest', async (req, reply, next) => {}), expectedError)
     })
 
     t.test('4 arguments', t => {
-      t.plan(9)
-      const stream = split(JSON.parse)
-      const fastify = Fastify({
-        logger: { stream }
-      })
+      t.plan(3)
+      const fastify = Fastify({})
 
-      stream.on('data', line => {
-        t.strictEqual(line.level, 40)
-        t.true(line.msg.startsWith("Async function has too many arguments. Async hooks should not use the 'next' argument."))
-        t.true(/test(\\|\/)hooks-async\.js/.test(line.msg))
-      })
-
-      fastify.addHook('onSend', async (req, reply, payload, next) => {})
-      fastify.addHook('preSerialization', async (req, reply, payload, next) => {})
-      fastify.addHook('onError', async (req, reply, error, next) => {})
+      t.throws(() => fastify.addHook('onSend', async (req, reply, payload, next) => {}), expectedError)
+      t.throws(() => fastify.addHook('preSerialization', async (req, reply, payload, next) => {}), expectedError)
+      t.throws(() => fastify.addHook('onError', async (req, reply, payload, next) => {}), expectedError)
     })
 
     t.end()


### PR DESCRIPTION
addHook throws an Error instead of logging with warning level

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
