### PR TITLE
quicker quick start + request to add to core contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,46 @@ How can you efficiently handle the resources of your server, knowing that you ar
 
 Enter Fastify. Fastify is a web framework highly focused on providing the best developer experience with the least overhead and a powerful plugin architecture. It is inspired by Hapi and Express and as far as we know, it is one of the fastest web frameworks in town.
 
+### Quick start
+
+Create a folder and make it your current working directory:
+
+```
+mkdir my-app
+cd my-app
+```
+
+Generate a fastify project with `npm init`:
+
+```sh
+npm init fastify
+```
+
+Install dependencies:
+
+```js
+npm install
+```
+
+To start the app in dev mode:
+
+```sh
+npm run dev
+```
+
+For production mode:
+
+```sh
+npm start
+```
+
+Under the hood `npm init` downloads and runs [Fastify Create](https://github.com/fastify/fastify-create),
+which in turn uses the generate functionality of [Fastify CLI](https://github.com/fastify/fastify-cli).
+
+
 ### Install
+
+If installing in an existing project, then Fastify can be installed into the project as a dependency:
 
 Install with npm:
 ```
@@ -80,29 +119,6 @@ fastify.listen(3000, (err, address) => {
 
 Do you want to know more? Head to the <a href="https://github.com/fastify/fastify/blob/master/docs/Getting-Started.md"><code><b>Getting Started</b></code></a>.
 
-### Quick start with Fastify CLI
-
-Good tools make API development quicker and easier to maintain than doing everything manually.
-
-The [Fastify CLI](https://github.com/fastify/fastify-cli) is a command line interface tool that can create new projects, manage plugins, and perform a variety of development tasks testing and running the application.
-
-The goal in this guide is to build and run a simple Fastify project, using the [Fastify CLI](https://github.com/fastify/fastify-cli), while adhering to the Style Guide recommendations that benefit every Fastify project.
-
-### Example
-
-Open a terminal window.
-
-```
-npm install fastify-cli --global
-```
-
-Generate a new project and default app by running the following command:
-
-```
-fastify generate
-```
-
-For more information, see the [Fastify CLI documentation](https://github.com/fastify/fastify-cli).
 
 ### Fastify v1.x
 
@@ -191,6 +207,7 @@ Team members are listed in alphabetical order.
 ### Fastify Core team
 * [__Tommaso Allevi__](https://github.com/allevo), <https://twitter.com/allevitommaso>, <https://www.npmjs.com/~allevo>
 * [__Ethan Arrowood__](https://github.com/Ethan-Arrowood/), <https://twitter.com/arrowoodtech>, <https://www.npmjs.com/~ethan_arrowood>
+* [__David Mark Clements__](https://github.com/davidmarkclements), <https://twitter.com/davidmarkclem>, <https://www.npmjs.com/~davidmarkclements>
 * [__Matteo Collina__](https://github.com/mcollina), <https://twitter.com/matteocollina>, <https://www.npmjs.com/~matteo.collina>
 * [__Tomas Della Vedova__](https://github.com/delvedor), <https://twitter.com/delvedor>, <https://www.npmjs.com/~delvedor>
 * [__Dustin Deus__](https://github.com/StarpTech), <https://twitter.com/dustindeus>, <https://www.npmjs.com/~starptech>


### PR DESCRIPTION
I stumbled on an `npm init` feature, if you do `npm init <name>` npm will execute the bin file of `create-<name>`.

Created http://npm.im/create-fastify to hook into that functionality, it just uses the generate cli function of fastify-cli.

So now if you do `npm init fastify` in a folder, it'll autogenerate a fastify project.

Before this can land we need to move https://github.com/davidmarkclements/create-fastify to https://github.com/fastify/create-fastify. 

As a form of request, I've also added myself to the list of core contributors.

Here's my case for making this request:

* fastify is literally the web framework of my dreams.
* I'm familiar with the internals
* I have a corpus of performance-related OSS and published analysis
* pino is a core part of fastify and I think we can do more to integrate
* avvio contribution (https://github.com/mcollina/avvio/pull/92)
* the fastify community has an amazing vibe, and I love to collaborate with value-centric and considerate people (https://twitter.com/matteocollina/status/1221795471431217153)

If this is acceptable, I'd like to perform a full documentation audit and rewrite (I have this provisionally scheduled for early-April). I have authoring/technical writing experience that can help here.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- ~~run `npm run test` and `npm run benchmark`~~
- ~~tests and/or benchmarks are included~~
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
