### PR TITLE
Add support for constrained routes from newer find-my-way

### DIFF
--- a/build/build-validation.js
+++ b/build/build-validation.js
@@ -79,7 +79,31 @@ const schema = {
     pluginTimeout: { type: 'integer', default: defaultInitOptions.pluginTimeout },
     requestIdHeader: { type: 'string', default: defaultInitOptions.requestIdHeader },
     requestIdLogLabel: { type: 'string', default: defaultInitOptions.requestIdLogLabel },
-    http2SessionTimeout: { type: 'integer', default: defaultInitOptions.http2SessionTimeout }
+    http2SessionTimeout: { type: 'integer', default: defaultInitOptions.http2SessionTimeout },
+    // deprecated style of passing the versioning constraint
+    versioning: {
+      type: 'object',
+      additionalProperties: true,
+      required: ['storage', 'deriveVersion'],
+      properties: {
+        storage: { },
+        deriveVersion: { }
+      }
+    },
+    constraints: {
+      type: 'object',
+      additionalProperties: {
+        type: 'object',
+        required: ['name', 'storage', 'validate', 'deriveConstraint'],
+        additionalProperties: true,
+        properties: {
+          name: { type: 'string' },
+          storage: { },
+          validate: { },
+          deriveConstraint: { }
+        }
+      }
+    }
   }
 }
 

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -333,13 +333,13 @@ Automatically creates a sibling `HEAD` route for each `GET` route defined. If yo
 
 + Default: `false`
 
-<a name="versioning"></a>
-### `versioning`
+<a name="constraints"></a>
+### `constraints`
 
-By default you can version your routes with [semver versioning](Routes.md#version), which is provided by `find-my-way`. There is still an option to provide custom versioning strategy. You can find more information in the [find-my-way](https://github.com/delvedor/find-my-way#versioned-routes) documentation.
+Fastify's built in route constraints are provided by `find-my-way`, which allow constraining routes by `version` or `host`. You are able to add new constraint strategies, or override the built in strategies by providing a `constraints` object with strategies for `find-my-way`. You can find more information on constraint strategies in the [find-my-way](https://github.com/delvedor/find-my-way) documentation.
 
 ```js
-const versioning = {
+const customVersionStrategy = {
   storage: function () {
     let versions = {}
     return {
@@ -355,7 +355,9 @@ const versioning = {
 }
 
 const fastify = require('fastify')({
-  versioning
+  constraints: {
+    version: customVersionStrategy
+  }
 })
 ```
 

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -2,6 +2,7 @@ import * as http from 'http'
 import * as http2 from 'http2'
 import * as https from 'https'
 import * as LightMyRequest from 'light-my-request'
+import * as FindMyWay from 'find-my-way'
 
 import { FastifyRequest, RequestGenericInterface } from './types/request'
 import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression } from './types/utils'
@@ -94,6 +95,9 @@ export type FastifyServerOptions<
   genReqId?: <RequestGeneric extends RequestGenericInterface = RequestGenericInterface>(req: FastifyRequest<RequestGeneric, RawServer, RawRequestDefaultExpression<RawServer>>) => string,
   trustProxy?: boolean | string | string[] | number | TrustProxyFunction,
   querystringParser?: (str: string) => { [key: string]: unknown },
+  /**
+   * @deprecated Prefer using the `constraints.version` property
+   */
   versioning?: {
     storage(): {
       get(version: string): string | null,
@@ -102,6 +106,9 @@ export type FastifyServerOptions<
       empty(): void
     },
     deriveVersion<Context>(req: Object, ctx?: Context): string // not a fan of using Object here. Also what is Context? Can either of these be better defined?
+  },
+  constraints?: {
+    [name: string]: FindMyWay.ConstraintStrategy<RawRequestDefaultExpression<RawServer>>,
   },
   return503OnClosing?: boolean,
   ajv?: {

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -2,7 +2,7 @@ import * as http from 'http'
 import * as http2 from 'http2'
 import * as https from 'https'
 import * as LightMyRequest from 'light-my-request'
-import * as FindMyWay from 'find-my-way'
+import { ConstraintStrategy, HTTPVersion } from 'find-my-way'
 
 import { FastifyRequest, RequestGenericInterface } from './types/request'
 import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression } from './types/utils'
@@ -70,6 +70,9 @@ export type FastifyHttpsOptions<
 > = FastifyServerOptions<Server, Logger> & {
   https: https.ServerOptions
 }
+
+type FindMyWayVersion<RawServer extends RawServerBase> = RawServer extends http.Server ? HTTPVersion.V1 : HTTPVersion.V2
+
 /**
  * Options for a fastify server instance. Utilizes conditional logic on the generic server parameter to enforce certain https and http2
  */
