### PR TITLE
forward error to reply.send() instead of done() onRequest and preHandler

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -227,11 +227,11 @@ fastify.addHook('onTimeout', async (request, reply) => {
 
 
 ### Manage Errors from a hook
-If you get an error during the execution of your hook, just pass it to `reply.send()` and Fastify will automatically close the request and send the appropriate error code to the user.
+If you get an error during the execution of your hook, just pass it to `done()` and Fastify will automatically close the request and send the appropriate error code to the user.
 
 ```js
 fastify.addHook('onRequest', (request, reply, done) => {
-  reply.send(new Error('Some error'))
+  done(new Error('Some error'))
 })
 ```
 
@@ -239,7 +239,7 @@ If you want to pass a custom error code to the user, just use `reply.code()`:
 ```js
 fastify.addHook('preHandler', (request, reply, done) => {
   reply.code(400)
-  reply.send(new Error('Some error'))
+  done(new Error('Some error'))
 })
 ```
 *The error will be handled by [`Reply`](Reply.md#errors).*

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -227,11 +227,11 @@ fastify.addHook('onTimeout', async (request, reply) => {
 
 
 ### Manage Errors from a hook
-If you get an error during the execution of your hook, just pass it to `done()` and Fastify will automatically close the request and send the appropriate error code to the user.
+If you get an error during the execution of your hook, just pass it to `reply.send()` and Fastify will automatically close the request and send the appropriate error code to the user.
 
 ```js
 fastify.addHook('onRequest', (request, reply, done) => {
-  done(new Error('Some error'))
+  reply.send(new Error('Some error'))
 })
 ```
 
@@ -239,7 +239,7 @@ If you want to pass a custom error code to the user, just use `reply.code()`:
 ```js
 fastify.addHook('preHandler', (request, reply, done) => {
   reply.code(400)
-  done(new Error('Some error'))
+  reply.send(new Error('Some error'))
 })
 ```
 *The error will be handled by [`Reply`](Reply.md#errors).*

--- a/docs/Lifecycle.md
+++ b/docs/Lifecycle.md
@@ -10,7 +10,7 @@ Incoming Request
         │
         └─▶ Instance Logger
              │
-       404 ◀─┴─▶ onRequest Hook
+   4**/5** ◀─┴─▶ onRequest Hook
                   │
         4**/5** ◀─┴─▶ preParsing Hook
                         │
@@ -20,7 +20,7 @@ Incoming Request
                                   │
                             415 ◀─┴─▶ Validation
                                         │
-                                  400 ◀─┴─▶ preHandler Hook
+                              4**/5** ◀─┴─▶ preHandler Hook
                                               │
                                     4**/5** ◀─┴─▶ User Handler
                                                     │


### PR DESCRIPTION

update document based on #2561 forward error to reply.send() instead of done() onRequest and preHandler from adding a hook. Please review, Thanks!