### PR TITLE
docs: add logger option in async/await example

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -43,7 +43,9 @@ fastify.listen(3000, function (err, address) {
 Do you prefer to use `async/await`? Fastify supports it out-of-the-box.<br>
 *(We also suggest using [make-promises-safe](https://github.com/mcollina/make-promises-safe) to avoid file descriptor and memory leaks.)*
 ```js
-const fastify = require('fastify')()
+const fastify = require('fastify')({
+  logger: true
+})
 
 fastify.get('/', async (request, reply) => {
   return { hello: 'world' }


### PR DESCRIPTION
The first example has this option and I think the async/await example should have it as well.

Adding `logger` option to the `async`/`await` example:
> Do you prefer to use `async/await`? Fastify supports it out-of-the-box.<be>
> *(We also suggest using [make-promises-safe](https://github.com/mcollina/make-promises-safe) to avoid file descriptor > > and memory leaks.)*
> ```js
> const fastify = require('fastify')({
>   logger: true
> })

The first example I mentioned:
>### Your first server
> Let's write our first server:
> ```js
> // Require the framework and instantiate it
> const fastify = require('fastify')({
>   logger: true
> })


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
