### PR TITLE
Fixes crash when using a non-standard error code

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -48,7 +48,7 @@ createError('FST_ERR_REP_ALREADY_SENT', 'Reply was already sent.')
 createError('FST_ERR_REP_SENT_VALUE', 'The only possible value for reply.sent is true.')
 createError('FST_ERR_SEND_INSIDE_ONERR', 'You cannot use `send` inside the `onError` hook')
 createError('FST_ERR_SEND_UNDEFINED_ERR', 'Undefined error has occured')
-createError('FST_ERR_BAD_STATUS_CODE', 'Called reply with malformed status code')
+createError('FST_ERR_BAD_STATUS_CODE', 'Called reply with an invalid status code: %s')
 
 /**
  * schemas

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -198,11 +198,12 @@ Reply.prototype.headers = function (headers) {
 }
 
 Reply.prototype.code = function (code) {
-  if (statusCodes[code] === undefined) {
+  const intValue = parseInt(code)
+  if (isNaN(intValue) || intValue < 100 || intValue > 600) {
     throw new FST_ERR_BAD_STATUS_CODE()
   }
 
-  this.res.statusCode = code
+  this.res.statusCode = intValue
   this[kReplyHasStatusCode] = true
   return this
 }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -200,7 +200,7 @@ Reply.prototype.headers = function (headers) {
 Reply.prototype.code = function (code) {
   const intValue = parseInt(code)
   if (isNaN(intValue) || intValue < 100 || intValue > 600) {
-    throw new FST_ERR_BAD_STATUS_CODE()
+    throw new FST_ERR_BAD_STATUS_CODE(String(code))
   }
 
   this.res.statusCode = intValue

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -426,3 +426,18 @@ invalidErrorCodes.forEach((invalidCode) => {
     })
   })
 })
+
+test('should not throw error for status code in range', t => {
+  t.plan(2)
+  const fastify = Fastify()
+  fastify.get('/', (request, reply) => {
+    return reply.code(525).send('Hello World')
+  })
+  fastify.inject({
+    url: '/',
+    method: 'GET'
+  }, (e, res) => {
+    t.is(525, res.statusCode)
+    t.is('Hello World', res.body)
+  })
+})

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -415,7 +415,7 @@ invalidErrorCodes.forEach((invalidCode) => {
       } catch (err) {
         t.is(err.name, 'FastifyError [FST_ERR_BAD_STATUS_CODE]')
         t.is(err.code, 'FST_ERR_BAD_STATUS_CODE')
-        t.is(err.message, 'FST_ERR_BAD_STATUS_CODE: Called reply with malformed status code')
+        t.is(err.message, `FST_ERR_BAD_STATUS_CODE: Called reply with an invalid status code: ${String(invalidCode)}`)
       }
     })
     fastify.inject({
@@ -424,20 +424,5 @@ invalidErrorCodes.forEach((invalidCode) => {
     }, (e, res) => {
       t.fail('should not be called')
     })
-  })
-})
-
-test('should not throw error for status code in range', t => {
-  t.plan(2)
-  const fastify = Fastify()
-  fastify.get('/', (request, reply) => {
-    return reply.code(525).send('Hello World')
-  })
-  fastify.inject({
-    url: '/',
-    method: 'GET'
-  }, (e, res) => {
-    t.is(525, res.statusCode)
-    t.is('Hello World', res.body)
   })
 })


### PR DESCRIPTION
Updates how we validate reply status code.
Now allowing only numbers in range between 100 and 600

Fixes: #2169 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
