### PR TITLE
add Promise version overload for FastifyPlugin

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -119,7 +119,7 @@ type TrustProxyFunction = (address: string, hop: number) => boolean
 /* Export all additional types */
 export { FastifyRequest, RequestGenericInterface } from './types/request'
 export { FastifyReply } from './types/reply'
-export { FastifyPlugin, FastifyPluginOptions } from './types/plugin'
+export { FastifyPluginCallback, FastifyPluginAsync, FastifyPluginOptions, FastifyPlugin } from './types/plugin'
 export { FastifyInstance } from './types/instance'
 export { FastifyLoggerOptions, FastifyLoggerInstance, FastifyLogFn, LogLevel } from './types/logger'
 export { FastifyContext } from './types/context'

--- a/test/types/plugin.test-d.ts
+++ b/test/types/plugin.test-d.ts
@@ -1,20 +1,38 @@
-import fastify, { FastifyPlugin, FastifyInstance, FastifyPluginOptions } from '../../fastify'
+import fastify, { FastifyInstance, FastifyPluginOptions } from '../../fastify'
 import * as http from 'http'
 import * as https from 'https'
 import { expectType, expectError, expectAssignable } from 'tsd'
+import { FastifyPluginCallback, FastifyPluginAsync } from '../../types/plugin'
 
 // FastifyPlugin & FastifyRegister
 interface TestOptions extends FastifyPluginOptions {
   option1: string;
   option2: boolean;
 }
-const testPlugin: FastifyPlugin<TestOptions> = function (instance, opts, next) { }
+const testPluginOpts: FastifyPluginCallback<TestOptions> = function (instance, opts, next) { }
 
-expectError(fastify().register(testPlugin, {})) // error because missing required options from generic declaration
-expectAssignable<FastifyInstance>(fastify().register(testPlugin, { option1: '', option2: true }))
-expectAssignable<FastifyInstance>(fastify().register(function (instace, opts, next) { }))
-expectAssignable<FastifyInstance>(fastify().register(function (instace, opts, next) { }, () => { }))
+const testPluginOptsAsync: FastifyPluginAsync<TestOptions> = async function (instance, opts) { }
+
+expectError(fastify().register(testPluginOpts, {})) // error because missing required options from generic declaration
+expectError(fastify().register(testPluginOptsAsync, {})) // error because missing required options from generic declaration
+
+expectAssignable<FastifyInstance>(fastify().register(testPluginOpts, { option1: '', option2: true }))
+expectAssignable<FastifyInstance>(fastify().register(testPluginOptsAsync, { option1: '', option2: true }))
+
+expectAssignable<FastifyInstance>(fastify().register(function (instance, opts, next) { }))
+expectAssignable<FastifyInstance>(fastify().register(function (instance, opts, next) { }, () => { }))
 expectAssignable<FastifyInstance>(fastify().register(function (instance, opts, next) { }, { logLevel: 'info', prefix: 'foobar' }))
+
+const testPluginCallback: FastifyPluginCallback = function (instance, opts, next) { }
+expectAssignable<FastifyInstance>(fastify().register(testPluginCallback, {}))
+
+const testPluginAsync: FastifyPluginAsync = async function (instance, opts) { }
+expectAssignable<FastifyInstance>(fastify().register(testPluginAsync, {}))
+
+expectAssignable<FastifyInstance>(fastify().register(function (instance, opts): Promise<void> { return Promise.resolve() }))
+expectAssignable<FastifyInstance>(fastify().register(async function (instance, opts) { }, () => { }))
+expectAssignable<FastifyInstance>(fastify().register(async function (instance, opts) { }, { logLevel: 'info', prefix: 'foobar' }))
+
 expectError(fastify().register(function (instance, opts, next) { }, { logLevel: '' })) // must use a valid logLevel
 
 const httpsServer = fastify({ https: {} });
@@ -22,7 +40,7 @@ expectType<FastifyInstance<https.Server, http.IncomingMessage, http.ServerRespon
 
 // Chainable
 httpsServer
-  .register(testPlugin)
+  .register(testPluginOpts)
   .after((_error) => { })
   .close(() => { })
   .ready((_error) => { })
@@ -31,10 +49,10 @@ httpsServer
 expectAssignable<PromiseLike<undefined>>(httpsServer.after());
 expectAssignable<PromiseLike<undefined>>(httpsServer.close());
 expectAssignable<PromiseLike<undefined>>(httpsServer.ready());
