### PR TITLE
test(types): add register test type

### DIFF
--- a/test/types/register.test-d.ts
+++ b/test/types/register.test-d.ts
@@ -1,0 +1,16 @@
+import { expectAssignable, expectError } from 'tsd'
+import fastify, { FastifyInstance, FastifyPluginAsync } from '../../fastify'
+
+const testPluginOptsAsync: FastifyPluginAsync = async function (_instance, _opts) { }
+
+// Type validation
+expectError(fastify().register(testPluginOptsAsync, { prefix: 1 }))
+expectError(fastify().register(testPluginOptsAsync, { logLevel: () => ({}) }))
+expectError(fastify().register(testPluginOptsAsync, { logSerializers: () => ({}) }))
+expectError(fastify().register({}))
+
+expectAssignable<FastifyInstance>(
+  fastify().register(
+    testPluginOptsAsync, { prefix: '/example', logLevel: 'info', logSerializers: { key: (value: any) => `${value}` } }
+  )
+)

--- a/types/register.d.ts
+++ b/types/register.d.ts
@@ -26,4 +26,5 @@ export type FastifyRegisterOptions<Options> = (RegisterOptions & Options) | (() 
 interface RegisterOptions {
   prefix?: string;
   logLevel?: LogLevel;
+  logSerializers?: Record<string, (value: any) => string>;
 }


### PR DESCRIPTION
## Checklist

ref: #2629 

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
