### PR TITLE
fix: throw hooks promise rejection (#2070)

### DIFF
--- a/docs/Errors.md
+++ b/docs/Errors.md
@@ -120,3 +120,8 @@ The JSON schema provided to one route is not valid.
 #### FST_ERR_PROMISE_NOT_FULLFILLED
 
 A promise may not be fulfilled with 'undefined' when statusCode is not 204.
+
+<a name="FST_ERR_SEND_UNDEFINED_ERR"></a>
+#### FST_ERR_SEND_UNDEFINED_ERR
+
+Undefined error has occured.

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -46,6 +46,7 @@ createError('FST_ERR_REP_INVALID_PAYLOAD_TYPE', "Attempted to send payload of in
 createError('FST_ERR_REP_ALREADY_SENT', 'Reply was already sent.')
 createError('FST_ERR_REP_SENT_VALUE', 'The only possible value for reply.sent is true.')
 createError('FST_ERR_SEND_INSIDE_ONERR', 'You cannot use `send` inside the `onError` hook')
+createError('FST_ERR_SEND_UNDEFINED_ERR', 'Undefined error has occured')
 
 /**
  * schemas

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -17,7 +17,8 @@ const supportedHooks = [
 const {
   codes: {
     FST_ERR_HOOK_INVALID_TYPE,
-    FST_ERR_HOOK_INVALID_HANDLER
+    FST_ERR_HOOK_INVALID_HANDLER,
+    FST_ERR_SEND_UNDEFINED_ERR
   }
 } = require('./errors')
 
@@ -78,6 +79,7 @@ function hookRunner (functions, runner, request, reply, cb) {
   }
 
   function handleReject (err) {
+    if (err === undefined) err = new FST_ERR_SEND_UNDEFINED_ERR()
     cb(err, request, reply)
   }
 

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -2727,6 +2727,35 @@ test('onRegister hook should be called / 4', t => {
   })
 })
 
+test('reply.send should throw if undefined error is thrown', t => {
+  /* eslint prefer-promise-reject-errors: ["error", {"allowEmptyReject": true}] */
+
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.addHook('onRequest', function (req, reply, next) {
+    return Promise.reject()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.send('hello')
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 500)
+    t.deepEqual(JSON.parse(res.payload), {
+      error: 'Internal Server Error',
+      code: 'FST_ERR_SEND_UNDEFINED_ERR',
+      message: 'FST_ERR_SEND_UNDEFINED_ERR: Undefined error has occured',
+      statusCode: 500
+    })
+  })
+})
+
 if (semver.gt(process.versions.node, '8.0.0')) {
   require('./hooks-async')(t)
 } else {


### PR DESCRIPTION
Fixes: #2070 

The reason why the error was not thrown because `Promise.reject()` was empty and it didn't have any error like `Promise.reject(new Error)` so when result.then is called it when to `handleReject` with error undefined.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
