### PR TITLE
Adds support for named imports in ESM context

### DIFF
--- a/fastify.mjs
+++ b/fastify.mjs
@@ -1,0 +1,5 @@
+import Fastify from './fastify.js'
+
+export const fastify = Fastify
+
+export default Fastify

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "Fast and low overhead web framework, for Node.js",
   "main": "fastify.js",
   "types": "fastify.d.ts",
+  "type": "commonjs",
+  "exports": {
+    "import": "./fastify.mjs",
+    "require": "./fastify.js"
+  },
   "scripts": {
     "lint": "npm run lint:standard && npm run lint:typescript",
     "lint:standard": "standard --verbose | snazzy",

--- a/test/esm/esm.mjs
+++ b/test/esm/esm.mjs
@@ -1,13 +1,37 @@
 import t from 'tap'
 import Fastify from '../../fastify.js'
+import DefaultFastify, { fastify } from '../../fastify.mjs'
 
-t.test('esm support', async t => {
-  const fastify = Fastify()
+t.test('esm support from CJS module.exports', async t => {
+  const app = Fastify()
 
-  fastify.register(import('./plugin.mjs'), { foo: 'bar' })
-  fastify.register(import('./other.mjs'))
+  app.register(import('./plugin.mjs'), { foo: 'bar' })
+  app.register(import('./other.mjs'))
 
-  await fastify.ready()
+  await app.ready()
 
-  t.strictEqual(fastify.foo, 'bar')
+  t.strictEqual(app.foo, 'bar')
+})
+
+t.test('esm default import', async t => {
+  const app = DefaultFastify()
+
+  await app.ready()
+
+  t.pass()
+})
+
+t.test('esm named import', async t => {
+  const app = fastify()
+
+  await app.ready()
+
+  t.pass()
+})
+
+t.only('CJS module.exports and esm default/named imports are the same object', t => {
+  t.plan(2)
+
+  t.is(DefaultFastify, fastify)
+  t.is(DefaultFastify, Fastify)
 })

--- a/test/esm/esm.mjs
+++ b/test/esm/esm.mjs
@@ -1,6 +1,7 @@
 import t from 'tap'
 import Fastify from '../../fastify.js'
-import DefaultFastify, { fastify } from '../../fastify.mjs'
+// since we have exports field in the package.json we can selfreference the package
+import DefaultFastify, { fastify } from 'fastify'
 
 t.test('esm support from CJS module.exports', async t => {
   const app = Fastify()


### PR DESCRIPTION
This PR adds named imports to ESM contexts: this is the last import that wasn't supported until now.
It follows the recommendation of the [official Node.js ESM support guide](https://nodejs.org/api/esm.html#esm_approach_1_use_an_es_module_wrapper), however, it uses `"type": "commonjs"` since Fasfiy is written in CommonJS.

We can use this PR to discuss if we want to fully support ESM named imports. In my opinion, this will allow us to have simpler documentation since all of the contexts support the same set of `import/export`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
