### PR TITLE
Removed empty 'return' lines at the end of Hooks examples

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -50,7 +50,6 @@ Or `async/await`:
 fastify.addHook('onRequest', async (request, reply) => {
   // Some code
   await asyncMethod()
-  return
 })
 ```
 
@@ -97,7 +96,6 @@ Or `async/await`:
 fastify.addHook('preValidation', async (request, reply) => {
   // Some code
   await asyncMethod()
-  return
 })
 ```
 ### preHandler
@@ -112,7 +110,6 @@ Or `async/await`:
 fastify.addHook('preHandler', async (request, reply) => {
   // Some code
   await asyncMethod()
-  return
 })
 ```
 ### preSerialization
@@ -200,7 +197,6 @@ Or `async/await`:
 fastify.addHook('onResponse', async (request, reply) => {
   // Some code
   await asyncMethod()
-  return
 })
 ```
 
@@ -220,7 +216,6 @@ Or `async/await`:
 fastify.addHook('onTimeout', async (request, reply) => {
   // Some code
   await asyncMethod()
-  return
 })
 ```
 `onTimeout` is useful if you need to monitor the request timed out in your service. (if the `connectionTimeout` property is set on the fastify instance). The `onTimeout` hook is executed when a request is timed out and the http socket has been hanged up. Therefore you will not be able to send data to the client.


### PR DESCRIPTION
As per issue #2639, this PR removes empty/redundant `return` lines at the end of several Hooks examples.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
