### PR TITLE
Add prettyPrint option to logger type definitions

### DIFF
--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -85,3 +85,32 @@ const serverWithAutoInferredPino = fastify({
 })
 
 expectType<pino.Logger>(serverWithAutoInferredPino.log)
+
+const serverAutoInferredPinoPrettyBooleanOption = fastify({
+  logger: {
+    prettyPrint: true
+  }
+})
+
+expectType<FastifyLoggerInstance>(serverAutoInferredPinoPrettyBooleanOption.log)
+
+const serverAutoInferredPinoPrettyObjectOption = fastify({
+  logger: {
+    prettyPrint: {
+      translateTime: true,
+      levelFirst: false,
+      messageKey: 'msg',
+      timestampKey: 'time',
+      messageFormat: false,
+      colorize: true,
+      crlf: false,
+      errorLikeObjectKeys: ['err', 'error'],
+      errorProps: '',
+      search: 'foo == `bar`',
+      ignore: 'pid,hostname',
+      suppressFlushSyncWarning: true
+    }
+  }
+})
+
+expectType<FastifyLoggerInstance>(serverAutoInferredPinoPrettyObjectOption.log)

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -30,6 +30,8 @@ export interface FastifyLoggerInstance {
   child(bindings: Bindings): FastifyLoggerInstance;
 }
 
+// This interface is accurate for pino 6.3 and was copied from the following permalink:
+// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/72c9bd83316bd31e93ab86d64ddf598d922f33cd/types/pino/index.d.ts#L514-L567
 export interface PrettyOptions {
   /**
    * Translate the epoch time value into a human readable date and time string.

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -1,7 +1,6 @@
 import { FastifyError } from 'fastify-error'
 import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression } from './utils'
 import { FastifyRequest, RequestGenericInterface } from './request'
-import { PrettyOptions } from 'pino'
 
 /**
  * Standard Fastify logging function
@@ -29,6 +28,61 @@ export interface FastifyLoggerInstance {
   trace: FastifyLogFn;
   debug: FastifyLogFn;
   child(bindings: Bindings): FastifyLoggerInstance;
+}
+
+export interface PrettyOptions {
+  /**
+   * Translate the epoch time value into a human readable date and time string.
+   * This flag also can set the format string to apply when translating the date to human readable format.
+   * The default format is yyyy-mm-dd HH:MM:ss.l o in UTC.
+   * For a list of available pattern letters see the {@link https://www.npmjs.com/package/dateformat|dateformat documentation}.
+   */
+  translateTime?: boolean | string;
+  /**
+   * If set to true, it will print the name of the log level as the first field in the log line. Default: `false`.
+   */
+  levelFirst?: boolean;
+  /**
+   * The key in the JSON object to use as the highlighted message. Default: "msg".
+   */
+  messageKey?: string;
+  /**
+   * The key in the JSON object to use for timestamp display. Default: "time".
+   */
+  timestampKey?: string;
+  /**
+   * Format output of message, e.g. {level} - {pid} will output message: INFO - 1123 Default: `false`.
+   */
+  messageFormat?: false | string;
+  /**
+   * If set to true, will add color information to the formatted output message. Default: `false`.
+   */
+  colorize?: boolean;
+  /**
+   * Appends carriage return and line feed, instead of just a line feed, to the formatted log line.
+   */
+  crlf?: boolean;
+  /**
+   * Define the log keys that are associated with error like objects. Default: ["err", "error"]
+   */
+  errorLikeObjectKeys?: string[];
+  /**
+   *  When formatting an error object, display this list of properties.
+   *  The list should be a comma separated list of properties. Default: ''
+   */
+  errorProps?: string;
+  /**
+   * Specify a search pattern according to {@link http://jmespath.org|jmespath}
+   */
+  search?: string;
+  /**
+   * Ignore one or several keys. Example: "time,hostname"
+   */
+  ignore?: string;
+  /**
+   * Suppress warning on first synchronous flushing.
+   */
+  suppressFlushSyncWarning?: boolean;
 }
 
 /**

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -1,3 +1,23 @@
+/*
+ * Rationale for not directly importing types from @types/pino for use in fastify interfaces:
+ * - pino does not itself provide types so the types from @types must be used.
+ * - the types from @types are unofficial and the preference is to avoid using them or requiring them as a dependency of fastify.
+ * - the goal is to provide the minimum viable type definitions necessary to use fastify's official logger, pino.
+ * - the types provided should cover the basic use cases for the majority of fastify users while also being easy to maintain.
+ * - for advanced use cases needing the full set of types, users should be directed to manually install the unofficial types with
+ *   `npm i -D @types/pino` and to supply their own logger instance as described at https://www.fastify.io/docs/latest/Logging/.
+ * - some fastify contributors have volunteered to maintain official types within pino (https://github.com/pinojs/pino/issues/910)
+ *   in which case if the proposal is followed through with then in the future fastify will be able to directly import the full
+ *   set of types rather than only duplicating and maintaining the subset chosen for providing a minimum viable logger api.
+ *
+ * Relevant discussions:
+ *
+ * https://github.com/fastify/fastify/pull/2550
+ * https://github.com/pinojs/pino/issues/910
+ * https://github.com/fastify/fastify/pull/1532
+ * https://github.com/fastify/fastify/issues/649
+ */
+
 import { FastifyError } from 'fastify-error'
 import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression } from './utils'
 import { FastifyRequest, RequestGenericInterface } from './request'

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -1,6 +1,7 @@
 import { FastifyError } from 'fastify-error'
 import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression } from './utils'
 import { FastifyRequest, RequestGenericInterface } from './request'
+import { PrettyOptions } from 'pino'
 
 /**
  * Standard Fastify logging function
@@ -61,5 +62,5 @@ export interface FastifyLoggerOptions<
   };
   level?: string;
   genReqId?: <RequestGeneric extends RequestGenericInterface = RequestGenericInterface>(req: FastifyRequest<RequestGeneric, RawServer, RawRequest>) => string;
-  prettyPrint?: boolean;
+  prettyPrint?: boolean | PrettyOptions;
 }

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -61,4 +61,5 @@ export interface FastifyLoggerOptions<
   };
   level?: string;
   genReqId?: <RequestGeneric extends RequestGenericInterface = RequestGenericInterface>(req: FastifyRequest<RequestGeneric, RawServer, RawRequest>) => string;
+  prettyPrint?: boolean;
 }


### PR DESCRIPTION
The `FastifyLoggerOptions` interface is missing a type definition for the `prettyPrint` option which `pino` supports when `pino-pretty` is installed.  The latest general [Logging docs](https://www.fastify.io/docs/latest/Logging/) already reference the `prettyPrint` option however without the type definition an error is shown when using TypeScript and passing the option to the logger when creating the Fastify instance. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
