### PR TITLE
registeredRoutes method

### DIFF
--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -17,6 +17,7 @@ You have two ways to declare a route with Fastify, the shorthand method and the 
   - [Custom Log Serializer](#custom-log-serializer)
 - [Route handler configuration](#routes-config)
 - [Route's Versioning](#version)
+- [Analyzing Routes](#analyzing-routes)
 
 <a name="full-declaration"></a>
 ### Full declaration
@@ -433,3 +434,55 @@ If the request will not have the `Accept-Version` header, a 404 error will be re
 
 #### Custom
 It's possible to define a custom versioning logic. This can be done through the [`versioning`](https://github.com/fastify/fastify/blob/master/docs/Server.md#versioning) configuration, when creating a fastify server instance.
+
+<a name="analyzing-routes"></a>
+### Analyzing Routes
+
+#### Getting Routes
+
+An array of registered routes can be dumped with the `fastify.registeredRoutes` method:
+
+```js
+fastify.get('/hello', helloHandler)
+fasttify.ready(() => {
+  console.log(fastify.registeredRoutes())
+})
+```
+
+The method returns an array of objects with keys: `method`, `path`, `opts`, `handler` and `store`. 
+
+The above would print an array similar to the following:
+
+```js
+[{  method: 'GET',
+    path: '/hello',
+    opts: { version: undefined },
+    handler: [Function: routeHandler],
+    store: Context {...} 
+}]
+```
+
+#### Printing Routes
+
+A ASCII tree map of routes can be generated with the `fastify.printRoutes` method:
+
+```js
+fastify.get('/test', handler1)
+fastify.get('/test/:hello', handler2)
+fastify.get('/hello/:world', handler3)
+fastify.ready(() => {
+  console.log(fastify.printRoutes())
+})
+```
+
+The above would output the following:
+
+```
+└── /
+    ├── test (GET)
+    │   └── /
+    │       └── :hello (GET)
+    └── hello/
+        └── :world (GET)
+```
+

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -736,7 +736,12 @@ declare namespace fastify {
     /**
      * Prints the representation of the internal radix tree used by the router
      */
-    printRoutes(): string
+    printRoutes(): string;
+
+    /**
+     * Outputs an array of registered routes
+     */
+    registeredRoutes(): Array<object>
   }
 }
 

--- a/fastify.js
+++ b/fastify.js
@@ -223,6 +223,8 @@ function build (options) {
     inject: inject,
     // pretty print of the registered routes
     printRoutes: router.printRoutes,
+    // output array of the registered routes
+    registeredRoutes: () => router.routes,
     // custom error handling
     setNotFoundHandler: setNotFoundHandler,
     setErrorHandler: setErrorHandler,

--- a/lib/route.js
+++ b/lib/route.js
@@ -87,7 +87,8 @@ function buildRouting (options) {
     prepareRoute,
     routeHandler,
     closeRoutes: () => { closing = true },
-    printRoutes: router.prettyPrint.bind(router)
+    printRoutes: router.prettyPrint.bind(router),
+    get routes () { return router.routes }
   }
 
   // Convert shorthand to extended route declaration

--- a/test/registered-routes.js
+++ b/test/registered-routes.js
@@ -1,0 +1,130 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('..')
+
+test('registered routes - basic', t => {
+  t.plan(11)
+
+  const fastify = Fastify()
+  fastify.get('/test', () => {})
+  fastify.post('/test/:hello', () => {})
+
+  fastify.ready(() => {
+    const routes = fastify.registeredRoutes()
+    t.ok(Array.isArray(routes))
+    const [get, post] = routes
+    t.is(get.method, 'GET')
+    t.is(get.path, '/test')
+    t.ok(get.opts)
+    t.ok(get.handler)
+    t.ok(get.store)
+    t.is(post.method, 'POST')
+    t.is(post.path, '/test/:hello')
+    t.ok(post.opts)
+    t.ok(post.handler)
+    t.ok(post.store)
+  })
+})
+
+test('registered routes - all', t => {
+  t.plan(36)
+
+  const fastify = Fastify()
+  fastify.all('/hello/*', () => {})
+
+  fastify.ready(() => {
+    const routes = fastify.registeredRoutes()
+    t.ok(Array.isArray(routes))
+    // routes for all are ordered alphabetically:
+    const [del, get, head, patch, post, put, options] = routes
+    t.is(del.method, 'DELETE')
+    t.is(del.path, '/hello/*')
+    t.ok(del.opts)
+    t.ok(del.handler)
+    t.ok(del.store)
+    t.is(get.method, 'GET')
+    t.is(get.path, '/hello/*')
+    t.ok(get.opts)
+    t.ok(get.handler)
+    t.ok(get.store)
+    t.is(head.method, 'HEAD')
+    t.is(head.path, '/hello/*')
+    t.ok(head.opts)
+    t.ok(head.handler)
+    t.ok(head.store)
+    t.is(patch.method, 'PATCH')
+    t.is(patch.path, '/hello/*')
+    t.ok(patch.opts)
+    t.ok(patch.handler)
+    t.ok(patch.store)
+    t.is(post.method, 'POST')
+    t.is(post.path, '/hello/*')
+    t.ok(post.opts)
+    t.ok(post.handler)
+    t.ok(post.store)
+    t.is(put.method, 'PUT')
+    t.is(put.path, '/hello/*')
+    t.ok(put.opts)
+    t.ok(put.handler)
+    t.ok(put.store)
+    t.is(options.method, 'OPTIONS')
+    t.is(options.path, '/hello/*')
+    t.ok(options.opts)
+    t.ok(options.handler)
+    t.ok(options.store)
+  })
+})
+
+test('registered routes - options / versions', t => {
+  t.plan(11)
+
+  const fastify = Fastify()
+  fastify.get('/hello', { version: 1 }, () => {})
+  fastify.get('/hello', { version: 2 }, () => {})
+
+  fastify.ready(() => {
+    const routes = fastify.registeredRoutes()
+    t.ok(Array.isArray(routes))
+    const [v1, v2] = routes
+    t.is(v1.method, 'GET')
+    t.is(v1.path, '/hello')
+    t.is(v1.opts.version, 1)
+    t.ok(v1.handler)
+    t.ok(v1.store)
+    t.is(v2.method, 'GET')
+    t.is(v2.path, '/hello')
+    t.is(v2.opts.version, 2)
+    t.ok(v2.handler)
+    t.ok(v2.store)
+  })
+})
+
+test('registered routes - schemas', t => {
+  t.plan(6)
+
+  const fastify = Fastify()
+  const schema = {
+    querystring: {
+      type: 'object',
+      required: ['name'],
+      properties: {
+        name: { type: 'string' },
+        excitement: { type: 'integer' }
+      }
+    }
+  }
+  fastify.get('/test', { schema }, () => {})
+
+  fastify.ready(() => {
+    const routes = fastify.registeredRoutes()
+    t.ok(Array.isArray(routes))
+    const [get] = routes
+    t.is(get.method, 'GET')
+    t.is(get.path, '/test')
+    t.ok(get.opts)
+    t.ok(get.handler)
+    t.same(get.store.schema, schema)
+  })
+})

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -640,6 +640,8 @@ if (typeof server.hasContentTypeParser('foo/bar') !== 'boolean') {
 
 server.printRoutes()
 
+server.registeredRoutes()
+
 server.ready(function (err) {
   if (err) throw err
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

This exposes the find-my-way routes. I also noticed `printRoutes` had not been documented so I documented that as well. 

The reason for this method is meta data analysis, I can think of three use cases but I'm sure there are more

* generating docs boilerplate
* generating route testing boilerplate
* opening up fullstack routing possibilities (e.g. generating a universal router JS bundle based on registered routes with a `clientSide: true` option or some such 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
