### PR TITLE
types: add type of `this` to the not found handler

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -688,7 +688,7 @@ declare namespace fastify {
     /**
      * Set the 404 handler
      */
-    setNotFoundHandler(handler: (request: FastifyRequest<HttpRequest>, reply: FastifyReply<HttpResponse>) => void): void
+    setNotFoundHandler(handler: (this: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, request: FastifyRequest<HttpRequest>, reply: FastifyReply<HttpResponse>) => void): void
 
     /**
      * Set a function that will be called whenever an error happens

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -505,7 +505,9 @@ server.get('/test-decorated-inputs', (req, reply) => {
   (reply as DecoratedReply).utility()
 })
 
-server.setNotFoundHandler((req, reply) => {
+server.setNotFoundHandler(function (req, reply) {
+  this.log.error('not found')
+  reply.code(404).send()
 })
 
 server.setErrorHandler((err, request, reply) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

In the not found handler, `this` refers to the current fastify instance. However, corresponding type declaration of `this` is absent.

https://github.com/fastify/fastify/blob/b44d859874a51558b207781533eb7208a7ce61bc/fastify.d.ts#L691

This pull request contains the fix and corresponding test.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
