### PR TITLE
Fix content length

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -349,6 +349,7 @@ function preserializeHookEnd (err, request, reply, payload) {
   }
 
   flatstr(payload)
+  reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)
 
   onSendHook(reply, payload)
 }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -349,7 +349,6 @@ function preserializeHookEnd (err, request, reply, payload) {
   }
 
   flatstr(payload)
-  reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)
 
   onSendHook(reply, payload)
 }
@@ -406,9 +405,7 @@ function onSendEnd (reply, payload) {
     throw new FST_ERR_REP_INVALID_PAYLOAD_TYPE(typeof payload)
   }
 
-  if (!reply[kReplyHeaders]['content-length']) {
-    reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)
-  }
+  reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)
 
   reply[kReplySent] = true
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -405,7 +405,9 @@ function onSendEnd (reply, payload) {
     throw new FST_ERR_REP_INVALID_PAYLOAD_TYPE(typeof payload)
   }
 
-  reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)
+  if (!reply[kReplyHeaders]['content-length']) {
+    reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)
+  }
 
   reply[kReplySent] = true
 
@@ -519,6 +521,7 @@ function handleError (reply, error, cb) {
     reply[kReplySent] = false
     reply[kReplyIsError] = false
     reply[kReplyErrorHandlerCalled] = true
+    reply[kReplyHeaders]['content-length'] = undefined
     var result = errorHandler(error, reply.request, reply)
     if (result && typeof result.then === 'function') {
       wrapThenable(result, reply)


### PR DESCRIPTION
Fixes: #2543 

~I'm not totally sure that's the best approach to it because override the content-length if has one. Otherwise, what reasons to sent a custom `content-type` from handlers?~

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
