### PR TITLE
fix: Chainable / thenable types & after signature

### DIFF
--- a/test/types/plugin.test-d.ts
+++ b/test/types/plugin.test-d.ts
@@ -1,7 +1,7 @@
 import fastify, { FastifyPlugin, FastifyInstance, FastifyPluginOptions } from '../../fastify'
 import * as http from 'http'
 import * as https from 'https'
-import { expectType, expectError } from 'tsd'
+import { expectType, expectError, expectAssignable } from 'tsd'
 
 // FastifyPlugin & FastifyRegister
 interface TestOptions extends FastifyPluginOptions {
@@ -11,14 +11,30 @@ interface TestOptions extends FastifyPluginOptions {
 const testPlugin: FastifyPlugin<TestOptions> = function (instance, opts, next) { }
 
 expectError(fastify().register(testPlugin, {})) // error because missing required options from generic declaration
-expectType<void>(fastify().register(testPlugin, { option1: '', option2: true }))
-
-expectType<void>(fastify().register(function (instace, opts, next) { }))
-expectType<void>(fastify().register(function (instace, opts, next) { }, () => { }))
-expectType<void>(fastify().register(function (instance, opts, next) { }, { logLevel: 'info', prefix: 'foobar' }))
+expectAssignable<FastifyInstance>(fastify().register(testPlugin, { option1: '', option2: true }))
+expectAssignable<FastifyInstance>(fastify().register(function (instace, opts, next) { }))
+expectAssignable<FastifyInstance>(fastify().register(function (instace, opts, next) { }, () => { }))
+expectAssignable<FastifyInstance>(fastify().register(function (instance, opts, next) { }, { logLevel: 'info', prefix: 'foobar' }))
 expectError(fastify().register(function (instance, opts, next) { }, { logLevel: '' })) // must use a valid logLevel
 
 const httpsServer = fastify({ https: {} });
 expectType<FastifyInstance<https.Server, http.IncomingMessage, http.ServerResponse>>(httpsServer)
 
-httpsServer.register(testPlugin);
+// Chainable
+httpsServer
+  .register(testPlugin)
+  .after((_error) => { })
+  .close(() => { })
+  .ready((_error) => { })
+
+// Thenable
+expectAssignable<PromiseLike<undefined>>(httpsServer.after());
+expectAssignable<PromiseLike<undefined>>(httpsServer.close());
+expectAssignable<PromiseLike<undefined>>(httpsServer.ready());
+expectAssignable<PromiseLike<undefined>>(httpsServer.register(testPlugin));
+
+async function testAsync() {
+  await httpsServer
+    .register(testPlugin)
+    .register(testPlugin)
+}

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -25,10 +25,11 @@ export interface FastifyInstance<
 
   addSchema(schema: FastifySchema): FastifyInstance<RawServer, RawRequest, RawReply>;
 
-  after(err: Error): FastifyInstance<RawServer, RawRequest, RawReply>;
+  after(): FastifyInstance<RawServer, RawRequest, RawReply> & PromiseLike<undefined>;
+  after(afterListener: (err: Error) => void): FastifyInstance<RawServer, RawRequest, RawReply>;
 
-  close(closeListener?: () => void): void;
-  close<T>(): Promise<T>; // what is this use case? Not documented on Server#close
+  close(): FastifyInstance<RawServer, RawRequest, RawReply> & PromiseLike<undefined>;
+  close(closeListener: () => void): FastifyInstance<RawServer, RawRequest, RawReply>;
 
   // should be able to define something useful with the decorator getter/setter pattern using Generics to enfore the users function returns what they expect it to
   decorate(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply>;
@@ -47,10 +48,10 @@ export interface FastifyInstance<
   listen(port: number, callback: (err: Error, address: string) => void): void;
   listen(port: number, address?: string, backlog?: number): Promise<string>;
 
-  ready(): Promise<FastifyInstance<RawServer, RawRequest, RawReply>>;
-  ready(readyListener: (err: Error) => void): void;
+  ready(): FastifyInstance<RawServer, RawRequest, RawReply> & PromiseLike<undefined>;
+  ready(readyListener: (err: Error) => void): FastifyInstance<RawServer, RawRequest, RawReply>;
 
-  register: FastifyRegister;
+  register: FastifyRegister<FastifyInstance<RawServer, RawRequest, RawReply> & PromiseLike<undefined>>;
   /**
    * This method is now deprecated and will throw a `FST_ERR_MISSING_MIDDLEWARE` error.
    * Visit fastify.io/docs/latest/Middleware/ for more info.
@@ -187,19 +188,19 @@ export interface FastifyInstance<
     hook: onRouteHookHandler<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>
   ): FastifyInstance<RawServer, RawRequest, RawReply>;
 
-   /**
-   * Triggered when a new plugin is registered and a new encapsulation context is created. The hook will be executed before the registered code.
-   * This hook can be useful if you are developing a plugin that needs to know when a plugin context is formed, and you want to operate in that specific context.
-   * Note: This hook will not be called if a plugin is wrapped inside fastify-plugin.
-   */
+  /**
+  * Triggered when a new plugin is registered and a new encapsulation context is created. The hook will be executed before the registered code.
+  * This hook can be useful if you are developing a plugin that needs to know when a plugin context is formed, and you want to operate in that specific context.
+  * Note: This hook will not be called if a plugin is wrapped inside fastify-plugin.
+  */
   addHook(
     name: 'onRegister',
     hook: onRegisterHookHandler<RawServer, RawRequest, RawReply, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply>;
 
-   /**
-   * Triggered when fastify.close() is invoked to stop the server. It is useful when plugins need a "shutdown" event, for example to close an open connection to a database.
-   */
+  /**
+  * Triggered when fastify.close() is invoked to stop the server. It is useful when plugins need a "shutdown" event, for example to close an open connection to a database.
+  */
   addHook(
     name: 'onClose',
     hook: onCloseHookHandler<RawServer, RawRequest, RawReply, Logger>

--- a/types/register.d.ts
+++ b/types/register.d.ts
@@ -6,14 +6,15 @@ import { LogLevels } from './logger'
  * 
  * Function for adding a plugin to fastify. The options are inferred from the passed in FastifyPlugin parameter.
  */
-export interface FastifyRegister {
+export interface FastifyRegister<T = void> {
   <Options extends FastifyPluginOptions>(
     plugin: FastifyPlugin<Options>,
     opts?: FastifyRegisterOptions<Options>
-  ): void;
+  ): T;
 }
 
 export type FastifyRegisterOptions<Options> = (RegisterOptions & Options) | (() => RegisterOptions & Options)
+
 interface RegisterOptions {
   prefix?: string;
   logLevel?: LogLevels;


### PR DESCRIPTION
Fixes function signature type of `instance.after()`
Fixes register / close / after not being thenable
Fixes register / close / after not being chainable

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
