### PR TITLE
Add option to configure clientErrorHandler (#2226)

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -469,6 +469,46 @@ const fastify = require('fastify')({
 })
 ```
 
+<a name="client-error-handler"></a>
+### `clientErrorHandler`
+
+Set a [clientErrorHandler](https://nodejs.org/api/http.html#http_event_clienterror) that listens to `error` events emitted by client connections and responds with a `400`.
+
+Using this option it is possible to override the default `clientErrorHandler`.
+
++ Default:
+```js
+function defaultClientErrorHandler (err, socket) {
+  const body = JSON.stringify({
+    error: http.STATUS_CODES['400'],
+    message: 'Client Error',
+    statusCode: 400
+  })
+  this.log.trace({ err }, 'client error')
+  socket.end(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n${body}`)
+}
+```
+
+*Note: `clientErrorHandler` operates with raw socket. The handler is expected to return a properly formed HTTP response that includes a status line, HTTP headers and a message body.*
+
+```js
+const fastify = require('fastify')({
+  clientErrorHandler: function (err, socket) {
+    const body = JSON.stringify({
+      error: {
+        message: 'Client error',
+        code: '400'
+      }
+    })
+
+    // `this` is bound to fastify instance
+    this.log.trace({ err }, 'client error')
+
+    // the handler is responsible for generating a valid HTTP response
+    socket.end(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n${body}`)
+  }
+})
+```
 
 ## Instance
 

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -138,10 +138,10 @@ test('Should set the response from client error handler', t => {
   })
   const response = `HTTP/1.1 400 Bad Request\r\nContent-Length: ${responseBody.length}\r\nContent-Type: application/json; charset=utf-8\r\n\r\n${responseBody}`
 
-  function clientErrorHandler (err, socket, logger) {
+  function clientErrorHandler (err, socket) {
     t.type(err, Error)
 
-    logger.warn({ err }, 'Handled client error')
+    this.log.warn({ err }, 'Handled client error')
     socket.end(response)
   }
 

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -5,6 +5,7 @@ const test = t.test
 const net = require('net')
 const Fastify = require('..')
 const statusCodes = require('http').STATUS_CODES
+const split = require('split2')
 
 const codes = Object.keys(statusCodes)
 codes.forEach(code => {
@@ -124,6 +125,58 @@ test('Should reply 400 on client error', t => {
       t.equal(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n${body}`, chunks)
       fastify.close()
     })
