### PR TITLE
fix: bind instance to error handler

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -558,7 +558,7 @@ function fastify (options) {
   function setErrorHandler (func) {
     throwIfAlreadyStarted('Cannot call "setErrorHandler" when fastify instance is already started!')
 
-    this._errorHandler = func
+    this._errorHandler = func.bind(this)
     return this
   }
 }

--- a/test/request-error.test.js
+++ b/test/request-error.test.js
@@ -126,3 +126,84 @@ test('default clientError handler ignores ECONNRESET', t => {
     client.write('\r\n\r\n')
   })
 })
+
+test('error handler binding', t => {
+  t.plan(5)
+
+  const fastify = Fastify()
+
+  fastify.setErrorHandler(function (err, request, reply) {
+    t.strictEqual(this, fastify)
+    reply
+      .code(err.statusCode)
+      .type('application/json; charset=utf-8')
+      .send(err)
+  })
+
+  fastify.post('/', function (req, reply) {
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    simulate: {
+      error: true
+    },
+    body: {
+      text: '12345678901234567890123456789012345678901234567890'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 400)
+    t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+    t.deepEqual(JSON.parse(res.payload), {
+      error: 'Bad Request',
+      message: 'Simulated',
+      statusCode: 400
+    })
+  })
+})
+
+test('encapsulated error handler binding', t => {
+  t.plan(7)
+
+  const fastify = Fastify()
+
+  fastify.register(function (app, opts, next) {
+    app.decorate('hello', 'world')
+    t.strictEqual(app.hello, 'world')
+    app.post('/', function (req, reply) {
+      reply.send({ hello: 'world' })
+    })
+    app.setErrorHandler(function (err, request, reply) {
+      t.strictEqual(this.hello, 'world')
+      reply
+        .code(err.statusCode)
+        .type('application/json; charset=utf-8')
+        .send(err)
+    })
+    next()
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    simulate: {
+      error: true
+    },
+    body: {
+      text: '12345678901234567890123456789012345678901234567890'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 400)
+    t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+    t.deepEqual(res.json(), {
+      error: 'Bad Request',
+      message: 'Simulated',
+      statusCode: 400
+    })
+    t.strictEqual(fastify.hello, undefined)
+  })
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This is basically a copy paste from https://github.com/fastify/fastify/pull/2305
with the ts for FastifyError excluded as it seems it's a separate package these days.

This is my first time looking at fastify source so forgive me if something escapes me here.

I'm getting an error when running `npm test` locally in test/http2/head.test.js and test/http2/plain.test.js (both seems to be flaky, has broken and passed sporadically in both master and in this branch) so I'm pushing this anyway because at glance it looks like my environment isn't correct rather than added lines breaking tests.

I don't think documentation applies as FastifyError seems to be a separate package? Correct me if I'm wrong.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
