### PR TITLE
fix: test slowness on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "ajv-i18n": "^3.5.0",
     "ajv-merge-patch": "^4.1.0",
     "ajv-pack": "^0.3.1",
+    "autocannon": "^6.0.0",
     "branch-comparer": "^1.0.2",
     "concurrently": "^5.0.2",
     "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "ajv-i18n": "^3.5.0",
     "ajv-merge-patch": "^4.1.0",
     "ajv-pack": "^0.3.1",
-    "autocannon": "^6.0.0",
     "branch-comparer": "^1.0.2",
     "concurrently": "^5.0.2",
     "cors": "^2.8.5",
@@ -154,6 +153,7 @@
     "then-sleep": "^1.0.1",
     "tsd": "^0.13.1",
     "typescript": "^3.7.4",
+    "undici": "^1.3.0",
     "x-xss-protection": "^2.0.0",
     "yup": "^0.29.0"
   },

--- a/test/close-pipelining.test.js
+++ b/test/close-pipelining.test.js
@@ -23,18 +23,16 @@ test('Should return 503 while closing - pipelining', t => {
     })
 
     const codes = [200, 503]
-    // eslint-disable-next-line no-unused-vars
-    for (const _ of Array(codes.length)) {
+    for (const code of codes) {
       instance.request(
         { path: '/', method: 'GET' }
       ).then(data => {
-        t.strictEqual(data.statusCode, codes.shift())
+        t.strictEqual(data.statusCode, code)
       }).catch((e) => {
         t.fail(e)
       })
     }
     instance.close(() => {
-      t.strictEqual(codes.length, 0)
       t.end('Done')
     })
   })
@@ -58,18 +56,16 @@ test('Should not return 503 while closing - pipelining - return503OnClosing', t 
     })
 
     const codes = [200, 200]
-    // eslint-disable-next-line no-unused-vars
-    for (const _ of Array(codes.length)) {
+    for (const code of codes) {
       instance.request(
         { path: '/', method: 'GET' }
       ).then(data => {
-        t.strictEqual(data.statusCode, codes.shift())
+        t.strictEqual(data.statusCode, code)
       }).catch((e) => {
         t.fail(e)
       })
     }
     instance.close(() => {
-      t.strictEqual(codes.length, 0)
       t.end('Done')
     })
   })

