### PR TITLE
correct typings for ready()

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -509,10 +509,8 @@ declare namespace fastify {
      * Registers a listener function that is invoked when all the plugins have
      * been loaded. It receives an error parameter if something went wrong.
      */
-    ready(): Promise<FastifyInstance<HttpServer, HttpRequest, HttpResponse>>
+    ready(): Promise<void>
     ready(readyListener: (err: Error) => void): void
-    ready(readyListener: (err: Error, done: Function) => void): void
-    ready(readyListener: (err: Error, context: FastifyInstance<HttpServer, HttpRequest, HttpResponse>, done: Function) => void): void
 
     /**
      * Call this function to close the server instance and run the "onClose" callback

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -690,18 +690,9 @@ server.ready(function (err) {
   if (err) throw err
 })
 
-server.ready(function (err: Error, done: Function) {
-  done(err)
-})
-
-server.ready(function (err: Error, context: fastify.FastifyInstance<http2.Http2SecureServer, http2.Http2ServerRequest, http2.Http2ServerResponse>, done: Function) {
-  server.log.debug(context)
-  done(err)
-})
-
 server.ready()
   .then((context) => {
-    server.log.debug(context)
+    server.log.debug(typeof context)
   })
   .catch((err) => {
     server.log.error(err)


### PR DESCRIPTION
fixes #2343

note: the current `ready` function was added by 655f28fcc36679b4538e0120eecb1f5524325298 that mentions a backport.

I adjusted the d.ts to match the implementation by removing 2 overloads, but I also had to remove corresponding tests.
you should check that 655f28fcc36679b4538e0120eecb1f5524325298 didn't break other runtime stuff
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
