### PR TITLE
fix hasContentTypeParser to include native types

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -25,11 +25,19 @@ const {
 const warning = require('./warnings')
 
 function ContentTypeParser (bodyLimit, onProtoPoisoning, onConstructorPoisoning) {
-  this[kDefaultJsonParse] = getDefaultJsonParser(onProtoPoisoning, onConstructorPoisoning)
+  this.nativeParsers = {
+    'application/json': getDefaultJsonParser(onProtoPoisoning, onConstructorPoisoning),
+    'text/plain': defaultPlainTextParser
+  }
+
+  this.parserList = []
   this.customParsers = {}
-  this.customParsers['application/json'] = new Parser(true, false, bodyLimit, this[kDefaultJsonParse])
-  this.customParsers['text/plain'] = new Parser(true, false, bodyLimit, defaultPlainTextParser)
-  this.parserList = ['application/json', 'text/plain']
+  for (const contentType in this.nativeParsers) {
+    this.customParsers[contentType] = new Parser(true, false, bodyLimit, this.nativeParsers[contentType])
+    this.parserList.push(contentType)
+  }
+
+  this[kDefaultJsonParse] = this.nativeParsers['application/json']
   this.cache = lru(100)
 }
 
@@ -38,7 +46,7 @@ ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
   if (contentType.length === 0) throw new FST_ERR_CTP_EMPTY_TYPE()
   if (typeof parserFn !== 'function') throw new FST_ERR_CTP_INVALID_HANDLER()
 
-  if (this.hasParser(contentType)) {
+  if (this.existingParser(contentType)) {
     throw new FST_ERR_CTP_ALREADY_PRESENT(contentType)
   }
 
@@ -67,11 +75,13 @@ ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
 }
 
 ContentTypeParser.prototype.hasParser = function (contentType) {
-  if (contentType === 'application/json') {
-    return this.customParsers['application/json'].fn !== this[kDefaultJsonParse]
-  }
-  if (contentType === 'text/plain') {
-    return this.customParsers['text/plain'].fn !== defaultPlainTextParser
+  return contentType in this.customParsers
+}
+
+ContentTypeParser.prototype.existingParser = function (contentType) {
+  this.nativeParsers['application/json'] = this[kDefaultJsonParse]
+  if (contentType in this.nativeParsers) {
+    return this.customParsers[contentType].fn !== this.nativeParsers[contentType]
   }
   return contentType in this.customParsers
 }

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "avvio": "^7.1.2",
     "fast-json-stringify": "^2.2.1",
     "fastify-error": "^0.2.0",
-    "fastify-warning": "^0.1.0",
+    "fastify-warning": "^0.2.0",
     "find-my-way": "^3.0.0",
     "flatstr": "^1.0.12",
     "light-my-request": "^4.0.0",

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('..')
+
+test('hasContentTypeParser should know about internal parsers', t => {
+  t.plan(4)
+  const fastify = Fastify()
+  fastify.ready(err => {
+    t.error(err)
+    t.ok(fastify.hasContentTypeParser('application/json'))
+    t.ok(fastify.hasContentTypeParser('text/plain'))
+    t.notOk(fastify.hasContentTypeParser('application/jsoff'))
+  })
+})


### PR DESCRIPTION
Hi,

this pull request lets `hasContentTypeParser` return true for native types  ('application/json' and 'text/plain') as discussed in https://github.com/fastify/fastify/issues/2448 .

+ Behavior now matches [Documentation](https://www.fastify.io/docs/latest/ContentTypeParser/#usage)
+ Unit test to confirm new behavior included.
+ Changes are not in the hot path.

Kind regards,
Hans


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
