### PR TITLE
Workaround for using one schema for multiple routes

### DIFF
--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -43,13 +43,9 @@ Schemas.prototype.resolve = function (id) {
 }
 
 Schemas.prototype.resolveRefs = function (routeSchemas, dontClearId, refResolver) {
-  // alias query to querystring schema
-  if (routeSchemas.query) {
-    // check if our schema has both querystring and query
-    if (routeSchemas.querystring) {
-      throw new FST_ERR_SCH_DUPLICATE('querystring')
-    }
-    routeSchemas.querystring = routeSchemas.query
+  // check if our schema has both querystring and query
+  if (routeSchemas.query && routeSchemas.querystring) {
+    throw new FST_ERR_SCH_DUPLICATE('querystring')
   }
 
   // let's check if our schemas have a custom prototype
@@ -62,17 +58,22 @@ Schemas.prototype.resolveRefs = function (routeSchemas, dontClearId, refResolver
   // See issue https://github.com/fastify/fastify/issues/1767
   const cachedSchema = Object.assign({}, routeSchemas)
 
+  // alias query to querystring schema
+  if (routeSchemas.query) {
+    cachedSchema.querystring = routeSchemas.query
+  }
+
   try {
     // this will work only for standard json schemas
     // other compilers such as Joi will fail
-    this.traverse(routeSchemas, refResolver)
+    this.traverse(cachedSchema, refResolver)
 
     // when a plugin uses the 'skip-override' and call addSchema
     // the same JSON will be pass throug all the avvio tree. In this case
     // it is not possible clean the id. The id will be cleared
     // in the startup phase by the call of validation.js. Details PR #1496
     if (dontClearId !== true) {
-      this.cleanId(routeSchemas)
+      this.cleanId(cachedSchema)
     }
   } catch (err) {
     // if we have failed because `resolve` has thrown
@@ -84,19 +85,19 @@ Schemas.prototype.resolveRefs = function (routeSchemas, dontClearId, refResolver
     return cachedSchema
   }
 
-  if (routeSchemas.headers) {
-    routeSchemas.headers = this.getSchemaAnyway(routeSchemas.headers)
+  if (cachedSchema.headers) {
+    cachedSchema.headers = this.getSchemaAnyway(cachedSchema.headers)
   }
 
-  if (routeSchemas.querystring) {
-    routeSchemas.querystring = this.getSchemaAnyway(routeSchemas.querystring)
+  if (cachedSchema.querystring) {
+    cachedSchema.querystring = this.getSchemaAnyway(cachedSchema.querystring)
   }
 
-  if (routeSchemas.params) {
-    routeSchemas.params = this.getSchemaAnyway(routeSchemas.params)
+  if (cachedSchema.params) {
+    cachedSchema.params = this.getSchemaAnyway(cachedSchema.params)
   }
 
-  return routeSchemas
+  return cachedSchema
 }
 
 Schemas.prototype.traverse = function (schema, refResolver) {

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -290,3 +290,43 @@ test('does not mutate joi schemas', t => {
     t.deepEqual(JSON.parse(result.payload), { hello: 'world' })
   })
 })
+
+test('multiple routes with one schema', t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  const schema = {
+    query: {
+      id: { type: 'number' }
+    }
+  }
+
+  fastify.route({
+    schema,
+    method: 'GET',
+    path: '/first/:id',
+    handler (req, res) {
+      res.send({ hello: 'world' })
+    }
+  })
+
+  fastify.route({
+    schema,
+    method: 'GET',
+    path: '/second/:id',
+    handler (req, res) {
+      res.send({ hello: 'world' })
+    }
+  })
+
+  fastify.listen(0, error => {
+    t.error(error)
+    t.strictSame(schema, {
+      query: {
+        id: { type: 'number' }
+      }
+    })
+    fastify.server.unref()
+  })
+})


### PR DESCRIPTION
This pull request fixes #2024.
I see it as a workaround because probably there is a better way to do it.
I'm not too familiar with the codebase, but maybe it's a good idea to create a deep clone of the original schema and then resolve it? This way any mutation won't modify the original schema.