### PR TITLE
Add fastify-response-caching to ecosystem

### DIFF
--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -128,6 +128,7 @@ Plugins maintained by the fastify team are listed under [Core](#core) while plug
 - [`fastify-rbac`](https://gitlab.com/m03geek/fastify-rbac) Fastify role-based access control plugin.
 - [`fastify-register-routes`](https://github.com/israeleriston/fastify-register-routes) Plugin to automatically load routes from a specified path and optionally limit loaded file names by a regular expression.
 - [`fastify-response-time`](https://github.com/lolo32/fastify-response-time) Add `X-Response-Time` header at each request for Fastify, in milliseconds.
+- [`fastify-response-caching`](https://github.com/codeaholicguy/fastify-response-caching) A Fastify plugin for caching the response.
 - [`fastify-reverse-routes`](https://github.com/dimonnwc3/fastify-reverse-routes) Fastify reverse routes plugin, allows to defined named routes and build path using name and parameters.
 - [`fastify-rob-config`](https://github.com/jeromemacias/fastify-rob-config) Fastify Rob-Config integration.
 - [`fastify-schema-constraint`](https://github.com/Eomm/fastify-schema-constraint) Choose the JSON schema to use based on request parameters.


### PR DESCRIPTION
Hello everyone,

We are using Fastify for the microservice edge-gateway solution in ShopBack. Our system usually has a spike in traffic so we need to reduce the workload for downstream services, as well as prevent redundant operations. Then, we developed a plugin for caching the response and preventing the gateway to fire the same request at the spike time.

We think it is worth sharing this plugin with the Fastify community and we can together improve this.

Thanks.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
