### PR TITLE
Schema error formatter bind to fastify instance

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -784,7 +784,7 @@ Set the schema validator compiler for all routes. See [#schema-validator](Valida
 
 <a name="set-schema-error-formatter"></a>
 #### setSchemaErrorFormatter
-Set the schema error formatter for all routes. See [#error-handling](Validation-and-Serialization.md#error-handling).
+Set the schema error formatter for all routes. See [#error-handling](Validation-and-Serialization.md#schemaerrorformatter).
 
 <a name="set-serializer-resolver"></a>
 #### setSerializerCompiler
@@ -803,7 +803,7 @@ The input `schema` can access all the shared schemas added with [`.addSchema`](#
 
 <a name="schema-error-formatter"></a>
 #### schemaErrorFormatter
-This property can be used to format errors that happen while the `validationCompiler` fails to validate the schema. See [#error-handling](Validation-and-Serialization.md#error-handling).
+This property can be used set a function to format errors that happen while the `validationCompiler` fails to validate the schema. See [#error-handling](Validation-and-Serialization.md#schemaerrorformatter).
 
 <a name="set-not-found-handler"></a>
 #### setNotFoundHandler

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -508,16 +508,27 @@ fastify.post('/', { schema, attachValidation: true }, function (req, reply) {
 })
 ```
 
+#### `schemaErrorFormatter`
+
 If you want to format errors yourself, you can provide a sync function that must return an error as the `schemaErrorFormatter` option to Fastify when instantiating.
+The context function will be the Fastify server instance.
 
 `errors` is an array of Fastify schema errors `FastifySchemaValidationError`.
 `dataVar` is the currently validated part of the schema. (params | body | querystring | headers).
+
 ```js
 const fastify = Fastify({
   schemaErrorFormatter: (errors, dataVar) => {
     // ... my formatting logic 
     return new Error(myErrorMessage)
   }
+})
+
+// or
+fastify.setSchemaErrorFormatter(function (errors, dataVar) {
+  this.log.error({ err: errors }, 'Validation failed')
+  // ... my formatting logic 
+  return new Error(myErrorMessage)
 })
 ```
 

--- a/fastify.js
+++ b/fastify.js
@@ -562,7 +562,7 @@ function fastify (options) {
   function setSchemaErrorFormatter (errorFormatter) {
     throwIfAlreadyStarted('Cannot call "setSchemaErrorFormatter" when fastify instance is already started!')
     validateSchemaErrorFormatter(errorFormatter)
-    this[kSchemaErrorFormatter] = errorFormatter
+    this[kSchemaErrorFormatter] = errorFormatter.bind(this)
     return this
   }
 

--- a/fastify.js
+++ b/fastify.js
@@ -95,10 +95,6 @@ function fastify (options) {
   const bodyLimit = options.bodyLimit || defaultInitOptions.bodyLimit
   const disableRequestLogging = options.disableRequestLogging || false
 
-  if (options.schemaErrorFormatter) {
-    validateSchemaErrorFormatter(options.schemaErrorFormatter)
-  }
-
   const ajvOptions = Object.assign({
     customOptions: {},
     plugins: []
@@ -176,7 +172,7 @@ function fastify (options) {
     [kHooks]: new Hooks(),
     [kSchemas]: schemas,
     [kValidatorCompiler]: null,
-    [kSchemaErrorFormatter]: options.schemaErrorFormatter,
+    [kSchemaErrorFormatter]: null,
     [kErrorHandler]: defaultErrorHandler,
     [kSerializerCompiler]: null,
     [kReplySerializerDefault]: null,
@@ -303,6 +299,11 @@ function fastify (options) {
   // can still access it (and get the expected error), but `decorate`
   // will not detect it, and allow the user to override it.
   Object.setPrototypeOf(fastify, { use })
+
+  if (options.schemaErrorFormatter) {
+    validateSchemaErrorFormatter(options.schemaErrorFormatter)
+    fastify[kSchemaErrorFormatter] = options.schemaErrorFormatter.bind(fastify)
+  }
 
   // Install and configure Avvio
   // Avvio will update the following Fastify methods:

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -403,6 +403,35 @@ test('should return a defined output message parsing JOI error details', t => {
   })
 })
 
+test('the context custom error formatter context must be the server instance', t => {
+  t.plan(4)
+
+  const fastify = Fastify()
+
+  fastify.setSchemaErrorFormatter(function (errors, dataVar) {
+    t.deepEquals(this, fastify)
+    return new Error('my error')
+  })
+
+  fastify.post('/', { schema }, echoBody)
+
+  fastify.inject({
+    method: 'POST',
+    payload: {
+      hello: 'michelangelo'
+    },
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.deepEqual(res.json(), {
+      statusCode: 400,
+      error: 'Bad Request',
+      message: 'my error'
+    })
+    t.strictEqual(res.statusCode, 400)
+  })
+})
+
 test('should call custom error formatter', t => {
   t.plan(6)
 

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -403,7 +403,7 @@ test('should return a defined output message parsing JOI error details', t => {
   })
 })
 
-test('the context custom error formatter context must be the server instance', t => {
+test('the custom error formatter context must be the server instance', t => {
   t.plan(4)
 
   const fastify = Fastify()
@@ -411,6 +411,35 @@ test('the context custom error formatter context must be the server instance', t
   fastify.setSchemaErrorFormatter(function (errors, dataVar) {
     t.deepEquals(this, fastify)
     return new Error('my error')
+  })
+
+  fastify.post('/', { schema }, echoBody)
+
+  fastify.inject({
+    method: 'POST',
+    payload: {
+      hello: 'michelangelo'
+    },
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.deepEqual(res.json(), {
+      statusCode: 400,
+      error: 'Bad Request',
+      message: 'my error'
+    })
+    t.strictEqual(res.statusCode, 400)
+  })
+})
+
+test('the custom error formatter context must be the server instance in options', t => {
+  t.plan(4)
+
+  const fastify = Fastify({
+    schemaErrorFormatter: function (errors, dataVar) {
+      t.deepEquals(this, fastify)
+      return new Error('my error')
+    }
   })
 
   fastify.post('/', { schema }, echoBody)


### PR DESCRIPTION
The `schemaErrorFormatter` function was not binded to the fastify instance and this may confuse the user that starts to be habit to have always the `this` like in hooks or `errorHandler` etc.

#### Checklist

- [c] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
