### PR TITLE
add missing kSchemaVisited symbol var

### DIFF
--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -31,6 +31,7 @@ const keys = {
   kReplyStartTime: Symbol('fastify.reply.startTime'),
   kReplyErrorHandlerCalled: Symbol('fastify.reply.errorHandlerCalled'),
   kReplyIsRunningOnErrorHook: Symbol('fastify.reply.isRunningOnErrorHook'),
+  kSchemaVisited: Symbol('fastify.kSchemaVisited'),
   kState: Symbol('fastify.state'),
   kOptions: Symbol('fastify.options'),
   kDisableRequestLogging: Symbol('fastify.disableRequestLogging'),

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -31,7 +31,7 @@ const keys = {
   kReplyStartTime: Symbol('fastify.reply.startTime'),
   kReplyErrorHandlerCalled: Symbol('fastify.reply.errorHandlerCalled'),
   kReplyIsRunningOnErrorHook: Symbol('fastify.reply.isRunningOnErrorHook'),
-  kSchemaVisited: Symbol('fastify.kSchemaVisited'),
+  kSchemaVisited: Symbol('fastify.schemas.visited'),
   kState: Symbol('fastify.state'),
   kOptions: Symbol('fastify.options'),
   kDisableRequestLogging: Symbol('fastify.disableRequestLogging'),

--- a/test/internals/validation.test.js
+++ b/test/internals/validation.test.js
@@ -9,6 +9,7 @@ const ajv = new Ajv({ coerceTypes: true })
 const validation = require('../../lib/validation')
 const { normalizeSchema } = require('../../lib/schemas')
 const symbols = require('../../lib/validation').symbols
+const { kSchemaVisited } = require('../../lib/symbols')
 
 test('Symbols', t => {
   t.plan(5)
@@ -76,6 +77,24 @@ test('build schema - payload schema', t => {
   }
   validation.compileSchemasForValidation(opts, ({ schema, method, url, httpPart }) => ajv.compile(schema))
   t.is(typeof opts[symbols.bodySchema], 'function')
+})
+
+test('build schema - avoid repeated normalize schema', t => {
+  t.plan(3)
+  const opts = {
+    schema: {
+      query: {
+        type: 'object',
+        properties: {
+          hello: { type: 'string' }
+        }
+      }
+    }
+  }
+  opts.schema = normalizeSchema(opts.schema)
+  t.notEqual(kSchemaVisited, undefined)
+  t.is(opts.schema[kSchemaVisited], true)
+  t.strictEqual(opts.schema, normalizeSchema(opts.schema))
 })
 
 test('build schema - query schema', t => {


### PR DESCRIPTION

In schemas.js use the kSchemaVisited symbol var , while symbols.js not find it. 
https://github.com/fastify/fastify/blob/283a1bde631645dc65b6499a29b16ccb95c89823/lib/schemas.js#L4
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
