### PR TITLE
add test to verify ND-JSON content is not serialized as JSON

### DIFF
--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -545,7 +545,7 @@ test('plain string with content type application/json should NOT be serialized a
 })
 
 test('plain string with custom json content type should NOT be serialized as json', t => {
-  t.plan(16)
+  t.plan(19)
 
   const fastify = require('../..')()
 
@@ -565,6 +565,10 @@ test('plain string with custom json content type should NOT be serialized as jso
     jsonld: {
       mimeType: 'application/ld+json',
       sample: '{"@context":"https://json-ld.org/contexts/person.jsonld","name":"John Doe"}'
+    },
+    ndjson: {
+      mimeType: 'application/x-ndjson',
+      sample: '{"a":"apple","b":{"bb":"bubble"}}\n{"c":"croissant","bd":{"dd":"dribble"}}'
     },
     siren: {
       mimeType: 'application/vnd.siren+json',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

In response to a short conversation on #2309 I have added a test for ND-JSON, a content type that has `json` in it's media type but should not be treated as JSON for serialization.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
