### PR TITLE
docs: fix spelling errors

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -542,7 +542,7 @@ For more details on using HTTP2 check out the Fastify [HTTP2](./HTTP2.md) docume
 
 ###### Example 4: Extended HTTP server
 
-Not only can you specify the server type, but also the request and reply types. Thus, allowing you to specify special properties, methods, and more! When specified at server instantiation, the custome type becomes available on all further instances of the custom type.
+Not only can you specify the server type, but also the request and reply types. Thus, allowing you to specify special properties, methods, and more! When specified at server instantiation, the custom type becomes available on all further instances of the custom type.
 ```typescript
 import fastify from 'fastify'
 import http from 'http'
@@ -607,7 +607,7 @@ Type alias for `http.Server`
 
 An interface of properties used in the instantiation of the Fastify server. Is used in the main [`fastify()`][Fastify] method. The `RawServer` and `Logger` generic parameters are passed down through that method.
 
-See the main [fastify][Fastify] method type definition section for examples on instatiating a Fastify server with TypeScript.
+See the main [fastify][Fastify] method type definition section for examples on instantiating a Fastify server with TypeScript.
 
 ##### fastify.FastifyInstance<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RequestGeneric][FastifyRequestGenericInterface], [Logger][LoggerGeneric]>
 
@@ -661,7 +661,7 @@ declare module 'fastify' {
 ##### fastify.RequestGenericInterface
 [src](./../types/request.d.ts#L4)
 
-Fastify request objects have four dynamic properties: `body`, `params`, `query`, and `headers`. Their respective types are assignable through this interface. It is a named property interface enabling the developer to ignore the properties they do not want to specify. All ommitted properties are defaulted to `unknown`. The corresponding property names are: `Body`, `Querystring`, `Params`, `Headers`.
+Fastify request objects have four dynamic properties: `body`, `params`, `query`, and `headers`. Their respective types are assignable through this interface. It is a named property interface enabling the developer to ignore the properties they do not want to specify. All omitted properties are defaulted to `unknown`. The corresponding property names are: `Body`, `Querystring`, `Params`, `Headers`.
 
 ```typescript
 import fastify, { RequestGenericInterface } from 'fastify'
