### PR TITLE
test for issue #2148 where typedefs for query params object were wrong

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "fast-json-stringify": "^1.18.0",
     "find-my-way": "^2.2.2",
     "flatstr": "^1.0.12",
-    "light-my-request": "^3.7.2",
+    "light-my-request": "^3.7.3",
     "middie": "^4.1.0",
     "pino": "^5.17.0",
     "proxy-addr": "^2.0.6",

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -627,6 +627,10 @@ server.inject({ url: '/testAgain' })
 server.inject({ url: '/testAgain' })
   .then((res: fastify.HTTPInjectResponse) => console.log(res.payload))
 
+// test query params
+server.inject({ url: '/testAgain', query: { param: 'value' } })
+  .then((res: LightMyRequest.Response) => console.log(res.payload))
+
 server.setSchemaCompiler(function (schema: object) {
   return () => true
 })


### PR DESCRIPTION
this is a breaking test that illustrates #2148 . It should pass once the issue is fixed
#### Checklist

- [x] run `npm run test` and `npm run benchmark` (fails obviously)
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
