### PR TITLE
Remove absolute URL's from docs

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -4,7 +4,7 @@
 ## Factory
 
 The Fastify module exports a factory function that is used to create new
-<a href="/Server.md"><code><b>Fastify server</b></code></a>
+<a href="./Server.md"><code><b>Fastify server</b></code></a>
 instances. This factory function accepts an options object which is used to
 customize the resulting instance. This document describes the properties
 available in that options object.

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -4,7 +4,7 @@
 ## Factory
 
 The Fastify module exports a factory function that is used to create new
-<a href="https://github.com/fastify/fastify/blob/master/docs/Server.md"><code><b>Fastify server</b></code></a>
+<a href="/Server.md"><code><b>Fastify server</b></code></a>
 instances. This factory function accepts an options object which is used to
 customize the resulting instance. This document describes the properties
 available in that options object.

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -25,7 +25,7 @@ are the same as the Node.js core
 When this property is `null`, the socket will not be configured for TLS.
 
 This option also applies when the
-<a href="https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-http2">
+<a href="./Server.md#factory-http2">
 <code><b>http2</b></code>
 </a> option is set.
 
@@ -95,7 +95,7 @@ Defines the maximum payload, in bytes, the server is allowed to accept.
 
 Defines what action the framework must take when parsing a JSON object
 with `__proto__`. This functionality is provided by
