### PR TITLE
Passes generic to RouteHandler return type

### DIFF
--- a/test/types/reply.test-d.ts
+++ b/test/types/reply.test-d.ts
@@ -13,7 +13,7 @@ const getHandler: RouteHandlerMethod = function (_request, reply) {
   expectType<(statusCode: number) => FastifyReply>(reply.status)
   expectType<number>(reply.statusCode)
   expectType<boolean>(reply.sent)
-  expectType<(<T>(payload?: T) => FastifyReply)>(reply.send)
+  expectType<((payload?: unknown) => FastifyReply)>(reply.send)
   expectType<(key: string, value: any) => FastifyReply>(reply.header)
   expectType<(values: {[key: string]: any}) => FastifyReply>(reply.headers)
   expectType<(key: string) => string | undefined>(reply.getHeader)
@@ -36,7 +36,7 @@ interface ReplyPayload {
 }
 
 const typedHandler: RouteHandler<ReplyPayload> = async (request, reply) => {
-  expectType<(<T = ReplyPayload['Reply']>(payload?: T) => FastifyReply<RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>, ReplyPayload>)>(reply.send)
+  expectType<((payload?: ReplyPayload['Reply']) => FastifyReply<RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>, ReplyPayload>)>(reply.send)
 }
 
 const server = fastify()

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -27,7 +27,7 @@ export interface FastifyReply<
   status(statusCode: number): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
   statusCode: number;
   sent: boolean;
-  send<T = RouteGeneric['Reply']>(payload?: T): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
+  send(payload?: RouteGeneric['Reply']): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
   header(key: string, value: any): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
   headers(values: {[key: string]: any}): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
   getHeader(key: string): string | undefined;

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -126,7 +126,7 @@ export type RouteHandlerMethod<
   this: FastifyInstance<RawServer, RawRequest, RawReply>,
   request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
   reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
-) => void | Promise<any>
+) => void | Promise<RouteGeneric['Reply'] | void>
 
 export type RouteHandler<
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
@@ -138,4 +138,4 @@ export type RouteHandler<
   this: FastifyInstance<RawServer, RawRequest, RawReply>,
   request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
   reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
-) => void | Promise<any>
+) => void | Promise<RouteGeneric['Reply'] | void>


### PR DESCRIPTION
Fix for https://github.com/fastify/fastify/issues/2529
This PR adds proper type tests for the`handler` and the `reply` types.

~At the moment, this PR fixes only one of the two problems pointed in that issue: the return type for the handler function.~
Both bugs are fixed.

~We still need a proper fix for the `send` method because this [line](https://github.com/fastify/fastify/blob/master/types/reply.d.ts#L30) isn't working: default `RouteGeneric['Reply']` value is never used, even if the `send` generic is not passed.~

I think this might be a TypeScript limitation and we need to find a better definition for this case. In my opinion, we don't even need that generic and we could write it like: `send(payload?: RouteGeneric['Reply']): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;` (I already tested it and it works, but of course breaks [this](https://github.com/fastify/fastify/blob/master/test/types/reply.test-d.ts#L33) test. This would be a breaking change.


~__Note: I added a non-passing test that will pass when we will fix the second problem.__~
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
