### PR TITLE
change *compiler api

### DIFF
--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -51,8 +51,8 @@ They need to be in
 * `onSend(request, reply, payload, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#route-hooks) called right before a response is sent, it could also be an array of functions.
 * `onResponse(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#onresponse) called when a response has been sent, so you will not be able to send more data to the client. It could also be an array of functions.
 * `handler(request, reply)`: the function that will handle this request.
-* `validatorCompiler(schema, method, url, httpPart)`: function that builds schemas for request validations. See the [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-validator) documentation.
-* `serializerCompiler(schema, method, url, httpPart)`: function that builds schemas for response serialization. See the [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-serializer) documentation.
+* `validatorCompiler({ schema, method, url, httpPart })`: function that builds schemas for request validations. See the [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-validator) documentation.
+* `serializerCompiler({ { schema, method, url, httpStatus } })`: function that builds schemas for response serialization. See the [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-serializer) documentation.
 * `bodyLimit`: prevents the default JSON body parser from parsing request bodies larger than this number of bytes. Must be an integer. You may also set this option globally when first creating the Fastify instance with `fastify(options)`. Defaults to `1048576` (1 MiB).
 * `logLevel`: set log level for this route. See below.
 * `logSerializers`: set serializers to log for this route.

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -51,8 +51,8 @@ They need to be in
 * `onSend(request, reply, payload, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#route-hooks) called right before a response is sent, it could also be an array of functions.
 * `onResponse(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#onresponse) called when a response has been sent, so you will not be able to send more data to the client. It could also be an array of functions.
 * `handler(request, reply)`: the function that will handle this request.
-* `validatorCompiler(method, url, httpPart, schema)`: function that builds schemas for request validations. See the [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-validator) documentation.
-* `serializerCompiler(method, url, httpPart, schema)`: function that builds schemas for response serialization. See the [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-serializer) documentation.
+* `validatorCompiler(schema, method, url, httpPart)`: function that builds schemas for request validations. See the [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-validator) documentation.
+* `serializerCompiler(schema, method, url, httpPart)`: function that builds schemas for response serialization. See the [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-serializer) documentation.
 * `bodyLimit`: prevents the default JSON body parser from parsing request bodies larger than this number of bytes. Must be an integer. You may also set this option globally when first creating the Fastify instance with `fastify(options)`. Defaults to `1048576` (1 MiB).
 * `logLevel`: set log level for this route. See below.
 * `logSerializers`: set serializers to log for this route.

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -762,12 +762,12 @@ Set the schema serializer compiler for all routes. See [#schema-serializer](http
 
 <a name="validator-compiler"></a>
 #### validatorCompiler
-This property can be used to get the schema validator. If not set, it will be `null` until the server starts, then it will be a function with the signature `function (schema, method, url, httpPart)` that returns the input `schema` compiled to a function for validating data.
+This property can be used to get the schema validator. If not set, it will be `null` until the server starts, then it will be a function with the signature `function ({ schema, method, url, httpPart })` that returns the input `schema` compiled to a function for validating data.
 The input `schema` can access all the shared schemas added with [`.addSchema`](#add-schema) function.
 
 <a name="serializer-compiler"></a>
 #### serializerCompiler
-This property can be used to get the schema serializer. If not set, it will be `null` until the server starts, then it will be a function with the signature `function (schema, method, url, httpPart)` that returns the input `schema` compiled to a function for validating data.
+This property can be used to get the schema serializer. If not set, it will be `null` until the server starts, then it will be a function with the signature `function ({ schema, method, url, httpPart })` that returns the input `schema` compiled to a function for validating data.
 The input `schema` can access all the shared schemas added with [`.addSchema`](#add-schema) function.
 
 <a name="set-not-found-handler"></a>

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -762,12 +762,12 @@ Set the schema serializer compiler for all routes. See [#schema-serializer](http
 
 <a name="validator-compiler"></a>
 #### validatorCompiler
-This property can be used to get the schema validator. If not set, it will be `null` until the server starts, then it will be a function with the signature `function (method, url, httpPart, schema)` that returns the input `schema` compiled to a function for validating data.
+This property can be used to get the schema validator. If not set, it will be `null` until the server starts, then it will be a function with the signature `function (schema, method, url, httpPart)` that returns the input `schema` compiled to a function for validating data.
 The input `schema` can access all the shared schemas added with [`.addSchema`](#add-schema) function.
 
 <a name="serializer-compiler"></a>
 #### serializerCompiler
-This property can be used to get the schema serializer. If not set, it will be `null` until the server starts, then it will be a function with the signature `function (method, url, httpPart, schema)` that returns the input `schema` compiled to a function for validating data.
+This property can be used to get the schema serializer. If not set, it will be `null` until the server starts, then it will be a function with the signature `function (schema, method, url, httpPart)` that returns the input `schema` compiled to a function for validating data.
 The input `schema` can access all the shared schemas added with [`.addSchema`](#add-schema) function.
 
 <a name="set-not-found-handler"></a>

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -292,7 +292,7 @@ const ajv = new Ajv({
   // any other options
   // ...
 })
-fastify.setValidatorCompiler((method, url, httpPart, schema) => {
+fastify.setValidatorCompiler((schema, method, url, httpPart) => {
   return ajv.compile(schema)
 })
 ```
@@ -312,7 +312,7 @@ fastify.post('/the/url', {
       hello: Joi.string().required()
     }).required()
   },
-  validatorCompiler: (method, url, httpPart, schema) => {
+  validatorCompiler: (schema, method, url, httpPart) => {
     return (data) => Joi.validate(data, schema)
   }
 }, handler)
@@ -337,7 +337,7 @@ fastify.post('/the/url', {
       }).required()
     })
   },
-  validatorCompiler: (method, url, httpPart, schema) => {
+  validatorCompiler: (schema, method, url, httpPart) => {
     return function (data) {
       // with option strict = false, yup `validateSync` function returns the coerced value if validation was successful, or throws if validation failed
       try {
@@ -445,7 +445,7 @@ fastify.post('/the/url', { schema }, handler)
 The `serializerCompiler` is a function that returns a function that must return a string from an input object. You must provide a function to serialize every route where you have defined a `response` JSON Schema.
 
 ```js
-fastify.setSerializerCompiler((method, url, httpPart, schema) => {
+fastify.setSerializerCompiler((schema, method, url, httpStatus) => {
   return data => JSON.stringify(data)
 })
 

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -292,7 +292,7 @@ const ajv = new Ajv({
   // any other options
   // ...
 })
-fastify.setValidatorCompiler((schema, method, url, httpPart) => {
+fastify.setValidatorCompiler(({ schema, method, url, httpPart }) => {
   return ajv.compile(schema)
 })
 ```
@@ -312,7 +312,7 @@ fastify.post('/the/url', {
       hello: Joi.string().required()
     }).required()
   },
-  validatorCompiler: (schema, method, url, httpPart) => {
+  validatorCompiler: ({ schema, method, url, httpPart }) => {
     return (data) => Joi.validate(data, schema)
   }
 }, handler)
@@ -337,7 +337,7 @@ fastify.post('/the/url', {
       }).required()
     })
   },
-  validatorCompiler: (schema, method, url, httpPart) => {
+  validatorCompiler: ({ schema, method, url, httpPart }) => {
     return function (data) {
       // with option strict = false, yup `validateSync` function returns the coerced value if validation was successful, or throws if validation failed
       try {
@@ -445,7 +445,7 @@ fastify.post('/the/url', { schema }, handler)
 The `serializerCompiler` is a function that returns a function that must return a string from an input object. You must provide a function to serialize every route where you have defined a `response` JSON Schema.
 
 ```js
-fastify.setSerializerCompiler((schema, method, url, httpStatus) => {
+fastify.setSerializerCompiler(({ schema, method, url, httpStatus }) => {
   return data => JSON.stringify(data)
 })
 

--- a/lib/schema-compilers.js
+++ b/lib/schema-compilers.js
@@ -43,13 +43,13 @@ function ValidatorCompiler (externalSchemas, options, cache) {
 
   Object.values(externalSchemas).forEach(s => ajv.addSchema(s))
 
-  return (schema, method, url, httpPart) => {
+  return ({ schema, method, url, httpPart }) => {
     return ajv.compile(schema)
   }
 }
 
 function SerializerCompiler (externalSchemas) {
-  return function (schema, method, url, httpStatus) {
+  return function ({ schema, method, url, httpStatus }) {
     return fastJsonStringify(schema, { schema: externalSchemas })
   }
 }

--- a/lib/schema-compilers.js
+++ b/lib/schema-compilers.js
@@ -43,13 +43,13 @@ function ValidatorCompiler (externalSchemas, options, cache) {
 
   Object.values(externalSchemas).forEach(s => ajv.addSchema(s))
 
-  return (method, url, httpPart, schema) => {
+  return (schema, method, url, httpPart) => {
     return ajv.compile(schema)
   }
 }
 
 function SerializerCompiler (externalSchemas) {
-  return function (method, url, httpStatus, schema) {
+  return function (schema, method, url, httpStatus) {
     return fastJsonStringify(schema, { schema: externalSchemas })
   }
 }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -15,7 +15,7 @@ function compileSchemasForSerialization (context, compile) {
   const { method, url } = context.config || {}
   context[responseSchema] = Object.keys(context.schema.response)
     .reduce(function (acc, statusCode) {
-      acc[statusCode] = compile(method, url, statusCode, context.schema.response[statusCode])
+      acc[statusCode] = compile(context.schema.response[statusCode], method, url, statusCode)
       return acc
     }, {})
 }
@@ -45,19 +45,19 @@ function compileSchemasForValidation (context, compile) {
         headersSchemaLowerCase.properties[k.toLowerCase()] = headers.properties[k]
       })
     }
-    context[headersSchema] = compile(method, url, 'headers', headersSchemaLowerCase)
+    context[headersSchema] = compile(headersSchemaLowerCase, method, url, 'headers')
   }
 
   if (context.schema.body) {
-    context[bodySchema] = compile(method, url, 'body', context.schema.body)
+    context[bodySchema] = compile(context.schema.body, method, url, 'body')
   }
 
   if (context.schema.querystring) {
-    context[querystringSchema] = compile(method, url, 'querystring', context.schema.querystring)
+    context[querystringSchema] = compile(context.schema.querystring, method, url, 'querystring')
   }
 
   if (context.schema.params) {
-    context[paramsSchema] = compile(method, url, 'params', context.schema.params)
+    context[paramsSchema] = compile(context.schema.params, method, url, 'params')
   }
 }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -30,7 +30,7 @@ function compileSchemasForValidation (context, compile) {
   const headers = context.schema.headers
   if (headers && Object.getPrototypeOf(headers) !== Object.prototype) {
     // do not mess with non-literals, e.g. Joi schemas
-    context[headersSchema] = compile(method, url, 'headers', headers)
+    context[headersSchema] = compile(headers, method, url, 'headers')
   } else if (headers) {
     // The header keys are case insensitive
     //  https://tools.ietf.org/html/rfc2616#section-4.2

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -15,7 +15,12 @@ function compileSchemasForSerialization (context, compile) {
   const { method, url } = context.config || {}
   context[responseSchema] = Object.keys(context.schema.response)
     .reduce(function (acc, statusCode) {
-      acc[statusCode] = compile(context.schema.response[statusCode], method, url, statusCode)
+      acc[statusCode] = compile({
+        schema: context.schema.response[statusCode],
+        url,
+        method,
+        httpStatus: statusCode
+      })
       return acc
     }, {})
 }
@@ -30,7 +35,7 @@ function compileSchemasForValidation (context, compile) {
   const headers = context.schema.headers
   if (headers && Object.getPrototypeOf(headers) !== Object.prototype) {
     // do not mess with non-literals, e.g. Joi schemas
-    context[headersSchema] = compile(headers, method, url, 'headers')
+    context[headersSchema] = compile({ schema: headers, method, url, httpPart: 'headers' })
   } else if (headers) {
     // The header keys are case insensitive
     //  https://tools.ietf.org/html/rfc2616#section-4.2
@@ -45,19 +50,19 @@ function compileSchemasForValidation (context, compile) {
         headersSchemaLowerCase.properties[k.toLowerCase()] = headers.properties[k]
       })
     }
-    context[headersSchema] = compile(headersSchemaLowerCase, method, url, 'headers')
+    context[headersSchema] = compile({ schema: headersSchemaLowerCase, method, url, httpPart: 'headers' })
   }
 
   if (context.schema.body) {
-    context[bodySchema] = compile(context.schema.body, method, url, 'body')
+    context[bodySchema] = compile({ schema: context.schema.body, method, url, httpPart: 'body' })
   }
 
   if (context.schema.querystring) {
-    context[querystringSchema] = compile(context.schema.querystring, method, url, 'querystring')
+    context[querystringSchema] = compile({ schema: context.schema.querystring, method, url, httpPart: 'querystring' })
   }
 
   if (context.schema.params) {
-    context[paramsSchema] = compile(context.schema.params, method, url, 'params')
+    context[paramsSchema] = compile({ schema: context.schema.params, method, url, httpPart: 'params' })
   }
 }
 

--- a/test/input-validation.js
+++ b/test/input-validation.js
@@ -37,7 +37,7 @@ module.exports.payloadMethod = function (method, t) {
         additionalProperties: false
       }
     },
-    validatorCompiler: function (method, url, httpPart, schema) {
+    validatorCompiler: function (schema, method, url, httpPart) {
       return ajv.compile(schema)
     }
   }
@@ -48,7 +48,7 @@ module.exports.payloadMethod = function (method, t) {
         hello: Joi.string().required()
       }).required()
     },
-    validatorCompiler: function (method, url, httpPart, schema) {
+    validatorCompiler: function (schema, method, url, httpPart) {
       return schema.validate.bind(schema)
     }
   }
@@ -66,7 +66,7 @@ module.exports.payloadMethod = function (method, t) {
         hello: yup.string().required()
       }).required()
     },
-    validatorCompiler: function (method, url, httpPart, schema) {
+    validatorCompiler: function (schema, method, url, httpPart) {
       return data => {
         try {
           const result = schema.validateSync(data, yupOptions)
@@ -95,7 +95,7 @@ module.exports.payloadMethod = function (method, t) {
       })
 
       fastify.register(function (fastify2, opts, next) {
-        fastify2.setValidatorCompiler(function schema (method, url, httpPart, schema) {
+        fastify2.setValidatorCompiler(function schema (schema, method, url, httpPart) {
           return body => ({ error: new Error('From custom schema compiler!') })
         })
         const withInstanceCustomCompiler = {
@@ -117,7 +117,7 @@ module.exports.payloadMethod = function (method, t) {
               additionalProperties: false
             }
           },
-          validatorCompiler: function (method, url, httpPart, schema) {
+          validatorCompiler: function (schema, method, url, httpPart) {
             return function (body) {
               return { error: new Error('Always fail!') }
             }

--- a/test/input-validation.js
+++ b/test/input-validation.js
@@ -37,7 +37,7 @@ module.exports.payloadMethod = function (method, t) {
         additionalProperties: false
       }
     },
-    validatorCompiler: function (schema, method, url, httpPart) {
+    validatorCompiler: function ({ schema, method, url, httpPart }) {
       return ajv.compile(schema)
     }
   }
@@ -48,7 +48,7 @@ module.exports.payloadMethod = function (method, t) {
         hello: Joi.string().required()
       }).required()
     },
-    validatorCompiler: function (schema, method, url, httpPart) {
+    validatorCompiler: function ({ schema, method, url, httpPart }) {
       return schema.validate.bind(schema)
     }
   }
@@ -66,7 +66,7 @@ module.exports.payloadMethod = function (method, t) {
         hello: yup.string().required()
       }).required()
     },
-    validatorCompiler: function (schema, method, url, httpPart) {
+    validatorCompiler: function ({ schema, method, url, httpPart }) {
       return data => {
         try {
           const result = schema.validateSync(data, yupOptions)
@@ -95,7 +95,7 @@ module.exports.payloadMethod = function (method, t) {
       })
 
       fastify.register(function (fastify2, opts, next) {
-        fastify2.setValidatorCompiler(function schema (schema, method, url, httpPart) {
+        fastify2.setValidatorCompiler(function schema ({ schema, method, url, httpPart }) {
           return body => ({ error: new Error('From custom schema compiler!') })
         })
         const withInstanceCustomCompiler = {
@@ -117,7 +117,7 @@ module.exports.payloadMethod = function (method, t) {
               additionalProperties: false
             }
           },
-          validatorCompiler: function (schema, method, url, httpPart) {
+          validatorCompiler: function ({ schema, method, url, httpPart }) {
             return function (body) {
               return { error: new Error('Always fail!') }
             }

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -11,7 +11,7 @@ const sget = require('simple-get').concat
 const Ajv = require('ajv')
 const ajv = new Ajv({ coerceTypes: true })
 
-function schemaValidator (schema, method, url, httpPart) {
+function schemaValidator ({ schema, method, url, httpPart }) {
   const validateFuncion = ajv.compile(schema)
   const fn = function (body) {
     const isOk = validateFuncion(body)

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -11,7 +11,7 @@ const sget = require('simple-get').concat
 const Ajv = require('ajv')
 const ajv = new Ajv({ coerceTypes: true })
 
-function schemaValidator (method, url, httpPart, schema) {
+function schemaValidator (schema, method, url, httpPart) {
   const validateFuncion = ajv.compile(schema)
   const fn = function (body) {
     const isOk = validateFuncion(body)

--- a/test/internals/validation.test.js
+++ b/test/internals/validation.test.js
@@ -57,7 +57,7 @@ test('build schema - output schema', t => {
       }
     }
   }
-  validation.compileSchemasForSerialization(opts, (method, url, httpPart, schema) => ajv.compile(schema))
+  validation.compileSchemasForSerialization(opts, (schema, method, url, httpPart) => ajv.compile(schema))
   t.is(typeof opts[symbols.responseSchema]['2xx'], 'function')
   t.is(typeof opts[symbols.responseSchema]['201'], 'function')
 })
@@ -74,7 +74,7 @@ test('build schema - payload schema', t => {
       }
     }
   }
-  validation.compileSchemasForValidation(opts, (method, url, httpPart, schema) => ajv.compile(schema))
+  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => ajv.compile(schema))
   t.is(typeof opts[symbols.bodySchema], 'function')
 })
 
@@ -91,7 +91,7 @@ test('build schema - query schema', t => {
     }
   }
   opts.schema = normalizeSchema(opts.schema)
-  validation.compileSchemasForValidation(opts, (method, url, httpPart, schema) => ajv.compile(schema))
+  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => ajv.compile(schema))
   t.type(opts[symbols.querystringSchema].schema.type, 'string')
   t.is(typeof opts[symbols.querystringSchema], 'function')
 })
@@ -106,7 +106,7 @@ test('build schema - query schema abbreviated', t => {
     }
   }
   opts.schema = normalizeSchema(opts.schema)
-  validation.compileSchemasForValidation(opts, (method, url, httpPart, schema) => ajv.compile(schema))
+  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => ajv.compile(schema))
   t.type(opts[symbols.querystringSchema].schema.type, 'string')
   t.is(typeof opts[symbols.querystringSchema], 'function')
 })
@@ -123,7 +123,7 @@ test('build schema - querystring schema', t => {
       }
     }
   }
-  validation.compileSchemasForValidation(opts, (method, url, httpPart, schema) => ajv.compile(schema))
+  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => ajv.compile(schema))
   t.type(opts[symbols.querystringSchema].schema.type, 'string')
   t.is(typeof opts[symbols.querystringSchema], 'function')
 })
@@ -138,7 +138,7 @@ test('build schema - querystring schema abbreviated', t => {
     }
   }
   opts.schema = normalizeSchema(opts.schema)
-  validation.compileSchemasForValidation(opts, (method, url, httpPart, schema) => ajv.compile(schema))
+  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => ajv.compile(schema))
   t.type(opts[symbols.querystringSchema].schema.type, 'string')
   t.is(typeof opts[symbols.querystringSchema], 'function')
 })
@@ -181,7 +181,7 @@ test('build schema - params schema', t => {
       }
     }
   }
-  validation.compileSchemasForValidation(opts, (method, url, httpPart, schema) => ajv.compile(schema))
+  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => ajv.compile(schema))
   t.is(typeof opts[symbols.paramsSchema], 'function')
 })
 
@@ -197,7 +197,7 @@ test('build schema - headers schema', t => {
       }
     }
   }
-  validation.compileSchemasForValidation(opts, (method, url, httpPart, schema) => ajv.compile(schema))
+  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => ajv.compile(schema))
   t.is(typeof opts[symbols.headersSchema], 'function')
 })
 
@@ -213,7 +213,7 @@ test('build schema - headers are lowercase', t => {
       }
     }
   }
-  validation.compileSchemasForValidation(opts, (method, url, httpPart, schema) => {
+  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => {
     t.ok(schema.properties['content-type'], 'lowercase content-type exists')
     return () => {}
   })
@@ -228,7 +228,7 @@ test('build schema - headers are not lowercased in case of custom object', t => 
       headers: new Headers()
     }
   }
-  validation.compileSchemasForValidation(opts, (method, url, httpPart, schema) => {
+  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => {
     t.type(schema, Headers)
     return () => {}
   })
@@ -246,7 +246,7 @@ test('build schema - uppercased headers are not included', t => {
       }
     }
   }
-  validation.compileSchemasForValidation(opts, (method, url, httpPart, schema) => {
+  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => {
     t.notOk('Content-Type' in schema.properties, 'uppercase does not exist')
     return () => {}
   })

--- a/test/internals/validation.test.js
+++ b/test/internals/validation.test.js
@@ -57,7 +57,7 @@ test('build schema - output schema', t => {
       }
     }
   }
-  validation.compileSchemasForSerialization(opts, (schema, method, url, httpPart) => ajv.compile(schema))
+  validation.compileSchemasForSerialization(opts, ({ schema, method, url, httpPart }) => ajv.compile(schema))
   t.is(typeof opts[symbols.responseSchema]['2xx'], 'function')
   t.is(typeof opts[symbols.responseSchema]['201'], 'function')
 })
