### PR TITLE
fix inject response types

### DIFF
--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -1,4 +1,4 @@
-import { InjectOptions, InjectPayload } from 'light-my-request'
+import { InjectOptions, Response as LightMyRequestResponse, CallbackFunc as LightMyRequestCallback } from 'light-my-request'
 import { RouteOptions, RouteShorthandMethod } from './route'
 import { FastifySchema, FastifySchemaCompiler } from './schema'
 import { RawServerBase, RawRequestDefaultExpression, RawServerDefault, RawReplyDefaultExpression, ContextConfigDefault } from './utils'
@@ -39,8 +39,8 @@ export interface FastifyInstance<
   hasRequestDecorator(decorator: string | symbol): boolean;
   hasReplyDecorator(decorator: string | symbol): boolean;
 
-  inject(opts: InjectOptions | string, cb: (err: Error, response: InjectPayload) => void): void;
-  inject(opts: InjectOptions | string): Promise<InjectPayload>;
+  inject(opts: InjectOptions | string, cb: LightMyRequestCallback): void;
+  inject(opts: InjectOptions | string): Promise<LightMyRequestResponse>;
 
   listen(port: number, address: string, backlog: number, callback: (err: Error, address: string) => void): void;
   listen(port: number, address: string, callback: (err: Error, address: string) => void): void;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)


I noticed that `fastify.inject` wasn't returning the right thing. Fixed it to use the correct types from light-my-request. 