### PR TITLE
feat: add warning on decorate

### DIFF
--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -121,7 +121,7 @@ If a dependency is not satisfied, the `decorate` method will throw an exception.
 The dependency check is performed before the server instance is booted. Thus,
 it cannot occur during runtime.
 
-#### `decorateReply(name, value, [dependencies])` *(deprecated)*
+#### `decorateReply(name, value, [dependencies])`
 <a name="decorate-reply"></a>
 
 As the name suggests, this API is used to add new methods/properties to the core
@@ -148,7 +148,7 @@ the [getter/setter](#getters-setters) feature.
 
 See [`decorate`](#decorate) for information about the `dependencies` parameter.
 
-#### `decorateRequest(name, value, [dependencies])` *(deprecated)*
+#### `decorateRequest(name, value, [dependencies])`
 <a name="decorate-request"></a>
 
 As above with [`decorateReply`](#decorate-reply), this API is used add new
@@ -169,9 +169,10 @@ Note2: using `decorateRequest` will emit a warning if used with a reference type
 // Don't do this
 fastify.decorateRequest('foo', { bar: 'fizz'})
 ```
-In this example the reference of the object is shared with all the requests, any
-mutation will impact all requests. To achieve an encapsulation like we suggest to use
-the [getter/setter](#getters-setters) feature.
+In this example the reference of the object is shared with all the requests: any
+mutation will impact all requests, potentially creating security vulnerabilities or memory leaks. 
+To achieve an encapsulation like we suggest to configure a new value for each incoming request
+in the [`'onRequest'` hook](Hooks.md#onrequest).
 
 See [`decorate`](#decorate) for information about the `dependencies` parameter.
 

--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -144,7 +144,7 @@ fastify.decorateReply('foo', { bar: 'fizz'})
 ```
 In this example the reference of the object is shared with all the requests: **any
 mutation will impact all requests, potentially creating security vulnerabilities or memory leaks**. 
-To achieve proper encapsulation across requests to configure a new value for each incoming request
+To achieve proper encapsulation across requests configure a new value for each incoming request
 in the [`'onRequest'` hook](Hooks.md#onrequest). Example:
 
 ```js
@@ -185,7 +185,7 @@ fastify.decorateRequest('foo', { bar: 'fizz'})
 ```
 In this example the reference of the object is shared with all the requests: **any
 mutation will impact all requests, potentially creating security vulnerabilities or memory leaks**. 
-To achieve proper encapsulation across requests to configure a new value for each incoming request
+To achieve proper encapsulation across requests configure a new value for each incoming request
 in the [`'onRequest'` hook](Hooks.md#onrequest). Example:
 
 ```js

--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -142,9 +142,10 @@ Note2: using `decorateReply` will emit a warning if used with a reference type:
 // Don't do this
 fastify.decorateReply('foo', { bar: 'fizz'})
 ```
-In this example the reference of the object is shared with all the requests, any
-mutation will impact all requests. To achieve an encapsulation like we suggest to use
-the [getter/setter](#getters-setters) feature.
+In this example the reference of the object is shared with all the requests: any
+mutation will impact all requests, potentially creating security vulnerabilities or memory leaks. 
+To achieve an encapsulation like we suggest to configure a new value for each incoming request
+in the [`'onRequest'` hook](Hooks.md#onrequest).
 
 See [`decorate`](#decorate) for information about the `dependencies` parameter.
 

--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -145,7 +145,20 @@ fastify.decorateReply('foo', { bar: 'fizz'})
 In this example the reference of the object is shared with all the requests: any
 mutation will impact all requests, potentially creating security vulnerabilities or memory leaks. 
 To achieve an encapsulation like we suggest to configure a new value for each incoming request
-in the [`'onRequest'` hook](Hooks.md#onrequest).
+in the [`'onRequest'` hook](Hooks.md#onrequest). Example:
+
+```js
+const fp = require('fastify-plugin')
+
+async function myPlugin (app) {
+  app.decorareRequest('foo', null)
+  app.addHook('onRequest', async (req, reply) => {
+    req.foo = { bar: 42 }
+  }) 
+}
+
+module.exports = fp(myPlugin)
+```
 
 See [`decorate`](#decorate) for information about the `dependencies` parameter.
 
@@ -173,7 +186,20 @@ fastify.decorateRequest('foo', { bar: 'fizz'})
 In this example the reference of the object is shared with all the requests: any
 mutation will impact all requests, potentially creating security vulnerabilities or memory leaks. 
 To achieve an encapsulation like we suggest to configure a new value for each incoming request
-in the [`'onRequest'` hook](Hooks.md#onrequest).
+in the [`'onRequest'` hook](Hooks.md#onrequest). Example:
+
+```js
+const fp = require('fastify-plugin')
+
+async function myPlugin (app) {
+  app.decorareRequest('foo', null)
+  app.addHook('onRequest', async (req, reply) => {
+    req.foo = { bar: 42 }
+  }) 
+}
+
+module.exports = fp(myPlugin)
+```
 
 See [`decorate`](#decorate) for information about the `dependencies` parameter.
 

--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -57,6 +57,9 @@ fastify.get('/', (req, reply) => {
 
 Note that it is important to keep initial shape of decorated field as close as possible to the value intended to be set dynamically in the future. Initialize a decorator as a `''` if the intended value is a string, and as `null` if it will be an object or a function.
 
+Remember this example works only with value types as reference types will be shared amongst all requests.
+See [decorateRequest](#decorate-request).
+
 See
 [JavaScript engine fundamentals: Shapes and Inline Caches](https://web.archive.org/web/20200201163000/https://mathiasbynens.be/notes/shapes-ics)
 for more information on this topic.
@@ -118,7 +121,7 @@ If a dependency is not satisfied, the `decorate` method will throw an exception.
 The dependency check is performed before the server instance is booted. Thus,
 it cannot occur during runtime.
 
-#### `decorateReply(name, value, [dependencies])`
+#### `decorateReply(name, value, [dependencies])` *(deprecated)*
 <a name="decorate-reply"></a>
 
 As the name suggests, this API is used to add new methods/properties to the core
@@ -133,9 +136,19 @@ fastify.decorateReply('utility', function () {
 Note: using an arrow function will break the binding of `this` to the Fastify
 `Reply` instance.
 
+Note2: using `decorateReply` will emit a warning if used with a reference type:
+
+```js
+// Don't do this
+fastify.decorateReply('foo', { bar: 'fizz'})
+```
+In this example the reference of the object is shared with all the requests, any
+mutation will impact all requests. To achieve an encapsulation like we suggest to use
+the [getter/setter](#getters-setters) feature.
+
 See [`decorate`](#decorate) for information about the `dependencies` parameter.
 
-#### `decorateRequest(name, value, [dependencies])`
+#### `decorateRequest(name, value, [dependencies])` *(deprecated)*
 <a name="decorate-request"></a>
 
 As above with [`decorateReply`](#decorate-reply), this API is used add new
@@ -149,6 +162,16 @@ fastify.decorateRequest('utility', function () {
 
 Note: using an arrow function will break the binding of `this` to the Fastify
 `Request` instance.
+
+Note2: using `decorateRequest` will emit a warning if used with a reference type:
+
+```js
+// Don't do this
+fastify.decorateRequest('foo', { bar: 'fizz'})
+```
+In this example the reference of the object is shared with all the requests, any
+mutation will impact all requests. To achieve an encapsulation like we suggest to use
+the [getter/setter](#getters-setters) feature.
 
 See [`decorate`](#decorate) for information about the `dependencies` parameter.
 

--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -136,15 +136,15 @@ fastify.decorateReply('utility', function () {
 Note: using an arrow function will break the binding of `this` to the Fastify
 `Reply` instance.
 
-Note2: using `decorateReply` will emit a warning if used with a reference type:
+Note: using `decorateReply` will emit a warning if used with a reference type:
 
 ```js
 // Don't do this
 fastify.decorateReply('foo', { bar: 'fizz'})
 ```
-In this example the reference of the object is shared with all the requests: any
-mutation will impact all requests, potentially creating security vulnerabilities or memory leaks. 
-To achieve an encapsulation like we suggest to configure a new value for each incoming request
+In this example the reference of the object is shared with all the requests: **any
+mutation will impact all requests, potentially creating security vulnerabilities or memory leaks**. 
+To achieve proper encapsulation across requests to configure a new value for each incoming request
 in the [`'onRequest'` hook](Hooks.md#onrequest). Example:
 
 ```js
@@ -177,15 +177,15 @@ fastify.decorateRequest('utility', function () {
 Note: using an arrow function will break the binding of `this` to the Fastify
 `Request` instance.
 
-Note2: using `decorateRequest` will emit a warning if used with a reference type:
+Note: using `decorateRequest` will emit a warning if used with a reference type:
 
 ```js
 // Don't do this
 fastify.decorateRequest('foo', { bar: 'fizz'})
 ```
-In this example the reference of the object is shared with all the requests: any
-mutation will impact all requests, potentially creating security vulnerabilities or memory leaks. 
-To achieve an encapsulation like we suggest to configure a new value for each incoming request
+In this example the reference of the object is shared with all the requests: **any
+mutation will impact all requests, potentially creating security vulnerabilities or memory leaks**. 
+To achieve proper encapsulation across requests to configure a new value for each incoming request
 in the [`'onRequest'` hook](Hooks.md#onrequest). Example:
 
 ```js

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -14,6 +14,8 @@ const {
   FST_ERR_DEC_AFTER_START
 } = require('./errors')
 
+const warning = require('./warnings')
+
 function decorate (instance, name, fn, dependencies) {
   if (instance.hasOwnProperty(name)) {
     throw new FST_ERR_DEC_ALREADY_PRESENT(name)
@@ -30,6 +32,12 @@ function decorate (instance, name, fn, dependencies) {
     })
   } else {
     instance[name] = fn
+  }
+}
+
+function checkReferenceType (name, fn) {
+  if (typeof fn === 'object') {
+    warning.emit('FSTDEP006', name)
   }
 }
 
@@ -65,12 +73,14 @@ function checkDependencies (instance, deps) {
 
 function decorateReply (name, fn, dependencies) {
   assertNotStarted(this, name)
+  checkReferenceType(name, fn)
   decorate(this[kReply].prototype, name, fn, dependencies)
   return this
 }
 
 function decorateRequest (name, fn, dependencies) {
   assertNotStarted(this, name)
+  checkReferenceType(name, fn)
   decorate(this[kRequest].prototype, name, fn, dependencies)
   return this
 }

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -36,7 +36,7 @@ function decorate (instance, name, fn, dependencies) {
 }
 
 function checkReferenceType (name, fn) {
-  if (typeof fn === 'object' && (typeof fn.getter === 'function' || typeof fn.setter === 'function')) {
+  if (typeof fn === 'object' && !(typeof fn.getter === 'function' || typeof fn.setter === 'function')) {
     warning.emit('FSTDEP006', name)
   }
 }

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -36,7 +36,7 @@ function decorate (instance, name, fn, dependencies) {
 }
 
 function checkReferenceType (name, fn) {
-  if (typeof fn === 'object') {
+  if (typeof fn === 'object' && (typeof fn.getter === 'function' || typeof fn.setter === 'function')) {
     warning.emit('FSTDEP006', name)
   }
 }

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -21,4 +21,6 @@ warning.create('FastifyDeprecation', 'FSTDEP004', 'You are using the legacy preP
 
 warning.create('FastifyDeprecation', 'FSTDEP005', 'You are accessing the deprecated "request.connection" property. Use "request.socket" instead.')
 
+warning.create('FastifyDeprecation', 'FSTDEP006', 'You are decorating Request/Reply with a reference type. This reference is shared amongst all requests. Use onRequest hook instead. Property: %s')
+
 module.exports = warning

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -744,3 +744,27 @@ test('decorate* should throw if called after ready', async t => {
   }
   await fastify.close()
 })
+
+test('decorate* should emit warning if reference type is passed', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+  fastify.get('/', (request, reply) => {
+    reply.send({
+      hello: 'world'
+    })
+  })
+  process.on('warning', onWarning)
+  function onWarning (warning) {
+    t.strictEqual(warning.name, 'FastifyDeprecation')
+    t.strictEqual(warning.code, 'FSTDEP006')
+  }
+  fastify.decorateRequest('test', { foo: 'bar' })
+  fastify.decorateRequest('test2', {
+    getter () {
+      return 'a getter'
+    }
+  })
+  await fastify.listen(0)
+  await fastify.close()
+  process.removeListener('warning', onWarning)
+})

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -777,10 +777,7 @@ test('decorate* should emit warning if object type is passed', t => {
 })
 
 test('decorate* should not emit warning if object with getter/setter is passed', t => {
-  t.plan(1)
-  let calls = 0
   function onWarning (warning) {
-    calls++
     t.fail('Should not call a warn')
   }
   const warning = {
@@ -797,15 +794,11 @@ test('decorate* should not emit warning if object with getter/setter is passed',
       return 'a getter'
     }
   })
-
-  t.is(calls, 0)
+  t.end('Done')
 })
 
 test('decorate* should not emit warning if string,bool,numbers are passed', t => {
-  t.plan(1)
-  let calls = 0
   function onWarning (warning) {
-    calls++
     t.fail('Should not call a warn')
   }
   const warning = {
@@ -818,5 +811,5 @@ test('decorate* should not emit warning if string,bool,numbers are passed', t =>
   fastify.decorateRequest('test_str', 'foo')
   fastify.decorateRequest('test_bool', true)
   fastify.decorateRequest('test_number', 42)
-  t.is(calls, 0)
+  t.end('Done')
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Like mentioned in https://github.com/fastify/fastify/issues/2598 . Emitting warning on `object` properties on `decorate`

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