--- a/test/close-pipelining.test.js
+++ b/test/close-pipelining.test.js
@@ -18,7 +18,7 @@ test('Should return 503 while closing - pipelining', t => {
   fastify.listen(0, async err => {
     t.error(err)
 
-    const instance = new Client('http://localhost:' + fastify.server.address().port,{
+    const instance = new Client('http://localhost:' + fastify.server.address().port, {
       pipelining: 1
     })
 
@@ -53,7 +53,7 @@ test('Should not return 503 while closing - pipelining - return503OnClosing', t 
   fastify.listen(0, async err => {
     t.error(err)
 
-    const instance = new Client('http://localhost:' + fastify.server.address().port,{
+    const instance = new Client('http://localhost:' + fastify.server.address().port, {
       pipelining: 1
     })
 

--- a/test/close-pipelining.test.js
+++ b/test/close-pipelining.test.js
@@ -24,13 +24,13 @@ test('Should return 503 while closing - pipelining', t => {
 
     const codes = [200, 503]
     // eslint-disable-next-line no-unused-vars
-    for (const _ of Array(2)) {
-      await instance.request(
+    for (const _ of Array(codes.length)) {
+      instance.request(
         { path: '/', method: 'GET' }
       ).then(data => {
         t.strictEqual(data.statusCode, codes.shift())
-      }).catch(() => {
-        t.strictEqual(codes.shift(), undefined)
+      }).catch((e) => {
+        t.fail(e)
       })
     }
     instance.close(() => {
@@ -50,7 +50,7 @@ test('Should not return 503 while closing - pipelining - return503OnClosing', t 
     reply.send({ hello: 'world' })
   })
 
-  fastify.listen(0, async err => {
+  fastify.listen(0, err => {
     t.error(err)
 
     const instance = new Client('http://localhost:' + fastify.server.address().port, {
@@ -59,13 +59,13 @@ test('Should not return 503 while closing - pipelining - return503OnClosing', t 
 
     const codes = [200, 200]
     // eslint-disable-next-line no-unused-vars
-    for (const _ of Array(2)) {
-      await instance.request(
+    for (const _ of Array(codes.length)) {
+      instance.request(
         { path: '/', method: 'GET' }
       ).then(data => {
         t.strictEqual(data.statusCode, codes.shift())
-      }).catch(() => {
-        t.strictEqual(codes.shift(), undefined)
+      }).catch((e) => {
+        t.fail(e)
       })
     }
     instance.close(() => {

--- a/test/close-pipelining.test.js
+++ b/test/close-pipelining.test.js
@@ -5,9 +5,7 @@ const test = t.test
 const Fastify = require('..')
 const autocannon = require('autocannon')
 
-// this tests on windows takes an unusually large amount of time.
-// https://github.com/fastify/fastify/issues/2470
-t.setTimeout(45000)
+t.jobs = 2
 
 test('Should return 503 while closing - pipelining', t => {
   const fastify = Fastify()

--- a/test/close-pipelining.test.js
+++ b/test/close-pipelining.test.js
@@ -3,41 +3,40 @@
 const t = require('tap')
 const test = t.test
 const Fastify = require('..')
-const autocannon = require('autocannon')
-
-t.jobs = 2
+const { Client } = require('undici')
 
 test('Should return 503 while closing - pipelining', t => {
-  const fastify = Fastify()
+  const fastify = Fastify({
+    return503OnClosing: true
+  })
 
   fastify.get('/', (req, reply) => {
     fastify.close()
     reply.send({ hello: 'world' })
   })
 
-  fastify.listen(0, err => {
+  fastify.listen(0, async err => {
     t.error(err)
 
-    const instance = autocannon({
-      url: 'http://localhost:' + fastify.server.address().port,
-      pipelining: 1,
-      connections: 1,
-      amount: 10
+    const instance = new Client('http://localhost:' + fastify.server.address().port,{
+      pipelining: 1
     })
 
     const codes = [200, 503]
-    instance.on('response', (client, statusCode) => {
-      t.strictEqual(statusCode, codes.shift())
-    })
-
-    instance.on('done', () => {
+    // eslint-disable-next-line no-unused-vars
+    for (const _ of Array(2)) {
+      await instance.request(
+        { path: '/', method: 'GET' }
+      ).then(data => {
+        t.strictEqual(data.statusCode, codes.shift())
+      }).catch(() => {
+        t.strictEqual(codes.shift(), undefined)
+      })
+    }
+    instance.close(() => {
       t.strictEqual(codes.length, 0)
       t.end('Done')
     })
-    instance.on('reqError', () => {
-      t.strictEqual(codes.shift(), undefined)
-    })
-    instance.on('error', err => t.fail(err))
   })
 })
 
@@ -51,28 +50,27 @@ test('Should not return 503 while closing - pipelining - return503OnClosing', t 
     reply.send({ hello: 'world' })
   })
 
-  fastify.listen(0, err => {
+  fastify.listen(0, async err => {
     t.error(err)
 
-    const instance = autocannon({
-      url: 'http://localhost:' + fastify.server.address().port,
-      pipelining: 1,
-      connections: 1,
-      amount: 10
+    const instance = new Client('http://localhost:' + fastify.server.address().port,{
+      pipelining: 1
     })
 
     const codes = [200, 200]
-    instance.on('response', (client, statusCode) => {
-      t.strictEqual(statusCode, codes.shift())
-    })
-
-    instance.on('done', () => {
+    // eslint-disable-next-line no-unused-vars
+    for (const _ of Array(2)) {
+      await instance.request(
+        { path: '/', method: 'GET' }
+      ).then(data => {
+        t.strictEqual(data.statusCode, codes.shift())
+      }).catch(() => {
+        t.strictEqual(codes.shift(), undefined)
+      })
+    }
+    instance.close(() => {
       t.strictEqual(codes.length, 0)
       t.end('Done')
     })
-    instance.on('reqError', () => {
-      t.strictEqual(codes.shift(), undefined)
-    })
-    instance.on('error', err => t.fail(err))
   })
 })


### PR DESCRIPTION
fix: #2470 

```
$ npx tap -J test/close-*.test.js
 PASS  test/close-pipelining.test.js 24 OK 15s
```

Looking at the doc, specifying `jobs` property seems to fix the issue : https://node-tap.org/docs/api/parallel-tests/#parallel-tests-from-the-api

Validated on my machine on W10

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
