### PR TITLE
Fix package-manager CI

### DIFF
--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -12,14 +12,14 @@ jobs:
     strategy:
       matrix:
         # Maintenance and active LTS
-        node-version: [8.x, 10.x]
+        node-version: [8.x, 10.x, 12.x]
         os: [ubuntu-16.04]
 
     steps:
       - uses: actions/checkout@v1
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -38,14 +38,14 @@ jobs:
     strategy:
       matrix:
         # Maintenance and active LTS
-        node-version: [8.x, 10.x]
+        node-version: [10.x, 12.x]
         os: [ubuntu-16.04]
 
     steps:
       - uses: actions/checkout@v1
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         # Maintenance and active LTS
-        node-version: [10.x, 12.x]
+        node-version: [8.x, 10.x, 12.x]
         os: [ubuntu-16.04]
 
     steps:
@@ -52,7 +52,7 @@ jobs:
       - name: Install with yarn
         run: |
           curl -o- -L https://yarnpkg.com/install.sh | bash
-          yarn install
+          yarn install --ignore-engines
 
       - name: Run tests
         run: |

--- a/docs/LTS.md
+++ b/docs/LTS.md
@@ -44,10 +44,8 @@ A "month" is to be a period of 30 consecutive days.
 |---------|------------------------|---------------------------|-----------|
 | Linux   | Ubuntu 16.04           | npm                       | 6,8,10,12 |
 | Linux   | Ubuntu 16.04           | pnpm                      | 8,10,12   |
-| Linux   | Ubuntu 16.04           | yarn                      | 10,12     |
+| Linux   | Ubuntu 16.04           | yarn                      | 8,10,12   |
 | Windows | Windows Server 2016 R2 | npm                       | 6,8,10,12 |
 | MacOS   | macOS X Mojave 10.14   | npm                       | 6,8,10,12 |
 
-Unfortunately it is not possible to provide Long Term Support for
-applications installed with Yarn as thee drop support of Node.js releases
-in minor versions.
+Using yarn might require passing the `--ignore-engines` flag.

--- a/docs/LTS.md
+++ b/docs/LTS.md
@@ -31,18 +31,23 @@ A "month" is to be a period of 30 consecutive days.
 
 ### Schedule
 
-| Version | Release Date | End Of LTS Date | Node.js         |
-| :------ | :----------- | :-------------- | :-------------- |
-| 1.0.0   | 2018-03-06   | 2019-09-01      | 6, 8, 9, 10, 11 |
-| 2.0.0   | 2019-02-25   | TBD             | 6, 8, 10, 11    |
+| Version | Release Date | End Of LTS Date | Node.js              |
+| :------ | :----------- | :-------------- | :------------------- |
+| 1.0.0   | 2018-03-06   | 2019-09-01      | 6, 8, 9, 10, 11      |
+| 2.0.0   | 2019-02-25   | TBD             | 6, 8, 10, 11, 12, 13 |
 
 <a name="supported-os"></a>
 
 ### CI tested operating systems
 
-| CI             | OS      | Version                | Package Manager           | Node.js   |
-|----------------|---------|------------------------|---------------------------|-----------|
-| Github Actions | Linux   | Ubuntu 16.04           | npm                       | 6,8,10,12 |
-| Github Actions | Linux   | Ubuntu 16.04           | yarn,pnpm                 | 8,10      |
-| Github Actions | Windows | Windows Server 2016 R2 | npm                       | 6,8,10,12 |
-| Github Actions | MacOS   | macOS X Mojave 10.14   | npm                       | 6,8,10,12 |
+| OS      | Version                | Package Manager           | Node.js   |
+|---------|------------------------|---------------------------|-----------|
+| Linux   | Ubuntu 16.04           | npm                       | 6,8,10,12 |
+| Linux   | Ubuntu 16.04           | pnpm                      | 8,10,12   |
+| Linux   | Ubuntu 16.04           | yarn                      | 10,12     |
+| Windows | Windows Server 2016 R2 | npm                       | 6,8,10,12 |
+| MacOS   | macOS X Mojave 10.14   | npm                       | 6,8,10,12 |
+
+Unfortunately it is not possible to provide Long Term Support for
+applications installed with Yarn as thee drop support of Node.js releases
+in minor versions.


### PR DESCRIPTION
A module updated to mkdirp in their tree and it has engine >= 10.x, so we need to install with `--ignore-engines` with yarn.

I've also done some cleanup in our LTS doc.