### PR TITLE
doc: doc example to use ajv-errors

### DIFF
--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -738,7 +738,9 @@ fastify.setErrorHandler(function (error, request, reply) {
   if (error.validation) {
     localize.ru(error.validation)
     reply.status(400).send(error.validation)
+    return
   }
+  reply.send(error)
 })
 ```
 

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -660,7 +660,7 @@ fastify.setErrorHandler(function (error, request, reply) {
 
 If you want custom error response in schema without headaches and quickly, you can take a look at [`ajv-errors`](https://github.com/epoberezkin/ajv-errors).
 
-Below is an example showing how to add custom error messages for each property of a schema by supplying a custom AJV instance. Inline comments describe how to can configure the schema to show a different error message for each case:
+Below is an example showing how to add custom error messages for each property of a schema by supplying a custom AJV instance. Inline comments describe how to configure the schema to show a different error message for each case:
 
 ```js
 const Ajv = require('ajv')
@@ -700,6 +700,48 @@ ajvErrors(ajv)
 
 fastify.setSchemaCompiler(function (schema) {
   return ajv.compile(schema)
+})
+```
+
+If you want to return localized error messages, take a look at [ajv-i18n](https://github.com/epoberezkin/ajv-i18n)
+
+```js
+const Ajv = require('ajv')
+const localize = require('ajv-i18n')
+
+const schema = {
+  body: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+      },
+      age: {
+        type: 'number',
+      }
+    },
+    required: ['name', 'age'],
+  }
+}
+
+const ajv = new Ajv({ allErrors: true, jsonPointers: true })
+
+fastify.setSchemaCompiler(function (schema) {
+  const validate =  ajv.compile(schema)
+
+  function validator (data) {
+    const result = validate(data)
+
+    if (!result) {
+      localize.ru(validate.errors);
+      ajv.errorsText(validate.errors, { separator: '\n' })
+    }
+
+    validator.errors = validate.errors
+    return result
+  }
+
+  return validator
 })
 ```
 

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -658,14 +658,13 @@ fastify.setErrorHandler(function (error, request, reply) {
 })
 ```
 
