### PR TITLE
fix: make .register() compatible with eslint rule

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -22,10 +22,8 @@ declare function fastify(opts?: fastify.ServerOptionsAsSecureHttp2): fastify.Fas
 // eslint-disable-next-line no-redeclare
 declare namespace fastify {
 
-  type Plugin<HttpServer, HttpRequest, HttpResponse, Options, PluginInstance extends Function = Function> =
-    PluginInstance extends () => Promise<void> ?
-      ((instance: FastifyInstance< HttpServer, HttpRequest, HttpResponse >, options: Options) => Promise<void>) :
-      (instance: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, options: Options, callback: (err?: FastifyError) => void) => void;
+  type Plugin<HttpServer, HttpRequest, HttpResponse, Options> =
+    (instance: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, options: Options, callback: (err?: FastifyError) => void) => Promise<void> | void;
 
   type Middleware < HttpServer, HttpRequest, HttpResponse > = (this: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, req: HttpRequest, res: HttpResponse, callback: (err?: FastifyError) => void) => void
 
@@ -569,7 +567,7 @@ declare namespace fastify {
     /**
      * Registers a plugin
      */
-    register<Options extends RegisterOptions<HttpServer, HttpRequest, HttpResponse>, PluginInstance extends Function>(plugin: Plugin<HttpServer, HttpRequest, HttpResponse, Options, PluginInstance>, options?: Options): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
+    register<Options extends RegisterOptions<HttpServer, HttpRequest, HttpResponse>>(plugin: Plugin<HttpServer, HttpRequest, HttpResponse, Options>, options?: Options): FastifyInstance<HttpServer, HttpRequest, HttpResponse>
 
     /**
      * `Register a callback that will be executed just after a register.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "npm run lint:standard && npm run lint:typescript",
     "lint:standard": "standard --verbose | snazzy",
-    "lint:typescript": "standard --parser @typescript-eslint/parser --plugin @typescript-eslint/eslint-plugin test/types/*.ts fastify.d.ts",
+    "lint:typescript": "npx eslint --config test/types/.eslintrc.js test/types/*.ts fastify.d.ts",
     "unit": "tap --no-esm -J test/*.test.js test/*/*.test.js",
     "unit:report": "tap --no-esm -J test/*.test.js test/*/*.test.js --cov --coverage-report=html --coverage-report=cobertura | tee out.tap",
     "unit:junit": "tap-mocha-reporter xunit < out.tap > test/junit-testresults.xml",

--- a/test/types/.eslintrc.js
+++ b/test/types/.eslintrc.js
@@ -1,0 +1,15 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  extends: [
+    'standard',
+    // 'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended-requiring-type-checking',
+  ],
+  parser: `@typescript-eslint/parser`,
+  parserOptions: {
+    project: `./test/types/tsconfig.json`,
+  },
+  rules: {
+    '@typescript-eslint/require-await': 0,
+  },
+};


### PR DESCRIPTION
Previous register did not accept async function with the following eslint rule.
```
Promise returned in function argument where a void return was expected.
eslint(@typescript-eslint/no-misused-promises)
```

I have no idea about how to test this fix.

**Detailed explanation**
```
import fastify, { FastifyInstance } from 'fastify';

const app = fastify();
app.register(root);
//           ^^^^
//           \: eslint(@typescript-eslint/no-misused-promises)
async function root(fastify: FastifyInstance): Promise<void> {
  fastify.get('/', async () => {
    return { hello: 'world' };
  });
}
```
The [`no-misused-promises`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-misused-promises.md) rule regards the above code as error. Typescript compiler considers assigning `() => Promise<any>` to `() => void` no problem. But in that rule it's invalid.

Existing type signature used `PluginInstance` type variable, but it was always just `Function` type in my think. The result was `register()`'s parameter type is always `() => void`, and previous [line 27](https://github.com/fastify/fastify/blob/master/fastify.d.ts#L27) was just unused. maybe mistake..?

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
