### PR TITLE
Update TypeScript type definitions for server options

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -561,7 +561,7 @@ server.get('/', async (request, reply) => {
 
 ###### Example 5: Specifying logger types
 
-Fastify uses the [Pino](http://getpino.io/#/) logging library under the hood. While the Fastify type system does provide the necessary types for you to use the included logger, if you'd like the specificity of the Pino types install them from `@types/pino` and pass the `pino.Logger` type to the fourth generic parameter. This generic also supports custom logging utilities such as creating custom serializers. See the [Logging]() documentation for more info.
+Fastify uses the [Pino](http://getpino.io/#/) logging library under the hood. While the Fastify type system does provide the necessary types for you to use the included logger, if you'd like the specificity of the Pino types install them from `@types/pino` and pass the `pino.Logger` type to the fourth generic parameter. This generic also supports custom logging utilities such as creating custom serializers. See the [Logging](./Logging.md) documentation for more info.
 
 ```typescript
 import fastify from 'fastify'

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -569,7 +569,9 @@ import http from 'http'
 import pino from 'pino'
 
 const server = fastify<http.Server, http.IncomingMessage, http.ServerResponse, pino.Logger>({
-  logger: true
+  logger: {
+    messageKey: 'message'
+  }
 })
 
 server.get('/', async (request, reply) => {

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -5,7 +5,7 @@ import * as LightMyRequest from 'light-my-request'
 
 import { FastifyRequest } from './types/request'
 import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression } from './types/utils'
-import { FastifyLoggerOptions } from './types/logger'
+import { FastifyLoggerOptions, FastifyLoggerInstance } from './types/logger'
 import { FastifyInstance } from './types/instance'
 import { FastifyServerFactory } from './types/serverFactory'
 import * as ajv from 'ajv'

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -120,7 +120,7 @@ export { FastifyRequest, FastifyRequestInterface, RequestGenericInterface } from
 export { FastifyReply, FastifyReplyInterface } from './types/reply'
 export { FastifyPlugin, FastifyPluginOptions } from './types/plugin'
 export { FastifyInstance } from './types/instance'
-export { FastifyLoggerOptions, FastifyLogFn, LogLevels } from './types/logger'
+export { FastifyLoggerOptions, FastifyLoggerInstance, FastifyLogFn, LogLevels } from './types/logger'
 export { FastifyContext } from './types/context'
 export { RouteHandlerMethod, RouteOptions, RouteShorthandMethod, RouteShorthandOptions, RouteShorthandOptionsWithHandler } from './types/route'
 export * from './types/register'

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -8,6 +8,9 @@ import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyD
 import { FastifyLoggerOptions } from './types/logger'
 import { FastifyInstance } from './types/instance'
 import { FastifyServerFactory } from './types/serverFactory'
+import * as ajv from 'ajv'
+import { FastifyError } from './types/error'
+import { FastifyReply } from './types/reply'
 
 /**
  * Fastify factor function for the standard fastify http, https, or http2 server instance.
@@ -71,18 +74,22 @@ export type FastifyServerOptions<
   RawServer extends RawServerBase = RawServerDefault,
   Logger = FastifyLoggerOptions<RawServer>
 > = {
+  http2?: boolean,
+  https?: https.ServerOptions
   ignoreTrailingSlash?: boolean,
   connectionTimeout?: number,
   keepAliveTimeout?: number,
-  bodyLimit?: number,
   pluginTimeout?: number,
+  bodyLimit?: number,
+  maxParamLength?: number,
   disableRequestLogging?: boolean,
-  requestIdLogLabel?: string;
   onProtoPoisoing?: 'error' | 'remove' | 'ignore',
+  onConstructorPoisoning?: 'error' | 'remove' | 'ignore',
   logger?: boolean | Logger,
   serverFactory?: FastifyServerFactory<RawServer>,
   caseSensitive?: boolean,
   requestIdHeader?: string,
+  requestIdLogLabel?: string;
   genReqId?: (req: FastifyRequest<RawServer, RawRequestDefaultExpression<RawServer>>) => string,
   trustProxy?: boolean | string | string[] | number | TrustProxyFunction,
   querystringParser?: (str: string) => { [key: string]: string | string[] },
@@ -94,7 +101,18 @@ export type FastifyServerOptions<
       empty(): void
     },
     deriveVersion<Context>(req: Object, ctx?: Context): string // not a fan of using Object here. Also what is Context? Can either of these be better defined?
-  }
+  },
+  return503OnClosing?: boolean,
+  ajv?: {
+    customOptions?: ajv.Options,
+    plugins?: Function[]
+  },
+  http2SessionTimeout?: number,
+  frameworkErrors?: (
+    error: FastifyError,
+    req: FastifyRequest<RawServer, RawRequestDefaultExpression<RawServer>>,
+    res: FastifyReply<RawServer, RawReplyDefaultExpression<RawServer>>
+  ) => void,
 }
 
 type TrustProxyFunction = (address: string, hop: number) => boolean

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -5,7 +5,7 @@ import * as LightMyRequest from 'light-my-request'
 
 import { FastifyRequest } from './types/request'
 import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression } from './types/utils'
-import { FastifyLoggerOptions, FastifyLoggerInstance } from './types/logger'
+import { FastifyLoggerOptions } from './types/logger'
 import { FastifyInstance } from './types/instance'
 import { FastifyServerFactory } from './types/serverFactory'
 import * as ajv from 'ajv'

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -76,6 +76,7 @@ export type FastifyServerOptions<
   keepAliveTimeout?: number,
   bodyLimit?: number,
   pluginTimeout?: number,
+  disableRequestLogging?: boolean,
   onProtoPoisoing?: 'error' | 'remove' | 'ignore',
   logger?: boolean | Logger,
   serverFactory?: FastifyServerFactory<RawServer>,

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -77,6 +77,7 @@ export type FastifyServerOptions<
   bodyLimit?: number,
   pluginTimeout?: number,
   disableRequestLogging?: boolean,
+  requestIdLogLabel?: string;
   onProtoPoisoing?: 'error' | 'remove' | 'ignore',
   logger?: boolean | Logger,
   serverFactory?: FastifyServerFactory<RawServer>,

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -58,7 +58,8 @@ type FastifyHttp2Options<
   Server extends http2.Http2Server,
   Logger
 > = FastifyServerOptions<Server, Logger> & {
-  http2: true
+  http2: true,
+  http2SessionTimeout?: number,
 }
 
 type FastifyHttpsOptions<
@@ -74,8 +75,6 @@ export type FastifyServerOptions<
   RawServer extends RawServerBase = RawServerDefault,
   Logger = FastifyLoggerOptions<RawServer>
 > = {
-  http2?: boolean,
-  https?: https.ServerOptions
   ignoreTrailingSlash?: boolean,
   connectionTimeout?: number,
   keepAliveTimeout?: number,
@@ -107,7 +106,6 @@ export type FastifyServerOptions<
     customOptions?: ajv.Options,
     plugins?: Function[]
   },
-  http2SessionTimeout?: number,
   frameworkErrors?: (
     error: FastifyError,
     req: FastifyRequest<RawServer, RawRequestDefaultExpression<RawServer>>,

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -88,7 +88,7 @@ export type FastifyServerOptions<
   querystringParser?: (str: string) => { [key: string]: string | string[] },
   versioning?: {
     storage(): {
-      get(version: string): Function | null,
+      get(version: string): string | null,
       set(version: string, store: Function): void
       del(version: string): void,
       empty(): void

--- a/fastify.js
+++ b/fastify.js
@@ -79,7 +79,7 @@ function fastify (options) {
     throw new Error(`ajv.customOptions option should be an object, instead got '${typeof ajvOptions.customOptions}'`)
   }
   if (!ajvOptions.plugins || !Array.isArray(ajvOptions.plugins)) {
-    throw new Error(`ajv.plugins option should be an array, instead got '${typeof ajvOptions.customOptions}'`)
+    throw new Error(`ajv.plugins option should be an array, instead got '${typeof ajvOptions.plugins}'`)
   }
   ajvOptions.plugins = ajvOptions.plugins.map(plugin => {
     return Array.isArray(plugin) ? plugin : [plugin]

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "yup": "^0.28.4"
   },
   "dependencies": {
+    "@types/pino": "^6.0.1",
     "abstract-logging": "^2.0.0",
     "ajv": "^6.12.2",
     "avvio": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,6 @@
     "yup": "^0.28.4"
   },
   "dependencies": {
-    "@types/pino": "^6.0.1",
     "abstract-logging": "^2.0.0",
     "ajv": "^6.12.2",
     "avvio": "^7.0.3",

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -38,6 +38,28 @@ fastify({ requestIdLogLabel: 'request-id' })
 fastify({ onProtoPoisoing: 'error' })
 fastify({ onConstructorPoisoning: 'error' })
 fastify({ logger: true })
+fastify({
+  logger: {
+    level: 'info',
+    genReqId: () => 'request-id',
+    serializers: {
+      req: () => {},
+      res: () => {},
+      err: () => {},
+    }
+  }
+})
+fastify({
+  logger: {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    fatal: () => {},
+    trace: () => {},
+    debug: () => {},
+    child: this
+  }
+})
 fastify({ serverFactory: () => http.createServer() })
 fastify({ caseSensitive: true })
 fastify({ requestIdHeader: 'request-id' })

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -2,6 +2,7 @@ import fastify, { FastifyInstance, FastifyServerOptions } from '../../fastify'
 import * as http from 'http'
 import * as https from 'https'
 import * as http2 from 'http2'
+import * as pino from 'pino';
 import { Chain as LightMyRequestChain } from 'light-my-request';
 import { expectType, expectError } from 'tsd'
 
@@ -59,6 +60,14 @@ fastify({
     debug: () => {},
     child: this
   }
+})
+fastify({
+  logger: {
+    messageKey: 'message'
+  }
+})
+fastify({
+  logger: pino()
 })
 fastify({ serverFactory: () => http.createServer() })
 fastify({ caseSensitive: true })

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -20,14 +20,23 @@ expectError(fastify<http2.Http2Server>({ http2: false })) // http2 option must b
 expectError(fastify<http2.Http2SecureServer>({ http2: false })) // http2 option must be true
 
 // server options
+fastify({ http2: true })
+fastify({
+  https: {
+    ca: 'foo',
+    cert: 'bar'
+  }
+})
 fastify({ ignoreTrailingSlash: true })
 fastify({ connectionTimeout: 1000 })
 fastify({ keepAliveTimeout: 1000 })
-fastify({ bodyLimit: 100 })
 fastify({ pluginTimeout: 1000 })
+fastify({ bodyLimit: 100 })
+fastify({ maxParamLength: 100 })
 fastify({ disableRequestLogging: true })
 fastify({ requestIdLogLabel: 'request-id' })
 fastify({ onProtoPoisoing: 'error' })
+fastify({ onConstructorPoisoning: 'error' })
 fastify({ logger: true })
 fastify({ serverFactory: () => http.createServer() })
 fastify({ caseSensitive: true })
@@ -43,6 +52,17 @@ fastify({
       del: () => {},
       empty: () => {}
     }),
-    deriveVersion: () => 'foo',
+    deriveVersion: () => 'foo'
   }
 })
+fastify({ return503OnClosing: true })
+fastify({
+  ajv: {
+    customOptions: {
+      nullable: false
+    },
+    plugins: [() => {}]
+  }
+})
+fastify({ http2SessionTimeout: 1000 })
+fastify({ frameworkErrors: () => {} })

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -1,4 +1,4 @@
-import fastify, { FastifyInstance } from '../../fastify'
+import fastify, { FastifyInstance, FastifyServerOptions } from '../../fastify'
 import * as http from 'http'
 import * as https from 'https'
 import * as http2 from 'http2'
@@ -18,3 +18,31 @@ expectType<LightMyRequestChain>(fastify({ http2: true, https: {}}).inject())
 
 expectError(fastify<http2.Http2Server>({ http2: false })) // http2 option must be true
 expectError(fastify<http2.Http2SecureServer>({ http2: false })) // http2 option must be true
+
+// server options
+fastify({ ignoreTrailingSlash: true })
+fastify({ connectionTimeout: 1000 })
+fastify({ keepAliveTimeout: 1000 })
+fastify({ bodyLimit: 100 })
+fastify({ pluginTimeout: 1000 })
+fastify({ disableRequestLogging: true })
+fastify({ requestIdLogLabel: 'request-id' })
+fastify({ onProtoPoisoing: 'error' })
+fastify({ logger: true })
+fastify({ serverFactory: () => http.createServer() })
+fastify({ caseSensitive: true })
+fastify({ requestIdHeader: 'request-id' })
+fastify({ genReqId: () => 'request-id' });
+fastify({ trustProxy: true })
+fastify({ querystringParser: () => ({ foo: 'bar' }) })
+fastify({
+  versioning: {
+    storage: () => ({
+      get: () => 'foo',
+      set: () => {},
+      del: () => {},
+      empty: () => {}
+    }),
+    deriveVersion: () => 'foo',
+  }
+})

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -2,9 +2,9 @@ import fastify, { FastifyInstance, FastifyServerOptions } from '../../fastify'
 import * as http from 'http'
 import * as https from 'https'
 import * as http2 from 'http2'
-import * as pino from 'pino';
 import { Chain as LightMyRequestChain } from 'light-my-request';
-import { expectType, expectError } from 'tsd'
+import { expectType, expectError, expectAssignable } from 'tsd'
+import { FastifyLoggerOptions } from '../../types/logger';
 
 // FastifyInstance
 // http server
@@ -21,25 +21,19 @@ expectError(fastify<http2.Http2Server>({ http2: false })) // http2 option must b
 expectError(fastify<http2.Http2SecureServer>({ http2: false })) // http2 option must be true
 
 // server options
-fastify({ http2: true })
-fastify({
-  https: {
-    ca: 'foo',
-    cert: 'bar'
-  }
-})
-fastify({ ignoreTrailingSlash: true })
-fastify({ connectionTimeout: 1000 })
-fastify({ keepAliveTimeout: 1000 })
-fastify({ pluginTimeout: 1000 })
-fastify({ bodyLimit: 100 })
-fastify({ maxParamLength: 100 })
-fastify({ disableRequestLogging: true })
-fastify({ requestIdLogLabel: 'request-id' })
-fastify({ onProtoPoisoing: 'error' })
-fastify({ onConstructorPoisoning: 'error' })
-fastify({ logger: true })
-fastify({
+expectAssignable<FastifyInstance>(fastify({ http2: true }))
+expectAssignable<FastifyInstance>(fastify({ ignoreTrailingSlash: true }))
+expectAssignable<FastifyInstance>(fastify({ connectionTimeout: 1000 }))
+expectAssignable<FastifyInstance>(fastify({ keepAliveTimeout: 1000 }))
+expectAssignable<FastifyInstance>(fastify({ pluginTimeout: 1000 }))
+expectAssignable<FastifyInstance>(fastify({ bodyLimit: 100 }))
+expectAssignable<FastifyInstance>(fastify({ maxParamLength: 100 }))
+expectAssignable<FastifyInstance>(fastify({ disableRequestLogging: true }))
+expectAssignable<FastifyInstance>(fastify({ requestIdLogLabel: 'request-id' }))
+expectAssignable<FastifyInstance>(fastify({ onProtoPoisoing: 'error' }))
+expectAssignable<FastifyInstance>(fastify({ onConstructorPoisoning: 'error' }))
+expectAssignable<FastifyInstance>(fastify({ logger: true }))
+expectAssignable<FastifyInstance>(fastify({
   logger: {
     level: 'info',
     genReqId: () => 'request-id',
@@ -49,30 +43,24 @@ fastify({
       err: () => {},
     }
   }
-})
-fastify({
-  logger: {
-    info: () => {},
-    warn: () => {},
-    error: () => {},
-    fatal: () => {},
-    trace: () => {},
-    debug: () => {},
-    child: this
-  }
-})
-fastify({
-  logger: {
-    messageKey: 'message'
-  }
-})
-fastify({ serverFactory: () => http.createServer() })
-fastify({ caseSensitive: true })
-fastify({ requestIdHeader: 'request-id' })
-fastify({ genReqId: () => 'request-id' });
-fastify({ trustProxy: true })
-fastify({ querystringParser: () => ({ foo: 'bar' }) })
-fastify({
+}))
+const customLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {},
+  trace: () => {},
+  debug: () => {},
+  child: () => customLogger
+}
+expectAssignable<FastifyInstance>(fastify({ logger: customLogger }))
+expectAssignable<FastifyInstance>(fastify({ serverFactory: () => http.createServer() }))
+expectAssignable<FastifyInstance>(fastify({ caseSensitive: true }))
+expectAssignable<FastifyInstance>(fastify({ requestIdHeader: 'request-id' }))
+expectAssignable<FastifyInstance>(fastify({ genReqId: () => 'request-id' }))
+expectAssignable<FastifyInstance>(fastify({ trustProxy: true }))
+expectAssignable<FastifyInstance>(fastify({ querystringParser: () => ({ foo: 'bar' }) }))
+expectAssignable<FastifyInstance>(fastify({
   versioning: {
     storage: () => ({
       get: () => 'foo',
@@ -82,14 +70,14 @@ fastify({
     }),
     deriveVersion: () => 'foo'
   }
-})
-fastify({ return503OnClosing: true })
-fastify({
+}))
+expectAssignable<FastifyInstance>(fastify({ return503OnClosing: true }))
+expectAssignable<FastifyInstance>(fastify({
   ajv: {
     customOptions: {
       nullable: false
     },
     plugins: [() => {}]
   }
-})
-fastify({ frameworkErrors: () => {} })
+}))
+expectAssignable<FastifyInstance>(fastify({ frameworkErrors: () => {} }))

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -4,7 +4,7 @@ import * as https from 'https'
 import * as http2 from 'http2'
 import { Chain as LightMyRequestChain } from 'light-my-request';
 import { expectType, expectError, expectAssignable } from 'tsd'
-import { FastifyLoggerOptions } from '../../types/logger';
+import { FastifyLoggerInstance } from '../../types/logger';
 
 // FastifyInstance
 // http server
@@ -32,7 +32,7 @@ expectAssignable<FastifyInstance>(fastify({ disableRequestLogging: true }))
 expectAssignable<FastifyInstance>(fastify({ requestIdLogLabel: 'request-id' }))
 expectAssignable<FastifyInstance>(fastify({ onProtoPoisoing: 'error' }))
 expectAssignable<FastifyInstance>(fastify({ onConstructorPoisoning: 'error' }))
-expectAssignable<FastifyInstance>(fastify({ logger: true }))
+expectAssignable<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse, true>>(fastify({ logger: true }))
 expectAssignable<FastifyInstance>(fastify({
   logger: {
     level: 'info',
@@ -53,7 +53,7 @@ const customLogger = {
   debug: () => {},
   child: () => customLogger
 }
-expectAssignable<FastifyInstance>(fastify({ logger: customLogger }))
+expectAssignable<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse, FastifyLoggerInstance>>(fastify({ logger: customLogger }))
 expectAssignable<FastifyInstance>(fastify({ serverFactory: () => http.createServer() }))
 expectAssignable<FastifyInstance>(fastify({ caseSensitive: true }))
 expectAssignable<FastifyInstance>(fastify({ requestIdHeader: 'request-id' }))

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -4,7 +4,7 @@ import * as https from 'https'
 import * as http2 from 'http2'
 import { Chain as LightMyRequestChain } from 'light-my-request';
 import { expectType, expectError, expectAssignable } from 'tsd'
-import { FastifyLoggerInstance } from '../../types/logger';
+import { FastifyLoggerInstance, FastifyLoggerOptions } from '../../types/logger';
 
 // FastifyInstance
 // http server
@@ -33,14 +33,33 @@ expectAssignable<FastifyInstance>(fastify({ requestIdLogLabel: 'request-id' }))
 expectAssignable<FastifyInstance>(fastify({ onProtoPoisoing: 'error' }))
 expectAssignable<FastifyInstance>(fastify({ onConstructorPoisoning: 'error' }))
 expectAssignable<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse, true>>(fastify({ logger: true }))
-expectAssignable<FastifyInstance>(fastify({
+expectAssignable<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse, FastifyLoggerOptions>>(fastify({
   logger: {
     level: 'info',
     genReqId: () => 'request-id',
     serializers: {
-      req: () => {},
-      res: () => {},
-      err: () => {},
+      req: () => {
+        return {
+          method: 'GET',
+          url: '/',
+          version: '1.0.0',
+          hostname: 'localhost',
+          remoteAddress: '127.0.0.1',
+          remotePort: 3000
+        }
+      },
+      res: () => {
+        return {
+          statusCode: 200
+        }
+      },
+      err: () => {
+        return {
+          type: 'Error',
+          message: 'foo',
+          stack: ''
+        }
+      },
     }
   }
 }))

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -66,9 +66,6 @@ fastify({
     messageKey: 'message'
   }
 })
-fastify({
-  logger: pino()
-})
 fastify({ serverFactory: () => http.createServer() })
 fastify({ caseSensitive: true })
 fastify({ requestIdHeader: 'request-id' })

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -12,7 +12,7 @@ expectType<FastifyInstance<http.Server, http.IncomingMessage, http.ServerRespons
 // https server
 expectType<FastifyInstance<https.Server, http.IncomingMessage, http.ServerResponse>>(fastify({ https: {} }))
 // http2 server
-expectType<FastifyInstance<http2.Http2Server, http2.Http2ServerRequest, http2.Http2ServerResponse>>(fastify({ http2: true }))
+expectType<FastifyInstance<http2.Http2Server, http2.Http2ServerRequest, http2.Http2ServerResponse>>(fastify({ http2: true, http2SessionTimeout: 1000 }))
 expectType<FastifyInstance<http2.Http2SecureServer, http2.Http2ServerRequest, http2.Http2ServerResponse>>(fastify({ http2: true, https: {}}))
 expectType<LightMyRequestChain>(fastify({ http2: true, https: {}}).inject())
 
@@ -64,5 +64,4 @@ fastify({
     plugins: [() => {}]
   }
 })
-fastify({ http2SessionTimeout: 1000 })
 fastify({ frameworkErrors: () => {} })

--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -1,14 +1,14 @@
 import { expectType, expectError } from 'tsd'
-import fastify, { FastifyLoggerOptions, FastifyLogFn, LogLevels } from '../../fastify'
+import fastify, { FastifyLoggerOptions, FastifyLogFn, LogLevels, FastifyLoggerInstance } from '../../fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
 
 expectType<FastifyLoggerOptions>(fastify().log)
 
 ;['trace', 'debug', 'info', 'warn', 'error', 'fatal'].forEach(logLevel => {
-  expectType<FastifyLogFn>(fastify().log[logLevel as LogLevels])
-  expectType<void>(fastify().log[logLevel as LogLevels](''))
-  expectType<void>(fastify().log[logLevel as LogLevels]({}))
-  expectError(fastify().log[logLevel as LogLevels](0))
+  expectType<FastifyLogFn>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevels])
+  expectType<void>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevels](''))
+  expectType<void>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevels]({}))
+  expectError(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevels](0))
 })
 
 interface CustomLogger {

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -18,7 +18,7 @@ export interface FastifyInstance<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   Logger = FastifyLoggerOptions<RawServer>
-  > {
+> {
   server: RawServer;
   prefix: string;
   log: Logger;

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -1,5 +1,6 @@
 import { FastifyError } from './error'
 import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression } from './utils'
+import { FastifyRequest } from './request'
 
 /**
  * Standard Fastify logging function
@@ -11,6 +12,16 @@ export interface FastifyLogFn {
 
 export type LogLevels = 'info' | 'error' | 'debug' | 'fatal' | 'warn' | 'trace'
 
+export interface FastifyLoggerInstance {
+  info: FastifyLogFn;
+  warn: FastifyLogFn;
+  error: FastifyLogFn;
+  fatal: FastifyLogFn;
+  trace: FastifyLogFn;
+  debug: FastifyLogFn;
+  child: FastifyLoggerInstance;
+}
+
 /**
  * Fastify Custom Logger options.
  */
@@ -18,7 +29,7 @@ export interface FastifyLoggerOptions<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>
-> {
+> extends FastifyLoggerInstance {
   serializers?: {
     req: (req: RawRequest) => {
       method: string;
@@ -38,12 +49,6 @@ export interface FastifyLoggerOptions<
       statusCode: string | number;
     };
   };
-  info: FastifyLogFn;
-  error: FastifyLogFn;
-  debug: FastifyLogFn;
-  fatal: FastifyLogFn;
-  warn: FastifyLogFn;
-  trace: FastifyLogFn;
-  child: FastifyLogFn | FastifyLoggerOptions<RawServer>;
-  genReqId?: string;
+  level?: string;
+  genReqId?: (req: FastifyRequest<RawServer, RawRequest>) => string;
 }

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -1,6 +1,7 @@
 import { FastifyError } from './error'
 import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression } from './utils'
 import { FastifyRequest } from './request'
+import { LoggerOptions as PinoLoggerOptions } from 'pino'
 
 /**
  * Standard Fastify logging function
@@ -29,7 +30,7 @@ export interface FastifyLoggerOptions<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>
-> extends FastifyLoggerInstance {
+> extends FastifyLoggerInstance, PinoLoggerOptions {
   serializers?: {
     req: (req: RawRequest) => {
       method: string;
@@ -49,6 +50,5 @@ export interface FastifyLoggerOptions<
       statusCode: string | number;
     };
   };
-  level?: string;
   genReqId?: (req: FastifyRequest<RawServer, RawRequest>) => string;
 }

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -19,7 +19,7 @@ export interface FastifyLoggerInstance {
   fatal: FastifyLogFn;
   trace: FastifyLogFn;
   debug: FastifyLogFn;
-  child: FastifyLoggerInstance;
+  child(): FastifyLoggerInstance;
 }
 
 /**

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -1,7 +1,6 @@
 import { FastifyError } from './error'
 import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression } from './utils'
 import { FastifyRequest } from './request'
-import { LoggerOptions as PinoLoggerOptions } from 'pino'
 
 /**
  * Standard Fastify logging function
@@ -24,13 +23,15 @@ export interface FastifyLoggerInstance {
 }
 
 /**
- * Fastify Custom Logger options.
+ * Fastify Custom Logger options. To enable configuration of all Pino options,
+ * refer to this example:
+ * https://github.com/fastify/fastify/blob/2f56e10a24ecb70c2c7950bfffd60eda8f7782a6/docs/TypeScript.md#example-5-specifying-logger-types
  */
 export interface FastifyLoggerOptions<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>
-> extends FastifyLoggerInstance, PinoLoggerOptions {
+> extends FastifyLoggerInstance {
   serializers?: {
     req: (req: RawRequest) => {
       method: string;
@@ -50,5 +51,6 @@ export interface FastifyLoggerOptions<
       statusCode: string | number;
     };
   };
+  level?: string;
   genReqId?: (req: FastifyRequest<RawServer, RawRequest>) => string;
 }

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -31,7 +31,7 @@ export interface FastifyLoggerOptions<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>
-> extends FastifyLoggerInstance {
+> {
   serializers?: {
     req: (req: RawRequest) => {
       method: string;

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -27,7 +27,8 @@ export interface FastifyReplyInterface<
   serialize(payload: any): string;
   serializer(fn: (payload: any) => string): FastifyReply<RawServer, RawReply>;
   status(statusCode: number): FastifyReply<RawServer, RawReply>;
-  statusCode: number
+  statusCode: number;
+  getResponseTime(): number;
   type(contentType: string): FastifyReply<RawServer, RawReply>;
   context: FastifyContext<ContextConfig>;
   raw: RawReply;


### PR DESCRIPTION
- Adds back definitions that were inadvertently removed in https://github.com/fastify/fastify/pull/1569
- Adds tests for server-option definitions
- Updates server-option definitions to match code and docs in master
- Fixes an error message for AJV plugin options 
- Adds a new `FastifyLoggerInstance` type 
- Removes `FastifyLoggerInstance` methods from `FastifyLoggerOptions`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
