### PR TITLE
fix: fastify plugin types exports

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -121,7 +121,7 @@ type TrustProxyFunction = (address: string, hop: number) => boolean
 /* Export all additional types */
 export { FastifyRequest, RequestGenericInterface } from './types/request'
 export { FastifyReply } from './types/reply'
-export { FastifyPluginOptions, FastifyPlugin } from './types/plugin'
+export { FastifyPluginCallback, FastifyPluginAsync, FastifyPluginOptions, FastifyPlugin } from './types/plugin'
 export { FastifyInstance } from './types/instance'
 export { FastifyLoggerOptions, FastifyLoggerInstance, FastifyLogFn, LogLevel } from './types/logger'
 export { FastifyContext } from './types/context'

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -1,4 +1,10 @@
-import fastify, { FastifyInstance } from '../../fastify'
+import fastify, {
+  FastifyInstance,
+  FastifyPlugin,
+  FastifyPluginAsync,
+  FastifyPluginCallback,
+  FastifyPluginOptions
+} from '../../fastify'
 import * as http from 'http'
 import * as https from 'https'
 import * as http2 from 'http2'
@@ -109,3 +115,7 @@ expectAssignable<FastifyInstance>(fastify({ schemaErrorFormatter: (errors, dataV
 // Thenable
 expectAssignable<PromiseLike<FastifyInstance>>(fastify({ return503OnClosing: true }))
 fastify().then(fastifyInstance => expectAssignable<FastifyInstance>(fastifyInstance))
+
+expectAssignable<FastifyPluginAsync>(async () => {})
+expectAssignable<FastifyPluginCallback>(() => {})
+expectAssignable<FastifyPlugin>(() => {})


### PR DESCRIPTION
These were accidentally removed in https://github.com/fastify/fastify/pull/2554

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Also adds tests to make sure these Types are exported.