@@ -108,7 +111,7 @@ export type FastifyServerOptions<
     deriveVersion<Context>(req: Object, ctx?: Context): string // not a fan of using Object here. Also what is Context? Can either of these be better defined?
   },
   constraints?: {
-    [name: string]: FindMyWay.ConstraintStrategy<RawRequestDefaultExpression<RawServer>>,
+    [name: string]: ConstraintStrategy<FindMyWayVersion<RawServer>>,
   },
   return503OnClosing?: boolean,
   ajv?: {

--- a/fastify.js
+++ b/fastify.js
@@ -140,6 +140,7 @@ function fastify (options) {
       ignoreTrailingSlash: options.ignoreTrailingSlash || defaultInitOptions.ignoreTrailingSlash,
       maxParamLength: options.maxParamLength || defaultInitOptions.maxParamLength,
       caseSensitive: options.caseSensitive,
+      constraints: options.constraints,
       versioning: options.versioning
     }
   })

--- a/lib/configValidator.js
+++ b/lib/configValidator.js
@@ -39,8 +39,9 @@ var validate = (function() {
         if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
           var dataType1 = typeof data1;
           var coerced1 = undefined;
-          if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
-          if (coerced1 === undefined) {
+          if (coerced1 !== undefined);
+          else if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
+          else {
             validate.errors = [{
               keyword: 'type',
               dataPath: (dataPath || '') + '.connectionTimeout',
@@ -51,7 +52,8 @@ var validate = (function() {
               message: 'should be integer'
             }];
             return false;
-          } else {
+          }
+          if (coerced1 !== undefined) {
             data1 = coerced1;
             data['connectionTimeout'] = coerced1;
           }
@@ -63,8 +65,9 @@ var validate = (function() {
           if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
             var dataType1 = typeof data1;
             var coerced1 = undefined;
-            if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
-            if (coerced1 === undefined) {
+            if (coerced1 !== undefined);
+            else if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
+            else {
               validate.errors = [{
                 keyword: 'type',
                 dataPath: (dataPath || '') + '.keepAliveTimeout',
@@ -75,7 +78,8 @@ var validate = (function() {
                 message: 'should be integer'
               }];
               return false;
-            } else {
+            }
+            if (coerced1 !== undefined) {
               data1 = coerced1;
               data['keepAliveTimeout'] = coerced1;
             }
@@ -87,8 +91,9 @@ var validate = (function() {
             if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
               var dataType1 = typeof data1;
               var coerced1 = undefined;
-              if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
-              if (coerced1 === undefined) {
+              if (coerced1 !== undefined);
+              else if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
+              else {
                 validate.errors = [{
                   keyword: 'type',
                   dataPath: (dataPath || '') + '.bodyLimit',
@@ -99,7 +104,8 @@ var validate = (function() {
                   message: 'should be integer'
                 }];
                 return false;
-              } else {
+              }
+              if (coerced1 !== undefined) {
                 data1 = coerced1;
                 data['bodyLimit'] = coerced1;
               }
@@ -111,9 +117,10 @@ var validate = (function() {
               if (typeof data1 !== "boolean") {
                 var dataType1 = typeof data1;
                 var coerced1 = undefined;
-                if (data1 === 'false' || data1 === 0 || data1 === null) coerced1 = false;
+                if (coerced1 !== undefined);
+                else if (data1 === 'false' || data1 === 0 || data1 === null) coerced1 = false;
                 else if (data1 === 'true' || data1 === 1) coerced1 = true;
-                if (coerced1 === undefined) {
+                else {
                   validate.errors = [{
                     keyword: 'type',
                     dataPath: (dataPath || '') + '.caseSensitive',
@@ -124,7 +131,8 @@ var validate = (function() {
                     message: 'should be boolean'
                   }];
                   return false;
-                } else {
+                }
+                if (coerced1 !== undefined) {
                   data1 = coerced1;
                   data['caseSensitive'] = coerced1;
                 }
@@ -139,9 +147,10 @@ var validate = (function() {
                   if (typeof data1 !== "boolean") {
                     var dataType1 = typeof data1;
                     var coerced1 = undefined;
-                    if (data1 === 'false' || data1 === 0 || data1 === null) coerced1 = false;
+                    if (coerced1 !== undefined);
+                    else if (data1 === 'false' || data1 === 0 || data1 === null) coerced1 = false;
                     else if (data1 === 'true' || data1 === 1) coerced1 = true;
-                    if (coerced1 === undefined) {
+                    else {
                       validate.errors = [{
                         keyword: 'type',
                         dataPath: (dataPath || '') + '.http2',
@@ -152,7 +161,8 @@ var validate = (function() {
                         message: 'should be boolean'
                       }];
                       return false;
-                    } else {
+                    }
+                    if (coerced1 !== undefined) {
                       data1 = coerced1;
                       data['http2'] = coerced1;
                     }
@@ -178,14 +188,16 @@ var validate = (function() {
                     if (typeof data1 !== "boolean") {
                       var dataType4 = typeof data1;
                       var coerced4 = undefined;
-                      if (data1 === 'false' || data1 === 0 || data1 === null) coerced4 = false;
+                      if (coerced4 !== undefined);
+                      else if (data1 === 'false' || data1 === 0 || data1 === null) coerced4 = false;
                       else if (data1 === 'true' || data1 === 1) coerced4 = true;
-                      if (coerced4 === undefined) {
+                      else {
                         var err = {};
                         if (vErrors === null) vErrors = [err];
                         else vErrors.push(err);
                         errors++;
-                      } else {
+                      }
+                      if (coerced4 !== undefined) {
                         data1 = coerced4;
                         data['https'] = coerced4;
                       }
@@ -199,13 +211,15 @@ var validate = (function() {
                     if (data1 !== null) {
                       var dataType4 = typeof data1;
                       var coerced4 = undefined;
-                      if (data1 === '' || data1 === 0 || data1 === false) coerced4 = null;
-                      if (coerced4 === undefined) {
+                      if (coerced4 !== undefined);
+                      else if (data1 === '' || data1 === 0 || data1 === false) coerced4 = null;
+                      else {
                         var err = {};
                         if (vErrors === null) vErrors = [err];
                         else vErrors.push(err);
                         errors++;
-                      } else {
+                      }
+                      if (coerced4 !== undefined) {
                         data1 = coerced4;
                         data['https'] = coerced4;
                       }
@@ -243,21 +257,25 @@ var validate = (function() {
                               if (typeof data2 !== "boolean") {
                                 var dataType5 = typeof data2;
                                 var coerced5 = undefined;
-                                if (data2 === 'false' || data2 === 0 || data2 === null) coerced5 = false;
+                                if (coerced5 !== undefined);
+                                else if (data2 === 'false' || data2 === 0 || data2 === null) coerced5 = false;
                                 else if (data2 === 'true' || data2 === 1) coerced5 = true;
-                                if (coerced5 === undefined) {
+                                else {
                                   var err = {};
                                   if (vErrors === null) vErrors = [err];
                                   else vErrors.push(err);
                                   errors++;
-                                } else {
+                                }
+                                if (coerced5 !== undefined) {
                                   data2 = coerced5;
                                   data1['allowHTTP1'] = coerced5;
                                 }
                               }
                               var valid5 = errors === errs_5;
                             }
+                            if (valid5) {}
                           }
+                          if (errs__4 == errors) {}
                         }
                       } else {
                         var err = {};
@@ -265,6 +283,7 @@ var validate = (function() {
                         else vErrors.push(err);
                         errors++;
                       }
+                      if (errors === errs_4) {}
                       var valid4 = errors === errs_4;
                       if (valid4 && prevValid3) {
                         valid3 = false;
@@ -288,6 +307,7 @@ var validate = (function() {
                         else vErrors = null;
                       }
                     }
+                    if (errors === errs_3) {}
                     var valid3 = errors === errs_3;
                     if (valid3) {
                       var err = {};
@@ -301,6 +321,7 @@ var validate = (function() {
                         else vErrors = null;
                       }
                     }
+                    if (errors === errs_2) {}
                     var valid2 = errors === errs_2;
                     errors = errs__1;
                     if (vErrors !== null) {
@@ -325,7 +346,8 @@ var validate = (function() {
                           message: 'should pass "setDefaultValue" keyword validation'
                         }];
                         return false;
-                      }
+                      } else {}
+                      if (errors === errs_2) {}
                       var valid2 = errors === errs_2;
                       valid1 = valid2;
                     }
@@ -344,7 +366,8 @@ var validate = (function() {
                       errors++;
                       validate.errors = vErrors;
                       return false;
-                    }
+                    } else {}
+                    if (errors === errs_1) {}
                     var valid1 = errors === errs_1;
                   }
                   if (valid1) {
@@ -353,9 +376,10 @@ var validate = (function() {
                     if (typeof data1 !== "boolean") {
                       var dataType1 = typeof data1;
                       var coerced1 = undefined;
-                      if (data1 === 'false' || data1 === 0 || data1 === null) coerced1 = false;
+                      if (coerced1 !== undefined);
+                      else if (data1 === 'false' || data1 === 0 || data1 === null) coerced1 = false;
                       else if (data1 === 'true' || data1 === 1) coerced1 = true;
-                      if (coerced1 === undefined) {
+                      else {
                         validate.errors = [{
                           keyword: 'type',
                           dataPath: (dataPath || '') + '.ignoreTrailingSlash',
@@ -366,7 +390,8 @@ var validate = (function() {
                           message: 'should be boolean'
                         }];
                         return false;
-                      } else {
+                      }
+                      if (coerced1 !== undefined) {
                         data1 = coerced1;
                         data['ignoreTrailingSlash'] = coerced1;
                       }
@@ -378,9 +403,10 @@ var validate = (function() {
                       if (typeof data1 !== "boolean") {
                         var dataType1 = typeof data1;
                         var coerced1 = undefined;
-                        if (data1 === 'false' || data1 === 0 || data1 === null) coerced1 = false;
+                        if (coerced1 !== undefined);
+                        else if (data1 === 'false' || data1 === 0 || data1 === null) coerced1 = false;
                         else if (data1 === 'true' || data1 === 1) coerced1 = true;
-                        if (coerced1 === undefined) {
+                        else {
                           validate.errors = [{
                             keyword: 'type',
                             dataPath: (dataPath || '') + '.disableRequestLogging',
@@ -391,7 +417,8 @@ var validate = (function() {
                             message: 'should be boolean'
                           }];
                           return false;
-                        } else {
+                        }
+                        if (coerced1 !== undefined) {
                           data1 = coerced1;
                           data['disableRequestLogging'] = coerced1;
                         }
@@ -403,8 +430,9 @@ var validate = (function() {
                         if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
                           var dataType1 = typeof data1;
                           var coerced1 = undefined;
-                          if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
-                          if (coerced1 === undefined) {
+                          if (coerced1 !== undefined);
+                          else if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
+                          else {
                             validate.errors = [{
                               keyword: 'type',
                               dataPath: (dataPath || '') + '.maxParamLength',
@@ -415,7 +443,8 @@ var validate = (function() {
                               message: 'should be integer'
                             }];
                             return false;
-                          } else {
+                          }
+                          if (coerced1 !== undefined) {
                             data1 = coerced1;
                             data['maxParamLength'] = coerced1;
                           }
@@ -427,9 +456,10 @@ var validate = (function() {
                           if (typeof data1 !== "string") {
                             var dataType1 = typeof data1;
                             var coerced1 = undefined;
-                            if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
+                            if (coerced1 !== undefined);
+                            else if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
                             else if (data1 === null) coerced1 = '';
-                            if (coerced1 === undefined) {
+                            else {
                               validate.errors = [{
                                 keyword: 'type',
                                 dataPath: (dataPath || '') + '.onProtoPoisoning',
@@ -440,7 +470,8 @@ var validate = (function() {
                                 message: 'should be string'
                               }];
                               return false;
-                            } else {
+                            }
+                            if (coerced1 !== undefined) {
                               data1 = coerced1;
                               data['onProtoPoisoning'] = coerced1;
                             }
@@ -452,9 +483,10 @@ var validate = (function() {
                             if (typeof data1 !== "string") {
                               var dataType1 = typeof data1;
                               var coerced1 = undefined;
-                              if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
+                              if (coerced1 !== undefined);
+                              else if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
                               else if (data1 === null) coerced1 = '';
-                              if (coerced1 === undefined) {
+                              else {
                                 validate.errors = [{
                                   keyword: 'type',
                                   dataPath: (dataPath || '') + '.onConstructorPoisoning',
@@ -465,7 +497,8 @@ var validate = (function() {
                                   message: 'should be string'
                                 }];
                                 return false;
-                              } else {
+                              }
+                              if (coerced1 !== undefined) {
                                 data1 = coerced1;
                                 data['onConstructorPoisoning'] = coerced1;
                               }
@@ -477,8 +510,9 @@ var validate = (function() {
                               if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
                                 var dataType1 = typeof data1;
                                 var coerced1 = undefined;
-                                if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
-                                if (coerced1 === undefined) {
+                                if (coerced1 !== undefined);
+                                else if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
+                                else {
                                   validate.errors = [{
                                     keyword: 'type',
                                     dataPath: (dataPath || '') + '.pluginTimeout',
@@ -489,7 +523,8 @@ var validate = (function() {
                                     message: 'should be integer'
                                   }];
                                   return false;
-                                } else {
+                                }
+                                if (coerced1 !== undefined) {
                                   data1 = coerced1;
                                   data['pluginTimeout'] = coerced1;
                                 }
@@ -501,9 +536,10 @@ var validate = (function() {
                                 if (typeof data1 !== "string") {
                                   var dataType1 = typeof data1;
                                   var coerced1 = undefined;
-                                  if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
+                                  if (coerced1 !== undefined);
+                                  else if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
                                   else if (data1 === null) coerced1 = '';
-                                  if (coerced1 === undefined) {
+                                  else {
                                     validate.errors = [{
                                       keyword: 'type',
                                       dataPath: (dataPath || '') + '.requestIdHeader',
@@ -514,7 +550,8 @@ var validate = (function() {
                                       message: 'should be string'
                                     }];
                                     return false;
-                                  } else {
+                                  }
+                                  if (coerced1 !== undefined) {
                                     data1 = coerced1;
                                     data['requestIdHeader'] = coerced1;
                                   }
@@ -526,9 +563,10 @@ var validate = (function() {
                                   if (typeof data1 !== "string") {
                                     var dataType1 = typeof data1;
                                     var coerced1 = undefined;
-                                    if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
+                                    if (coerced1 !== undefined);
+                                    else if (dataType1 == 'number' || dataType1 == 'boolean') coerced1 = '' + data1;
                                     else if (data1 === null) coerced1 = '';
-                                    if (coerced1 === undefined) {
+                                    else {
                                       validate.errors = [{
                                         keyword: 'type',
                                         dataPath: (dataPath || '') + '.requestIdLogLabel',
@@ -539,7 +577,8 @@ var validate = (function() {
                                         message: 'should be string'
                                       }];
                                       return false;
-                                    } else {
+                                    }
+                                    if (coerced1 !== undefined) {
                                       data1 = coerced1;
                                       data['requestIdLogLabel'] = coerced1;
                                     }
@@ -551,8 +590,9 @@ var validate = (function() {
                                     if ((typeof data1 !== "number" || (data1 % 1) || data1 !== data1)) {
                                       var dataType1 = typeof data1;
                                       var coerced1 = undefined;
-                                      if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
-                                      if (coerced1 === undefined) {
+                                      if (coerced1 !== undefined);
+                                      else if (dataType1 == 'boolean' || data1 === null || (dataType1 == 'string' && data1 && data1 == +data1 && !(data1 % 1))) coerced1 = +data1;
+                                      else {
                                         validate.errors = [{
                                           keyword: 'type',
                                           dataPath: (dataPath || '') + '.http2SessionTimeout',
@@ -563,12 +603,180 @@ var validate = (function() {
                                           message: 'should be integer'
                                         }];
                                         return false;
-                                      } else {
+                                      }
+                                      if (coerced1 !== undefined) {
                                         data1 = coerced1;
                                         data['http2SessionTimeout'] = coerced1;
                                       }
                                     }
                                     var valid1 = errors === errs_1;
+                                    if (valid1) {
+                                      var data1 = data.versioning;
+                                      if (data1 === undefined) {
+                                        valid1 = true;
+                                      } else {
+                                        var errs_1 = errors;
+                                        if ((data1 && typeof data1 === "object" && !Array.isArray(data1))) {
+                                          var missing1;
+                                          if (((data1.storage === undefined) && (missing1 = '.storage')) || ((data1.deriveVersion === undefined) && (missing1 = '.deriveVersion'))) {
+                                            validate.errors = [{
+                                              keyword: 'required',
+                                              dataPath: (dataPath || '') + '.versioning',
+                                              schemaPath: '#/properties/versioning/required',
+                                              params: {
+                                                missingProperty: '' + missing1 + ''
+                                              },
+                                              message: 'should have required property \'' + missing1 + '\''
+                                            }];
+                                            return false;
+                                          } else {
+                                            var errs__1 = errors;
+                                            var valid2 = true;
+                                            for (var key1 in data1) {
+                                              var isAdditional1 = !(false || key1 == 'storage' || key1 == 'deriveVersion');
+                                              if (isAdditional1) {}
+                                            }
+                                            if (valid2) {
+                                              if (valid2) {
+                                                if (valid2) {}
+                                              }
+                                            }
+                                            if (errs__1 == errors) {}
+                                          }
+                                        } else {
+                                          validate.errors = [{
+                                            keyword: 'type',
+                                            dataPath: (dataPath || '') + '.versioning',
+                                            schemaPath: '#/properties/versioning/type',
+                                            params: {
+                                              type: 'object'
+                                            },
+                                            message: 'should be object'
+                                          }];
+                                          return false;
+                                        }
+                                        if (errors === errs_1) {}
+                                        var valid1 = errors === errs_1;
+                                      }
+                                      if (valid1) {
+                                        var data1 = data.constraints;
+                                        if (data1 === undefined) {
+                                          valid1 = true;
+                                        } else {
+                                          var errs_1 = errors;
+                                          if ((data1 && typeof data1 === "object" && !Array.isArray(data1))) {
+                                            var errs__1 = errors;
+                                            var valid2 = true;
+                                            for (var key1 in data1) {
+                                              var data2 = data1[key1];
+                                              var errs_2 = errors;
+                                              if ((data2 && typeof data2 === "object" && !Array.isArray(data2))) {
+                                                var missing2;
+                                                if (((data2.storage === undefined) && (missing2 = '.storage')) || ((data2.validate === undefined) && (missing2 = '.validate')) || ((data2.deriveConstraint === undefined) && (missing2 = '.deriveConstraint'))) {
+                                                  validate.errors = [{
+                                                    keyword: 'required',
+                                                    dataPath: (dataPath || '') + '.constraints[\'' + key1 + '\']',
+                                                    schemaPath: '#/properties/constraints/additionalProperties/required',
+                                                    params: {
+                                                      missingProperty: '' + missing2 + ''
+                                                    },
+                                                    message: 'should have required property \'' + missing2 + '\''
+                                                  }];
+                                                  return false;
+                                                } else {
+                                                  var errs__2 = errors;
+                                                  var valid3 = true;
+                                                  for (var key2 in data2) {
+                                                    var isAdditional2 = !(false || key2 == 'name' || key2 == 'storage' || key2 == 'validate' || key2 == 'deriveConstraint');
+                                                    if (isAdditional2) {}
+                                                  }
+                                                  if (valid3) {
+                                                    var data3 = data2.name;
+                                                    if (data3 === undefined) {
+                                                      valid3 = false;
+                                                      validate.errors = [{
+                                                        keyword: 'required',
+                                                        dataPath: (dataPath || '') + '.constraints[\'' + key1 + '\']',
+                                                        schemaPath: '#/properties/constraints/additionalProperties/required',
+                                                        params: {
+                                                          missingProperty: 'name'
+                                                        },
+                                                        message: 'should have required property \'name\''
+                                                      }];
+                                                      return false;
+                                                    } else {
+                                                      var errs_3 = errors;
+                                                      if (typeof data3 !== "string") {
+                                                        var dataType3 = typeof data3;
+                                                        var coerced3 = undefined;
+                                                        if (coerced3 !== undefined);
+                                                        else if (dataType3 == 'number' || dataType3 == 'boolean') coerced3 = '' + data3;
+                                                        else if (data3 === null) coerced3 = '';
+                                                        else {
+                                                          validate.errors = [{
+                                                            keyword: 'type',
+                                                            dataPath: (dataPath || '') + '.constraints[\'' + key1 + '\'].name',
+                                                            schemaPath: '#/properties/constraints/additionalProperties/properties/name/type',
+                                                            params: {
+                                                              type: 'string'
+                                                            },
+                                                            message: 'should be string'
+                                                          }];
+                                                          return false;
+                                                        }
+                                                        if (coerced3 !== undefined) {
+                                                          data3 = coerced3;
+                                                          data2['name'] = coerced3;
+                                                        }
+                                                      }
+                                                      var valid3 = errors === errs_3;
+                                                    }
+                                                    if (valid3) {
+                                                      if (valid3) {
+                                                        if (valid3) {
+                                                          if (valid3) {}
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                  if (errs__2 == errors) {}
+                                                }
+                                              } else {
+                                                validate.errors = [{
+                                                  keyword: 'type',
+                                                  dataPath: (dataPath || '') + '.constraints[\'' + key1 + '\']',
+                                                  schemaPath: '#/properties/constraints/additionalProperties/type',
+                                                  params: {
+                                                    type: 'object'
+                                                  },
+                                                  message: 'should be object'
+                                                }];
+                                                return false;
+                                              }
+                                              if (errors === errs_2) {}
+                                              var valid2 = errors === errs_2;
+                                              if (!valid2) break;
+                                            }
+                                            if (valid2) {}
+                                            if (errs__1 == errors) {}
+                                          } else {
+                                            validate.errors = [{
+                                              keyword: 'type',
+                                              dataPath: (dataPath || '') + '.constraints',
+                                              schemaPath: '#/properties/constraints/type',
+                                              params: {
+                                                type: 'object'
+                                              },
+                                              message: 'should be object'
+                                            }];
+                                            return false;
+                                          }
+                                          if (errors === errs_1) {}
+                                          var valid1 = errors === errs_1;
+                                        }
+                                        if (valid1) {}
+                                      }
+                                    }
                                   }
                                 }
                               }
@@ -584,6 +792,7 @@ var validate = (function() {
           }
         }
       }
+      if (errs__0 == errors) {}
     } else {
       validate.errors = [{
         keyword: 'type',
@@ -596,6 +805,7 @@ var validate = (function() {
       }];
       return false;
     }
+    if (errors === 0) {}
     validate.errors = vErrors;
     return errors === 0;
   };
@@ -681,6 +891,31 @@ validate.schema = {
     "http2SessionTimeout": {
       "type": "integer",
       "default": 5000
+    },
+    "versioning": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["storage", "deriveVersion"],
+      "properties": {
+        "storage": {},
+        "deriveVersion": {}
+      }
+    },
+    "constraints": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["name", "storage", "validate", "deriveConstraint"],
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "storage": {},
+          "validate": {},
+          "deriveConstraint": {}
+        }
+      }
     }
   }
 };

--- a/lib/route.js
+++ b/lib/route.js
@@ -233,7 +233,10 @@ function buildRouting (options) {
         method: opts.method
       }
       const constraints = opts.constraints || {}
-      if (opts.version) constraints.version = opts.version
+      if (opts.version) {
+        warning.emit('FSTDEP006')
+        constraints.version = opts.version
+      }
 
       const context = new Context(
         opts.schema,

--- a/lib/route.js
+++ b/lib/route.js
@@ -232,6 +232,8 @@ function buildRouting (options) {
         url,
         method: opts.method
       }
+      const constraints = opts.constraints || {}
+      if (opts.version) constraints.version = opts.version
 
       const context = new Context(
         opts.schema,
@@ -252,7 +254,7 @@ function buildRouting (options) {
       const headRouteExists = router.find('HEAD', path) != null
 
       try {
-        router.on(opts.method, opts.url, { version: opts.version }, routeHandler, context)
+        router.on(opts.method, opts.url, { constraints }, routeHandler, context)
       } catch (err) {
         done(err)
         return

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -25,4 +25,8 @@ warning.create('FastifyDeprecation', 'FSTDEP006', 'You are decorating Request/Re
 
 warning.create('FastifyDeprecation', 'FSTDEP007', 'You are trying to set a HEAD route using "exposeHeadRoute" route flag when a sibling route is already set. See documentation for more info.')
 
+warning.create('FastifyDeprecation', 'FSTDEP008', 'You are using route constraints via the route { version: "..." } option, use { constraints: { version: "..." } } option instead.')
+
+warning.create('FastifyDeprecation', 'FSTDEP009', 'You are using a custom route versioning strategy via the server { versioning: "..." } option, use { constraints: { version: "..." } } option instead.')
+
 module.exports = warning

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "fast-json-stringify": "^2.2.1",
     "fastify-error": "^0.3.0",
     "fastify-warning": "^0.2.0",
-    "find-my-way": "^3.0.5",
+    "find-my-way": "^4.0.0",
     "flatstr": "^1.0.12",
     "light-my-request": "^4.2.0",
     "pino": "^6.2.1",

--- a/test/constrained-routes.test.js
+++ b/test/constrained-routes.test.js
@@ -1,0 +1,183 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('../fastify')
+
+test('Should register a host constrained route', t => {
+  t.plan(7)
+  const fastify = Fastify()
+
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    constraints: { host: 'fastify.io' },
+    handler: (req, reply) => {
+      reply.send({ hello: 'world' })
+    }
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      host: 'fastify.io'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.deepEqual(JSON.parse(res.payload), { hello: 'world' })
+    t.strictEqual(res.statusCode, 200)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      host: 'example.com'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 404)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 404)
+  })
+})
+
+test('Should register the same route with host constraints', t => {
+  t.plan(8)
+  const fastify = Fastify()
+
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    constraints: { host: 'fastify.io' },
+    handler: (req, reply) => {
+      reply.send('fastify.io')
+    }
+  })
+
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    constraints: { host: 'example.com' },
+    handler: (req, reply) => {
+      reply.send('example.com')
+    }
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      host: 'fastify.io'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual(res.payload, 'fastify.io')
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      host: 'example.com'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual(res.payload, 'example.com')
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      host: 'fancy.ca'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 404)
+  })
+})
+
+test('Should allow registering custom constrained routes', t => {
+  t.plan(8)
+
+  const constraint = {
+    name: 'secret',
+    storage: function () {
+      let secrets = {}
+      return {
+        get: (secret) => { return secrets[secret] || null },
+        set: (secret, store) => { secrets[secret] = store },
+        del: (secret) => { delete secrets[secret] },
+        empty: () => { secrets = {} }
+      }
+    },
+    deriveConstraint: (req, ctx) => {
+      return req.headers['x-secret']
+    }
+  }
+
+  const fastify = Fastify({ constraints: { secret: constraint } })
+
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    constraints: { secret: 'alpha' },
+    handler: (req, reply) => {
+      reply.send({ hello: 'from alpha' })
+    }
+  })
+
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    constraints: { secret: 'beta' },
+    handler: (req, reply) => {
+      reply.send({ hello: 'from beta' })
+    }
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      'X-Secret': 'alpha'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.deepEqual(JSON.parse(res.payload), { hello: 'from alpha' })
+    t.strictEqual(res.statusCode, 200)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      'X-Secret': 'beta'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.deepEqual(JSON.parse(res.payload), { hello: 'from beta' })
+    t.strictEqual(res.statusCode, 200)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      'X-Secret': 'gamma'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 404)
+  })
+})

--- a/test/constrained-routes.test.js
+++ b/test/constrained-routes.test.js
@@ -123,7 +123,8 @@ test('Should allow registering custom constrained routes', t => {
     },
     deriveConstraint: (req, ctx) => {
       return req.headers['x-secret']
-    }
+    },
+    validate () { return true }
   }
 
   const fastify = Fastify({ constraints: { secret: constraint } })

--- a/test/internals/initialConfig.test.js
+++ b/test/internals/initialConfig.test.js
@@ -86,7 +86,9 @@ test('Fastify.initialConfig should expose all options', t => {
       return reqId++
     },
     logger: pino({ level: 'info' }),
-    versioning,
+    constraints: {
+      version: versioning
+    },
     trustProxy: function myTrustFn (address, hop) {
       return address === '1.2.3.4' || hop === 1
     }
@@ -111,7 +113,7 @@ test('Fastify.initialConfig should expose all options', t => {
   t.strictEqual(fastify.initialConfig.genReqId, undefined)
   t.strictEqual(fastify.initialConfig.querystringParser, undefined)
   t.strictEqual(fastify.initialConfig.logger, undefined)
-  t.strictEqual(fastify.initialConfig.versioning, undefined)
+  t.strictEqual(fastify.initialConfig.constraints, undefined)
   t.strictEqual(fastify.initialConfig.trustProxy, undefined)
 })
 

--- a/test/internals/initialConfig.test.js
+++ b/test/internals/initialConfig.test.js
@@ -49,6 +49,7 @@ test('Fastify.initialConfig should expose all options', t => {
   }
 
   const versioning = {
+    name: 'version',
     storage: function () {
       let versions = {}
       return {
@@ -58,7 +59,7 @@ test('Fastify.initialConfig should expose all options', t => {
         empty: () => { versions = {} }
       }
     },
-    deriveVersion: (req, ctx) => {
+    deriveConstraint: (req, ctx) => {
       return req.headers.accept
     }
   }

--- a/test/throw.test.js
+++ b/test/throw.test.js
@@ -21,7 +21,7 @@ test('Fastify should throw on multiple assignment to the same route', t => {
   fastify.get('/', () => {})
 
   fastify.ready(err => {
-    t.is(err.message, "Method 'GET' already declared for route '/'")
+    t.is(err.message, "Method 'GET' already declared for route '/' with constraints '{}'")
   })
 })
 

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -98,6 +98,33 @@ expectAssignable<FastifyInstance>(fastify({
     deriveVersion: () => 'foo'
   }
 }))
+expectAssignable<FastifyInstance>(fastify({ constraints: {} }))
+expectAssignable<FastifyInstance>(fastify({
+  constraints: {
+    version: {
+      name: 'version',
+      storage: () => ({
+        get: () => () => {},
+        set: () => { },
+        del: () => { },
+        empty: () => { }
+      }),
+      validate () {},
+      deriveConstraint: () => 'foo'
+    },
+    host: {
+      name: 'host',
+      storage: () => ({
+        get: () => () => {},
+        set: () => { },
+        del: () => { },
+        empty: () => { }
+      }),
+      validate () {},
+      deriveConstraint: () => 'foo'
+    }
+  }
+}))
 expectAssignable<FastifyInstance>(fastify({ return503OnClosing: true }))
 expectAssignable<FastifyInstance>(fastify({
   ajv: {

--- a/test/versioned-routes.test.js
+++ b/test/versioned-routes.test.js
@@ -69,6 +69,44 @@ test('Should register a versioned route', t => {
   })
 })
 
+test('Should register a versioned route via route constraints', t => {
+  t.plan(6)
+  const fastify = Fastify()
+
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    constraints: { version: '1.2.0' },
+    handler: (req, reply) => {
+      reply.send({ hello: 'world' })
+    }
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      'Accept-Version': '1.x'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.deepEqual(JSON.parse(res.payload), { hello: 'world' })
+    t.strictEqual(res.statusCode, 200)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      'Accept-Version': '1.2.x'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.deepEqual(JSON.parse(res.payload), { hello: 'world' })
+    t.strictEqual(res.statusCode, 200)
+  })
+})
+
 test('Should register the same route with different versions', t => {
   t.plan(8)
   const fastify = Fastify()

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -28,6 +28,7 @@ export interface RouteShorthandOptions<
   logLevel?: LogLevel;
   config?: ContextConfig;
   version?: string;
+  constraints?: { [name: string]: any },
   prefixTrailingSlash?: 'slash'|'no-slash'|'both';
   errorHandler?: (this: FastifyInstance, error: FastifyError, request: FastifyRequest, reply: FastifyReply) => void;
   // TODO: Change to actual type.


### PR DESCRIPTION
Closes https://github.com/fastify/fastify/issues/2498

### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [x] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This is the fastify side of https://github.com/delvedor/find-my-way/pull/170 which adds support for constraining routes to certain hostnames or using custom constraining strategies. 

It would need those bits of `find-my-way` to be merged and released before really being ready, but I'm opening this now for transparency and so anyone who wants to test can do so! Woop woop! 

No need to review quite yet, but if you want to use this feature, I'd love any help testing in your apps! To test, you'll have to import that branch of `find-my-way`, as well as this branch of `fastify`. `npm link` worked for me to do this. 