### PR TITLE
Add a second route for optional parameters (with a '?' suffix) - only…

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -142,6 +142,15 @@ function buildRouting (options) {
       throw new Error(`Error Handler for ${opts.method}:${opts.url} route, if defined, must be a function`)
     }
 
+    // Handle optional parameter
+    const path = opts.url || opts.path
+    const optionalParam = path.match(/:([^/]*)\?\/?$/)
+    if (optionalParam) {
+      opts.url = path.replace(/(:[^/]*)\?(\/?)$/, '$1$2')
+      const optionalPath = path.replace(/\/:([^/]*)\?(\/?)$/, '$2')
+      route.call(this, Object.assign({}, options, { url: optionalPath }))
+    }
+
     validateBodyLimitOption(opts.bodyLimit)
 
     const prefix = this[kRoutePrefix]

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -545,3 +545,40 @@ test('throws when route-level error handler is not a function', t => {
     t.is(err.message, 'Error Handler for GET:/tea route, if defined, must be a function')
   }
 })
+
+test('route - optional parameter', t => {
+  t.plan(4)
+
+  const fastify = Fastify()
+
+  fastify.route({
+    method: 'GET',
+    path: '/foo/:opt?',
+    handler: (req, res) => {
+      res.send({ opt: req.params?.opt || false })
+    }
+  })
+
+  fastify.listen(0, function (err) {
+    if (err) t.error(err)
+    fastify.server.unref()
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port + '/foo'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.deepEqual(JSON.parse(body), { opt: false })
+    })
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port + '/foo/bar'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.deepEqual(JSON.parse(body), { opt: 'bar' })
+    })
+  })
+})


### PR DESCRIPTION
Add a second route for optional parameters (with a '?' suffix) - only if the parameter is at the end of the path
Added test for optional route parameter

Hapi uses the same route format, their documentation:

>  An optional '?' suffix following the parameter name indicates an optional parameter (only allowed if the parameter is at the ends of the path or only covers part of the segment as in '/a{param?}/b'). For example, the route '/book/{id?}' matches '/book/' with the value of request.params.id set to an empty string ''.

Issue reference: https://github.com/fastify/fastify/issues/1206

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
