### PR TITLE
Improve dec merging dev experience

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -15,6 +15,7 @@
   - [.callNotFound()](#callnotfound)
   - [.getResponseTime()](#getresponsetime)
   - [.type(contentType)](#typecontenttype)
+  - [.raw](#raw)
   - [.serializer(func)](#serializerfunc)
   - [.sent](#sent)
   - [.send(data)](#senddata)
@@ -206,6 +207,23 @@ reply
 ```
 
 See [`.send()`](#send) for more information on sending different types of values.
+
+<a name="raw"></a>
+### .raw
+This is the [`http.ServerResponse`](https://nodejs.org/dist/latest/docs/api/http.html#http_class_http_serverresponse) from Node core. While you're using the fastify `Reply` object, the use of `Reply.raw` functions is at your own risk as you're skipping all the fastify
+logic of handling the http response. eg:
+
+```js
+app.get('/cookie-2', (req, reply) => {
+  reply.setCookie('session', 'value', { secure: false }) // this will not be used
+
+  // in this case we are using only the nodejs http server response object
+  reply.raw.writeHead(200, { 'Content-Type': 'text/plain' })
+  reply.raw.write('ok')
+  reply.raw.end()
+})
+```
+Another example of the misuse of `Reply.raw` is explained in [Reply.md#getheaders](Reply.md#getheaders).
 
 <a name="sent"></a>
 ### .sent

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -10,6 +10,7 @@ The type system was changed in Fastify version 3. The new type system introduces
 
 > Plugins may or may not include typings. See [Plugins](#plugins) for more information. We encourage users to send pull requests to improve typings support.
 
+🚨 Don't foget to install `@types/node`
 
 ## Learn By Example
 

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -243,7 +243,7 @@ One of Fastify's most distinguishable features is its extensive plugin ecosystem
   ```bash
   npm init -y
   npm i fastify fastify-plugin
-  npm i -D typescript
+  npm i -D typescript @types/node
   ```
 2. Add a `build` script to the `"scripts"` section and `'index.d.ts'` to the `"types"` section of the `package.json` file:
   ```json

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -119,8 +119,8 @@ export type FastifyServerOptions<
 type TrustProxyFunction = (address: string, hop: number) => boolean
 
 /* Export all additional types */
-export { FastifyRequest, RequestGenericInterface } from './types/request'
-export { FastifyReply } from './types/reply'
+export * from './types/request'
+export * from './types/reply'
 export { FastifyPluginCallback, FastifyPluginAsync, FastifyPluginOptions, FastifyPlugin } from './types/plugin'
 export { FastifyInstance } from './types/instance'
 export { FastifyLoggerOptions, FastifyLoggerInstance, FastifyLogFn, LogLevel } from './types/logger'

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
   "devDependencies": {
     "@hapi/joi": "^17.1.1",
     "@sinonjs/fake-timers": "^6.0.1",
-    "@types/node": "^14.0.1",
     "@types/pino": "^6.0.1",
     "@typescript-eslint/eslint-plugin": "^2.29.0",
     "@typescript-eslint/parser": "^2.29.0",
@@ -184,6 +183,9 @@
     "rfdc": "^1.1.4",
     "secure-json-parse": "^2.0.0",
     "tiny-lru": "^7.0.0"
+  },
+  "peerDependencies": {
+    "@types/node": "^14.10.3"
   },
   "standard": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "@hapi/joi": "^17.1.1",
     "@sinonjs/fake-timers": "^6.0.1",
     "@types/pino": "^6.0.1",
+    "@types/node": "^14.10.3",
     "@typescript-eslint/eslint-plugin": "^2.29.0",
     "@typescript-eslint/parser": "^2.29.0",
     "JSONStream": "^1.3.5",
@@ -183,9 +184,6 @@
     "rfdc": "^1.1.4",
     "secure-json-parse": "^2.0.0",
     "tiny-lru": "^7.0.0"
-  },
-  "peerDependencies": {
-    "@types/node": "^14.10.3"
   },
   "standard": {
     "ignore": [

--- a/test/types/decorate-request-reply.test-d.ts
+++ b/test/types/decorate-request-reply.test-d.ts
@@ -1,0 +1,19 @@
+import fastify from '../../fastify'
+import { expectType } from 'tsd'
+
+type TestType = void
+
+// using declaration merging, add your plugin props to the appropriate fastify interfaces
+declare module '../../fastify' {
+  interface FastifyRequest {
+    testProp: TestType;
+  }
+  interface FastifyReply {
+    testProp: TestType;
+  }
+}
+
+fastify().get('/', (req, res) => {
+  expectType<TestType>(req.testProp)
+  expectType<TestType>(res.testProp)
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Fixes #2557 

Wasn't sure how we feel about shipping @types/node. I listed it as a peer dep instead. Our type definitions do actually depend on it so I'm not sure if it should be a proper dependency or not. The reason this sorta goes unnoticed is whenever a dev creates a TS + Node project its second nature to just `npm i -D typescript @types/node`. I'm assuming by listing this as a peer dep is at least another way to indicate to our TS users they need to install node types in order to use our types.