### PR TITLE
Fix a wrong TypeScript typing issue at register() function

### DIFF
--- a/test/types/plugin.test-d.ts
+++ b/test/types/plugin.test-d.ts
@@ -3,6 +3,7 @@ import * as http from 'http'
 import * as https from 'https'
 import { expectType, expectError, expectAssignable } from 'tsd'
 import { FastifyPluginCallback, FastifyPluginAsync } from '../../types/plugin'
+import { FastifyError } from 'fastify-error'
 
 // FastifyPlugin & FastifyRegister
 interface TestOptions extends FastifyPluginOptions {
@@ -10,8 +11,10 @@ interface TestOptions extends FastifyPluginOptions {
   option2: boolean;
 }
 const testPluginOpts: FastifyPluginCallback<TestOptions> = function (instance, opts, next) { }
-
 const testPluginOptsAsync: FastifyPluginAsync<TestOptions> = async function (instance, opts) { }
+
+const testPluginOptsWithType = (instance: FastifyInstance, opts: FastifyPluginOptions, next: (error?: FastifyError) => void) => { };
+const testPluginOptsWithTypeAsync = async (instance: FastifyInstance, opts: FastifyPluginOptions) => { };
 
 expectError(fastify().register(testPluginOpts, {})) // error because missing required options from generic declaration
 expectError(fastify().register(testPluginOptsAsync, {})) // error because missing required options from generic declaration
@@ -50,6 +53,10 @@ expectAssignable<PromiseLike<undefined>>(httpsServer.after());
 expectAssignable<PromiseLike<undefined>>(httpsServer.close());
 expectAssignable<PromiseLike<undefined>>(httpsServer.ready());
 expectAssignable<PromiseLike<undefined>>(httpsServer.register(testPluginOpts));
+expectAssignable<PromiseLike<undefined>>(httpsServer.register(testPluginOptsWithType));
+expectAssignable<PromiseLike<undefined>>(httpsServer.register(testPluginOptsWithTypeAsync));
+expectAssignable<PromiseLike<undefined>>(httpsServer.register(testPluginOptsWithType, { prefix: "/test" }));
+expectAssignable<PromiseLike<undefined>>(httpsServer.register(testPluginOptsWithTypeAsync, { prefix: "/test" }));
 
 async function testAsync() {
   await httpsServer

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -1,13 +1,13 @@
 import { FastifyInstance } from './instance'
-import { RawServerBase, RawRequestDefaultExpression, RawReplyDefaultExpression } from './utils'
+import { RawServerBase, RawRequestDefaultExpression, RawReplyDefaultExpression, RawServerDefault } from './utils'
 
 /**
  * FastifyPluginCallback
  *
  * Fastify allows the user to extend its functionalities with plugins. A plugin can be a set of routes, a server decorator or whatever. To activate plugins, use the `fastify.register()` method.
  */
-export type FastifyPluginCallback<Options extends FastifyPluginOptions = {}> = (
-  instance: FastifyInstance<RawServerBase, RawRequestDefaultExpression<RawServerBase>, RawReplyDefaultExpression<RawServerBase>>,
+export type FastifyPluginCallback<Options extends FastifyPluginOptions = {}, Server extends RawServerBase = RawServerDefault> = (
+  instance: FastifyInstance<Server, RawRequestDefaultExpression<Server>, RawReplyDefaultExpression<Server>>,
   opts: Options,
   next: (err?: Error) => void
 ) => void
@@ -17,8 +17,8 @@ export type FastifyPluginCallback<Options extends FastifyPluginOptions = {}> = (
  *
  * Fastify allows the user to extend its functionalities with plugins. A plugin can be a set of routes, a server decorator or whatever. To activate plugins, use the `fastify.register()` method.
  */
-export type FastifyPluginAsync<Options extends FastifyPluginOptions = {}> = (
-  instance: FastifyInstance<RawServerBase, RawRequestDefaultExpression<RawServerBase>, RawReplyDefaultExpression<RawServerBase>>,
+export type FastifyPluginAsync<Options extends FastifyPluginOptions = {}, Server extends RawServerBase = RawServerDefault> = (
+  instance: FastifyInstance<Server, RawRequestDefaultExpression<Server>, RawReplyDefaultExpression<Server>>,
   opts: Options
 ) => Promise<void>;
 


### PR DESCRIPTION
Hi all,

Here's a pull request for fixing this issue: https://github.com/fastify/help/issues/215

Test reports are shown below:

![image](https://user-images.githubusercontent.com/4463497/87224283-647c5700-c3c7-11ea-8353-3dd412337f92.png)

![image](https://user-images.githubusercontent.com/4463497/87224307-a907f280-c3c7-11ea-90ce-c42fdbdc41db.png)

Please point out if there are any other issues related to this PR that I need to fix, or please review and approve it. Thanks!

Regards,
Jackson Hu

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
