### PR TITLE
Relaced request with got

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -129,16 +129,12 @@ tap.test('GET `/` route', async t => {
   
   t.tearDown(() => fastify.close())
   
-  try {
-    await fastify.listen(0)
-    const response = await got(`http://localhost:${fastify.server.address().port}`)
-    t.strictEqual(response.statusCode, 200)
-    t.strictEqual(response.headers['content-type'], 'application/json; charset=utf-8')
-    t.deepEqual(JSON.parse(response.body), { hello: 'world' })
-    t.end()
-  } catch (err) {
-     t.error(err)
-  }
+  await fastify.listen(0)
+  const response = await got(`http://localhost:${fastify.server.address().port}`)
+  t.strictEqual(response.statusCode, 200)
+  t.strictEqual(response.headers['content-type'], 'application/json; charset=utf-8')
+  t.deepEqual(JSON.parse(response.body), { hello: 'world' })
+  t.end()
 })
 ```
 

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,7 +1,7 @@
 <h1 align="center">Fastify</h1>
 
 ## Testing
-Testing is one of the most important parts of developing an application. Fastify is very flexible when it comes to testing and is compatible with most testing frameworks (such as [Tap](https://www.npmjs.com/package/tap), which is used in the examples below).
+Testing is one of the most important parts of developing an application. Fastify is very flexible when it comes to testing and is compatible with most testing frameworks (such as [Tap](https://www.npmjs.com/package/tap) & [Mocha](https://www.npmjs.com/package/mocha), which are used in the examples below).
 
 <a name="inject"></a>
 ### Testing with http injection
@@ -116,7 +116,9 @@ Fastify can also be tested after starting the server with `fastify.listen()` or 
 
 Uses **app.js** from the previous example.
 
-**test-listen.js** (testing with [`Got`](https://www.npmjs.com/package/got))
+Let's compare 3 examples with different test frameworks:
+
+**test-listen.js** (with [`Got`](https://www.npmjs.com/package/got) & [`Tap`](https://www.npmjs.com/package/tap))
 ```js
 const tap = require('tap')
 const got = require('got')