-If you want custom error response in schema without headaches and quickly, you can take a look at [here](https://github.com/epoberezkin/ajv-errors).
+If you want custom error response in schema without headaches and quickly, you can take a look at [`ajv-errors`](https://github.com/epoberezkin/ajv-errors).
 
-Below is an example to add custom error messages for each property. Inline comments describe how you can configure your schema to show different error message for each case
+Below is an example showing how to add custom error messages for each property of a schema by supplying a custom AJV instance. Inline comments describe how to can configure the schema to show a different error message for each case:
 
 ```js
 const Ajv = require('ajv')
-const AjvErrors = require('ajv-errors')
-...
+const ajvErrors = require('ajv-errors')
 
 const schema = {
   body: {
@@ -695,11 +694,9 @@ const schema = {
   }
 }
 
-...
-
 const ajv = new Ajv({ allErrors: true, jsonPointers: true })
-// enhance the ajv instance
-AjvErrors(ajv)
+// extend the AJV instance with custom errors support
+ajvErrors(ajv)
 
 fastify.setSchemaCompiler(function (schema) {
   return ajv.compile(schema)

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -658,7 +658,53 @@ fastify.setErrorHandler(function (error, request, reply) {
 })
 ```
 
-If you want custom error response in schema without headaches and quickly, you can take a look at [here](https://github.com/epoberezkin/ajv-errors)
+If you want custom error response in schema without headaches and quickly, you can take a look at [here](https://github.com/epoberezkin/ajv-errors).
+
+Below is an example to add custom error messages for each property. Inline comments describe how you can configure your schema to show different error message for each case
+
+```js
+const Ajv = require('ajv')
+const AjvErrors = require('ajv-errors')
+...
+
+const schema = {
+  body: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+        errorMessage: {
+          type: 'Bad name'
+        }
+      },
+      age: {
+        type: 'number',
+        errorMessage: {
+          type: 'Bad age', // specify custom message for
+          min: 'Too young' // all constraints except required
+        }
+      }
+    },
+    required: ['name', 'age'],
+    errorMessage: {
+      required: {
+        name: 'Why no name!', // specify error message for when the
+        age: 'Why no age!' // property is missing from input
+      }
+    }
+  }
+}
+
+...
+
+const ajv = new Ajv({ allErrors: true, jsonPointers: true })
+// enhance the ajv instance
+AjvErrors(ajv)
+
+fastify.setSchemaCompiler(function (schema) {
+  return ajv.compile(schema)
+})
+```
 
 ### JSON Schema and Shared Schema support
 

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -713,6 +713,12 @@ If you want to return localized error messages, take a look at [ajv-i18n](https:
 ```js
 const localize = require('ajv-i18n')
 
+const fastify = Fastify({
+  ajv: {
+    customOptions: { allErrors: true }
+  }
+})
+
 const schema = {
   body: {
     type: 'object',
@@ -728,16 +734,9 @@ const schema = {
   }
 }
 
-const ajv = new Ajv({ allErrors: true, jsonPointers: true })
-
-fastify.setSchemaCompiler(function (schema) {
-  return ajv.compile(schema)
-})
-
 fastify.setErrorHandler(function (error, request, reply) {
   if (error.validation) {
     localize.ru(error.validation)
-    ajv.errorsText(error.validation, { separator: '\n' })
     reply.status(400).send(error.validation)
   }
 })

--- a/package.json
+++ b/package.json
@@ -96,6 +96,8 @@
     "@typescript-eslint/eslint-plugin": "^2.24.0",
     "@typescript-eslint/parser": "^2.24.0",
     "JSONStream": "^1.3.5",
+    "ajv-errors": "^1.0.1",
+    "ajv-i18n": "^3.5.0",
     "ajv-merge-patch": "^4.1.0",
     "ajv-pack": "^0.3.1",
     "autocannon": "^3.2.2",

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -2,6 +2,7 @@
 
 const t = require('tap')
 const Joi = require('joi')
+const localize = require('ajv-i18n')
 const Fastify = require('..')
 const test = t.test
 
@@ -61,6 +62,103 @@ test('should fail immediately with invalid payload', t => {
       error: 'Bad Request',
       message: "body should have required property 'name', body should have required property 'work'"
     })
+    t.strictEqual(res.statusCode, 400)
+  })
+})
+
+test('should return custom error messages with ajv-errors', t => {
+  t.plan(3)
+
+  const fastify = Fastify({
+    ajv: {
+      customOptions: { allErrors: true, jsonPointers: true },
+      plugins: [
+        require('ajv-errors')
+      ]
+    }
+  })
+
+  const schema = {
+    body: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        work: { type: 'string' },
+        age: {
+          type: 'number',
+          errorMessage: {
+            type: 'bad age - should be num'
+          }
+        }
+      },
+      required: ['name', 'work'],
+      errorMessage: {
+        required: {
+          name: 'name please',
+          work: 'work please',
+          age: 'age please'
+        }
+      }
+    }
+  }
+
+  fastify.post('/', { schema }, function (req, reply) {
+    reply.code(200).send(req.body.name)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    payload: {
+      hello: 'salman',
+      age: 'bad'
+    },
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.deepEqual(JSON.parse(res.payload), {
+      statusCode: 400,
+      error: 'Bad Request',
+      message: 'body/age bad age - should be num, body name please, body work please'
+    })
+    t.strictEqual(res.statusCode, 400)
+  })
+})
+
+test('should return localized error messages with ajv-i18n', t => {
+  t.plan(3)
+
+  const fastify = Fastify({
+    ajv: {
+      customOptions: { allErrors: true }
+    }
+  })
+
+  fastify.setErrorHandler(function (error, request, reply) {
+    if (error.validation) {
+      localize.ru(error.validation)
+      reply.status(400).send(error.validation)
+    }
+  })
+
+  fastify.post('/', { schema }, function (req, reply) {
+    reply.code(200).send(req.body.name)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    payload: {
+      name: 'salman'
+    },
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.deepEqual(JSON.parse(res.payload), [{
+      dataPath: '',
+      keyword: 'required',
+      message: 'должно иметь обязательное поле work',
+      params: { missingProperty: 'work' },
+      schemaPath: '#/required'
+    }])
     t.strictEqual(res.statusCode, 400)
   })
 })

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -137,7 +137,9 @@ test('should return localized error messages with ajv-i18n', t => {
     if (error.validation) {
       localize.ru(error.validation)
       reply.status(400).send(error.validation)
+      return
     }
+    reply.send(error)
   })
 
   fastify.post('/', { schema }, function (req, reply) {


### PR DESCRIPTION
Added docs example to demonstrate usage with ajv-errors & ajv-i18n.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
