### PR TITLE
fix ready order execution

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -100,8 +100,8 @@ function hookRunnerApplication (hookName, boot, server, cb) {
         exit()
       } else {
         boot(function manageTimeout (err, done) {
-          done(err)
           exit(err)
+          done(err)
         })
       }
       return

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -101,8 +101,8 @@ function hookRunnerApplication (hookName, boot, server, cb) {
       } else {
         // This is the last function executed for every fastify instance
         boot(function manageTimeout (err, done) {
-          // this callback is needed by fastify to provide an hook interface without error
-          // and managing the error for the user
+          // this callback is needed by fastify to provide an hook interface without the error
+          // as first parameter and managing it on behalf the user
           exit(err)
 
           // this callback is needed by avvio to continue the loading of the next `register` plugins

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -99,8 +99,13 @@ function hookRunnerApplication (hookName, boot, server, cb) {
       if (i === 0 && c === 0) { // speed up start
         exit()
       } else {
+        // This is the last function executed for every fastify instance
         boot(function manageTimeout (err, done) {
+          // this callback is needed by fastify to provide an hook interface without error
+          // and managing the error for the user
           exit(err)
+
+          // this callback is needed by avvio to continue the loading of the next `register` plugins
           done(err)
         })
       }

--- a/test/hooks.on-ready.test.js
+++ b/test/hooks.on-ready.test.js
@@ -313,3 +313,13 @@ t.test('onReady does not call done', t => {
     t.equal(err.code, 'ERR_AVVIO_READY_TIMEOUT')
   })
 })
+
+t.test('onReady execution order', t => {
+  t.plan(3)
+  const fastify = Fastify({ })
+
+  let i = 0
+  fastify.ready(() => { i++; t.equals(i, 1) })
+  fastify.ready(() => { i++; t.equals(i, 2) })
+  fastify.ready(() => { i++; t.equals(i, 3) })
+})


### PR DESCRIPTION
This test was failing in v3: the order was reverted

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
