### PR TITLE
Exposed isNotFound is request object (#2143)

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -10,6 +10,7 @@ function Request (params, req, query, headers, log, ip, ips, hostname) {
   this.ip = ip
   this.ips = ips
   this.hostname = hostname
+  this.isNotFound = false
 }
 
 function buildRequest (R) {
@@ -23,6 +24,7 @@ function buildRequest (R) {
     this.ip = ip
     this.ips = ips
     this.hostname = hostname
+    this.isNotFound = false
   }
   _Request.prototype = new R()
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -29,6 +29,7 @@ const {
   kSchemaCompiler,
   kSchemaResolver,
   kContentTypeParser,
+  kFourOhFourContext,
   kReply,
   kReplySerializerDefault,
   kRequest,
@@ -342,6 +343,10 @@ function buildRouting (options) {
     var query = querystringParser(queryPrefix > -1 ? req.url.slice(queryPrefix + 1) : '')
     var request = new context.Request(params, req, query, req.headers, childLogger, ip, ips, hostname)
     var reply = new context.Reply(res, context, request, childLogger)
+
+    if (context[kFourOhFourContext] === null) {
+      request.isNotFound = true
+    }
 
     if (hasLogger === true || context.onResponse !== null) {
       setupResponseListeners(reply)

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -1156,7 +1156,7 @@ test('cannot set notFoundHandler after binding', t => {
     t.error(err)
 
     try {
-      fastify.setNotFoundHandler(() => { })
+      fastify.setNotFoundHandler(() => {})
       t.fail()
     } catch (e) {
       t.pass()
@@ -1565,6 +1565,36 @@ test('reply.notFound invoked the notFound handler', t => {
 
   fastify.inject({
     url: '/',
+    method: 'GET'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 404)
+    t.deepEqual(JSON.parse(res.payload), {
+      error: 'Not Found',
+      message: 'kaboom',
+      statusCode: 404
+    })
+  })
+})
+
+test('isNotFound should be present in request object and true if route doesn\'t exist', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  fastify.addHook('onRequest', (req, reply, done) => {
+    if (req.isNotFound) {
+      reply.code(404).send(new Error('kaboom'))
+    }
+    done()
+  })
+
+  fastify.get('/', function (req, reply) {
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.inject({
+    url: '/notFound',
     method: 'GET'
   }, (err, res) => {
     t.error(err)


### PR DESCRIPTION
Hi,

This is my first pull request so let me know if something isn't right.

The feature proposal in issue #2143 was to expose `isNotFound` in the request object. The variable default value is false and it is automatically set to true by checking the context on the route handler. 

It works like this:

```javascript
fastify.addHook('onRequest', (req, reply, done) => {
    if (req.isNotFound) {
      reply.code(404).send(new Error('kaboom'))
    }
    done()
  })

  fastify.get('/', function (req, reply) {
    reply.send({ hello: 'world' })
  })
```

Closes: #2143

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
