### PR TITLE
Allow async handler to resolve with undefined

### DIFF
--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -238,19 +238,19 @@ fastify.get('/', options, async function (request, reply) {
 
 **Warning:**
 * When using both `return value` and `reply.send(value)` at the same time, the first one that happens takes precedence, the second value will be discarded, and a *warn* log will also be emitted because you tried to send a response twice.
-* You can't return `undefined`. For more details read [promise-resolution](#promise-resolution).
+* Calling `reply.send()` outside of the promise is possible, but requires special attention. For more details read [promise-resolution](#promise-resolution).
 
 <a name="promise-resolution"></a>
 ### Promise resolution
 
-If your handler is an `async` function or returns a promise, you should be aware of a special behaviour which is necessary to support the callback and promise control-flow. If the handler's promise is resolved with `undefined`, it will be ignored causing the request to hang and an *error* log to be emitted.
+If your handler is an `async` function or returns a promise, you should be aware of a special behaviour which is necessary to support the callback and promise control-flow. When the handler's promise is resolved, the reply will be automatically sent with its value unless you explicitly await or return `reply` in your handler.
 
 1. If you want to use `async/await` or promises but respond a value with `reply.send`:
-    - **Don't** `return` any value.
+    - **Do** `return reply` / `await reply`.
     - **Don't** forget to call `reply.send`.
 2. If you want to use `async/await` or promises:
     - **Don't** use `reply.send`.
-    - **Don't** return `undefined`.
+    - **Do** return the value that you want to send.
 
 In this way, we can support both `callback-style` and `async-await`, with the minimum trade-off. In spite of so much freedom we highly recommend to go with only one style because error handling should be handled in a consistent way within your application.
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -169,14 +169,6 @@ const codes = {
   ),
 
   /**
-   * wrapThenable
-   */
-  FST_ERR_PROMISE_NOT_FULFILLED: createError(
-    'FST_ERR_PROMISE_NOT_FULFILLED',
-    "Promise may not be fulfilled with 'undefined' when statusCode is not 204"
-  ),
-
-  /**
    * http2
    */
   FST_ERR_HTTP2_INVALID_VERSION: createError(

--- a/lib/wrapThenable.js
+++ b/lib/wrapThenable.js
@@ -6,8 +6,6 @@ const {
   kReplySentOverwritten
 } = require('./symbols')
 
-const { FST_ERR_PROMISE_NOT_FULFILLED } = require('./errors')
-
 function wrapThenable (thenable, reply) {
   thenable.then(function (payload) {
     if (reply[kReplySentOverwritten] === true) {
@@ -16,7 +14,7 @@ function wrapThenable (thenable, reply) {
 
     // this is for async functions that
     // are using reply.send directly
-    if (payload !== undefined || (reply.raw.statusCode === 204 && reply[kReplySent] === false)) {
+    if (payload !== undefined || reply[kReplySent] === false) {
       // we use a try-catch internally to avoid adding a catch to another
       // promise, increase promise perf by 10%
       try {
@@ -26,8 +24,6 @@ function wrapThenable (thenable, reply) {
         reply[kReplyIsError] = true
         reply.send(err)
       }
-    } else if (reply[kReplySent] === false) {
-      reply.log.error({ err: new FST_ERR_PROMISE_NOT_FULFILLED() }, "Promise may not be fulfilled with 'undefined' when statusCode is not 204")
     }
   }, function (err) {
     if (reply[kReplySentOverwritten] === true || reply.sent === true) {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -3184,6 +3184,7 @@ test('onTimeout should be triggered', t => {
   })
 
   fastify.get('/timeout', async (req, reply) => {
+    return reply
   })
 
   fastify.listen(0, (err, address) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### Afterword

1. This is a follow up from https://github.com/fastify/fastify/issues/2664.

2. This PR fixes the following bug:
Using HTTP response codes which do not require body content (beside 204) using promise control flow.
```js
fastify.post('/', async (request, reply) => {
  reply.code(202);
});
```
Previously this block would never resolve in case we did not explicitly call reply.send().

3. Changes introduced:

- Documentation states that async handler cannot resolve with "undefined", so fastify can support callback-style control flow. The example that was brought up in the referred issue was the following:
```js
fastify.post('/', async (request, reply) => {
  setTimeout(() => {
    reply.code(200).send('hello world');
  }, 1000)
});
```
While this block will technically work, the code does explicitly discourage it and in my opinion also documentation implicitly discourages it. Since the promise will also resolve with "undefined" in this example, fastify will log an error:
https://github.com/fastify/fastify/blob/528a5f74dbf4ecae0ffd33096bc9ab44599a9293/lib/wrapThenable.js#L30
Looking at the documentation (https://www.fastify.io/docs/latest/Routes/#async-await), it states that we should return or await reply in such case. Therefore our example should be changed to this:
```js
fastify.post('/', async (request, reply) => {
  setTimeout(() => {
    reply.code(200).send('hello world');
  }, 1000)

  return reply
});
```
Therefore, the argument why "undefined" couldn't be returned from async handler is in my opinion dispelled.

- With this change every payload that is valid for reply.send() is also valid as a return value for async handler. I found it rather confusing that I could not return "undefined" from async handler (but could call `reply.send(undefined)`.

4.  Breaking change?
I believe there is no breaking change introduced here. It is true, that the documentation says that you cannot return "undefined" from the async handler due to the support of callback-style handling, but it shows no example of such usage. On the other hand, it shows two examples of the proper usage, that remain unchanged even with my proposed changes.
You can find them at https://www.fastify.io/docs/latest/Routes/#async-await; it's either you return or await reply when you want to use reply.send() outside the promise chain.
As I demonstrated earlier, not returning anything and depending on reply.send() outside promise chain is already **not** supported. It eventually returns "undefined" which the documentation says is clearly something you can't do and also the code itself logs an error.

5. TL;TR
You can now return "undefined" from an async handler. It does not introduce a breaking change in my opinion, and only adds additional functionality.