### PR TITLE
Provide additional clarification for decorated fields

### DIFF
--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -55,6 +55,8 @@ fastify.get('/', (req, reply) => {
 })
 ```
 
+Note that it is important to keep initial shape of decorated field as close as possible to the value you intend to set dynamically in the future, so instantiate it as a `''` if intended value is string, and as `null` if it will be an object or a function.
+
 See
 [JavaScript engine fundamentals: Shapes and Inline Caches](https://web.archive.org/web/20200201163000/https://mathiasbynens.be/notes/shapes-ics)
 for more information on this topic.


### PR DESCRIPTION
Rationale behind this change: I'm seeing our developers instantiating decorated object fields with `''` because that's what they are seeing in current documentation, and I believe that defeats the whole point of avoiding the deoptimization.
Now I'm not sure if changing from null to object also causes deoptimization, but that's what I remember being instructed to use for dynamically set objects by @mcollina. If that doesn't help with deoptimization at all, and is just cleaner, I'd be happy to reword the documentation. Alternatively, would it be a better idea to instantiate such fields as `{}`?

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
