### PR TITLE
Added support for TRACE and CONNECT

### DIFF
--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -28,7 +28,7 @@ fastify.route(options)
 <a name="options"></a>
 ### Routes option
 
-* `method`: currently it supports `'DELETE'`, `'GET'`, `'HEAD'`, `'PATCH'`, `'POST'`, `'PUT'` and `'OPTIONS'`. It could also be an array of methods.
+* `method`: currently it supports `'DELETE'`, `'GET'`, `'HEAD'`, `'PATCH'`, `'POST'`, `'PUT'`, `'OPTIONS'`, `'TRACE'` AND `'CONNECT'`. It could also be an array of methods.
 * `url`: the path of the url to match this route (alias: `path`).
 * `schema`: an object containing the schemas for the request and response.
 They need to be in
@@ -103,7 +103,9 @@ The above route declaration is more *Hapi*-like, but if you prefer an *Express/R
 `fastify.put(path, [options], handler)`<br>
 `fastify.delete(path, [options], handler)`<br>
 `fastify.options(path, [options], handler)`<br>
-`fastify.patch(path, [options], handler)`
+`fastify.patch(path, [options], handler)`<br>
+`fastify.trace(path, [options], handler)`<br>
+`fastify.connect(path, [options], handler)`
 
 Example:
 ```js

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -587,7 +587,7 @@ server.get('/', async (request, reply) => {
 ##### fastify.HTTPMethods 
 [src](./../types/utils.d.ts#L8)
 
-Union type of: `'DELETE' | 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'OPTIONS'`
+Union type of: `'DELETE' | 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'OPTIONS' | 'TRACE' | 'CONNECT'`
 
 ##### fastify.RawServerBase 
 [src](./../types/utils.d.ts#L13)

--- a/fastify.js
+++ b/fastify.js
@@ -179,6 +179,12 @@ function fastify (options) {
     options: function _options (url, opts, handler) {
       return router.prepareRoute.call(this, 'OPTIONS', url, opts, handler)
     },
+    trace: function _trace (url, opts, handler) {
+      return router.prepareRoute.call(this, 'TRACE', url, opts, handler)
+    },
+    connect: function _connect (url, opts, handler) {
+      return router.prepareRoute.call(this, 'CONNECT', url, opts, handler)
+    },
     all: function _all (url, opts, handler) {
       return router.prepareRoute.call(this, supportedMethods, url, opts, handler)
     },

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -21,7 +21,7 @@ function handleRequest (err, request, reply) {
 
   var contentType = headers['content-type']
 
-  if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
+  if (method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'TRACE') {
     if (contentType === undefined) {
       if (
         headers['transfer-encoding'] === undefined &&

--- a/lib/route.js
+++ b/lib/route.js
@@ -4,7 +4,7 @@ const FindMyWay = require('find-my-way')
 const Context = require('./context')
 const handleRequest = require('./handleRequest')
 const { hookRunner, hookIterator, lifecycleHooks } = require('./hooks')
-const supportedMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']
+const supportedMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS', 'TRACE', 'CONNECT']
 const validation = require('./validation')
 const { normalizeSchema } = require('./schemas')
 const {

--- a/test/internals/all.test.js
+++ b/test/internals/all.test.js
@@ -3,7 +3,7 @@
 const t = require('tap')
 const test = t.test
 const Fastify = require('../..')
-const supportedMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']
+const supportedMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS', 'TRACE', 'CONNECT']
 
 test('fastify.all should add all the methods to the same url', t => {
   t.plan(supportedMethods.length * 2)
@@ -22,7 +22,7 @@ test('fastify.all should add all the methods to the same url', t => {
       method: method
     }
 
-    if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
+    if (method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'TRACE') {
       options.payload = { hello: 'world' }
     }
 

--- a/test/trace.test.js
+++ b/test/trace.test.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const t = require('tap')
+require('./helper').payloadMethod('trace', t)
+require('./input-validation').payloadMethod('trace', t)

--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -20,9 +20,9 @@ const routeHandler: RouteHandlerMethod = function (request, reply) {
   expectType<FastifyReply>(reply)
 }
 
-type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete' | 'options'
+type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete' | 'options' | 'trace' | 'connect'
 
-;['GET', 'POST', 'PUT', 'PATCH', 'HEAD', 'DELETE', 'OPTIONS'].forEach(method => {
+;['GET', 'POST', 'PUT', 'PATCH', 'HEAD', 'DELETE', 'OPTIONS', 'TRACE', 'CONNECT'].forEach(method => {
   // route method
   expectType<FastifyInstance>(fastify().route({
     method: method as HTTPMethods,
@@ -36,7 +36,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
   expectType<FastifyInstance>(fastify()[lowerCaseMethod]('/', routeHandler))
   expectType<FastifyInstance>(fastify()[lowerCaseMethod]('/', {}, routeHandler))
   expectType<FastifyInstance>(fastify()[lowerCaseMethod]('/', { handler: routeHandler }))
-  
+
   expectType<FastifyInstance>(fastify()[lowerCaseMethod]('/', { handler: routeHandler, errorHandler: (error, request, reply) => reply.send('error') }))
 
   interface BodyInterface { prop: string }

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -5,7 +5,7 @@ import * as https from 'https'
 /**
  * Standard HTTP method strings
  */
-export type HTTPMethods = 'DELETE' | 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'OPTIONS'
+export type HTTPMethods = 'DELETE' | 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'OPTIONS' | 'TRACE' | 'CONNECT'
 
 /**
  * A union type of the Node.js server types from the http, https, and http2 modules.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->
This PR will add support for `TRACE` and `CONNECT`. Currently, only `TRACE` is supported, as the node.js http module provides a special event for incoming `CONNECT` requests and I'm still examining the best way to transform this into something fitting well into fastify.  
Additionally, a `TRACE` test fails currently due to something that appears to be a bug.

#### Checklist
- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