@@ -128,8 +130,8 @@ tap.test('GET `/` route', async t => {
   t.tearDown(() => fastify.close())
   
   try {
-    await fastify.listen(3000)
-    const response = await got('http://localhost:3000');
+    await fastify.listen(0);
+    const response = await got(`http://localhost:${fastify.server.address().port}`);
     t.strictEqual(response.statusCode, 200)
     t.strictEqual(response.headers['content-type'], 'application/json; charset=utf-8')
     t.deepEqual(JSON.parse(response.body), { hello: 'world' })
@@ -138,6 +140,32 @@ tap.test('GET `/` route', async t => {
      t.error(err)
   }
 })
+```
+
+**test-listen.js** (with [`Got`](https://www.npmjs.com/package/got) & [`Mocha`](https://www.npmjs.com/package/mocha))
+```js
+const got = require('got')
+const buildFastify = require('./app')
+const assert = require('assert').strict;
+
+
+describe('Fastify server tests', function() {
+    before(async function() {
+        await fastify.listen(0);
+    });
+
+    it('GET `/` route', async function() {
+        const response = await got(`http://localhost:${fastify.server.address().port}`);
+
+        assert.equal(response.statusCode, 200, 'StatusCode is not 200');
+        assert.equal(response.headers['content-type'], 'application/json; charset=utf-8', 'Content-Type is not JSON');
+        assert.deepEqual(JSON.parse(response.body), { hello: 'world' }, 'Expected another body');
+    });
+
+    after(function() {
+        fastify.close()
+    });
+});
 ```
 
 **test-ready.js** (testing with [`SuperTest`](https://www.npmjs.com/package/supertest))

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -148,6 +148,7 @@ const got = require('got')
 const buildFastify = require('./app')
 const assert = require('assert').strict;
 
+const fastify = buildFastify();
 
 describe('Fastify server tests', function() {
   before(async function() {

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -116,32 +116,27 @@ Fastify can also be tested after starting the server with `fastify.listen()` or 
 
 Uses **app.js** from the previous example.
 
-**test-listen.js** (testing with [`Request`](https://www.npmjs.com/package/request))
+**test-listen.js** (testing with [`Got`](https://www.npmjs.com/package/got))
 ```js
 const tap = require('tap')
-const request = require('request')
+const got = require('got')
 const buildFastify = require('./app')
 
-tap.test('GET `/` route', t => {
-  t.plan(5)
-  
+tap.test('GET `/` route', async t => {
   const fastify = buildFastify()
   
   t.tearDown(() => fastify.close())
   
-  fastify.listen(0, (err) => {
-    t.error(err)
-    
-    request({
-      method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port
-    }, (err, response, body) => {
-      t.error(err)
-      t.strictEqual(response.statusCode, 200)
-      t.strictEqual(response.headers['content-type'], 'application/json; charset=utf-8')
-      t.deepEqual(JSON.parse(body), { hello: 'world' })
-    })
-  })
+  try {
+    await fastify.listen(3000)
+    const response = await got('http://localhost:3000');
+    t.strictEqual(response.statusCode, 200)
+    t.strictEqual(response.headers['content-type'], 'application/json; charset=utf-8')
+    t.deepEqual(JSON.parse(response.body), { hello: 'world' })
+    t.end()
+  } catch (err) {
+     t.error(err)
+  }
 })
 ```
 

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -116,7 +116,7 @@ Fastify can also be tested after starting the server with `fastify.listen()` or 
 
 Uses **app.js** from the previous example.
 
-Let's compare 3 examples with different test frameworks:
+Let's compare 2 examples using different test frameworks:
 
 **test-listen.js** (with [`Got`](https://www.npmjs.com/package/got) & [`Tap`](https://www.npmjs.com/package/tap))
 ```js

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -150,21 +150,21 @@ const assert = require('assert').strict;
 
 
 describe('Fastify server tests', function() {
-    before(async function() {
-        await fastify.listen(0)
-    })
+  before(async function() {
+    await fastify.listen(0)
+  })
 
-    it('GET `/` route', async function() {
-        const response = await got(`http://localhost:${fastify.server.address().port}`)
+  it('GET `/` route', async function() {
+    const response = await got(`http://localhost:${fastify.server.address().port}`)
 
-        assert.equal(response.statusCode, 200, 'StatusCode is not 200')
-        assert.equal(response.headers['content-type'], 'application/json; charset=utf-8', 'Content-Type is not JSON')
-        assert.deepEqual(JSON.parse(response.body), { hello: 'world' }, 'Expected another body')
-    })
+    assert.equal(response.statusCode, 200, 'StatusCode is not 200')
+    assert.equal(response.headers['content-type'], 'application/json; charset=utf-8', 'Content-Type is not JSON')
+    assert.deepEqual(JSON.parse(response.body), { hello: 'world' }, 'Expected another body')
+  })
 
-    after(function() {
-        fastify.close()
-    })
+  after(function() {
+    fastify.close()
+  })
 });
 ```
 

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -719,21 +719,24 @@ test('decorate* should throw if called after ready', t => {
     })
   })
 
-  fastify.ready().then(() => {
-    try {
-      fastify.decorate('test', true)
-    } catch (e) {
-      t.is(e.message, "FST_ERR_DEC_AFTER_START: The decorator 'test' has been added after start!")
-    }
-    try {
-      fastify.decorateRequest('test', true)
-    } catch (e) {
-      t.is(e.message, "FST_ERR_DEC_AFTER_START: The decorator 'test' has been added after start!")
-    }
-    try {
-      fastify.decorateReply('test', true)
-    } catch (e) {
-      t.is(e.message, "FST_ERR_DEC_AFTER_START: The decorator 'test' has been added after start!")
-    }
-  })
+  fastify.listen(0)
+    .then(() => {
+      try {
+        fastify.decorate('test', true)
+      } catch (e) {
+        t.is(e.message, "FST_ERR_DEC_AFTER_START: The decorator 'test' has been added after start!")
+      }
+      try {
+        fastify.decorateRequest('test', true)
+      } catch (e) {
+        t.is(e.message, "FST_ERR_DEC_AFTER_START: The decorator 'test' has been added after start!")
+      }
+      try {
+        fastify.decorateReply('test', true)
+      } catch (e) {
+        t.is(e.message, "FST_ERR_DEC_AFTER_START: The decorator 'test' has been added after start!")
+      }
+      return fastify.close()
+    })
+    .catch(err => t.fail(err))
 })


### PR DESCRIPTION
Documentation uses "request" library to explain testing process.
But it's abandoned & shouldn't be used anymore.

I replaced that example with another popular library -  "got".