### PR TITLE
add routePath in onRoute hook

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -339,7 +339,9 @@ fastify.addHook('onRoute', (routeOptions) => {
   //Some code
   routeOptions.method
   routeOptions.schema
-  routeOptions.url
+  routeOptions.url // the complete URL of the route, it will inclued the prefix if any
+  routeOptions.path // `url` alias 
+  routeOptions.routePath // the URL of the route without the prefix
   routeOptions.bodyLimit
   routeOptions.logLevel
   routeOptions.logSerializers

--- a/lib/route.js
+++ b/lib/route.js
@@ -176,6 +176,7 @@ function buildRouting (options) {
 
       opts.url = url
       opts.path = url
+      opts.routePath = path
       opts.prefix = prefix
       opts.logLevel = opts.logLevel || this[kLogLevel]
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -175,7 +175,7 @@ function buildRouting (options) {
       const url = prefix + path
 
       opts.url = url
-      opts.path = url
+      opts.path = path
       opts.prefix = prefix
       opts.logLevel = opts.logLevel || this[kLogLevel]
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -175,7 +175,7 @@ function buildRouting (options) {
       const url = prefix + path
 
       opts.url = url
-      opts.path = path
+      opts.path = url
       opts.prefix = prefix
       opts.logLevel = opts.logLevel || this[kLogLevel]
 

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -730,10 +730,10 @@ test('onRoute hook with many prefix', t => {
     instance.addHook('onRoute', (route) => {
       t.like(route, onRouteChecks.pop())
     })
-    instance.get('/aPath', handler)
+    instance.route({ method: 'GET', url: '/aPath', handler })
 
     instance.register((instance, opts, next) => {
-      instance.get('/anotherPath', handler)
+      instance.route({ method: 'GET', path: '/anotherPath', handler })
       next()
     }, { prefix: '/two' })
     next()

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -549,7 +549,7 @@ test('onRoute hook should pass correct route with custom prefix', t => {
   fastify.addHook('onRoute', function (route) {
     t.strictEqual(route.method, 'GET')
     t.strictEqual(route.url, '/v1/foo')
-    t.strictEqual(route.path, '/foo')
+    t.strictEqual(route.path, '/v1/foo')
     t.strictEqual(route.prefix, '/v1')
   })
 
@@ -557,7 +557,7 @@ test('onRoute hook should pass correct route with custom prefix', t => {
     instance.addHook('onRoute', function (route) {
       t.strictEqual(route.method, 'GET')
       t.strictEqual(route.url, '/v1/foo')
-      t.strictEqual(route.path, '/foo')
+      t.strictEqual(route.path, '/v1/foo')
       t.strictEqual(route.prefix, '/v1')
     })
     instance.get('/foo', opts, function (req, reply) {
@@ -572,13 +572,12 @@ test('onRoute hook should pass correct route with custom prefix', t => {
 })
 
 test('onRoute hook should pass correct route with custom options', t => {
-  t.plan(7)
+  t.plan(6)
   const fastify = Fastify()
   fastify.register((instance, opts, done) => {
     instance.addHook('onRoute', function (route) {
       t.strictEqual(route.method, 'GET')
       t.strictEqual(route.url, '/foo')
-      t.strictEqual(route.path, '/foo')
       t.strictEqual(route.logLevel, 'info')
       t.strictEqual(route.bodyLimit, 100)
       t.type(route.logSerializers.test, 'function')
@@ -601,13 +600,12 @@ test('onRoute hook should pass correct route with custom options', t => {
 })
 
 test('onRoute hook should receive any route option', t => {
-  t.plan(5)
+  t.plan(4)
   const fastify = Fastify()
   fastify.register((instance, opts, done) => {
     instance.addHook('onRoute', function (route) {
       t.strictEqual(route.method, 'GET')
       t.strictEqual(route.url, '/foo')
-      t.strictEqual(route.path, '/foo')
       t.strictEqual(route.auth, 'basic')
     })
     instance.get('/foo', { auth: 'basic' }, function (req, reply) {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -549,7 +549,7 @@ test('onRoute hook should pass correct route with custom prefix', t => {
   fastify.addHook('onRoute', function (route) {
     t.strictEqual(route.method, 'GET')
     t.strictEqual(route.url, '/v1/foo')
-    t.strictEqual(route.path, '/v1/foo')
+    t.strictEqual(route.path, '/foo')
     t.strictEqual(route.prefix, '/v1')
   })
 
@@ -557,7 +557,7 @@ test('onRoute hook should pass correct route with custom prefix', t => {
     instance.addHook('onRoute', function (route) {
       t.strictEqual(route.method, 'GET')
       t.strictEqual(route.url, '/v1/foo')
-      t.strictEqual(route.path, '/v1/foo')
+      t.strictEqual(route.path, '/foo')
       t.strictEqual(route.prefix, '/v1')
     })
     instance.get('/foo', opts, function (req, reply) {
@@ -572,12 +572,13 @@ test('onRoute hook should pass correct route with custom prefix', t => {
 })
 
 test('onRoute hook should pass correct route with custom options', t => {
-  t.plan(6)
+  t.plan(7)
   const fastify = Fastify()
   fastify.register((instance, opts, done) => {
     instance.addHook('onRoute', function (route) {
       t.strictEqual(route.method, 'GET')
       t.strictEqual(route.url, '/foo')
+      t.strictEqual(route.path, '/foo')
       t.strictEqual(route.logLevel, 'info')
       t.strictEqual(route.bodyLimit, 100)
       t.type(route.logSerializers.test, 'function')
@@ -600,12 +601,13 @@ test('onRoute hook should pass correct route with custom options', t => {
 })
 
 test('onRoute hook should receive any route option', t => {
-  t.plan(4)
+  t.plan(5)
   const fastify = Fastify()
   fastify.register((instance, opts, done) => {
     instance.addHook('onRoute', function (route) {
       t.strictEqual(route.method, 'GET')
       t.strictEqual(route.url, '/foo')
+      t.strictEqual(route.path, '/foo')
       t.strictEqual(route.auth, 'basic')
     })
     instance.get('/foo', { auth: 'basic' }, function (req, reply) {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -518,12 +518,13 @@ test('onRoute should keep the context', t => {
 })
 
 test('onRoute hook should pass correct route', t => {
-  t.plan(7)
+  t.plan(9)
   const fastify = Fastify()
   fastify.addHook('onRoute', (route) => {
     t.strictEqual(route.method, 'GET')
     t.strictEqual(route.url, '/')
     t.strictEqual(route.path, '/')
+    t.strictEqual(route.routePath, '/')
   })
 
   fastify.register((instance, opts, done) => {
@@ -531,6 +532,7 @@ test('onRoute hook should pass correct route', t => {
       t.strictEqual(route.method, 'GET')
       t.strictEqual(route.url, '/')
       t.strictEqual(route.path, '/')
+      t.strictEqual(route.routePath, '/')
     })
     instance.get('/', opts, function (req, reply) {
       reply.send()
@@ -544,12 +546,13 @@ test('onRoute hook should pass correct route', t => {
 })
 
 test('onRoute hook should pass correct route with custom prefix', t => {
-  t.plan(9)
+  t.plan(11)
   const fastify = Fastify()
   fastify.addHook('onRoute', function (route) {
     t.strictEqual(route.method, 'GET')
     t.strictEqual(route.url, '/v1/foo')
     t.strictEqual(route.path, '/v1/foo')
+    t.strictEqual(route.routePath, '/foo')
     t.strictEqual(route.prefix, '/v1')
   })
 
@@ -558,6 +561,7 @@ test('onRoute hook should pass correct route with custom prefix', t => {
       t.strictEqual(route.method, 'GET')
       t.strictEqual(route.url, '/v1/foo')
       t.strictEqual(route.path, '/v1/foo')
+      t.strictEqual(route.routePath, '/foo')
       t.strictEqual(route.prefix, '/v1')
     })
     instance.get('/foo', opts, function (req, reply) {
@@ -600,12 +604,13 @@ test('onRoute hook should pass correct route with custom options', t => {
 })
 
 test('onRoute hook should receive any route option', t => {
-  t.plan(4)
+  t.plan(5)
   const fastify = Fastify()
   fastify.register((instance, opts, done) => {
     instance.addHook('onRoute', function (route) {
       t.strictEqual(route.method, 'GET')
       t.strictEqual(route.url, '/foo')
+      t.strictEqual(route.routePath, '/foo')
       t.strictEqual(route.auth, 'basic')
     })
     instance.get('/foo', { auth: 'basic' }, function (req, reply) {
@@ -620,12 +625,13 @@ test('onRoute hook should receive any route option', t => {
 })
 
 test('onRoute hook should preserve system route configuration', t => {
-  t.plan(4)
+  t.plan(5)
   const fastify = Fastify()
   fastify.register((instance, opts, done) => {
     instance.addHook('onRoute', function (route) {
       t.strictEqual(route.method, 'GET')
       t.strictEqual(route.url, '/foo')
+      t.strictEqual(route.routePath, '/foo')
       t.strictEqual(route.handler.length, 2)
     })
     instance.get('/foo', { url: '/bar', method: 'POST' }, function (req, reply) {
@@ -708,6 +714,32 @@ test('onRoute hook that throws should be caught ', t => {
   fastify.ready(err => {
     t.ok(err)
   })
+})
+
+test('onRoute hook with many prefix', t => {
+  t.plan(3)
+  const fastify = Fastify()
+  const handler = (req, reply) => { reply.send({}) }
+
+  const onRouteChecks = [
+    { routePath: '/anotherPath', prefix: '/two', url: '/one/two/anotherPath' },
+    { routePath: '/aPath', prefix: '/one', url: '/one/aPath' }
+  ]
+
+  fastify.register((instance, opts, next) => {
+    instance.addHook('onRoute', (route) => {
+      t.like(route, onRouteChecks.pop())
+    })
+    instance.get('/aPath', handler)
+
+    instance.register((instance, opts, next) => {
+      instance.get('/anotherPath', handler)
+      next()
+    }, { prefix: '/two' })
+    next()
+  }, { prefix: '/one' })
+
+  fastify.ready(err => { t.error(err) })
 })
 
 test('onResponse hook should log request error', t => {

--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -83,7 +83,7 @@ server.addHook('onError', (request, reply, error, done) => {
 })
 
 server.addHook('onRoute', (opts) => {
-  expectType<RouteOptions & { path: string, prefix: string}>(opts)
+  expectType<RouteOptions & { routePath: string, path: string, prefix: string}>(opts)
 })
 
 server.addHook('onRegister', (instance, done) => {

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -187,7 +187,7 @@ export interface onRouteHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
-    opts: RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> & { path: string; prefix: string }
+    opts: RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> & { routePath: string, path: string; prefix: string }
   ): Promise<unknown> | void;
 }
 


### PR DESCRIPTION
In the onRoute hook, the argument has two key with the same value.
I think this was not the intended behaviour

cc @delvedor 

Ref https://github.com/Eomm/fastify-405/pull/25


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
