### PR TITLE
fix: typings for hooks

### DIFF
--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -55,6 +55,7 @@ server.addHook<TestPayloadType>('preSerialization', function (request, reply, pa
   expectType<void>(done(new Error()))
   expectType<void>(done(null, 'foobar'))
   expectType<void>(done())
+  expectError<void>(done(new Error(), 'foobar'))
 })
 
 server.addHook<TestPayloadType>('onSend', (request, reply, payload, done) => {
@@ -64,6 +65,7 @@ server.addHook<TestPayloadType>('onSend', (request, reply, payload, done) => {
   expectType<void>(done(new Error()))
   expectType<void>(done(null, 'foobar'))
   expectType<void>(done())
+  expectError<void>(done(new Error(), 'foobar'))
 })
 
 server.addHook('onResponse', (request, reply, done) => {

--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -54,7 +54,7 @@ server.addHook<TestPayloadType>('preSerialization', function (request, reply, pa
   expectType<TestPayloadType>(payload) // we expect this to be unknown when not specified like in the previous test
   expectType<void>(done(new Error()))
   expectType<void>(done(null, 'foobar'))
-  expectError(done())
+  expectType<void>(done())
 })
 
 server.addHook<TestPayloadType>('onSend', (request, reply, payload, done) => {
@@ -63,7 +63,7 @@ server.addHook<TestPayloadType>('onSend', (request, reply, payload, done) => {
   expectType<TestPayloadType>(payload)
   expectType<void>(done(new Error()))
   expectType<void>(done(null, 'foobar'))
-  expectError(done())
+  expectType<void>(done())
 })
 
 server.addHook('onResponse', (request, reply, done) => {

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -11,6 +11,9 @@ import { FastifyLoggerInstance } from './logger'
 
 type HookHandlerDoneFunction = <TError extends Error = FastifyError>(err?: TError) => void
 
+// This is used within the `preSerialization` and `onSend` hook handlers
+type DoneFuncWithErrOrRes = <TError extends Error = FastifyError>(err?: TError | null, res?: unknown) => void
+
 interface RequestPayload extends Readable {
   receivedEncodedLength?: number;
 }
@@ -86,12 +89,6 @@ export interface preHandlerHookHandler<
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
   ): Promise<unknown> | void;
-}
-
-// This is used within the `preSerialization` and `onSend` hook handlers
-interface DoneFuncWithErrOrRes {
-  <TError extends Error = FastifyError>(err: TError): void;
-  (err: null, res: unknown): void;
 }
 
 /**

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -11,9 +11,6 @@ import { FastifyLoggerInstance } from './logger'
 
 type HookHandlerDoneFunction = <TError extends Error = FastifyError>(err?: TError) => void
 
-// This is used within the `preSerialization` and `onSend` hook handlers
-type DoneFuncWithErrOrRes = <TError extends Error = FastifyError>(err?: TError | null, res?: unknown) => void
-
 interface RequestPayload extends Readable {
   receivedEncodedLength?: number;
 }
@@ -89,6 +86,13 @@ export interface preHandlerHookHandler<
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
   ): Promise<unknown> | void;
+}
+
+// This is used within the `preSerialization` and `onSend` hook handlers
+interface DoneFuncWithErrOrRes {
+  (): void;
+  <TError extends Error = FastifyError>(err: TError): void;
+  (err: null, res: unknown): void;
 }
 
 /**


### PR DESCRIPTION
This fixes #2439 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
