### PR TITLE
Fix: call preHandler on reply.callNotFound

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -162,7 +162,8 @@ reply.code(303).redirect(302, '/home')
 
 <a name="call-not-found"></a>
 ### .callNotFound()
-Invokes the custom not found handler.
+Invokes the custom not found handler. Note that it will only call `preHandler` hook specified in [`setNotFoundHandler`](https://github.com/fastify/fastify/blob/master/docs/Server.md#set-not-found-handler).
+
 ```js
 reply.callNotFound()
 ```

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -817,6 +817,8 @@ The input `schema` can access all the shared schemas added with [`.addSchema`](#
 
 You can also register [`preValidation`](https://www.fastify.io/docs/latest/Hooks/#route-hooks) and [`preHandler`](https://www.fastify.io/docs/latest/Hooks/#route-hooks) hooks for the 404 handler.
 
+_Note: The `preValidation` hook registered using this method will run for a route that Fastify does not recognize and **not** when a route handler manually calls [`reply.callNotFound`](https://github.com/fastify/fastify/blob/master/docs/Reply.md#call-not-found)_. In which case only preHandler will be run.
+
 ```js
 fastify.setNotFoundHandler({
   preValidation: (req, reply, done) => {

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -133,4 +133,4 @@ function preHandlerCallback (err, request, reply) {
 }
 
 module.exports = handleRequest
-module.exports[Symbol.for('internals')] = { handler }
+module.exports[Symbol.for('internals')] = { handler, preHandlerCallback }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -22,6 +22,7 @@ const { hookRunner, hookIterator, onSendHookRunner } = require('./hooks')
 const validation = require('./validation')
 const serialize = validation.serialize
 
+const internals = require('./handleRequest')[Symbol.for('internals')]
 const loggerUtils = require('./logger')
 const now = loggerUtils.now
 const wrapThenable = require('./wrapThenable')
@@ -613,26 +614,10 @@ function notFound (reply) {
       hookIterator,
       reply.request,
       reply,
-      preHandlerCallback
+      internals.preHandlerCallback
     )
   } else {
-    preHandlerCallback(null, reply.request, reply)
-  }
-
-  function preHandlerCallback (err, request, reply) {
-    if (reply.sent === true ||
-      reply.res.writableEnded === true ||
-      (reply.res.writable === false && reply.res.finished === true)) return
-
-    if (err != null) {
-      reply.send(err)
-      return
-    }
-
-    var result = reply.context.handler(request, reply)
-    if (result && typeof result.then === 'function') {
-      wrapThenable(result, reply)
-    }
+    internals.preHandlerCallback(null, reply.request, reply)
   }
 }
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -18,7 +18,7 @@ const {
   kReplyIsRunningOnErrorHook,
   kDisableRequestLogging
 } = require('./symbols.js')
-const { hookRunner, onSendHookRunner } = require('./hooks')
+const { hookRunner, hookIterator, onSendHookRunner } = require('./hooks')
 const validation = require('./validation')
 const serialize = validation.serialize
 
@@ -605,7 +605,35 @@ function notFound (reply) {
   }
 
   reply.context = reply.context[kFourOhFourContext]
-  reply.context.handler(reply.request, reply)
+
+  // preHandler hook
+  if (reply.context.preHandler !== null) {
+    hookRunner(
+      reply.context.preHandler,
+      hookIterator,
+      reply.request,
+      reply,
+      preHandlerCallback
+    )
+  } else {
+    preHandlerCallback(null, reply.request, reply)
+  }
+
+  function preHandlerCallback (err, request, reply) {
+    if (reply.sent === true ||
+      reply.res.writableEnded === true ||
+      (reply.res.writable === false && reply.res.finished === true)) return
+
+    if (err != null) {
+      reply.send(err)
+      return
+    }
+
+    var result = reply.context.handler(request, reply)
+    if (result && typeof result.then === 'function') {
+      wrapThenable(result, reply)
+    }
+  }
 }
 
 function noop () { }

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -1194,7 +1194,7 @@ test('onSend hooks run when an encapsulated route invokes the notFound handler',
 
 // https://github.com/fastify/fastify/issues/713
 test('preHandler option for setNotFoundHandler', t => {
-  t.plan(8)
+  t.plan(10)
 
   t.test('preHandler option', t => {
     t.plan(2)
@@ -1217,6 +1217,68 @@ test('preHandler option for setNotFoundHandler', t => {
       t.error(err)
       var payload = JSON.parse(res.payload)
       t.deepEqual(payload, { preHandler: true, hello: 'world' })
+    })
+  })
+
+  t.test('preHandler hook in setNotFoundHandler should be called when callNotFound', t => {
+    t.plan(2)
+    const fastify = Fastify()
+
+    fastify.setNotFoundHandler({
+      preHandler: (req, reply, done) => {
+        req.body.preHandler = true
+        done()
+      }
+    }, function (req, reply) {
+      reply.code(404).send(req.body)
+    })
+
+    fastify.post('/', function (req, reply) {
+      reply.callNotFound()
+    })
+
+    fastify.inject({
+      method: 'POST',
+      url: '/',
+      payload: { hello: 'world' }
+    }, (err, res) => {
+      t.error(err)
+      var payload = JSON.parse(res.payload)
+      t.deepEqual(payload, { preHandler: true, hello: 'world' })
+    })
+  })
+
+  t.test('preHandler hook in setNotFoundHandler should accept an array of functions and be called when callNotFound', t => {
+    t.plan(2)
+    const fastify = Fastify()
+
+    fastify.setNotFoundHandler({
+      preHandler: [
+        (req, reply, done) => {
+          req.body.preHandler1 = true
+          done()
+        },
+        (req, reply, done) => {
+          req.body.preHandler2 = true
+          done()
+        }
+      ]
+    }, function (req, reply) {
+      reply.code(404).send(req.body)
+    })
+
+    fastify.post('/', function (req, reply) {
+      reply.callNotFound()
+    })
+
+    fastify.inject({
+      method: 'POST',
+      url: '/',
+      payload: { hello: 'world' }
+    }, (err, res) => {
+      t.error(err)
+      var payload = JSON.parse(res.payload)
+      t.deepEqual(payload, { preHandler1: true, preHandler2: true, hello: 'world' })
     })
   })
 

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -1220,6 +1220,7 @@ test('preHandler option for setNotFoundHandler', t => {
     })
   })
 
+  // https://github.com/fastify/fastify/issues/2229
   t.test('preHandler hook in setNotFoundHandler should be called when callNotFound', t => {
     t.plan(2)
     const fastify = Fastify()


### PR DESCRIPTION
Fixes https://github.com/fastify/fastify/issues/2229

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
