### PR TITLE
fix: use opts of onRoute hook

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -252,7 +252,7 @@ function buildRouting (options) {
       }
 
       try {
-        router.on(opts.method, url, { version: opts.version }, routeHandler, context)
+        router.on(opts.method, opts.url, { version: opts.version }, routeHandler, context)
       } catch (err) {
         done(err)
         return


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

I had to modify the route urls for some reason. However, i noticed that not affecting the url changes in onRoute hook and made such a little fix.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
