### PR TITLE
add generic to typescript Reply.send payload

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -178,7 +178,7 @@ declare namespace fastify {
     redirect(statusCode: number, url: string): FastifyReply<HttpResponse>
     serialize(payload: any): string
     serializer(fn: Function): FastifyReply<HttpResponse>
-    send(payload?: any): FastifyReply<HttpResponse>
+    send<T>(payload?: T): FastifyReply<HttpResponse>
     sent: boolean
     res: HttpResponse
     context: FastifyContext

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -440,6 +440,13 @@ interface Body {
   }
 }
 
+server.get('/', (req, reply) => {
+  type ResponseShape = {
+    hello: string
+  }
+  reply.send<ResponseShape>({ hello: 'world' })
+})
+
 // Query, Params, Headers, and Body can be provided as generics
 server.get<Query, Params, Headers, Body>('/', ({ query, params, headers, body }, reply) => {
   const bar: number = query.bar


### PR DESCRIPTION
fixes #2030 for v2

using `T` instead of`Payload` as it's much more readable

![Screenshot 2020-01-08 at 18 00 15](https://user-images.githubusercontent.com/4562878/71999574-f7cea700-3241-11ea-9e38-393bc41939d4.png)
![Screenshot 2020-01-08 at 18 00 35](https://user-images.githubusercontent.com/4562878/71999576-f7cea700-3241-11ea-94fe-7fdce41fd2c2.png)
