### PR TITLE
Add missing TS definition for ServerOptions.genReqId function arg

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -236,7 +236,7 @@ Defines the label used for the request identifier when logging the request.
 
 Function for generating the request id. It will receive the incoming request as a parameter.
 
-+ Default: `value of 'request-id' if provided or monotonically increasing integers`
++ Default: `value of 'request-id' header if provided or monotonically increasing integers`
 
 Especially in distributed systems, you may want to override the default id generation behaviour as shown below. For generating `UUID`s you may want to checkout [hyperid](https://github.com/mcollina/hyperid)
 
@@ -247,7 +247,7 @@ const fastify = require('fastify')({
 })
 ```
 
-**Note: genReqId will _not_ be called if the 'request-id' header is available.**
+**Note: genReqId will _not_ be called if the header set in <code>[requestIdHeader](#requestidheader)</code> is available (defaults to 'request-id').**
 
 <a name="factory-trust-proxy"></a>
 ### `trustProxy`

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -211,7 +211,7 @@ declare namespace fastify {
     },
     modifyCoreObjects?: boolean,
     return503OnClosing?: boolean,
-    genReqId?: () => number | string,
+    genReqId?: (req: FastifyRequest) => number | string,
     requestIdHeader?: string,
     requestIdLogLabel?: string,
     serverFactory?: ServerFactoryFunction,

--- a/test/genReqId.test.js
+++ b/test/genReqId.test.js
@@ -5,7 +5,7 @@ test('Should accept a custom genReqId function', t => {
   t.plan(4)
 
   const fastify = Fastify({
-    genReqId: function () {
+    genReqId: function (req) {
       return 'a'
     }
   })

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -318,7 +318,7 @@ test('The request id header key can be customized along with a custom id generat
   const fastify = Fastify({
     logger: { stream: stream, level: 'info' },
     requestIdHeader: 'my-custom-request-id',
-    genReqId () {
+    genReqId (req) {
       return 'foo'
     }
   })

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -65,7 +65,7 @@ const cors = require('cors')
     querystringParser: (str: string) => ({ str: str, strArray: [str] }),
     modifyCoreObjects: true,
     return503OnClosing: true,
-    genReqId: () => {
+    genReqId: (req) => {
       if (Math.random() > 0.5) {
         return Math.random().toString()
       }


### PR DESCRIPTION
## tl;dr
This pull request adds a missing Typescript definition for the `ServerOptions.genReqId` function's request argument, which renders the function unusable for processing the request under Typescript.

## Motivation
I was trying to use the incoming request inside `genReqId` to parse the `x-apigateway-context` header and use the request id provided by the AWS API Gateway service, falling back to a newly generated UUID v4 if not present, but then realized that Typescript was complaining whenever I added the request argument.

## Investigation details
According to both [the documentation](https://github.com/fastify/fastify/blob/master/docs/Server.md#genreqid) and [the codebase](https://github.com/fastify/fastify/blob/master/lib/reqIdGenFactory.js#L6), this function receives the incoming request as an argument, but its type definition is missing in [the namespace](https://github.com/fastify/fastify/blob/master/fastify.d.ts#L214) and hence trying to use it in Typescript produces an overload error.

**Example code used to reproduce the error:**
```
import * as fastify from 'fastify'
import { IncomingMessage, ServerResponse } from 'http'

const app = fastify({
  genReqId: (req: fastify.FastifyRequest): string => {
    return 'foo'
  }
})

app.get('/', async (req: fastify.FastifyRequest<IncomingMessage>, res: fastify.FastifyReply<ServerResponse>) => {
  res.send('Hello, World!')
})

app.listen(3000)
```

**Error message:**
```
src/index.ts:5:3 - error TS2769: No overload matches this call.
  The last overload gave the following error.
    Type '(req: fastify.FastifyRequest<IncomingMessage, fastify.DefaultQuery, fastify.DefaultParams, fastify.DefaultHeaders, any>) => string' is not assignable to type '() => string | number'.

5   genReqId: (req: fastify.FastifyRequest): string => {
    ~~~~~~~~

  ../../git/fastify/fastify.d.ts:214:5
    214     genReqId?: () => number | string,
            ~~~~~~~~
    The expected type comes from property 'genReqId' which is declared here on type 'ServerOptionsAsSecureHttp2'
  ../../git/fastify/fastify.d.ts:20:18
    20 declare function fastify(opts?: fastify.ServerOptionsAsSecureHttp2): fastify.FastifyInstance<http2.Http2SecureServer, http2.Http2ServerRequest, http2.Http2ServerResponse>;
                        ~~~~~~~
    The last overload is declared here.


Found 1 error.
```

## Outcome
After adding the missing type definition Typescript compiles just fine and `genReqId` accepts the request argument.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
