### PR TITLE
warning test on deprecate request.connection usage

### DIFF
--- a/test/emit-warning.test.js
+++ b/test/emit-warning.test.js
@@ -3,6 +3,7 @@
 const sget = require('simple-get').concat
 const { test } = require('tap')
 const Fastify = require('..')
+const semver = require('semver')
 
 process.removeAllListeners('warning')
 
@@ -129,3 +130,33 @@ test('Should emit a warning when using payload less preParsing hook', t => {
     })
   })
 })
+
+if (semver.gte(process.versions.node, '13.0.0')) {
+  test('Should emit a warning when accessing request.connection instead of request.socket on Node process greater than 13.0.0', t => {
+    t.plan(4)
+
+    process.on('warning', onWarning)
+    function onWarning (warning) {
+      t.strictEqual(warning.name, 'FastifyDeprecation')
+      t.strictEqual(warning.code, 'FSTDEP005')
+      t.strictEqual(warning.message, 'You are accessing the deprecated "request.connection" property. Use "request.socket" instead.')
+
+      // removed listener before light-my-request emit second warning
+      process.removeListener('warning', onWarning)
+    }
+
+    const fastify = Fastify()
+
+    fastify.get('/', (request, reply) => {
+      reply.send(request.connection)
+    })
+
+    fastify.inject({
+      method: 'GET',
+      path: '/'
+    }, (err, res) => {
+      t.error(err)
+      process.removeListener('warning', onWarning)
+    })
+  })
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Missing test, helps with https://github.com/fastify/fastify/issues/2381

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
