### PR TITLE
Log clientError as trace to avoid dev confusion

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -384,7 +384,11 @@ function fastify (options) {
       message: 'Client Error',
       statusCode: 400
     })
-    logger.debug({ err }, 'client error')
+
+    // Most devs do not know what to do with this error.
+    // In the vast majority of cases, it's a network error and/or some
+    // config issue on the the load balancer side.
+    logger.trace({ err }, 'client error')
     socket.end(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n${body}`)
   }
 


### PR DESCRIPTION
See: https://github.com/fastify/fastify/issues/2036

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
