### PR TITLE
Make error argument optional in fastify.d.ts

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -526,12 +526,12 @@ declare namespace fastify {
      * internally waits for the .ready() event. The callback is the same as the
      * Node core.
      */
-    listen(callback: (err: Error, address: string) => void): void
-    listen(port: number, callback: (err: Error, address: string) => void): void
-    listen(port: number, address: string, callback: (err: Error, address: string) => void): void
-    listen(port: number, address: string, backlog: number, callback: (err: Error, address: string) => void): void
-    listen(options: ListenOptions, callback: (err: Error, address: string) => void): void
-    listen(sockFile: string, callback: (err: Error, address: string) => void): void
+    listen(callback: (err: Error | null, address: string) => void): void
+    listen(port: number, callback: (err: Error | null, address: string) => void): void
+    listen(port: number, address: string, callback: (err: Error | null, address: string) => void): void
+    listen(port: number, address: string, backlog: number, callback: (err: Error | null, address: string) => void): void
+    listen(options: ListenOptions, callback: (err: Error | null, address: string) => void): void
+    listen(sockFile: string, callback: (err: Error | null, address: string) => void): void
     listen(port: number, address?: string, backlog?: number): Promise<string>
     listen(sockFile: string): Promise<string>
     listen(options: ListenOptions): Promise<string>
@@ -541,9 +541,9 @@ declare namespace fastify {
      * been loaded. It receives an error parameter if something went wrong.
      */
     ready(): Promise<FastifyInstance<HttpServer, HttpRequest, HttpResponse>>
-    ready(readyListener: (err: Error) => void): void
-    ready(readyListener: (err: Error, done: Function) => void): void
-    ready(readyListener: (err: Error, context: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, done: Function) => void): void
+    ready(readyListener: (err: Error | null) => void): void
+    ready(readyListener: (err: Error | null, done: Function) => void): void
+    ready(readyListener: (err: Error | null, context: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, done: Function) => void): void
 
     /**
      * Call this function to close the server instance and run the "onClose" callback
@@ -575,9 +575,9 @@ declare namespace fastify {
      * `Register a callback that will be executed just after a register.
      * It can take up to three parameters
      */
-    after(afterListener: (err: Error) => void): void
-    after(afterListener: (err: Error, done: Function) => void): void
-    after(afterListener: (err: Error, context: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, done: Function) => void): void
+    after(afterListener: (err: Error | null) => void): void
+    after(afterListener: (err: Error | null, done: Function) => void): void
+    after(afterListener: (err: Error | null, context: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, done: Function) => void): void
 
     /**
      * Decorate this fastify instance with new properties. Throws an execption if
@@ -678,7 +678,7 @@ declare namespace fastify {
     /**
      * Useful for testing http requests without running a sever
      */
-    inject(opts: HTTPInjectOptions | string, cb: (err: Error, res: HTTPInjectResponse) => void): void
+    inject(opts: HTTPInjectOptions | string, cb: (err: Error | null, res: HTTPInjectResponse) => void): void
 
     /**
      * Useful for testing http requests without running a sever


### PR DESCRIPTION
Currently in most places error argument is defined as being of type `Error`, which is an object. However, `null` is also a possible value.

In my current project we have strict TypeScript linter settings, and performing a condition on `err` (that the compiler considers to always be truthy) fails the linter.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
