### PR TITLE
typings: add getSchema and getSchemas

### DIFF
--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -13,6 +13,9 @@ expectAssignable<FastifyInstance>(server.addSchema({
     schemas: []
 }))
 
+expectType<Record<string, unknown>>(server.getSchemas())
+expectType<unknown>(server.getSchema('SchemaId'))
+
 expectType<unknown>(server.use(() => {}))
 expectType<unknown>(server.use('/foo', () => {}))
 

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -24,6 +24,8 @@ export interface FastifyInstance<
   log: Logger;
 
   addSchema(schema: unknown): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+  getSchema(schemaId: string): unknown;
+  getSchemas(): Record<string, unknown>;
 
   after(): FastifyInstance<RawServer, RawRequest, RawReply, Logger> & PromiseLike<undefined>;
   after(afterListener: (err: Error) => void): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;


### PR DESCRIPTION
this typings present in Fastify v2 and disappeared in Fastify v3

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
