### PR TITLE
ci: update checkout action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
             node-version: 6.x
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Use Node.js
         uses: actions/setup-node@v1


### PR DESCRIPTION
I'm quite sad for all the failing checkout in this PR https://github.com/fastify/fastify/pull/2077/checks?check_run_id=475848653

I saw that there is a new version of this action... hope it will decrease our fail ci

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
