### PR TITLE
Removed modifyCoreObjects option

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -188,7 +188,7 @@ const serverFactory = (handler, opts) => {
   return server
 }
 
-const fastify = Fastify({ serverFactory, modifyCoreObjects: false })
+const fastify = Fastify({ serverFactory })
 
 fastify.get('/', (req, reply) => {
   reply.send({ hello: 'world' })
@@ -198,7 +198,6 @@ fastify.listen(3000)
 ```
 
 Internally Fastify uses the API of Node core http server, so if you are using a custom server you must be sure to have the same API exposed. If not, you can enhance the server instance inside the `serverFactory` function before the `return` statement.<br/>
-*Note that we have also added `modifyCoreObjects: false` because in some serverless environments such as Google Cloud Functions, some Node.js core properties are not writable.*
 
 <a name="factory-case-sensitive"></a>
 ### `caseSensitive`
@@ -327,41 +326,6 @@ const versioning = {
 
 const fastify = require('fastify')({
   versioning
-})
-```
-
-<a name="factory-modify-core-objects"></a>
-### `modifyCoreObjects`
-
-+ Default: `true`
-
-By default, Fastify will add the `ip`, `ips`, `hostname`, and `log` properties to Node's raw request object (see [`Request`](https://github.com/fastify/fastify/blob/master/docs/Request.md)) and the `log` property to Node's raw response object. Set to `false` to prevent these properties from being added to the Node core objects.
-
-```js
-const fastify = Fastify({ modifyCoreObjects: true }) // the default
-
-fastify.get('/', (request, reply) => {
-  console.log(request.raw.ip)
-  console.log(request.raw.ips)
-  console.log(request.raw.hostname)
-  request.raw.log.info('Hello')
-  reply.raw.log.info('World')
-})
-```
-
-Disable this option could help in serverless environments such as Google Cloud Functions, where `ip` and `ips` are not writable properties.
-
-**Note that these properties are deprecated and will be removed in the next major version of Fastify along with this option.** It is recommended to use the same properties on Fastify's [`Request`](https://github.com/fastify/fastify/blob/master/docs/Request.md) and [`Reply`](https://github.com/fastify/fastify/blob/master/docs/Reply.md) objects instead.
-
-```js
-const fastify = Fastify({ modifyCoreObjects: false })
-
-fastify.get('/', (request, reply) => {
-  console.log(request.ip)
-  console.log(request.ips)
-  console.log(request.hostname)
-  request.log('Hello')
-  reply.log('World')
 })
 ```
 

--- a/fastify.js
+++ b/fastify.js
@@ -56,7 +56,6 @@ function fastify (options) {
 
   validateBodyLimitOption(options.bodyLimit)
 
-  const modifyCoreObjects = options.modifyCoreObjects !== false
   const requestIdHeader = options.requestIdHeader || defaultInitOptions.requestIdHeader
   const querystringParser = options.querystringParser || querystring.parse
   const genReqId = options.genReqId || reqIdGenFactory()
@@ -84,12 +83,10 @@ function fastify (options) {
 
   // Update the options with the fixed values
   options.logger = logger
-  options.modifyCoreObjects = modifyCoreObjects
   options.genReqId = genReqId
   options.requestIdHeader = requestIdHeader
   options.querystringParser = querystringParser
   options.requestIdLogLabel = requestIdLogLabel
-  options.modifyCoreObjects = modifyCoreObjects
   options.disableRequestLogging = disableRequestLogging
   options.ajv = ajvOptions
 

--- a/lib/fourOhFour.js
+++ b/lib/fourOhFour.js
@@ -29,7 +29,7 @@ const { lifecycleHooks } = require('./hooks')
  * kFourOhFourContext: the context in the reply object where the handler will be executed
  */
 function fourOhFour (options) {
-  const { logger, modifyCoreObjects, genReqId } = options
+  const { logger, genReqId } = options
 
   // 404 router, used for handling encapsulated 404 handlers
   const router = FindMyWay({ defaultRoute: fourOhFourFallBack })
@@ -152,16 +152,12 @@ function fourOhFour (options) {
     // we might want to do some hard debugging
     // here, let's print out as much info as
     // we can
-    req.id = genReqId(req)
-    req.originalUrl = req.url
-    var childLogger = logger.child({ reqId: req.id })
-    if (modifyCoreObjects) {
-      req.log = res.log = childLogger
-    }
+    var id = genReqId(req)
+    var childLogger = logger.child({ reqId: id })
 
     childLogger.info({ req }, 'incoming request')
 
-    var request = new Request(null, req, null, req.headers, childLogger)
+    var request = new Request(id, null, req, null, req.headers, childLogger)
     var reply = new Reply(res, { onSend: [], onError: [] }, request, childLogger)
 
     request.log.warn('the default handler for 404 did not catch this, this is likely a fastify bug, please report it')

--- a/lib/request.js
+++ b/lib/request.js
@@ -2,7 +2,8 @@
 
 const { emitWarning } = require('./warnings')
 
-function Request (params, req, query, headers, log, ip, ips, hostname) {
+function Request (id, params, req, query, headers, log, ip, ips, hostname) {
+  this.id = id
   this.params = params
   this.raw = req
   this.query = query
@@ -15,7 +16,8 @@ function Request (params, req, query, headers, log, ip, ips, hostname) {
 }
 
 function buildRequest (R) {
-  function _Request (params, req, query, headers, log, ip, ips, hostname) {
+  function _Request (id, params, req, query, headers, log, ip, ips, hostname) {
+    this.id = id
     this.params = params
     this.raw = req
     this.query = query
@@ -36,11 +38,6 @@ Object.defineProperties(Request.prototype, {
     get () {
       emitWarning('FSTDEP001')
       return this.raw
-    }
-  },
-  id: {
-    get () {
-      return this.raw.id
     }
   }
 })

--- a/lib/route.js
+++ b/lib/route.js
@@ -51,7 +51,6 @@ function buildRouting (options) {
   let setupResponseListeners
   let throwIfAlreadyStarted
   let proxyFn
-  let modifyCoreObjects
   let genReqId
   let disableRequestLogging
   let ignoreTrailingSlash
@@ -73,7 +72,6 @@ function buildRouting (options) {
       requestIdHeader = options.requestIdHeader
       querystringParser = options.querystringParser
       requestIdLogLabel = options.requestIdLogLabel
-      modifyCoreObjects = options.modifyCoreObjects
       genReqId = options.genReqId
       disableRequestLogging = options.disableRequestLogging
       ignoreTrailingSlash = options.ignoreTrailingSlash
@@ -281,8 +279,7 @@ function buildRouting (options) {
       }
     }
 
-    req.id = req.headers[requestIdHeader] || genReqId(req)
-    req.originalUrl = req.url
+    var id = req.headers[requestIdHeader] || genReqId(req)
     var hostname = req.headers.host
     var ip = req.connection.remoteAddress
     var ips
@@ -296,7 +293,7 @@ function buildRouting (options) {
     }
 
     var loggerOpts = {
-      [requestIdLogLabel]: req.id,
+      [requestIdLogLabel]: id,
       level: context.logLevel
     }
 
@@ -306,22 +303,13 @@ function buildRouting (options) {
     var childLogger = logger.child(loggerOpts)
     childLogger[kDisableRequestLogging] = disableRequestLogging
 
-    // added hostname, ip, and ips back to the Node req object to maintain backward compatibility
-    if (modifyCoreObjects) {
-      req.hostname = hostname
-      req.ip = ip
-      req.ips = ips
-
-      req.log = res.log = childLogger
-    }
-
     if (disableRequestLogging === false) {
       childLogger.info({ req }, 'incoming request')
     }
 
     var queryPrefix = req.url.indexOf('?')
     var query = querystringParser(queryPrefix > -1 ? req.url.slice(queryPrefix + 1) : '')
-    var request = new context.Request(params, req, query, req.headers, childLogger, ip, ips, hostname)
+    var request = new context.Request(id, params, req, query, req.headers, childLogger, ip, ips, hostname)
     var reply = new context.Reply(res, context, request, childLogger)
 
     if (hasLogger === true || context.onResponse !== null) {

--- a/test/genReqId.test.js
+++ b/test/genReqId.test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const Fastify = require('..')
 
@@ -11,8 +13,8 @@ test('Should accept a custom genReqId function', t => {
   })
 
   fastify.get('/', (req, reply) => {
-    t.ok(req.raw.id)
-    reply.send({ id: req.raw.id })
+    t.ok(req.id)
+    reply.send({ id: req.id })
   })
 
   fastify.listen(0, err => {

--- a/test/internals/contentTypeParser.test.js
+++ b/test/internals/contentTypeParser.test.js
@@ -40,7 +40,7 @@ test('rawBody function', t => {
   const rs = new Readable()
   rs._read = function () {}
   rs.headers = { 'content-length': body.length }
-  const request = new Request('params', rs, 'query', { 'content-length': body.length }, 'log')
+  const request = new Request('id', 'params', rs, 'query', { 'content-length': body.length }, 'log')
   const reply = new Reply(res, context, {})
   const done = () => {}
 

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -25,16 +25,20 @@ function schemaCompiler (schema) {
 }
 
 test('Request object', t => {
-  t.plan(8)
-  const req = new Request('params', 'req', 'query', 'headers', 'log')
+  t.plan(12)
+  const req = new Request('id', 'params', 'req', 'query', 'headers', 'log', 'ip', 'ips', 'hostname')
   t.type(req, Request)
-  t.equal(req.params, 'params')
+  t.strictEqual(req.id, 'id')
+  t.strictEqual(req.params, 'params')
   t.strictEqual(req.raw, 'req')
   t.strictEqual(req.req, 'req')
-  t.equal(req.query, 'query')
-  t.equal(req.headers, 'headers')
-  t.equal(req.log, 'log')
-  t.strictDeepEqual(req.body, null)
+  t.strictEqual(req.query, 'query')
+  t.strictEqual(req.headers, 'headers')
+  t.strictEqual(req.log, 'log')
+  t.strictEqual(req.ip, 'ip')
+  t.strictEqual(req.ips, 'ips')
+  t.strictEqual(req.hostname, 'hostname')
+  t.strictEqual(req.body, null)
 })
 
 test('handleRequest function - sent reply', t => {

--- a/test/internals/logger.test.js
+++ b/test/internals/logger.test.js
@@ -16,8 +16,8 @@ test('The logger should add a unique id for every request', t => {
 
   const fastify = Fastify()
   fastify.get('/', (req, reply) => {
-    t.ok(req.raw.id)
-    reply.send({ id: req.raw.id })
+    t.ok(req.id)
+    reply.send({ id: req.id })
   })
 
   fastify.listen(0, err => {
@@ -49,8 +49,8 @@ test('The logger should add a unique id for every request', t => {
 test('The logger should reuse request id header for req.id', t => {
   const fastify = Fastify()
   fastify.get('/', (req, reply) => {
-    t.ok(req.raw.id)
-    reply.send({ id: req.raw.id })
+    t.ok(req.id)
+    reply.send({ id: req.id })
   })
 
   fastify.listen(0, err => {

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -277,9 +277,9 @@ test('The request id header key can be customized', t => {
   t.tearDown(() => fastify.close())
 
   fastify.get('/', (req, reply) => {
-    t.equal(req.raw.id, REQUEST_ID)
+    t.equal(req.id, REQUEST_ID)
     req.log.info('some log message')
-    reply.send({ id: req.raw.id })
+    reply.send({ id: req.id })
   })
 
   fastify.inject({
@@ -1389,7 +1389,6 @@ test('should not rely on raw request to log errors', t => {
   t.plan(7)
   const stream = split(JSON.parse)
   const fastify = Fastify({
-    modifyCoreObjects: false,
     logger: {
       stream: stream,
       level: 'info'

--- a/test/trust-proxy.test.js
+++ b/test/trust-proxy.test.js
@@ -18,55 +18,17 @@ const sgetForwardedRequest = (app, forHeader, path) => {
 
 const testRequestValues = (t, req, options) => {
   if (options.ip) {
-    if (options.modifyCoreObjects) {
-      t.ok(req.raw.ip, 'ip is defined')
-      t.equal(req.raw.ip, options.ip, 'gets ip from x-forwarded-for')
-    }
     t.ok(req.ip, 'ip is defined')
     t.equal(req.ip, options.ip, 'gets ip from x-forwarded-for')
   }
   if (options.hostname) {
-    if (options.modifyCoreObjects) {
-      t.ok(req.raw.hostname, 'hostname is defined')
-      t.equal(req.raw.hostname, options.hostname, 'gets hostname from x-forwarded-host')
-    }
     t.ok(req.hostname, 'hostname is defined')
     t.equal(req.hostname, options.hostname, 'gets hostname from x-forwarded-host')
   }
   if (options.ips) {
-    if (options.modifyCoreObjects) {
-      t.deepEqual(req.raw.ips, options.ips, 'gets ips from x-forwarded-for')
-    }
     t.deepEqual(req.ips, options.ips, 'gets ips from x-forwarded-for')
   }
 }
-
-test('trust proxy, add properties to node req', (t) => {
-  t.plan(15)
-  const modifyCoreObjects = true
-  const app = fastify({
-    trustProxy: true,
-    modifyCoreObjects
-  })
-  app.get('/trustproxy', function (req, reply) {
-    testRequestValues(t, req, { ip: '1.1.1.1', hostname: 'example.com', modifyCoreObjects })
-    reply.code(200).send({ ip: req.ip, hostname: req.hostname })
-  })
-
-  app.get('/trustproxychain', function (req, reply) {
-    testRequestValues(t, req, { ip: '2.2.2.2', ips: ['127.0.0.1', '1.1.1.1', '2.2.2.2'], modifyCoreObjects })
-    reply.code(200).send({ ip: req.ip, hostname: req.hostname })
-  })
-
-  t.tearDown(app.close.bind(app))
-
-  app.listen(0, (err) => {
-    app.server.unref()
-    t.error(err)
-    sgetForwardedRequest(app, '1.1.1.1', '/trustproxy')
-    sgetForwardedRequest(app, '2.2.2.2, 1.1.1.1', '/trustproxychain')
-  })
-})
 
 test('trust proxy, not add properties to node req', (t) => {
   t.plan(8)


### PR DESCRIPTION
As titled, with this pr we also stop enhancing the Node.js core request/response objects.
Once this one is merged, I'll work on https://github.com/fastify/fastify/issues/1551.

Closes: #2013 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
