### PR TITLE
Drop Windows-latest and Node 6 from CI as its failing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ jobs:
       matrix:
         node-version: [6.x, 8.x, 10.x, 12.x, 13.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        exclude:
+          # Excludes node 6 on Windows
+          # FIXME if this ever become a problem
+          - os: windows-latest
+            node-version: 6.x
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
I'm removing the Windows / Node 6 combo from CI. A couple of reasons:

1. it's a flaky test with 50% chance of failing on that platform
2. Node 6 is long in the past
3. We are still testing Node 6 all across the other envs.

I'm happy to investigate in this if there is a strong need but otherwise I'm not convinced we should go and fix this.