### PR TITLE
Hook scope binding

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -382,7 +382,7 @@ function fastify (options) {
     return this
 
     function _addHook (name, fn) {
-      this[kHooks].add(name, fn.bind(this))
+      this[kHooks].add(name, fn)
       this[kChildren].forEach(child => _addHook.call(child, name, fn))
     }
   }

--- a/lib/fourOhFour.js
+++ b/lib/fourOhFour.js
@@ -19,6 +19,7 @@ const {
   kHooks
 } = require('./symbols.js')
 const { buildMiddie } = require('./middleware')
+const { lifecycleHooks } = require('./hooks')
 
 /**
  * Each fastify instance have a:
@@ -126,25 +127,12 @@ function fourOhFour (options) {
 
     avvio.once('preReady', () => {
       const context = this[kFourOhFourContext]
-
-      const onRequest = this[kHooks].onRequest
-      const preParsing = this[kHooks].preParsing.concat(opts.preParsing || [])
-      const preValidation = this[kHooks].preValidation.concat(opts.preValidation || [])
-      const preSerialization = this[kHooks].preSerialization.concat(opts.preSerialization || [])
-      const preHandler = this[kHooks].preHandler.concat(opts.preHandler || [])
-      const onSend = this[kHooks].onSend
-      const onError = this[kHooks].onError
-      const onResponse = this[kHooks].onResponse
-
-      context.onRequest = onRequest.length ? onRequest : null
-      context.preParsing = preParsing.length ? preParsing : null
-      context.preValidation = preValidation.length ? preValidation : null
-      context.preSerialization = preSerialization.length ? preSerialization : null
-      context.preHandler = preHandler.length ? preHandler : null
-      context.onSend = onSend.length ? onSend : null
-      context.onError = onError.length ? onError : null
-      context.onResponse = onResponse.length ? onResponse : null
-
+      for (const hook of lifecycleHooks) {
+        const toSet = this[kHooks][hook]
+          .concat(opts[hook] || [])
+          .map(h => h.bind(this))
+        context[hook] = toSet.length ? toSet : null
+      }
       context._middie = buildMiddie(this[kMiddlewares])
     })
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,19 +1,21 @@
 'use strict'
 
-const supportedHooks = [
+const applicationHooks = [
+  'onRoute',
+  'onRegister',
+  'onClose'
+]
+const lifecycleHooks = [
   'onRequest',
   'preParsing',
   'preValidation',
   'preSerialization',
   'preHandler',
-  'onResponse',
   'onSend',
-  'onError',
-  // executed at start/close time
-  'onRoute',
-  'onRegister',
-  'onClose'
+  'onResponse',
+  'onError'
 ]
+const supportedHooks = lifecycleHooks.concat(applicationHooks)
 const {
   codes: {
     FST_ERR_HOOK_INVALID_TYPE,
@@ -129,5 +131,6 @@ module.exports = {
   buildHooks,
   hookRunner,
   onSendHookRunner,
-  hookIterator
+  hookIterator,
+  lifecycleHooks
 }

--- a/lib/route.js
+++ b/lib/route.js
@@ -4,9 +4,8 @@ const FindMyWay = require('find-my-way')
 const proxyAddr = require('proxy-addr')
 const Context = require('./context')
 const { buildMiddie, onRunMiddlewares } = require('./middleware')
-const { hookRunner, hookIterator } = require('./hooks')
+const { hookRunner, hookIterator, lifecycleHooks } = require('./hooks')
 const supportedMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']
-const supportedHooks = ['preParsing', 'preValidation', 'onRequest', 'preHandler', 'preSerialization', 'onResponse']
 const validation = require('./validation')
 const buildSchema = validation.build
 const { buildSchemaCompiler } = validation
@@ -235,16 +234,6 @@ function buildRouting (options) {
         }
       }
 
-      for (const hook of supportedHooks) {
-        if (opts[hook]) {
-          if (Array.isArray(opts[hook])) {
-            opts[hook] = opts[hook].map(fn => fn.bind(this))
-          } else {
-            opts[hook] = opts[hook].bind(this)
-          }
-        }
-      }
-
       try {
         router.on(opts.method, url, { version: opts.version }, routeHandler, context)
       } catch (err) {
@@ -256,16 +245,10 @@ function buildRouting (options) {
       // the route registration. To be sure to load also that hooks/middlewares,
       // we must listen for the avvio's preReady event, and update the context object accordingly.
       avvio.once('preReady', () => {
-        const onResponse = this[kHooks].onResponse
-        const onSend = this[kHooks].onSend
-        const onError = this[kHooks].onError
-
-        context.onSend = onSend.length ? onSend : null
-        context.onError = onError.length ? onError : null
-        context.onResponse = onResponse.length ? onResponse : null
-
-        for (const hook of supportedHooks) {
-          const toSet = this[kHooks][hook].concat(opts[hook] || [])
+        for (const hook of lifecycleHooks) {
+          const toSet = this[kHooks][hook]
+            .concat(opts[hook] || [])
+            .map(h => h.bind(this))
           context[hook] = toSet.length ? toSet : null
         }
 


### PR DESCRIPTION
In the past, the `this` of every hook was the same as the context where it has been registered, while the `this` of the route-specific hooks is the same as the plugin where the route is registered. This could lead to some confusion, as the `this` changes during time, while it's better to have it consistent.

This pr addresses this issue, take a look at the test to see the new behavior.
This should not break current application code, but it's safer to release it in a server major change.

Closes: https://github.com/fastify/fastify/issues/1587

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
