### PR TITLE
feat: add hook onTimeout

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -15,6 +15,7 @@ By using hooks you can interact directly with the lifecycle of Fastify. There ar
   - [onError](#onerror)
   - [onSend](#onsend)
   - [onResponse](#onresponse)
+  - [onTimeout](#ontimeout)
   - [Manage Errors from a hook](#manage-errors-from-a-hook)
   - [Respond to a request from a hook](#respond-to-a-request-from-a-hook)
 - [Application Hooks](#application-hooks)
@@ -202,6 +203,26 @@ fastify.addHook('onResponse', async (request, reply) => {
 ```
 
 The `onResponse` hook is executed when a response has been sent, so you will not be able to send more data to the client. It can however be useful for sending data to external services, for example to gather statistics.
+
+### onTimeout
+
+```js
+
+fastify.addHook('onTimeout', (request, reply, done) => {
+  // Some code
+  done()
+})
+```
+Or `async/await`:
+```js
+fastify.addHook('onTimeout', async (request, reply) => {
+  // Some code
+  await asyncMethod()
+  return
+})
+```
+`onTimeout` is useful if you need to monitor the request timed out in your service. (if the `connectionTimeout` property is set on the fastify instance). The `onTimeout` hook is executed when a request is timed out and the http socket has been hanged up. Therefore you will not be able to send data to the client.
+
 
 ### Manage Errors from a hook
 If you get an error during the execution of your hook, just pass it to `done()` and Fastify will automatically close the request and send the appropriate error code to the user.

--- a/lib/context.js
+++ b/lib/context.js
@@ -13,6 +13,7 @@ function Context (schema, handler, Reply, Request, contentTypeParser, config, er
   this.onRequest = null
   this.onSend = null
   this.onError = null
+  this.onTimeout = null
   this.preHandler = null
   this.onResponse = null
   this.config = config

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -7,6 +7,7 @@ const applicationHooks = [
   'onClose'
 ]
 const lifecycleHooks = [
+  'onTimeout',
   'onRequest',
   'preParsing',
   'preValidation',
@@ -41,6 +42,7 @@ function Hooks () {
   this.onRoute = []
   this.onRegister = []
   this.onReady = []
+  this.onTimeout = []
 }
 
 Hooks.prototype.validate = function (hook, fn) {
@@ -68,6 +70,7 @@ function buildHooks (h) {
   hooks.onError = h.onError.slice()
   hooks.onRoute = h.onRoute.slice()
   hooks.onRegister = h.onRegister.slice()
+  hooks.onTimeout = h.onTimeout.slice()
   hooks.onReady = []
   return hooks
 }

--- a/lib/route.js
+++ b/lib/route.js
@@ -340,17 +340,23 @@ function buildRouting (options) {
     }
 
     if (context.onTimeout !== null) {
-      request.raw.socket.on('timeout', () => {
-        hookRunner(
-          context.onTimeout,
-          hookIterator,
-          request,
-          reply,
-          noop
-        )
-      })
+      if (!request.raw.socket._meta) {
+        request.raw.socket.on('timeout', handleTimeout)
+      }
+      request.raw.socket._meta = { context, request, reply }
     }
   }
+}
+
+function handleTimeout () {
+  const { context, request, reply } = this._meta
+  hookRunner(
+    context.onTimeout,
+    hookIterator,
+    request,
+    reply,
+    noop
+  )
 }
 
 function validateBodyLimitOption (bodyLimit) {

--- a/lib/route.js
+++ b/lib/route.js
@@ -338,6 +338,18 @@ function buildRouting (options) {
     } else {
       runPreParsing(null, request, reply)
     }
+
+    if (context.onTimeout !== null) {
+      request.raw.socket.on('timeout', () => {
+        hookRunner(
+          context.onTimeout,
+          hookIterator,
+          request,
+          reply,
+          noop
+        )
+      })
+    }
   }
 }
 
@@ -409,5 +421,7 @@ function preParsingHookRunner (functions, request, reply, cb) {
 
   next(null, request[kRequestPayloadStream])
 }
+
+function noop () { }
 
 module.exports = { buildRouting, validateBodyLimitOption }

--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -161,6 +161,12 @@ server.addHook('onResponse', async (request, reply) => {
   return;
 })
 
+server.addHook('onTimeout', async (request, reply) => {
+  expectType<FastifyRequest>(request)
+  expectType<FastifyReply>(reply)
+  return;
+})
+
 server.addHook('onError', async (request, reply, error) => {
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)
@@ -177,3 +183,4 @@ server.addHook('onClose', async (instance) => {
   expectType<FastifyInstance>(instance)
   return;
 })
+

--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -74,6 +74,14 @@ server.addHook('onResponse', (request, reply, done) => {
   expectType<void>(done(new Error()))
 })
 
+server.addHook('onTimeout', (request, reply, done) => {
+  expectType<FastifyRequest>(request)
+  expectType<FastifyReply>(reply)
+  expectAssignable<(err?: FastifyError) => void>(done)
+  expectAssignable<(err?: NodeJS.ErrnoException) => void>(done)
+  expectType<void>(done(new Error()))
+})
+
 server.addHook('onError', (request, reply, error, done) => {
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)

--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -183,4 +183,3 @@ server.addHook('onClose', async (instance) => {
   expectType<FastifyInstance>(instance)
   return;
 })
-

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -152,6 +152,20 @@ export interface onResponseHookHandler<
   ): Promise<unknown> | void;
 }
 
+export interface onTimeoutHookHandler<
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
+  RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
+  ContextConfig = ContextConfigDefault
+> {
+  (
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
+    done: HookHandlerDoneFunction
+  ): Promise<unknown> | void;
+}
+
 /**
  * This hook is useful if you need to do some custom error logging or add some specific header in case of error.
  * It is not intended for changing the error, and calling reply.send will throw an exception.

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -152,6 +152,10 @@ export interface onResponseHookHandler<
   ): Promise<unknown> | void;
 }
 
+/**
+ * `onTimeout` is useful if you need to monitor the request timed out in your service. (if the `connectionTimeout` property is set on the fastify instance)
+ * The onTimeout hook is executed when a request is timed out and the http socket has been hanged up. Therefore you will not be able to send data to the client.
+ */
 export interface onTimeoutHookHandler<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -4,7 +4,7 @@ import { FastifySchemaCompiler } from './schema'
 import { RawServerBase, RawRequestDefaultExpression, RawServerDefault, RawReplyDefaultExpression, ContextConfigDefault } from './utils'
 import { FastifyLoggerInstance } from './logger'
 import { FastifyRegister } from './register'
-import { onRequestHookHandler, preParsingHookHandler, onSendHookHandler, preValidationHookHandler, preHandlerHookHandler, preSerializationHookHandler, onResponseHookHandler, onErrorHookHandler, onRouteHookHandler, onRegisterHookHandler, onCloseHookHandler, onReadyHookHandler } from './hooks'
+import { onRequestHookHandler, preParsingHookHandler, onSendHookHandler, preValidationHookHandler, preHandlerHookHandler, preSerializationHookHandler, onResponseHookHandler, onErrorHookHandler, onRouteHookHandler, onRegisterHookHandler, onCloseHookHandler, onReadyHookHandler, onTimeoutHookHandler } from './hooks'
 import { FastifyRequest } from './request'
 import { FastifyReply } from './reply'
 import { FastifyError } from 'fastify-error'
@@ -165,6 +165,14 @@ export interface FastifyInstance<
   >(
     name: 'onResponse',
     hook: onResponseHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+
+  addHook<
+    RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
+    ContextConfig = ContextConfigDefault
+  >(
+    name: 'onTimeout',
+    hook: onTimeoutHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -167,6 +167,10 @@ export interface FastifyInstance<
     hook: onResponseHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
+  /**
+   * `onTimeout` is useful if you need to monitor the request timed out in your service. (if the `connectionTimeout` property is set on the fastify instance)
+   * The onTimeout hook is executed when a request is timed out and the http socket has been hanged up. Therefore you will not be able to send data to the client.
+   */
   addHook<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
     ContextConfig = ContextConfigDefault

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -81,6 +81,7 @@ export interface RouteShorthandOptions<
   preSerialization?: preSerializationHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> | preSerializationHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>[];
   onSend?: onSendHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> | onSendHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>[];
   onResponse?: onResponseHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> | onResponseHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>[];
+  onTimeout?: onResponseHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> | onResponseHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>[];
   onError?: onErrorHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> | onErrorHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>[];
 }
 

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -4,7 +4,7 @@ import { FastifyReply, ReplyGenericInterface } from './reply'
 import { FastifySchema, FastifySchemaCompiler } from './schema'
 import { HTTPMethods, RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, ContextConfigDefault } from './utils'
 import { LogLevel } from './logger'
-import { preValidationHookHandler, preHandlerHookHandler, preSerializationHookHandler, onRequestHookHandler, preParsingHookHandler, onResponseHookHandler, onSendHookHandler, onErrorHookHandler } from './hooks'
+import { preValidationHookHandler, preHandlerHookHandler, preSerializationHookHandler, onRequestHookHandler, preParsingHookHandler, onResponseHookHandler, onSendHookHandler, onErrorHookHandler, onTimeoutHookHandler } from './hooks'
 import { FastifyError } from 'fastify-error'
 
 export interface RouteGenericInterface extends RequestGenericInterface, ReplyGenericInterface {}
@@ -81,7 +81,7 @@ export interface RouteShorthandOptions<
   preSerialization?: preSerializationHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> | preSerializationHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>[];
   onSend?: onSendHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> | onSendHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>[];
   onResponse?: onResponseHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> | onResponseHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>[];
-  onTimeout?: onResponseHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> | onResponseHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>[];
+  onTimeout?: onTimeoutHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> | onTimeoutHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>[];
   onError?: onErrorHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> | onErrorHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>[];
 }
 


### PR DESCRIPTION
Fixes: https://github.com/fastify/fastify/issues/2203

This is set as draft for now because no documentation neither tests have been properly written. Wanted to have feedback on the implementation.

In the end the use of it will be:
```js
fastify.addHook('onTimeout', (request, reply, done) => {
  console.log('Hook Timeout')
  done()
})
```
But in here the reply can't be mutated because the socket has already hanged-up. Any opinion on this?

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
