### PR TITLE
Add connectionTimeout option

### DIFF
--- a/build/build-validation.js
+++ b/build/build-validation.js
@@ -13,7 +13,7 @@ const ajv = new Ajv({
 })
 
 const defaultInitOptions = {
-  connectionTimeout: 60000, // 60 sec
+  connectionTimeout: 0, // 0 sec
   bodyLimit: 1024 * 1024, // 1 MiB
   caseSensitive: true,
   disableRequestLogging: false,

--- a/build/build-validation.js
+++ b/build/build-validation.js
@@ -14,6 +14,7 @@ const ajv = new Ajv({
 
 const defaultInitOptions = {
   connectionTimeout: 0, // 0 sec
+  keepAliveTimeout: 5000, // 5 sec
   bodyLimit: 1024 * 1024, // 1 MiB
   caseSensitive: true,
   disableRequestLogging: false,
@@ -44,6 +45,7 @@ const schema = {
   additionalProperties: false,
   properties: {
     connectionTimeout: { type: 'integer', default: defaultInitOptions.connectionTimeout },
+    keepAliveTimeout: { type: 'integer', default: defaultInitOptions.keepAliveTimeout },
     bodyLimit: { type: 'integer', default: defaultInitOptions.bodyLimit },
     caseSensitive: { type: 'boolean', default: defaultInitOptions.caseSensitive },
     http2: { type: 'boolean' },

--- a/build/build-validation.js
+++ b/build/build-validation.js
@@ -13,6 +13,7 @@ const ajv = new Ajv({
 })
 
 const defaultInitOptions = {
+  connectionTimeout: 60000, // 60 sec
   bodyLimit: 1024 * 1024, // 1 MiB
   caseSensitive: true,
   disableRequestLogging: false,
@@ -42,6 +43,7 @@ const schema = {
   type: 'object',
   additionalProperties: false,
   properties: {
+    connectionTimeout: { type: 'integer', default: defaultInitOptions.connectionTimeout },
     bodyLimit: { type: 'integer', default: defaultInitOptions.bodyLimit },
     caseSensitive: { type: 'boolean', default: defaultInitOptions.caseSensitive },
     http2: { type: 'boolean' },

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -39,7 +39,7 @@ Defines the server timeout in milliseconds. See documentation for
 to understand the effect of this option. When `serverFactory` option is
 specified, this option is ignored.
 
-+ Default: `60000` (60 seconds)
++ Default: `0` (no timeout)
 
 <a name="factory-ignore-slash"></a>
 ### `ignoreTrailingSlash`

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -41,6 +41,16 @@ specified, this option is ignored.
 
 + Default: `0` (no timeout)
 
+<a name="factory-keep-alive-timeout"></a>
+### `keepAliveTimeout`
+
+Defines the server keep-alive timeout in milliseconds. See documentation for
+[`server.timeout` property](https://nodejs.org/dist/latest-v8.x/docs/api/http.html#http_server_keepalivetimeout)
+to understand the effect of this option. This option only applies when HTTP/1
+is in use. Also, when `serverFactory` option is specified, this option is ignored.
+
++ Default: `5000` (5 seconds)
+
 <a name="factory-ignore-slash"></a>
 ### `ignoreTrailingSlash`
 
@@ -738,6 +748,7 @@ options passed down by the user to the fastify instance.
 
 Currently the properties that can be exposed are:
 - connectionTimeout
+- keepAliveTimeout
 - bodyLimit
 - caseSensitive
 - http2

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -36,7 +36,8 @@ This option also applies when the
 
 Defines the server timeout in milliseconds. See documentation for
 [`server.timeout` property](https://nodejs.org/dist/latest-v8.x/docs/api/http.html#http_server_timeout)
-to understand the effect of this option.
+to understand the effect of this option. When `serverFactory` option is
+specified, this option is ignored.
 
 + Default: `60000` (60 seconds)
 

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -35,7 +35,7 @@ This option also applies when the
 ### `connectionTimeout`
 
 Defines the server timeout in milliseconds. See documentation for
-[`server.timeout` property](https://nodejs.org/dist/latest-v8.x/docs/api/http.html#http_server_timeout)
+[`server.timeout` property](https://nodejs.org/api/http.html#http_server_timeout)
 to understand the effect of this option. When `serverFactory` option is
 specified, this option is ignored.
 
@@ -45,7 +45,7 @@ specified, this option is ignored.
 ### `keepAliveTimeout`
 
 Defines the server keep-alive timeout in milliseconds. See documentation for
-[`server.timeout` property](https://nodejs.org/dist/latest-v8.x/docs/api/http.html#http_server_keepalivetimeout)
+[`server.timeout` property](https://nodejs.org/api/http.html#http_server_keepalivetimeout)
 to understand the effect of this option. This option only applies when HTTP/1
 is in use. Also, when `serverFactory` option is specified, this option is ignored.
 

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -31,6 +31,15 @@ This option also applies when the
 
 + Default: `null`
 
+<a name="factory-connection-timeout"></a>
+### `connectionTimeout`
+
+Defines the server timeout in milliseconds. See documentation for
+[`server.timeout` property](https://nodejs.org/dist/latest-v8.x/docs/api/http.html#http_server_timeout)
+to understand the effect of this option.
+
++ Default: `60000` (60 seconds)
+
 <a name="factory-ignore-slash"></a>
 ### `ignoreTrailingSlash`
 
@@ -727,6 +736,7 @@ fastify.ready(() => {
 options passed down by the user to the fastify instance.
 
 Currently the properties that can be exposed are:
+- connectionTimeout
 - bodyLimit
 - caseSensitive
 - http2

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -72,6 +72,7 @@ export type FastifyServerOptions<
 > = {
   ignoreTrailingSlash?: boolean,
   connectionTimeout?: number,
+  keepAliveTimeout?: number,
   bodyLimit?: number,
   pluginTimeout?: number,
   onProtoPoisoing?: 'error' | 'remove' | 'ignore',

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -71,6 +71,7 @@ export type FastifyServerOptions<
   Logger = FastifyLoggerOptions<RawServer>
 > = {
   ignoreTrailingSlash?: boolean,
+  connectionTimeout?: number,
   bodyLimit?: number,
   pluginTimeout?: number,
   onProtoPoisoing?: 'error' | 'remove' | 'ignore',

--- a/fastify.js
+++ b/fastify.js
@@ -56,6 +56,7 @@ function fastify (options) {
 
   validateBodyLimitOption(options.bodyLimit)
 
+  const connectionTimeout = options.connectionTimeout || defaultInitOptions.connectionTimeout
   const requestIdHeader = options.requestIdHeader || defaultInitOptions.requestIdHeader
   const querystringParser = options.querystringParser || querystring.parse
   const genReqId = options.genReqId || reqIdGenFactory()
@@ -82,6 +83,7 @@ function fastify (options) {
   const { logger, hasLogger } = createLogger(options)
 
   // Update the options with the fixed values
+  options.connectionTimeout = connectionTimeout
   options.logger = logger
   options.genReqId = genReqId
   options.requestIdHeader = requestIdHeader

--- a/fastify.js
+++ b/fastify.js
@@ -56,7 +56,6 @@ function fastify (options) {
 
   validateBodyLimitOption(options.bodyLimit)
 
-  const connectionTimeout = options.connectionTimeout || defaultInitOptions.connectionTimeout
   const requestIdHeader = options.requestIdHeader || defaultInitOptions.requestIdHeader
   const querystringParser = options.querystringParser || querystring.parse
   const genReqId = options.genReqId || reqIdGenFactory()
@@ -83,7 +82,7 @@ function fastify (options) {
   const { logger, hasLogger } = createLogger(options)
 
   // Update the options with the fixed values
-  options.connectionTimeout = connectionTimeout
+  options.connectionTimeout = options.connectionTimeout || defaultInitOptions.connectionTimeout
   options.logger = logger
   options.genReqId = genReqId
   options.requestIdHeader = requestIdHeader

--- a/fastify.js
+++ b/fastify.js
@@ -83,6 +83,7 @@ function fastify (options) {
 
   // Update the options with the fixed values
   options.connectionTimeout = options.connectionTimeout || defaultInitOptions.connectionTimeout
+  options.keepAliveTimeout = options.keepAliveTimeout || defaultInitOptions.keepAliveTimeout
   options.logger = logger
   options.genReqId = genReqId
   options.requestIdHeader = requestIdHeader

--- a/lib/configValidator.js
+++ b/lib/configValidator.js
@@ -12,6 +12,7 @@ var validate = (function() {
     var errors = 0;
     if (rootData === undefined) rootData = data;
     if ((data && typeof data === "object" && !Array.isArray(data))) {
+      if (data.connectionTimeout === undefined) data.connectionTimeout = 60000;
       if (data.bodyLimit === undefined) data.bodyLimit = 1048576;
       if (data.caseSensitive === undefined) data.caseSensitive = true;
       if (data.ignoreTrailingSlash === undefined) data.ignoreTrailingSlash = false;
@@ -31,7 +32,7 @@ var validate = (function() {
         }
       }
       if (valid1) {
-        var data1 = data.bodyLimit;
+        var data1 = data.connectionTimeout;
         var errs_1 = errors;
         if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
           var dataType1 = typeof data1;
@@ -40,8 +41,8 @@ var validate = (function() {
           if (coerced1 === undefined) {
             validate.errors = [{
               keyword: 'type',
-              dataPath: (dataPath || '') + '.bodyLimit',
-              schemaPath: '#/properties/bodyLimit/type',
+              dataPath: (dataPath || '') + '.connectionTimeout',
+              schemaPath: '#/properties/connectionTimeout/type',
               params: {
                 type: 'integer'
               },
@@ -50,254 +51,64 @@ var validate = (function() {
             return false;
           } else {
             data1 = coerced1;
-            data['bodyLimit'] = coerced1;
+            data['connectionTimeout'] = coerced1;
           }
         }
         var valid1 = errors === errs_1;
         if (valid1) {
-          var data1 = data.caseSensitive;
+          var data1 = data.bodyLimit;
           var errs_1 = errors;
-          if (typeof data1 !== "boolean") {
+          if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
             var dataType1 = typeof data1;
             var coerced1 = undefined;
-            if (data1 === 'false' || data1 === 0 || data1 === null) coerced1 = false;
-            else if (data1 === 'true' || data1 === 1) coerced1 = true;
+            if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
             if (coerced1 === undefined) {
               validate.errors = [{
                 keyword: 'type',
-                dataPath: (dataPath || '') + '.caseSensitive',
-                schemaPath: '#/properties/caseSensitive/type',
+                dataPath: (dataPath || '') + '.bodyLimit',
+                schemaPath: '#/properties/bodyLimit/type',
                 params: {
-                  type: 'boolean'
+                  type: 'integer'
                 },
-                message: 'should be boolean'
+                message: 'should be integer'
               }];
               return false;
             } else {
               data1 = coerced1;
-              data['caseSensitive'] = coerced1;
+              data['bodyLimit'] = coerced1;
             }
           }
           var valid1 = errors === errs_1;
           if (valid1) {
-            var data1 = data.http2;
-            if (data1 === undefined) {
-              valid1 = true;
-            } else {
-              var errs_1 = errors;
-              if (typeof data1 !== "boolean") {
-                var dataType1 = typeof data1;
-                var coerced1 = undefined;
-                if (data1 === 'false' || data1 === 0 || data1 === null) coerced1 = false;
-                else if (data1 === 'true' || data1 === 1) coerced1 = true;
-                if (coerced1 === undefined) {
-                  validate.errors = [{
-                    keyword: 'type',
-                    dataPath: (dataPath || '') + '.http2',
-                    schemaPath: '#/properties/http2/type',
-                    params: {
-                      type: 'boolean'
-                    },
-                    message: 'should be boolean'
-                  }];
-                  return false;
-                } else {
-                  data1 = coerced1;
-                  data['http2'] = coerced1;
-                }
+            var data1 = data.caseSensitive;
+            var errs_1 = errors;
+            if (typeof data1 !== "boolean") {
+              var dataType1 = typeof data1;
+              var coerced1 = undefined;
+              if (data1 === 'false' || data1 === 0 || data1 === null) coerced1 = false;
+              else if (data1 === 'true' || data1 === 1) coerced1 = true;
+              if (coerced1 === undefined) {
+                validate.errors = [{
+                  keyword: 'type',
+                  dataPath: (dataPath || '') + '.caseSensitive',
+                  schemaPath: '#/properties/caseSensitive/type',
+                  params: {
+                    type: 'boolean'
+                  },
+                  message: 'should be boolean'
+                }];
+                return false;
+              } else {
+                data1 = coerced1;
+                data['caseSensitive'] = coerced1;
               }
-              var valid1 = errors === errs_1;
             }
+            var valid1 = errors === errs_1;
             if (valid1) {
-              var data1 = data.https;
+              var data1 = data.http2;
               if (data1 === undefined) {
                 valid1 = true;
               } else {
-                var errs_1 = errors;
-                var errs__1 = errors;
-                var valid1 = true;
-                var errs_2 = errors;
-                var errs__2 = errors;
-                var errs_3 = errors;
-                var errs__3 = errors,
-                  prevValid3 = false,
-                  valid3 = false,
-                  passingSchemas3 = null;
-                var errs_4 = errors;
-                if (typeof data1 !== "boolean") {
-                  var dataType4 = typeof data1;
-                  var coerced4 = undefined;
-                  if (data1 === 'false' || data1 === 0 || data1 === null) coerced4 = false;
-                  else if (data1 === 'true' || data1 === 1) coerced4 = true;
-                  if (coerced4 === undefined) {
-                    var err = {};
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  } else {
-                    data1 = coerced4;
-                    data['https'] = coerced4;
-                  }
-                }
-                var valid4 = errors === errs_4;
-                if (valid4) {
-                  valid3 = prevValid3 = true;
-                  passingSchemas3 = 0;
-                }
-                var errs_4 = errors;
-                if (data1 !== null) {
-                  var dataType4 = typeof data1;
-                  var coerced4 = undefined;
-                  if (data1 === '' || data1 === 0 || data1 === false) coerced4 = null;
-                  if (coerced4 === undefined) {
-                    var err = {};
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  } else {
-                    data1 = coerced4;
-                    data['https'] = coerced4;
-                  }
-                }
-                var valid4 = errors === errs_4;
-                if (valid4 && prevValid3) {
-                  valid3 = false;
-                  passingSchemas3 = [passingSchemas3, 1];
-                } else {
-                  if (valid4) {
-                    valid3 = prevValid3 = true;
-                    passingSchemas3 = 1;
-                  }
-                  var errs_4 = errors;
-                  if ((data1 && typeof data1 === "object" && !Array.isArray(data1))) {
-                    if (true) {
-                      var errs__4 = errors;
-                      var valid5 = true;
-                      for (var key4 in data1) {
-                        var isAdditional4 = !(false || key4 == 'allowHTTP1');
-                        if (isAdditional4) {
-                          delete data1[key4];
-                        }
-                      }
-                      if (valid5) {
-                        var data2 = data1.allowHTTP1;
-                        if (data2 === undefined) {
-                          valid5 = false;
-                          var err = {};
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        } else {
-                          var errs_5 = errors;
-                          if (typeof data2 !== "boolean") {
-                            var dataType5 = typeof data2;
-                            var coerced5 = undefined;
-                            if (data2 === 'false' || data2 === 0 || data2 === null) coerced5 = false;
-                            else if (data2 === 'true' || data2 === 1) coerced5 = true;
-                            if (coerced5 === undefined) {
-                              var err = {};
-                              if (vErrors === null) vErrors = [err];
-                              else vErrors.push(err);
-                              errors++;
-                            } else {
-                              data2 = coerced5;
-                              data1['allowHTTP1'] = coerced5;
-                            }
-                          }
-                          var valid5 = errors === errs_5;
-                        }
-                      }
-                    }
-                  } else {
-                    var err = {};
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid4 = errors === errs_4;
-                  if (valid4 && prevValid3) {
-                    valid3 = false;
-                    passingSchemas3 = [passingSchemas3, 2];
-                  } else {
-                    if (valid4) {
-                      valid3 = prevValid3 = true;
-                      passingSchemas3 = 2;
-                    }
-                  }
-                }
-                if (!valid3) {
-                  var err = {};
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  errors = errs__3;
-                  if (vErrors !== null) {
-                    if (errs__3) vErrors.length = errs__3;
-                    else vErrors = null;
-                  }
-                }
-                var valid3 = errors === errs_3;
-                if (valid3) {
-                  var err = {};
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  errors = errs__2;
-                  if (vErrors !== null) {
-                    if (errs__2) vErrors.length = errs__2;
-                    else vErrors = null;
-                  }
-                }
-                var valid2 = errors === errs_2;
-                errors = errs__1;
-                if (vErrors !== null) {
-                  if (errs__1) vErrors.length = errs__1;
-                  else vErrors = null;
-                }
-                if (valid2) {
-                  var errs_2 = errors;
-                  customRule0.errors = null;
-                  var errs__2 = errors;
-                  var valid2;
-                  valid2 = customRule0.call(self, validate.schema.properties.https.then.setDefaultValue, data1, validate.schema.properties.https.then, (dataPath || '') + '.https', data, 'https', rootData);
-                  if (data) data1 = data['https'];
-                  if (!valid2) {
-                    validate.errors = [{
-                      keyword: 'setDefaultValue',
-                      dataPath: (dataPath || '') + '.https',
-                      schemaPath: '#/properties/https/then/setDefaultValue',
-                      params: {
-                        keyword: 'setDefaultValue'
-                      },
-                      message: 'should pass "setDefaultValue" keyword validation'
-                    }];
-                    return false;
-                  }
-                  var valid2 = errors === errs_2;
-                  valid1 = valid2;
-                }
-                if (!valid1) {
-                  var err = {
-                    keyword: 'if',
-                    dataPath: (dataPath || '') + '.https',
-                    schemaPath: '#/properties/https/if',
-                    params: {
-                      failingKeyword: 'then'
-                    },
-                    message: 'should match "' + 'then' + '" schema'
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                  validate.errors = vErrors;
-                  return false;
-                }
-                var valid1 = errors === errs_1;
-              }
-              if (valid1) {
-                var data1 = data.ignoreTrailingSlash;
                 var errs_1 = errors;
                 if (typeof data1 !== "boolean") {
                   var dataType1 = typeof data1;
@@ -307,8 +118,8 @@ var validate = (function() {
                   if (coerced1 === undefined) {
                     validate.errors = [{
                       keyword: 'type',
-                      dataPath: (dataPath || '') + '.ignoreTrailingSlash',
-                      schemaPath: '#/properties/ignoreTrailingSlash/type',
+                      dataPath: (dataPath || '') + '.http2',
+                      schemaPath: '#/properties/http2/type',
                       params: {
                         type: 'boolean'
                       },
@@ -317,12 +128,201 @@ var validate = (function() {
                     return false;
                   } else {
                     data1 = coerced1;
-                    data['ignoreTrailingSlash'] = coerced1;
+                    data['http2'] = coerced1;
                   }
                 }
                 var valid1 = errors === errs_1;
+              }
+              if (valid1) {
+                var data1 = data.https;
+                if (data1 === undefined) {
+                  valid1 = true;
+                } else {
+                  var errs_1 = errors;
+                  var errs__1 = errors;
+                  var valid1 = true;
+                  var errs_2 = errors;
+                  var errs__2 = errors;
+                  var errs_3 = errors;
+                  var errs__3 = errors,
+                    prevValid3 = false,
+                    valid3 = false,
+                    passingSchemas3 = null;
+                  var errs_4 = errors;
+                  if (typeof data1 !== "boolean") {
+                    var dataType4 = typeof data1;
+                    var coerced4 = undefined;
+                    if (data1 === 'false' || data1 === 0 || data1 === null) coerced4 = false;
+                    else if (data1 === 'true' || data1 === 1) coerced4 = true;
+                    if (coerced4 === undefined) {
+                      var err = {};
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    } else {
+                      data1 = coerced4;
+                      data['https'] = coerced4;
+                    }
+                  }
+                  var valid4 = errors === errs_4;
+                  if (valid4) {
+                    valid3 = prevValid3 = true;
+                    passingSchemas3 = 0;
+                  }
+                  var errs_4 = errors;
+                  if (data1 !== null) {
+                    var dataType4 = typeof data1;
+                    var coerced4 = undefined;
+                    if (data1 === '' || data1 === 0 || data1 === false) coerced4 = null;
+                    if (coerced4 === undefined) {
+                      var err = {};
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    } else {
+                      data1 = coerced4;
+                      data['https'] = coerced4;
+                    }
+                  }
+                  var valid4 = errors === errs_4;
+                  if (valid4 && prevValid3) {
+                    valid3 = false;
+                    passingSchemas3 = [passingSchemas3, 1];
+                  } else {
+                    if (valid4) {
+                      valid3 = prevValid3 = true;
+                      passingSchemas3 = 1;
+                    }
+                    var errs_4 = errors;
+                    if ((data1 && typeof data1 === "object" && !Array.isArray(data1))) {
+                      if (true) {
+                        var errs__4 = errors;
+                        var valid5 = true;
+                        for (var key4 in data1) {
+                          var isAdditional4 = !(false || key4 == 'allowHTTP1');
+                          if (isAdditional4) {
+                            delete data1[key4];
+                          }
+                        }
+                        if (valid5) {
+                          var data2 = data1.allowHTTP1;
+                          if (data2 === undefined) {
+                            valid5 = false;
+                            var err = {};
+                            if (vErrors === null) vErrors = [err];
+                            else vErrors.push(err);
+                            errors++;
+                          } else {
+                            var errs_5 = errors;
+                            if (typeof data2 !== "boolean") {
+                              var dataType5 = typeof data2;
+                              var coerced5 = undefined;
+                              if (data2 === 'false' || data2 === 0 || data2 === null) coerced5 = false;
+                              else if (data2 === 'true' || data2 === 1) coerced5 = true;
+                              if (coerced5 === undefined) {
+                                var err = {};
+                                if (vErrors === null) vErrors = [err];
+                                else vErrors.push(err);
+                                errors++;
+                              } else {
+                                data2 = coerced5;
+                                data1['allowHTTP1'] = coerced5;
+                              }
+                            }
+                            var valid5 = errors === errs_5;
+                          }
+                        }
+                      }
+                    } else {
+                      var err = {};
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid4 = errors === errs_4;
+                    if (valid4 && prevValid3) {
+                      valid3 = false;
+                      passingSchemas3 = [passingSchemas3, 2];
+                    } else {
+                      if (valid4) {
+                        valid3 = prevValid3 = true;
+                        passingSchemas3 = 2;
+                      }
+                    }
+                  }
+                  if (!valid3) {
+                    var err = {};
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  } else {
+                    errors = errs__3;
+                    if (vErrors !== null) {
+                      if (errs__3) vErrors.length = errs__3;
+                      else vErrors = null;
+                    }
+                  }
+                  var valid3 = errors === errs_3;
+                  if (valid3) {
+                    var err = {};
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  } else {
+                    errors = errs__2;
+                    if (vErrors !== null) {
+                      if (errs__2) vErrors.length = errs__2;
+                      else vErrors = null;
+                    }
+                  }
+                  var valid2 = errors === errs_2;
+                  errors = errs__1;
+                  if (vErrors !== null) {
+                    if (errs__1) vErrors.length = errs__1;
+                    else vErrors = null;
+                  }
+                  if (valid2) {
+                    var errs_2 = errors;
+                    customRule0.errors = null;
+                    var errs__2 = errors;
+                    var valid2;
+                    valid2 = customRule0.call(self, validate.schema.properties.https.then.setDefaultValue, data1, validate.schema.properties.https.then, (dataPath || '') + '.https', data, 'https', rootData);
+                    if (data) data1 = data['https'];
+                    if (!valid2) {
+                      validate.errors = [{
+                        keyword: 'setDefaultValue',
+                        dataPath: (dataPath || '') + '.https',
+                        schemaPath: '#/properties/https/then/setDefaultValue',
+                        params: {
+                          keyword: 'setDefaultValue'
+                        },
+                        message: 'should pass "setDefaultValue" keyword validation'
+                      }];
+                      return false;
+                    }
+                    var valid2 = errors === errs_2;
+                    valid1 = valid2;
+                  }
+                  if (!valid1) {
+                    var err = {
+                      keyword: 'if',
+                      dataPath: (dataPath || '') + '.https',
+                      schemaPath: '#/properties/https/if',
+                      params: {
+                        failingKeyword: 'then'
+                      },
+                      message: 'should match "' + 'then' + '" schema'
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                    validate.errors = vErrors;
+                    return false;
+                  }
+                  var valid1 = errors === errs_1;
+                }
                 if (valid1) {
-                  var data1 = data.disableRequestLogging;
+                  var data1 = data.ignoreTrailingSlash;
                   var errs_1 = errors;
                   if (typeof data1 !== "boolean") {
                     var dataType1 = typeof data1;
@@ -332,8 +332,8 @@ var validate = (function() {
                     if (coerced1 === undefined) {
                       validate.errors = [{
                         keyword: 'type',
-                        dataPath: (dataPath || '') + '.disableRequestLogging',
-                        schemaPath: '#/properties/disableRequestLogging/type',
+                        dataPath: (dataPath || '') + '.ignoreTrailingSlash',
+                        schemaPath: '#/properties/ignoreTrailingSlash/type',
                         params: {
                           type: 'boolean'
                         },
@@ -342,61 +342,61 @@ var validate = (function() {
                       return false;
                     } else {
                       data1 = coerced1;
-                      data['disableRequestLogging'] = coerced1;
+                      data['ignoreTrailingSlash'] = coerced1;
                     }
                   }
                   var valid1 = errors === errs_1;
                   if (valid1) {
-                    var data1 = data.maxParamLength;
+                    var data1 = data.disableRequestLogging;
                     var errs_1 = errors;
-                    if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
+                    if (typeof data1 !== "boolean") {
                       var dataType1 = typeof data1;
                       var coerced1 = undefined;
-                      if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
+                      if (data1 === 'false' || data1 === 0 || data1 === null) coerced1 = false;
+                      else if (data1 === 'true' || data1 === 1) coerced1 = true;
                       if (coerced1 === undefined) {
                         validate.errors = [{
                           keyword: 'type',
-                          dataPath: (dataPath || '') + '.maxParamLength',
-                          schemaPath: '#/properties/maxParamLength/type',
+                          dataPath: (dataPath || '') + '.disableRequestLogging',
+                          schemaPath: '#/properties/disableRequestLogging/type',
                           params: {
-                            type: 'integer'
+                            type: 'boolean'
                           },
-                          message: 'should be integer'
+                          message: 'should be boolean'
                         }];
                         return false;
                       } else {
                         data1 = coerced1;
-                        data['maxParamLength'] = coerced1;
+                        data['disableRequestLogging'] = coerced1;
                       }
                     }
                     var valid1 = errors === errs_1;
                     if (valid1) {
-                      var data1 = data.onProtoPoisoning;
+                      var data1 = data.maxParamLength;
                       var errs_1 = errors;
-                      if (typeof data1 !== "string") {
+                      if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
                         var dataType1 = typeof data1;
                         var coerced1 = undefined;
-                        if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
-                        else if (data1 === null) coerced1 = '';
+                        if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
                         if (coerced1 === undefined) {
                           validate.errors = [{
                             keyword: 'type',
-                            dataPath: (dataPath || '') + '.onProtoPoisoning',
-                            schemaPath: '#/properties/onProtoPoisoning/type',
+                            dataPath: (dataPath || '') + '.maxParamLength',
+                            schemaPath: '#/properties/maxParamLength/type',
                             params: {
-                              type: 'string'
+                              type: 'integer'
                             },
-                            message: 'should be string'
+                            message: 'should be integer'
                           }];
                           return false;
                         } else {
                           data1 = coerced1;
-                          data['onProtoPoisoning'] = coerced1;
+                          data['maxParamLength'] = coerced1;
                         }
                       }
                       var valid1 = errors === errs_1;
                       if (valid1) {
-                        var data1 = data.onConstructorPoisoning;
+                        var data1 = data.onProtoPoisoning;
                         var errs_1 = errors;
                         if (typeof data1 !== "string") {
                           var dataType1 = typeof data1;
@@ -406,8 +406,8 @@ var validate = (function() {
                           if (coerced1 === undefined) {
                             validate.errors = [{
                               keyword: 'type',
-                              dataPath: (dataPath || '') + '.onConstructorPoisoning',
-                              schemaPath: '#/properties/onConstructorPoisoning/type',
+                              dataPath: (dataPath || '') + '.onProtoPoisoning',
+                              schemaPath: '#/properties/onProtoPoisoning/type',
                               params: {
                                 type: 'string'
                               },
@@ -416,61 +416,61 @@ var validate = (function() {
                             return false;
                           } else {
                             data1 = coerced1;
-                            data['onConstructorPoisoning'] = coerced1;
+                            data['onProtoPoisoning'] = coerced1;
                           }
                         }
                         var valid1 = errors === errs_1;
                         if (valid1) {
-                          var data1 = data.pluginTimeout;
+                          var data1 = data.onConstructorPoisoning;
                           var errs_1 = errors;
-                          if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
+                          if (typeof data1 !== "string") {
                             var dataType1 = typeof data1;
                             var coerced1 = undefined;
-                            if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
+                            if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
+                            else if (data1 === null) coerced1 = '';
                             if (coerced1 === undefined) {
                               validate.errors = [{
                                 keyword: 'type',
-                                dataPath: (dataPath || '') + '.pluginTimeout',
-                                schemaPath: '#/properties/pluginTimeout/type',
+                                dataPath: (dataPath || '') + '.onConstructorPoisoning',
+                                schemaPath: '#/properties/onConstructorPoisoning/type',
                                 params: {
-                                  type: 'integer'
+                                  type: 'string'
                                 },
-                                message: 'should be integer'
+                                message: 'should be string'
                               }];
                               return false;
                             } else {
                               data1 = coerced1;
-                              data['pluginTimeout'] = coerced1;
+                              data['onConstructorPoisoning'] = coerced1;
                             }
                           }
                           var valid1 = errors === errs_1;
                           if (valid1) {
-                            var data1 = data.requestIdHeader;
+                            var data1 = data.pluginTimeout;
                             var errs_1 = errors;
-                            if (typeof data1 !== "string") {
+                            if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
                               var dataType1 = typeof data1;
                               var coerced1 = undefined;
-                              if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
-                              else if (data1 === null) coerced1 = '';
+                              if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
                               if (coerced1 === undefined) {
                                 validate.errors = [{
                                   keyword: 'type',
-                                  dataPath: (dataPath || '') + '.requestIdHeader',
-                                  schemaPath: '#/properties/requestIdHeader/type',
+                                  dataPath: (dataPath || '') + '.pluginTimeout',
+                                  schemaPath: '#/properties/pluginTimeout/type',
                                   params: {
-                                    type: 'string'
+                                    type: 'integer'
                                   },
-                                  message: 'should be string'
+                                  message: 'should be integer'
                                 }];
                                 return false;
                               } else {
                                 data1 = coerced1;
-                                data['requestIdHeader'] = coerced1;
+                                data['pluginTimeout'] = coerced1;
                               }
                             }
                             var valid1 = errors === errs_1;
                             if (valid1) {
-                              var data1 = data.requestIdLogLabel;
+                              var data1 = data.requestIdHeader;
                               var errs_1 = errors;
                               if (typeof data1 !== "string") {
                                 var dataType1 = typeof data1;
@@ -480,8 +480,8 @@ var validate = (function() {
                                 if (coerced1 === undefined) {
                                   validate.errors = [{
                                     keyword: 'type',
-                                    dataPath: (dataPath || '') + '.requestIdLogLabel',
-                                    schemaPath: '#/properties/requestIdLogLabel/type',
+                                    dataPath: (dataPath || '') + '.requestIdHeader',
+                                    schemaPath: '#/properties/requestIdHeader/type',
                                     params: {
                                       type: 'string'
                                     },
@@ -490,10 +490,36 @@ var validate = (function() {
                                   return false;
                                 } else {
                                   data1 = coerced1;
-                                  data['requestIdLogLabel'] = coerced1;
+                                  data['requestIdHeader'] = coerced1;
                                 }
                               }
                               var valid1 = errors === errs_1;
+                              if (valid1) {
+                                var data1 = data.requestIdLogLabel;
+                                var errs_1 = errors;
+                                if (typeof data1 !== "string") {
+                                  var dataType1 = typeof data1;
+                                  var coerced1 = undefined;
+                                  if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
+                                  else if (data1 === null) coerced1 = '';
+                                  if (coerced1 === undefined) {
+                                    validate.errors = [{
+                                      keyword: 'type',
+                                      dataPath: (dataPath || '') + '.requestIdLogLabel',
+                                      schemaPath: '#/properties/requestIdLogLabel/type',
+                                      params: {
+                                        type: 'string'
+                                      },
+                                      message: 'should be string'
+                                    }];
+                                    return false;
+                                  } else {
+                                    data1 = coerced1;
+                                    data['requestIdLogLabel'] = coerced1;
+                                  }
+                                }
+                                var valid1 = errors === errs_1;
+                              }
                             }
                           }
                         }
@@ -526,6 +552,10 @@ validate.schema = {
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "connectionTimeout": {
+      "type": "integer",
+      "default": 60000
+    },
     "bodyLimit": {
       "type": "integer",
       "default": 1048576
@@ -602,4 +632,4 @@ function customRule0 (schemaParamValue, validatedParamValue, validationSchemaObj
   return true
 }
 
-module.exports.defaultInitOptions = {"bodyLimit":1048576,"caseSensitive":true,"disableRequestLogging":false,"ignoreTrailingSlash":false,"maxParamLength":100,"onProtoPoisoning":"error","onConstructorPoisoning":"ignore","pluginTimeout":10000,"requestIdHeader":"request-id","requestIdLogLabel":"reqId"}
+module.exports.defaultInitOptions = {"connectionTimeout":60000,"bodyLimit":1048576,"caseSensitive":true,"disableRequestLogging":false,"ignoreTrailingSlash":false,"maxParamLength":100,"onProtoPoisoning":"error","onConstructorPoisoning":"ignore","pluginTimeout":10000,"requestIdHeader":"request-id","requestIdLogLabel":"reqId"}

--- a/lib/configValidator.js
+++ b/lib/configValidator.js
@@ -13,6 +13,7 @@ var validate = (function() {
     if (rootData === undefined) rootData = data;
     if ((data && typeof data === "object" && !Array.isArray(data))) {
       if (data.connectionTimeout === undefined) data.connectionTimeout = 0;
+      if (data.keepAliveTimeout === undefined) data.keepAliveTimeout = 5000;
       if (data.bodyLimit === undefined) data.bodyLimit = 1048576;
       if (data.caseSensitive === undefined) data.caseSensitive = true;
       if (data.ignoreTrailingSlash === undefined) data.ignoreTrailingSlash = false;
@@ -56,7 +57,7 @@ var validate = (function() {
         }
         var valid1 = errors === errs_1;
         if (valid1) {
-          var data1 = data.bodyLimit;
+          var data1 = data.keepAliveTimeout;
           var errs_1 = errors;
           if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
             var dataType1 = typeof data1;
@@ -65,8 +66,8 @@ var validate = (function() {
             if (coerced1 === undefined) {
               validate.errors = [{
                 keyword: 'type',
-                dataPath: (dataPath || '') + '.bodyLimit',
-                schemaPath: '#/properties/bodyLimit/type',
+                dataPath: (dataPath || '') + '.keepAliveTimeout',
+                schemaPath: '#/properties/keepAliveTimeout/type',
                 params: {
                   type: 'integer'
                 },
@@ -75,254 +76,64 @@ var validate = (function() {
               return false;
             } else {
               data1 = coerced1;
-              data['bodyLimit'] = coerced1;
+              data['keepAliveTimeout'] = coerced1;
             }
           }
           var valid1 = errors === errs_1;
           if (valid1) {
-            var data1 = data.caseSensitive;
+            var data1 = data.bodyLimit;
             var errs_1 = errors;
-            if (typeof data1 !== "boolean") {
+            if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
               var dataType1 = typeof data1;
               var coerced1 = undefined;
-              if (data1 === 'false' || data1 === 0 || data1 === null) coerced1 = false;
-              else if (data1 === 'true' || data1 === 1) coerced1 = true;
+              if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
               if (coerced1 === undefined) {
                 validate.errors = [{
                   keyword: 'type',
-                  dataPath: (dataPath || '') + '.caseSensitive',
-                  schemaPath: '#/properties/caseSensitive/type',
+                  dataPath: (dataPath || '') + '.bodyLimit',
+                  schemaPath: '#/properties/bodyLimit/type',
                   params: {
-                    type: 'boolean'
+                    type: 'integer'
                   },
-                  message: 'should be boolean'
+                  message: 'should be integer'
                 }];
                 return false;
               } else {
                 data1 = coerced1;
-                data['caseSensitive'] = coerced1;
+                data['bodyLimit'] = coerced1;
               }
             }
             var valid1 = errors === errs_1;
             if (valid1) {
-              var data1 = data.http2;
-              if (data1 === undefined) {
-                valid1 = true;
-              } else {
-                var errs_1 = errors;
-                if (typeof data1 !== "boolean") {
-                  var dataType1 = typeof data1;
-                  var coerced1 = undefined;
-                  if (data1 === 'false' || data1 === 0 || data1 === null) coerced1 = false;
-                  else if (data1 === 'true' || data1 === 1) coerced1 = true;
-                  if (coerced1 === undefined) {
-                    validate.errors = [{
-                      keyword: 'type',
-                      dataPath: (dataPath || '') + '.http2',
-                      schemaPath: '#/properties/http2/type',
-                      params: {
-                        type: 'boolean'
-                      },
-                      message: 'should be boolean'
-                    }];
-                    return false;
-                  } else {
-                    data1 = coerced1;
-                    data['http2'] = coerced1;
-                  }
+              var data1 = data.caseSensitive;
+              var errs_1 = errors;
+              if (typeof data1 !== "boolean") {
+                var dataType1 = typeof data1;
+                var coerced1 = undefined;
+                if (data1 === 'false' || data1 === 0 || data1 === null) coerced1 = false;
+                else if (data1 === 'true' || data1 === 1) coerced1 = true;
+                if (coerced1 === undefined) {
+                  validate.errors = [{
+                    keyword: 'type',
+                    dataPath: (dataPath || '') + '.caseSensitive',
+                    schemaPath: '#/properties/caseSensitive/type',
+                    params: {
+                      type: 'boolean'
+                    },
+                    message: 'should be boolean'
+                  }];
+                  return false;
+                } else {
+                  data1 = coerced1;
+                  data['caseSensitive'] = coerced1;
                 }
-                var valid1 = errors === errs_1;
               }
+              var valid1 = errors === errs_1;
               if (valid1) {
-                var data1 = data.https;
+                var data1 = data.http2;
                 if (data1 === undefined) {
                   valid1 = true;
                 } else {
-                  var errs_1 = errors;
-                  var errs__1 = errors;
-                  var valid1 = true;
-                  var errs_2 = errors;
-                  var errs__2 = errors;
-                  var errs_3 = errors;
-                  var errs__3 = errors,
-                    prevValid3 = false,
-                    valid3 = false,
-                    passingSchemas3 = null;
-                  var errs_4 = errors;
-                  if (typeof data1 !== "boolean") {
-                    var dataType4 = typeof data1;
-                    var coerced4 = undefined;
-                    if (data1 === 'false' || data1 === 0 || data1 === null) coerced4 = false;
-                    else if (data1 === 'true' || data1 === 1) coerced4 = true;
-                    if (coerced4 === undefined) {
-                      var err = {};
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    } else {
-                      data1 = coerced4;
-                      data['https'] = coerced4;
-                    }
-                  }
-                  var valid4 = errors === errs_4;
-                  if (valid4) {
-                    valid3 = prevValid3 = true;
-                    passingSchemas3 = 0;
-                  }
-                  var errs_4 = errors;
-                  if (data1 !== null) {
-                    var dataType4 = typeof data1;
-                    var coerced4 = undefined;
-                    if (data1 === '' || data1 === 0 || data1 === false) coerced4 = null;
-                    if (coerced4 === undefined) {
-                      var err = {};
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    } else {
-                      data1 = coerced4;
-                      data['https'] = coerced4;
-                    }
-                  }
-                  var valid4 = errors === errs_4;
-                  if (valid4 && prevValid3) {
-                    valid3 = false;
-                    passingSchemas3 = [passingSchemas3, 1];
-                  } else {
-                    if (valid4) {
-                      valid3 = prevValid3 = true;
-                      passingSchemas3 = 1;
-                    }
-                    var errs_4 = errors;
-                    if ((data1 && typeof data1 === "object" && !Array.isArray(data1))) {
-                      if (true) {
-                        var errs__4 = errors;
-                        var valid5 = true;
-                        for (var key4 in data1) {
-                          var isAdditional4 = !(false || key4 == 'allowHTTP1');
-                          if (isAdditional4) {
-                            delete data1[key4];
-                          }
-                        }
-                        if (valid5) {
-                          var data2 = data1.allowHTTP1;
-                          if (data2 === undefined) {
-                            valid5 = false;
-                            var err = {};
-                            if (vErrors === null) vErrors = [err];
-                            else vErrors.push(err);
-                            errors++;
-                          } else {
-                            var errs_5 = errors;
-                            if (typeof data2 !== "boolean") {
-                              var dataType5 = typeof data2;
-                              var coerced5 = undefined;
-                              if (data2 === 'false' || data2 === 0 || data2 === null) coerced5 = false;
-                              else if (data2 === 'true' || data2 === 1) coerced5 = true;
-                              if (coerced5 === undefined) {
-                                var err = {};
-                                if (vErrors === null) vErrors = [err];
-                                else vErrors.push(err);
-                                errors++;
-                              } else {
-                                data2 = coerced5;
-                                data1['allowHTTP1'] = coerced5;
-                              }
-                            }
-                            var valid5 = errors === errs_5;
-                          }
-                        }
-                      }
-                    } else {
-                      var err = {};
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    }
-                    var valid4 = errors === errs_4;
-                    if (valid4 && prevValid3) {
-                      valid3 = false;
-                      passingSchemas3 = [passingSchemas3, 2];
-                    } else {
-                      if (valid4) {
-                        valid3 = prevValid3 = true;
-                        passingSchemas3 = 2;
-                      }
-                    }
-                  }
-                  if (!valid3) {
-                    var err = {};
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  } else {
-                    errors = errs__3;
-                    if (vErrors !== null) {
-                      if (errs__3) vErrors.length = errs__3;
-                      else vErrors = null;
-                    }
-                  }
-                  var valid3 = errors === errs_3;
-                  if (valid3) {
-                    var err = {};
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  } else {
-                    errors = errs__2;
-                    if (vErrors !== null) {
-                      if (errs__2) vErrors.length = errs__2;
-                      else vErrors = null;
-                    }
-                  }
-                  var valid2 = errors === errs_2;
-                  errors = errs__1;
-                  if (vErrors !== null) {
-                    if (errs__1) vErrors.length = errs__1;
-                    else vErrors = null;
-                  }
-                  if (valid2) {
-                    var errs_2 = errors;
-                    customRule0.errors = null;
-                    var errs__2 = errors;
-                    var valid2;
-                    valid2 = customRule0.call(self, validate.schema.properties.https.then.setDefaultValue, data1, validate.schema.properties.https.then, (dataPath || '') + '.https', data, 'https', rootData);
-                    if (data) data1 = data['https'];
-                    if (!valid2) {
-                      validate.errors = [{
-                        keyword: 'setDefaultValue',
-                        dataPath: (dataPath || '') + '.https',
-                        schemaPath: '#/properties/https/then/setDefaultValue',
-                        params: {
-                          keyword: 'setDefaultValue'
-                        },
-                        message: 'should pass "setDefaultValue" keyword validation'
-                      }];
-                      return false;
-                    }
-                    var valid2 = errors === errs_2;
-                    valid1 = valid2;
-                  }
-                  if (!valid1) {
-                    var err = {
-                      keyword: 'if',
-                      dataPath: (dataPath || '') + '.https',
-                      schemaPath: '#/properties/https/if',
-                      params: {
-                        failingKeyword: 'then'
-                      },
-                      message: 'should match "' + 'then' + '" schema'
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                    validate.errors = vErrors;
-                    return false;
-                  }
-                  var valid1 = errors === errs_1;
-                }
-                if (valid1) {
-                  var data1 = data.ignoreTrailingSlash;
                   var errs_1 = errors;
                   if (typeof data1 !== "boolean") {
                     var dataType1 = typeof data1;
@@ -332,8 +143,8 @@ var validate = (function() {
                     if (coerced1 === undefined) {
                       validate.errors = [{
                         keyword: 'type',
-                        dataPath: (dataPath || '') + '.ignoreTrailingSlash',
-                        schemaPath: '#/properties/ignoreTrailingSlash/type',
+                        dataPath: (dataPath || '') + '.http2',
+                        schemaPath: '#/properties/http2/type',
                         params: {
                           type: 'boolean'
                         },
@@ -342,12 +153,201 @@ var validate = (function() {
                       return false;
                     } else {
                       data1 = coerced1;
-                      data['ignoreTrailingSlash'] = coerced1;
+                      data['http2'] = coerced1;
                     }
                   }
                   var valid1 = errors === errs_1;
+                }
+                if (valid1) {
+                  var data1 = data.https;
+                  if (data1 === undefined) {
+                    valid1 = true;
+                  } else {
+                    var errs_1 = errors;
+                    var errs__1 = errors;
+                    var valid1 = true;
+                    var errs_2 = errors;
+                    var errs__2 = errors;
+                    var errs_3 = errors;
+                    var errs__3 = errors,
+                      prevValid3 = false,
+                      valid3 = false,
+                      passingSchemas3 = null;
+                    var errs_4 = errors;
+                    if (typeof data1 !== "boolean") {
+                      var dataType4 = typeof data1;
+                      var coerced4 = undefined;
+                      if (data1 === 'false' || data1 === 0 || data1 === null) coerced4 = false;
+                      else if (data1 === 'true' || data1 === 1) coerced4 = true;
+                      if (coerced4 === undefined) {
+                        var err = {};
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      } else {
+                        data1 = coerced4;
+                        data['https'] = coerced4;
+                      }
+                    }
+                    var valid4 = errors === errs_4;
+                    if (valid4) {
+                      valid3 = prevValid3 = true;
+                      passingSchemas3 = 0;
+                    }
+                    var errs_4 = errors;
+                    if (data1 !== null) {
+                      var dataType4 = typeof data1;
+                      var coerced4 = undefined;
+                      if (data1 === '' || data1 === 0 || data1 === false) coerced4 = null;
+                      if (coerced4 === undefined) {
+                        var err = {};
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      } else {
+                        data1 = coerced4;
+                        data['https'] = coerced4;
+                      }
+                    }
+                    var valid4 = errors === errs_4;
+                    if (valid4 && prevValid3) {
+                      valid3 = false;
+                      passingSchemas3 = [passingSchemas3, 1];
+                    } else {
+                      if (valid4) {
+                        valid3 = prevValid3 = true;
+                        passingSchemas3 = 1;
+                      }
+                      var errs_4 = errors;
+                      if ((data1 && typeof data1 === "object" && !Array.isArray(data1))) {
+                        if (true) {
+                          var errs__4 = errors;
+                          var valid5 = true;
+                          for (var key4 in data1) {
+                            var isAdditional4 = !(false || key4 == 'allowHTTP1');
+                            if (isAdditional4) {
+                              delete data1[key4];
+                            }
+                          }
+                          if (valid5) {
+                            var data2 = data1.allowHTTP1;
+                            if (data2 === undefined) {
+                              valid5 = false;
+                              var err = {};
+                              if (vErrors === null) vErrors = [err];
+                              else vErrors.push(err);
+                              errors++;
+                            } else {
+                              var errs_5 = errors;
+                              if (typeof data2 !== "boolean") {
+                                var dataType5 = typeof data2;
+                                var coerced5 = undefined;
+                                if (data2 === 'false' || data2 === 0 || data2 === null) coerced5 = false;
+                                else if (data2 === 'true' || data2 === 1) coerced5 = true;
+                                if (coerced5 === undefined) {
+                                  var err = {};
+                                  if (vErrors === null) vErrors = [err];
+                                  else vErrors.push(err);
+                                  errors++;
+                                } else {
+                                  data2 = coerced5;
+                                  data1['allowHTTP1'] = coerced5;
+                                }
+                              }
+                              var valid5 = errors === errs_5;
+                            }
+                          }
+                        }
+                      } else {
+                        var err = {};
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                      var valid4 = errors === errs_4;
+                      if (valid4 && prevValid3) {
+                        valid3 = false;
+                        passingSchemas3 = [passingSchemas3, 2];
+                      } else {
+                        if (valid4) {
+                          valid3 = prevValid3 = true;
+                          passingSchemas3 = 2;
+                        }
+                      }
+                    }
+                    if (!valid3) {
+                      var err = {};
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    } else {
+                      errors = errs__3;
+                      if (vErrors !== null) {
+                        if (errs__3) vErrors.length = errs__3;
+                        else vErrors = null;
+                      }
+                    }
+                    var valid3 = errors === errs_3;
+                    if (valid3) {
+                      var err = {};
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    } else {
+                      errors = errs__2;
+                      if (vErrors !== null) {
+                        if (errs__2) vErrors.length = errs__2;
+                        else vErrors = null;
+                      }
+                    }
+                    var valid2 = errors === errs_2;
+                    errors = errs__1;
+                    if (vErrors !== null) {
+                      if (errs__1) vErrors.length = errs__1;
+                      else vErrors = null;
+                    }
+                    if (valid2) {
+                      var errs_2 = errors;
+                      customRule0.errors = null;
+                      var errs__2 = errors;
+                      var valid2;
+                      valid2 = customRule0.call(self, validate.schema.properties.https.then.setDefaultValue, data1, validate.schema.properties.https.then, (dataPath || '') + '.https', data, 'https', rootData);
+                      if (data) data1 = data['https'];
+                      if (!valid2) {
+                        validate.errors = [{
+                          keyword: 'setDefaultValue',
+                          dataPath: (dataPath || '') + '.https',
+                          schemaPath: '#/properties/https/then/setDefaultValue',
+                          params: {
+                            keyword: 'setDefaultValue'
+                          },
+                          message: 'should pass "setDefaultValue" keyword validation'
+                        }];
+                        return false;
+                      }
+                      var valid2 = errors === errs_2;
+                      valid1 = valid2;
+                    }
+                    if (!valid1) {
+                      var err = {
+                        keyword: 'if',
+                        dataPath: (dataPath || '') + '.https',
+                        schemaPath: '#/properties/https/if',
+                        params: {
+                          failingKeyword: 'then'
+                        },
+                        message: 'should match "' + 'then' + '" schema'
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                      validate.errors = vErrors;
+                      return false;
+                    }
+                    var valid1 = errors === errs_1;
+                  }
                   if (valid1) {
-                    var data1 = data.disableRequestLogging;
+                    var data1 = data.ignoreTrailingSlash;
                     var errs_1 = errors;
                     if (typeof data1 !== "boolean") {
                       var dataType1 = typeof data1;
@@ -357,8 +357,8 @@ var validate = (function() {
                       if (coerced1 === undefined) {
                         validate.errors = [{
                           keyword: 'type',
-                          dataPath: (dataPath || '') + '.disableRequestLogging',
-                          schemaPath: '#/properties/disableRequestLogging/type',
+                          dataPath: (dataPath || '') + '.ignoreTrailingSlash',
+                          schemaPath: '#/properties/ignoreTrailingSlash/type',
                           params: {
                             type: 'boolean'
                           },
@@ -367,61 +367,61 @@ var validate = (function() {
                         return false;
                       } else {
                         data1 = coerced1;
-                        data['disableRequestLogging'] = coerced1;
+                        data['ignoreTrailingSlash'] = coerced1;
                       }
                     }
                     var valid1 = errors === errs_1;
                     if (valid1) {
-                      var data1 = data.maxParamLength;
+                      var data1 = data.disableRequestLogging;
                       var errs_1 = errors;
-                      if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
+                      if (typeof data1 !== "boolean") {
                         var dataType1 = typeof data1;
                         var coerced1 = undefined;
-                        if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
+                        if (data1 === 'false' || data1 === 0 || data1 === null) coerced1 = false;
+                        else if (data1 === 'true' || data1 === 1) coerced1 = true;
                         if (coerced1 === undefined) {
                           validate.errors = [{
                             keyword: 'type',
-                            dataPath: (dataPath || '') + '.maxParamLength',
-                            schemaPath: '#/properties/maxParamLength/type',
+                            dataPath: (dataPath || '') + '.disableRequestLogging',
+                            schemaPath: '#/properties/disableRequestLogging/type',
                             params: {
-                              type: 'integer'
+                              type: 'boolean'
                             },
-                            message: 'should be integer'
+                            message: 'should be boolean'
                           }];
                           return false;
                         } else {
                           data1 = coerced1;
-                          data['maxParamLength'] = coerced1;
+                          data['disableRequestLogging'] = coerced1;
                         }
                       }
                       var valid1 = errors === errs_1;
                       if (valid1) {
-                        var data1 = data.onProtoPoisoning;
+                        var data1 = data.maxParamLength;
                         var errs_1 = errors;
-                        if (typeof data1 !== "string") {
+                        if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
                           var dataType1 = typeof data1;
                           var coerced1 = undefined;
-                          if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
-                          else if (data1 === null) coerced1 = '';
+                          if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
                           if (coerced1 === undefined) {
                             validate.errors = [{
                               keyword: 'type',
-                              dataPath: (dataPath || '') + '.onProtoPoisoning',
-                              schemaPath: '#/properties/onProtoPoisoning/type',
+                              dataPath: (dataPath || '') + '.maxParamLength',
+                              schemaPath: '#/properties/maxParamLength/type',
                               params: {
-                                type: 'string'
+                                type: 'integer'
                               },
-                              message: 'should be string'
+                              message: 'should be integer'
                             }];
                             return false;
                           } else {
                             data1 = coerced1;
-                            data['onProtoPoisoning'] = coerced1;
+                            data['maxParamLength'] = coerced1;
                           }
                         }
                         var valid1 = errors === errs_1;
                         if (valid1) {
-                          var data1 = data.onConstructorPoisoning;
+                          var data1 = data.onProtoPoisoning;
                           var errs_1 = errors;
                           if (typeof data1 !== "string") {
                             var dataType1 = typeof data1;
@@ -431,8 +431,8 @@ var validate = (function() {
                             if (coerced1 === undefined) {
                               validate.errors = [{
                                 keyword: 'type',
-                                dataPath: (dataPath || '') + '.onConstructorPoisoning',
-                                schemaPath: '#/properties/onConstructorPoisoning/type',
+                                dataPath: (dataPath || '') + '.onProtoPoisoning',
+                                schemaPath: '#/properties/onProtoPoisoning/type',
                                 params: {
                                   type: 'string'
                                 },
@@ -441,61 +441,61 @@ var validate = (function() {
                               return false;
                             } else {
                               data1 = coerced1;
-                              data['onConstructorPoisoning'] = coerced1;
+                              data['onProtoPoisoning'] = coerced1;
                             }
                           }
                           var valid1 = errors === errs_1;
                           if (valid1) {
-                            var data1 = data.pluginTimeout;
+                            var data1 = data.onConstructorPoisoning;
                             var errs_1 = errors;
-                            if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
+                            if (typeof data1 !== "string") {
                               var dataType1 = typeof data1;
                               var coerced1 = undefined;
-                              if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
+                              if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
+                              else if (data1 === null) coerced1 = '';
                               if (coerced1 === undefined) {
                                 validate.errors = [{
                                   keyword: 'type',
-                                  dataPath: (dataPath || '') + '.pluginTimeout',
-                                  schemaPath: '#/properties/pluginTimeout/type',
+                                  dataPath: (dataPath || '') + '.onConstructorPoisoning',
+                                  schemaPath: '#/properties/onConstructorPoisoning/type',
                                   params: {
-                                    type: 'integer'
+                                    type: 'string'
                                   },
-                                  message: 'should be integer'
+                                  message: 'should be string'
                                 }];
                                 return false;
                               } else {
                                 data1 = coerced1;
-                                data['pluginTimeout'] = coerced1;
+                                data['onConstructorPoisoning'] = coerced1;
                               }
                             }
                             var valid1 = errors === errs_1;
                             if (valid1) {
-                              var data1 = data.requestIdHeader;
+                              var data1 = data.pluginTimeout;
                               var errs_1 = errors;
-                              if (typeof data1 !== "string") {
+                              if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
                                 var dataType1 = typeof data1;
                                 var coerced1 = undefined;
-                                if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
-                                else if (data1 === null) coerced1 = '';
+                                if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
                                 if (coerced1 === undefined) {
                                   validate.errors = [{
                                     keyword: 'type',
-                                    dataPath: (dataPath || '') + '.requestIdHeader',
-                                    schemaPath: '#/properties/requestIdHeader/type',
+                                    dataPath: (dataPath || '') + '.pluginTimeout',
+                                    schemaPath: '#/properties/pluginTimeout/type',
                                     params: {
-                                      type: 'string'
+                                      type: 'integer'
                                     },
-                                    message: 'should be string'
+                                    message: 'should be integer'
                                   }];
                                   return false;
                                 } else {
                                   data1 = coerced1;
-                                  data['requestIdHeader'] = coerced1;
+                                  data['pluginTimeout'] = coerced1;
                                 }
                               }
                               var valid1 = errors === errs_1;
                               if (valid1) {
-                                var data1 = data.requestIdLogLabel;
+                                var data1 = data.requestIdHeader;
                                 var errs_1 = errors;
                                 if (typeof data1 !== "string") {
                                   var dataType1 = typeof data1;
@@ -505,8 +505,8 @@ var validate = (function() {
                                   if (coerced1 === undefined) {
                                     validate.errors = [{
                                       keyword: 'type',
-                                      dataPath: (dataPath || '') + '.requestIdLogLabel',
-                                      schemaPath: '#/properties/requestIdLogLabel/type',
+                                      dataPath: (dataPath || '') + '.requestIdHeader',
+                                      schemaPath: '#/properties/requestIdHeader/type',
                                       params: {
                                         type: 'string'
                                       },
@@ -515,10 +515,36 @@ var validate = (function() {
                                     return false;
                                   } else {
                                     data1 = coerced1;
-                                    data['requestIdLogLabel'] = coerced1;
+                                    data['requestIdHeader'] = coerced1;
                                   }
                                 }
                                 var valid1 = errors === errs_1;
+                                if (valid1) {
+                                  var data1 = data.requestIdLogLabel;
+                                  var errs_1 = errors;
+                                  if (typeof data1 !== "string") {
+                                    var dataType1 = typeof data1;
+                                    var coerced1 = undefined;
+                                    if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
+                                    else if (data1 === null) coerced1 = '';
+                                    if (coerced1 === undefined) {
+                                      validate.errors = [{
+                                        keyword: 'type',
+                                        dataPath: (dataPath || '') + '.requestIdLogLabel',
+                                        schemaPath: '#/properties/requestIdLogLabel/type',
+                                        params: {
+                                          type: 'string'
+                                        },
+                                        message: 'should be string'
+                                      }];
+                                      return false;
+                                    } else {
+                                      data1 = coerced1;
+                                      data['requestIdLogLabel'] = coerced1;
+                                    }
+                                  }
+                                  var valid1 = errors === errs_1;
+                                }
                               }
                             }
                           }
@@ -555,6 +581,10 @@ validate.schema = {
     "connectionTimeout": {
       "type": "integer",
       "default": 0
+    },
+    "keepAliveTimeout": {
+      "type": "integer",
+      "default": 5000
     },
     "bodyLimit": {
       "type": "integer",
@@ -632,4 +662,4 @@ function customRule0 (schemaParamValue, validatedParamValue, validationSchemaObj
   return true
 }
 
-module.exports.defaultInitOptions = {"connectionTimeout":0,"bodyLimit":1048576,"caseSensitive":true,"disableRequestLogging":false,"ignoreTrailingSlash":false,"maxParamLength":100,"onProtoPoisoning":"error","onConstructorPoisoning":"ignore","pluginTimeout":10000,"requestIdHeader":"request-id","requestIdLogLabel":"reqId"}
+module.exports.defaultInitOptions = {"connectionTimeout":0,"keepAliveTimeout":5000,"bodyLimit":1048576,"caseSensitive":true,"disableRequestLogging":false,"ignoreTrailingSlash":false,"maxParamLength":100,"onProtoPoisoning":"error","onConstructorPoisoning":"ignore","pluginTimeout":10000,"requestIdHeader":"request-id","requestIdLogLabel":"reqId"}

--- a/lib/configValidator.js
+++ b/lib/configValidator.js
@@ -12,7 +12,7 @@ var validate = (function() {
     var errors = 0;
     if (rootData === undefined) rootData = data;
     if ((data && typeof data === "object" && !Array.isArray(data))) {
-      if (data.connectionTimeout === undefined) data.connectionTimeout = 60000;
+      if (data.connectionTimeout === undefined) data.connectionTimeout = 0;
       if (data.bodyLimit === undefined) data.bodyLimit = 1048576;
       if (data.caseSensitive === undefined) data.caseSensitive = true;
       if (data.ignoreTrailingSlash === undefined) data.ignoreTrailingSlash = false;
@@ -554,7 +554,7 @@ validate.schema = {
   "properties": {
     "connectionTimeout": {
       "type": "integer",
-      "default": 60000
+      "default": 0
     },
     "bodyLimit": {
       "type": "integer",
@@ -632,4 +632,4 @@ function customRule0 (schemaParamValue, validatedParamValue, validationSchemaObj
   return true
 }
 
-module.exports.defaultInitOptions = {"connectionTimeout":60000,"bodyLimit":1048576,"caseSensitive":true,"disableRequestLogging":false,"ignoreTrailingSlash":false,"maxParamLength":100,"onProtoPoisoning":"error","onConstructorPoisoning":"ignore","pluginTimeout":10000,"requestIdHeader":"request-id","requestIdLogLabel":"reqId"}
+module.exports.defaultInitOptions = {"connectionTimeout":0,"bodyLimit":1048576,"caseSensitive":true,"disableRequestLogging":false,"ignoreTrailingSlash":false,"maxParamLength":100,"onProtoPoisoning":"error","onConstructorPoisoning":"ignore","pluginTimeout":10000,"requestIdHeader":"request-id","requestIdLogLabel":"reqId"}

--- a/lib/server.js
+++ b/lib/server.js
@@ -28,6 +28,8 @@ function createServer (options, httpHandler) {
     server = http.createServer(httpHandler)
   }
 
+  server.setTimeout(options.connectionTimeout)
+
   return { server, listen }
 
   // `this` is the Fastify object

--- a/lib/server.js
+++ b/lib/server.js
@@ -21,11 +21,13 @@ function createServer (options, httpHandler) {
       server = http2().createSecureServer(options.https, httpHandler)
     } else {
       server = https.createServer(options.https, httpHandler)
+      server.keepAliveTimeout = options.keepAliveTimeout
     }
   } else if (options.http2) {
     server = http2().createServer(httpHandler)
   } else {
     server = http.createServer(httpHandler)
+    server.keepAliveTimeout = options.keepAliveTimeout
   }
 
   if (!options.serverFactory) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -28,7 +28,9 @@ function createServer (options, httpHandler) {
     server = http.createServer(httpHandler)
   }
 
-  server.setTimeout(options.connectionTimeout)
+  if (!options.serverFactory) {
+    server.setTimeout(options.connectionTimeout)
+  }
 
   return { server, listen }
 

--- a/test/connectionTimeout.test.js
+++ b/test/connectionTimeout.test.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const Fastify = require('..')
+const http = require('http')
+const t = require('tap')
+const test = t.test
+
+test('connectionTimeout', t => {
+  t.plan(4)
+
+  try {
+    Fastify({ connectionTimeout: 1.3 })
+    t.fail('option must be an integer')
+  } catch (err) {
+    t.ok(err)
+  }
+
+  try {
+    Fastify({ connectionTimeout: [] })
+    t.fail('option must be an integer')
+  } catch (err) {
+    t.ok(err)
+  }
+
+  const serverFactory = (handler, _) => {
+    const server = http.createServer((req, res) => {
+      handler(req, res)
+    })
+    server.setTimeout = () => {
+      t.ok('called')
+    }
+    return server
+  }
+
+  const fastify = Fastify({ connectionTimeout: 50, serverFactory })
+
+  fastify.listen(0, function (err) {
+    t.error(err)
+    fastify.server.unref()
+  })
+})

--- a/test/connectionTimeout.test.js
+++ b/test/connectionTimeout.test.js
@@ -23,13 +23,13 @@ test('connectionTimeout', t => {
   }
 
   const httpServer = Fastify({ connectionTimeout: 1 }).server
-  t.is(httpServer.timeout, 1)
+  t.equal(httpServer.timeout, 1)
 
   const httpsServer = Fastify({ connectionTimeout: 2, https: {} }).server
-  t.is(httpsServer.timeout, 2)
+  t.equal(httpsServer.timeout, 2)
 
   const http2Server = Fastify({ connectionTimeout: 3, http2: true }).server
-  t.is(http2Server.timeout, 3)
+  t.equal(http2Server.timeout, 3)
 
   const serverFactory = (handler, _) => {
     const server = http.createServer((req, res) => {
@@ -39,5 +39,5 @@ test('connectionTimeout', t => {
     return server
   }
   const customServer = Fastify({ connectionTimeout: 4, serverFactory }).server
-  t.is(customServer.timeout, 5)
+  t.equal(customServer.timeout, 5)
 })

--- a/test/internals/initialConfig.test.js
+++ b/test/internals/initialConfig.test.js
@@ -19,6 +19,7 @@ test('without options passed to Fastify, initialConfig should expose default val
   t.plan(1)
 
   const fastifyDefaultOptions = {
+    connectionTimeout: 60000,
     bodyLimit: 1024 * 1024,
     caseSensitive: true,
     disableRequestLogging: false,
@@ -35,7 +36,7 @@ test('without options passed to Fastify, initialConfig should expose default val
 })
 
 test('Fastify.initialConfig should expose all options', t => {
-  t.plan(16)
+  t.plan(17)
 
   const serverFactory = (handler, opts) => {
     const server = http.createServer((req, res) => {
@@ -69,6 +70,7 @@ test('Fastify.initialConfig should expose all options', t => {
     },
     ignoreTrailingSlash: true,
     maxParamLength: 200,
+    connectionTimeout: 60000,
     bodyLimit: 1049600,
     onProtoPoisoning: 'remove',
     serverFactory,
@@ -91,6 +93,7 @@ test('Fastify.initialConfig should expose all options', t => {
   t.strictEqual(fastify.initialConfig.https, true)
   t.strictEqual(fastify.initialConfig.ignoreTrailingSlash, true)
   t.strictEqual(fastify.initialConfig.maxParamLength, 200)
+  t.strictEqual(fastify.initialConfig.connectionTimeout, 60000)
   t.strictEqual(fastify.initialConfig.bodyLimit, 1049600)
   t.strictEqual(fastify.initialConfig.onProtoPoisoning, 'remove')
   t.strictEqual(fastify.initialConfig.caseSensitive, true)
@@ -223,6 +226,7 @@ test('Should not have issues when passing stream options to Pino.js', t => {
 
     t.type(fastify, 'object')
     t.deepEqual(fastify.initialConfig, {
+      connectionTimeout: 60000,
       bodyLimit: 1024 * 1024,
       caseSensitive: true,
       disableRequestLogging: false,

--- a/test/internals/initialConfig.test.js
+++ b/test/internals/initialConfig.test.js
@@ -19,7 +19,7 @@ test('without options passed to Fastify, initialConfig should expose default val
   t.plan(1)
 
   const fastifyDefaultOptions = {
-    connectionTimeout: 60000,
+    connectionTimeout: 0,
     bodyLimit: 1024 * 1024,
     caseSensitive: true,
     disableRequestLogging: false,
@@ -70,7 +70,7 @@ test('Fastify.initialConfig should expose all options', t => {
     },
     ignoreTrailingSlash: true,
     maxParamLength: 200,
-    connectionTimeout: 60000,
+    connectionTimeout: 0,
     bodyLimit: 1049600,
     onProtoPoisoning: 'remove',
     serverFactory,
@@ -93,7 +93,7 @@ test('Fastify.initialConfig should expose all options', t => {
   t.strictEqual(fastify.initialConfig.https, true)
   t.strictEqual(fastify.initialConfig.ignoreTrailingSlash, true)
   t.strictEqual(fastify.initialConfig.maxParamLength, 200)
-  t.strictEqual(fastify.initialConfig.connectionTimeout, 60000)
+  t.strictEqual(fastify.initialConfig.connectionTimeout, 0)
   t.strictEqual(fastify.initialConfig.bodyLimit, 1049600)
   t.strictEqual(fastify.initialConfig.onProtoPoisoning, 'remove')
   t.strictEqual(fastify.initialConfig.caseSensitive, true)
@@ -226,7 +226,7 @@ test('Should not have issues when passing stream options to Pino.js', t => {
 
     t.type(fastify, 'object')
     t.deepEqual(fastify.initialConfig, {
-      connectionTimeout: 60000,
+      connectionTimeout: 0,
       bodyLimit: 1024 * 1024,
       caseSensitive: true,
       disableRequestLogging: false,

--- a/test/internals/initialConfig.test.js
+++ b/test/internals/initialConfig.test.js
@@ -20,6 +20,7 @@ test('without options passed to Fastify, initialConfig should expose default val
 
   const fastifyDefaultOptions = {
     connectionTimeout: 0,
+    keepAliveTimeout: 5000,
     bodyLimit: 1024 * 1024,
     caseSensitive: true,
     disableRequestLogging: false,
@@ -36,7 +37,7 @@ test('without options passed to Fastify, initialConfig should expose default val
 })
 
 test('Fastify.initialConfig should expose all options', t => {
-  t.plan(17)
+  t.plan(18)
 
   const serverFactory = (handler, opts) => {
     const server = http.createServer((req, res) => {
@@ -71,6 +72,7 @@ test('Fastify.initialConfig should expose all options', t => {
     ignoreTrailingSlash: true,
     maxParamLength: 200,
     connectionTimeout: 0,
+    keepAliveTimeout: 5000,
     bodyLimit: 1049600,
     onProtoPoisoning: 'remove',
     serverFactory,
@@ -94,6 +96,7 @@ test('Fastify.initialConfig should expose all options', t => {
   t.strictEqual(fastify.initialConfig.ignoreTrailingSlash, true)
   t.strictEqual(fastify.initialConfig.maxParamLength, 200)
   t.strictEqual(fastify.initialConfig.connectionTimeout, 0)
+  t.strictEqual(fastify.initialConfig.keepAliveTimeout, 5000)
   t.strictEqual(fastify.initialConfig.bodyLimit, 1049600)
   t.strictEqual(fastify.initialConfig.onProtoPoisoning, 'remove')
   t.strictEqual(fastify.initialConfig.caseSensitive, true)
@@ -227,6 +230,7 @@ test('Should not have issues when passing stream options to Pino.js', t => {
     t.type(fastify, 'object')
     t.deepEqual(fastify.initialConfig, {
       connectionTimeout: 0,
+      keepAliveTimeout: 5000,
       bodyLimit: 1024 * 1024,
       caseSensitive: true,
       disableRequestLogging: false,

--- a/test/keepAliveTimeout.test.js
+++ b/test/keepAliveTimeout.test.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const Fastify = require('..')
+const http = require('http')
+const t = require('tap')
+const test = t.test
+
+test('keepAliveTimeout', t => {
+  t.plan(6)
+
+  try {
+    Fastify({ keepAliveTimeout: 1.3 })
+    t.fail('option must be an integer')
+  } catch (err) {
+    t.ok(err)
+  }
+
+  try {
+    Fastify({ keepAliveTimeout: [] })
+    t.fail('option must be an integer')
+  } catch (err) {
+    t.ok(err)
+  }
+
+  const httpServer = Fastify({ keepAliveTimeout: 1 }).server
+  t.equal(httpServer.keepAliveTimeout, 1)
+
+  const httpsServer = Fastify({ keepAliveTimeout: 2, https: {} }).server
+  t.equal(httpsServer.keepAliveTimeout, 2)
+
+  const http2Server = Fastify({ keepAliveTimeout: 3, http2: true }).server
+  t.notEqual(http2Server.keepAliveTimeout, 3)
+
+  const serverFactory = (handler, _) => {
+    const server = http.createServer((req, res) => {
+      handler(req, res)
+    })
+    server.keepAliveTimeout = 5
+    return server
+  }
+  const customServer = Fastify({ keepAliveTimeout: 4, serverFactory }).server
+  t.equal(customServer.keepAliveTimeout, 5)
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

* Implements #2058

#### Outstanding questions

* ~~Both `http` and `https` also have `server.keepAliveTimeout` setting (for `Keep-Alive` connections; 5 seconds by default), but I'm not sure if it makes sense to add option for that one~~
  - Introduced `keepAliveTimeout` (HTTP/1 only; 5 seconds by default - same as in `http[s]`)
* ~~Current default (60 seconds) may lead to problems in serverless environments. See https://github.com/nodejs/node/issues/27556. So, maybe default should be 0 (no timeout at all), like it's done in `http[2s]` modules in recent versions of Node.js?~~
  - Set to `0`
* ~~I'm not sure if it makes sense to apply `connectionTimeout` when `serverFactory` is in use~~
  - Implemented this behavior and updated documentation

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
