### PR TITLE
http2: handle graceful close

### DIFF
--- a/build/build-validation.js
+++ b/build/build-validation.js
@@ -23,7 +23,8 @@ const defaultInitOptions = {
   onConstructorPoisoning: 'ignore',
   pluginTimeout: 10000,
   requestIdHeader: 'request-id',
-  requestIdLogLabel: 'reqId'
+  requestIdLogLabel: 'reqId',
+  http2SessionTimeout: 5000
 }
 
 function customRule0 (schemaParamValue, validatedParamValue, validationSchemaObject, currentDataPath, validatedParamObject, validatedParam) {
@@ -74,7 +75,8 @@ const schema = {
     onConstructorPoisoning: { type: 'string', default: defaultInitOptions.onConstructorPoisoning },
     pluginTimeout: { type: 'integer', default: defaultInitOptions.pluginTimeout },
     requestIdHeader: { type: 'string', default: defaultInitOptions.requestIdHeader },
-    requestIdLogLabel: { type: 'string', default: defaultInitOptions.requestIdLogLabel }
+    requestIdLogLabel: { type: 'string', default: defaultInitOptions.requestIdLogLabel },
+    http2SessionTimeout: { type: 'integer', default: defaultInitOptions.http2SessionTimeout }
   }
 }
 

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -409,6 +409,15 @@ const fastify = require('fastify')({
 })
 ```
 
+<a name="http2-session-timeout"></a>
+### `http2SessionTimeout`
+
+Set a default
+[timeout](https://nodejs.org/api/http2.html#http2_http2session_settimeout_msecs_callback) to every incoming http2 session. The session will be closed on the timeout. Default: `5000` ms.
+
+Note that this is needed to offer the graceful "close" experience when
+using http2. Node core defaults this to `0`.
+
 ## Instance
 
 ### Server Methods

--- a/fastify.js
+++ b/fastify.js
@@ -99,6 +99,8 @@ function build (options) {
   options.disableRequestLogging = disableRequestLogging
   options.ajv = ajvOptions
 
+  const initialConfig = getSecuredInitialConfig(options)
+
   // Default router
   const router = buildRouting({
     config: {
@@ -115,10 +117,11 @@ function build (options) {
 
   // HTTP server and its handler
   const httpHandler = router.routing
+
+  // we need to set this before calling createServer
+  options.http2SessionTimeout = initialConfig.http2SessionTimeout
   const { server, listen } = createServer(options, httpHandler)
-  if (Number(process.version.match(/v(\d+)/)[1]) >= 6) {
-    server.on('clientError', handleClientError)
-  }
+  server.on('clientError', handleClientError)
 
   const setupResponseListeners = Reply.setupResponseListeners
   const schemas = new Schemas()
@@ -227,7 +230,7 @@ function build (options) {
     setNotFoundHandler: setNotFoundHandler,
     setErrorHandler: setErrorHandler,
     // Set fastify initial configuration options read-only object
-    initialConfig: getSecuredInitialConfig(options)
+    initialConfig
   }
 
   Object.defineProperty(fastify, 'schemaCompiler', {

--- a/lib/configValidator.js
+++ b/lib/configValidator.js
@@ -22,6 +22,7 @@ var validate = (function() {
       if (data.pluginTimeout === undefined) data.pluginTimeout = 10000;
       if (data.requestIdHeader === undefined) data.requestIdHeader = "request-id";
       if (data.requestIdLogLabel === undefined) data.requestIdLogLabel = "reqId";
+      if (data.http2SessionTimeout === undefined) data.http2SessionTimeout = 5000;
       var errs__0 = errors;
       var valid1 = true;
       for (var key0 in data) {
@@ -494,6 +495,31 @@ var validate = (function() {
                                 }
                               }
                               var valid1 = errors === errs_1;
+                              if (valid1) {
+                                var data1 = data.http2SessionTimeout;
+                                var errs_1 = errors;
+                                if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
+                                  var dataType1 = typeof data1;
+                                  var coerced1 = undefined;
+                                  if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
+                                  if (coerced1 === undefined) {
+                                    validate.errors = [{
+                                      keyword: 'type',
+                                      dataPath: (dataPath || '') + '.http2SessionTimeout',
+                                      schemaPath: '#/properties/http2SessionTimeout/type',
+                                      params: {
+                                        type: 'integer'
+                                      },
+                                      message: 'should be integer'
+                                    }];
+                                    return false;
+                                  } else {
+                                    data1 = coerced1;
+                                    data['http2SessionTimeout'] = coerced1;
+                                  }
+                                }
+                                var valid1 = errors === errs_1;
+                              }
                             }
                           }
                         }
@@ -591,6 +617,10 @@ validate.schema = {
     "requestIdLogLabel": {
       "type": "string",
       "default": "reqId"
+    },
+    "http2SessionTimeout": {
+      "type": "integer",
+      "default": 5000
     }
   }
 };
@@ -602,4 +632,4 @@ function customRule0 (schemaParamValue, validatedParamValue, validationSchemaObj
   return true
 }
 
-module.exports.defaultInitOptions = {"bodyLimit":1048576,"caseSensitive":true,"disableRequestLogging":false,"ignoreTrailingSlash":false,"maxParamLength":100,"onProtoPoisoning":"error","onConstructorPoisoning":"ignore","pluginTimeout":10000,"requestIdHeader":"request-id","requestIdLogLabel":"reqId"}
+module.exports.defaultInitOptions = {"bodyLimit":1048576,"caseSensitive":true,"disableRequestLogging":false,"ignoreTrailingSlash":false,"maxParamLength":100,"onProtoPoisoning":"error","onConstructorPoisoning":"ignore","pluginTimeout":10000,"requestIdHeader":"request-id","requestIdLogLabel":"reqId","http2SessionTimeout":5000}

--- a/lib/server.js
+++ b/lib/server.js
@@ -24,6 +24,7 @@ function createServer (options, httpHandler) {
     }
   } else if (options.http2) {
     server = http2().createServer(httpHandler)
+    server.on('session', sessionTimeout(options.http2SessionTimeout))
   } else {
     server = http.createServer(httpHandler)
   }
@@ -146,6 +147,16 @@ function http2 () {
   } catch (err) {
     throw new FST_ERR_HTTP2_INVALID_VERSION()
   }
+}
+
+function sessionTimeout (timeout) {
+  return function (session) {
+    session.setTimeout(timeout, close)
+  }
+}
+
+function close () {
+  this.close()
 }
 
 module.exports = { createServer }

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "dns-prefetch-control": "^0.2.0",
     "eslint": "^6.7.2",
     "eslint-import-resolver-node": "^0.3.2",
+    "events.once": "^2.0.2",
     "fast-json-body": "^1.1.0",
     "fastify-plugin": "^1.5.0",
     "fluent-schema": "^0.9.0",

--- a/test/http2/closing.js
+++ b/test/http2/closing.js
@@ -6,6 +6,7 @@ const http2 = require('http2')
 const semver = require('semver')
 const { promisify } = require('util')
 const connect = promisify(http2.connect)
+const once = require('events.once')
 
 t.test('http/2 request while fastify closing', t => {
   let fastify
@@ -109,13 +110,45 @@ t.test('http/2 closes successfully with async await', { skip: semver.lt(process.
     http2: true
   })
 
-  fastify.get('/', async () => {})
-
   await fastify.listen(0)
 
   const url = `http://127.0.0.1:${fastify.server.address().port}`
   const session = await connect(url)
   // An error might or might not happen, as it's OS dependent.
   session.on('error', () => {})
