### PR TITLE
Allow case insensitivity to query strings

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -242,6 +242,10 @@ fastify.get('/user/:username', (request, reply) => {
 Please note that setting this option to `false` goes against
 [RFC3986](https://tools.ietf.org/html/rfc3986#section-6.2.2.1).
 
+Also note that when this option is `false` and there is any schema regarding the
+query strings, the schema should use lowercase for the query properties,
+otherwise it will fail or cause mismatch.
+
 <a name="factory-request-id-header"></a>
 ### `requestIdHeader`
 

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -228,6 +228,10 @@ By default, value equal to `true`, routes are registered as case sensitive. That
 
 By setting `caseSensitive` to `false`, all paths will be matched as lowercase, but the route parameters or wildcards will maintain their original letter casing.
 
+This option also applies to query strings. When `caseSensitive` is set to
+`false`, `/foo?query=bar` is equivalent to `/foo?QUERY=bar` and the other
+variants (`qUerY`, `Query`, etc.).
+
 ```js
 fastify.get('/user/:username', (request, reply) => {
   // Given the URL: /USER/NodeJS
@@ -235,7 +239,7 @@ fastify.get('/user/:username', (request, reply) => {
 })
 ```
 
-Please note this setting this option to `false` goes against
+Please note that setting this option to `false` goes against
 [RFC3986](https://tools.ietf.org/html/rfc3986#section-6.2.2.1).
 
 <a name="factory-request-id-header"></a>

--- a/lib/route.js
+++ b/lib/route.js
@@ -49,6 +49,7 @@ function buildRouting (options) {
 
   let avvio
   let fourOhFour
+  let caseSensitive
   let requestIdHeader
   let querystringParser
   let requestIdLogLabel
@@ -73,6 +74,7 @@ function buildRouting (options) {
       setupResponseListeners = fastifyArgs.setupResponseListeners
       throwIfAlreadyStarted = fastifyArgs.throwIfAlreadyStarted
 
+      caseSensitive = options.caseSensitive
       requestIdHeader = options.requestIdHeader
       querystringParser = options.querystringParser
       requestIdLogLabel = options.requestIdLogLabel
@@ -325,7 +327,27 @@ function buildRouting (options) {
     childLogger[kDisableRequestLogging] = disableRequestLogging
 
     var queryPrefix = req.url.indexOf('?')
-    var query = querystringParser(queryPrefix > -1 ? req.url.slice(queryPrefix + 1) : '')
+
+    var queryString = queryPrefix > -1 ? req.url.slice(queryPrefix + 1) : ''
+
+    var query = querystringParser(queryString)
+
+    if (caseSensitive === false) {
+      function lowercaseQuery (query) {
+        return Object.entries(query).reduce((entries, currentEntry) => {
+          const [key, value] = currentEntry
+
+          const lowercaseKey = key.toLowerCase()
+
+          entries[lowercaseKey] = value
+
+          return entries
+        }, {})
+      }
+
+      query = lowercaseQuery(query)
+    }
+
     var request = new context.Request(id, params, req, query, childLogger, context)
     var reply = new context.Reply(res, request, childLogger)
 

--- a/test/case-insensitive.test.js
+++ b/test/case-insensitive.test.js
@@ -118,3 +118,61 @@ test('case insensitive (wildcard)', t => {
     })
   })
 })
+
+test('case insensitive query string', t => {
+  t.plan(5)
+
+  const fastify = Fastify({
+    caseSensitive: false
+  })
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.get('/foo', (req, reply) => {
+    t.deepEqual(req.query, { test: 'bar' })
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port + '/foo?tEsT=bar'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.deepEqual(JSON.parse(body), {
+        hello: 'world'
+      })
+    })
+  })
+})
+
+test('case insensitive query string (order of query)', t => {
+  t.plan(5)
+
+  const fastify = Fastify({
+    caseSensitive: false
+  })
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.get('/foo', (req, reply) => {
+    t.deepEqual(req.query, { test: 'bar4' })
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port + '/foo?tEsT=bar1&test=bar2&TEST=bar3&teST=bar4'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.deepEqual(JSON.parse(body), {
+        hello: 'world'
+      })
+    })
+  })
+})


### PR DESCRIPTION
By setting the caseSensitive option to false, it also gets applied to query strings, not only routes.

See https://github.com/fastify/fastify/issues/2644.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
