### PR TITLE
Add a getHeaders() method to Reply

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -8,6 +8,7 @@
   - [.header(key, value)](#headerkey-value)
   - [.headers(object)](#headersobject)
   - [.getHeader(key)](#getheaderkey)
+  - [.getHeaders()](#getheaders)
   - [.removeHeader(key)](#removeheaderkey)
   - [.hasHeader(key)](#hasheaderkey)
   - [.redirect(dest)](#redirectdest)
@@ -38,6 +39,7 @@ and properties:
 - `.header(name, value)` - Sets a response header.
 - `.headers(object)` - Sets all the keys of the object as a response headers.
 - `.getHeader(name)` - Retrieve value of already set header.
+- `.getHeaders()` - Gets a shallow copy of all current response headers.
 - `.removeHeader(key)` - Remove the value of a previously set header.
 - `.hasHeader(name)` - Determine if a header has been set.
 - `.type(value)` - Sets the header `Content-Type`.
@@ -106,6 +108,18 @@ Retrieves the value of a previously set header.
 ```js
 reply.header('x-foo', 'foo') // setHeader: key, value
 reply.getHeader('x-foo') // 'foo'
+```
+
+<a name="getHeaders"></a>
+### .getHeaders()
+
+Gets a shallow copy of all current response headers, including those set via the raw `http.ServerResponse`. Note that headers set via Fastify take precedence over those set via `http.ServerResponse`.
+
+```js
+reply.header('x-foo', 'foo')
+reply.header('x-bar', 'bar')
+reply.raw.setHeader('x-foo', 'foo2')
+reply.getHeaders() // { 'x-foo': 'foo', 'x-bar': 'bar' }
 ```
 
 <a name="getHeader"></a>

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -168,6 +168,13 @@ Reply.prototype.getHeader = function (key) {
   return value
 }
 
+Reply.prototype.getHeaders = function () {
+  return {
+    ...this.raw.getHeaders(),
+    ...this[kReplyHeaders]
+  }
+}
+
 Reply.prototype.hasHeader = function (key) {
   return this[kReplyHeaders][key.toLowerCase()] !== undefined
 }

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -766,6 +766,41 @@ test('reply.getHeader returns correct values', t => {
   })
 })
 
+test('reply.getHeaders returns correct values', t => {
+  t.plan(3)
+
+  const fastify = require('../../')()
+
+  fastify.get('/headers', function (req, reply) {
+    reply.header('x-foo', 'foo')
+
+    t.strictDeepEqual(reply.getHeaders(), {
+      'x-foo': 'foo'
+    })
+
+    reply.header('x-bar', 'bar')
+    reply.raw.setHeader('x-foo', 'foo2')
+    reply.raw.setHeader('x-baz', 'baz')
+
+    t.strictDeepEqual(reply.getHeaders(), {
+      'x-foo': 'foo',
+      'x-bar': 'bar',
+      'x-baz': 'baz'
+    })
+
+    reply.send()
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port + '/headers'
+    }, () => {})
+  })
+})
+
 test('reply.removeHeader can remove the value', t => {
   t.plan(5)
 

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -791,13 +791,8 @@ test('reply.getHeaders returns correct values', t => {
     reply.send()
   })
 
-  fastify.listen(0, err => {
+  fastify.inject('/headers', (err) => {
     t.error(err)
-    fastify.server.unref()
-    sget({
-      method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port + '/headers'
-    }, () => {})
   })
 })
 

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -15,6 +15,10 @@ export type FastifyReply<
   hasHeader(key: string): boolean;
   header(key: string, value: any): FastifyReply<RawServer, RawReply>;
   getHeader(key: string): string | undefined;
+  getHeaders(): {
+    // Node's `getHeaders()` can return numbers and arrays, so they're included here as possible types.
+    [key: string]: number | string | string[] | undefined;
+  };
   // Note: should consider refactoring the argument order for redirect. statusCode is optional so it should be after the required url param
   redirect(statusCode: number, url: string): FastifyReply<RawServer, RawReply>;
   redirect(url: string): FastifyReply<RawServer, RawReply>;


### PR DESCRIPTION
This adds a `getHeaders()` method to Reply.

It returns a shallow copy of all current response headers, including those set via the raw `http.ServerResponse`. Headers set via Fastify take precedence over those set via `http.ServerResponse` to match the behavior of `res.writeHead()`.

See https://github.com/fastify/fastify-nextjs/issues/84 for an example of a use case that would benefit from this feature.

Some things to note:

-   I've opened this PR against the `next` branch because it relies on `http.ServerResponse`'s [`getHeaders()` method](https://nodejs.org/dist/latest-v12.x/docs/api/http.html#http_response_getheaders), which was added in Node 7.7.0. I'm not sure if there's a way to do this that's compatible with Node 6.x, but I'm open to suggestions!

-   Node's `getHeaders()` returns an object without a prototype, but this method returns a normal object with a prototype since that's how headers are stored internally. Would it be preferable to match Node's behavior?

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