@@ -74,7 +74,7 @@ test('build schema - payload schema', t => {
       }
     }
   }
-  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => ajv.compile(schema))
+  validation.compileSchemasForValidation(opts, ({ schema, method, url, httpPart }) => ajv.compile(schema))
   t.is(typeof opts[symbols.bodySchema], 'function')
 })
 
@@ -91,7 +91,7 @@ test('build schema - query schema', t => {
     }
   }
   opts.schema = normalizeSchema(opts.schema)
-  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => ajv.compile(schema))
+  validation.compileSchemasForValidation(opts, ({ schema, method, url, httpPart }) => ajv.compile(schema))
   t.type(opts[symbols.querystringSchema].schema.type, 'string')
   t.is(typeof opts[symbols.querystringSchema], 'function')
 })
@@ -106,7 +106,7 @@ test('build schema - query schema abbreviated', t => {
     }
   }
   opts.schema = normalizeSchema(opts.schema)
-  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => ajv.compile(schema))
+  validation.compileSchemasForValidation(opts, ({ schema, method, url, httpPart }) => ajv.compile(schema))
   t.type(opts[symbols.querystringSchema].schema.type, 'string')
   t.is(typeof opts[symbols.querystringSchema], 'function')
 })
@@ -123,7 +123,7 @@ test('build schema - querystring schema', t => {
       }
     }
   }
