### PR TITLE
fix schema lock in

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -268,7 +268,9 @@ function buildRouting (options) {
             throw new FST_ERR_SCH_VALIDATION_BUILD(opts.method, url, error.message)
           }
 
-          if (opts.schema.response && !opts.serializerCompiler && !this[kSerializerCompiler]) {
+          if (opts.schema.response &&
+            !opts.serializerCompiler &&
+            (!this[kSerializerCompiler] || (this[kSerializerCompiler] && schemaBucket.hasNewSchemas()))) {
             // if the instance doesn't have a serializer, build the default one for the single fastify instance
             this.setSerializerCompiler(buildDefaultSerializer(schemaBucket.getSchemas()))
           }

--- a/lib/route.js
+++ b/lib/route.js
@@ -255,23 +255,25 @@ function buildRouting (options) {
         if (opts.schema) {
           context.schema = normalizeSchema(context.schema)
 
-          const sBucket = this[kSchemas]
-          if (!opts.validatorCompiler && !this[kValidatorCompiler]) {
+          const schemaBucket = this[kSchemas]
+          if (!opts.validatorCompiler && (
+            !this[kValidatorCompiler] ||
+            (this[kValidatorCompiler] && schemaBucket.hasNewSchemas()))) {
             // if the instance doesn't have a validator, build the default one for the single fastify instance
-            this.setValidatorCompiler(buildPerformanceValidator(sBucket.getSchemas(), this[kOptions].ajv))
+            this.setValidatorCompiler(buildPerformanceValidator(schemaBucket.getSchemas(), this[kOptions].ajv))
           }
           try {
-            compileSchemasForValidation(context, opts.validatorCompiler || this[kValidatorCompiler], sBucket)
+            compileSchemasForValidation(context, opts.validatorCompiler || this[kValidatorCompiler])
           } catch (error) {
             throw new FST_ERR_SCH_VALIDATION_BUILD(opts.method, url, error.message)
           }
 
           if (opts.schema.response && !opts.serializerCompiler && !this[kSerializerCompiler]) {
             // if the instance doesn't have a serializer, build the default one for the single fastify instance
-            this.setSerializerCompiler(buildDefaultSerializer(sBucket.getSchemas()))
+            this.setSerializerCompiler(buildDefaultSerializer(schemaBucket.getSchemas()))
           }
           try {
-            compileSchemasForSerialization(context, opts.serializerCompiler || this[kSerializerCompiler], sBucket)
+            compileSchemasForSerialization(context, opts.serializerCompiler || this[kSerializerCompiler])
           } catch (error) {
             throw new FST_ERR_SCH_SERIALIZATION_BUILD(opts.method, url, error.message)
           }

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -12,6 +12,7 @@ const {
 
 function Schemas () {
   this.store = {}
+  this.newSchemasAdded = false
 }
 
 Schemas.prototype.add = function (inputSchema) {
@@ -31,6 +32,7 @@ Schemas.prototype.add = function (inputSchema) {
   }
 
   this.store[id] = schema
+  this.newSchemasAdded = true
 }
 
 Schemas.prototype.getSchemas = function () {
@@ -39,6 +41,10 @@ Schemas.prototype.getSchemas = function () {
 
 Schemas.prototype.getSchema = function (schemaId) {
   return this.store[schemaId]
+}
+
+Schemas.prototype.hasNewSchemas = function () {
+  return this.newSchemasAdded
 }
 
 function normalizeSchema (routeSchemas) {
@@ -120,6 +126,7 @@ function getSchemaAnyway (schema) {
 function buildSchemas (s) {
   const schema = new Schemas()
   Object.values(s.getSchemas()).forEach(_ => schema.add(_))
+  schema.newSchemasAdded = false
   return schema
 }
 

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -1132,3 +1132,30 @@ test('Add schema order should not break the startup', t => {
 
   fastify.ready(err => { t.error(err) })
 })
+
+test('The schema compiler recreate itself if needed', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  fastify.options('/', { schema: { hide: true } }, echoBody)
+
+  fastify.register(function (fastify, options, done) {
+    fastify.addSchema({
+      $id: 'identifier',
+      type: 'string',
+      format: 'uuid'
+    })
+
+    fastify.get('/:foobarId', {
+      schema: {
+        params: {
+          foobarId: { $ref: 'identifier#' }
+        }
+      }
+    }, echoBody)
+
+    done()
+  })
+
+  fastify.ready(err => { t.error(err) })
+})


### PR DESCRIPTION
Fix #2462 

The issue:

the first route of a context trigger the creation of the default schema validator, then all the children will use the same so ajv is instantiated only once.

This PR adds a check that, if the validator is not customized by the user, the validator will be recreated every time the user changes the schemas in the fastify instance.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
