### PR TITLE
Drop support for Joi.

### DIFF
--- a/docs/Migration-Guide-V3.md
+++ b/docs/Migration-Guide-V3.md
@@ -280,3 +280,5 @@ option ([#2086](https://github.com/fastify/fastify/pull/2086))
 ([#2093](https://github.com/fastify/fastify/pull/2093))
 - Added the feature to throw object as error
 ([#2134](https://github.com/fastify/fastify/pull/2134))
+- Dropped formal support for [joi](https://github.com/hapijs/joi) due to
+  uncertain future ([#2355](https://github.com/fastify/fastify/pull/2355))

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -301,22 +301,7 @@ _**Note:** If you use a custom instance of any validator (even Ajv), you have to
 <a name="using-other-validation-libraries"></a>
 ##### Using other validation libraries
 
-The `setValidatorCompiler` function makes it easy to substitute `ajv` with almost any Javascript validation library ([joi](https://github.com/hapijs/joi/), [yup](https://github.com/jquense/yup/), ...) or a custom one:
-
-```js
-const Joi = require('@hapi/joi')
-
-fastify.post('/the/url', {
-  schema: {
-    body: Joi.object().keys({
-      hello: Joi.string().required()
-    }).required()
-  },
-  validatorCompiler: ({ schema, method, url, httpPart }) => {
-    return data => schema.validate(data)
-  }
-}, handler)
-```
+The `setValidatorCompiler` function makes it easy to substitute `ajv` with almost any Javascript validation library or a custom one:
 
 ```js
 const yup = require('yup')

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "node": ">=10.16.0"
   },
   "devDependencies": {
-    "@hapi/joi": "^17.1.1",
     "@sinonjs/fake-timers": "^6.0.1",
     "@types/node": "^14.0.1",
     "@types/pino": "^6.0.1",

--- a/test/input-validation.js
+++ b/test/input-validation.js
@@ -2,7 +2,6 @@
 
 const sget = require('simple-get').concat
 const Ajv = require('ajv')
-const Joi = require('@hapi/joi')
 const yup = require('yup')
 
 module.exports.payloadMethod = function (method, t) {
@@ -42,17 +41,6 @@ module.exports.payloadMethod = function (method, t) {
     }
   }
 
-  const optsWithJoiValidator = {
-    schema: {
-      body: Joi.object().keys({
-        hello: Joi.string().required()
-      }).required()
-    },
-    validatorCompiler: function ({ schema, method, url, httpPart }) {
-      return schema.validate.bind(schema)
-    }
-  }
-
   const yupOptions = {
     strict: true, // don't coerce
     abortEarly: false, // return all errors
@@ -85,9 +73,6 @@ module.exports.payloadMethod = function (method, t) {
         reply.send(req.body)
       })
       fastify[loMethod]('/custom', optsWithCustomValidator, function (req, reply) {
-        reply.send(req.body)
-      })
-      fastify[loMethod]('/joi', optsWithJoiValidator, function (req, reply) {
         reply.send(req.body)
       })
       fastify[loMethod]('/yup', optsWithYupValidator, function (req, reply) {
@@ -217,42 +202,6 @@ module.exports.payloadMethod = function (method, t) {
         t.error(err)
         t.strictEqual(response.statusCode, 200)
         t.deepEqual(body, { hello: 42 })
-      })
-    })
-
-    test(`${upMethod} - input-validation joi schema compiler ok`, t => {
-      t.plan(3)
-      sget({
-        method: upMethod,
-        url: 'http://localhost:' + fastify.server.address().port + '/joi',
-        body: {
-          hello: '42'
-        },
-        json: true
-      }, (err, response, body) => {
-        t.error(err)
-        t.strictEqual(response.statusCode, 200)
-        t.deepEqual(body, { hello: 42 })
-      })
-    })
-
-    test(`${upMethod} - input-validation joi schema compiler ko`, t => {
-      t.plan(3)
-      sget({
-        method: upMethod,
-        url: 'http://localhost:' + fastify.server.address().port + '/joi',
-        body: {
-          hello: 44
-        },
-        json: true
-      }, (err, response, body) => {
-        t.error(err)
-        t.strictEqual(response.statusCode, 400)
-        t.deepEqual(body, {
-          error: 'Bad Request',
-          message: '"hello" must be a string',
-          statusCode: 400
-        })
       })
     })
 

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -3,7 +3,6 @@
 const t = require('tap')
 const test = t.test
 const sget = require('simple-get').concat
-const joi = require('@hapi/joi')
 const Fastify = require('..')
 
 test('route', t => {
@@ -254,48 +253,6 @@ test('handler function in options of shorthand route should works correctly', t 
     t.error(err)
     t.strictEqual(res.statusCode, 200)
     t.deepEqual(JSON.parse(res.payload), { hello: 'world' })
-  })
-})
-
-test('does not mutate joi schemas', t => {
-  t.plan(4)
-
-  const fastify = Fastify()
-  function validatorCompiler ({ schema, method, url, httpPart }) {
-    // Needed to extract the params part,
-    // without the JSON-schema encapsulation
-    // that is automatically added by the short
-    // form of params.
-    schema = joi.object(schema.properties)
-
-    return validateHttpData
-
-    function validateHttpData (data) {
-      return schema.validate(data)
-    }
-  }
-
-  fastify.setValidatorCompiler(validatorCompiler)
-
-  fastify.route({
-    path: '/foo/:an_id',
-    method: 'GET',
-    schema: {
-      params: { an_id: joi.number() }
-    },
-    handler (req, res) {
-      t.deepEqual(req.params, { an_id: 42 })
-      res.send({ hello: 'world' })
-    }
-  })
-
-  fastify.inject({
-    method: 'GET',
-    url: '/foo/42'
-  }, (err, result) => {
-    t.error(err)
-    t.strictEqual(result.statusCode, 200)
-    t.deepEqual(JSON.parse(result.payload), { hello: 'world' })
   })
 })
 

--- a/test/schema-examples.test.js
+++ b/test/schema-examples.test.js
@@ -219,26 +219,6 @@ test('Example - ajv config', t => {
   fastify.ready(err => t.error(err))
 })
 
-test('Example Joi', t => {
-  t.plan(1)
-  const fastify = Fastify()
-  const handler = () => { }
-
-  const Joi = require('@hapi/joi')
-  fastify.post('/the/url', {
-    schema: {
-      body: Joi.object().keys({
-        hello: Joi.string().required()
-      }).required()
-    },
-    validatorCompiler: ({ schema, method, url, httpPart }) => {
-      return data => schema.validate(data)
-    }
-  }, handler)
-
-  fastify.ready(err => t.error(err))
-})
-
 test('Example yup', t => {
   t.plan(1)
   const fastify = Fastify()

--- a/test/schema-serialization.test.js
+++ b/test/schema-serialization.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const t = require('tap')
-// const Joi = require('@hapi/joi')
 const Fastify = require('..')
 const test = t.test
 

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { test } = require('tap')
-const Joi = require('@hapi/joi')
 const Fastify = require('..')
 
 const schema = {
@@ -278,68 +277,5 @@ test('should return a defined output message parsing AJV errors', t => {
   }, (err, res) => {
     t.error(err)
     t.strictEqual(res.payload, '{"statusCode":400,"error":"Bad Request","message":"body should have required property \'name\', body should have required property \'work\'"}')
-  })
-})
-
-test('should return a defined output message parsing JOI errors', t => {
-  t.plan(2)
-
-  const body = Joi.object().keys({
-    name: Joi.string().required(),
-    work: Joi.string().required()
-  }).required()
-
-  const fastify = Fastify()
-
-  fastify.post('/', {
-    schema: { body },
-    validatorCompiler: ({ schema, method, url, httpPart }) => {
-      return data => schema.validate(data)
-    }
-  },
-  function (req, reply) {
-    t.fail()
-  })
-
-  fastify.inject({
-    method: 'POST',
-    payload: {},
-    url: '/'
-  }, (err, res) => {
-    t.error(err)
-    t.strictEqual(res.payload, '{"statusCode":400,"error":"Bad Request","message":"\\"name\\" is required"}')
-  })
-})
-
-test('should return a defined output message parsing JOI error details', t => {
-  t.plan(2)
-
-  const body = Joi.object().keys({
-    name: Joi.string().required(),
-    work: Joi.string().required()
-  }).required()
-
-  const fastify = Fastify()
-
-  fastify.post('/', {
-    schema: { body },
-    validatorCompiler: ({ schema, method, url, httpPart }) => {
-      return data => {
-        const validation = schema.validate(data)
-        return { error: validation.error.details }
-      }
-    }
-  },
-  function (req, reply) {
-    t.fail()
-  })
-
-  fastify.inject({
-    method: 'POST',
-    payload: {},
-    url: '/'
-  }, (err, res) => {
-    t.error(err)
-    t.strictEqual(res.payload, '{"statusCode":400,"error":"Bad Request","message":"body \\"name\\" is required"}')
   })
 })


### PR DESCRIPTION
It seems we cannot guarantee the support for Joi during the LTS cycle of
Fastify v3. As a result, it seems prudent to drop it before we make
3.0.0 official.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
