### PR TITLE
add GH action benchmark

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,39 @@
+name: benchmark-on-command
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  on-master:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: master
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - run: npm install --ignore-scripts
+    - uses: Eomm/action-journalist@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        keywords: '["$run-benchmark"]'
+        command: npm run benchmark
+
+  on-issue:
+    needs: on-master
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - run: npm install --ignore-scripts
+    - uses: Eomm/action-journalist@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        keywords: '["$run-benchmark"]'
+        command: npm run benchmark

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fastify = require('../fastify')({
-  logger: true
+  logger: false
 })
 
 const schema = {


### PR DESCRIPTION
This action would like to be a utility to check roughly/fastest way the benchmark for some PR (like this one #1929)

So this action will run the bench on master and on the PR branch if we comment on the PR with the text `$run-benchmark`

Here an example of the output: https://github.com/Eomm/fastify/pull/2#issuecomment-602052050

I would test if this utility gives good data or not, but it should since the bench on https://github.com/fastify/benchmarks are run in GH

Ideas welcome!

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
