### PR TITLE
Proposal: registerSync API

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -72,6 +72,11 @@ createError('FST_ERR_HTTP2_INVALID_VERSION', 'HTTP2 is available only from node 
  */
 createError('FST_ERR_INIT_OPTS_INVALID', "Invalid initialization options: '%s'")
 
+/**
+ * Plugins
+ */
+createError('FST_ERR_SYNC_PLUGIN', 'You are registering a sync plugin, but th plugin you are using is synchronous')
+
 function createError (code, message, statusCode = 500, Base = Error) {
   if (!code) throw new Error('Fastify error code must not be empty')
   if (!message) throw new Error('Fastify error message must not be empty')

--- a/test/plugin-sync.test.js
+++ b/test/plugin-sync.test.js
@@ -1,0 +1,168 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('..')
+const fp = require('fastify-plugin')
+const {
+  codes: {
+    FST_ERR_SYNC_PLUGIN
+  }
+} = require('../lib/errors')
+
+test('Register a plugin synchronously / 1', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.registerSync(fp(plugin))
+  t.strictEqual(fastify.foo, 'bar')
+
+  fastify.ready(() => {
+    t.strictEqual(fastify.foo, 'bar')
+  })
+
+  function plugin (fastify, opts) {
+    fastify.decorate('foo', 'bar')
+  }
+})
+
+test('Register a plugin synchronously / 2', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.registerSync(fp(pluginSync))
+  fastify.register(fp(pluginAsync))
+
+  t.strictEqual(fastify.foo, 'bar')
+  t.strictEqual(fastify.faz, undefined)
+
+  fastify.ready(() => {
+    t.strictEqual(fastify.foo, 'bar')
+    t.strictEqual(fastify.faz, 'baz')
+  })
+
+  function pluginSync (fastify, opts) {
+    fastify.decorate('foo', 'bar')
+  }
+
+  function pluginAsync (fastify, opts, next) {
+    fastify.decorate('faz', 'baz')
+    next()
+  }
+})
+
+test('Register a plugin synchronously / 3', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.register(fp(pluginAsync))
+
+  fastify.ready(() => {
+    t.strictEqual(fastify.foo, 'bar')
+    t.strictEqual(fastify.faz, 'baz')
+  })
+
+  function pluginSync (fastify, opts) {
+    fastify.decorate('foo', 'bar')
+  }
+
+  function pluginAsync (fastify, opts, next) {
+    fastify.registerSync(fp(pluginSync))
+    t.strictEqual(fastify.foo, 'bar')
+    fastify.decorate('faz', 'baz')
+    next()
+  }
+})
+
+test('Should throw in case of an async plugin / 1', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  try {
+    fastify.registerSync(plugin)
+    t.fail('Should throw')
+  } catch (err) {
+    t.ok(err instanceof FST_ERR_SYNC_PLUGIN)
+  }
+
+  function plugin (fastify, opts, next) {
+    next()
+  }
+})
+
+test('Should throw in case of an async plugin / 2', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  try {
+    fastify.registerSync(plugin)
+    t.fail('Should throw')
+  } catch (err) {
+    t.ok(err instanceof FST_ERR_SYNC_PLUGIN)
+  }
+
+  async function plugin (fastify, opts) {}
+})
+
+test('Should throw in case of an async plugin / 3', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  try {
+    fastify.registerSync(plugin)
+    t.fail('Should throw')
+  } catch (err) {
+    t.ok(err instanceof FST_ERR_SYNC_PLUGIN)
+  }
+
+  function plugin (fastify, opts) {
+    return Promise.resolve()
+  }
+})
+
+test('Register route and hooks inside sync plugin', t => {
+  t.plan(3)
+  const fastify = Fastify()
+  fastify.registerSync(plugin)
+
+  fastify.inject({
+    method: 'GET',
+    path: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.headers.foo, 'bar')
+    t.strictEqual(res.payload, 'hello')
+  })
+
+  function plugin (fastify, opts) {
+    fastify.addHook('onSend', (req, reply, payload, next) => {
+      reply.header('foo', 'bar')
+      next()
+    })
+
+    fastify.get('/', (req, reply) => {
+      reply.send('hello')
+    })
+  }
+})
+
+test('Encapsulation support', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.registerSync(plugin)
+  t.strictEqual(fastify.foo, undefined)
+
+  fastify.ready(() => {
+    t.strictEqual(fastify.foo, undefined)
+  })
+
+  function plugin (fastify, opts) {
+    fastify.decorate('foo', 'bar')
+    fastify.registerSync(nestedPlugin)
+  }
+
+  function nestedPlugin (fastify, opts) {
+    t.strictEqual(fastify.foo, 'bar')
+  }
+})


### PR DESCRIPTION
Hello folks!
As you know the Fastify plugin system currently handles asynchronous plugins only, which means that if we have a plugin that adds only a decorator and we need to access it just after, it's not possible:

```js
fastify.register(fp(plugin))
console.log(fastify.foo) // undefined

function plugin (fastify, opts, next) {
  fastify.decorate('foo', 'bar')
  next()
}
```
At the moment you need to use an `after` block if you want to use it:
```js
fastify.register(fp(plugin))
  .after(() => {
    console.log(fastify.foo) // 'bar'
  })

function plugin (fastify, opts, next) {
  fastify.decorate('foo', 'bar')
  next()
}
```

There are many plugins that do not require an async load, which would benefit from a synchronous loading. Hence this proposal, `registerSync` API.
The previous example will change as it follows:

```js
fastify.registerSync(fp(plugin))
console.log(fastify.foo) // 'bar'

function plugin (fastify, opts) {
  fastify.decorate('foo', 'bar')
}
```

As you can see I've added a few checks to be sure that the user is not registering an asynchronous plugin with the sync API, which means that we should rely on the plugin's creators to document which API to use.

For now, I'm targeting v3, we can think is we want to backport it to v2.
Feedback is welcome!

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
