### PR TITLE
Deprecated API usage (#2575)

### DIFF
--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -159,7 +159,7 @@ const fastify = Fastify({
           headers: request.headers,
           hostname: request.hostname,
           remoteAddress: request.ip,
-          remotePort: request.connection.remotePort
+          remotePort: request.socket.remotePort
         }
       }
     }

--- a/docs/Request.md
+++ b/docs/Request.md
@@ -20,7 +20,9 @@ Request is a core Fastify object containing the following fields:
 - `routerMethod` - the method defined for the router that is handling the request
 - `routerPath` - the path pattern defined for the router that is handling the request
 - `is404` - true if request is being handled by 404 handler, false if it is not
-- `connection` - the underlying connection of the incoming request
+- `connection` - Deprecated, use `socket` instead. The underlying connection of the incoming request.
+- `socket` - the underlying connection of the incoming request
+
 
 ```js
 fastify.post('/:params', options, function (request, reply) {

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -360,7 +360,7 @@ const fastify = Fastify({
           headers: req.headers,
           hostname: req.hostname,
           remoteAddress: req.ip,
-          remotePort: req.connection.remotePort
+          remotePort: req.socket.remotePort
         }
       }
     }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -53,7 +53,7 @@ const serializers = {
       version: req.headers['accept-version'],
       hostname: req.hostname,
       remoteAddress: req.ip,
-      remotePort: req.connection.remotePort
+      remotePort: req.socket.remotePort
     }
   },
   err: pino.stdSerializers.err,

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const proxyAddr = require('proxy-addr')
+const semver = require('semver')
 const warning = require('./warnings')
 
 function Request (id, params, req, query, log, context) {
@@ -87,7 +88,7 @@ function buildRequestWithTrustProxy (R, trustProxy) {
           const lastIndex = proto.lastIndexOf(',')
           return lastIndex === -1 ? proto.trim() : proto.slice(lastIndex + 1).trim()
         }
-        return this.connection.encrypted ? 'https' : 'http'
+        return this.socket.encrypted ? 'https' : 'http'
       }
     }
   })
@@ -129,12 +130,20 @@ Object.defineProperties(Request.prototype, {
   },
   connection: {
     get () {
+      if (semver.gte(process.versions.node, '13.0.0')) {
+        warning.emit('FSTDEP005')
+      }
       return this.raw.connection
+    }
+  },
+  socket: {
+    get () {
+      return this.raw.socket
     }
   },
   ip: {
     get () {
-      return this.connection.remoteAddress
+      return this.socket.remoteAddress
     }
   },
   hostname: {
@@ -144,7 +153,7 @@ Object.defineProperties(Request.prototype, {
   },
   protocol: {
     get () {
-      return this.connection.encrypted ? 'https' : 'http'
+      return this.socket.encrypted ? 'https' : 'http'
     }
   },
   headers: {

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -8,6 +8,7 @@ const warning = require('fastify-warning')()
  *   - FSTDEP002
  *   - FSTDEP003
  *   - FSTDEP004
+ *   - FSTDEP005
  */
 
 warning.create('FastifyDeprecation', 'FSTDEP001', 'You are accessing the Node.js core request object via "request.req", Use "request.raw" instead.')
@@ -17,5 +18,7 @@ warning.create('FastifyDeprecation', 'FSTDEP002', 'You are accessing the Node.js
 warning.create('FastifyDeprecation', 'FSTDEP003', 'You are using the legacy Content Type Parser function signature. Use the one suggested in the documentation instead.')
 
 warning.create('FastifyDeprecation', 'FSTDEP004', 'You are using the legacy preParsing hook signature. Use the one suggested in the documentation instead.')
+
+warning.create('FastifyDeprecation', 'FSTDEP005', 'You are accessing the deprecated "request.connection" property. Use "request.socket" instead.')
 
 module.exports = warning

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "fastify-warning": "^0.2.0",
     "find-my-way": "^3.0.0",
     "flatstr": "^1.0.12",
-    "light-my-request": "^4.0.2",
+    "light-my-request": "^4.1.0",
     "pino": "^6.2.1",
     "proxy-addr": "^2.0.5",
     "readable-stream": "^3.4.0",

--- a/test/internals/request.test.js
+++ b/test/internals/request.test.js
@@ -12,7 +12,7 @@ test('Regular request', t => {
   const req = {
     method: 'GET',
     url: '/',
-    connection: { remoteAddress: 'ip' },
+    socket: { remoteAddress: 'ip' },
     headers
   }
   const request = new Request('id', 'params', req, 'query', 'log')
@@ -29,7 +29,7 @@ test('Regular request', t => {
   t.strictEqual(request.body, null)
   t.strictEqual(request.method, 'GET')
   t.strictEqual(request.url, '/')
-  t.deepEqual(request.connection, req.connection)
+  t.deepEqual(request.socket, req.socket)
 })
 
 test('Regular request - hostname from authority', t => {
@@ -40,7 +40,7 @@ test('Regular request - hostname from authority', t => {
   const req = {
     method: 'GET',
     url: '/',
-    connection: { remoteAddress: 'ip' },
+    socket: { remoteAddress: 'ip' },
     headers
   }
 
@@ -58,7 +58,7 @@ test('Regular request - host header has precedence over authority', t => {
   const req = {
     method: 'GET',
     url: '/',
-    connection: { remoteAddress: 'ip' },
+    socket: { remoteAddress: 'ip' },
     headers
   }
   const request = new Request('id', 'params', req, 'query', 'log')
@@ -75,6 +75,9 @@ test('Request with trust proxy', t => {
   const req = {
     method: 'GET',
     url: '/',
+    // Some dependencies (proxy-addr, forwarded) still depend on the deprecated
+    // .connection property, we use .socket. Include both to satisfy everyone.
+    socket: { remoteAddress: 'ip' },
     connection: { remoteAddress: 'ip' },
     headers
   }
@@ -94,7 +97,7 @@ test('Request with trust proxy', t => {
   t.strictEqual(request.body, null)
   t.strictEqual(request.method, 'GET')
   t.strictEqual(request.url, '/')
-  t.deepEqual(request.connection, req.connection)
+  t.deepEqual(request.socket, req.socket)
 })
 
 test('Request with trust proxy - no x-forwarded-host header', t => {

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1423,7 +1423,7 @@ test('should redact the authorization header if so specified', t => {
             headers: req.headers,
             hostname: req.hostname,
             remoteAddress: req.ip,
-            remotePort: req.connection.remotePort
+            remotePort: req.socket.remotePort
           }
         }
       }

--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -53,7 +53,7 @@ const getHandler: RouteHandler = function (request, _reply) {
   expectType<RequestQuerystringDefault>(request.query)
   expectType<any>(request.id)
   expectType<FastifyLoggerInstance>(request.log)
-  expectType<RawRequestDefaultExpression['socket']>(request.connection)
+  expectType<RawRequestDefaultExpression['socket']>(request.socket)
   expectType<Error & { validation: any; validationContext: string } | undefined>(request.validationError)
 }
 

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -42,7 +42,9 @@ export interface FastifyRequest<
   readonly routerPath: string;
   readonly routerMethod: string;
   readonly is404: boolean;
+  readonly socket: RawRequest['socket'];
 
-  // `connection` is a deprecated alias for `socket` and doesn't exist in `Http2ServerRequest`
+  // Prefer `socket` over deprecated `connection` property in node 13.0.0 or higher
+  // @deprecated
   readonly connection: RawRequest['socket'];
 }


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This fixes #2575, switching to use `request.socket` over the [deprecated `request.connection`](https://nodejs.org/api/http.html#http_request_connection).  It relies on https://github.com/fastify/light-my-request/pull/99, and updates `light-my-request` to 4.1.0.  I've also updated `request.test.js` to provide the required `socket` and/or `connection` properties as necessary.