### PR TITLE
Fix double logging + reduced log level for streams

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -385,6 +385,16 @@ function onSendEnd (reply, payload) {
   res.end(payload, null, null)
 }
 
+function logStreamError (logger, err, res) {
+  if (err.code === 'ERR_STREAM_PREMATURE_CLOSE') {
+    if (!logger[kDisableRequestLogging]) {
+      logger.info({ res }, 'stream closed prematurely')
+    }
+  } else {
+    logger.warn({ err }, 'response terminated with an error with headers already sent')
+  }
+}
+
 function sendStream (payload, res, reply) {
   var sourceOpen = true
   var errorLogged = false
@@ -395,11 +405,7 @@ function sendStream (payload, res, reply) {
       if (res.headersSent) {
         if (!errorLogged) {
           errorLogged = true
-          if (err.code === 'ERR_STREAM_PREMATURE_CLOSE') {
-            reply.log.info({ res }, 'stream closed prematurely')
-          } else {
-            reply.log.warn({ err }, 'response terminated with an error with headers already sent')
-          }
+          logStreamError(reply.log, err, res)
         }
         res.destroy()
       } else {
@@ -415,11 +421,7 @@ function sendStream (payload, res, reply) {
         if (res.headersSent) {
           if (!errorLogged) {
             errorLogged = true
-            if (err.code === 'ERR_STREAM_PREMATURE_CLOSE') {
-              reply.log.info({ res }, 'stream closed prematurely')
-            } else {
-              reply.log.warn({ err }, 'response terminated with an error with headers already sent')
-            }
+            logStreamError(reply.log, err, res)
           }
         }
         if (payload.destroy) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -387,12 +387,20 @@ function onSendEnd (reply, payload) {
 
 function sendStream (payload, res, reply) {
   var sourceOpen = true
+  var errorLogged = false
 
   eos(payload, { readable: true, writable: false }, function (err) {
     sourceOpen = false
     if (err != null) {
       if (res.headersSent) {
-        reply.log.warn({ err }, 'response terminated with an error with headers already sent')
+        if (!errorLogged) {
+          errorLogged = true
+          if (err.code === 'ERR_STREAM_PREMATURE_CLOSE') {
+            reply.log.info({ res }, 'stream closed prematurely')
+          } else {
+            reply.log.warn({ err }, 'response terminated with an error with headers already sent')
+          }
+        }
         res.destroy()
       } else {
         onErrorHook(reply, err)
@@ -403,10 +411,17 @@ function sendStream (payload, res, reply) {
 
   eos(res, function (err) {
     if (err != null) {
-      if (res.headersSent) {
-        reply.log.warn({ err }, 'response terminated with an error with headers already sent')
-      }
       if (sourceOpen) {
+        if (res.headersSent) {
+          if (!errorLogged) {
+            errorLogged = true
+            if (err.code === 'ERR_STREAM_PREMATURE_CLOSE') {
+              reply.log.info({ res }, 'stream closed prematurely')
+            } else {
+              reply.log.warn({ err }, 'response terminated with an error with headers already sent')
+            }
+          }
+        }
         if (payload.destroy) {
           payload.destroy()
         } else if (typeof payload.close === 'function') {
@@ -583,7 +598,7 @@ function notFound (reply) {
   reply.context.handler(reply.request, reply)
 }
 
-function noop () {}
+function noop () { }
 
 module.exports = Reply
 module.exports.buildReply = buildReply

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -148,7 +148,7 @@ test('Destroying streams prematurely', t => {
     fastify = Fastify({
       logger: {
         stream: logStream,
-        level: 'warn'
+        level: 'info'
       }
     })
   } catch (e) {
@@ -158,9 +158,11 @@ test('Destroying streams prematurely', t => {
   const http = require('http')
 
   // Test that "premature close" errors are logged with level warn
-  logStream.once('data', line => {
-    t.equal(line.msg, 'response terminated with an error with headers already sent')
-    t.equal(line.level, 40)
+  logStream.on('data', line => {
+    if (line.res) {
+      t.equal(line.msg, 'stream closed prematurely')
+      t.equal(line.level, 30)
+    }
   })
 
   fastify.get('/', function (request, reply) {
@@ -208,7 +210,7 @@ test('Destroying streams prematurely should call close method', t => {
     fastify = Fastify({
       logger: {
         stream: logStream,
-        level: 'warn'
+        level: 'info'
       }
     })
   } catch (e) {
@@ -218,9 +220,11 @@ test('Destroying streams prematurely should call close method', t => {
   const http = require('http')
 
   // Test that "premature close" errors are logged with level warn
-  logStream.once('data', line => {
-    t.equal(line.msg, 'response terminated with an error with headers already sent')
-    t.equal(line.level, 40)
+  logStream.on('data', line => {
+    if (line.res) {
+      t.equal(line.msg, 'stream closed prematurely')
+      t.equal(line.level, 30)
+    }
   })
 
   fastify.get('/', function (request, reply) {
@@ -268,7 +272,7 @@ test('Destroying streams prematurely should call abort method', t => {
     fastify = Fastify({
       logger: {
         stream: logStream,
-        level: 'warn'
+        level: 'info'
       }
     })
   } catch (e) {
@@ -278,9 +282,11 @@ test('Destroying streams prematurely should call abort method', t => {
   const http = require('http')
 
   // Test that "premature close" errors are logged with level warn
-  logStream.once('data', line => {
-    t.equal(line.msg, 'response terminated with an error with headers already sent')
-    t.equal(line.level, 40)
+  logStream.on('data', line => {
+    if (line.res) {
+      t.equal(line.msg, 'stream closed prematurely')
+      t.equal(line.level, 30)
+    }
   })
 
   fastify.get('/', function (request, reply) {


### PR DESCRIPTION
- This PR fixes an issue where prematurely closed sockets would cause duplicate log lines
- This PR also reduces the log level of prematurely closed sockets from WARN to INFO (clients closing sockets is expected behaviour)

Fixes  fastify/fastify-static#116

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
