### PR TITLE
Fix hook encapsulation

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -252,7 +252,7 @@ fastify.addHook('onRequest', (request, reply, done) => {
 
 ## Application Hooks
 
-You can hook into the application-lifecycle as well. It's important to note that these hooks aren't fully encapsulated. The `this` inside the hooks are encapsulated but the handlers can respond to an event outside the encapsulation boundaries.
+You can hook into the application-lifecycle as well.
 
 - [onClose](#onclose)
 - [onRoute](#onroute)
@@ -271,7 +271,7 @@ fastify.addHook('onClose', (instance, done) => {
 ```
 <a name="on-route"></a>
 ### onRoute
-Triggered when a new route is registered. Listeners are passed a `routeOptions` object as the sole parameter. The interface is synchronous, and, as such, the listeners do not get passed a callback.
+Triggered when a new route is registered. Listeners are passed a `routeOptions` object as the sole parameter. The interface is synchronous, and, as such, the listeners do not get passed a callback. This hook is encapsulated.
 ```js
 fastify.addHook('onRoute', (routeOptions) => {
   //Some code
@@ -301,7 +301,7 @@ fastify.addHook('onRoute', (routeOptions) => {
 <a name="on-register"></a>
 ### onRegister
 Triggered when a new plugin is registered and a new encapsulation context is created. The hook will be executed **before** the registered code.<br/>
-This hook can be useful if you are developing a plugin that needs to know when a plugin context is formed, and you want to operate in that specific context.<br/>
+This hook can be useful if you are developing a plugin that needs to know when a plugin context is formed, and you want to operate in that specific context, thus this hook is encapsulated.<br/>
 **Note:** This hook will not be called if a plugin is wrapped inside [`fastify-plugin`](https://github.com/fastify/fastify-plugin).
 ```js
 fastify.decorate('data', [])
@@ -331,7 +331,7 @@ fastify.addHook('onRegister', (instance) => {
 
 <a name="scope"></a>
 ### Scope
-Except for [Application Hooks](#application-hooks), all hooks are encapsulated. This means that you can decide where your hooks should run by using `register` as explained in the [plugins guide](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md). If you pass a function, that function is bound to the right Fastify context and from there you have full access to the Fastify API.
+Except for [onClose](#onclose), all hooks are encapsulated. This means that you can decide where your hooks should run by using `register` as explained in the [plugins guide](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md). If you pass a function, that function is bound to the right Fastify context and from there you have full access to the Fastify API.
 
 ```js
 fastify.addHook('onRequest', function (request, reply, done) {

--- a/fastify.js
+++ b/fastify.js
@@ -23,7 +23,6 @@ const {
   kFourOhFour,
   kState,
   kOptions,
-  kGlobalHooks,
   kPluginNameChain
 } = require('./lib/symbols.js')
 
@@ -146,10 +145,6 @@ function fastify (options) {
     [kRequest]: Request.buildRequest(Request),
     [kMiddlewares]: [],
     [kFourOhFour]: fourOhFour,
-    [kGlobalHooks]: {
-      onRoute: [],
-      onRegister: []
-    },
     [pluginUtils.registeredPlugins]: [],
     [kPluginNameChain]: [],
     // routes shorthand methods
@@ -367,12 +362,6 @@ function fastify (options) {
     if (name === 'onClose') {
       this[kHooks].validate(name, fn)
       this.onClose(fn)
-    } else if (name === 'onRoute') {
-      this[kHooks].validate(name, fn)
-      this[kGlobalHooks].onRoute.push(fn)
-    } else if (name === 'onRegister') {
-      this[kHooks].validate(name, fn)
-      this[kGlobalHooks].onRegister.push(fn)
     } else {
       this.after((err, done) => {
         _addHook.call(this, name, fn)
@@ -494,7 +483,7 @@ function override (old, fn, opts) {
     instance[kFourOhFour].arrange404(instance)
   }
 
-  for (const hook of instance[kGlobalHooks].onRegister) hook.call(this, instance)
+  for (const hook of instance[kHooks].onRegister) hook.call(this, instance, opts)
 
   return instance
 }

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -30,6 +30,8 @@ function Hooks () {
   this.onResponse = []
   this.onSend = []
   this.onError = []
+  this.onRoute = []
+  this.onRegister = []
 }
 
 Hooks.prototype.validate = function (hook, fn) {
@@ -55,6 +57,8 @@ function buildHooks (h) {
   hooks.onSend = h.onSend.slice()
   hooks.onResponse = h.onResponse.slice()
   hooks.onError = h.onError.slice()
+  hooks.onRoute = h.onRoute.slice()
+  hooks.onRegister = h.onRegister.slice()
   return hooks
 }
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -32,7 +32,6 @@ const {
   kReplySerializerDefault,
   kRequest,
   kMiddlewares,
-  kGlobalHooks,
   kDisableRequestLogging
 } = require('./symbols.js')
 
@@ -185,7 +184,7 @@ function buildRouting (options) {
       }
 
       // run 'onRoute' hooks
-      for (const hook of this[kGlobalHooks].onRoute) {
+      for (const hook of this[kHooks].onRoute) {
         try {
           hook.call(this, opts)
         } catch (error) {

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -31,7 +31,6 @@ const keys = {
   kReplyIsRunningOnErrorHook: Symbol('fastify.reply.isRunningOnErrorHook'),
   kState: Symbol('fastify.state'),
   kOptions: Symbol('fastify.options'),
-  kGlobalHooks: Symbol('fastify.globalHooks'),
   kDisableRequestLogging: Symbol('fastify.disableRequestLogging'),
   kPluginNameChain: Symbol('fastify.pluginNameChain')
 }


### PR DESCRIPTION
Back in https://github.com/fastify/fastify/pull/642 we have decided to not encapsulate `onRoute` and `onRegister`, almost two years after, the use of this hooks in our plugins has changed, and make this two hooks encapsulated is now the right choice.

Unfortunately, doing so will introduce a breaking change, since the behavior of those hooks will change slightly.

**`onRoute`**
The hook will be called asynchronously, in v1/v2 it's called as soon as a route is registered. This means that if you want to use it, you should register this hook as soon as possible in your code.

**`onRegister`**
Same as the `onRoute` hook, the only difference is that now the very first call will no longer be the framework itself, but the first registered plugin.

Fixes: #1970

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