-[secure-json-parse](https://github.com/fastify/secure-json-parse).
+[secure-json-parse](../fastify/secure-json-parse).
 See https://hueniverse.com/a-tale-of-prototype-poisoning-2610fa170061
 for more details about prototype poisoning attacks.
 
@@ -108,7 +108,7 @@ Possible values are `'error'`, `'remove'` and `'ignore'`.
 
 Defines what action the framework must take when parsing a JSON object
 with `constructor`. This functionality is provided by
-[secure-json-parse](https://github.com/fastify/secure-json-parse).
+[secure-json-parse](../fastify/secure-json-parse).
 See https://hueniverse.com/a-tale-of-prototype-poisoning-2610fa170061
 for more details about prototype poisoning attacks.
 
@@ -239,7 +239,7 @@ Please note this setting this option to `false` goes against
 <a name="factory-request-id-header"></a>
 ### `requestIdHeader`
 
-The header name used to know the request id. See [the request id](https://github.com/fastify/fastify/blob/master/docs/Logging.md#logging-request-id) section.
+The header name used to know the request id. See [the request id](./Logging.md#logging-request-id) section.
 
 + Default: `'request-id'`
 
@@ -291,7 +291,7 @@ const fastify = Fastify({ trustProxy: true })
 
 For more examples refer to [proxy-addr](https://www.npmjs.com/package/proxy-addr) package.
 
-You may access the `ip`, `ips`, and `hostname` values on the [`request`](https://github.com/fastify/fastify/blob/master/docs/Request.md) object.
+You may access the `ip`, `ips`, and `hostname` values on the [`request`](./Request.md) object.
 
 ```js
 fastify.get('/', (request, reply) => {
@@ -305,7 +305,7 @@ fastify.get('/', (request, reply) => {
 ### `pluginTimeout`
 
 The maximum amount of time in *milliseconds* in which a plugin can load.
-If not, [`ready`](https://github.com/fastify/fastify/blob/master/docs/Server.md#ready)
+If not, [`ready`](./Server.md#ready)
 will complete with an `Error` with code `'ERR_AVVIO_PLUGIN_TIMEOUT'`.
 
 + Default: `10000`
@@ -326,7 +326,7 @@ const fastify = require('fastify')({
 <a name="versioning"></a>
 ### `versioning`
 
-By default you can version your routes with [semver versioning](https://github.com/fastify/fastify/blob/master/docs/Routes.md#version), which is provided by `find-my-way`. There is still an option to provide custom versioning strategy. You can find more information in the [find-my-way](https://github.com/delvedor/find-my-way#versioned-routes) documentation.
+By default you can version your routes with [semver versioning](./Routes.md#version), which is provided by `find-my-way`. There is still an option to provide custom versioning strategy. You can find more information in the [find-my-way](https://github.com/delvedor/find-my-way#versioned-routes) documentation.
 
 ```js
 const versioning = {
@@ -516,7 +516,7 @@ const fastify = require('fastify')({
 
 <a name="server"></a>
 #### server
-`fastify.server`: The Node core [server](https://nodejs.org/api/http.html#http_class_http_server) object as returned by the [**`Fastify factory function`**](https://github.com/fastify/fastify/blob/master/docs/Server.md).
+`fastify.server`: The Node core [server](https://nodejs.org/api/http.html#http_class_http_server) object as returned by the [**`Fastify factory function`**](./Server.md).
 
 <a name="after"></a>
 #### after
@@ -687,13 +687,13 @@ fastify.listen({
 
 <a name="route"></a>
 #### route
-Method to add routes to the server, it also has shorthand functions, check [here](https://github.com/fastify/fastify/blob/master/docs/Routes.md).
+Method to add routes to the server, it also has shorthand functions, check [here](./Routes.md).
 
 <a name="close"></a>
 #### close
-`fastify.close(callback)`: call this function to close the server instance and run the [`'onClose'`](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#on-close) hook.<br>
+`fastify.close(callback)`: call this function to close the server instance and run the [`'onClose'`](./Hooks.md#on-close) hook.<br>
 Calling `close` will also cause the server to respond to every new incoming request with a `503` error and destroy that request.
-See [`return503OnClosing` flags](https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-return-503-on-closing) for changing this behaviour.
+See [`return503OnClosing` flags](./Server.md#factory-return-503-on-closing) for changing this behaviour.
 
 If it is called without any arguments, it will return a Promise:
 
@@ -707,16 +707,16 @@ fastify.close().then(() => {
 
 <a name="decorate"></a>
 #### decorate*
-Function useful if you need to decorate the fastify instance, Reply or Request, check [here](https://github.com/fastify/fastify/blob/master/docs/Decorators.md).
+Function useful if you need to decorate the fastify instance, Reply or Request, check [here](./Decorators.md).
 
 <a name="register"></a>
 #### register
 Fastify allows the user to extend its functionality with plugins.
-A plugin can be a set of routes, a server decorator or whatever, check [here](https://github.com/fastify/fastify/blob/master/docs/Plugins.md).
+A plugin can be a set of routes, a server decorator or whatever, check [here](./Plugins.md).
 
 <a name="addHook"></a>
 #### addHook
-Function to add a specific hook in the lifecycle of Fastify, check [here](https://github.com/fastify/fastify/blob/master/docs/Hooks.md).
+Function to add a specific hook in the lifecycle of Fastify, check [here](./Hooks.md).
 
 <a name="prefix"></a>
 #### prefix
@@ -760,16 +760,16 @@ Important: If you have to deal with nested plugins the name differs with the usa
 
 <a name="log"></a>
 #### log
-The logger instance, check [here](https://github.com/fastify/fastify/blob/master/docs/Logging.md).
+The logger instance, check [here](./Logging.md).
 
 <a name="inject"></a>
 #### inject
-Fake http injection (for testing purposes) [here](https://github.com/fastify/fastify/blob/master/docs/Testing.md#inject).
+Fake http injection (for testing purposes) [here](./Testing.md#inject).
 
 <a name="add-schema"></a>
 #### addSchema
 `fastify.addSchema(schemaObj)`, adds a JSON schema to the Fastify instance. This allows you to reuse it everywhere in your application just by using the standard `$ref` keyword.<br/>
-To learn more, read the [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) documentation.
+To learn more, read the [Validation and Serialization](./Validation-and-Serialization.md) documentation.
 
 <a name="get-schemas"></a>
 #### getSchemas
@@ -781,8 +781,8 @@ To learn more, read the [Validation and Serialization](https://github.com/fastif
 
 <a name="set-reply-serializer"></a>
 #### setReplySerializer
-Set the reply serializer for all the routes. This will used as default if a [Reply.serializer(func)](https://github.com/fastify/fastify/blob/master/docs/Reply.md#serializerfunc) has not been set. The handler is fully encapsulated, so different plugins can set different error handlers.
-Note: the function parameter is called only for status `2xx`. Checkout the [`setErrorHandler`](https://github.com/fastify/fastify/blob/master/docs/Server.md#seterrorhandler) for errors.
+Set the reply serializer for all the routes. This will used as default if a [Reply.serializer(func)](./Reply.md#serializerfunc) has not been set. The handler is fully encapsulated, so different plugins can set different error handlers.
+Note: the function parameter is called only for status `2xx`. Checkout the [`setErrorHandler`](./Server.md#seterrorhandler) for errors.
 
 ```js
 fastify.setReplySerializer(function (payload, statusCode){
@@ -793,11 +793,11 @@ fastify.setReplySerializer(function (payload, statusCode){
 
 <a name="set-validator-compiler"></a>
 #### setValidatorCompiler
-Set the schema validator compiler for all routes. See [#schema-validator](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-validator).
+Set the schema validator compiler for all routes. See [#schema-validator](./Validation-and-Serialization.md#schema-validator).
 
 <a name="set-serializer-resolver"></a>
 #### setSerializerCompiler
-Set the schema serializer compiler for all routes. See [#schema-serializer](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-serializer).
+Set the schema serializer compiler for all routes. See [#schema-serializer](./Validation-and-Serialization.md#schema-serializer).
 **Note:** [`setReplySerializer`](#set-reply-serializer) has priority if set!
 
 <a name="validator-compiler"></a>
@@ -813,11 +813,11 @@ The input `schema` can access all the shared schemas added with [`.addSchema`](#
 <a name="set-not-found-handler"></a>
 #### setNotFoundHandler
 
-`fastify.setNotFoundHandler(handler(request, reply))`: set the 404 handler. This call is encapsulated by prefix, so different plugins can set different not found handlers if a different [`prefix` option](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#route-prefixing-option) is passed to `fastify.register()`. The handler is treated like a regular route handler so requests will go through the full [Fastify lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md#lifecycle).
+`fastify.setNotFoundHandler(handler(request, reply))`: set the 404 handler. This call is encapsulated by prefix, so different plugins can set different not found handlers if a different [`prefix` option](./Plugins.md#route-prefixing-option) is passed to `fastify.register()`. The handler is treated like a regular route handler so requests will go through the full [Fastify lifecycle](./Lifecycle.md#lifecycle).
 
 You can also register [`preValidation`](https://www.fastify.io/docs/latest/Hooks/#route-hooks) and [`preHandler`](https://www.fastify.io/docs/latest/Hooks/#route-hooks) hooks for the 404 handler.
 
-_Note: The `preValidation` hook registered using this method will run for a route that Fastify does not recognize and **not** when a route handler manually calls [`reply.callNotFound`](https://github.com/fastify/fastify/blob/master/docs/Reply.md#call-not-found)_. In which case only preHandler will be run.
+_Note: The `preValidation` hook registered using this method will run for a route that Fastify does not recognize and **not** when a route handler manually calls [`reply.callNotFound`](./Reply.md#call-not-found)_. In which case only preHandler will be run.
 
 ```js
 fastify.setNotFoundHandler({

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -95,7 +95,7 @@ Defines the maximum payload, in bytes, the server is allowed to accept.
 
 Defines what action the framework must take when parsing a JSON object
 with `__proto__`. This functionality is provided by
-[secure-json-parse](../fastify/secure-json-parse).
+[secure-json-parse](https://github.com/fastify/secure-json-parse).
 See https://hueniverse.com/a-tale-of-prototype-poisoning-2610fa170061
 for more details about prototype poisoning attacks.
 
@@ -108,7 +108,7 @@ Possible values are `'error'`, `'remove'` and `'ignore'`.
 
 Defines what action the framework must take when parsing a JSON object
 with `constructor`. This functionality is provided by
-[secure-json-parse](../fastify/secure-json-parse).
+[secure-json-parse](https://github.com/fastify/secure-json-parse).
 See https://hueniverse.com/a-tale-of-prototype-poisoning-2610fa170061
 for more details about prototype poisoning attacks.
 


### PR DESCRIPTION
In reference to #2265, I have converted the absolute urls from Server.md to relative urls.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
