### PR TITLE
Move ip, ips and hostname to getters in request

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -150,7 +150,7 @@ function fastify (options) {
       (options.onConstructorPoisoning || defaultInitOptions.onConstructorPoisoning)
     ),
     [kReply]: Reply.buildReply(Reply),
-    [kRequest]: Request.buildRequest(Request),
+    [kRequest]: Request.buildRequest(Request, options.trustProxy),
     [kFourOhFour]: fourOhFour,
     [pluginUtils.registeredPlugins]: [],
     [kPluginNameChain]: [],

--- a/lib/request.js
+++ b/lib/request.js
@@ -111,11 +111,6 @@ Object.defineProperties(Request.prototype, {
       return this.connection.remoteAddress
     }
   },
-  ips: {
-    get () {
-      return undefined
-    }
-  },
   hostname: {
     get () {
       return this.headers.host || this.headers[':authority']

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,8 +1,9 @@
 'use strict'
 
+const proxyAddr = require('proxy-addr')
 const { emitWarning } = require('./warnings')
 
-function Request (id, params, req, query, headers, log, ip, ips, hostname) {
+function Request (id, params, req, query, headers, log) {
   this.id = id
   this.params = params
   this.raw = req
@@ -10,13 +11,38 @@ function Request (id, params, req, query, headers, log, ip, ips, hostname) {
   this.headers = headers
   this.log = log
   this.body = null
-  this.ip = ip
-  this.ips = ips
-  this.hostname = hostname
 }
 
-function buildRequest (R) {
-  function _Request (id, params, req, query, headers, log, ip, ips, hostname) {
+function getTrustProxyFn (tp) {
+  if (typeof tp === 'function') {
+    return tp
+  }
+  if (tp === true) {
+    // Support plain true/false
+    return function () { return true }
+  }
+  if (typeof tp === 'number') {
+    // Support trusting hop count
+    return function (a, i) { return i < tp }
+  }
+  if (typeof tp === 'string') {
+    // Support comma-separated tps
+    const vals = tp.split(',').map(it => it.trim())
+    return proxyAddr.compile(vals)
+  }
+  return proxyAddr.compile(tp || [])
+}
+
+function buildRequest (R, trustProxy) {
+  if (trustProxy) {
+    return buildRequestWithTrustProxy(R, trustProxy)
+  }
+
+  return buildRegularRequest(R)
+}
+
+function buildRegularRequest (R) {
+  function _Request (id, params, req, query, headers, log) {
     this.id = id
     this.params = params
     this.raw = req
@@ -24,11 +50,36 @@ function buildRequest (R) {
     this.headers = headers
     this.log = log
     this.body = null
-    this.ip = ip
-    this.ips = ips
-    this.hostname = hostname
   }
   _Request.prototype = new R()
+
+  return _Request
+}
+
+function buildRequestWithTrustProxy (R, trustProxy) {
+  const _Request = buildRegularRequest(R)
+  const proxyFn = getTrustProxyFn(trustProxy)
+
+  Object.defineProperties(_Request.prototype, {
+    ip: {
+      get () {
+        return proxyAddr(this.req, proxyFn)
+      }
+    },
+    ips: {
+      get () {
+        return proxyAddr.all(this.req, proxyFn)
+      }
+    },
+    hostname: {
+      get () {
+        if (this.ip !== undefined && this.headers['x-forwarded-host']) {
+          return this.headers['x-forwarded-host']
+        }
+        return this.headers.host || this.headers[':authority']
+      }
+    }
+  })
 
   return _Request
 }
@@ -53,6 +104,21 @@ Object.defineProperties(Request.prototype, {
   connection: {
     get () {
       return this.raw.connection
+    }
+  },
+  ip: {
+    get () {
+      return this.connection.remoteAddress
+    }
+  },
+  ips: {
+    get () {
+      return undefined
+    }
+  },
+  hostname: {
+    get () {
+      return this.headers.host || this.headers[':authority']
     }
   }
 })

--- a/lib/route.js
+++ b/lib/route.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const FindMyWay = require('find-my-way')
-const proxyAddr = require('proxy-addr')
 const Context = require('./context')
 const handleRequest = require('./handleRequest')
 const { hookRunner, hookIterator, lifecycleHooks } = require('./hooks')
@@ -48,7 +47,6 @@ function buildRouting (options) {
 
   let avvio
   let fourOhFour
-  let trustProxy
   let requestIdHeader
   let querystringParser
   let requestIdLogLabel
@@ -56,7 +54,6 @@ function buildRouting (options) {
   let hasLogger
   let setupResponseListeners
   let throwIfAlreadyStarted
-  let proxyFn
   let genReqId
   let disableRequestLogging
   let ignoreTrailingSlash
@@ -74,8 +71,6 @@ function buildRouting (options) {
       setupResponseListeners = fastifyArgs.setupResponseListeners
       throwIfAlreadyStarted = fastifyArgs.throwIfAlreadyStarted
 
-      proxyFn = getTrustProxyFn(options)
-      trustProxy = options.trustProxy
       requestIdHeader = options.requestIdHeader
       querystringParser = options.querystringParser
       requestIdLogLabel = options.requestIdLogLabel
@@ -302,17 +297,6 @@ function buildRouting (options) {
     }
 
     var id = req.headers[requestIdHeader] || genReqId(req)
-    var hostname = req.headers.host || req.headers[':authority']
-    var ip = req.connection.remoteAddress
-    var ips
-
-    if (trustProxy) {
-      ip = proxyAddr(req, proxyFn)
-      ips = proxyAddr.all(req, proxyFn)
-      if (ip !== undefined && req.headers['x-forwarded-host']) {
-        hostname = req.headers['x-forwarded-host']
-      }
-    }
 
     var loggerOpts = {
       [requestIdLogLabel]: id,
@@ -327,7 +311,7 @@ function buildRouting (options) {
 
     var queryPrefix = req.url.indexOf('?')
     var query = querystringParser(queryPrefix > -1 ? req.url.slice(queryPrefix + 1) : '')
-    var request = new context.Request(id, params, req, query, req.headers, childLogger, ip, ips, hostname)
+    var request = new context.Request(id, params, req, query, req.headers, childLogger)
     var reply = new context.Reply(res, context, request, childLogger)
 
     if (disableRequestLogging === false) {
@@ -419,27 +403,6 @@ function preParsingHookRunner (functions, request, reply, cb) {
   }
 
   next(null, request[kRequestPayloadStream])
-}
-
-function getTrustProxyFn (options) {
-  const tp = options.trustProxy
-  if (typeof tp === 'function') {
-    return tp
-  }
-  if (tp === true) {
-    // Support plain true/false
-    return function () { return true }
-  }
-  if (typeof tp === 'number') {
-    // Support trusting hop count
-    return function (a, i) { return i < tp }
-  }
-  if (typeof tp === 'string') {
-    // Support comma-separated tps
-    const vals = tp.split(',').map(it => it.trim())
-    return proxyAddr.compile(vals)
-  }
-  return proxyAddr.compile(tp || [])
 }
 
 module.exports = { buildRouting, validateBodyLimitOption }

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -23,30 +23,6 @@ function schemaValidator ({ schema, method, url, httpPart }) {
   return fn
 }
 
-test('Request object', t => {
-  t.plan(14)
-  const req = {
-    method: 'GET',
-    url: '/',
-    connection: { foo: 'bar' }
-  }
-  const request = new Request('id', 'params', req, 'query', 'headers', 'log', 'ip', 'ips', 'hostname')
-  t.type(request, Request)
-  t.strictEqual(request.id, 'id')
-  t.strictEqual(request.params, 'params')
-  t.deepEqual(request.raw, req)
-  t.strictEqual(request.query, 'query')
-  t.strictEqual(request.headers, 'headers')
-  t.strictEqual(request.log, 'log')
-  t.strictEqual(request.ip, 'ip')
-  t.strictEqual(request.ips, 'ips')
-  t.strictEqual(request.hostname, 'hostname')
-  t.strictEqual(request.body, null)
-  t.strictEqual(request.method, 'GET')
-  t.strictEqual(request.url, '/')
-  t.deepEqual(request.connection, req.connection)
-})
-
 test('handleRequest function - sent reply', t => {
   t.plan(1)
   const request = {}

--- a/test/internals/request.test.js
+++ b/test/internals/request.test.js
@@ -1,0 +1,133 @@
+'use strict'
+
+const { test } = require('tap')
+
+const Request = require('../../lib/request')
+
+test('Regular request', t => {
+  t.plan(14)
+  const req = {
+    method: 'GET',
+    url: '/',
+    connection: { remoteAddress: 'ip' }
+  }
+  const headers = {
+    host: 'hostname'
+  }
+  const request = new Request('id', 'params', req, 'query', headers, 'log')
+  t.type(request, Request)
+  t.strictEqual(request.id, 'id')
+  t.strictEqual(request.params, 'params')
+  t.deepEqual(request.raw, req)
+  t.strictEqual(request.query, 'query')
+  t.strictEqual(request.headers, headers)
+  t.strictEqual(request.log, 'log')
+  t.strictEqual(request.ip, 'ip')
+  t.strictEqual(request.ips, undefined)
+  t.strictEqual(request.hostname, 'hostname')
+  t.strictEqual(request.body, null)
+  t.strictEqual(request.method, 'GET')
+  t.strictEqual(request.url, '/')
+  t.deepEqual(request.connection, req.connection)
+})
+
+test('Regular request - hostname from authority', t => {
+  t.plan(2)
+  const req = {
+    method: 'GET',
+    url: '/',
+    connection: { remoteAddress: 'ip' }
+  }
+  const headers = {
+    ':authority': 'authority'
+  }
+  const request = new Request('id', 'params', req, 'query', headers, 'log')
+  t.type(request, Request)
+  t.strictEqual(request.hostname, 'authority')
+})
+
+test('Regular request - host header has precedence over authority', t => {
+  t.plan(2)
+  const req = {
+    method: 'GET',
+    url: '/',
+    connection: { remoteAddress: 'ip' }
+  }
+  const headers = {
+    host: 'hostname',
+    ':authority': 'authority'
+  }
+  const request = new Request('id', 'params', req, 'query', headers, 'log')
+  t.type(request, Request)
+  t.strictEqual(request.hostname, 'hostname')
+})
+
+test('Request with trust proxy', t => {
+  t.plan(14)
+  const headers = {
+    'x-forwarded-for': '2.2.2.2, 1.1.1.1',
+    'x-forwarded-host': 'example.com'
+  }
+  const req = {
+    method: 'GET',
+    url: '/',
+    connection: { remoteAddress: 'ip' },
+    headers
+  }
+
+  const TpRequest = Request.buildRequest(Request, true)
+  const request = new TpRequest('id', 'params', req, 'query', headers, 'log')
+  t.type(request, TpRequest)
+  t.strictEqual(request.id, 'id')
+  t.strictEqual(request.params, 'params')
+  t.deepEqual(request.raw, req)
+  t.strictEqual(request.query, 'query')
+  t.strictEqual(request.headers, headers)
+  t.strictEqual(request.log, 'log')
+  t.strictEqual(request.ip, '2.2.2.2')
+  t.deepEqual(request.ips, ['ip', '1.1.1.1', '2.2.2.2'])
+  t.strictEqual(request.hostname, 'example.com')
+  t.strictEqual(request.body, null)
+  t.strictEqual(request.method, 'GET')
+  t.strictEqual(request.url, '/')
+  t.deepEqual(request.connection, req.connection)
+})
+
+test('Request with trust proxy - no x-forwarded-host header', t => {
+  t.plan(2)
+  const headers = {
+    'x-forwarded-for': '2.2.2.2, 1.1.1.1',
+    host: 'hostname'
+  }
+  const req = {
+    method: 'GET',
+    url: '/',
+    connection: { remoteAddress: 'ip' },
+    headers
+  }
+
+  const TpRequest = Request.buildRequest(Request, true)
+  const request = new TpRequest('id', 'params', req, 'query', headers, 'log')
+  t.type(request, TpRequest)
+  t.strictEqual(request.hostname, 'hostname')
+})
+
+test('Request with trust proxy - x-forwarded-host header has precedence over host', t => {
+  t.plan(2)
+  const headers = {
+    'x-forwarded-for': ' 2.2.2.2, 1.1.1.1',
+    'x-forwarded-host': 'example.com',
+    host: 'hostname'
+  }
+  const req = {
+    method: 'GET',
+    url: '/',
+    connection: { remoteAddress: 'ip' },
+    headers
+  }
+
+  const TpRequest = Request.buildRequest(Request, true)
+  const request = new TpRequest('id', 'params', req, 'query', headers, 'log')
+  t.type(request, TpRequest)
+  t.strictEqual(request.hostname, 'example.com')
+})


### PR DESCRIPTION
In this PR I'm moving `ip`, `ips` and `hostname` to be getters instead of fields on the request as suggested my @mcollina in https://github.com/fastify/fastify/issues/2416

As part of that I extracted the tests on the request object from `handleRequest.test.js`, moved them to their own file and expanded them.

I've run the benchmarks and I can't see any significant change.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
