### PR TITLE
Move headers to be a getter on Request

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -482,7 +482,7 @@ function fastify (options) {
 
       childLogger.info({ req }, 'incoming request')
 
-      const request = new Request(id, req, null, req.headers, childLogger)
+      const request = new Request(id, req, null, childLogger)
       const reply = new Reply(res, { onSend: [], onError: [] }, request, childLogger)
       return frameworkErrors(new FST_ERR_BAD_URL(path), request, reply)
     }

--- a/lib/fourOhFour.js
+++ b/lib/fourOhFour.js
@@ -154,7 +154,7 @@ function fourOhFour (options) {
 
     childLogger.info({ req }, 'incoming request')
 
-    var request = new Request(id, null, req, null, req.headers, childLogger)
+    var request = new Request(id, null, req, null, childLogger)
     var reply = new Reply(res, { onSend: [], onError: [] }, request, childLogger)
 
     request.log.warn('the default handler for 404 did not catch this, this is likely a fastify bug, please report it')

--- a/lib/request.js
+++ b/lib/request.js
@@ -3,12 +3,11 @@
 const proxyAddr = require('proxy-addr')
 const { emitWarning } = require('./warnings')
 
-function Request (id, params, req, query, headers, log) {
+function Request (id, params, req, query, log) {
   this.id = id
   this.params = params
   this.raw = req
   this.query = query
-  this.headers = headers
   this.log = log
   this.body = null
 }
@@ -42,12 +41,11 @@ function buildRequest (R, trustProxy) {
 }
 
 function buildRegularRequest (R) {
-  function _Request (id, params, req, query, headers, log) {
+  function _Request (id, params, req, query, log) {
     this.id = id
     this.params = params
     this.raw = req
     this.query = query
-    this.headers = headers
     this.log = log
     this.body = null
   }
@@ -114,6 +112,11 @@ Object.defineProperties(Request.prototype, {
   hostname: {
     get () {
       return this.headers.host || this.headers[':authority']
+    }
+  },
+  headers: {
+    get () {
+      return this.raw.headers
     }
   }
 })

--- a/lib/request.js
+++ b/lib/request.js
@@ -111,7 +111,7 @@ Object.defineProperties(Request.prototype, {
   },
   hostname: {
     get () {
-      return this.headers.host || this.headers[':authority']
+      return this.raw.headers.host || this.raw.headers[':authority']
     }
   },
   headers: {

--- a/lib/route.js
+++ b/lib/route.js
@@ -311,7 +311,7 @@ function buildRouting (options) {
 
     var queryPrefix = req.url.indexOf('?')
     var query = querystringParser(queryPrefix > -1 ? req.url.slice(queryPrefix + 1) : '')
-    var request = new context.Request(id, params, req, query, req.headers, childLogger)
+    var request = new context.Request(id, params, req, query, childLogger)
     var reply = new context.Reply(res, context, request, childLogger)
 
     if (disableRequestLogging === false) {

--- a/test/internals/contentTypeParser.test.js
+++ b/test/internals/contentTypeParser.test.js
@@ -41,7 +41,7 @@ test('rawBody function', t => {
   const rs = new Readable()
   rs._read = function () {}
   rs.headers = { 'content-length': body.length }
-  const request = new Request('id', 'params', rs, 'query', { 'content-length': body.length }, 'log')
+  const request = new Request('id', 'params', rs, 'query', 'log')
   const reply = new Reply(res, context, {})
   const done = () => {}
 

--- a/test/internals/request.test.js
+++ b/test/internals/request.test.js
@@ -6,15 +6,16 @@ const Request = require('../../lib/request')
 
 test('Regular request', t => {
   t.plan(14)
-  const req = {
-    method: 'GET',
-    url: '/',
-    connection: { remoteAddress: 'ip' }
-  }
   const headers = {
     host: 'hostname'
   }
-  const request = new Request('id', 'params', req, 'query', headers, 'log')
+  const req = {
+    method: 'GET',
+    url: '/',
+    connection: { remoteAddress: 'ip' },
+    headers
+  }
+  const request = new Request('id', 'params', req, 'query', 'log')
   t.type(request, Request)
   t.strictEqual(request.id, 'id')
   t.strictEqual(request.params, 'params')
@@ -33,31 +34,34 @@ test('Regular request', t => {
 
 test('Regular request - hostname from authority', t => {
   t.plan(2)
-  const req = {
-    method: 'GET',
-    url: '/',
-    connection: { remoteAddress: 'ip' }
-  }
   const headers = {
     ':authority': 'authority'
   }
-  const request = new Request('id', 'params', req, 'query', headers, 'log')
+  const req = {
+    method: 'GET',
+    url: '/',
+    connection: { remoteAddress: 'ip' },
+    headers
+  }
+
+  const request = new Request('id', 'params', req, 'query', 'log')
   t.type(request, Request)
   t.strictEqual(request.hostname, 'authority')
 })
 
 test('Regular request - host header has precedence over authority', t => {
   t.plan(2)
-  const req = {
-    method: 'GET',
-    url: '/',
-    connection: { remoteAddress: 'ip' }
-  }
   const headers = {
     host: 'hostname',
     ':authority': 'authority'
   }
-  const request = new Request('id', 'params', req, 'query', headers, 'log')
+  const req = {
+    method: 'GET',
+    url: '/',
+    connection: { remoteAddress: 'ip' },
+    headers
+  }
+  const request = new Request('id', 'params', req, 'query', 'log')
   t.type(request, Request)
   t.strictEqual(request.hostname, 'hostname')
 })
@@ -76,7 +80,7 @@ test('Request with trust proxy', t => {
   }
 
   const TpRequest = Request.buildRequest(Request, true)
-  const request = new TpRequest('id', 'params', req, 'query', headers, 'log')
+  const request = new TpRequest('id', 'params', req, 'query', 'log')
   t.type(request, TpRequest)
   t.strictEqual(request.id, 'id')
   t.strictEqual(request.params, 'params')
@@ -107,7 +111,7 @@ test('Request with trust proxy - no x-forwarded-host header', t => {
   }
 
   const TpRequest = Request.buildRequest(Request, true)
-  const request = new TpRequest('id', 'params', req, 'query', headers, 'log')
+  const request = new TpRequest('id', 'params', req, 'query', 'log')
   t.type(request, TpRequest)
   t.strictEqual(request.hostname, 'hostname')
 })
@@ -127,7 +131,7 @@ test('Request with trust proxy - x-forwarded-host header has precedence over hos
   }
 
   const TpRequest = Request.buildRequest(Request, true)
-  const request = new TpRequest('id', 'params', req, 'query', headers, 'log')
+  const request = new TpRequest('id', 'params', req, 'query', 'log')
   t.type(request, TpRequest)
   t.strictEqual(request.hostname, 'example.com')
 })


### PR DESCRIPTION
This is a follow up to https://github.com/fastify/fastify/pull/2418 where I also move headers to be a getter on Request.

As for that PR I'm not seeing consistently better performance on my machine, but I guess it's worth investigating on the dedicated one.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