-  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => ajv.compile(schema))
+  validation.compileSchemasForValidation(opts, ({ schema, method, url, httpPart }) => ajv.compile(schema))
   t.type(opts[symbols.querystringSchema].schema.type, 'string')
   t.is(typeof opts[symbols.querystringSchema], 'function')
 })
@@ -138,7 +138,7 @@ test('build schema - querystring schema abbreviated', t => {
     }
   }
   opts.schema = normalizeSchema(opts.schema)
-  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => ajv.compile(schema))
+  validation.compileSchemasForValidation(opts, ({ schema, method, url, httpPart }) => ajv.compile(schema))
   t.type(opts[symbols.querystringSchema].schema.type, 'string')
   t.is(typeof opts[symbols.querystringSchema], 'function')
 })
@@ -181,7 +181,7 @@ test('build schema - params schema', t => {
       }
     }
   }
-  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => ajv.compile(schema))
+  validation.compileSchemasForValidation(opts, ({ schema, method, url, httpPart }) => ajv.compile(schema))
   t.is(typeof opts[symbols.paramsSchema], 'function')
 })
 
@@ -197,7 +197,7 @@ test('build schema - headers schema', t => {
       }
     }
   }
-  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => ajv.compile(schema))
+  validation.compileSchemasForValidation(opts, ({ schema, method, url, httpPart }) => ajv.compile(schema))
   t.is(typeof opts[symbols.headersSchema], 'function')
 })
 