@@ -782,7 +782,7 @@ A loosely typed object used to constrain the `options` parameter of [`fastify.re
 ##### fastify.FastifyRegister(plugin: [FastifyPlugin][FastifyPlugin], opts: [FastifyRegisterOptions][FastifyRegisterOptions])
 [src](../types/register.d.ts#L5)
 
-This type interface specifies the type for the [`fastify.register()`](./Server.md#register) method. The type interface returns a function signature with an underlying generic `Options` which is defaulted to [FastifyPluginOptions][FastifyPluginOptions]. It infers this generic from the FastifyPlugin parameter when calling this function so there is no need to specify the underlying generic. The options parameter is the intersection of the plugin's options and two additional optional propeties: `prefix: string` and `logLevel`: [LogLevels][LogLevels].
+This type interface specifies the type for the [`fastify.register()`](./Server.md#register) method. The type interface returns a function signature with an underlying generic `Options` which is defaulted to [FastifyPluginOptions][FastifyPluginOptions]. It infers this generic from the FastifyPlugin parameter when calling this function so there is no need to specify the underlying generic. The options parameter is the intersection of the plugin's options and two additional optional properties: `prefix: string` and `logLevel`: [LogLevels][LogLevels].
 
 Below is an example of the options inference in action:
 
@@ -894,7 +894,7 @@ A generic type that is either a `string` or `Buffer`
 
 [src](../types/content-type-parser.d.ts#L7)
 
-A function type definition for specifying a body parser method. Use the `RawBody` generic to specify the type of the body beig parsed.
+A function type definition for specifying a body parser method. Use the `RawBody` generic to specify the type of the body being parsed.
 
 ##### fastify.FastifyContentTypeParser<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric]>
 
@@ -906,13 +906,13 @@ A function type definition for specifying a body parser method. Content is typed
 
 [src](../types/content-type-parser.d.ts#L46)
 
-An overloaded interface function definition for the `addContentTypeParser` method. If `parseAs` is passed to the `opts` parameter, the defintion uses [FastifyBodyParser][] for the `parser` parameter; otherwise, it uses [FastifyContentTypeParser][].
+An overloaded interface function definition for the `addContentTypeParser` method. If `parseAs` is passed to the `opts` parameter, the definition uses [FastifyBodyParser][] for the `parser` parameter; otherwise, it uses [FastifyContentTypeParser][].
 
 ##### fastify.hasContentTypeParser
 
 [src](../types/content-type-parser.d.ts#L63)
 
-A method for checking the existince of a type parser of a certain content type
+A method for checking the existence of a type parser of a certain content type
 
 ---
 

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -17,7 +17,7 @@ The validation and the serialization tasks are processed by two different, and c
 - [Ajv](https://www.npmjs.com/package/ajv) for the validation of a request
 - [fast-json-stringify](https://www.npmjs.com/package/fast-json-stringify) for the serialization of a response's body
 
-These two separate entities share only the JSON shemas added to Fastify's instance through `.addSchema(schema)`.
+These two separate entities share only the JSON schemas added to Fastify's instance through `.addSchema(schema)`.
 
 <a name="shared-schema"></a>
 #### Adding a shared schema
@@ -354,7 +354,7 @@ fastify.post('/the/url', {
 
 ##### Validation messages with other validation libraries
 
-Fastify's validation error messages are tightly coupled to the default validation engine: errors returned from `ajv` are eventually run through the `schemaErrorsText` function which is responsible for building human-friendly error messages. However, the `schemaErrorsText` function is written with `ajv` in mind : as a result, you may run into odd or incomplete error messages when using other validation librairies.
+Fastify's validation error messages are tightly coupled to the default validation engine: errors returned from `ajv` are eventually run through the `schemaErrorsText` function which is responsible for building human-friendly error messages. However, the `schemaErrorsText` function is written with `ajv` in mind : as a result, you may run into odd or incomplete error messages when using other validation libraries.
 
 To circumvent this issue, you have 2 main options :
 
@@ -379,7 +379,7 @@ const errorHandler = (error, request, reply) => {
   if (validation) {
     response = {
       // validationContext will be 'body' or 'params' or 'headers' or 'query'
-      message: `A validation error occured when validating the ${validationContext}...`,
+      message: `A validation error occurred when validating the ${validationContext}...`,
       // this is the result of your validation library...
       errors: validation
     }
@@ -430,7 +430,7 @@ const schema = {
       }
     },
     201: {
-      // the contract sintax
+      // the contract syntax
       value: { type: 'string' }
     }
   }
@@ -467,7 +467,7 @@ fastify.get('/user', {
 *If you need a custom serializer in a very specific part of your code, you can set one with [`reply.serializer(...)`](https://github.com/fastify/fastify/blob/master/docs/Reply.md#serializerfunc).*
 
 ### Error Handling
-When schema validation fails for a request, Fastify will automtically return a  status 400 response including the result from the validator in the payload. As an example, if you have the following schema for your route
+When schema validation fails for a request, Fastify will automatically return a  status 400 response including the result from the validator in the payload. As an example, if you have the following schema for your route
 
 ```js
 const schema = {
@@ -519,7 +519,7 @@ If you want custom error response in schema without headaches and quickly, you c
 ### JSON Schema support
 
 JSON Schema has some type of utilities in order to optimize your schemas that,
-in conjuction with the Fastify's shared schema, let you reuse all your schemas easily.
+in conjunction with the Fastify's shared schema, let you reuse all your schemas easily.
 
 | Use Case                          | Validator | Serializer |
 |-----------------------------------|-----------|------------|


### PR DESCRIPTION
This fixes the spelling of various words in the "TypeScript" and "Validation and Serialization" documentation. 

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
