### PR TITLE
http2: fix req.hostname not set

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -307,7 +307,7 @@ function buildRouting (options) {
 
     req.id = req.headers[requestIdHeader] || genReqId(req)
     req.originalUrl = req.url
-    var hostname = req.headers[':authority'] || req.headers.host
+    var hostname = req.headers.host || req.headers[':authority']
     var ip = req.connection.remoteAddress
     var ips
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -307,7 +307,7 @@ function buildRouting (options) {
 
     req.id = req.headers[requestIdHeader] || genReqId(req)
     req.originalUrl = req.url
-    var hostname = req.headers.host
+    var hostname = req.headers[':authority'] || req.headers.host
     var ip = req.connection.remoteAddress
     var ips
 

--- a/test/http2/plain.js
+++ b/test/http2/plain.js
@@ -20,6 +20,10 @@ fastify.get('/', function (req, reply) {
   reply.code(200).send(msg)
 })
 
+fastify.get('/hostname', function (req, reply) {
+  reply.code(200).send(req.hostname)
+})
+
 fastify.listen(0, err => {
   t.error(err)
   fastify.server.unref()
@@ -34,5 +38,16 @@ fastify.listen(0, err => {
     t.strictEqual(res.headers['content-length'], '' + JSON.stringify(msg).length)
 
     t.deepEqual(JSON.parse(res.body), msg)
+  })
+
+  test('http hostname', async (t) => {
+    t.plan(1)
+
+    const hostname = `localhost:${fastify.server.address().port}`
+
+    const url = `http://${hostname}/hostname`
+    const res = await h2url.concat({ url })
+
+    t.strictEqual(res.body, hostname)
   })
 })


### PR DESCRIPTION
Fixes #2112

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)