### PR TITLE
Removed var in favour of let and const in logger.

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -28,9 +28,9 @@ function createPinoLogger (opts, stream) {
     delete opts.file
   }
 
-  var prevLogger = opts.logger
-  var prevGenReqId = opts.genReqId
-  var logger = null
+  const prevLogger = opts.logger
+  const prevGenReqId = opts.genReqId
+  let logger = null
 
   if (prevLogger) {
     opts.logger = undefined
@@ -70,7 +70,7 @@ const serializers = {
 }
 
 function now () {
-  var ts = process.hrtime()
+  const ts = process.hrtime()
   return (ts[0] * 1e3) + (ts[1] / 1e6)
 }
 


### PR DESCRIPTION
Removed `var` and use `let` or `const` in logger module.

#### Checklist
- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
