### PR TITLE
fix(typo) Correct typo: Alternativies to Alternatives

### DIFF
--- a/docs/Middleware.md
+++ b/docs/Middleware.md
@@ -47,6 +47,6 @@ fastify.use('/css/*', serveStatic(path.join(__dirname, '/assets')))
 fastify.use(['/css', '/js'], serveStatic(path.join(__dirname, '/assets')))
 ```
 
-### Alternativies
+### Alternatives
 
 Fastify offers some alternatives to the most commonly used middlewares, such as [`fastify-helmet`](https://github.com/fastify/fastify-helmet) in case of [`helmet`](https://github.com/helmetjs/helmet), [`fastify-cors`](https://github.com/fastify/fastify-cors) for [`cors`](https://github.com/expressjs/cors) and [`fastify-static`](https://github.com/fastify/fastify-static) for [`serve-static`](https://github.com/expressjs/serve-static).


### PR DESCRIPTION
This PR fixes typo from Alternativies to Alternatives in Middleware document.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
