### PR TITLE
docs: use computed key when assigning property to request

### DIFF
--- a/docs/Plugins-Guide.md
+++ b/docs/Plugins-Guide.md
@@ -181,7 +181,7 @@ We've seen how to extend server functionality and how to handle the encapsulatio
 ## Hooks
 You just built an amazing utility, but now you need to execute that for every request, this is what you will likely do:
 ```js
-fastify.decorate('util', (request, key, value) => { request.key = value })
+fastify.decorate('util', (request, key, value) => { request[key] = value })
 
 fastify.get('/plugin1', (request, reply) => {
   fastify.util(request, 'timestamp', new Date())


### PR DESCRIPTION
Noticed this when reading through docs on plugins.  I think the intention was for the util to be the same in every case, but in the first case it was assigning the value to the literal key property of request instead of the computed value of key using square brackets.

Since it's the first example it confused me, but made sense when I looked further down and noticed the second and third examples using square bracket notation. This makes them all the same.

```
request.key = value
request[key] = value
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
