### PR TITLE
Added validationError property to request

### DIFF
--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -51,7 +51,7 @@ const getHandler: RouteHandler = function (request, _reply) {
   expectType<any>(request.id)
   expectType<FastifyLoggerInstance>(request.log)
   expectType<RawRequestDefaultExpression['socket']>(request.connection)
-  expectType<Error & { validation: any; validationContext: string }>(request.validationError)
+  expectType<Error & { validation: any; validationContext: string } | undefined>(request.validationError)
 }
 
 const postHandler: Handler = function (request) {

--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -51,6 +51,7 @@ const getHandler: RouteHandler = function (request, _reply) {
   expectType<any>(request.id)
   expectType<FastifyLoggerInstance>(request.log)
   expectType<RawRequestDefaultExpression['socket']>(request.connection)
+  expectType<Error & { validation: any; validationContext: string }>(request.validationError)
 }
 
 const postHandler: Handler = function (request) {

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -30,6 +30,7 @@ export interface FastifyRequest<
   hostname: string;
   url: string;
   method: string;
+  validationError: Record<string, object>; // in order for this to be used the user should ensure they have set the attachValidation option.
 
   // `connection` is a deprecated alias for `socket` and doesn't exist in `Http2ServerRequest`
   connection: RawRequest['socket'];

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -31,7 +31,7 @@ export interface FastifyRequest<
   url: string;
   method: string;
   /** in order for this to be used the user should ensure they have set the attachValidation option. */
-  validationError?: Error & { validation: any; validationContext: string };
+  validationError?: undefined | Error & { validation: any; validationContext: string };
 
   // `connection` is a deprecated alias for `socket` and doesn't exist in `Http2ServerRequest`
   connection: RawRequest['socket'];

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -31,7 +31,7 @@ export interface FastifyRequest<
   url: string;
   method: string;
   /** in order for this to be used the user should ensure they have set the attachValidation option. */
-  validationError: undefined | Error & { validation: any; validationContext: string };
+  validationError?: Error & { validation: any; validationContext: string };
 
   // `connection` is a deprecated alias for `socket` and doesn't exist in `Http2ServerRequest`
   connection: RawRequest['socket'];

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -31,7 +31,7 @@ export interface FastifyRequest<
   url: string;
   method: string;
   /** in order for this to be used the user should ensure they have set the attachValidation option. */
-  validationError?: undefined | Error & { validation: any; validationContext: string };
+  validationError?: Error & { validation: any; validationContext: string };
 
   // `connection` is a deprecated alias for `socket` and doesn't exist in `Http2ServerRequest`
   connection: RawRequest['socket'];

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -30,7 +30,8 @@ export interface FastifyRequest<
   hostname: string;
   url: string;
   method: string;
-  validationError: Record<string, object>; // in order for this to be used the user should ensure they have set the attachValidation option.
+  /** in order for this to be used the user should ensure they have set the attachValidation option. */
+  validationError: undefined | Error & { validation: any; validationContext: string };
 
   // `connection` is a deprecated alias for `socket` and doesn't exist in `Http2ServerRequest`
   connection: RawRequest['socket'];


### PR DESCRIPTION
closes #2409 

There isn't any specific `validationError` object to create an interface from (or I missed it, and I'd be happy if you show me). Therefore I made it a generic record that contains the errors from `validation.js`.

The documentation also specifies the object as `validationErrors`, but I couldn't find a use for this property in the code (Is the scope of this PR to change the docs and the implementation?) .

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
