### PR TITLE
Fix defined type for route option "prefixTrailingSlash"

### DIFF
--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -69,6 +69,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
     url: '/',
     method: method as HTTPMethods,
     config: { foo: 'bar', bar: 100 },
+    prefixTrailingSlash: 'slash',
     onRequest: (req, res, done) => { // these handlers are tested in `hooks.test-d.ts`
       expectType<BodyInterface>(req.body)
       expectType<QuerystringInterface>(req.query)
@@ -178,4 +179,8 @@ expectType<FastifyInstance>(fastify().route({
   method: 'GET',
   handler: routeHandler,
   schemaErrorFormatter: (errors, dataVar) => new Error('')
+}))
+
+expectError(fastify().route({
+  prefixTrailingSlash: true // Not a valid value
 }))

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -27,7 +27,7 @@ export interface RouteShorthandOptions<
   logLevel?: LogLevel;
   config?: ContextConfig;
   version?: string;
-  prefixTrailingSlash?: boolean;
+  prefixTrailingSlash?: 'slash'|'no-slash'|'both';
   errorHandler?: (this: FastifyInstance, error: FastifyError, request: FastifyRequest, reply: FastifyReply) => void;
   // TODO: Change to actual type.
   schemaErrorFormatter?: (errors: FastifySchemaValidationError[], dataVar: string) => Error;


### PR DESCRIPTION
Ran into the `prefixTrailingSlash` option for a route having an incorrect type definition. The type definition erroneously said that it's supposed to be a `boolean`, but it's supposed to be one of `'slash'|'no-slash'|'both'`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] ~~documentation is changed or added~~
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
