### PR TITLE
fix(internals): fix typo in handleRequest

### DIFF
--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -72,7 +72,7 @@ function handler (request, reply) {
 
 function preValidationCallback (err, request, reply) {
   if (reply.sent === true ||
-    reply.writableEnded === true ||
+    reply.raw.writableEnded === true ||
     (reply.raw.writable === false && reply.raw.finished === true)) return
 
   if (err != null) {

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { test } = require('tap')
+const semver = require('semver')
 const handleRequest = require('../../lib/handleRequest')
 const internals = require('../../lib/handleRequest')[Symbol.for('internals')]
 const Request = require('../../lib/request')
@@ -128,9 +129,13 @@ test('handler function - reply', t => {
 test('handler function - preValidationCallback with finished response', t => {
   t.plan(0)
   const res = {}
-  res.writableEnded = true
-  res.writable = false
-  res.finished = true
+  // Be sure to check only `writableEnded` where is available
+  if (semver.gte(process.versions.node, '12.9.0')) {
+    res.writableEnded = true
+  } else {
+    res.writable = false
+    res.finished = true
+  }
   res.end = () => {
     t.fail()
   }


### PR DESCRIPTION
Add missing `raw` property in path when accessing `writableEnded`.
Explicitly set `writableEnded` only in Node versions greather than equal
to 12.9.0 in `preValidationCallback` test.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