+  })
+})
+
+test('Should set the response from client error handler', t => {
+  t.plan(5)
+
+  function clientErrorHandler (err, socket, logger) {
+    t.type(err, Error)
+
+    const body = JSON.stringify({
+      error: 'Ended Request',
+      message: 'Serious Client Error',
+      statusCode: 400
+    })
+    logger.warn({ err }, 'Handled client error')
+    socket.end(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json; charset=utf-8\r\n\r\n${body}`)
+  }
+
+  const logStream = split(JSON.parse)
+  const fastify = Fastify({
+    clientErrorHandler,
+    logger: {
+      stream: logStream,
+      level: 'warn'
+    }
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    const client = net.connect(fastify.server.address().port)
+    client.end('oooops!')
+
+    var chunks = ''
+    client.on('data', chunk => {
+      chunks += chunk
+    })
+
+    client.once('end', () => {
+      const body = JSON.stringify({
+        error: 'Ended Request',
+        message: 'Serious Client Error',
+        statusCode: 400
+      })
+      t.equal(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json; charset=utf-8\r\n\r\n${body}`, chunks)
+      fastify.close()
+    })
+  })
+
+  logStream.once('data', line => {
+    t.equal('Handled client error', line.msg)
+    t.equal(40, line.level, 'Log level is not warn')
   })
 })
 

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -131,16 +131,18 @@ test('Should reply 400 on client error', t => {
 test('Should set the response from client error handler', t => {
   t.plan(5)
 
+  const responseBody = JSON.stringify({
+    error: 'Ended Request',
+    message: 'Serious Client Error',
+    statusCode: 400
+  })
+  const response = `HTTP/1.1 400 Bad Request\r\nContent-Length: ${responseBody.length}\r\nContent-Type: application/json; charset=utf-8\r\n\r\n${responseBody}`
+
   function clientErrorHandler (err, socket, logger) {
     t.type(err, Error)
 
-    const body = JSON.stringify({
-      error: 'Ended Request',
-      message: 'Serious Client Error',
-      statusCode: 400
-    })
     logger.warn({ err }, 'Handled client error')
-    socket.end(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json; charset=utf-8\r\n\r\n${body}`)
+    socket.end(response)
   }
 
   const logStream = split(JSON.parse)
@@ -164,12 +166,7 @@ test('Should set the response from client error handler', t => {
     })
 
     client.once('end', () => {
-      const body = JSON.stringify({
-        error: 'Ended Request',
-        message: 'Serious Client Error',
-        statusCode: 400
-      })
-      t.equal(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json; charset=utf-8\r\n\r\n${body}`, chunks)
+      t.equal(response, chunks)
       fastify.close()
     })
   })


### PR DESCRIPTION
The custom clientError handler function has the signature `(err, socket, logger) => void`

The extra logger is injected to allow the custom clientHandler to have parity with the default `clientError` handler. The default `clientError` handler has access to `logger`, so the custom one should have access to `logger` as well.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

---

`npm run bench` results are as follows. The tests were run a MacBook Pro laptop (Retina, 15-inch, Mid 2015).

```
> fastify@3.0.0-rc.1 bench /Users/chiku/code/fastify
> branchcmp -r 2 -g -s "npm run benchmark"

Current Branch is client-error-handler ba6508a
? What's your branches to compare? client-error-handler, master
? Please enter the command you want to execute in all branches! npm run benchmark
Checking out "client-error-handler"
Execute "npm run benchmark"

> fastify@3.0.0-rc.1 benchmark /Users/chiku/code/fastify
> npx concurrently -k -s first "node ./examples/simple.js" "npx autocannon -c 100 -d 5 -p 10 localhost:3000/"

[1] Running 5s test @ http://localhost:3000/
[1] 100 connections with 10 pipelining factor
[1]
[1] ┌─────────┬──────┬──────┬───────┬───────┬─────────┬──────────┬───────────┐
[1] │ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%   │ Avg     │ Stdev    │ Max       │
[1] ├─────────┼──────┼──────┼───────┼───────┼─────────┼──────────┼───────────┤
[1] │ Latency │ 0 ms │ 0 ms │ 48 ms │ 59 ms │ 4.71 ms │ 15.37 ms │ 387.34 ms │
[1] └─────────┴──────┴──────┴───────┴───────┴─────────┴──────────┴───────────┘
[1] ┌───────────┬────────┬────────┬─────────┬───────┬─────────┬─────────┬────────┐
[1] │ Stat      │ 1%     │ 2.5%   │ 50%     │ 97.5% │ Avg     │ Stdev   │ Min    │
[1] ├───────────┼────────┼────────┼─────────┼───────┼─────────┼─────────┼────────┤
[1] │ Req/Sec   │ 15855  │ 15855  │ 21023   │ 24415 │ 20719.2 │ 2786.06 │ 15853  │
[1] ├───────────┼────────┼────────┼─────────┼───────┼─────────┼─────────┼────────┤
[1] │ Bytes/Sec │ 2.6 MB │ 2.6 MB │ 3.45 MB │ 4 MB  │ 3.4 MB  │ 457 kB  │ 2.6 MB │
[1] └───────────┴────────┴────────┴─────────┴───────┴─────────┴─────────┴────────┘
[1]
[1] Req/Bytes counts sampled once per second.
[1]
[1] 104k requests in 5.06s, 17 MB read
[1] 137 errors (0 timeouts)
[1] npx autocannon -c 100 -d 5 -p 10 localhost:3000/ exited with code 0
--> Sending SIGTERM to other processes..
Executed: "npm run benchmark" and exited with code: 0
Execute "npm run benchmark"

> fastify@3.0.0-rc.1 benchmark /Users/chiku/code/fastify
> npx concurrently -k -s first "node ./examples/simple.js" "npx autocannon -c 100 -d 5 -p 10 localhost:3000/"

[1] Running 5s test @ http://localhost:3000/
[1] 100 connections with 10 pipelining factor
[1]
[1] ┌─────────┬──────┬──────┬───────┬───────┬─────────┬──────────┬───────────┐
[1] │ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%   │ Avg     │ Stdev    │ Max       │
[1] ├─────────┼──────┼──────┼───────┼───────┼─────────┼──────────┼───────────┤
[1] │ Latency │ 0 ms │ 0 ms │ 41 ms │ 46 ms │ 4.05 ms │ 13.71 ms │ 367.21 ms │
[1] └─────────┴──────┴──────┴───────┴───────┴─────────┴──────────┴───────────┘
[1] ┌───────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg     │ Stdev   │ Min     │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
[1] │ Req/Sec   │ 16111   │ 16111   │ 26367   │ 27903   │ 24130.4 │ 4233.68 │ 16110   │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
[1] │ Bytes/Sec │ 2.64 MB │ 2.64 MB │ 4.33 MB │ 4.58 MB │ 3.96 MB │ 694 kB  │ 2.64 MB │
[1] └───────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
[1]
[1] Req/Bytes counts sampled once per second.
[1]
[1] 121k requests in 5.06s, 19.8 MB read
[1] 107 errors (0 timeouts)
[1] npx autocannon -c 100 -d 5 -p 10 localhost:3000/ exited with code 0
--> Sending SIGTERM to other processes..
Executed: "npm run benchmark" and exited with code: 0
Checking out "master"
Execute "npm run benchmark"

> fastify@3.0.0-rc.1 benchmark /Users/chiku/code/fastify
> npx concurrently -k -s first "node ./examples/simple.js" "npx autocannon -c 100 -d 5 -p 10 localhost:3000/"

[1] Running 5s test @ http://localhost:3000/
[1] 100 connections with 10 pipelining factor
[1]
[1] ┌─────────┬──────┬──────┬───────┬───────┬─────────┬──────────┬───────────┐
[1] │ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%   │ Avg     │ Stdev    │ Max       │
[1] ├─────────┼──────┼──────┼───────┼───────┼─────────┼──────────┼───────────┤
[1] │ Latency │ 0 ms │ 0 ms │ 50 ms │ 55 ms │ 4.79 ms │ 15.47 ms │ 358.76 ms │
[1] └─────────┴──────┴──────┴───────┴───────┴─────────┴──────────┴───────────┘
[1] ┌───────────┬─────────┬─────────┬─────────┬─────────┬─────────┬────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg     │ Stdev  │ Min     │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼────────┼─────────┤
[1] │ Req/Sec   │ 17503   │ 17503   │ 19919   │ 23135   │ 20417.6 │ 1944.4 │ 17501   │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼────────┼─────────┤
[1] │ Bytes/Sec │ 2.87 MB │ 2.87 MB │ 3.27 MB │ 3.79 MB │ 3.35 MB │ 318 kB │ 2.87 MB │
[1] └───────────┴─────────┴─────────┴─────────┴─────────┴─────────┴────────┴─────────┘
[1]
[1] Req/Bytes counts sampled once per second.
[1]
[1] 102k requests in 5.07s, 16.7 MB read
[1] 106 errors (0 timeouts)
[1] npx autocannon -c 100 -d 5 -p 10 localhost:3000/ exited with code 0
--> Sending SIGTERM to other processes..
Executed: "npm run benchmark" and exited with code: 0
Execute "npm run benchmark"

> fastify@3.0.0-rc.1 benchmark /Users/chiku/code/fastify
> npx concurrently -k -s first "node ./examples/simple.js" "npx autocannon -c 100 -d 5 -p 10 localhost:3000/"

[1] Running 5s test @ http://localhost:3000/
[1] 100 connections with 10 pipelining factor
[1]
[1] ┌─────────┬──────┬──────┬───────┬───────┬─────────┬──────────┬───────────┐
[1] │ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%   │ Avg     │ Stdev    │ Max       │
[1] ├─────────┼──────┼──────┼───────┼───────┼─────────┼──────────┼───────────┤
[1] │ Latency │ 0 ms │ 0 ms │ 49 ms │ 64 ms │ 4.99 ms │ 16.78 ms │ 408.18 ms │
[1] └─────────┴──────┴──────┴───────┴───────┴─────────┴──────────┴───────────┘
[1] ┌───────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg     │ Stdev   │ Min     │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
[1] │ Req/Sec   │ 14679   │ 14679   │ 19759   │ 22927   │ 19575.2 │ 3083.41 │ 14679   │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
[1] │ Bytes/Sec │ 2.41 MB │ 2.41 MB │ 3.24 MB │ 3.76 MB │ 3.21 MB │ 506 kB  │ 2.41 MB │
[1] └───────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
[1]
[1] Req/Bytes counts sampled once per second.
[1]
[1] 98k requests in 5.06s, 16.1 MB read
[1] 123 errors (0 timeouts)
[1] npx autocannon -c 100 -d 5 -p 10 localhost:3000/ exited with code 0
```