### PR TITLE
feat: delete non existent files references

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,9 +7,6 @@
 .nyc_output
 coverage/
 tools/
-azure-pipelines-npm-template.yml
-azure-pipelines-yarn-template.yml
-azure-pipelines.yml
 CODE_OF_CONDUCT.md
 CONTRIBUTING.md
 .dependabot


### PR DESCRIPTION
As mentionned in https://github.com/fastify/help/issues/243

Deleting azure pipelines references in npmignore

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
