### PR TITLE
fix type definitions for CommonJS require style

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -134,3 +134,7 @@ export { HTTPMethods, RawServerBase, RawRequestDefaultExpression, RawReplyDefaul
 export * from './types/hooks'
 export { FastifyServerFactory, FastifyServerFactoryHandler } from './types/serverFactory'
 export { fastify }
+
+declare module 'fastify' {
+  export = fastify;
+}


### PR DESCRIPTION
While using Fastify with TypeScript there is no problem, but using just JavaScript, vscode is not able to use the type definitions due to the difference in CommonJS require style and it's special syntax for type definitions.

Minimal reproduction example: https://github.com/PabloSzx/fastify-js-types-bug

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
