### PR TITLE
Checked if error handler is default before setting headers

### DIFF
--- a/docs/Errors.md
+++ b/docs/Errors.md
@@ -37,7 +37,7 @@ For customizing this behaviour, you should use [`setErrorHandler`](Server.md#set
 From the [Hooks documentation](Hooks/#manage-errors-from-a-hook): 
 > If you get an error during the execution of your hook, just pass it to `done()` and Fastify will automatically close the request and send the appropriate error code to the user.
 
-If you have defined a custom error handler for using `setErrorHandler` the error will be routed there, otherwise it will be routed to Fastify’s generic error handler. 
+If you have defined a custom error handler using `setErrorHandler` the error will be routed there, otherwise it will be routed to Fastify’s generic error handler. Fastify's generic error handler will use the header and status code in the Error object if it exists. The headers and status code will not be automatically set if a custom error handler is provided.
 
 Some things to consider in your custom error handler: 
 
@@ -48,6 +48,7 @@ Some things to consider in your custom error handler:
 - You can throw a new error in your custom error handler
 	- errors (new error or the received error parameter re-thrown) - will trigger the `onError` lifecycle hook and send the error to the user
 	- an error will not be triggered twice from a lifecycle hook - Fastify internally monitors the error invocation to avoid infinite loops for errors thrown in the reply phases of the lifecycle. (those after the route handler) 
+	- errors sent or thrown by a custom error handler will be routed to Fastify's default error handler
 
 
 <a name="fastify-error-codes"></a>

--- a/fastify.js
+++ b/fastify.js
@@ -46,6 +46,7 @@ const build404 = require('./lib/fourOhFour')
 const getSecuredInitialConfig = require('./lib/initialConfigValidation')
 const override = require('./lib/pluginOverride')
 const { defaultInitOptions } = getSecuredInitialConfig
+const setErrorHeaders = require('./lib/setErrorHeaders')
 
 const {
   FST_ERR_BAD_URL,
@@ -60,6 +61,7 @@ const onBadUrlContext = {
 }
 
 function defaultErrorHandler (error, request, reply) {
+  setErrorHeaders(error, reply)
   if (reply.statusCode < 500) {
     reply.log.info(
       { res: reply, err: error },

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -26,6 +26,7 @@ const internals = require('./handleRequest')[Symbol.for('internals')]
 const loggerUtils = require('./logger')
 const now = loggerUtils.now
 const wrapThenable = require('./wrapThenable')
+const setErrorHeaders = require('./setErrorHeaders')
 
 const serializeError = FJS({
   type: 'object',
@@ -503,21 +504,7 @@ function onErrorHook (reply, error, cb) {
 function handleError (reply, error, cb) {
   reply[kReplyIsRunningOnErrorHook] = false
   const res = reply.raw
-  let statusCode = res.statusCode
-  statusCode = (statusCode >= 400) ? statusCode : 500
-  // treat undefined and null as same
-  if (error != null) {
-    if (error.headers !== undefined) {
-      reply.headers(error.headers)
-    }
-    if (error.status >= 400) {
-      statusCode = error.status
-    } else if (error.statusCode >= 400) {
-      statusCode = error.statusCode
-    }
-  }
-
-  res.statusCode = statusCode
+  setErrorHeaders(error, reply)
 
   const errorHandler = reply.context.errorHandler
   if (errorHandler && reply[kReplyErrorHandlerCalled] === false) {
@@ -533,10 +520,10 @@ function handleError (reply, error, cb) {
   }
 
   const payload = serializeError({
-    error: statusCodes[statusCode + ''],
+    error: statusCodes[res.statusCode + ''],
     code: error.code,
     message: error.message || '',
-    statusCode: statusCode
+    statusCode: res.statusCode
   })
   flatstr(payload)
   reply[kReplyHeaders]['content-type'] = CONTENT_TYPE.JSON

--- a/lib/setErrorHeaders.js
+++ b/lib/setErrorHeaders.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const { kReplyErrorHandlerCalled } = require('./symbols.js')
+
+function setErrorHeaders (error, reply) {
+  const res = reply.raw
+  let statusCode = res.statusCode
+  statusCode = (statusCode >= 400) ? statusCode : 500
+  // treat undefined and null as same
+  if (error != null && reply[kReplyErrorHandlerCalled] === true) {
+    if (error.headers !== undefined) {
+      reply.headers(error.headers)
+    }
+    if (error.status >= 400) {
+      statusCode = error.status
+    } else if (error.statusCode >= 400) {
+      statusCode = error.statusCode
+    }
+    res.statusCode = statusCode
+  }
+}
+
+module.exports = setErrorHeaders

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -288,7 +288,7 @@ test('Support rejection with values that are not Error instances', t => {
         } else {
           t.strictEqual(err, nonErr)
         }
-        reply.send('error')
+        reply.code(500).send('error')
       })
 
       fastify.inject({
@@ -335,7 +335,7 @@ test('invalid schema - ajv', t => {
   })
 })
 
-test('should set the status code and the headers from the error object (from route handler)', t => {
+test('should set the status code and the headers from the error object (from route handler) (no custom error handler)', t => {
   t.plan(4)
   const fastify = Fastify()
 
@@ -373,7 +373,7 @@ test('should set the status code and the headers from the error object (from cus
 
   fastify.setErrorHandler((err, request, reply) => {
     t.is(err.message, 'ouch')
-    t.is(reply.raw.statusCode, 401)
+    t.is(reply.raw.statusCode, 200)
     const error = new Error('kaboom')
     error.headers = { hello: 'world' }
     error.statusCode = 400
@@ -441,6 +441,74 @@ test('should throw an error if the custom serializer does not serialize the payl
     method: 'GET'
   }, (e, res) => {
     t.fail('should not be called')
+  })
+})
+
+test('should not set headers or status code for custom error handler', t => {
+  t.plan(7)
+
+  const fastify = Fastify()
+  fastify.get('/', function (req, reply) {
+    const err = new Error('kaboom')
+    err.headers = {
+      'fake-random-header': 'abc'
+    }
+    reply.send(err)
+  })
+
+  fastify.setErrorHandler(async (err, req, res) => {
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual('fake-random-header' in res.headers, false)
+    res.code(500).send(err.message)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 500)
+    t.strictEqual('fake-random-header' in res.headers, false)
+    t.strictEqual(res.headers['content-length'], ('kaboom'.length).toString())
+    t.deepEqual(res.payload, 'kaboom')
+  })
+})
+
+test('error thrown by custom error handler routes to default error handler', t => {
+  t.plan(6)
+
+  const fastify = Fastify()
+
+  const error = new Error('kaboom')
+  error.headers = {
+    'fake-random-header': 'abc'
+  }
+
+  fastify.get('/', function (req, reply) {
+    reply.send(error)
+  })
+
+  const newError = new Error('kabong')
+
+  fastify.setErrorHandler(async (err, req, res) => {
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual('fake-random-header' in res.headers, false)
+    t.deepEqual(err.headers, error.headers)
+
+    res.send(newError)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 500)
+    t.deepEqual(JSON.parse(res.payload), {
+      error: statusCodes['500'],
+      message: newError.message,
+      statusCode: 500
+    })
   })
 })
 

--- a/test/route-hooks.test.js
+++ b/test/route-hooks.test.js
@@ -220,7 +220,7 @@ function testBeforeHandlerHook (hook) {
 
     fastify.setErrorHandler(async (error, request, reply) => {
       t.deepEqual(error, myError, 'the error object throws by the user')
-      reply.send({ this: 'is', my: 'error' })
+      reply.code(500).send({ this: 'is', my: 'error' })
     })
 
     fastify.get('/', {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
Seems like the fix suggested in #2602 did not change the behavior accurately. I added an extra isDefaultErrorHandler attribute to Context and checked for it before setting headers. 
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