-expectAssignable<PromiseLike<undefined>>(httpsServer.register(testPlugin));
+expectAssignable<PromiseLike<undefined>>(httpsServer.register(testPluginOpts));
 
 async function testAsync() {
   await httpsServer
-    .register(testPlugin)
-    .register(testPlugin)
+    .register(testPluginOpts)
+    .register(testPluginOpts)
 }

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -1,19 +1,32 @@
 import { FastifyInstance } from './instance'
-import { FastifyError } from 'fastify-error'
 import { RawServerBase, RawRequestDefaultExpression, RawReplyDefaultExpression } from './utils'
 
 /**
- * FastifyPlugin
+ * FastifyPluginCallback
  *
  * Fastify allows the user to extend its functionalities with plugins. A plugin can be a set of routes, a server decorator or whatever. To activate plugins, use the `fastify.register()` method.
  */
-export interface FastifyPlugin<Options extends FastifyPluginOptions = {}> {
-  (
-    instance: FastifyInstance<RawServerBase, RawRequestDefaultExpression<RawServerBase>, RawReplyDefaultExpression<RawServerBase>>,
-    opts: Options,
-    next: (err?: FastifyError) => void
-  ): void;
-}
+export type FastifyPluginCallback<Options extends FastifyPluginOptions = {}> = (
+  instance: FastifyInstance<RawServerBase, RawRequestDefaultExpression<RawServerBase>, RawReplyDefaultExpression<RawServerBase>>,
+  opts: Options,
+  next: (err?: Error) => void
+) => void
+
+/**
+ * FastifyPluginAsync
+ *
+ * Fastify allows the user to extend its functionalities with plugins. A plugin can be a set of routes, a server decorator or whatever. To activate plugins, use the `fastify.register()` method.
+ */
+export type FastifyPluginAsync<Options extends FastifyPluginOptions = {}> = (
+  instance: FastifyInstance<RawServerBase, RawRequestDefaultExpression<RawServerBase>, RawReplyDefaultExpression<RawServerBase>>,
+  opts: Options
+) => Promise<void>;
+
+/**
+ * Generic plugin type.
+ * @deprecated union type doesn't work well with type inference in TS and is therefore deprecated in favor of explicit types. See FastifyRegister.
+ */
+export type FastifyPlugin<Options extends FastifyPluginOptions = {}> = FastifyPluginCallback<Options> | FastifyPluginAsync<Options>
 
 export interface FastifyPluginOptions {
   [key: string]: any;

--- a/types/register.d.ts
+++ b/types/register.d.ts
@@ -1,4 +1,4 @@
-import { FastifyPlugin, FastifyPluginOptions } from './plugin'
+import { FastifyPluginOptions, FastifyPluginCallback, FastifyPluginAsync } from './plugin'
 import { LogLevel } from './logger'
 
 /**
@@ -8,7 +8,15 @@ import { LogLevel } from './logger'
  */
 export interface FastifyRegister<T = void> {
   <Options extends FastifyPluginOptions>(
-    plugin: FastifyPlugin<Options>,
+    plugin: FastifyPluginCallback<Options>,
+    opts?: FastifyRegisterOptions<Options>
+  ): T;
+  <Options extends FastifyPluginOptions>(
+    plugin: FastifyPluginAsync<Options>,
+    opts?: FastifyRegisterOptions<Options>
+  ): T;
+  <Options extends FastifyPluginOptions>(
+    plugin: FastifyPluginCallback<Options> | FastifyPluginAsync<Options>,
     opts?: FastifyRegisterOptions<Options>
   ): T;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

I usually write TS with [no-misused-promises](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-misused-promises.md) rule on since it provides such benefits as prohibiting passing `async` function where it is not expected (i.e. event listener on `EventEmitter` etc.)
The `fastify.register` didn't have a correct overload for a plugin function that returns a promise therefore that rule failed even though such use-case is supported.

This adds an overload to `FastifyPlugin` that returns a Promise, therefore, telling TS that `register` can handle such functions.

Unfortunately, I couldn't get TS to properly infer types for async versions of functions, therefore a need to explicitly specify type. Furthermore, since the type was explicitly defined on `FastifyPlugin.instance` TS refused to accept just `FastifyInstance` type for instance argument on plugin function and I had to change the signature of `FastifyPlugin` to accept any extension of `FastifyInstance`.
Definitely want to hear @Ethan-Arrowood opinion on this.

