### PR TITLE
Add .protocol to request

### DIFF
--- a/docs/Request.md
+++ b/docs/Request.md
@@ -13,6 +13,7 @@ Request is a core Fastify object containing the following fields:
 - `ip` - the IP address of the incoming request
 - `ips` - an array of the IP addresses in the `X-Forwarded-For` header of the incoming request (only when the [`trustProxy`](https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-trust-proxy) option is enabled)
 - `hostname` - the hostname of the incoming request
+- `protocol` - the protocol (`https` or `http`) of the incoming request or the `X-Forwarded-Proto` header of the incoming request (only when the [`trustProxy`](https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-trust-proxy) option is enabled)
 
 ```js
 fastify.post('/:params', options, function (request, reply) {

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -132,6 +132,11 @@ declare namespace fastify {
     | ((req: HttpRequest, done: (err: Error | null, body?: any) => void) => void)
     | ((req: HttpRequest) => Promise<any>)
 
+  enum RequestProtocol {
+    https = 'https',
+    http = 'http'
+  }
+
   interface FastifyContext {
     config: any
   }
@@ -159,6 +164,7 @@ declare namespace fastify {
     ip: string
     ips: string[]
     hostname: string
+    protocol: RequestProtocol
 
     raw: HttpRequest
     req: HttpRequest

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,6 +1,6 @@
 'use strict'
 
-function Request (params, req, query, headers, log, ip, ips, hostname) {
+function Request (params, req, query, headers, log, ip, ips, hostname, trustProxy) {
   this.params = params
   this.raw = req
   this.query = query
@@ -10,10 +10,11 @@ function Request (params, req, query, headers, log, ip, ips, hostname) {
   this.ip = ip
   this.ips = ips
   this.hostname = hostname
+  this.trustProxy = trustProxy
 }
 
 function buildRequest (R) {
-  function _Request (params, req, query, headers, log, ip, ips, hostname) {
+  function _Request (params, req, query, headers, log, ip, ips, hostname, trustProxy) {
     this.params = params
     this.raw = req
     this.query = query
@@ -23,6 +24,7 @@ function buildRequest (R) {
     this.ip = ip
     this.ips = ips
     this.hostname = hostname
+    this.trustProxy = trustProxy
   }
   _Request.prototype = new R()
 
@@ -38,6 +40,17 @@ Object.defineProperties(Request.prototype, {
   id: {
     get: function () {
       return this.raw.id
+    }
+  },
+  protocol: {
+    get: function () {
+      // https://nodejs.org/api/tls.html#tls_tlssocket_encrypted
+      const protocol = this.raw.socket.encrypted ? 'https' : 'http'
+      if (this.trustProxy && this.headers['x-forwarded-proto']) {
+        const [forwardedProto] = this.headers['x-forwarded-proto'].split(',')
+        return forwardedProto || protocol
+      }
+      return protocol
     }
   }
 })

--- a/lib/route.js
+++ b/lib/route.js
@@ -340,7 +340,7 @@ function buildRouting (options) {
 
     var queryPrefix = req.url.indexOf('?')
     var query = querystringParser(queryPrefix > -1 ? req.url.slice(queryPrefix + 1) : '')
-    var request = new context.Request(params, req, query, req.headers, childLogger, ip, ips, hostname)
+    var request = new context.Request(params, req, query, req.headers, childLogger, ip, ips, hostname, trustProxy)
     var reply = new context.Reply(res, context, request, childLogger)
 
     if (hasLogger === true || context.onResponse !== null) {

--- a/test/http2/plain.js
+++ b/test/http2/plain.js
@@ -24,6 +24,10 @@ fastify.get('/hostname', function (req, reply) {
   reply.code(200).send(req.hostname)
 })
 
+fastify.get('/protocol', function (req, reply) {
+  reply.code(200).send(req.protocol)
+})
+
 fastify.listen(0, err => {
   t.error(err)
   fastify.server.unref()
@@ -49,5 +53,17 @@ fastify.listen(0, err => {
     const res = await h2url.concat({ url })
 
     t.strictEqual(res.body, hostname)
+  })
+
+  test('http protocol', async (t) => {
+    t.plan(1)
+
+    const protocol = 'http'
+    const hostname = `localhost:${fastify.server.address().port}`
+
+    const url = `${protocol}://${hostname}/protocol`
+    const res = await h2url.concat({ url })
+
+    t.strictEqual(res.body, protocol)
   })
 })

--- a/test/http2/secure.js
+++ b/test/http2/secure.js
@@ -26,6 +26,10 @@ fastify.get('/', function (req, reply) {
   reply.code(200).send(msg)
 })
 
+fastify.get('/protocol', function (req, reply) {
+  reply.code(200).send(req.protocol)
+})
+
 fastify.listen(0, err => {
   t.error(err)
   fastify.server.unref()
@@ -39,5 +43,16 @@ fastify.listen(0, err => {
     t.strictEqual(res.headers[':status'], 200)
     t.strictEqual(res.headers['content-length'], '' + JSON.stringify(msg).length)
     t.deepEqual(JSON.parse(res.body), msg)
+  })
+
+  test('https protocol', async (t) => {
+    t.plan(1)
+
+    const protocol = 'https'
+
+    const url = `${protocol}://localhost:${fastify.server.address().port}/protocol`
+    const res = await h2url.concat({ url })
+
+    t.strictEqual(res.body, protocol)
   })
 })


### PR DESCRIPTION
My issue:
While deploying fastify to Google App Engine I needed to know the protocol of the request in order to redirect users from http to https

Other issues this may fix: #1800 #1777
Other PR: #1805

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
