### PR TITLE
fix test per security release

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "abstract-logging": "^2.0.0",
     "ajv": "^6.12.2",
     "avvio": "^7.0.3",
-    "fast-json-stringify": "^2.0.0",
+    "fast-json-stringify": "^2.2.1",
     "fastify-error": "^0.1.0",
     "find-my-way": "^3.0.0",
     "flatstr": "^1.0.12",

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -212,7 +212,7 @@ test('should handle response validation error', t => {
     url: '/'
   }, (err, res) => {
     t.error(err)
-    t.strictEqual(res.payload, '{"statusCode":500,"error":"Internal Server Error","message":"name is required!"}')
+    t.strictEqual(res.payload, '{"statusCode":500,"error":"Internal Server Error","message":"\\"name\\" is required!"}')
   })
 })
 
@@ -242,7 +242,7 @@ test('should handle response validation error with promises', t => {
     url: '/'
   }, (err, res) => {
     t.error(err)
-    t.strictEqual(res.payload, '{"statusCode":500,"error":"Internal Server Error","message":"name is required!"}')
+    t.strictEqual(res.payload, '{"statusCode":500,"error":"Internal Server Error","message":"\\"name\\" is required!"}')
   })
 })
 


### PR DESCRIPTION
Due the security release of fast-json-stringify, the CI is always red

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
