### PR TITLE
doc: add scope & route level to Hooks ToC

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -23,6 +23,8 @@ By using hooks you can interact directly with the lifecycle of Fastify. There ar
   - [onClose](#onclose)
   - [onRoute](#onroute)
   - [onRegister](#onregister)
+- [Scope](#scope)
+- [Route level hooks](#route-level-hooks)
 
 **Notice:** the `done` callback is not available when using `async`/`await` or returning a `Promise`. If you do invoke a `done` callback in this situation unexpected behaviour may occur, e.g. duplicate invocation of handlers.
 
@@ -56,7 +58,7 @@ fastify.addHook('onRequest', async (request, reply) => {
 
 ### preParsing
 
-If you are using the `preParsing` hook, you can transform the request payload stream before it is parsed. It receives the request and reply objects as other hooks, and a stream with the current request payload. 
+If you are using the `preParsing` hook, you can transform the request payload stream before it is parsed. It receives the request and reply objects as other hooks, and a stream with the current request payload.
 
 If it returns a value (via `return` or via the callback function), it must return a stream.
 
@@ -79,7 +81,7 @@ fastify.addHook('preParsing', async (request, reply, payload) => {
 
 **Notice:** in the [preParsing](#preparsing) hook, `request.body` will always be `null`, because the body parsing happens before the [preValidation](#prevalidation) hook.
 
-**Notice:** you should also add `receivedEncodedLength` property to the returned stream. This property is used to correctly match the request payload with the `Content-Length` header value. Ideally, this property should be updated on each received chunk. 
+**Notice:** you should also add `receivedEncodedLength` property to the returned stream. This property is used to correctly match the request payload with the `Content-Length` header value. Ideally, this property should be updated on each received chunk.
 
 **Notice**: The old syntaxes `function(request, reply, done)` and `async function(request, reply)` for the parser are still supported but they are deprecated.
 
@@ -361,7 +363,7 @@ fastify.addHook('onRoute', (routeOptions) => {
   routeOptions.method
   routeOptions.schema
   routeOptions.url // the complete URL of the route, it will inclued the prefix if any
-  routeOptions.path // `url` alias 
+  routeOptions.path // `url` alias
   routeOptions.routePath // the URL of the route without the prefix
   routeOptions.bodyLimit
   routeOptions.logLevel


### PR DESCRIPTION
Minor doc change: I noticed that the "Scope" and "Route level hooks" sections of the Hooks documentation were not linked in the ToC.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] ~tests and/or benchmarks are included~ N/A doc change only
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
