### PR TITLE
change require style for autocomplete & fastify-gql to mercurius

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ yarn add fastify
 
 ```js
 // Require the framework and instantiate it
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   logger: true
 })
 
@@ -107,7 +107,7 @@ fastify.listen(3000, (err, address) => {
 with async-await:
 
 ```js
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   logger: true
 })
 

--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -189,7 +189,7 @@ throw an exception.
 As an example, the following will throw:
 
 ```js
-const server = require('fastify')()
+const server = require('fastify').fastify()
 
 server.decorateReply('view', function (template, args) {
   // Amazing view rendering engine
@@ -212,7 +212,7 @@ server.listen(3000)
 But this will not:
 
 ```js
-const server = require('fastify')()
+const server = require('fastify').fastify()
 
 server.decorateReply('view', function (template, args) {
   // Amazing view rendering engine.

--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -82,7 +82,7 @@ Plugins maintained by the fastify team are listed under [Core](#core) while plug
 - [`fastify-google-cloud-storage`](https://github.com/carlozamagni/fastify-google-cloud-storage) Fastify plugin that exposes a GCP Cloud Storage client instance.
 - [`fastify-grant`](https://github.com/simov/fastify-grant) Authentication/Authorization plugin for Fastify that supports 200+ OAuth Providers.
 - [`fastify-guard`](https://github.com/hsynlms/fastify-guard) A fastify plugin that protects endpoints by checking authenticated user roles and/or scopes.
-- [`fastify-gql`](https://github.com/mcollina/fastify-gql) A GraphQL server implementation for Fastify with caching and [`graphql-jit`](https://github.com/ruiaraujo/graphql-jit).
+- [`mercurius`](http://mercurius.dev/) A GraphQL server implementation for Fastify with caching and [`graphql-jit`](https://github.com/ruiaraujo/graphql-jit).
 - [`fastify-graceful-shutdown`](https://github.com/hemerajs/fastify-graceful-shutdown) Shutdown Fastify gracefully and asynchronously.
 - [`fastify-healthcheck`](https://github.com/smartiniOnGitHub/fastify-healthcheck) Fastify plugin to serve an health check route and a probe script.
 - [`fastify-hemera`](https://github.com/hemerajs/fastify-hemera) Fastify Hemera plugin, for writing reliable & fault-tolerant microservices with [nats.io](https://nats.io/).

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -21,7 +21,7 @@ yarn add fastify
 Let's write our first server:
 ```js
 // Require the framework and instantiate it
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   logger: true
 })
 
@@ -43,7 +43,7 @@ fastify.listen(3000, function (err, address) {
 Do you prefer to use `async/await`? Fastify supports it out-of-the-box.<br>
 *(We also suggest using [make-promises-safe](https://github.com/mcollina/make-promises-safe) to avoid file descriptor and memory leaks.)*
 ```js
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   logger: true
 })
 
@@ -89,7 +89,7 @@ As with JavaScript, where everything is an object, with Fastify everything is a 
 Before digging into it, let's see how it works!<br>
 Let's declare our basic server, but instead of declaring the route inside the entry point, we'll declare it in an external file (check out the [route declaration](Routes.md) docs).
 ```js
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   logger: true
 })
 
@@ -132,7 +132,7 @@ npm i --save fastify-plugin fastify-mongodb
 
 **server.js**
 ```js
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   logger: true
 })
 

--- a/docs/HTTP2.md
+++ b/docs/HTTP2.md
@@ -20,7 +20,7 @@ connection__:
 
 const fs = require('fs')
 const path = require('path')
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   http2: true,
   https: {
     key: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.key')),
@@ -45,7 +45,7 @@ _Fastify_ supports this out of the box:
 
 const fs = require('fs')
 const path = require('path')
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   http2: true,
   https: {
     allowHTTP1: true, // fallback support for HTTP1
@@ -76,7 +76,7 @@ text, however this is not supported by browsers.
 ```js
 'use strict'
 
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   http2: true
 })
 

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -14,7 +14,7 @@ Since Fastify is focused on performance, it uses [pino](https://github.com/pinoj
 Enabling the logger is extremely easy:
 
 ```js
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   logger: true
 })
 
@@ -28,7 +28,7 @@ If you want to pass some options to the logger, just pass them to Fastify.
 You can find all available options in the [Pino documentation](https://github.com/pinojs/pino/blob/master/docs/api.md#pinooptions-stream). If you want to specify a file destination, use:
 
 ```js
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   logger: {
     level: 'info',
     file: '/path/to/file' // Will use pino.destination()
@@ -47,7 +47,7 @@ If you want to pass a custom stream to the Pino instance, just add a stream fiel
 const split = require('split2')
 const stream = split(JSON.parse)
 
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   logger: {
     level: 'info',
     stream: stream
@@ -62,7 +62,7 @@ By default, fastify adds an id to every request for easier tracking. If the "req
 The default logger is configured with a set of standard serializers that serialize objects with `req`, `res`, and `err` properties. The object received by `req` is the Fastify [`Request`](Request.md) object, while the object received by `res` is the Fastify [`Reply`](Reply.md) object.  
 This behaviour can be customized by specifying custom serializers.
 ```js
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   logger: {
     serializers: {
       req (request) {
@@ -75,7 +75,7 @@ const fastify = require('fastify')({
 For example, the response payload and headers could be logged using the approach below (even if it is *not recommended*):
 
 ```js
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   logger: {
     prettyPrint: true,
     serializers: {
@@ -126,7 +126,7 @@ Example:
 
 ```js
 const log = require('pino')({ level: 'info' })
-const fastify = require('fastify')({ logger: log })
+const fastify = require('fastify').fastify({ logger: log })
 
 log.info('does not have request information')
 

--- a/docs/Migration-Guide-V3.md
+++ b/docs/Migration-Guide-V3.md
@@ -44,7 +44,7 @@ properties that are present on the native objects but not the Fastify objects.
 **v2:**
 
 ```js
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   logger: {
     serializers: {
       res(res) {
@@ -61,7 +61,7 @@ const fastify = require('fastify')({
 **v3:**
 
 ```js
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   logger: {
     serializers: {
       res(reply) {

--- a/docs/Plugins-Guide.md
+++ b/docs/Plugins-Guide.md
@@ -267,7 +267,7 @@ As we mentioned earlier, Fastify starts loading its plugins __after__ `.listen()
 
 In case you rely on a variable injected by a preceding plugin and want to pass that in the `options` argument of `register`, you can do so by using a function instead of an object:
 ```js
-const fastify = require('fastify')()
+const fastify = require('fastify').fastify()
 const fp = require('fastify-plugin')
 const dbClient = require('db-client')
 

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -257,7 +257,7 @@ Fastify offers you a fast and smart way to create different version of the same 
 
 ```js
 // server.js
-const fastify = require('fastify')()
+const fastify = require('fastify').fastify()
 
 fastify.register(require('./routes/v1/users'), { prefix: '/v1' })
 fastify.register(require('./routes/v2/users'), { prefix: '/v2' })
@@ -308,7 +308,7 @@ Be aware that if you set the `logLevel` at plugin level, also the [`setNotFoundH
 
 ```js
 // server.js
-const fastify = require('fastify')({ logger: true })
+const fastify = require('fastify').fastify({ logger: true })
 
 fastify.register(require('./routes/user'), { logLevel: 'warn' })
 fastify.register(require('./routes/events'), { logLevel: 'debug' })
@@ -330,7 +330,7 @@ fastify.get('/', { logLevel: 'warn' }, (request, reply) => {
 In some context, you may need to log a large object but it could be a waste of resources for some routes. In this case, you can define some [`serializer`](https://github.com/pinojs/pino/blob/master/docs/api.md#bindingsserializers-object) and attach them in the right context!
 
 ```js
-const fastify = require('fastify')({ logger: true })
+const fastify = require('fastify').fastify({ logger: true })
 
 fastify.register(require('./routes/user'), {
   logSerializers: {
@@ -390,7 +390,7 @@ Registering a new handler, you can pass a configuration object to it and retriev
 
 ```js
 // server.js
-const fastify = require('fastify')()
+const fastify = require('fastify').fastify()
 
 function handler (req, reply) {
   reply.send(reply.context.config.output)

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -62,7 +62,7 @@ instance.
 + Default: `false`
 
 ```js
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   ignoreTrailingSlash: true
 })
 
@@ -168,7 +168,7 @@ interface by having the following methods: `info`, `error`, `debug`, `fatal`, `w
     },
   };
 
-  const fastify = require('fastify')({logger: customLogger});
+  const fastify = require('fastify').fastify({logger: customLogger});
   ```
 
 <a name="factory-disable-request-logging"></a>
@@ -263,7 +263,7 @@ Especially in distributed systems, you may want to override the default id gener
 
 ```js
 let i = 0
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   genReqId: function (req) { return i++ }
 })
 ```
@@ -321,7 +321,7 @@ You can change this default setting by passing the option `querystringParser` an
 
 ```js
 const qs = require('qs')
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   querystringParser: str => qs.parse(str)
 })
 ```
@@ -347,7 +347,7 @@ const versioning = {
   }
 }
 
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   versioning
 })
 ```
@@ -381,7 +381,7 @@ Configure the ajv instance used by Fastify without providing a custom one.
 ```
 
 ```js
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   ajv: {
     customOptions: {
       nullable: false // Refer to [ajv options](https://ajv.js.org/#options)
@@ -416,7 +416,7 @@ Using this option it is possible to override one or more of those handlers with 
 *Note: Only `FST_ERR_BAD_URL` is implemented at the moment.*
 
 ```js
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   frameworkErrors: function (error, req, res) {
     if (error instanceof FST_ERR_BAD_URL) {
       res.code(400)
@@ -458,7 +458,7 @@ function defaultClientErrorHandler (err, socket) {
 *Note: `clientErrorHandler` operates with raw socket. The handler is expected to return a properly formed HTTP response that includes a status line, HTTP headers and a message body. Before attempting to write the socket, the handler should check if the socket it's still writable as it may already have been destroyed.*
 
 ```js
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   clientErrorHandler: function (err, socket) {
     const body = JSON.stringify({
       error: {
@@ -948,7 +948,7 @@ Currently the properties that can be exposed are:
 
 ```js
 const { readFileSync } = require('fs')
-const Fastify = require('fastify')
+const Fastify = require('fastify').fastify
 
 const fastify = Fastify({
   https: {

--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -29,7 +29,7 @@ and RESTful APIs using Fastify on top of AWS Lambda and Amazon API Gateway.
 ### app.js
 
 ```js
-const fastify = require('fastify');
+const { fastify } = require('fastify');
 
 function init() {
   const app = fastify();
@@ -319,7 +319,7 @@ And a `api/index.js` file:
 ```js
 'use strict'
 
-const fastify = require('fastify')
+const { fastify } = require('fastify')
 
 function build () {
   const app = fastify({

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -17,7 +17,7 @@ run `npm install fastify && npm install tap pino-pretty --save-dev`
 ```js
 'use strict'
 
-const fastify = require('fastify')
+const { fastify } = require('fastify')
 
 function build(opts={}) {
   const app = fastify(opts)
@@ -183,7 +183,7 @@ try {
 
 **app.js**
 ```js
-const Fastify = require('fastify')
+const Fastify = require('fastify').fastify
 
 function buildFastify () {
   const fastify = Fastify()

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -405,7 +405,7 @@ All `http`, `https`, and `http2` types are inferred from `@types/node`
 
 #### How to import
 
-The Fastify API is powered by the `fastify()` method. In JavaScript you would import it using `const fastify = require('fastify')`. In TypeScript it is recommended to use the `import/from` syntax instead so types can be resolved. There are a couple supported import methods with the Fastify type system.
+The Fastify API is powered by the `fastify()` method. In JavaScript you would import it using `const { fastify } = require('fastify')`. In TypeScript it is recommended to use the `import/from` syntax instead so types can be resolved. There are a couple supported import methods with the Fastify type system.
 
 1. `import fastify from 'fastify'`
     - Types are resolved but not accessible using dot notation
@@ -440,11 +440,11 @@ The Fastify API is powered by the `fastify()` method. In JavaScript you would im
     const f: Fastify.FastifyInstance = Fastify.fastify()
     f.listen(8080, () => { console.log('running') })
     ```
-3. `const fastify = require('fastify')`
+3. `const { fastify } = require('fastify')`
     - This syntax is valid and will import fastify as expected; however, types will **not** be resolved
     - Example:
     ```typescript
-    const fastify = require('fastify')
+    const { fastify } = require('fastify')
 
     const f = fastify()
     f.listen(8080, () => { console.log('running') })

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -207,7 +207,7 @@ You can provide a list of plugins you want to use with Ajv:
 > Refer to [`ajv options`](Server.md#ajv) to check plugins format
 
 ```js
-const fastify = require('fastify')({
+const fastify = require('fastify').fastify({
   ajv: {
     plugins: [
       require('ajv-merge-patch')
@@ -285,7 +285,7 @@ This baseline configuration can be modified by providing [`ajv.customOptions`](S
 If you want to change or set additional config options, you will need to create your own instance and override the existing one like:
 
 ```js
-const fastify = require('fastify')()
+const fastify = require('fastify').fastify()
 const Ajv = require('ajv')
 const ajv = new Ajv({
   // the fastify defaults (if needed)


### PR DESCRIPTION
 > as mentioned in #2635, [comment](https://github.com/fastify/fastify/pull/2635#issuecomment-713601215)
## require
This first version is clearly not intended to be final, because I need some feedback on the intended new style, because, for example, this style exists in the docs

```js
const fastify = require('fastify')({
  logger: true
})
```

And just adding `.fastify` is too cumbersome

```js
const fastify = require('fastify').fastify({
  logger: true
})
```

One option is to simply rename the `const fastify =` to `const app =`

```js
const app = require('fastify').fastify({
  logger: true
})
```

But still feels like repeating yourself. Honestly, I don't know... 🤷‍♂️ 

## fastify-gql

Renamed `fastify-gql` to `mercurius`, and pointing the link to [it's website](https://mercurius.dev/#/), but shouldn't it be at `Core`?

--- 
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