+  await fastify.close()
+})
+
+// Skipped because there is likely a bug on Node 8.
+t.test('http/2 server side session emits a timeout event', { skip: semver.lt(process.versions.node, '10.15.0') }, async t => {
+  let _resolve
+  const p = new Promise((resolve) => { _resolve = resolve })
+
+  const fastify = Fastify({
+    http2SessionTimeout: 100,
+    http2: true
+  })
+
+  fastify.get('/', async (req) => {
+    req.raw.stream.session.on('timeout', () => _resolve())
+    return {}
+  })
+
+  await fastify.listen(0)
+
+  const url = `http://127.0.0.1:${fastify.server.address().port}`
+  const session = await connect(url)
+  const req = session.request({
+    ':method': 'GET',
+    ':path': '/'
+  }).end()
+
+  const [headers] = await once(req, 'response')
+  t.strictEqual(headers[':status'], 200)
+  req.resume()
+
+  // An error might or might not happen, as it's OS dependent.
+  session.on('error', () => {})
+  await p
   await fastify.close()
 })

--- a/test/internals/initialConfig.test.js
+++ b/test/internals/initialConfig.test.js
@@ -28,7 +28,8 @@ test('without options passed to Fastify, initialConfig should expose default val
     onConstructorPoisoning: 'ignore',
     pluginTimeout: 10000,
     requestIdHeader: 'request-id',
-    requestIdLogLabel: 'reqId'
+    requestIdLogLabel: 'reqId',
+    http2SessionTimeout: 5000
   }
 
   t.deepEquals(Fastify().initialConfig, fastifyDefaultOptions)
@@ -232,7 +233,8 @@ test('Should not have issues when passing stream options to Pino.js', t => {
       onConstructorPoisoning: 'ignore',
       pluginTimeout: 10000,
       requestIdHeader: 'request-id',
-      requestIdLogLabel: 'reqId'
+      requestIdLogLabel: 'reqId',
+      http2SessionTimeout: 5000
     })
   } catch (error) {
     t.fail()


### PR DESCRIPTION
This commit adds an option http2SessionTimeout to be able to gracefully
closing an http2 server. This is analogous to the 5000ms timeout of
keepalive connections.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
