### PR TITLE
treat x-forwarded-host headers as x-forwarded-proto

### DIFF
--- a/docs/Request.md
+++ b/docs/Request.md
@@ -13,7 +13,7 @@ Request is a core Fastify object containing the following fields:
 - `log` - the logger instance of the incoming request
 - `ip` - the IP address of the incoming request
 - `ips` - an array of the IP addresses in the `X-Forwarded-For` header of the incoming request (only when the [`trustProxy`](Server.md#factory-trust-proxy) option is enabled)
-- `hostname` - the hostname of the incoming request
+- `hostname` - the hostname of the incoming request (derived from `X-Forwarded-Host` header when the [`trustProxy`](Server.md#factory-trust-proxy) option is enabled)
 - `protocol` - the protocol of the incoming request (`https` or `http`)
 - `method` - the method of the incoming request
 - `url` - the url of the incoming request

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -304,6 +304,8 @@ fastify.get('/', (request, reply) => {
 })
 ```
 
+**Note: if a request contains multiple <code>x-forwarded-host</code> or <code>x-forwarded-proto</code> headers, it is only the last one that is used to derive <code>request.hostname</code> and <code>request.protocol</code>**
+
 <a name="plugin-timeout"></a>
 ### `pluginTimeout`
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -57,6 +57,12 @@ function buildRegularRequest (R) {
   return _Request
 }
 
+function getLastEntryInMultiHeaderValue (headerValue) {
+  // we use the last one if the header is set more than once
+  const lastIndex = headerValue.lastIndexOf(',')
+  return lastIndex === -1 ? headerValue.trim() : headerValue.slice(lastIndex + 1).trim()
+}
+
 function buildRequestWithTrustProxy (R, trustProxy) {
   const _Request = buildRegularRequest(R)
   const proxyFn = getTrustProxyFn(trustProxy)
@@ -75,7 +81,7 @@ function buildRequestWithTrustProxy (R, trustProxy) {
     hostname: {
       get () {
         if (this.ip !== undefined && this.headers['x-forwarded-host']) {
-          return this.headers['x-forwarded-host']
+          return getLastEntryInMultiHeaderValue(this.headers['x-forwarded-host'])
         }
         return this.headers.host || this.headers[':authority']
       }
@@ -83,10 +89,7 @@ function buildRequestWithTrustProxy (R, trustProxy) {
     protocol: {
       get () {
         if (this.headers['x-forwarded-proto']) {
-          const proto = this.headers['x-forwarded-proto']
-          // we use the last one if the header is set more than once
-          const lastIndex = proto.lastIndexOf(',')
-          return lastIndex === -1 ? proto.trim() : proto.slice(lastIndex + 1).trim()
+          return getLastEntryInMultiHeaderValue(this.headers['x-forwarded-proto'])
         }
         return this.socket.encrypted ? 'https' : 'http'
       }

--- a/test/internals/request.test.js
+++ b/test/internals/request.test.js
@@ -157,3 +157,26 @@ test('Request with trust proxy - x-forwarded-host header has precedence over hos
   t.type(request, TpRequest)
   t.strictEqual(request.hostname, 'example.com')
 })
+
+test('Request with trust proxy - handles multiple entries in x-forwarded-host/proto', t => {
+  t.plan(3)
+  const headers = {
+    'x-forwarded-host': 'example2.com, example.com',
+    'x-forwarded-proto': 'http, https'
+  }
+  const req = {
+    method: 'GET',
+    url: '/',
+    // Some dependencies (proxy-addr, forwarded) still depend on the deprecated
+    // .connection property, we use .socket. Include both to satisfy everyone.
+    socket: { remoteAddress: 'ip' },
+    connection: { remoteAddress: 'ip' },
+    headers
+  }
+
+  const TpRequest = Request.buildRequest(Request, true)
+  const request = new TpRequest('id', 'params', req, 'query', 'log')
+  t.type(request, TpRequest)
+  t.strictEqual(request.hostname, 'example.com')
+  t.strictEqual(request.protocol, 'https')
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

### Background

We're runnning our fastify server on **Azure Linux Web Apps** behind **Akamai** that (for some reason) adds 2 `x-forwarded-host` headers resulting in `request.hostname` to appear as `"host.com, host.com"` - which certainly feels incorrect.

In our own code we've handled this in a plugin prior to using `request.hostname` - but we felt the issue should be addressed here 😄 

This PR simply handles `x-forwarded-host` in the same fashion that `x-forwarded-proto` already is when `trustProxy` is `true`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
