### PR TITLE
fix setNotFoundHandler and setErrorHandler types

### DIFF
--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -19,6 +19,10 @@ expectType<unknown>(server.getSchema('SchemaId'))
 expectType<unknown>(server.use(() => {}))
 expectType<unknown>(server.use('/foo', () => {}))
 
+// Assert that a Promise is explicity declared as a return type of the handler functions
+expectAssignable<ReturnType<Parameters<FastifyInstance['setNotFoundHandler']>[0]>>(Promise.resolve())
+expectAssignable<ReturnType<Parameters<FastifyInstance['setErrorHandler']>[0]>>(Promise.resolve())
+
 server.setErrorHandler((function (error, request, reply) {
   expectAssignable<FastifyInstance>(this)
 }))

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -224,14 +224,14 @@ export interface FastifyInstance<
    * Set the 404 handler
    */
   setNotFoundHandler<RouteGeneric extends RouteGenericInterface = RouteGenericInterface>(
-    handler: (request: FastifyRequest<RouteGeneric, RawServer, RawRequest>, reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric>) => void
+    handler: (request: FastifyRequest<RouteGeneric, RawServer, RawRequest>, reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric>) => void | Promise<any>
   ): void;
 
   /**
    * Set a function that will be called whenever an error happens
    */
   setErrorHandler<TError extends Error = FastifyError, RouteGeneric extends RouteGenericInterface = RouteGenericInterface>(
-    handler: (this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>, error: TError, request: FastifyRequest<RouteGeneric, RawServer, RawRequest>, reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric>) => void
+    handler: (this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>, error: TError, request: FastifyRequest<RouteGeneric, RawServer, RawRequest>, reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric>) => void | Promise<any>
   ): void;
 
   /**


### PR DESCRIPTION
Update the type on the handler function argument to setNotFoundHandler and setErrorHandler to accept functions returning promises. This is consistent with how the handlers are actually used by Fastify, and prevents spurious ESLint errors originating from the function argument's signature not including a `Promise<>` return type.

Fixes #2466

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
