### PR TITLE
docs: fix header and body generic types

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -110,8 +110,8 @@ const opts: fastify.RouteShorthandOptions = {
 server.get<Query, Params, Headers, Body>('/ping/:bar', opts, (request, reply) => {
   console.log(request.query) // this is of type Query!
   console.log(request.params) // this is of type Params!
-  console.log(request.body) // this is of type Body!
   console.log(request.headers) // this is of type Headers!
+  console.log(request.body) // this is of type Body!
   reply.code(200).send({ pong: 'it worked!' })
 })
 ```
@@ -143,8 +143,8 @@ const opts: fastify.RouteShorthandOptions = {
 server.get<fastify.DefaultQuery, Params, unknown>('/ping/:bar', opts, (request, reply) => {
   console.log(request.query) // this is of type fastify.DefaultQuery!
   console.log(request.params) // this is of type Params!
-  console.log(request.body) // this is of type unknown!
-  console.log(request.headers) // this is of type fastify.DefaultHeader because typescript will use the default type value!
+  console.log(request.headers) // this is of type unknown!
+  console.log(request.body) // this is of type fastify.DefaultBody because typescript will use the default type value!
   reply.code(200).send({ pong: 'it worked!' })
 })
 
@@ -155,8 +155,8 @@ server.get<fastify.DefaultQuery, Params, unknown>('/ping/:bar', opts, (request, 
 server.get<unknown, Params, unknown, unknown>('/ping/:bar', opts, (request, reply) => {
   console.log(request.query) // this is of type unknown!
   console.log(request.params) // this is of type Params!
-  console.log(request.body) // this is of type unknown!
   console.log(request.headers) // this is of type unknown!
+  console.log(request.body) // this is of type unknown!
   reply.code(200).send({ pong: 'it worked!' })
 })
 ```


### PR DESCRIPTION
The generic short-hand types follow order `<Query = DefaultQuery, Params = DefaultParams, Headers = DefaultHeaders, Body = DefaultBody>`
but the docs has them listed as `<Query, Params, Body, Headers>`. This caused one of the examples to be incorrect when it assigned `unknown` to the `Headers` type but explained that it was `unknown` on the `Body` type. The body was undefined which mean it would default to `DefaultBody` which is `any`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
