### PR TITLE
add startup benchmark

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "ajv-merge-patch": "^4.1.0",
     "ajv-pack": "^0.3.1",
     "autocannon": "^4.0.0",
+    "benchmark": "^2.1.4",
     "branch-comparer": "^0.4.0",
     "concurrently": "^5.0.2",
     "cors": "^2.8.5",

--- a/tools/startup-benchmark.js
+++ b/tools/startup-benchmark.js
@@ -1,0 +1,74 @@
+'use strict'
+
+const benchmark = require('benchmark')
+const suite = new benchmark.Suite()
+
+const S = require('fluent-schema')
+const Fastify = require('../fastify')
+
+let lastSchema = null
+const typeGen = getSchemaType()
+const handler = async () => 'hello'
+
+const suiteBuilder = [
+  { routes: 1 },
+  { routes: 100 },
+  { routes: 1000 }
+]
+
+suiteBuilder.forEach(({ routes }) => {
+  const f = Fastify()
+
+  for (let i = 0; i < routes; i++) {
+    f.post(`/${i}`, { schema: genSchema(), handler })
+  }
+
+  suite.add(`instance with ${routes} routes`, function (deferred) {
+    f.ready(() => {
+      deferred.resolve()
+    })
+  }, { defer: true })
+})
+
+suite.on('cycle', cycle)
+
+suite.run()
+
+function cycle (e) {
+  console.log(e.target.toString())
+}
+
+function genSchema (fields = ['body', 'response'], prop = 6, keepOld = false) {
+  if (keepOld && lastSchema) {
+    return lastSchema
+  }
+
+  const schema = S.object()
+  while (prop-- > 0) {
+    schema.prop(`random-${prop}-${Math.round(Math.random() * 1000)}`, typeGen.next().value)
+  }
+
+  const built = schema.valueOf()
+  const schemaConfig = fields.reduce((schema, field) => {
+    if (field === 'response') {
+      schema[field] = { 200: built }
+    } else {
+      schema[field] = built
+    }
+    return schema
+  }, {})
+
+  lastSchema = schemaConfig
+  return lastSchema
+}
+
+function * getSchemaType () {
+  while (true) {
+    yield S.string()
+    yield S.integer()
+    yield S.object()
+      .prop('created', S.string().format('date-time'))
+      .prop('updated', S.string().format('date-time'))
+    yield S.array().items(S.object().prop('id', S.string()))
+  }
+}


### PR DESCRIPTION
Starting from #2179 : it would be interesting adding a startup bench to check improvements to this phase. For example, I'm really curious to verify in `next` the changes made on the validation flow since the boost exists only in theory right now.

This is a quick demo that generates random schemas as the worst case in the universe, but we should define a set of "common used" schemas to tests, so I think we should define these tests:

- [ ] app with X routes without schema
- [ ] app with X routes and X schema for `body` and `Y` for `response` using shared schema
- [ ] app with X routes and X schema for `body` and `Y` for `response` **without** using shared schema
- more?

WDYT?


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