@@ -213,7 +213,7 @@ test('build schema - headers are lowercase', t => {
       }
     }
   }
-  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => {
+  validation.compileSchemasForValidation(opts, ({ schema, method, url, httpPart }) => {
     t.ok(schema.properties['content-type'], 'lowercase content-type exists')
     return () => {}
   })
@@ -228,7 +228,7 @@ test('build schema - headers are not lowercased in case of custom object', t => 
       headers: new Headers()
     }
   }
-  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => {
+  validation.compileSchemasForValidation(opts, ({ schema, method, url, httpPart }) => {
     t.type(schema, Headers)
     return () => {}
   })
@@ -246,7 +246,7 @@ test('build schema - uppercased headers are not included', t => {
       }
     }
   }
-  validation.compileSchemasForValidation(opts, (schema, method, url, httpPart) => {
+  validation.compileSchemasForValidation(opts, ({ schema, method, url, httpPart }) => {
     t.notOk('Content-Type' in schema.properties, 'uppercase does not exist')
     return () => {}
   })

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -261,7 +261,7 @@ test('does not mutate joi schemas', t => {
   t.plan(4)
 
   const fastify = Fastify()
-  function validatorCompiler (method, url, httpPart, schema) {
+  function validatorCompiler (schema, method, url, httpPart) {
     // Needed to extract the params part,
     // without the JSON-schema encapsulation
     // that is automatically added by the short

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -261,7 +261,7 @@ test('does not mutate joi schemas', t => {
   t.plan(4)
 
   const fastify = Fastify()
-  function validatorCompiler (schema, method, url, httpPart) {
+  function validatorCompiler ({ schema, method, url, httpPart }) {
     // Needed to extract the params part,
     // without the JSON-schema encapsulation
     // that is automatically added by the short

--- a/test/schema-examples.test.js
+++ b/test/schema-examples.test.js
@@ -230,7 +230,7 @@ test('Example Joi', t => {
         hello: Joi.string().required()
       }).required()
     },
-    validatorCompiler: (method, url, httpPart, schema) => {
+    validatorCompiler: (schema, method, url, httpPart) => {
       return (data) => Joi.validate(data, schema)
     }
   }, handler)
@@ -261,7 +261,7 @@ test('Example yup', t => {
         }).required()
       })
     },
-    validatorCompiler: (method, url, httpPart, schema) => {
+    validatorCompiler: (schema, method, url, httpPart) => {
       return function (data) {
         // with option strict = false, yup `validateSync` function returns the coerced value if validation was successful, or throws if validation failed
         try {
@@ -327,7 +327,7 @@ test('Example - serializator', t => {
   t.plan(1)
   const fastify = Fastify()
 
-  fastify.setSerializerCompiler((method, url, httpPart, schema) => {
+  fastify.setSerializerCompiler((schema, method, url, httpStatus) => {
     return data => JSON.stringify(data)
   })
 

--- a/test/schema-examples.test.js
+++ b/test/schema-examples.test.js
@@ -230,7 +230,7 @@ test('Example Joi', t => {
         hello: Joi.string().required()
       }).required()
     },
-    validatorCompiler: (schema, method, url, httpPart) => {
+    validatorCompiler: ({ schema, method, url, httpPart }) => {
       return (data) => Joi.validate(data, schema)
     }
   }, handler)
@@ -261,7 +261,7 @@ test('Example yup', t => {
         }).required()
       })
     },
-    validatorCompiler: (schema, method, url, httpPart) => {
+    validatorCompiler: ({ schema, method, url, httpPart }) => {
       return function (data) {
         // with option strict = false, yup `validateSync` function returns the coerced value if validation was successful, or throws if validation failed
         try {
@@ -327,7 +327,7 @@ test('Example - serializator', t => {
   t.plan(1)
   const fastify = Fastify()
 
-  fastify.setSerializerCompiler((schema, method, url, httpStatus) => {
+  fastify.setSerializerCompiler(({ schema, method, url, httpStatus }) => {
     return data => JSON.stringify(data)
   })
 

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -100,8 +100,8 @@ test('Get compilers is empty when settle on routes', t => {
       body: { type: 'object', properties: { hello: { type: 'string' } } },
       response: { '2xx': { foo: { type: 'array', items: { type: 'string' } } } }
     },
-    validatorCompiler: (method, url, httpPart, schema) => {},
-    serializerCompiler: (method, url, httpPart, schema) => {}
+    validatorCompiler: (schema, method, url, httpPart) => {},
+    serializerCompiler: (schema, method, url, httpPart) => {}
   }, function (req, reply) {
     reply.send('ok')
   })
@@ -279,7 +279,7 @@ test('Customize validator compiler in instance and route', t => {
   t.plan(28)
   const fastify = Fastify()
 
-  fastify.setValidatorCompiler((method, url, httpPart, schema) => {
+  fastify.setValidatorCompiler((schema, method, url, httpPart) => {
     t.equals(method, 'POST') // run 4 times
     t.equals(url, '/:id') // run 4 times
     switch (httpPart) {
@@ -330,7 +330,7 @@ test('Customize validator compiler in instance and route', t => {
 
   fastify.get('/wow/:id', {
     handler: echoParams,
-    validatorCompiler: (method, url, httpPart, schema) => {
+    validatorCompiler: (schema, method, url, httpPart) => {
       t.equals(method, 'GET') // run 3 times (params, headers, query)
       t.equals(url, '/wow/:id') // run 4 times
       return () => { return true } // ignore the validation

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -100,8 +100,8 @@ test('Get compilers is empty when settle on routes', t => {
       body: { type: 'object', properties: { hello: { type: 'string' } } },
       response: { '2xx': { foo: { type: 'array', items: { type: 'string' } } } }
     },
-    validatorCompiler: (schema, method, url, httpPart) => {},
-    serializerCompiler: (schema, method, url, httpPart) => {}
+    validatorCompiler: ({ schema, method, url, httpPart }) => {},
+    serializerCompiler: ({ schema, method, url, httpPart }) => {}
   }, function (req, reply) {
     reply.send('ok')
   })
@@ -279,7 +279,7 @@ test('Customize validator compiler in instance and route', t => {
   t.plan(28)
   const fastify = Fastify()
 
-  fastify.setValidatorCompiler((schema, method, url, httpPart) => {
+  fastify.setValidatorCompiler(({ schema, method, url, httpPart }) => {
     t.equals(method, 'POST') // run 4 times
     t.equals(url, '/:id') // run 4 times
     switch (httpPart) {
@@ -330,7 +330,7 @@ test('Customize validator compiler in instance and route', t => {
 
   fastify.get('/wow/:id', {
     handler: echoParams,
-    validatorCompiler: (schema, method, url, httpPart) => {
+    validatorCompiler: ({ schema, method, url, httpPart }) => {
       t.equals(method, 'GET') // run 3 times (params, headers, query)
       t.equals(url, '/wow/:id') // run 4 times
       return () => { return true } // ignore the validation

--- a/test/schema-serialization.test.js
+++ b/test/schema-serialization.test.js
@@ -262,10 +262,10 @@ test('Custom setSerializerCompiler', t => {
     whatever: 'need to be parsed by the custom serializer'
   }
 
-  fastify.setSerializerCompiler((method, url, httpPart, schema) => {
+  fastify.setSerializerCompiler((schema, method, url, httpStatus) => {
     t.equals(method, 'GET')
     t.equals(url, '/foo/:id')
-    t.equals(httpPart, '200')
+    t.equals(httpStatus, '200')
     t.deepEqual(schema, outSchema)
     return data => JSON.stringify(data)
   })
@@ -312,7 +312,7 @@ test('Custom serializer per route', async t => {
 
   let hit = 0
   fastify.register((instance, opts, next) => {
-    instance.setSerializerCompiler((method, url, httpPart, schema) => {
+    instance.setSerializerCompiler((schema, method, url, httpStatus) => {
       hit++
       return data => JSON.stringify({ mean: 'custom' })
     })
@@ -322,7 +322,7 @@ test('Custom serializer per route', async t => {
     })
     instance.get('/route', {
       handler (req, reply) { reply.send({}) },
-      serializerCompiler: (method, url, httpPart, schema) => {
+      serializerCompiler: (schema, method, url, httpPart) => {
         hit++
         return data => JSON.stringify({ mean: 'route' })
       },
@@ -365,7 +365,7 @@ test('Reply serializer win over serializer ', t => {
         }
       }
     },
-    serializerCompiler: (method, url, httpPart, schema) => {
+    serializerCompiler: (schema, method, url, httpPart) => {
       t.ok(method, 'the custom compiler has been created')
       return () => {
         t.fail('the serializer must not be called when there is a reply serializer')
@@ -404,7 +404,7 @@ test('Reply serializer win over serializer ', t => {
         }
       }
     },
-    serializerCompiler: (method, url, httpPart, schema) => {
+    serializerCompiler: (schema, method, url, httpPart) => {
       t.ok(method, 'the custom compiler has been created')
       return () => {
         t.fail('the serializer must not be called when there is a reply serializer')

--- a/test/schema-serialization.test.js
+++ b/test/schema-serialization.test.js
@@ -262,7 +262,7 @@ test('Custom setSerializerCompiler', t => {
     whatever: 'need to be parsed by the custom serializer'
   }
 
-  fastify.setSerializerCompiler((schema, method, url, httpStatus) => {
+  fastify.setSerializerCompiler(({ schema, method, url, httpStatus }) => {
     t.equals(method, 'GET')
     t.equals(url, '/foo/:id')
     t.equals(httpStatus, '200')
@@ -312,7 +312,7 @@ test('Custom serializer per route', async t => {
 
   let hit = 0
   fastify.register((instance, opts, next) => {
-    instance.setSerializerCompiler((schema, method, url, httpStatus) => {
+    instance.setSerializerCompiler(({ schema, method, url, httpStatus }) => {
       hit++
       return data => JSON.stringify({ mean: 'custom' })
     })
@@ -322,7 +322,7 @@ test('Custom serializer per route', async t => {
     })
     instance.get('/route', {
       handler (req, reply) { reply.send({}) },
-      serializerCompiler: (schema, method, url, httpPart) => {
+      serializerCompiler: ({ schema, method, url, httpPart }) => {
         hit++
         return data => JSON.stringify({ mean: 'route' })
       },
@@ -365,7 +365,7 @@ test('Reply serializer win over serializer ', t => {
         }
       }
     },
-    serializerCompiler: (schema, method, url, httpPart) => {
+    serializerCompiler: ({ schema, method, url, httpPart }) => {
       t.ok(method, 'the custom compiler has been created')
       return () => {
         t.fail('the serializer must not be called when there is a reply serializer')
@@ -404,7 +404,7 @@ test('Reply serializer win over serializer ', t => {
         }
       }
     },
-    serializerCompiler: (schema, method, url, httpPart) => {
+    serializerCompiler: ({ schema, method, url, httpPart }) => {
       t.ok(method, 'the custom compiler has been created')
       return () => {
         t.fail('the serializer must not be called when there is a reply serializer')

--- a/test/schema-validation.test.js
+++ b/test/schema-validation.test.js
@@ -90,7 +90,7 @@ test('External AJV instance', t => {
   fastify.addSchema(schemaA)
   fastify.addSchema(schemaBRefToA)
 
-  fastify.setValidatorCompiler((schema, method, url, httpPart) => {
+  fastify.setValidatorCompiler(({ schema, method, url, httpPart }) => {
     return ajv.compile(schema)
   })
 
@@ -136,7 +136,7 @@ test('Encapsulation', t => {
   fastify.addSchema(schemaBRefToA)
 
   fastify.register((instance, opts, next) => {
-    const validator = (schema, method, url, httpPart) => {
+    const validator = ({ schema, method, url, httpPart }) => {
       return ajv.compile(schema)
     }
     instance.setValidatorCompiler(validator)
@@ -158,7 +158,7 @@ test('Encapsulation', t => {
         }
       })
 
-      const anotherValidator = (schema, method, url, httpPart) => {
+      const anotherValidator = ({ schema, method, url, httpPart }) => {
         return () => { return true } // always valid
       }
       instance.post('/three', {
@@ -257,7 +257,7 @@ test('Triple $ref with a simple $id', t => {
   fastify.addSchema(schemaBRefToA)
   fastify.addSchema(schemaCRefToB)
 
-  fastify.setValidatorCompiler((schema, method, url, httpPart) => {
+  fastify.setValidatorCompiler(({ schema, method, url, httpPart }) => {
     return ajv.compile(schema)
   })
 

--- a/test/schema-validation.test.js
+++ b/test/schema-validation.test.js
@@ -90,7 +90,7 @@ test('External AJV instance', t => {
   fastify.addSchema(schemaA)
   fastify.addSchema(schemaBRefToA)
 
-  fastify.setValidatorCompiler((method, url, httpPart, schema) => {
+  fastify.setValidatorCompiler((schema, method, url, httpPart) => {
     return ajv.compile(schema)
   })
 
@@ -136,7 +136,7 @@ test('Encapsulation', t => {
   fastify.addSchema(schemaBRefToA)
 
   fastify.register((instance, opts, next) => {
-    const validator = (method, url, httpPart, schema) => {
+    const validator = (schema, method, url, httpPart) => {
       return ajv.compile(schema)
     }
     instance.setValidatorCompiler(validator)
@@ -158,7 +158,7 @@ test('Encapsulation', t => {
         }
       })
 
-      const anotherValidator = (method, url, httpPart, schema) => {
+      const anotherValidator = (schema, method, url, httpPart) => {
         return () => { return true } // always valid
       }
       instance.post('/three', {
@@ -257,7 +257,7 @@ test('Triple $ref with a simple $id', t => {
   fastify.addSchema(schemaBRefToA)
   fastify.addSchema(schemaCRefToB)
 
-  fastify.setValidatorCompiler((method, url, httpPart, schema) => {
+  fastify.setValidatorCompiler((schema, method, url, httpPart) => {
     return ajv.compile(schema)
   })
 

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -293,7 +293,7 @@ test('should return a defined output message parsing JOI errors', t => {
 
   fastify.post('/', {
     schema: { body },
-    validatorCompiler: (schema, method, url, httpPart) => {
+    validatorCompiler: ({ schema, method, url, httpPart }) => {
       return data => schema.validate(data)
     }
   },
@@ -323,7 +323,7 @@ test('should return a defined output message parsing JOI error details', t => {
 
   fastify.post('/', {
     schema: { body },
-    validatorCompiler: (schema, method, url, httpPart) => {
+    validatorCompiler: ({ schema, method, url, httpPart }) => {
       return data => {
         const validation = schema.validate(data)
         return { error: validation.error.details }

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -293,7 +293,7 @@ test('should return a defined output message parsing JOI errors', t => {
 
   fastify.post('/', {
     schema: { body },
-    validatorCompiler: (method, url, httpPart, schema) => {
+    validatorCompiler: (schema, method, url, httpPart) => {
       return data => schema.validate(data)
     }
   },
@@ -323,7 +323,7 @@ test('should return a defined output message parsing JOI error details', t => {
 
   fastify.post('/', {
     schema: { body },
-    validatorCompiler: (method, url, httpPart, schema) => {
+    validatorCompiler: (schema, method, url, httpPart) => {
       return data => {
         const validation = schema.validate(data)
         return { error: validation.error.details }

--- a/types/schema.d.ts
+++ b/types/schema.d.ts
@@ -14,4 +14,4 @@ export interface FastifySchema {
 /**
  * Compiler for FastifySchema Type
  */
-export type FastifySchemaCompiler = (method: string, url: string, httpPart: string, schema: FastifySchema) => unknown
+export type FastifySchemaCompiler = (schema: FastifySchema, method: string, url: string, httpPart: string) => unknown

--- a/types/schema.d.ts
+++ b/types/schema.d.ts
@@ -11,7 +11,15 @@ export interface FastifySchema {
   headers?: unknown;
 }
 
+export interface FastifyRouteSchemaDef {
+  schema: FastifySchema;
+  method: string;
+  url: string;
+  httpPart?: string;
+  httpStatus?: string;
+}
+
 /**
  * Compiler for FastifySchema Type
  */
-export type FastifySchemaCompiler = (schema: FastifySchema, method: string, url: string, httpPart: string) => unknown
+export type FastifySchemaCompiler = (routeSchema: FastifyRouteSchemaDef) => unknown


### PR DESCRIPTION
I would like to change the new API interface for *compilers, this would ease the migration from v2 to v3.

I thought it was a good idea to put the `schema` at the end... 😅

Edit:

the target is that the migration would be: "replace `setSchemaCompiler()` to `setValidatorCompiler()`"

cc #2140 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
