### PR TITLE
test async preSerialization with a failed response schema

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -195,7 +195,11 @@ function onSendHookRunner (functions, request, reply, payload, cb) {
     }
 
     if (i === functions.length) {
-      cb(null, request, reply, payload)
+      try {
+        cb(null, request, reply, payload)
+      } catch (err) {
+        handleReject(err)
+      }
       return
     }
 

--- a/test/hooks-async.test.js
+++ b/test/hooks-async.test.js
@@ -660,8 +660,8 @@ test('preSerializationEnd should handle errors if the serialize method throws', 
     })
 
     fastify.post('/', {
-      handler (req, reply) { reply.send({ status: 'not ok' }) },
-      schema: { response: { 200: { status: { type: 'array' } } } }
+      handler (req, reply) { reply.send({ notOk: true }) },
+      schema: { response: { 200: { required: ['ok'], properties: { ok: { type: 'boolean' } } } } }
     })
 
     fastify.inject({
@@ -682,8 +682,8 @@ test('preSerializationEnd should handle errors if the serialize method throws', 
     })
 
     fastify.post('/', {
-      handler (req, reply) { reply.send({ status: 'not ok' }) },
-      schema: { response: { 200: { status: { type: 'array' } } } }
+      handler (req, reply) { reply.send({ notOk: true }) },
+      schema: { response: { 200: { required: ['ok'], properties: { ok: { type: 'boolean' } } } } }
     })
 
     fastify.inject({


### PR DESCRIPTION
Fixes #2707 and adds a test for the edge case

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
