### PR TITLE
http2: fix HEAD requests hanging

### DIFF
--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -71,7 +71,10 @@ function handler (request, reply) {
 }
 
 function preValidationCallback (err, request, reply) {
-  if (reply.sent === true || reply.raw.finished === true) return
+  if (reply.sent === true ||
+    reply.writableEnded === true ||
+    (reply.raw.writable === false && reply.raw.finished === true)) return
+
   if (err != null) {
     reply.send(err)
     return
@@ -102,7 +105,10 @@ function preValidationCallback (err, request, reply) {
 }
 
 function preHandlerCallback (err, request, reply) {
-  if (reply.sent || reply.raw.finished === true) return
+  if (reply.sent ||
+    reply.raw.writableEnded === true ||
+    (reply.raw.writable === false && reply.raw.finished === true)) return
+
   if (err != null) {
     reply.send(err)
     return

--- a/test/http2/head.test.js
+++ b/test/http2/head.test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('../..')
+const h2url = require('h2url')
+const msg = { hello: 'world' }
+
+var fastify
+try {
+  fastify = Fastify({
+    http2: true
+  })
+  t.pass('http2 successfully loaded')
+} catch (e) {
+  t.fail('http2 loading failed', e)
+}
+
+fastify.all('/', function (req, reply) {
+  reply.code(200).send(msg)
+})
+
+fastify.listen(0, err => {
+  t.error(err)
+  fastify.server.unref()
+
+  test('http HEAD request', async (t) => {
+    t.plan(1)
+
+    const url = `http://localhost:${fastify.server.address().port}`
+    const res = await h2url.concat({ url, method: 'HEAD' })
+
+    t.strictEqual(res.headers[':status'], 200)
+  })
+})

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -128,6 +128,8 @@ test('handler function - reply', t => {
 test('handler function - preValidationCallback with finished response', t => {
   t.plan(0)
   const res = {}
+  res.writableEnded = true
+  res.writable = false
   res.finished = true
   res.end = () => {
     t.fail()


### PR DESCRIPTION
Fix HEAD requests hanging in Node version 10 and 13.5.0.
On these requests, the `preValidationCallback` and `preHandlerCallback`
were exiting prematurely because of `reply.raw.finished` being `true`
with the handler not having sent the response yet. Using `writableEnded`
where available and a combined check of the `writable` and `finished`
properties solved this problem.

Fix #1993
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
