### PR TITLE
#2430 add validationContext to custom errors passed into the custom e…

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -97,6 +97,7 @@ function validate (context, request) {
 
 function wrapValidationError (result, dataVar, schemaErrorFormatter) {
   if (result instanceof Error) {
+    result.validationContext = result.validationContext || dataVar
     return result
   }
 

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -129,7 +129,7 @@ test('error inside custom error handler should have validationContext', t => {
   }, () => {})
 })
 
-test('error inside custom error handler should have validationContext if specified by customer error handler', t => {
+test('error inside custom error handler should have validationContext if specified by custom error handler', t => {
   t.plan(1)
 
   const fastify = Fastify()

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -97,6 +97,72 @@ test('should be able to use setErrorHandler specify custom validation error', t 
   })
 })
 
+test('error inside custom error handler should have validationContext', t => {
+  t.plan(1)
+
+  const fastify = Fastify()
+
+  fastify.post('/', {
+    schema,
+    validatorCompiler: ({ schema, method, url, httpPart }) => {
+      return function (data) {
+        return { error: new Error('this failed') }
+      }
+    }
+  }, function (req, reply) {
+    t.fail('should not be here')
+    reply.code(200).send(req.body.name)
+  })
+
+  fastify.setErrorHandler(function (error, request, reply) {
+    t.strictEqual(error.validationContext, 'body')
+    reply.status(500).send(error)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    payload: {
+      name: 'michelangelo',
+      work: 'artist'
+    },
+    url: '/'
+  }, () => {})
+})
+
+test('error inside custom error handler should have validationContext if specified by customer error handler', t => {
+  t.plan(1)
+
+  const fastify = Fastify()
+
+  fastify.post('/', {
+    schema,
+    validatorCompiler: ({ schema, method, url, httpPart }) => {
+      return function (data) {
+        const error = new Error('this failed')
+        error.validationContext = 'customContext'
+        return { error: error }
+      }
+    }
+  }, function (req, reply) {
+    t.fail('should not be here')
+    reply.code(200).send(req.body.name)
+  })
+
+  fastify.setErrorHandler(function (error, request, reply) {
+    t.strictEqual(error.validationContext, 'customContext')
+    reply.status(500).send(error)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    payload: {
+      name: 'michelangelo',
+      work: 'artist'
+    },
+    url: '/'
+  }, () => {})
+})
+
 test('should be able to attach validation to request', t => {
   t.plan(3)
 


### PR DESCRIPTION
…rror handler

I believe I've implemented what this issue was after: https://github.com/fastify/fastify/issues/2430 in a non-breaking way and I have added unit tests for the two cases I believe are relevant.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
