### PR TITLE
docs: fastify server is this in handlers

### DIFF
--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -93,6 +93,16 @@ fastify.utility()
 console.log(fastify.conf.db)
 ```
 
+The decorated [Fastify server](./Server.md) is bound to `this` in route [route]() handlers:
+
+```js
+fastify.decorate('db', new DbConnection())
+
+fastify.get('/', async function (request, reply) {
+  reply({hello: await this.db.query('world')})
+})
+```
+
 The `dependencies` parameter is an optional list of decorators that the
 decorator being defined relies upon. This list is simply a list of string names
 of other decorators. In the following example, the "utility" decorator depends

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -50,7 +50,7 @@ They need to be in
 * `preSerialization(request, reply, payload, done)`: a [function](./Hooks.md#preserialization) called just before the serialization, it could also be an array of functions.
 * `onSend(request, reply, payload, done)`: a [function](./Hooks.md#route-hooks) called right before a response is sent, it could also be an array of functions.
 * `onResponse(request, reply, done)`: a [function](./Hooks.md#onresponse) called when a response has been sent, so you will not be able to send more data to the client. It could also be an array of functions.
-* `handler(request, reply)`: the function that will handle this request.
+* `handler(request, reply)`: the function that will handle this request. The [Fastify server](./Server.md) will be bound to `this` when the handler is called. Note: using an arrow function will break the binding of `this`.
 * `validatorCompiler({ schema, method, url, httpPart })`: function that builds schemas for request validations. See the [Validation and Serialization](./Validation-and-Serialization.md#schema-validator) documentation.
 * `serializerCompiler({ { schema, method, url, httpStatus } })`: function that builds schemas for response serialization. See the [Validation and Serialization](./Validation-and-Serialization.md#schema-serializer) documentation.
 * `bodyLimit`: prevents the default JSON body parser from parsing request bodies larger than this number of bytes. Must be an integer. You may also set this option globally when first creating the Fastify instance with `fastify(options)`. Defaults to `1048576` (1 MiB).


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

I documented that handler functions have `this` bound to the fastify server as I couldn't find this anywhere in the docs.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] ~tests and/or benchmarks are included~ N/A: doc change only
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
