### PR TITLE
Add `PATCH` to `body` validation

### DIFF
--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -14,7 +14,7 @@ Fastify uses a schema-based approach, and even if it is not mandatory we recomme
 <a name="validation"></a>
 ### Validation
 The route validation internally relies upon [Ajv](https://www.npmjs.com/package/ajv), which is a high-performance JSON schema validator. Validating the input is very easy: just add the fields that you need inside the route schema, and you are done! The supported validations are:
-- `body`: validates the body of the request if it is a POST or a PUT.
+- `body`: validates the body of the request if it is a POST, a PATCH or a PUT.
 - `querystring` or `query`: validates the query string. This can be a complete JSON Schema object (with a `type` property of `'object'` and a `'properties'` object containing parameters) or a simpler variation in which the `type` and `properties` attributes are forgone and the query parameters are listed at the top level (see the example below).
 - `params`: validates the route params.
 - `headers`: validates the request headers.


### PR DESCRIPTION
Hello,

I propose this documentation change so as it is explicit `body` validation also happens during `PATCH` requests.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
