### PR TITLE
docs: add reply lifecycle

### DIFF
--- a/docs/Lifecycle.md
+++ b/docs/Lifecycle.md
@@ -38,17 +38,24 @@ Incoming Request
 
 ## Reply Lifecycle
 
-Whenever a reply is being submitted, the flow the data sent performs is the following:
+Whenever the user handles the request the result may be:
+
+- in async handler: it returns a payload
+- in async handler: it throws an `Error`
+- in sync handler: it sends a payload
+- in sync handler: it sends an `Error` instance
+
+So, when the reply is being submitted, the data flow performed is the following:
 
 ```
-                       🌟 schema validation Error
+                        ★ schema validation Error
                                     │
                                     └─▶ schemaErrorFormatter
                                                │
                           reply sent ◀── JSON ─┴─ Error instance
                                                       │
-                                                      │        🌟 any uncaught Errors
-                   🌟 reply.send()                    │                 │
+                                                      │         ★ throw an Error
+                     ★ send or return                 │                 │
                             │                         ▼                 │
        reply sent ◀── JSON ─┴─ Error instance ──▶ setErrorHandler ◀─────┘
                                                       │

--- a/docs/Lifecycle.md
+++ b/docs/Lifecycle.md
@@ -63,3 +63,9 @@ So, when the reply is being submitted, the data flow performed is the following:
                                                                                 │
                                                                                 └─▶ reply sent
 ```
+
+Note: `reply sent` means that the JSON payload will be serialized by:
+
+- the [reply serialized](Server.md#setreplyserializer) if set
+- or by the [serializer compiler](Server.md#setserializercompiler) when a JSON schema has been set for the returning HTTP status code
+- or by the default `JSON.stringify` function

--- a/docs/Lifecycle.md
+++ b/docs/Lifecycle.md
@@ -3,6 +3,7 @@
 ## Lifecycle
 Following the schema of the internal lifecycle of Fastify.<br>
 On the right branch of every section there is the next phase of the lifecycle, on the left branch there is the corresponding error code that will be generated if the parent throws an error *(note that all the errors are automatically handled by Fastify)*.
+
 ```
 Incoming Request
   │
@@ -33,4 +34,25 @@ Incoming Request
                                                             4**/5** ◀─┴─▶ Outgoing Response
                                                                             │
                                                                             └─▶ onResponse Hook
+```
+
+## Reply Lifecycle
+
+Whenever a reply is being submitted, the flow the data sent performs is the following:
+
+```
+                       🌟 schema validation Error
+                                    │
+                                    └─▶ schemaErrorFormatter
+                                               │
+                          reply sent ◀── JSON ─┴─ Error instance
+                                                      │
+                                                      │        🌟 any uncaught Errors
+                   🌟 reply.send()                    │                 │
+                            │                         ▼                 │
+       reply sent ◀── JSON ─┴─ Error instance ──▶ setErrorHandler ◀─────┘
+                                                      │
+                                 reply sent ◀── JSON ─┴─ Error instance ──▶ onError Hook
+                                                                                │
+                                                                                └─▶ reply sent
 ```


### PR DESCRIPTION
Improve #2687 

This PR add a "reply lifecycle" that aims to explain what is happening when devs write `reply.send(<something>)`.

The stars 🌟 would like to emphasize the possible entry point to this flow

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
