### PR TITLE
Reverting `export *` syntax

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -119,8 +119,8 @@ export type FastifyServerOptions<
 type TrustProxyFunction = (address: string, hop: number) => boolean
 
 /* Export all additional types */
-export * from './types/request'
-export * from './types/reply'
+export { FastifyRequest, RequestGenericInterface } from './types/request'
+export { FastifyReply } from './types/reply'
 export { FastifyPluginCallback, FastifyPluginAsync, FastifyPluginOptions, FastifyPlugin } from './types/plugin'
 export { FastifyInstance } from './types/instance'
 export { FastifyLoggerOptions, FastifyLoggerInstance, FastifyLogFn, LogLevel } from './types/logger'


### PR DESCRIPTION
Reverting `export *` syntax because it is breaking module augmentation for `FastifyReply`

For example, the following code fails:

```
import fastify from 'fastify';

declare module 'fastify' {
  interface FastifyReply {
    hello: string;
  }
}

const server = fastfiy();
server.decorateReply('hello', 'world');

server.get('/hello', async (request, reply) => {
  reply.send(reply.hello);
})
```
with error: `Property 'hello' does not exist on type 'FastifyReply<Server, IncomingMessage, ServerResponse, RouteGenericInterface, unknown>'.`

And after applying the fix, the code works as expected and returns `world`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
