### PR TITLE
[Backport 2.x] Fix: call preHandler on reply.callNotFound (#2256)

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -147,7 +147,8 @@ reply.code(303).redirect(302, '/home')
 
 <a name="call-not-found"></a>
 ### .callNotFound()
-Invokes the custom not found handler.
+Invokes the custom not found handler. Note that it will only call `preHandler` hook specified in [`setNotFoundHandler`](https://github.com/fastify/fastify/blob/master/docs/Server.md#set-not-found-handler).
+
 ```js
 reply.callNotFound()
 ```

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -720,6 +720,8 @@ This property can be used to set the schema compiler, it is a shortcut for the `
 
 You can also register a [`preValidation`](https://www.fastify.io/docs/latest/Hooks/#route-hooks) and [preHandler](https://www.fastify.io/docs/latest/Hooks/#route-hooks) hook for the 404 handler.
 
+_Note: The `preValidation` hook registered using this method will run for a route that Fastify does not recognize and **not** when a route handler manually calls [`reply.callNotFound`](https://github.com/fastify/fastify/blob/master/docs/Reply.md#call-not-found)_. In which case only preHandler will be run.
+
 ```js
 fastify.setNotFoundHandler({
   preValidation: (req, reply, done) => {

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -121,4 +121,4 @@ function preHandlerCallback (err, request, reply) {
 }
 
 module.exports = handleRequest
-module.exports[Symbol.for('internals')] = { handler }
+module.exports[Symbol.for('internals')] = { handler, preHandlerCallback }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -18,10 +18,11 @@ const {
   kReplyIsRunningOnErrorHook,
   kDisableRequestLogging
 } = require('./symbols.js')
-const { hookRunner, onSendHookRunner } = require('./hooks')
+const { hookRunner, hookIterator, onSendHookRunner } = require('./hooks')
 const validation = require('./validation')
 const serialize = validation.serialize
 
+const internals = require('./handleRequest')[Symbol.for('internals')]
 const loggerUtils = require('./logger')
 const now = loggerUtils.now
 const wrapThenable = require('./wrapThenable')
@@ -569,7 +570,19 @@ function notFound (reply) {
   }
 
   reply.context = reply.context[kFourOhFourContext]
-  reply.context.handler(reply.request, reply)
+
+  // preHandler hook
+  if (reply.context.preHandler !== null) {
+    hookRunner(
+      reply.context.preHandler,
+      hookIterator,
+      reply.request,
+      reply,
+      internals.preHandlerCallback
+    )
+  } else {
+    internals.preHandlerCallback(null, reply.request, reply)
+  }
 }
 
 function noop () {}


### PR DESCRIPTION
Backport ae6b57c94cbfcec10b66c4a19d8a62df540486c1 from #2256 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
