### PR TITLE
Added Attribute 'protocol' to Request

### DIFF
--- a/docs/Request.md
+++ b/docs/Request.md
@@ -14,6 +14,7 @@ Request is a core Fastify object containing the following fields:
 - `ip` - the IP address of the incoming request
 - `ips` - an array of the IP addresses in the `X-Forwarded-For` header of the incoming request (only when the [`trustProxy`](Server.md#factory-trust-proxy) option is enabled)
 - `hostname` - the hostname of the incoming request
+- `protocol` - the protocol of the incoming request (`https` or `http`)
 - `method` - the method of the incoming request
 - `url` - the url of the incoming request
 - `routerMethod` - the method defined for the router that is handling the request
@@ -32,6 +33,7 @@ fastify.post('/:params', options, function (request, reply) {
   console.log(request.ip)
   console.log(request.ips)
   console.log(request.hostname)
+  console.log(request.protocol)
   request.log.info('some info')
 })
 ```

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -293,13 +293,14 @@ const fastify = Fastify({ trustProxy: true })
 
 For more examples refer to [proxy-addr](https://www.npmjs.com/package/proxy-addr) package.
 
-You may access the `ip`, `ips`, and `hostname` values on the [`request`](Request.md) object.
+You may access the `ip`, `ips`, `hostname` and `protocol` values on the [`request`](Request.md) object.
 
 ```js
 fastify.get('/', (request, reply) => {
   console.log(request.ip)
   console.log(request.ips)
   console.log(request.hostname)
+  console.log(request.protocol)
 })
 ```
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -78,6 +78,17 @@ function buildRequestWithTrustProxy (R, trustProxy) {
         }
         return this.headers.host || this.headers[':authority']
       }
+    },
+    protocol: {
+      get () {
+        if (this.headers['x-forwarded-proto']) {
+          const proto = this.headers['x-forwarded-proto']
+          // we use the last one if the header is set more than once
+          const lastIndex = proto.lastIndexOf(',')
+          return lastIndex === -1 ? proto.trim() : proto.slice(lastIndex + 1).trim()
+        }
+        return this.connection.encrypted ? 'https' : 'http'
+      }
     }
   })
 
@@ -129,6 +140,11 @@ Object.defineProperties(Request.prototype, {
   hostname: {
     get () {
       return this.raw.headers.host || this.raw.headers[':authority']
+    }
+  },
+  protocol: {
+    get () {
+      return this.connection.encrypted ? 'https' : 'http'
     }
   },
   headers: {

--- a/test/http2/secure.test.js
+++ b/test/http2/secure.test.js
@@ -25,6 +25,9 @@ try {
 fastify.get('/', function (req, reply) {
   reply.code(200).send(msg)
 })
+fastify.get('/proto', function (req, reply) {
+  reply.code(200).send({ proto: req.protocol })
+})
 
 fastify.listen(0, err => {
   t.error(err)
@@ -39,5 +42,13 @@ fastify.listen(0, err => {
     t.strictEqual(res.headers[':status'], 200)
     t.strictEqual(res.headers['content-length'], '' + JSON.stringify(msg).length)
     t.deepEqual(JSON.parse(res.body), msg)
+  })
+
+  test('https get request without trust proxy - protocol', async (t) => {
+    t.plan(2)
+
+    const url = `https://localhost:${fastify.server.address().port}/proto`
+    t.deepEqual(JSON.parse((await h2url.concat({ url })).body), { proto: 'https' })
+    t.deepEqual(JSON.parse((await h2url.concat({ url, headers: { 'X-Forwarded-Proto': 'lorem' } })).body), { proto: 'https' })
   })
 })

--- a/test/https/https.test.js
+++ b/test/https/https.test.js
@@ -25,6 +25,9 @@ test('https get', t => {
     fastify.get('/', function (req, reply) {
       reply.code(200).send({ hello: 'world' })
     })
+    fastify.get('/proto', function (req, reply) {
+      reply.code(200).send({ proto: req.protocol })
+    })
     t.pass()
   } catch (e) {
     t.fail()
@@ -46,6 +49,29 @@ fastify.listen(0, err => {
       t.strictEqual(response.statusCode, 200)
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.deepEqual(JSON.parse(body), { hello: 'world' })
+    })
+  })
+
+  test('https get request without trust proxy - protocol', t => {
+    t.plan(4)
+    sget({
+      method: 'GET',
+      url: 'https://localhost:' + fastify.server.address().port + '/proto',
+      rejectUnauthorized: false
+    }, (err, response, body) => {
+      t.error(err)
+      t.deepEqual(JSON.parse(body), { proto: 'https' })
+    })
+    sget({
+      method: 'GET',
+      url: 'https://localhost:' + fastify.server.address().port + '/proto',
+      rejectUnauthorized: false,
+      headers: {
+        'x-forwarded-proto': 'lorem'
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.deepEqual(JSON.parse(body), { proto: 'https' })
     })
   })
 })

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -28,6 +28,7 @@ export interface FastifyRequest<
   ip: string;
   ips?: string[];
   hostname: string;
+  protocol: string;
   url: string;
   method: string;
   routerPath: string;

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -28,7 +28,7 @@ export interface FastifyRequest<
   ip: string;
   ips?: string[];
   hostname: string;
-  protocol: string;
+  protocol: 'http' | 'https';
   url: string;
   method: string;
   routerPath: string;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Hey,
one thing I missed in fastify was a way to easily determine whether the used protocol is `http` or `https`.
So I added that feature analogous to `ip` and `hostname` with the `X-Forwarded-Proto`-header.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
