### PR TITLE
test: Add test to verify async onClose hooks. (#2250)

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
   "dependencies": {
     "abstract-logging": "^2.0.0",
     "ajv": "^6.12.2",
-    "avvio": "^7.0.1",
+    "avvio": "^7.0.3",
     "fast-json-stringify": "^2.0.0",
     "find-my-way": "^3.0.0",
     "flatstr": "^1.0.12",

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -95,7 +95,7 @@ test('close order - async', async t => {
   })
 
   await fastify.listen(0)
-  await fastify.close(0)
+  await fastify.close()
 
   t.is(order.shift(), 3)
 })

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -77,6 +77,29 @@ test('close order', t => {
   })
 })
 
+test('close order - async', async t => {
+  t.plan(3)
+  const fastify = Fastify()
+  const order = [1, 2, 3]
+
+  fastify.register(function (f, opts, next) {
+    f.addHook('onClose', async instance => {
+      t.is(order.shift(), 1)
+    })
+
+    next()
+  })
+
+  fastify.addHook('onClose', () => {
+    t.is(order.shift(), 2)
+  })
+
+  await fastify.listen(0)
+  await fastify.close(0)
+
+  t.is(order.shift(), 3)
+})
+
 test('should not throw an error if the server is not listening', t => {
   t.plan(2)
   const fastify = Fastify()


### PR DESCRIPTION
This PR bumps minimum avvio version in order to avoid fastify/avvio#110.
It also added test to address #2250.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
