### PR TITLE
Added (probably) missing line for http2 server

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -17,6 +17,7 @@ function createServer (options, httpHandler) {
   } else if (options.https) {
     if (options.http2) {
       server = http2().createSecureServer(options.https, httpHandler)
+      server.on('session', sessionTimeout(options.http2SessionTimeout))
     } else {
       server = https.createServer(options.https, httpHandler)
       server.keepAliveTimeout = options.keepAliveTimeout

--- a/test/http2/closing.test.js
+++ b/test/http2/closing.test.js
@@ -4,6 +4,8 @@ const t = require('tap')
 const Fastify = require('../..')
 const http2 = require('http2')
 const semver = require('semver')
+const fs = require('fs')
+const path = require('path')
 const { promisify } = require('util')
 const connect = promisify(http2.connect)
 const once = require('events.once')
@@ -108,6 +110,26 @@ t.test('http/2 closes successfully with async await', { skip: semver.lt(process.
   const fastify = Fastify({
     http2SessionTimeout: 100,
     http2: true
+  })
+
+  await fastify.listen(0)
+
+  const url = `http://127.0.0.1:${fastify.server.address().port}`
+  const session = await connect(url)
+  // An error might or might not happen, as it's OS dependent.
+  session.on('error', () => {})
+  await fastify.close()
+})
+
+// Skipped because there is likely a bug on Node 8.
+t.test('https/2 closes successfully with async await', { skip: semver.lt(process.versions.node, '10.15.0') }, async t => {
+  const fastify = Fastify({
+    http2SessionTimeout: 100,
+    http2: true,
+    https: {
+      key: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.key')),
+      cert: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.cert'))
+    }
   })
 
   await fastify.listen(0)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

I guess when the graceful closing for http2 was [added](https://github.com/fastify/fastify/commit/d0c976e82549488ecd27c17421cd3b51264468de#diff-1b48bb429de959672dadab9c87c215e19177dd70e3bd932d131ce74294c44cd5R27), it was simply forgotten to add this line for https too.


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
