### PR TITLE
Added github backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,16 @@
+name: Backport
+on:
+  pull_request:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    runs-on: ubuntu-latest
+    name: Backport
+    steps:
+      - name: Backport
+        uses: tibdex/backport@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As titled!
This GitHub action should help us easily backport changes from `master` to `2.x` or `1.x`, you just need to add the correct backport label and it will work automagically!

If the can't be automatically backported, the GitHub bot will comment the failure on the pr.
I've already renamed our backport labels so the bot can understand them.

### How does this works?

It's quite easy, as soon as someone opens a pr against `master`, and the change should be backported to `2.x` and/or `1.x`, you should add the corresponding backport label.
For example, if we need to backport something to both `2.x` and `1.x`, we will add:
- `backport 2.x`
- `backport 1.x`

And you are done! If there are no conflicts, the action will open a separate pr with the backport, and after the tests pass, you should manually merge it :)

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)