### PR TITLE
TypeScript: fix logger typings #2289

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -560,17 +560,20 @@ server.get('/', async (request, reply) => {
 
 ###### Example 5: Specifying logger types
 
-Fastify uses the [Pino](http://getpino.io/#/) logging library under the hood. While the Fastify type system does provide the necessary types for you to use the included logger, if you'd like the specificity of the Pino types install them from `@types/pino` and pass the `pino.Logger` type to the fourth generic parameter. This generic also supports custom logging utilities such as creating custom serializers. See the [Logging](./Logging.md) documentation for more info.
+Fastify uses [Pino](http://getpino.io/#/) logging library under the hood. Some of it's properties can be configured via `logger` field when constructing Fastify's instance. If properties you need aren't exposed, it's also possible to pass a preconfigured external instance of Pino (or any other compatible logger) to Fastify via the same field. This allows creating custom serializers as well, see the [Logging](./Logging.md) documentation for more info.
+
+To use an external instance of Pino, add `@types/pino` to devDependencies and pass the instance to `logger` field:
 
 ```typescript
 import fastify from 'fastify'
-import http from 'http'
 import pino from 'pino'
 
-const server = fastify<http.Server, http.IncomingMessage, http.ServerResponse, pino.Logger>({
-  logger: {
+const server = fastify({
+  logger: pino({
+    level: 'info',
+    redact: ['x-userinfo'],
     messageKey: 'message'
-  }
+  })
 })
 
 server.get('/', async (request, reply) => {

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -584,14 +584,14 @@ server.get('/', async (request, reply) => {
 ##### fastify.HTTPMethods 
 [src](./../types/utils.d.ts#L8)
 
-Intersection type of: `'DELETE' | 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'OPTIONS'`
+Union type of: `'DELETE' | 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'OPTIONS'`
 
 ##### fastify.RawServerBase 
 [src](./../types/utils.d.ts#L13)
 
 Dependant on `@types/node` modules `http`, `https`, `http2`
 
-Intersection type of: `http.Server | https.Server | http2.Http2Server | http2.Http2SecureServer`
+Union type of: `http.Server | https.Server | http2.Http2Server | http2.Http2SecureServer`
 
 ##### fastify.RawServerDefault 
 [src](./../types/utils.d.ts#L18)
@@ -828,7 +828,7 @@ An overload function interface that implements the two ways Fastify calls log me
 
 [src](../types/logger.d.ts#L12)
 
-Intersection type of: `'info' | 'error' | 'debug' | 'fatal' | 'warn' | 'trace'`
+Union type of: `'info' | 'error' | 'debug' | 'fatal' | 'warn' | 'trace'`
 
 ---
 

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -783,7 +783,7 @@ A loosely typed object used to constrain the `options` parameter of [`fastify.re
 ##### fastify.FastifyRegister(plugin: [FastifyPlugin][FastifyPlugin], opts: [FastifyRegisterOptions][FastifyRegisterOptions])
 [src](../types/register.d.ts#L5)
 
-This type interface specifies the type for the [`fastify.register()`](./Server.md#register) method. The type interface returns a function signature with an underlying generic `Options` which is defaulted to [FastifyPluginOptions][FastifyPluginOptions]. It infers this generic from the FastifyPlugin parameter when calling this function so there is no need to specify the underlying generic. The options parameter is the intersection of the plugin's options and two additional optional properties: `prefix: string` and `logLevel`: [LogLevels][LogLevels].
+This type interface specifies the type for the [`fastify.register()`](./Server.md#register) method. The type interface returns a function signature with an underlying generic `Options` which is defaulted to [FastifyPluginOptions][FastifyPluginOptions]. It infers this generic from the FastifyPlugin parameter when calling this function so there is no need to specify the underlying generic. The options parameter is the intersection of the plugin's options and two additional optional properties: `prefix: string` and `logLevel`: [LogLevel][LogLevel].
 
 Below is an example of the options inference in action:
 
@@ -804,7 +804,7 @@ See the Learn By Example, [Plugins](#plugins) section for more detailed examples
 ##### fastify.FastifytRegisterOptions<Options>
 [src](../types/register.d.ts#L16)
 
-This type is the intersection of the `Options` generic and a non-exported interface `RegisterOptions` that specifies two optional properties: `prefix: string` and `logLevel`: [LogLevels][LogLevels]. This type can also be specified as a function that returns the previously described intersection.
+This type is the intersection of the `Options` generic and a non-exported interface `RegisterOptions` that specifies two optional properties: `prefix: string` and `logLevel`: [LogLevel][LogLevel]. This type can also be specified as a function that returns the previously described intersection.
 
 ---
 
@@ -824,7 +824,7 @@ An interface definition for the internal Fastify logger. It is emulative of the 
 
 An overload function interface that implements the two ways Fastify calls log methods. This interface is passed to all associated log level properties on the FastifyLoggerOptions object.
 
-##### fastify.LogLevels
+##### fastify.LogLevel
 
 [src](../types/logger.d.ts#L12)
 
@@ -1054,6 +1054,6 @@ Triggered when fastify.close() is invoked to stop the server. It is useful when 
 [FastifyPluginOptions]: #fastifyfastifypluginoptions
 [FastifyRegister]: #fastifyfastifyregisterrawserver-rawrequest-requestgenericplugin-fastifyplugin-opts-fastifyregisteroptions
 [FastifyRegisterOptions]: #fastifyfastifytregisteroptions
-[LogLevels]: #fastifyloglevels
+[LogLevel]: #fastifyloglevel
 [FastifyError]: #fastifyfastifyerror
 [RouteOptions]: #fastifyrouteoptionsrawserver-rawrequest-rawreply-requestgeneric-contextconfig

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -5,7 +5,7 @@ import * as LightMyRequest from 'light-my-request'
 
 import { FastifyRequest } from './types/request'
 import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression } from './types/utils'
-import { FastifyLoggerOptions } from './types/logger'
+import { FastifyLoggerInstance, FastifyLoggerOptions } from './types/logger'
 import { FastifyInstance } from './types/instance'
 import { FastifyServerFactory } from './types/serverFactory'
 import * as ajv from 'ajv'
@@ -24,31 +24,31 @@ declare function fastify<
   Server extends http2.Http2SecureServer,
   Request extends RawRequestDefaultExpression<Server> = RawRequestDefaultExpression<Server>,
   Reply extends RawReplyDefaultExpression<Server> = RawReplyDefaultExpression<Server>,
-  Logger = FastifyLoggerOptions<Server>,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 >(opts: FastifyHttp2SecureOptions<Server, Logger>): FastifyInstance<Server, Request, Reply, Logger>
 declare function fastify<
   Server extends http2.Http2Server,
   Request extends RawRequestDefaultExpression<Server> = RawRequestDefaultExpression<Server>,
   Reply extends RawReplyDefaultExpression<Server> = RawReplyDefaultExpression<Server>,
-  Logger = FastifyLoggerOptions<Server>,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 >(opts: FastifyHttp2Options<Server, Logger>): FastifyInstance<Server, Request, Reply, Logger>
 declare function fastify<
   Server extends https.Server,
   Request extends RawRequestDefaultExpression<Server> = RawRequestDefaultExpression<Server>,
   Reply extends RawReplyDefaultExpression<Server> = RawReplyDefaultExpression<Server>,
-  Logger = FastifyLoggerOptions<Server>,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 >(opts: FastifyHttpsOptions<Server, Logger>): FastifyInstance<Server, Request, Reply, Logger>
 declare function fastify<
   Server extends http.Server,
   Request extends RawRequestDefaultExpression<Server> = RawRequestDefaultExpression<Server>,
   Reply extends RawReplyDefaultExpression<Server> = RawReplyDefaultExpression<Server>,
-  Logger = FastifyLoggerOptions<Server>,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 >(opts?: FastifyServerOptions<Server, Logger>): FastifyInstance<Server, Request, Reply, Logger>
 export default fastify
 
 type FastifyHttp2SecureOptions<
   Server extends http2.Http2SecureServer,
-  Logger
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > = FastifyServerOptions<Server, Logger> & {
   http2: true,
   https: http2.SecureServerOptions
@@ -56,7 +56,7 @@ type FastifyHttp2SecureOptions<
 
 type FastifyHttp2Options<
   Server extends http2.Http2Server,
-  Logger
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > = FastifyServerOptions<Server, Logger> & {
   http2: true,
   http2SessionTimeout?: number,
@@ -64,7 +64,7 @@ type FastifyHttp2Options<
 
 type FastifyHttpsOptions<
   Server extends https.Server,
-  Logger
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > = FastifyServerOptions<Server, Logger> & {
   https: https.ServerOptions
 }
@@ -73,7 +73,7 @@ type FastifyHttpsOptions<
  */
 export type FastifyServerOptions<
   RawServer extends RawServerBase = RawServerDefault,
-  Logger = FastifyLoggerOptions<RawServer>
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > = {
   ignoreTrailingSlash?: boolean,
   connectionTimeout?: number,
@@ -84,7 +84,7 @@ export type FastifyServerOptions<
   disableRequestLogging?: boolean,
   onProtoPoisoning?: 'error' | 'remove' | 'ignore',
   onConstructorPoisoning?: 'error' | 'remove' | 'ignore',
-  logger?: boolean | Logger,
+  logger?: boolean | FastifyLoggerOptions<RawServer> | Logger,
   serverFactory?: FastifyServerFactory<RawServer>,
   caseSensitive?: boolean,
   requestIdHeader?: string,

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -121,7 +121,7 @@ export { FastifyRequest, FastifyRequestInterface, RequestGenericInterface } from
 export { FastifyReply, FastifyReplyInterface } from './types/reply'
 export { FastifyPlugin, FastifyPluginOptions } from './types/plugin'
 export { FastifyInstance } from './types/instance'
-export { FastifyLoggerOptions, FastifyLoggerInstance, FastifyLogFn, LogLevels } from './types/logger'
+export { FastifyLoggerOptions, FastifyLoggerInstance, FastifyLogFn, LogLevel } from './types/logger'
 export { FastifyContext } from './types/context'
 export { RouteHandlerMethod, RouteOptions, RouteShorthandMethod, RouteShorthandOptions, RouteShorthandOptionsWithHandler } from './types/route'
 export * from './types/register'

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@hapi/joi": "^17.1.1",
     "@sinonjs/fake-timers": "^6.0.1",
     "@types/node": "^14.0.1",
+    "@types/pino": "^6.0.1",
     "@typescript-eslint/eslint-plugin": "^2.29.0",
     "@typescript-eslint/parser": "^2.29.0",
     "JSONStream": "^1.3.5",

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -32,8 +32,9 @@ expectAssignable<FastifyInstance>(fastify({ disableRequestLogging: true }))
 expectAssignable<FastifyInstance>(fastify({ requestIdLogLabel: 'request-id' }))
 expectAssignable<FastifyInstance>(fastify({ onProtoPoisoning: 'error' }))
 expectAssignable<FastifyInstance>(fastify({ onConstructorPoisoning: 'error' }))
-expectAssignable<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse, true>>(fastify({ logger: true }))
-expectAssignable<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse, FastifyLoggerOptions>>(fastify({
+expectAssignable<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>>(fastify({ logger: true }))
+expectAssignable<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse, FastifyLoggerInstance>>(fastify({ logger: true }))
+expectAssignable<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse, FastifyLoggerInstance>>(fastify({
   logger: {
     level: 'info',
     genReqId: () => 'request-id',

--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -75,3 +75,12 @@ const serverAutoInferringTypes = fastify({
 })
 
 expectType<FastifyLoggerInstance>(serverAutoInferringTypes.log)
+
+const serverWithAutoInferredPino = fastify({
+  logger: pino({
+    level: 'info',
+    redact: ['x-userinfo']
+  })
+})
+
+expectType<pino.Logger>(serverWithAutoInferredPino.log)

--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -1,8 +1,9 @@
 import { expectType, expectError } from 'tsd'
-import fastify, { FastifyLoggerOptions, FastifyLogFn, LogLevel, FastifyLoggerInstance } from '../../fastify'
+import fastify, { FastifyLogFn, LogLevel, FastifyLoggerInstance } from '../../fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
+import * as pino from 'pino'
 
-expectType<FastifyLoggerOptions>(fastify().log)
+expectType<FastifyLoggerInstance>(fastify().log)
 
 ;['trace', 'debug', 'info', 'warn', 'error', 'fatal'].forEach(logLevel => {
   expectType<FastifyLogFn>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel])
@@ -11,23 +12,66 @@ expectType<FastifyLoggerOptions>(fastify().log)
   expectError(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel](0))
 })
 
-interface CustomLogger {
-  log: {
-    specialFunc: (...args: any[]) => void;
-  };
+interface CustomLogger extends FastifyLoggerInstance {
+  customMethod(msg: string, ...args: unknown[]): void
 }
 
-const customLogger: CustomLogger = {
-  log: {
-    specialFunc: (...args) => console.log(...args)
+class CustomLoggerImpl implements CustomLogger {
+  customMethod(msg: string, ...args: unknown[]) { console.log(msg, args) }
+
+  // Implementation signature must be compatible with all overloads of FastifyLogFn
+  info(arg1: string | object, arg2?: string | unknown, ...args: unknown[]): void {
+    console.log(arg1, arg2, ...args)
   }
+  warn(...args: unknown[]) { console.log(args) }
+  error(...args: unknown[]) { console.log(args) }
+  fatal(...args: unknown[]) { console.log(args) }
+  trace(...args: unknown[]) { console.log(args) }
+  debug(...args: unknown[]) { console.log(args) }
+  child() { return new CustomLoggerImpl() }
 }
+
+const customLogger = new CustomLoggerImpl()
 
 const serverWithCustomLogger = fastify<
   Server,
   IncomingMessage,
   ServerResponse,
-  CustomLogger
+  CustomLoggerImpl
 >({ logger: customLogger })
 
-expectType<CustomLogger>(serverWithCustomLogger.log)
+expectType<CustomLoggerImpl>(serverWithCustomLogger.log)
+
+const serverWithPino = fastify<
+  Server,
+  IncomingMessage,
+  ServerResponse,
+  pino.Logger
+>({
+  logger: pino({
+    level: 'info',
+    redact: ['x-userinfo']
+  })
+})
+
+expectType<pino.Logger>(serverWithPino.log)
+
+const serverWithLogOptions = fastify<
+  Server,
+  IncomingMessage,
+  ServerResponse
+>({
+  logger: {
+    level: 'info'
+  }
+})
+
+expectType<FastifyLoggerInstance>(serverWithLogOptions.log)
+
+const serverAutoInferringTypes = fastify({
+  logger: {
+    level: 'info'
+  }
+})
+
+expectType<FastifyLoggerInstance>(serverAutoInferringTypes.log)

--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -1,14 +1,14 @@
 import { expectType, expectError } from 'tsd'
-import fastify, { FastifyLoggerOptions, FastifyLogFn, LogLevels, FastifyLoggerInstance } from '../../fastify'
+import fastify, { FastifyLoggerOptions, FastifyLogFn, LogLevel, FastifyLoggerInstance } from '../../fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
 
 expectType<FastifyLoggerOptions>(fastify().log)
 
 ;['trace', 'debug', 'info', 'warn', 'error', 'fatal'].forEach(logLevel => {
-  expectType<FastifyLogFn>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevels])
-  expectType<void>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevels](''))
-  expectType<void>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevels]({}))
-  expectError(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevels](0))
+  expectType<FastifyLogFn>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel])
+  expectType<void>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel](''))
+  expectType<void>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel]({}))
+  expectError(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel](0))
 })
 
 interface CustomLogger {

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -7,7 +7,7 @@ import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyD
 import { FastifyRequest, RequestGenericInterface } from './request'
 import { FastifyReply } from './reply'
 import { FastifyError } from './error'
-import { FastifyLoggerOptions } from './logger'
+import { FastifyLoggerInstance } from './logger'
 
 type HookHandlerDoneFunction = (err?: FastifyError) => void
 
@@ -199,7 +199,7 @@ export interface onRegisterHookHandler<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
-  Logger = FastifyLoggerOptions<RawServer>
+  Logger = FastifyLoggerInstance
 > {
   (
     instance: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
@@ -212,7 +212,7 @@ export interface onRegisterHookHandler<
  */
 export interface onReadyHookHandler<
   RawServer extends RawServerBase = RawServerDefault,
-  Logger = FastifyLoggerOptions<RawServer>
+  Logger = FastifyLoggerInstance
 > {
   (
     done: HookHandlerDoneFunction
@@ -226,7 +226,7 @@ export interface onCloseHookHandler<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
-  Logger = FastifyLoggerOptions<RawServer>
+  Logger = FastifyLoggerInstance
 > {
   (
     instance: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -2,7 +2,7 @@ import { Chain as LightMyRequestChain, InjectOptions, Response as LightMyRequest
 import { RouteOptions, RouteShorthandMethod } from './route'
 import { FastifySchemaCompiler } from './schema'
 import { RawServerBase, RawRequestDefaultExpression, RawServerDefault, RawReplyDefaultExpression, ContextConfigDefault } from './utils'
-import { FastifyLoggerOptions } from './logger'
+import { FastifyLoggerInstance } from './logger'
 import { FastifyRegister } from './register'
 import { onRequestHookHandler, preParsingHookHandler, onSendHookHandler, preValidationHookHandler, preHandlerHookHandler, preSerializationHookHandler, onResponseHookHandler, onErrorHookHandler, onRouteHookHandler, onRegisterHookHandler, onCloseHookHandler, onReadyHookHandler } from './hooks'
 import { FastifyRequest, RequestGenericInterface } from './request'
@@ -17,24 +17,24 @@ export interface FastifyInstance<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
-  Logger = FastifyLoggerOptions<RawServer>
+  Logger = FastifyLoggerInstance
 > {
   server: RawServer;
   prefix: string;
   log: Logger;
 
-  addSchema(schema: unknown): FastifyInstance<RawServer, RawRequest, RawReply>;
+  addSchema(schema: unknown): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
-  after(): FastifyInstance<RawServer, RawRequest, RawReply> & PromiseLike<undefined>;
-  after(afterListener: (err: Error) => void): FastifyInstance<RawServer, RawRequest, RawReply>;
+  after(): FastifyInstance<RawServer, RawRequest, RawReply, Logger> & PromiseLike<undefined>;
+  after(afterListener: (err: Error) => void): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
-  close(): FastifyInstance<RawServer, RawRequest, RawReply> & PromiseLike<undefined>;
-  close(closeListener: () => void): FastifyInstance<RawServer, RawRequest, RawReply>;
+  close(): FastifyInstance<RawServer, RawRequest, RawReply, Logger> & PromiseLike<undefined>;
+  close(closeListener: () => void): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   // should be able to define something useful with the decorator getter/setter pattern using Generics to enfore the users function returns what they expect it to
-  decorate(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply>;
-  decorateRequest(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply>;
-  decorateReply(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply>;
+  decorate(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+  decorateRequest(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+  decorateReply(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   hasDecorator(decorator: string | symbol): boolean;
   hasRequestDecorator(decorator: string | symbol): boolean;
@@ -50,9 +50,9 @@ export interface FastifyInstance<
   listen(port: number, address?: string, backlog?: number): Promise<string>;
 
   ready(): FastifyInstance<RawServer, RawRequest, RawReply> & PromiseLike<undefined>;
-  ready(readyListener: (err: Error) => void): FastifyInstance<RawServer, RawRequest, RawReply>;
+  ready(readyListener: (err: Error) => void): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
-  register: FastifyRegister<FastifyInstance<RawServer, RawRequest, RawReply> & PromiseLike<undefined>>;
+  register: FastifyRegister<FastifyInstance<RawServer, RawRequest, RawReply, Logger> & PromiseLike<undefined>>;
   /**
    * This method is now deprecated and will throw a `FST_ERR_MISSING_MIDDLEWARE` error.
    * Visit fastify.io/docs/latest/Middleware/ for more info.
@@ -62,7 +62,7 @@ export interface FastifyInstance<
   route<
     RequestGeneric extends RequestGenericInterface = RequestGenericInterface,
     ContextConfig = ContextConfigDefault
-  >(opts: RouteOptions<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>): FastifyInstance<RawServer, RawRequest, RawReply>;
+  >(opts: RouteOptions<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   get: RouteShorthandMethod<RawServer, RawRequest, RawReply>;
   head: RouteShorthandMethod<RawServer, RawRequest, RawReply>;
@@ -87,7 +87,7 @@ export interface FastifyInstance<
   >(
     name: 'onRequest',
     hook: onRequestHookHandler<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>
-  ): FastifyInstance<RawServer, RawRequest, RawReply>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
    * `preParsing` is the second hook to be executed in the request lifecycle. The previous hook was `onRequest`, the next hook will be `preValidation`.
@@ -99,7 +99,7 @@ export interface FastifyInstance<
   >(
     name: 'preParsing',
     hook: preParsingHookHandler<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>
-  ): FastifyInstance<RawServer, RawRequest, RawReply>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
    * `preValidation` is the third hook to be executed in the request lifecycle. The previous hook was `preParsing`, the next hook will be `preHandler`.
@@ -110,7 +110,7 @@ export interface FastifyInstance<
   >(
     name: 'preValidation',
     hook: preValidationHookHandler<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>
-  ): FastifyInstance<RawServer, RawRequest, RawReply>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
    * `preHandler` is the fourth hook to be executed in the request lifecycle. The previous hook was `preValidation`, the next hook will be `preSerialization`.
@@ -121,7 +121,7 @@ export interface FastifyInstance<
   >(
     name: 'preHandler',
     hook: preHandlerHookHandler<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>
-  ): FastifyInstance<RawServer, RawRequest, RawReply>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
    * `preSerialization` is the fifth hook to be executed in the request lifecycle. The previous hook was `preHandler`, the next hook will be `onSend`.
@@ -134,7 +134,7 @@ export interface FastifyInstance<
   >(
     name: 'preSerialization',
     hook: preSerializationHookHandler<PreSerializationPayload, RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>
-  ): FastifyInstance<RawServer, RawRequest, RawReply>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
    * You can change the payload with the `onSend` hook. It is the sixth hook to be executed in the request lifecycle. The previous hook was `preSerialization`, the next hook will be `onResponse`.
@@ -147,7 +147,7 @@ export interface FastifyInstance<
   >(
     name: 'onSend',
     hook: onSendHookHandler<OnSendPayload, RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>
-  ): FastifyInstance<RawServer, RawRequest, RawReply>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
    * `onResponse` is the seventh and last hook in the request hook lifecycle. The previous hook was `onSend`, there is no next hook.
@@ -159,7 +159,7 @@ export interface FastifyInstance<
   >(
     name: 'onResponse',
     hook: onResponseHookHandler<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>
-  ): FastifyInstance<RawServer, RawRequest, RawReply>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
    * This hook is useful if you need to do some custom error logging or add some specific header in case of error.
@@ -173,7 +173,7 @@ export interface FastifyInstance<
   >(
     name: 'onError',
     hook: onErrorHookHandler<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>
-  ): FastifyInstance<RawServer, RawRequest, RawReply>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   // Application addHooks
 
@@ -186,7 +186,7 @@ export interface FastifyInstance<
   >(
     name: 'onRoute',
     hook: onRouteHookHandler<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>
-  ): FastifyInstance<RawServer, RawRequest, RawReply>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
   * Triggered when a new plugin is registered and a new encapsulation context is created. The hook will be executed before the registered code.
@@ -196,7 +196,7 @@ export interface FastifyInstance<
   addHook(
     name: 'onRegister',
     hook: onRegisterHookHandler<RawServer, RawRequest, RawReply, Logger>
-  ): FastifyInstance<RawServer, RawRequest, RawReply>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
   * Triggered when fastify.listen() or fastify.ready() is invoked to start the server. It is useful when plugins need a "ready" event, for example to load data before the server start listening for requests.
@@ -204,7 +204,7 @@ export interface FastifyInstance<
   addHook(
     name: 'onReady',
     hook: onReadyHookHandler<RawServer, Logger>
-  ): FastifyInstance<RawServer, RawRequest, RawReply>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
   * Triggered when fastify.close() is invoked to stop the server. It is useful when plugins need a "shutdown" event, for example to close an open connection to a database.
@@ -212,7 +212,7 @@ export interface FastifyInstance<
   addHook(
     name: 'onClose',
     hook: onCloseHookHandler<RawServer, RawRequest, RawReply, Logger>
-  ): FastifyInstance<RawServer, RawRequest, RawReply>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
    * Set the 404 handler
@@ -231,12 +231,12 @@ export interface FastifyInstance<
   /**
    * Set the schema validator for all routes.
    */
-  setValidatorCompiler(schemaCompiler: FastifySchemaCompiler): FastifyInstance<RawServer, RawRequest, RawReply>;
+  setValidatorCompiler(schemaCompiler: FastifySchemaCompiler): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
    * Set the schema serializer for all routes.
    */
-  setSerializerCompiler(schemaCompiler: FastifySchemaCompiler): FastifyInstance<RawServer, RawRequest, RawReply>;
+  setSerializerCompiler(schemaCompiler: FastifySchemaCompiler): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
    * Add a content type parser

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -12,6 +12,14 @@ export interface FastifyLogFn {
 
 export type LogLevel = 'info' | 'error' | 'debug' | 'fatal' | 'warn' | 'trace'
 
+export type SerializerFn = (value: unknown) => unknown;
+
+export interface Bindings {
+  level?: LogLevel | string;
+  serializers?: { [key: string]: SerializerFn };
+  [key: string]: unknown;
+}
+
 export interface FastifyLoggerInstance {
   info: FastifyLogFn;
   warn: FastifyLogFn;
@@ -19,7 +27,7 @@ export interface FastifyLoggerInstance {
   fatal: FastifyLogFn;
   trace: FastifyLogFn;
   debug: FastifyLogFn;
-  child(): FastifyLoggerInstance;
+  child(bindings: Bindings): FastifyLoggerInstance;
 }
 
 /**

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -6,8 +6,8 @@ import { FastifyRequest } from './request'
  * Standard Fastify logging function
  */
 export interface FastifyLogFn {
-  (msg: string, ...args: any[]): void;
-  (obj: object, msg?: string, ...args: any[]): void;
+  (msg: string, ...args: unknown[]): void;
+  (obj: object, msg?: string, ...args: unknown[]): void;
 }
 
 export type LogLevel = 'info' | 'error' | 'debug' | 'fatal' | 'warn' | 'trace'

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -10,7 +10,7 @@ export interface FastifyLogFn {
   (obj: object, msg?: string, ...args: any[]): void;
 }
 
-export type LogLevels = 'info' | 'error' | 'debug' | 'fatal' | 'warn' | 'trace'
+export type LogLevel = 'info' | 'error' | 'debug' | 'fatal' | 'warn' | 'trace'
 
 export interface FastifyLoggerInstance {
   info: FastifyLogFn;

--- a/types/register.d.ts
+++ b/types/register.d.ts
@@ -1,5 +1,5 @@
 import { FastifyPlugin, FastifyPluginOptions } from './plugin'
-import { LogLevels } from './logger'
+import { LogLevel } from './logger'
 
 /**
  * FastifyRegister
@@ -17,5 +17,5 @@ export type FastifyRegisterOptions<Options> = (RegisterOptions & Options) | (() 
 
 interface RegisterOptions {
   prefix?: string;
-  logLevel?: LogLevels;
+  logLevel?: LogLevel;
 }

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -1,4 +1,4 @@
-import { FastifyLoggerOptions } from './logger'
+import { FastifyLoggerInstance } from './logger'
 import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RequestBodyDefault, RequestQuerystringDefault, RequestParamsDefault, RequestHeadersDefault } from './utils'
 
 export interface RequestGenericInterface {
@@ -19,7 +19,7 @@ export interface FastifyRequestInterface<
 > {
   body: RequestGeneric['Body'];
   id: any;
-  log: FastifyLoggerOptions<RawServer>;
+  log: FastifyLoggerInstance;
   params: RequestGeneric['Params'];
   query: RequestGeneric['Querystring'];
   raw: RawRequest;

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -3,7 +3,7 @@ import { FastifyRequest, RequestGenericInterface } from './request'
 import { FastifyReply } from './reply'
 import { FastifySchema, FastifySchemaCompiler } from './schema'
 import { HTTPMethods, RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, ContextConfigDefault } from './utils'
-import { LogLevels } from './logger'
+import { LogLevel } from './logger'
 import { preValidationHookHandler, preHandlerHookHandler, preSerializationHookHandler, onRequestHookHandler, preParsingHookHandler, onResponseHookHandler, onSendHookHandler, onErrorHookHandler } from './hooks'
 
 /**
@@ -64,7 +64,7 @@ export interface RouteShorthandOptions<
   validatorCompiler?: FastifySchemaCompiler;
   serializerCompiler?: FastifySchemaCompiler;
   bodyLimit?: number;
-  logLevel?: LogLevels;
+  logLevel?: LogLevel;
   config?: ContextConfig;
   version?: string;
   prefixTrailingSlash?: boolean;


### PR DESCRIPTION
Fix logger typings (per discussion in #2289)

- log() method of FastifyInstance and FastifyRequest now has correct type
- external logger is now checked for conformance to FastifyLoggerInstance interface
- adjust FastifyLoggerInstance to be compatible with pino.Logger
- logger type is now propagated to builder method declarations (addHook etc)
- add tests for external pino instance
- adjust custom logger test (it hasn't been conforming to FastifyLoggerInstance)
- update tests and add a couple of new ones
- update docs

Please see individual commits for more details.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
