### PR TITLE
Added sum type for Fastify server options.

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -43,13 +43,25 @@ declare function fastify<
   Request extends RawRequestDefaultExpression<Server> = RawRequestDefaultExpression<Server>,
   Reply extends RawReplyDefaultExpression<Server> = RawReplyDefaultExpression<Server>,
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
->(opts?: FastifyServerOptions<Server, Logger>): FastifyInstance<Server, Request, Reply, Logger>
+>(opts?: FastifyHttpOptions<Server, Logger>): FastifyInstance<Server, Request, Reply, Logger>
 export default fastify
+
+/**
+ * Options for a fastify server instance. Utilizes conditional logic on the generic server parameter to enforce certain https and http2
+ */
+export type FastifyServerOptions<
+  Server extends RawServerBase,
+  Logger extends FastifyLoggerInstance
+> = Server extends http.Server ? FastifyHttpOptions<Server, Logger>
+  : Server extends https.Server ? FastifyHttpsOptions<Server, Logger>
+  : Server extends http2.Http2Server ? FastifyHttp2Options<Server, Logger>
+  : Server extends http2.Http2SecureServer ? FastifyHttp2SecureOptions<Server, Logger>
+  : never;
 
 type FastifyHttp2SecureOptions<
   Server extends http2.Http2SecureServer,
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
-> = FastifyServerOptions<Server, Logger> & {
+> = FastifyServerOptionsBase<Server, Logger> & {
   http2: true,
   https: http2.SecureServerOptions
 }
@@ -57,7 +69,7 @@ type FastifyHttp2SecureOptions<
 type FastifyHttp2Options<
   Server extends http2.Http2Server,
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
-> = FastifyServerOptions<Server, Logger> & {
+> = FastifyServerOptionsBase<Server, Logger> & {
   http2: true,
   http2SessionTimeout?: number,
 }
@@ -65,13 +77,16 @@ type FastifyHttp2Options<
 type FastifyHttpsOptions<
   Server extends https.Server,
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
-> = FastifyServerOptions<Server, Logger> & {
+> = FastifyServerOptionsBase<Server, Logger> & {
   https: https.ServerOptions
 }
-/**
- * Options for a fastify server instance. Utilizes conditional logic on the generic server parameter to enforce certain https and http2
- */
-export type FastifyServerOptions<
+
+type FastifyHttpOptions<
+  Server extends http.Server,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
+> = FastifyServerOptionsBase<Server, Logger>;
+
+type FastifyServerOptionsBase<
   RawServer extends RawServerBase = RawServerDefault,
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > = {


### PR DESCRIPTION
So far Fastify only exports `FastifyServerOptions`. Since this is the base type of options with additional HTTP2/HTTPS attributes, if I were to write a wrapper for the `fastify` constructor function, there's no way to type the options parameter correctly -- `FastifyServerOptions` doesn't allow `http2` and `https`, and `any` should be avoided. 

This PR replaces the previous `FastifyServerOptions` with a new one that's the sum type of all possible shapes the options can take. 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
