### PR TITLE
Support for named export in Node v14.13.0

### DIFF
--- a/examples/simple.mjs
+++ b/examples/simple.mjs
@@ -1,0 +1,27 @@
+// works on Node v14.13.0+
+import { fastify } from '../fastify.js'
+
+const app = fastify({
+  logger: false
+})
+
+const schema = {
+  schema: {
+    response: {
+      200: {
+        type: 'object',
+        properties: {
+          hello: {
+            type: 'string'
+          }
+        }
+      }
+    }
+  }
+}
+
+app.get('/', schema, async function (req, reply) {
+  return { hello: 'world' }
+})
+
+app.listen(3000).catch(console.error)

--- a/fastify.js
+++ b/fastify.js
@@ -608,6 +608,6 @@ function loadVersion () {
  * - `import fastify from 'fastify'`
  * - `import fastify, { TSC_definition } from 'fastify'`
  */
-fastify.fastify = fastify
-fastify.default = fastify
 module.exports = fastify
+module.exports.fastify = fastify
+module.exports.default = fastify

--- a/test/esm/index.test.js
+++ b/test/esm/index.test.js
@@ -4,14 +4,27 @@ const t = require('tap')
 const semver = require('semver')
 
 if (semver.lt(process.versions.node, '13.3.0')) {
-  t.skip('Skip because Node version <= 13.3.0')
-  t.end()
+  t.skip('Skip esm because Node version <= 13.3.0')
 } else {
   // Node v8 throw a `SyntaxError: Unexpected token import`
   // even if this branch is never touch in the code,
   // by using `eval` we can avoid this issue.
   // eslint-disable-next-line
   new Function('module', 'return import(module)')('./esm.mjs').catch((err) => {
+    process.nextTick(() => {
+      throw err
+    })
+  })
+}
+
+if (semver.lt(process.versions.node, '14.13.0')) {
+  t.skip('Skip named exports because Node version < 14.13.0')
+} else {
+  // Node v8 throw a `SyntaxError: Unexpected token import`
+  // even if this branch is never touch in the code,
+  // by using `eval` we can avoid this issue.
+  // eslint-disable-next-line
+  new Function('module', 'return import(module)')('./named-exports.mjs').catch((err) => {
     process.nextTick(() => {
       throw err
     })

--- a/test/esm/named-exports.mjs
+++ b/test/esm/named-exports.mjs
@@ -1,0 +1,13 @@
+import t from 'tap'
+import { fastify } from '../../fastify.js'
+
+t.test('named exports support', async t => {
+  const app = fastify()
+
+  app.register(import('./plugin.mjs'), { foo: 'bar' })
+  app.register(import('./other.mjs'))
+
+  await app.ready()
+
+  t.strictEqual(app.foo, 'bar')
+})


### PR DESCRIPTION

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
