### PR TITLE
docs: Fixing typo pointing at FastifytRegisterOptions

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -794,7 +794,7 @@ fastify().register(plugin, { option1: '', option2: true }) // OK - options objec
 
 See the Learn By Example, [Plugins](#plugins) section for more detailed examples of creating TypeScript plugins in Fastify.
 
-##### fastify.FastifytRegisterOptions<Options>
+##### fastify.FastifyRegisterOptions<Options>
 [src](../types/register.d.ts#L16)
 
 This type is the intersection of the `Options` generic and a non-exported interface `RegisterOptions` that specifies two optional properties: `prefix: string` and `logLevel`: [LogLevel][LogLevel]. This type can also be specified as a function that returns the previously described intersection.


### PR DESCRIPTION
Fixing typo incorrectly pointing at FastifytRegisterOptions found during doc search

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
