### PR TITLE
Expose router config via getters on Request

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -3,8 +3,9 @@
 const proxyAddr = require('proxy-addr')
 const warning = require('./warnings')
 
-function Request (id, params, req, query, log) {
+function Request (id, params, req, query, log, context) {
   this.id = id
+  this.context = context
   this.params = params
   this.raw = req
   this.query = query
@@ -41,8 +42,9 @@ function buildRequest (R, trustProxy) {
 }
 
 function buildRegularRequest (R) {
-  function _Request (id, params, req, query, log) {
+  function _Request (id, params, req, query, log, context) {
     this.id = id
+    this.context = context
     this.params = params
     this.raw = req
     this.query = query
@@ -97,6 +99,16 @@ Object.defineProperties(Request.prototype, {
   method: {
     get () {
       return this.raw.method
+    }
+  },
+  routerUrl: {
+    get () {
+      return this.context.config.url
+    }
+  },
+  routerMethod: {
+    get () {
+      return this.context.config.method
     }
   },
   connection: {

--- a/lib/route.js
+++ b/lib/route.js
@@ -320,7 +320,7 @@ function buildRouting (options) {
 
     var queryPrefix = req.url.indexOf('?')
     var query = querystringParser(queryPrefix > -1 ? req.url.slice(queryPrefix + 1) : '')
-    var request = new context.Request(id, params, req, query, childLogger)
+    var request = new context.Request(id, params, req, query, childLogger, context)
     var reply = new context.Reply(res, context, request, childLogger)
 
     if (disableRequestLogging === false) {

--- a/test/router-options.test.js
+++ b/test/router-options.test.js
@@ -60,6 +60,25 @@ test('Should honor maxParamLength option', t => {
   })
 })
 
+test('Should expose router options via getters on request', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.get('/test/:id', (req, reply) => {
+    t.strictEqual(req.routerUrl, '/test/:id')
+    t.strictEqual(req.routerMethod, 'GET')
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/test/123456789'
+  }, (error, res) => {
+    t.error(error)
+    t.strictEqual(res.statusCode, 200)
+  })
+})
+
 test('Should honor frameworkErrors option', t => {
   t.plan(3)
   const fastify = Fastify({

--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -40,6 +40,8 @@ type CustomRequest = FastifyRequest<{
 const getHandler: RouteHandler = function (request, _reply) {
   expectType<string>(request.url)
   expectType<string>(request.method)
+  expectType<string>(request.routerUrl)
+  expectType<string>(request.routerMethod)
   expectType<string>(request.hostname)
   expectType<string>(request.ip)
   expectType<string[] | undefined>(request.ips)

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -30,6 +30,8 @@ export interface FastifyRequest<
   hostname: string;
   url: string;
   method: string;
+  routerUrl: string;
+  routerMethod: string;
   /** in order for this to be used the user should ensure they have set the attachValidation option. */
   validationError?: Error & { validation: any; validationContext: string };
 


### PR DESCRIPTION
fixes #2435

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Benchmarks:
After change:  148k requests in 5.12s, 27.6 MB read
Before change:  146k requests in 5.12s, 26.8 MB read

