### PR TITLE
fix: throw in `onSend` causes fastify to not respond

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -199,7 +199,12 @@ function onSendHookRunner (functions, request, reply, payload, cb) {
       return
     }
 
-    const result = functions[i++](request, reply, payload, next)
+    let result
+    try {
+      result = functions[i++](request, reply, payload, next)
+    } catch (error) {
+      next(error)
+    }
     if (result && typeof result.then === 'function') {
       result.then(handleResolve, handleReject)
     }

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -159,7 +159,13 @@ function hookRunner (functions, runner, request, reply, cb) {
       return
     }
 
-    const result = runner(functions[i++], request, reply, next)
+    let result
+    try {
+      result = runner(functions[i++], request, reply, next)
+    } catch (error) {
+      next(error)
+      return
+    }
     if (result && typeof result.then === 'function') {
       result.then(handleResolve, handleReject)
     }

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -204,6 +204,7 @@ function onSendHookRunner (functions, request, reply, payload, cb) {
       result = functions[i++](request, reply, payload, next)
     } catch (error) {
       next(error)
+      return
     }
     if (result && typeof result.then === 'function') {
       result.then(handleResolve, handleReject)

--- a/lib/route.js
+++ b/lib/route.js
@@ -416,11 +416,15 @@ function preParsingHookRunner (functions, request, reply, cb) {
 
     const fn = functions[i++]
     let result
-
-    if (fn[kHooksDeprecatedPreParsing]) {
-      result = fn(request, reply, next)
-    } else {
-      result = fn(request, reply, request[kRequestPayloadStream], next)
+    try {
+      if (fn[kHooksDeprecatedPreParsing]) {
+        result = fn(request, reply, next)
+      } else {
+        result = fn(request, reply, request[kRequestPayloadStream], next)
+      }
+    } catch (error) {
+      next(error)
+      return
     }
 
     if (result && typeof result.then === 'function') {

--- a/test/internals/hookRunner.test.js
+++ b/test/internals/hookRunner.test.js
@@ -70,6 +70,38 @@ test('hookRunner - In case of error should skip to done', t => {
   }
 })
 
+test('hookRunner - Should handle throw', t => {
+  t.plan(7)
+
+  hookRunner([fn1, fn2, fn3], iterator, 'a', 'b', done)
+
+  function iterator (fn, a, b, next) {
+    return fn(a, b, next)
+  }
+
+  function fn1 (a, b, next) {
+    t.strictEqual(a, 'a')
+    t.strictEqual(b, 'b')
+    next()
+  }
+
+  function fn2 (a, b, next) {
+    t.strictEqual(a, 'a')
+    t.strictEqual(b, 'b')
+    throw new Error('kaboom')
+  }
+
+  function fn3 () {
+    t.fail('We should not be here')
+  }
+
+  function done (err, a, b) {
+    t.strictEqual(err.message, 'kaboom')
+    t.strictEqual(a, 'a')
+    t.strictEqual(b, 'b')
+  }
+})
+
 test('hookRunner - Should handle promises', t => {
   t.plan(9)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
fixes the issue described in #2692 


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
