### PR TITLE
Throws error if undefined status code is sent

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -47,6 +47,7 @@ createError('FST_ERR_REP_ALREADY_SENT', 'Reply was already sent.')
 createError('FST_ERR_REP_SENT_VALUE', 'The only possible value for reply.sent is true.')
 createError('FST_ERR_SEND_INSIDE_ONERR', 'You cannot use `send` inside the `onError` hook')
 createError('FST_ERR_SEND_UNDEFINED_ERR', 'Undefined error has occured')
+createError('FST_ERR_BAD_STATUS_CODE', 'Called reply with malformed status code')
 
 /**
  * schemas

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -46,7 +46,8 @@ const {
     FST_ERR_REP_INVALID_PAYLOAD_TYPE,
     FST_ERR_REP_ALREADY_SENT,
     FST_ERR_REP_SENT_VALUE,
-    FST_ERR_SEND_INSIDE_ONERR
+    FST_ERR_SEND_INSIDE_ONERR,
+    FST_ERR_BAD_STATUS_CODE
   }
 } = require('./errors')
 
@@ -197,6 +198,10 @@ Reply.prototype.headers = function (headers) {
 }
 
 Reply.prototype.code = function (code) {
+  if (statusCodes[code] === undefined) {
+    throw new FST_ERR_BAD_STATUS_CODE()
+  }
+
   this.res.statusCode = code
   this[kReplyHasStatusCode] = true
   return this

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -396,3 +396,33 @@ test('should throw an error if the custom serializer does not serialize the payl
     t.fail('should not be called')
   })
 })
+
+// Issue 2078 https://github.com/fastify/fastify/issues/2078
+// Supported error code list: http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+const invalidErrorCodes = [
+  undefined,
+  null,
+  'error_code',
+  700 // out of the 100-600 range
+]
+invalidErrorCodes.forEach((invalidCode) => {
+  test(`should throw error if error code is ${invalidCode}`, t => {
+    t.plan(3)
+    const fastify = Fastify()
+    fastify.get('/', (request, reply) => {
+      try {
+        return reply.code(invalidCode).send('You should not read this')
+      } catch (err) {
+        t.is(err.name, 'FastifyError [FST_ERR_BAD_STATUS_CODE]')
+        t.is(err.code, 'FST_ERR_BAD_STATUS_CODE')
+        t.is(err.message, 'FST_ERR_BAD_STATUS_CODE: Called reply with malformed status code')
+      }
+    })
+    fastify.inject({
+      url: '/',
+      method: 'GET'
+    }, (e, res) => {
+      t.fail('should not be called')
+    })
+  })
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

When setting an `undedined` status code in reply, it will throw a new custom error message.

Fixes #2078

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
