### PR TITLE
types: add guards on hasDecorator checks

### DIFF
--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -48,6 +48,17 @@ expectError(server.setReplySerializer(invalidReplySerialzer))
 function serializerWithInvalidReturn(payload: unknown, statusCode: number) {}
 expectError(server.setReplySerializer(serializerWithInvalidReturn))
 
+expectType<boolean>(server.hasDecorator('method'));
+
+if (server.hasDecorator('method')) {
+  expectType<any>(server.method);
+} else if (server.hasDecorator<'methodTyped', () => number>('methodTyped')) {
+  expectType<() => number>(server.methodTyped);
+} else {
+  expectError(server.method());
+  expectError(server.methodTyped());
+}
+
 expectAssignable<PromiseLike<string>>(server.listen({ port: 3000 }))
 expectAssignable<PromiseLike<string>>(server.listen({ port: 3000, host: '0.0.0.0' }))
 expectAssignable<PromiseLike<string>>(server.listen({ port: 3000, host: '0.0.0.0', backlog: 42 }))

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -52,11 +52,8 @@ expectType<boolean>(server.hasDecorator('method'));
 
 if (server.hasDecorator('method')) {
   expectType<any>(server.method);
-} else if (server.hasDecorator<'methodTyped', () => number>('methodTyped')) {
-  expectType<() => number>(server.methodTyped);
 } else {
   expectError(server.method());
-  expectError(server.methodTyped());
 }
 
 expectAssignable<PromiseLike<string>>(server.listen({ port: 3000 }))

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -38,7 +38,7 @@ export interface FastifyInstance<
   decorateRequest(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
   decorateReply(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
-  hasDecorator(decorator: string | symbol): boolean;
+  hasDecorator<K extends string | symbol, T = any>(decorator: K): this is FastifyInstance<RawServer, RawRequest, RawReply, Logger> & Record<K, T>;
   hasRequestDecorator(decorator: string | symbol): boolean;
   hasReplyDecorator(decorator: string | symbol): boolean;
 

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -38,7 +38,7 @@ export interface FastifyInstance<
   decorateRequest(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
   decorateReply(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
-  hasDecorator<K extends string | symbol, T = any>(decorator: K): this is FastifyInstance<RawServer, RawRequest, RawReply, Logger> & Record<K, T>;
+  hasDecorator<K extends string | symbol>(decorator: K): this is FastifyInstance<RawServer, RawRequest, RawReply, Logger> & Record<K, any>;
   hasRequestDecorator(decorator: string | symbol): boolean;
   hasReplyDecorator(decorator: string | symbol): boolean;
 


### PR DESCRIPTION
A micro PR on adding better typing for decorators, since I'm not too sure if this alleviates the issue #2495 while fitting within the constraints presented in https://github.com/fastify/fastify/issues/2495#issuecomment-675744137. 
If this is somewhat in the correct direction then I'll continue on request/reply (since those are harder), and on .decorate itself (not sure if it's even possible given TS limitations).

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
