### PR TITLE
Politely link to source rather than archive.org

### DIFF
--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -61,7 +61,7 @@ Remember this example works only with value types as reference types will be sha
 See [decorateRequest](#decorate-request).
 
 See
-[JavaScript engine fundamentals: Shapes and Inline Caches](https://web.archive.org/web/20200201163000/https://mathiasbynens.be/notes/shapes-ics)
+[JavaScript engine fundamentals: Shapes and Inline Caches](https://mathiasbynens.be/notes/shapes-ics)
 for more information on this topic.
 
 ### Usage


### PR DESCRIPTION
Git is timestamped. One knows when a link was added. One can always go back and add an archive.org link later. Someone might even create and share a GitHub Action or something for it if there's a major need for it. Pre-emptively linking to archive.org is just rude.

Sure domain names doesn't live forever and people can by them own kill URL:s if they like to, but that's what the current world wide web delivers.

If one has a problem with that, then one can push towards eg. https://ipfs.io/, but lets not do it like this?

Also, a domain owner can always request retroactive removal from archive.org, so that URL sure can become invalid as well.

Twitter discussion: https://twitter.com/mathias/status/1331666134807048193