### PR TITLE
feat(decorators): throw error if called after start

### DIFF
--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -4,13 +4,15 @@
 
 const {
   kReply,
-  kRequest
+  kRequest,
+  kState
 } = require('./symbols.js')
 
 const {
   codes: {
     FST_ERR_DEC_ALREADY_PRESENT,
-    FST_ERR_DEC_MISSING_DEPENDENCY
+    FST_ERR_DEC_MISSING_DEPENDENCY,
+    FST_ERR_DEC_AFTER_START
   }
 } = require('./errors')
 
@@ -34,6 +36,7 @@ function decorate (instance, name, fn, dependencies) {
 }
 
 function decorateFastify (name, fn, dependencies) {
+  assertNotStarted(this, name)
   decorate(this, name, fn, dependencies)
   return this
 }
@@ -63,13 +66,21 @@ function checkDependencies (instance, deps) {
 }
 
 function decorateReply (name, fn, dependencies) {
+  assertNotStarted(this, name)
   decorate(this[kReply].prototype, name, fn, dependencies)
   return this
 }
 
 function decorateRequest (name, fn, dependencies) {
+  assertNotStarted(this, name)
   decorate(this[kRequest].prototype, name, fn, dependencies)
   return this
+}
+
+function assertNotStarted (instance, name) {
+  if (instance[kState].started) {
+    throw new FST_ERR_DEC_AFTER_START(name)
+  }
 }
 
 module.exports = {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -27,6 +27,7 @@ createError('FST_ERR_CTP_EMPTY_JSON_BODY', "Body cannot be empty when content-ty
 */
 createError('FST_ERR_DEC_ALREADY_PRESENT', "The decorator '%s' has already been added!")
 createError('FST_ERR_DEC_MISSING_DEPENDENCY', "The decorator is missing dependency '%s'.")
+createError('FST_ERR_DEC_AFTER_START', "The decorator '%s' has been added after start!")
 
 /**
  * hooks

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -708,3 +708,32 @@ test('after can access to a decorated instance and previous plugin decoration', 
       t.equal(response.statusCode, 200)
     })
 })
+
+test('decorate* should throw if called after ready', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.get('/', (request, reply) => {
+    reply.send({
+      hello: 'world'
+    })
+  })
+
+  fastify.ready().then(() => {
+    try {
+      fastify.decorate('test', true)
+    } catch (e) {
+      t.is(e.message, "FST_ERR_DEC_AFTER_START: The decorator 'test' has been added after start!")
+    }
+    try {
+      fastify.decorateRequest('test', true)
+    } catch (e) {
+      t.is(e.message, "FST_ERR_DEC_AFTER_START: The decorator 'test' has been added after start!")
+    }
+    try {
+      fastify.decorateReply('test', true)
+    } catch (e) {
+      t.is(e.message, "FST_ERR_DEC_AFTER_START: The decorator 'test' has been added after start!")
+    }
+  })
+})

--- a/test/internals/decorator.test.js
+++ b/test/internals/decorator.test.js
@@ -5,11 +5,19 @@
 const t = require('tap')
 const test = t.test
 const decorator = require('../../lib/decorate')
+const {
+  kState
+} = require('../../lib/symbols')
 
 test('decorate should add the given method to its instance', t => {
   t.plan(1)
   function build () {
     server.add = decorator.add
+    server[kState] = {
+      listening: false,
+      closing: false,
+      started: false
+    }
     return server
     function server () {}
   }
@@ -23,6 +31,11 @@ test('decorate is chainable', t => {
   t.plan(3)
   function build () {
     server.add = decorator.add
+    server[kState] = {
+      listening: false,
+      closing: false,
+      started: false
+    }
     return server
     function server () {}
   }
@@ -49,6 +62,11 @@ test('checkExistence should find the instance if not given', t => {
   function build () {
     server.add = decorator.add
     server.check = decorator.exist
+    server[kState] = {
+      listening: false,
+      closing: false,
+      started: false
+    }
     return server
     function server () {}
   }
@@ -83,6 +101,11 @@ test('decorate should internally call checkDependencies', t => {
   t.plan(2)
   function build () {
     server.add = decorator.add
+    server[kState] = {
+      listening: false,
+      closing: false,
+      started: false
+    }
     return server
     function server () {}
   }
@@ -101,7 +124,13 @@ test('decorate should internally call checkDependencies', t => {
 test('decorate should recognize getter/setter objects', t => {
   t.plan(6)
 
-  const one = {}
+  const one = {
+    [kState]: {
+      listening: false,
+      closing: false,
+      started: false
+    }
+  }
   decorator.add.call(one, 'foo', {
     getter: () => this._a,
     setter: (val) => {
@@ -115,7 +144,13 @@ test('decorate should recognize getter/setter objects', t => {
   t.is(one.foo, 'a')
 
   // getter only
-  const two = {}
+  const two = {
+    [kState]: {
+      listening: false,
+      closing: false,
+      started: false
+    }
+  }
   decorator.add.call(two, 'foo', {
     getter: () => 'a getter'
   })


### PR DESCRIPTION
Check if fastify has started when calling decorate* and throw an error if it has.

Fix #2116 .
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
