### PR TITLE
fix: remove `.use` from types

### DIFF
--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -16,9 +16,6 @@ expectAssignable<FastifyInstance>(server.addSchema({
 expectType<Record<string, unknown>>(server.getSchemas())
 expectType<unknown>(server.getSchema('SchemaId'))
 
-expectType<unknown>(server.use(() => {}))
-expectType<unknown>(server.use('/foo', () => {}))
-
 expectAssignable<FastifyInstance>(
   server.setErrorHandler(function (error, request, reply) {
     expectAssignable<FastifyInstance>(this)

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -59,13 +59,6 @@ export interface FastifyInstance<
 
   register: FastifyRegister<FastifyInstance<RawServer, RawRequest, RawReply, Logger> & PromiseLike<undefined>>;
 
-  /**
-   * This method will throw a `FST_ERR_MISSING_MIDDLEWARE` error unless support
-   * for Express-style middlewares is first enabled. Visit
-   * https://fastify.io/docs/latest/Middleware/ for more info.
-   */
-  use(...args: unknown[]): unknown;
-
   route<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
     ContextConfig = ContextConfigDefault


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

As discussed in https://github.com/fastify/fastify-express/pull/7, it's currently not possible to overload the `use` from here with a properly typed one. I _think_ just removing `use` from core makes sense since it'll throw an error during runtime anyways, but I might be wrong.