### PR TITLE
fix replace way enum

### DIFF
--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -117,7 +117,8 @@ Schemas.prototype.traverse = function (schema, refResolver) {
       }
     }
 
-    if (schema[key] !== null && typeof schema[key] === 'object') {
+    if (schema[key] !== null && typeof schema[key] === 'object' && key !== 'enum') {
+      // don't traverse non-object values and the `enum` keyword
       this.traverse(schema[key], refResolver)
     }
   }

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -117,8 +117,9 @@ Schemas.prototype.traverse = function (schema, refResolver) {
       }
     }
 
-    if (schema[key] !== null && typeof schema[key] === 'object' && key !== 'enum') {
-      // don't traverse non-object values and the `enum` keyword
+    if (schema[key] !== null && typeof schema[key] === 'object' &&
+    (key !== 'enum' || (key === 'enum' && schema.type !== 'string'))) {
+      // don't traverse non-object values and the `enum` keyword when used for string type
       this.traverse(schema[key], refResolver)
     }
   }

--- a/test/shared-schemas.test.js
+++ b/test/shared-schemas.test.js
@@ -1233,3 +1233,27 @@ test('Cross shared schema reference with encapsulation references', t => {
 
   fastify.ready(t.error)
 })
+
+test('shared schema should be ignored in enum', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    schema: {
+      $id: '/ProgrammingLanguage',
+      description: 'Programming Language',
+      type: 'string',
+      enum: ['Javascript', 'C++', 'C#']
+    },
+    handler: (req, reply) => {
+      reply.send('ok')
+    }
+  })
+
+  fastify.inject('/', (err, res) => {
+    t.error(err)
+    t.strictEqual(res.payload, 'ok')
+  })
+})


### PR DESCRIPTION
Fixes #2021 

Reading the spec of [enum](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.6.1.2) I have added a check to avoid the shared schema "replace way" only when we are traversing a `type: string enum: [values]` JSON schema.

Because this is a valid use case:

```
{
  type: 'object',
  enum: [{hello:'C#'}]
}
```

That some users can write with shared schema:

```
{
  type: 'object',
  enum: ['helloJson#']
}
```


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
