### PR TITLE
Add type commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.2.0",
   "description": "Fast and low overhead web framework, for Node.js",
   "main": "fastify.js",
+  "type": "commonjs",
   "types": "fastify.d.ts",
   "scripts": {
     "lint": "npm run lint:standard && npm run lint:typescript",


### PR DESCRIPTION
As suggested in the [ESM](https://nodejs.org/api/esm.html#esm_package_json_type_field) guidelines of nodejs it would be good to explicit the `type` of the module.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
