### PR TITLE
doc: doc example to use ajv-errors (#2254)

### DIFF
--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -514,7 +514,91 @@ fastify.setErrorHandler(function (error, request, reply) {
 })
 ```
 
-If you want custom error response in schema without headaches and quickly, you can take a look at [here](https://github.com/epoberezkin/ajv-errors)
+If you want custom error response in schema without headaches and quickly, you can take a look at [`ajv-errors`](https://github.com/epoberezkin/ajv-errors). Checkout the [example](https://github.com/fastify/example/blob/master/validation-messages/custom-errors-messages.js) usage.
+
+Below is an example showing how to add **custom error messages for each property** of a schema by supplying custom AJV options.
+Inline comments in the schema below describe how to configure it to show a different error message for each case:
+
+```js
+const fastify = Fastify({
+  ajv: {
+    customOptions: { allErrors: true, jsonPointers: true },
+    plugins: [
+      require('ajv-errors')
+    ]
+  }
+})
+
+const schema = {
+  body: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+        errorMessage: {
+          type: 'Bad name'
+        }
+      },
+      age: {
+        type: 'number',
+        errorMessage: {
+          type: 'Bad age', // specify custom message for
+          min: 'Too young' // all constraints except required
+        }
+      }
+    },
+    required: ['name', 'age'],
+    errorMessage: {
+      required: {
+        name: 'Why no name!', // specify error message for when the
+        age: 'Why no age!' // property is missing from input
+      }
+    }
+  }
+}
+
+fastify.post('/', { schema, }, (request, reply) => {
+  reply.send({
+    hello: 'world'
+  })
+})
+```
+
+If you want to return localized error messages, take a look at [ajv-i18n](https://github.com/epoberezkin/ajv-i18n)
+
+```js
+const localize = require('ajv-i18n')
+
+const fastify = Fastify({
+  ajv: {
+    customOptions: { allErrors: true }
+  }
+})
+
+const schema = {
+  body: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+      },
+      age: {
+        type: 'number',
+      }
+    },
+    required: ['name', 'age'],
+  }
+}
+
+fastify.setErrorHandler(function (error, request, reply) {
+  if (error.validation) {
+    localize.ru(error.validation)
+    reply.status(400).send(error.validation)
+    return
+  }
+  reply.send(error)
+})
+```
 
 ### JSON Schema support
 

--- a/package.json
+++ b/package.json
@@ -98,6 +98,8 @@
     "@typescript-eslint/eslint-plugin": "^2.29.0",
     "@typescript-eslint/parser": "^2.29.0",
     "JSONStream": "^1.3.5",
+    "ajv-errors": "^1.0.1",
+    "ajv-i18n": "^3.5.0",
     "ajv-merge-patch": "^4.1.0",
     "ajv-pack": "^0.3.1",
     "autocannon": "^4.0.0",

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -2,7 +2,6 @@
 
 const t = require('tap')
 const Joi = require('@hapi/joi')
-const localize = require('ajv-i18n')
 const Fastify = require('..')
 const test = t.test
 
@@ -62,105 +61,6 @@ test('should fail immediately with invalid payload', t => {
       error: 'Bad Request',
       message: "body should have required property 'name', body should have required property 'work'"
     })
-    t.strictEqual(res.statusCode, 400)
-  })
-})
-
-test('should return custom error messages with ajv-errors', t => {
-  t.plan(3)
-
-  const fastify = Fastify({
-    ajv: {
-      customOptions: { allErrors: true, jsonPointers: true },
-      plugins: [
-        require('ajv-errors')
-      ]
-    }
-  })
-
-  const schema = {
-    body: {
-      type: 'object',
-      properties: {
-        name: { type: 'string' },
-        work: { type: 'string' },
-        age: {
-          type: 'number',
-          errorMessage: {
-            type: 'bad age - should be num'
-          }
-        }
-      },
-      required: ['name', 'work'],
-      errorMessage: {
-        required: {
-          name: 'name please',
-          work: 'work please',
-          age: 'age please'
-        }
-      }
-    }
-  }
-
-  fastify.post('/', { schema }, function (req, reply) {
-    reply.code(200).send(req.body.name)
-  })
-
-  fastify.inject({
-    method: 'POST',
-    payload: {
-      hello: 'salman',
-      age: 'bad'
-    },
-    url: '/'
-  }, (err, res) => {
-    t.error(err)
-    t.deepEqual(JSON.parse(res.payload), {
-      statusCode: 400,
-      error: 'Bad Request',
-      message: 'body/age bad age - should be num, body name please, body work please'
-    })
-    t.strictEqual(res.statusCode, 400)
-  })
-})
-
-test('should return localized error messages with ajv-i18n', t => {
-  t.plan(3)
-
-  const fastify = Fastify({
-    ajv: {
-      customOptions: { allErrors: true }
-    }
-  })
-
-  fastify.setErrorHandler(function (error, request, reply) {
-    if (error.validation) {
-      localize.ru(error.validation)
-      reply.status(400).send(error.validation)
-      return
-    }
-    reply.send(error)
-  })
-
-  fastify.post('/', { schema }, function (req, reply) {
-    reply.code(200).send(req.body.name)
-  })
-
-  fastify.inject({
-    method: 'POST',
-    payload: {
-      name: 'salman'
-    },
-    url: '/'
-  }, (err, res) => {
-    t.error(err)
-    t.deepEqual(JSON.parse(res.payload), [{
-      dataPath: '',
-      keyword: 'required',
-      message: 'должно иметь обязательное поле work',
-      params: { missingProperty: 'work' },
-      schemaPath: '#/required'
-    }])
     t.strictEqual(res.statusCode, 400)
   })
 })

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -1,8 +1,10 @@
 'use strict'
 
-const { test } = require('tap')
+const t = require('tap')
 const Joi = require('@hapi/joi')
+const localize = require('ajv-i18n')
 const Fastify = require('..')
+const test = t.test
 
 const schema = {
   body: {
@@ -60,6 +62,105 @@ test('should fail immediately with invalid payload', t => {
       error: 'Bad Request',
       message: "body should have required property 'name', body should have required property 'work'"
     })
+    t.strictEqual(res.statusCode, 400)
+  })
+})
+
+test('should return custom error messages with ajv-errors', t => {
+  t.plan(3)
+
+  const fastify = Fastify({
+    ajv: {
+      customOptions: { allErrors: true, jsonPointers: true },
+      plugins: [
+        require('ajv-errors')
+      ]
+    }
+  })
+
+  const schema = {
+    body: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        work: { type: 'string' },
+        age: {
+          type: 'number',
+          errorMessage: {
+            type: 'bad age - should be num'
+          }
+        }
+      },
+      required: ['name', 'work'],
+      errorMessage: {
+        required: {
+          name: 'name please',
+          work: 'work please',
+          age: 'age please'
+        }
+      }
+    }
+  }
+
+  fastify.post('/', { schema }, function (req, reply) {
+    reply.code(200).send(req.body.name)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    payload: {
+      hello: 'salman',
+      age: 'bad'
+    },
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.deepEqual(JSON.parse(res.payload), {
+      statusCode: 400,
+      error: 'Bad Request',
+      message: 'body/age bad age - should be num, body name please, body work please'
+    })
+    t.strictEqual(res.statusCode, 400)
+  })
+})
+
+test('should return localized error messages with ajv-i18n', t => {
+  t.plan(3)
+
+  const fastify = Fastify({
+    ajv: {
+      customOptions: { allErrors: true }
+    }
+  })
+
+  fastify.setErrorHandler(function (error, request, reply) {
+    if (error.validation) {
+      localize.ru(error.validation)
+      reply.status(400).send(error.validation)
+      return
+    }
+    reply.send(error)
+  })
+
+  fastify.post('/', { schema }, function (req, reply) {
+    reply.code(200).send(req.body.name)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    payload: {
+      name: 'salman'
+    },
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.deepEqual(JSON.parse(res.payload), [{
+      dataPath: '',
+      keyword: 'required',
+      message: 'должно иметь обязательное поле work',
+      params: { missingProperty: 'work' },
+      schemaPath: '#/required'
+    }])
     t.strictEqual(res.statusCode, 400)
   })
 })

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('tap')
 const Joi = require('@hapi/joi')
 const Fastify = require('..')
-const test = t.test
 
 const schema = {
   body: {


### PR DESCRIPTION
Port f12f4871a1053b6caaa8627921eb8096e2e9f9ab from #2254 to master

* docs: added example docs to show usage with ajv-errors

* doc: fix wordings

* docs: added example docs to show usage with ajv-i18n

* docs: feedback

* doc: fix doc for i18n

* add tests to verify ajv-errors & i18n examples from docs

* Update test/validation-error-handling.test.js

Co-authored-by: Manuel Spigolon <behemoth89@gmail.com>

* Update docs/Validation-and-Serialization.md

Co-authored-by: Matteo Collina <matteo.collina@gmail.com>
Co-authored-by: Manuel Spigolon <behemoth89@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
