### PR TITLE
Drop request.req and rename reply.res to reply.raw

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -48,6 +48,7 @@ and properties:
 - `.send(payload)` - Sends the payload to the user, could be a plain text, a buffer, JSON, stream, or an Error object.
 - `.sent` - A boolean value that you can use if you need to know if `send` has already been called.
 - `.raw` - The [`http.ServerResponse`](https://nodejs.org/dist/latest/docs/api/http.html#http_class_http_serverresponse) from Node core.
+- `.res` *(deprecated, use `.raw` instead)* - The [`http.ServerResponse`](https://nodejs.org/dist/latest/docs/api/http.html#http_class_http_serverresponse) from Node core.
 - `.log` - The logger instance of the incoming request.
 - `.request` - The incoming request.
 

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -47,7 +47,7 @@ and properties:
 - `.serializer(function)` - Sets a custom serializer for the payload.
 - `.send(payload)` - Sends the payload to the user, could be a plain text, a buffer, JSON, stream, or an Error object.
 - `.sent` - A boolean value that you can use if you need to know if `send` has already been called.
-- `.res` - The [`http.ServerResponse`](https://nodejs.org/dist/latest/docs/api/http.html#http_class_http_serverresponse) from Node core.
+- `.raw` - The [`http.ServerResponse`](https://nodejs.org/dist/latest/docs/api/http.html#http_class_http_serverresponse) from Node core.
 - `.log` - The logger instance of the incoming request.
 - `.request` - The incoming request.
 
@@ -190,7 +190,7 @@ As an example:
 ```js
 app.get('/', (req, reply) => {
   reply.sent = true
-  reply.res.end('hello world')
+  reply.raw.end('hello world')
 
   return Promise.resolve('this will be skipped')
 })

--- a/docs/Request.md
+++ b/docs/Request.md
@@ -7,7 +7,7 @@ Request is a core Fastify object containing the following fields:
 - `body` - the body
 - `params` - the params matching the URL
 - `headers` - the headers
-- `raw` - the incoming HTTP request from Node core *(you can use the alias `req`)*
+- `raw` - the incoming HTTP request from Node core
 - `id` - the request id
 - `log` - the logger instance of the incoming request
 - `ip` - the IP address of the incoming request

--- a/docs/Request.md
+++ b/docs/Request.md
@@ -8,6 +8,7 @@ Request is a core Fastify object containing the following fields:
 - `params` - the params matching the URL
 - `headers` - the headers
 - `raw` - the incoming HTTP request from Node core
+- `req` *(deprecated, use `.raw` instead)* - the incoming HTTP request from Node core
 - `id` - the request id
 - `log` - the logger instance of the incoming request
 - `ip` - the IP address of the incoming request

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -169,7 +169,7 @@ fastify.addHook('onRequest', (req, reply, done) => {
 })
 
 fastify.addHook('onResponse', (req, reply, done) => {
-  req.log.info({ url: req.req.originalUrl, statusCode: res.res.statusCode }, 'request completed')
+  req.log.info({ url: req.req.originalUrl, statusCode: res.raw.statusCode }, 'request completed')
   done()
 })
 ```
@@ -345,7 +345,7 @@ fastify.get('/', (request, reply) => {
   console.log(request.raw.ips)
   console.log(request.raw.hostname)
   request.raw.log('Hello')
-  reply.res.log('World')
+  reply.raw.log('World')
 })
 ```
 

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -164,12 +164,12 @@ custom `onRequest` and `onResponse` hooks.
 ```js
 // Examples of hooks to replicate the disabled functionality.
 fastify.addHook('onRequest', (req, reply, done) => {
-  req.log.info({ url: req.req.url, id: req.id }, 'received request')
+  req.log.info({ url: req.raw.url, id: req.id }, 'received request')
   done()
 })
 
 fastify.addHook('onResponse', (req, reply, done) => {
-  req.log.info({ url: req.req.originalUrl, statusCode: res.raw.statusCode }, 'request completed')
+  req.log.info({ url: req.raw.originalUrl, statusCode: res.raw.statusCode }, 'request completed')
   done()
 })
 ```

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -344,8 +344,8 @@ fastify.get('/', (request, reply) => {
   console.log(request.raw.ip)
   console.log(request.raw.ips)
   console.log(request.raw.hostname)
-  request.raw.log('Hello')
-  reply.raw.log('World')
+  request.raw.log.info('Hello')
+  reply.raw.log.info('World')
 })
 ```
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -27,7 +27,7 @@ function Context (schema, handler, Reply, Request, contentTypeParser, config, er
 }
 
 function defaultErrorHandler (error, request, reply) {
-  var res = reply.res
+  var res = reply.raw
   if (res.statusCode >= 500) {
     reply.log.error({ req: reply.request.raw, res: res, err: error }, error && error.message)
   } else if (res.statusCode >= 400) {

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -71,7 +71,7 @@ function handler (request, reply) {
 }
 
 function preValidationCallback (err, request, reply) {
-  if (reply.sent === true || reply.res.finished === true) return
+  if (reply.sent === true || reply.raw.finished === true) return
   if (err != null) {
     reply.send(err)
     return
@@ -102,7 +102,7 @@ function preValidationCallback (err, request, reply) {
 }
 
 function preHandlerCallback (err, request, reply) {
-  if (reply.sent || reply.res.finished === true) return
+  if (reply.sent || reply.raw.finished === true) return
   if (err != null) {
     reply.send(err)
     return

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -49,6 +49,11 @@ const {
     FST_ERR_SEND_INSIDE_ONERR
   }
 } = require('./errors')
+const {
+  codes: {
+    FSTDEP002
+  }
+} = require('./warnings')
 
 var warningEmitted = false
 
@@ -74,10 +79,7 @@ Object.defineProperties(Reply.prototype, {
         return this.raw
       }
       warningEmitted = true
-      const warn = new Error('You are accessing the Node.js core response object via "reply.res", Use "reply.raw" instead.')
-      warn.name = 'FastifyDeprecation'
-      warn.code = 'FST_WARN'
-      process.emitWarning(warn)
+      process.emitWarning(new FSTDEP002())
       return this.raw
     }
   },

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -49,13 +49,7 @@ const {
     FST_ERR_SEND_INSIDE_ONERR
   }
 } = require('./errors')
-const {
-  codes: {
-    FSTDEP002
-  }
-} = require('./warnings')
-
-var warningEmitted = false
+const { emitWarning } = require('./warnings')
 
 function Reply (res, context, request, log) {
   this.raw = res
@@ -75,11 +69,7 @@ function Reply (res, context, request, log) {
 Object.defineProperties(Reply.prototype, {
   res: {
     get () {
-      if (warningEmitted === true) {
-        return this.raw
-      }
-      warningEmitted = true
-      process.emitWarning(new FSTDEP002())
+      emitWarning('FSTDEP002')
       return this.raw
     }
   },

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -65,31 +65,38 @@ function Reply (res, context, request, log) {
   this.log = log
 }
 
-Object.defineProperty(Reply.prototype, 'sent', {
-  enumerable: true,
-  get () {
-    return this[kReplySent]
-  },
-  set (value) {
-    if (value !== true) {
-      throw new FST_ERR_REP_SENT_VALUE()
+Object.defineProperties(Reply.prototype, {
+  res: {
+    get () {
+      process.emitWarning('You are accessing the Node.js core response object via "reply.res", Use "reply.raw" instead.')
+      return this.raw
     }
-
-    if (this[kReplySent]) {
-      throw new FST_ERR_REP_ALREADY_SENT()
-    }
-
-    this[kReplySentOverwritten] = true
-    this[kReplySent] = true
-  }
-})
-
-Object.defineProperty(Reply.prototype, 'statusCode', {
-  get () {
-    return this.raw.statusCode
   },
-  set (value) {
-    this.code(value)
+  sent: {
+    enumerable: true,
+    get () {
+      return this[kReplySent]
+    },
+    set (value) {
+      if (value !== true) {
+        throw new FST_ERR_REP_SENT_VALUE()
+      }
+
+      if (this[kReplySent]) {
+        throw new FST_ERR_REP_ALREADY_SENT()
+      }
+
+      this[kReplySentOverwritten] = true
+      this[kReplySent] = true
+    }
+  },
+  statusCode: {
+    get () {
+      return this.raw.statusCode
+    },
+    set (value) {
+      this.code(value)
+    }
   }
 })
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -51,7 +51,7 @@ const {
 } = require('./errors')
 
 function Reply (res, context, request, log) {
-  this.res = res
+  this.raw = res
   this.context = context
   this[kReplySent] = false
   this[kReplySerializer] = null
@@ -86,7 +86,7 @@ Object.defineProperty(Reply.prototype, 'sent', {
 
 Object.defineProperty(Reply.prototype, 'statusCode', {
   get () {
-    return this.res.statusCode
+    return this.raw.statusCode
   },
   set (value) {
     this.code(value)
@@ -150,7 +150,7 @@ Reply.prototype.send = function (payload) {
 
 Reply.prototype.getHeader = function (key) {
   key = key.toLowerCase()
-  var res = this.res
+  var res = this.raw
   var value = this[kReplyHeaders][key]
   if (value === undefined && res.hasHeader(key)) {
     value = res.getHeader(key)
@@ -200,7 +200,7 @@ Reply.prototype.headers = function (headers) {
 }
 
 Reply.prototype.code = function (code) {
-  this.res.statusCode = code
+  this.raw.statusCode = code
   this[kReplyHasStatusCode] = true
   return this
 }
@@ -212,9 +212,9 @@ Reply.prototype.serialize = function (payload) {
     return this[kReplySerializer](payload)
   } else {
     if (this.context && this.context[kReplySerializerDefault]) {
-      return this.context[kReplySerializerDefault](payload, this.res.statusCode)
+      return this.context[kReplySerializerDefault](payload, this.raw.statusCode)
     } else {
-      return serialize(this.context, payload, this.res.statusCode)
+      return serialize(this.context, payload, this.raw.statusCode)
     }
   }
 }
@@ -232,7 +232,7 @@ Reply.prototype.type = function (type) {
 Reply.prototype.redirect = function (code, url) {
   if (typeof code === 'string') {
     url = code
-    code = this[kReplyHasStatusCode] ? this.res.statusCode : 302
+    code = this[kReplyHasStatusCode] ? this.raw.statusCode : 302
   }
 
   this.header('location', url).code(code).send()
@@ -263,7 +263,7 @@ Reply.prototype.then = function (fullfilled, rejected) {
     return
   }
 
-  eos(this.res, function (err) {
+  eos(this.raw, function (err) {
     // We must not treat ERR_STREAM_PREMATURE_CLOSE as
     // an error because it is created by eos, not by the stream.
     if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
@@ -297,9 +297,9 @@ function preserializeHookEnd (err, request, reply, payload) {
   }
 
   if (reply.context && reply.context[kReplySerializerDefault]) {
-    payload = reply.context[kReplySerializerDefault](payload, reply.res.statusCode)
+    payload = reply.context[kReplySerializerDefault](payload, reply.raw.statusCode)
   } else {
-    payload = serialize(reply.context, payload, reply.res.statusCode)
+    payload = serialize(reply.context, payload, reply.raw.statusCode)
   }
 
   flatstr(payload)
@@ -331,7 +331,7 @@ function wrapOnSendEnd (err, request, reply, payload) {
 }
 
 function onSendEnd (reply, payload) {
-  var res = reply.res
+  var res = reply.raw
   var statusCode = res.statusCode
 
   if (payload === undefined || payload === null) {
@@ -436,7 +436,7 @@ function onErrorHook (reply, error, cb) {
 
 function handleError (reply, error, cb) {
   reply[kReplyIsRunningOnErrorHook] = false
-  var res = reply.res
+  var res = reply.raw
   var statusCode = res.statusCode
   statusCode = (statusCode >= 400) ? statusCode : 500
   // treat undefined and null as same
@@ -489,8 +489,8 @@ function setupResponseListeners (reply) {
   reply[kReplyStartTime] = now()
 
   var onResFinished = err => {
-    reply.res.removeListener('finish', onResFinished)
-    reply.res.removeListener('error', onResFinished)
+    reply.raw.removeListener('finish', onResFinished)
+    reply.raw.removeListener('error', onResFinished)
 
     var ctx = reply.context
 
@@ -507,8 +507,8 @@ function setupResponseListeners (reply) {
     }
   }
 
-  reply.res.on('finish', onResFinished)
-  reply.res.on('error', onResFinished)
+  reply.raw.on('finish', onResFinished)
+  reply.raw.on('error', onResFinished)
 }
 
 function onResponseIterator (fn, request, reply, next) {
@@ -524,7 +524,7 @@ function onResponseCallback (err, request, reply) {
 
   if (err != null) {
     reply.log.error({
-      res: reply.res,
+      res: reply.raw,
       err,
       responseTime
     }, 'request errored')
@@ -532,14 +532,14 @@ function onResponseCallback (err, request, reply) {
   }
 
   reply.log.info({
-    res: reply.res,
+    res: reply.raw,
     responseTime
   }, 'request completed')
 }
 
 function buildReply (R) {
   function _Reply (res, context, request, log) {
-    this.res = res
+    this.raw = res
     this.context = context
     this[kReplyIsError] = false
     this[kReplyErrorHandlerCalled] = false

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -50,6 +50,8 @@ const {
   }
 } = require('./errors')
 
+var warningEmitted = false
+
 function Reply (res, context, request, log) {
   this.raw = res
   this.context = context
@@ -68,7 +70,14 @@ function Reply (res, context, request, log) {
 Object.defineProperties(Reply.prototype, {
   res: {
     get () {
-      process.emitWarning('You are accessing the Node.js core response object via "reply.res", Use "reply.raw" instead.')
+      if (warningEmitted === true) {
+        return this.raw
+      }
+      warningEmitted = true
+      const warn = new Error('You are accessing the Node.js core response object via "reply.res", Use "reply.raw" instead.')
+      warn.name = 'FastifyDeprecation'
+      warn.code = 'FST_WARN'
+      process.emitWarning(warn)
       return this.raw
     }
   },

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,11 +1,6 @@
 'use strict'
 
-var warningEmitted = false
-const {
-  codes: {
-    FSTDEP001
-  }
-} = require('./warnings')
+const { emitWarning } = require('./warnings')
 
 function Request (params, req, query, headers, log, ip, ips, hostname) {
   this.params = params
@@ -39,11 +34,7 @@ function buildRequest (R) {
 Object.defineProperties(Request.prototype, {
   req: {
     get () {
-      if (warningEmitted === true) {
-        return this.raw
-      }
-      warningEmitted = true
-      process.emitWarning(new FSTDEP001())
+      emitWarning('FSTDEP001')
       return this.raw
     }
   },

--- a/lib/request.js
+++ b/lib/request.js
@@ -30,11 +30,6 @@ function buildRequest (R) {
 }
 
 Object.defineProperties(Request.prototype, {
-  req: {
-    get: function () {
-      return this.raw
-    }
-  },
   id: {
     get: function () {
       return this.raw.id

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,5 +1,7 @@
 'use strict'
 
+var warningEmitted = false
+
 function Request (params, req, query, headers, log, ip, ips, hostname) {
   this.params = params
   this.raw = req
@@ -32,7 +34,14 @@ function buildRequest (R) {
 Object.defineProperties(Request.prototype, {
   req: {
     get () {
-      process.emitWarning('You are accessing the Node.js core request object via "request.req", Use "request.raw" instead.')
+      if (warningEmitted === true) {
+        return this.raw
+      }
+      warningEmitted = true
+      const warn = new Error('You are accessing the Node.js core request object via "request.req", Use "request.raw" instead.')
+      warn.name = 'FastifyDeprecation'
+      warn.code = 'FST_WARN'
+      process.emitWarning(warn)
       return this.raw
     }
   },

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,6 +1,11 @@
 'use strict'
 
 var warningEmitted = false
+const {
+  codes: {
+    FSTDEP001
+  }
+} = require('./warnings')
 
 function Request (params, req, query, headers, log, ip, ips, hostname) {
   this.params = params
@@ -38,10 +43,7 @@ Object.defineProperties(Request.prototype, {
         return this.raw
       }
       warningEmitted = true
-      const warn = new Error('You are accessing the Node.js core request object via "request.req", Use "request.raw" instead.')
-      warn.name = 'FastifyDeprecation'
-      warn.code = 'FST_WARN'
-      process.emitWarning(warn)
+      process.emitWarning(new FSTDEP001())
       return this.raw
     }
   },

--- a/lib/request.js
+++ b/lib/request.js
@@ -30,8 +30,14 @@ function buildRequest (R) {
 }
 
 Object.defineProperties(Request.prototype, {
+  req: {
+    get () {
+      process.emitWarning('You are accessing the Node.js core request object via "request.req", Use "request.raw" instead.')
+      return this.raw
+    }
+  },
   id: {
-    get: function () {
+    get () {
       return this.raw.id
     }
   }

--- a/lib/route.js
+++ b/lib/route.js
@@ -375,7 +375,7 @@ function middlewareCallback (err, request, reply) {
   }
 
   if (reply.context._middie !== null) {
-    reply.context._middie.run(request.raw, reply.res, reply)
+    reply.context._middie.run(request.raw, reply.raw, reply)
   } else {
     onRunMiddlewares(null, null, null, reply)
   }

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const { inherits, format } = require('util')
+const codes = {}
+
+/**
+ * Deprecation codes:
+ *   - FSTDEP001
+ *   - FSTDEP002
+ */
+
+createWarning('FastifyDeprecation', 'FSTDEP001', 'You are accessing the Node.js core request object via "request.req", Use "request.raw" instead.')
+
+createWarning('FastifyDeprecation', 'FSTDEP002', 'You are accessing the Node.js core response object via "reply.res", Use "reply.raw" instead.')
+
+function createWarning (name, code, message) {
+  if (!code) throw new Error('Fastify warning code must not be empty')
+  if (!message) throw new Error('Fastify warning message must not be empty')
+
+  code = code.toUpperCase()
+
+  function FastifyWarning (a, b, c) {
+    Error.captureStackTrace(this, FastifyWarning)
+    this.name = name
+    this.code = code
+
+    // more performant than spread (...) operator
+    if (a && b && c) {
+      this.message = format(message, a, b, c)
+    } else if (a && b) {
+      this.message = format(message, a, b)
+    } else if (a) {
+      this.message = format(message, a)
+    } else {
+      this.message = message
+    }
+  }
+  FastifyWarning.prototype[Symbol.toStringTag] = 'Warning'
+
+  FastifyWarning.prototype.toString = function () {
+    return `${this.name} [${this.code}]: ${this.message}`
+  }
+
+  inherits(FastifyWarning, Error)
+
+  codes[code] = FastifyWarning
+
+  return codes[code]
+}
+
+module.exports = { codes, createWarning }

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -2,6 +2,7 @@
 
 const { inherits, format } = require('util')
 const codes = {}
+const emittedWarnings = new Map()
 
 /**
  * Deprecation codes:
@@ -48,4 +49,11 @@ function createWarning (name, code, message) {
   return codes[code]
 }
 
-module.exports = { codes, createWarning }
+function emitWarning (code) {
+  if (codes[code] === undefined) throw new Error(`The code '${code}' does not exist`)
+  if (emittedWarnings.has(code) === true) return
+  emittedWarnings.set(code, true)
+  process.emitWarning(new codes[code]())
+}
+
+module.exports = { codes, createWarning, emitWarning }

--- a/lib/wrapThenable.js
+++ b/lib/wrapThenable.js
@@ -20,7 +20,7 @@ function wrapThenable (thenable, reply) {
 
     // this is for async functions that
     // are using reply.send directly
-    if (payload !== undefined || (reply.res.statusCode === 204 && reply[kReplySent] === false)) {
+    if (payload !== undefined || (reply.raw.statusCode === 204 && reply[kReplySent] === false)) {
       // we use a try-catch internally to avoid adding a catch to another
       // promise, increase promise perf by 10%
       try {

--- a/test/emit-warning.test.js
+++ b/test/emit-warning.test.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('..')
+
+test('Should emit a warning when accessing request.req instead of request.raw', t => {
+  t.plan(2)
+
+  process.once('warning', warning => {
+    t.strictEqual(warning.message, 'You are accessing the Node.js core request object via "request.req", Use "request.raw" instead.')
+  })
+
+  const fastify = Fastify()
+
+  fastify.get('/', (request, reply) => {
+    reply.send(request.req.headers)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    path: '/'
+  }, (err, res) => {
+    t.error(err)
+  })
+})
+
+test('Should emit a warning when accessing reply.res instead of reply.raw', t => {
+  t.plan(2)
+
+  process.once('warning', warning => {
+    t.strictEqual(warning.message, 'You are accessing the Node.js core response object via "reply.res", Use "reply.raw" instead.')
+  })
+
+  const fastify = Fastify()
+
+  fastify.get('/', (request, reply) => {
+    reply.send(reply.res.statusCode)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    path: '/'
+  }, (err, res) => {
+    t.error(err)
+  })
+})

--- a/test/emit-warning.test.js
+++ b/test/emit-warning.test.js
@@ -9,7 +9,7 @@ test('Should emit a warning when accessing request.req instead of request.raw', 
   process.on('warning', onWarning)
   function onWarning (warning) {
     t.strictEqual(warning.name, 'FastifyDeprecation')
-    t.strictEqual(warning.code, 'FST_WARN')
+    t.strictEqual(warning.code, 'FSTDEP001')
     t.strictEqual(warning.message, 'You are accessing the Node.js core request object via "request.req", Use "request.raw" instead.')
   }
 
@@ -34,7 +34,7 @@ test('Should emit a warning when accessing reply.res instead of reply.raw', t =>
   process.on('warning', onWarning)
   function onWarning (warning) {
     t.strictEqual(warning.name, 'FastifyDeprecation')
-    t.strictEqual(warning.code, 'FST_WARN')
+    t.strictEqual(warning.code, 'FSTDEP002')
     t.strictEqual(warning.message, 'You are accessing the Node.js core response object via "reply.res", Use "reply.raw" instead.')
   }
 

--- a/test/emit-warning.test.js
+++ b/test/emit-warning.test.js
@@ -4,16 +4,19 @@ const { test } = require('tap')
 const Fastify = require('..')
 
 test('Should emit a warning when accessing request.req instead of request.raw', t => {
-  t.plan(2)
+  t.plan(4)
 
-  process.once('warning', warning => {
+  process.on('warning', onWarning)
+  function onWarning (warning) {
+    t.strictEqual(warning.name, 'FastifyDeprecation')
+    t.strictEqual(warning.code, 'FST_WARN')
     t.strictEqual(warning.message, 'You are accessing the Node.js core request object via "request.req", Use "request.raw" instead.')
-  })
+  }
 
   const fastify = Fastify()
 
   fastify.get('/', (request, reply) => {
-    reply.send(request.req.headers)
+    reply.send(request.req.method + request.req.method)
   })
 
   fastify.inject({
@@ -21,20 +24,24 @@ test('Should emit a warning when accessing request.req instead of request.raw', 
     path: '/'
   }, (err, res) => {
     t.error(err)
+    process.removeListener('warning', onWarning)
   })
 })
 
 test('Should emit a warning when accessing reply.res instead of reply.raw', t => {
-  t.plan(2)
+  t.plan(4)
 
-  process.once('warning', warning => {
+  process.on('warning', onWarning)
+  function onWarning (warning) {
+    t.strictEqual(warning.name, 'FastifyDeprecation')
+    t.strictEqual(warning.code, 'FST_WARN')
     t.strictEqual(warning.message, 'You are accessing the Node.js core response object via "reply.res", Use "reply.raw" instead.')
-  })
+  }
 
   const fastify = Fastify()
 
   fastify.get('/', (request, reply) => {
-    reply.send(reply.res.statusCode)
+    reply.send(reply.res.statusCode + reply.res.statusCode)
   })
 
   fastify.inject({
@@ -42,5 +49,6 @@ test('Should emit a warning when accessing reply.res instead of reply.raw', t =>
     path: '/'
   }, (err, res) => {
     t.error(err)
+    process.removeListener('warning', onWarning)
   })
 })

--- a/test/hooks-async.test.js
+++ b/test/hooks-async.test.js
@@ -348,7 +348,7 @@ test('onRequest respond with a stream', t => {
       // stream.pipe(res)
       // res.once('finish', resolve)
       reply.send(stream)
-      reply.res.once('finish', () => resolve())
+      reply.raw.once('finish', () => resolve())
     })
   })
 
@@ -397,7 +397,7 @@ test('preHandler respond with a stream', t => {
     return new Promise((resolve, reject) => {
       const stream = fs.createReadStream(process.cwd() + '/test/stream.test.js', 'utf8')
       reply.send(stream)
-      reply.res.once('finish', () => {
+      reply.raw.once('finish', () => {
         t.is(order.shift(), 2)
         resolve()
       })

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -1464,7 +1464,7 @@ test('preHandler respond with a stream', t => {
   fastify.addHook('preHandler', (req, reply, done) => {
     const stream = fs.createReadStream(process.cwd() + '/test/stream.test.js', 'utf8')
     reply.send(stream)
-    reply.res.once('finish', () => {
+    reply.raw.once('finish', () => {
       t.is(order.shift(), 2)
       done()
     })

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -25,11 +25,12 @@ function schemaCompiler (schema) {
 }
 
 test('Request object', t => {
-  t.plan(7)
+  t.plan(8)
   const req = new Request('params', 'req', 'query', 'headers', 'log')
   t.type(req, Request)
   t.equal(req.params, 'params')
-  t.deepEqual(req.raw, 'req')
+  t.strictEqual(req.raw, 'req')
+  t.strictEqual(req.req, 'req')
   t.equal(req.query, 'query')
   t.equal(req.headers, 'headers')
   t.equal(req.log, 'log')

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -25,12 +25,11 @@ function schemaCompiler (schema) {
 }
 
 test('Request object', t => {
-  t.plan(8)
+  t.plan(7)
   const req = new Request('params', 'req', 'query', 'headers', 'log')
   t.type(req, Request)
   t.equal(req.params, 'params')
   t.deepEqual(req.raw, 'req')
-  t.deepEqual(req.req, req.raw)
   t.equal(req.query, 'query')
   t.equal(req.headers, 'headers')
   t.equal(req.log, 'log')

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -15,7 +15,7 @@ const {
 } = require('../../lib/symbols')
 
 test('Once called, Reply should return an object with methods', t => {
-  t.plan(13)
+  t.plan(14)
   const response = { res: 'res' }
   function context () {}
   function request () {}
@@ -30,7 +30,8 @@ test('Once called, Reply should return an object with methods', t => {
   t.is(typeof reply.serialize, 'function')
   t.is(typeof reply.getResponseTime, 'function')
   t.is(typeof reply[kReplyHeaders], 'object')
-  t.strictEqual(reply.raw, response)
+  t.deepEqual(reply.raw, response)
+  t.deepEqual(reply.res, response)
   t.strictEqual(reply.context, context)
   t.strictEqual(reply.request, request)
 })

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -30,7 +30,7 @@ test('Once called, Reply should return an object with methods', t => {
   t.is(typeof reply.serialize, 'function')
   t.is(typeof reply.getResponseTime, 'function')
   t.is(typeof reply[kReplyHeaders], 'object')
-  t.strictEqual(reply.res, response)
+  t.strictEqual(reply.raw, response)
   t.strictEqual(reply.context, context)
   t.strictEqual(reply.request, request)
 })
@@ -409,7 +409,7 @@ test('stream with content type should not send application/octet-stream', t => {
   })
 })
 
-test('stream using reply.res.writeHead should return customize headers', t => {
+test('stream using reply.raw.writeHead should return customize headers', t => {
   t.plan(6)
 
   const fastify = require('../..')()
@@ -424,7 +424,7 @@ test('stream using reply.res.writeHead should return customize headers', t => {
     reply.log.warn = function mockWarn (message) {
       t.equal(message, 'response will send, but you shouldn\'t use res.writeHead in stream mode')
     }
-    reply.res.writeHead(200, {
+    reply.raw.writeHead(200, {
       location: '/'
     })
     reply.send(stream)
@@ -1008,7 +1008,7 @@ test('should throw error when attempting to set reply.sent more than once', t =>
       t.is(err.code, 'FST_ERR_REP_ALREADY_SENT')
       t.strictEqual(err.message, 'Reply was already sent.')
     }
-    reply.res.end()
+    reply.raw.end()
   })
 
   fastify.inject('/', (err, res) => {

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -824,7 +824,7 @@ test('middlewares should run in the order in which they are defined', t => {
     })
 
     instance.get('/', function (request, reply) {
-      t.strictEqual(request.req.previous, 5)
+      t.strictEqual(request.raw.previous, 5)
       reply.send({ hello: 'world' })
     })
 

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -323,7 +323,7 @@ test('should set the status code and the headers from the error object (from cus
 
   fastify.setErrorHandler((err, request, reply) => {
     t.is(err.message, 'ouch')
-    t.is(reply.res.statusCode, 401)
+    t.is(reply.raw.statusCode, 401)
     const error = new Error('kaboom')
     error.headers = { hello: 'world' }
     error.statusCode = 400

--- a/test/skip-reply-send.js
+++ b/test/skip-reply-send.js
@@ -19,7 +19,7 @@ test('skip automatic reply.send() with reply.sent = true and a body', (t) => {
 
   app.get('/', (req, reply) => {
     reply.sent = true
-    reply.res.end('hello world')
+    reply.raw.end('hello world')
 
     return Promise.resolve('this will be skipped')
   })
@@ -48,7 +48,7 @@ test('skip automatic reply.send() with reply.sent = true and no body', (t) => {
 
   app.get('/', (req, reply) => {
     reply.sent = true
-    reply.res.end('hello world')
+    reply.raw.end('hello world')
 
     return Promise.resolve()
   })
@@ -82,7 +82,7 @@ test('skip automatic reply.send() with reply.sent = true and an error', (t) => {
 
   app.get('/', (req, reply) => {
     reply.sent = true
-    reply.res.end('hello world')
+    reply.raw.end('hello world')
 
     return Promise.reject(new Error('kaboom'))
   })

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -382,12 +382,12 @@ test('should support send module 200 and 404', t => {
   const fastify = Fastify()
 
   fastify.get('/', function (req, reply) {
-    const stream = send(req.req, __filename)
+    const stream = send(req.raw, __filename)
     reply.code(200).send(stream)
   })
 
   fastify.get('/error', function (req, reply) {
-    const stream = send(req.req, 'non-existing-file')
+    const stream = send(req.raw, 'non-existing-file')
     reply.code(200).send(stream)
   })
 

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -25,6 +25,6 @@ export type FastifyReply<
   status(statusCode: number): FastifyReply<RawServer, RawReply>;
   type(contentType: string): FastifyReply<RawServer, RawReply>;
   context: FastifyContext<ContextConfig>;
-  res: RawReply;
+  raw: RawReply;
   sent: boolean;
 }


### PR DESCRIPTION
The current API is not consistent, we have `request.req`, `request.raw` and `reply.res`.
I don't recall why we kept  `request.req`, but I think it's useless and also ugly to use, as people usually would write the shorthand version: `req.req`.
This pr removes completely `request.req` and renames `reply.res` to `reply.raw`.
We can choose to keep `.req` and `.res` as aliases, but since we are about to cut a major, I would prefer just to remove those and avoid maintaining an almost useless alias.

We can even choose to be more strict and have a function, such as `unwrap` that returns the Node.js core objects.
Note: this will not introduce any benefit, just a more explicit contract between our APIs and the user.
```js
fastify.get('/', (req, reply) => {
  const res = reply.unwrap()
  res.statusCode = 200
  res.end('hello world')
})
```

What do you think?

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
