### PR TITLE
Replace greenkeeper with dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,24 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "daily"
+    ignored_updates:
+      - match:
+          dependency_name: "autocannon"
+      - match:
+          dependency_name: "boom"
+      - match:
+          dependency_name: "joi"
+      - match:
+          dependency_name: "@types/*"
+      - match:
+          dependency_name: "semver"
+      - match:
+          dependency_name: "tap"
+      - match:
+          dependency_name: "tap-mocha-reporter"
+      - match:
+          dependency_name: "@typescript-eslint/eslint-plugin"
+      - match:
+          dependency_name: "lolex"

--- a/package.json
+++ b/package.json
@@ -154,19 +154,6 @@
     "secure-json-parse": "^2.1.0",
     "tiny-lru": "^7.0.2"
   },
-  "greenkeeper": {
-    "ignore": [
-      "autocannon",
-      "boom",
-      "joi",
-      "@types/node",
-      "semver",
-      "tap",
-      "tap-mocha-reporter",
-      "@typescript-eslint/eslint-plugin",
-      "lolex"
-    ]
-  },
   "standard": {
     "ignore": [
       "lib/configValidator.js"


### PR DESCRIPTION
greenkpeer is shutting down, let's move to dependabot

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
