### PR TITLE
Serialize Fastify objects instead of Node.js

### DIFF
--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -59,7 +59,7 @@ const fastify = require('fastify')({
 
 By default, fastify adds an id to every request for easier tracking. If the "request-id" header is present its value is used, otherwise a new incremental id is generated. See Fastify Factory [`requestIdHeader`](https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-request-id-header) and Fastify Factory [`genReqId`](https://github.com/fastify/fastify/blob/master/docs/Server.md#gen-request-id) for customization options.
 
-The default logger is configured with a set of standard serializers that serialize objects with `req`, `res`, and `err` properties. The object received by `req` is the Fastify `Request` object, while the object receivedby `res` is the Fastify `reply` object.  
+The default logger is configured with a set of standard serializers that serialize objects with `req`, `res`, and `err` properties. The object received by `req` is the Fastify [`Request`](https://github.com/fastify/fastify/blob/master/docs/Request.md) object, while the object received by `res` is the Fastify [`Reply`](https://github.com/fastify/fastify/blob/master/docs/Reply.md) object.  
 This behaviour can be customized by specifying custom serializers.
 ```js
 const fastify = require('fastify')({

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -59,13 +59,14 @@ const fastify = require('fastify')({
 
 By default, fastify adds an id to every request for easier tracking. If the "request-id" header is present its value is used, otherwise a new incremental id is generated. See Fastify Factory [`requestIdHeader`](https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-request-id-header) and Fastify Factory [`genReqId`](https://github.com/fastify/fastify/blob/master/docs/Server.md#gen-request-id) for customization options.
 
-The default logger is configured with a set of standard serializers that serialize objects with `req`, `res`, and `err` properties. This behaviour can be customized by specifying custom serializers.
+The default logger is configured with a set of standard serializers that serialize objects with `req`, `res`, and `err` properties. The object received by `req` is the Fastify `Request` object, while the object receivedby `res` is the Fastify `reply` object.  
+This behaviour can be customized by specifying custom serializers.
 ```js
 const fastify = require('fastify')({
   logger: {
     serializers: {
-      req: function (req) {
-        return { url: req.url }
+      req (request) {
+        return { url: request.url }
       }
     }
   }
@@ -78,23 +79,23 @@ const fastify = require('fastify')({
   logger: {
     prettyPrint: true,
     serializers: {
-      res(res) {
+      res (reply) {
         // The default
         return {
-          statusCode: res.statusCode
+          statusCode: reply.statusCode
         }
       },
-      req(req) {
+      req (request) {
         return {
-          method: req.method,
-          url: req.url,
-          path: req.path,
-          parameters: req.parameters,
-          // Including the headers in the log could be in violation 
+          method: request.method,
+          url: request.url,
+          path: request.path,
+          parameters: request.parameters,
+          // Including the headers in the log could be in violation
           // of privacy laws, e.g. GDPR. You should use the "redact" option to
           // remove sensitive fields. It could also leak authentication data in
           // the logs.
-          headers: req.headers
+          headers: request.headers
         };
       }
     }
@@ -151,14 +152,14 @@ const fastify = Fastify({
     redact: ['req.headers.authorization'],
     level: 'info',
     serializers: {
-      req (req) {
+      req (request) {
         return {
-          method: req.method,
-          url: req.url,
-          headers: req.headers,
-          hostname: req.hostname,
-          remoteAddress: req.ip,
-          remotePort: req.connection.remotePort
+          method: request.method,
+          url: request.url,
+          headers: request.headers,
+          hostname: request.hostname,
+          remoteAddress: request.ip,
+          remotePort: request.connection.remotePort
         }
       }
     }

--- a/docs/Request.md
+++ b/docs/Request.md
@@ -14,6 +14,9 @@ Request is a core Fastify object containing the following fields:
 - `ip` - the IP address of the incoming request
 - `ips` - an array of the IP addresses in the `X-Forwarded-For` header of the incoming request (only when the [`trustProxy`](https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-trust-proxy) option is enabled)
 - `hostname` - the hostname of the incoming request
+- `method` - the method of the incoming request
+- `url` - the url of the incoming request
+- `connection` - the underlying connection of the incoming request
 
 ```js
 fastify.post('/:params', options, function (request, reply) {

--- a/lib/context.js
+++ b/lib/context.js
@@ -27,11 +27,16 @@ function Context (schema, handler, Reply, Request, contentTypeParser, config, er
 }
 
 function defaultErrorHandler (error, request, reply) {
-  var res = reply.raw
-  if (res.statusCode >= 500) {
-    reply.log.error({ req: reply.request.raw, res: res, err: error }, error && error.message)
-  } else if (res.statusCode >= 400) {
-    reply.log.info({ res: res, err: error }, error && error.message)
+  if (reply.statusCode >= 500) {
+    reply.log.error(
+      { req: request, res: reply, err: error },
+      error && error.message
+    )
+  } else if (reply.statusCode >= 400) {
+    reply.log.info(
+      { res: reply, err: error },
+      error && error.message
+    )
   }
   reply.send(error)
 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -62,9 +62,9 @@ const serializers = {
     }
   },
   err: pino.stdSerializers.err,
-  res: function asResValue (res) {
+  res: function asResValue (reply) {
     return {
-      statusCode: res.statusCode
+      statusCode: reply.statusCode
     }
   }
 }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -532,7 +532,7 @@ function onResponseCallback (err, request, reply) {
 
   if (err != null) {
     reply.log.error({
-      res: reply.raw,
+      res: reply,
       err,
       responseTime
     }, 'request errored')
@@ -540,7 +540,7 @@ function onResponseCallback (err, request, reply) {
   }
 
   reply.log.info({
-    res: reply.raw,
+    res: reply,
     responseTime
   }, 'request completed')
 }

--- a/lib/request.js
+++ b/lib/request.js
@@ -39,6 +39,21 @@ Object.defineProperties(Request.prototype, {
       emitWarning('FSTDEP001')
       return this.raw
     }
+  },
+  url: {
+    get () {
+      return this.raw.url
+    }
+  },
+  method: {
+    get () {
+      return this.raw.method
+    }
+  },
+  connection: {
+    get () {
+      return this.raw.connection
+    }
   }
 })
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -303,14 +303,14 @@ function buildRouting (options) {
     var childLogger = logger.child(loggerOpts)
     childLogger[kDisableRequestLogging] = disableRequestLogging
 
-    if (disableRequestLogging === false) {
-      childLogger.info({ req }, 'incoming request')
-    }
-
     var queryPrefix = req.url.indexOf('?')
     var query = querystringParser(queryPrefix > -1 ? req.url.slice(queryPrefix + 1) : '')
     var request = new context.Request(id, params, req, query, req.headers, childLogger, ip, ips, hostname)
     var reply = new context.Reply(res, context, request, childLogger)
+
+    if (disableRequestLogging === false) {
+      childLogger.info({ req: request }, 'incoming request')
+    }
 
     if (hasLogger === true || context.onResponse !== null) {
       setupResponseListeners(reply)

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -25,20 +25,28 @@ function schemaCompiler (schema) {
 }
 
 test('Request object', t => {
-  t.plan(12)
-  const req = new Request('id', 'params', 'req', 'query', 'headers', 'log', 'ip', 'ips', 'hostname')
-  t.type(req, Request)
-  t.strictEqual(req.id, 'id')
-  t.strictEqual(req.params, 'params')
-  t.strictEqual(req.raw, 'req')
-  t.strictEqual(req.req, 'req')
-  t.strictEqual(req.query, 'query')
-  t.strictEqual(req.headers, 'headers')
-  t.strictEqual(req.log, 'log')
-  t.strictEqual(req.ip, 'ip')
-  t.strictEqual(req.ips, 'ips')
-  t.strictEqual(req.hostname, 'hostname')
-  t.strictEqual(req.body, null)
+  t.plan(15)
+  const req = {
+    method: 'GET',
+    url: '/',
+    connection: { foo: 'bar' }
+  }
+  const request = new Request('id', 'params', req, 'query', 'headers', 'log', 'ip', 'ips', 'hostname')
+  t.type(request, Request)
+  t.strictEqual(request.id, 'id')
+  t.strictEqual(request.params, 'params')
+  t.deepEqual(request.raw, req)
+  t.deepEqual(request.req, req)
+  t.strictEqual(request.query, 'query')
+  t.strictEqual(request.headers, 'headers')
+  t.strictEqual(request.log, 'log')
+  t.strictEqual(request.ip, 'ip')
+  t.strictEqual(request.ips, 'ips')
+  t.strictEqual(request.hostname, 'hostname')
+  t.strictEqual(request.body, null)
+  t.strictEqual(req.method, 'GET')
+  t.strictEqual(req.url, '/')
+  t.deepEqual(req.connection, req.connection)
 })
 
 test('handleRequest function - sent reply', t => {

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -44,9 +44,9 @@ test('Request object', t => {
   t.strictEqual(request.ips, 'ips')
   t.strictEqual(request.hostname, 'hostname')
   t.strictEqual(request.body, null)
-  t.strictEqual(req.method, 'GET')
-  t.strictEqual(req.url, '/')
-  t.deepEqual(req.connection, req.connection)
+  t.strictEqual(request.method, 'GET')
+  t.strictEqual(request.url, '/')
+  t.deepEqual(request.connection, req.connection)
 })
 
 test('handleRequest function - sent reply', t => {


### PR DESCRIPTION
As titled. I've also added a few new getters in our `request` object, which not only improves the API, but also softens the breaking change.

Closes: #1551 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
