### PR TITLE
Ignore clientError on reset connections. (#2036)

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -479,17 +479,24 @@ Using this option it is possible to override the default `clientErrorHandler`.
 + Default:
 ```js
 function defaultClientErrorHandler (err, socket) {
+  if(err.code === 'ECONNRESET') {
+    return
+  }
+
   const body = JSON.stringify({
     error: http.STATUS_CODES['400'],
     message: 'Client Error',
     statusCode: 400
   })
   this.log.trace({ err }, 'client error')
-  socket.end(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n${body}`)
+
+  if(socket.writable) {
+    socket.end(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n${body}`)
+  }
 }
 ```
 
-*Note: `clientErrorHandler` operates with raw socket. The handler is expected to return a properly formed HTTP response that includes a status line, HTTP headers and a message body.*
+*Note: `clientErrorHandler` operates with raw socket. The handler is expected to return a properly formed HTTP response that includes a status line, HTTP headers and a message body. Before attempting to write the socket, the handler should check if the socket it's still writable as it may already have been destroyed.*
 
 ```js
 const fastify = require('fastify')({

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -479,7 +479,7 @@ Using this option it is possible to override the default `clientErrorHandler`.
 + Default:
 ```js
 function defaultClientErrorHandler (err, socket) {
-  if(err.code === 'ECONNRESET') {
+  if (err.code === 'ECONNRESET') {
     return
   }
 
@@ -490,7 +490,7 @@ function defaultClientErrorHandler (err, socket) {
   })
   this.log.trace({ err }, 'client error')
 
-  if(socket.writable) {
+  if (socket.writable) {
     socket.end(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n${body}`)
   }
 }

--- a/fastify.js
+++ b/fastify.js
@@ -390,7 +390,8 @@ function fastify (options) {
 
   function defaultClientErrorHandler (err, socket) {
     // In case of a connection reset, the socket has been destroyed and there is nothing that needs to be done.
-    // See: https://github.com/nodejs/node/issues/33302
+    // https://github.com/fastify/fastify/issues/2036
+    // https://github.com/nodejs/node/issues/33302
     if (err.code === 'ECONNRESET') {
       return
     }

--- a/fastify.js
+++ b/fastify.js
@@ -389,6 +389,11 @@ function fastify (options) {
   }
 
   function defaultClientErrorHandler (err, socket) {
+    // In case of a connection reset, the socket has been destroyed and there is nothing that needs to be done.
+    if (err.code === 'ECONNRESET') {
+      return
+    }
+
     const body = JSON.stringify({
       error: http.STATUS_CODES['400'],
       message: 'Client Error',
@@ -399,7 +404,11 @@ function fastify (options) {
     // In the vast majority of cases, it's a network error and/or some
     // config issue on the the load balancer side.
     this.log.trace({ err }, 'client error')
-    socket.end(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n${body}`)
+
+    // If the socket is not writable, there is no reason to try to send data.
+    if (socket.writable) {
+      socket.end(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n${body}`)
+    }
   }
 
   // If the router does not match any route, every request will land here

--- a/fastify.js
+++ b/fastify.js
@@ -390,6 +390,7 @@ function fastify (options) {
 
   function defaultClientErrorHandler (err, socket) {
     // In case of a connection reset, the socket has been destroyed and there is nothing that needs to be done.
+    // See: https://github.com/nodejs/node/issues/33302
     if (err.code === 'ECONNRESET') {
       return
     }

--- a/test/request-error.test.js
+++ b/test/request-error.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { connect } = require('net')
 const t = require('tap')
 const test = t.test
 const Fastify = require('..')
@@ -71,5 +72,57 @@ test('default 400 on request error with custom error handler', t => {
       message: 'Simulated',
       statusCode: 400
     })
+  })
+})
+
+test('default clientError handler ignores ECONNRESET', t => {
+  t.plan(3)
+  
+  let logs = ''
+  let response = ''
+
+  const fastify = Fastify({ 
+    bodyLimit: 1, 
+    keepAliveTimeout: 100, 
+    logger: {
+      level: 'trace',
+      stream: {
+        write() {
+          logs += JSON.stringify(arguments)
+        }
+      }
+    }    
+  })
+
+  fastify.get('/', (request, reply) => {
+    reply.send('OK')
+    
+    process.nextTick(() => {
+      const error = new Error()
+      error.code = 'ECONNRESET'
+
+      fastify.server.emit('clientError', error, request.raw.socket);      
+    })
+  })
+
+  fastify.listen(0, function (err) {
+    t.error(err)
+    fastify.server.unref()
+
+    const client = connect(fastify.server.address().port)
+
+    client.on('data', chunk => {
+      response += chunk.toString('utf-8')
+    })
+
+    client.on('end', () => {
+      t.match(response, /^HTTP\/1.1 200 OK/)
+      t.notMatch(logs, /ECONNRESET/)
+    })
+
+    client.resume()
+    client.write('GET / HTTP/1.1\r\n')
+    client.write('Connection: close\r\n')
+    client.write('\r\n\r\n')
   })
 })

--- a/test/request-error.test.js
+++ b/test/request-error.test.js
@@ -77,31 +77,31 @@ test('default 400 on request error with custom error handler', t => {
 
 test('default clientError handler ignores ECONNRESET', t => {
   t.plan(3)
-  
+
   let logs = ''
   let response = ''
 
-  const fastify = Fastify({ 
-    bodyLimit: 1, 
-    keepAliveTimeout: 100, 
+  const fastify = Fastify({
+    bodyLimit: 1,
+    keepAliveTimeout: 100,
     logger: {
       level: 'trace',
       stream: {
-        write() {
+        write () {
           logs += JSON.stringify(arguments)
         }
       }
-    }    
+    }
   })
 
   fastify.get('/', (request, reply) => {
     reply.send('OK')
-    
+
     process.nextTick(() => {
       const error = new Error()
       error.code = 'ECONNRESET'
 
-      fastify.server.emit('clientError', error, request.raw.socket);      
+      fastify.server.emit('clientError', error, request.raw.socket)
     })
   })
 


### PR DESCRIPTION
This PR implements the new recommended approach (https://github.com/nodejs/node/issues/33302) on how to handle `ECONNRESET` during `clientError` events.

Fixes #2036.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
