### PR TITLE
Allow TS type augmentation for Fastify.prototype.use

### DIFF
--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -14,19 +14,19 @@ expectAssignable<FastifyInstance>(server.addSchema({
     schemas: []
 }))
 
-expectType<void>(server.use((req, res, next) => {
+expectAssignable<FastifyInstance>(server.use((req, res, next) => {
   expectType<IncomingMessage>(req)
   expectType<ServerResponse>(res)
   expectType<void>(next())
   expectType<void>(next(new Error('foo')))
 }))
-expectType<void>(server.use('/foo', (req, res, next) => {
+expectAssignable<FastifyInstance>(server.use('/foo', (req, res, next) => {
   expectType<IncomingMessage>(req)
   expectType<ServerResponse>(res)
   expectType<void>(next())
   expectType<void>(next(new Error('foo')))
 }))
-expectType<void>(server.use(['/foo', '/bar'], (req, res, next) => {
+expectAssignable<FastifyInstance>(server.use(['/foo', '/bar'], (req, res, next) => {
   expectType<IncomingMessage>(req)
   expectType<ServerResponse>(res)
   expectType<void>(next())

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -1,6 +1,5 @@
 import fastify, { FastifyError, FastifyInstance } from '../../fastify';
 import { expectAssignable, expectError, expectType } from 'tsd';
-import { IncomingMessage, ServerResponse } from 'http'
 
 const server = fastify()
 

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -1,5 +1,6 @@
 import fastify, { FastifyInstance } from '../../fastify'
-import { expectAssignable } from 'tsd'
+import { expectAssignable, expectType } from 'tsd'
+import { IncomingMessage, ServerResponse } from 'http'
 
 const server = fastify()
 
@@ -11,4 +12,23 @@ expectAssignable<FastifyInstance>(server.addSchema({
 }))
 expectAssignable<FastifyInstance>(server.addSchema({
     schemas: []
+}))
+
+expectType<void>(server.use((req, res, next) => {
+  expectType<IncomingMessage>(req)
+  expectType<ServerResponse>(res)
+  expectType<void>(next())
+  expectType<void>(next(new Error('foo')))
+}))
+expectType<void>(server.use('/foo', (req, res, next) => {
+  expectType<IncomingMessage>(req)
+  expectType<ServerResponse>(res)
+  expectType<void>(next())
+  expectType<void>(next(new Error('foo')))
+}))
+expectType<void>(server.use(['/foo', '/bar'], (req, res, next) => {
+  expectType<IncomingMessage>(req)
+  expectType<ServerResponse>(res)
+  expectType<void>(next())
+  expectType<void>(next(new Error('foo')))
 }))

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -14,21 +14,5 @@ expectAssignable<FastifyInstance>(server.addSchema({
     schemas: []
 }))
 
-expectAssignable<FastifyInstance>(server.use((req, res, next) => {
-  expectType<IncomingMessage>(req)
-  expectType<ServerResponse>(res)
-  expectType<void>(next())
-  expectType<void>(next(new Error('foo')))
-}))
-expectAssignable<FastifyInstance>(server.use('/foo', (req, res, next) => {
-  expectType<IncomingMessage>(req)
-  expectType<ServerResponse>(res)
-  expectType<void>(next())
-  expectType<void>(next(new Error('foo')))
-}))
-expectAssignable<FastifyInstance>(server.use(['/foo', '/bar'], (req, res, next) => {
-  expectType<IncomingMessage>(req)
-  expectType<ServerResponse>(res)
-  expectType<void>(next())
-  expectType<void>(next(new Error('foo')))
-}))
+expectType<unknown>(server.use(() => {}))
+expectType<unknown>(server.use('/foo', () => {}))

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -53,11 +53,28 @@ export interface FastifyInstance<
   ready(readyListener: (err: Error) => void): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   register: FastifyRegister<FastifyInstance<RawServer, RawRequest, RawReply, Logger> & PromiseLike<undefined>>;
+
   /**
-   * This method is now deprecated and will throw a `FST_ERR_MISSING_MIDDLEWARE` error.
-   * Visit fastify.io/docs/latest/Middleware/ for more info.
+   * Mounts an Express-style middleware. However, support for Express-style
+   * middlewares should first be enabled via either
+   * https://github.com/fastify/middie or
+   * https://github.com/fastify/fastiy-express.
    */
-  use(...args: unknown[]): void;
+  use(
+    middleware: (
+      req: RawRequest,
+      res: RawReply,
+      next: (err?: Error | unknown) => void
+    ) => void
+  ): void;
+  use(
+    path: string | string[],
+    middleware: (
+      req: RawRequest,
+      res: RawReply,
+      next: (err?: Error | unknown) => void
+    ) => void
+  ): void;
 
   route<
     RequestGeneric extends RequestGenericInterface = RequestGenericInterface,

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -59,21 +59,7 @@ export interface FastifyInstance<
    * for Express-style middlewares is first enabled. Visit
    * https://fastify.io/docs/latest/Middleware/ for more info.
    */
-  use(
-    middleware: (
-      req: RawRequest,
-      res: RawReply,
-      next: (err?: Error | unknown) => void
-    ) => void
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
-  use(
-    path: string | string[],
-    middleware: (
-      req: RawRequest,
-      res: RawReply,
-      next: (err?: Error | unknown) => void
-    ) => void
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+  use(...args: unknown[]): unknown;
 
   route<
     RequestGeneric extends RequestGenericInterface = RequestGenericInterface,

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -66,7 +66,7 @@ export interface FastifyInstance<
       res: RawReply,
       next: (err?: Error | unknown) => void
     ) => void
-  ): void;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
   use(
     path: string | string[],
     middleware: (
@@ -74,7 +74,7 @@ export interface FastifyInstance<
       res: RawReply,
       next: (err?: Error | unknown) => void
     ) => void
-  ): void;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   route<
     RequestGeneric extends RequestGenericInterface = RequestGenericInterface,

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -55,10 +55,9 @@ export interface FastifyInstance<
   register: FastifyRegister<FastifyInstance<RawServer, RawRequest, RawReply, Logger> & PromiseLike<undefined>>;
 
   /**
-   * Mounts an Express-style middleware. However, support for Express-style
-   * middlewares should first be enabled via either
-   * https://github.com/fastify/middie or
-   * https://github.com/fastify/fastiy-express.
+   * This method will throw a `FST_ERR_MISSING_MIDDLEWARE` error unless support
+   * for Express-style middlewares is first enabled. Visit
+   * https://fastify.io/docs/latest/Middleware/ for more info.
    */
   use(
     middleware: (

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -57,7 +57,7 @@ export interface FastifyInstance<
    * This method is now deprecated and will throw a `FST_ERR_MISSING_MIDDLEWARE` error.
    * Visit fastify.io/docs/latest/Middleware/ for more info.
    */
-  use: void;
+  use(...args: unknown[]): void;
 
   route<
     RequestGeneric extends RequestGenericInterface = RequestGenericInterface,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

This change allows use of `Fastify.prototype.use` as is or with custom type augmentations. 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
