### PR TITLE
Adds support for plugin dynamic imports in TS projects

### DIFF
--- a/test/types/dummy-plugin.ts
+++ b/test/types/dummy-plugin.ts
@@ -1,0 +1,9 @@
+import { FastifyPlugin } from '../../fastify'
+
+export interface DummyPluginOptions {
+  foo?: number
+}
+
+declare const DummyPlugin: FastifyPlugin<DummyPluginOptions>
+
+export default DummyPlugin

--- a/test/types/plugin.test-d.ts
+++ b/test/types/plugin.test-d.ts
@@ -26,6 +26,9 @@ expectAssignable<FastifyInstance>(fastify().register(function (instance, opts, n
 expectAssignable<FastifyInstance>(fastify().register(function (instance, opts, next) { }, () => { }))
 expectAssignable<FastifyInstance>(fastify().register(function (instance, opts, next) { }, { logLevel: 'info', prefix: 'foobar' }))
 
+expectAssignable<FastifyInstance>(fastify().register(import('./dummy-plugin')))
+expectAssignable<FastifyInstance>(fastify().register(import('./dummy-plugin'), { foo: 1 }))
+
 const testPluginCallback: FastifyPluginCallback = function (instance, opts, next) { }
 expectAssignable<FastifyInstance>(fastify().register(testPluginCallback, {}))
 

--- a/types/register.d.ts
+++ b/types/register.d.ts
@@ -16,7 +16,7 @@ export interface FastifyRegister<T = void> {
     opts?: FastifyRegisterOptions<Options>
   ): T;
   <Options extends FastifyPluginOptions>(
-    plugin: FastifyPluginCallback<Options> | FastifyPluginAsync<Options>,
+    plugin: FastifyPluginCallback<Options> | FastifyPluginAsync<Options> | Promise<{ default: FastifyPluginCallback<Options> }> | Promise<{ default: FastifyPluginAsync<Options> }>,
     opts?: FastifyRegisterOptions<Options>
   ): T;
 }


### PR DESCRIPTION
Fixes: https://github.com/fastify/fastify/issues/2403
The issue was because dynamic import in Typescript always imports an object that have `.default` property instead of assigning the default export to "top" level. In fact the compiler outputs this JS
```js
fastify.register(Promise.resolve().then(() => __importStar(require("fastify-formbody"))));
```
for this ts
```ts
fastify.register(import("fastify-formbody"));
```
It compiles it like this because `import()` is implemented `using require()` and promises.

This PR works thanks to https://github.com/fastify/avvio/blob/76f83492819c0cbc64e6a255e92df11fe4f094fb/plugin.js#L245 that works if an object with `.default` property is passed.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
