### PR TITLE
Allow send content-length header for empty body on HEAD request

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -378,6 +378,7 @@ function wrapOnSendEnd (err, request, reply, payload) {
 
 function onSendEnd (reply, payload) {
   var res = reply.raw
+  var req = reply.request
   var statusCode = res.statusCode
 
   if (payload === undefined || payload === null) {
@@ -386,7 +387,8 @@ function onSendEnd (reply, payload) {
     // according to https://tools.ietf.org/html/rfc7230#section-3.3.2
     // we cannot send a content-length for 304 and 204, and all status code
     // < 200.
-    if (statusCode >= 200 && statusCode !== 204 && statusCode !== 304) {
+    // For HEAD we don't overwrite the `content-length`
+    if (statusCode >= 200 && statusCode !== 204 && statusCode !== 304 && req.method !== 'HEAD') {
       reply[kReplyHeaders]['content-length'] = '0'
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
Allow sending `content-length` header when sending an empty body on HEAD requests.
See #2619 

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
