### PR TITLE
Note explaining the importance of inject, listen, or ready

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -112,7 +112,7 @@ tap.test('GET `/` route', t => {
 ### Testing with a running server
 Fastify can also be tested after starting the server with `fastify.listen()` or after initializing routes and plugins with `fastify.ready()`. 
 
-Note: `fastify.inject`, `fastify.listen`, or `fastify.ready` must be invoked before the callback of `register(plugin).after(callback)` will execute.
+Note: `fastify.inject`, `fastify.listen`, or `fastify.ready` must be invoked before the callback of `fastify.register(plugin).after(callback)` will execute.
 
 
 #### Example:

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -110,7 +110,10 @@ tap.test('GET `/` route', t => {
 ```
 
 ### Testing with a running server
-Fastify can also be tested after starting the server with `fastify.listen()` or after initializing routes and plugins with `fastify.ready()`.
+Fastify can also be tested after starting the server with `fastify.listen()` or after initializing routes and plugins with `fastify.ready()`. 
+
+Note: `fastify.inject`, `fastify.listen`, or `fastify.ready` must be invoked before the callback of `register(plugin).after(callback)` will execute.
+
 
 #### Example:
 


### PR DESCRIPTION
In retrospect, the documentation outlines the need to call `inject`,  `listen`,`ready` while testing but it was not clear on my first pass through of getting started. 

I was trying to test a plugin without calling one of the above, using `fastify.register(myPlugin).after((...)=>{ expect(myPluginWorks) })` and it was hanging. It was my mistake but hopefully a note may save someone else from running into the same confusion.