### PR TITLE
use overloads for stricter type inference

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -16,13 +16,53 @@ import { FastifyServerFactory } from './types/serverFactory'
  * @param opts Fastify server options
  * @returns Fastify server instance
  */
-export default function fastify<
-  RawServer extends RawServerBase = RawServerDefault,
-  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
-  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
-  Logger = FastifyLoggerOptions<RawServer>
->(opts?: FastifyServerOptions<RawServer, Logger>): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+declare function fastify<
+  Server extends http2.Http2SecureServer,
+  Request extends RawRequestDefaultExpression<Server> = RawRequestDefaultExpression<Server>,
+  Reply extends RawReplyDefaultExpression<Server> = RawReplyDefaultExpression<Server>,
+  Logger = FastifyLoggerOptions<Server>,
+>(opts: FastifyHttp2SecureOptions<Server, Logger>): FastifyInstance<Server, Request, Reply, Logger>
+declare function fastify<
+  Server extends http2.Http2Server,
+  Request extends RawRequestDefaultExpression<Server> = RawRequestDefaultExpression<Server>,
+  Reply extends RawReplyDefaultExpression<Server> = RawReplyDefaultExpression<Server>,
+  Logger = FastifyLoggerOptions<Server>,
+>(opts: FastifyHttp2Options<Server, Logger>): FastifyInstance<Server, Request, Reply, Logger>
+declare function fastify<
+  Server extends https.Server,
+  Request extends RawRequestDefaultExpression<Server> = RawRequestDefaultExpression<Server>,
+  Reply extends RawReplyDefaultExpression<Server> = RawReplyDefaultExpression<Server>,
+  Logger = FastifyLoggerOptions<Server>,
+>(opts: FastifyHttpsOptions<Server, Logger>): FastifyInstance<Server, Request, Reply, Logger>
+declare function fastify<
+  Server extends http.Server,
+  Request extends RawRequestDefaultExpression<Server> = RawRequestDefaultExpression<Server>,
+  Reply extends RawReplyDefaultExpression<Server> = RawReplyDefaultExpression<Server>,
+  Logger = FastifyLoggerOptions<Server>,
+>(opts?: FastifyServerOptions<Server, Logger>): FastifyInstance<Server, Request, Reply, Logger>
+export default fastify
 
+type FastifyHttp2SecureOptions<
+  Server extends http2.Http2SecureServer,
+  Logger
+> = FastifyServerOptions<Server, Logger> & {
+  http2: true,
+  https: http2.SecureServerOptions
+}
+
+type FastifyHttp2Options<
+  Server extends http2.Http2Server,
+  Logger
+> = FastifyServerOptions<Server, Logger> & {
+  http2: true
+}
+
+type FastifyHttpsOptions<
+  Server extends https.Server,
+  Logger
+> = FastifyServerOptions<Server, Logger> & {
+  https: https.ServerOptions
+}
 /**
  * Options for a fastify server instance. Utilizes conditional logic on the generic server parameter to enforce certain https and http2
  */
@@ -30,12 +70,6 @@ export type FastifyServerOptions<
   RawServer extends RawServerBase = RawServerDefault,
   Logger = FastifyLoggerOptions<RawServer>
 > = {
-  http2?: RawServer extends http2.Http2Server ? true : false,
-  https?: RawServer extends https.Server 
-    ? https.ServerOptions
-    : RawServer extends http2.Http2SecureServer
-      ? http2.SecureServerOptions
-      : null,
   ignoreTrailingSlash?: boolean,
   bodyLimit?: number,
   pluginTimeout?: number,

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -7,11 +7,11 @@ import { expectType, expectError } from 'tsd'
 // FastifyInstance
 // http server
 expectType<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>>(fastify())
-expectType<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>>(fastify<http.Server>())
+expectType<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>>(fastify({}))
 // https server
-expectType<FastifyInstance<https.Server, http.IncomingMessage, http.ServerResponse>>(fastify<https.Server>())
+expectType<FastifyInstance<https.Server, http.IncomingMessage, http.ServerResponse>>(fastify({ https: {} }))
 // http2 server
-expectType<FastifyInstance<http2.Http2Server, http2.Http2ServerRequest, http2.Http2ServerResponse>>(fastify<http2.Http2Server>())
-expectType<FastifyInstance<http2.Http2SecureServer, http2.Http2ServerRequest, http2.Http2ServerResponse>>(fastify<http2.Http2SecureServer>())
+expectType<FastifyInstance<http2.Http2Server, http2.Http2ServerRequest, http2.Http2ServerResponse>>(fastify({ http2: true }))
+expectType<FastifyInstance<http2.Http2SecureServer, http2.Http2ServerRequest, http2.Http2ServerResponse>>(fastify({ http2: true, https: {}}))
 expectError(fastify<http2.Http2Server>({ http2: false })) // http2 option must be true
 expectError(fastify<http2.Http2SecureServer>({ http2: false })) // http2 option must be true

--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -24,10 +24,10 @@ const customLogger: CustomLogger = {
 }
 
 const serverWithCustomLogger = fastify<
-Server,
-IncomingMessage,
-ServerResponse,
-CustomLogger
+  Server,
+  IncomingMessage,
+  ServerResponse,
+  CustomLogger
 >({ logger: customLogger })
 
 expectType<CustomLogger>(serverWithCustomLogger.log)

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -20,11 +20,20 @@ export type RawServerDefault = http.Server
 /**
  * The default request type based on the server type. Utilizes generic constraining.
  */
-export type RawRequestDefaultExpression<RawServer = RawServerDefault> = RawServer extends http.Server | https.Server ? http.IncomingMessage : http2.Http2ServerRequest
+export type RawRequestDefaultExpression<
+  RawServer extends RawServerBase = RawServerDefault
+> = RawServer extends http.Server | https.Server ? http.IncomingMessage 
+  : RawServer extends http2.Http2Server | http2.Http2SecureServer ? http2.Http2ServerRequest
+  : never
+
 /**
  * The default reply type based on the server type. Utilizes generic constraining.
  */
-export type RawReplyDefaultExpression<RawServer = RawServerDefault> = RawServer extends http.Server | https.Server ? http.ServerResponse : http2.Http2ServerResponse
+export type RawReplyDefaultExpression<
+  RawServer extends RawServerBase = RawServerDefault
+> = RawServer extends http.Server | https.Server ? http.ServerResponse 
+  : RawServer extends http2.Http2Server | http2.Http2SecureServer ? http2.Http2ServerResponse
+  : never
 
 export type RequestBodyDefault = unknown
 export type RequestQuerystringDefault = unknown


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

Introducing a better typescript developer experience. Now using overloads, discriminant unions, and generic parameter inference the user no longer has to specify the type of their server in the generic parameters when instantiating. They simply have to use the correct server options and the interpreter will figure out which server type to return to them.

`{ http2: true, https: {} }` -> `http2.Http2SecureServer`

`{ http2: true }` -> `http.Http2Server`

`{ https: {} }` -> `https.Server`

`{} | undefined` -> `http.Server`