### PR TITLE
docs: Clarify thrown values must be Errors

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -338,7 +338,7 @@ fastify.get('/async-await', options, async function (request, reply) {
 })
 ```
 
-Rejected promises default to a `500` HTTP status code. Reject the promise, or `throw` in an `async function`, with an object that has `statusCode` (or `status`) and `message` properties to modify the reply.
+Rejected promises default to a `500` HTTP status code. Reject the promise, or `throw` in an `async function`, with an _Error_ object that has `statusCode` (or `status`) and `message` properties to modify the reply. Throwing plain objects is not supported, it must be an instance of _Error_, see:
 
 ```js
 fastify.get('/teapot', async function (request, reply) => {


### PR DESCRIPTION
This is an attempt at fixing #1680.

#### Checklist

- [ ] ~~run `npm run test` and `npm run benchmark`~~
- [ ] ~~tests and/or benchmarks are included~~
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
