### PR TITLE
Update the type definition of querystringParser

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -92,7 +92,7 @@ export type FastifyServerOptions<
   requestIdLogLabel?: string;
   genReqId?: <RequestGeneric extends RequestGenericInterface = RequestGenericInterface>(req: FastifyRequest<RequestGeneric, RawServer, RawRequestDefaultExpression<RawServer>>) => string,
   trustProxy?: boolean | string | string[] | number | TrustProxyFunction,
-  querystringParser?: (str: string) => { [key: string]: string | string[] },
+  querystringParser?: (str: string) => { [key: string]: unknown },
   versioning?: {
     storage(): {
       get(version: string): string | null,

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -85,6 +85,8 @@ expectAssignable<FastifyInstance>(fastify({ requestIdHeader: 'request-id' }))
 expectAssignable<FastifyInstance>(fastify({ genReqId: () => 'request-id' }))
 expectAssignable<FastifyInstance>(fastify({ trustProxy: true }))
 expectAssignable<FastifyInstance>(fastify({ querystringParser: () => ({ foo: 'bar' }) }))
+expectAssignable<FastifyInstance>(fastify({ querystringParser: () => ({ foo: { bar: 'fuzz' } }) }))
+expectAssignable<FastifyInstance>(fastify({ querystringParser: () => ({ foo: ['bar', 'fuzz'] }) }))
 expectAssignable<FastifyInstance>(fastify({
   versioning: {
     storage: () => ({


### PR DESCRIPTION
Change the value type from return object of querystringParser to unknown.

Why: 
With the current definition it is not possible to return nested queries when using an external parser (e.g. qs).
Since the type of the return value is not important at this point, the `unknown` type can be used.

Example:
```typescript
type QuerystringParserOld = (str: string) => { [key: string]: string | string[] },
type QuerystringParserNew = (str: string) => { [key: string]: unknown },

// URL: /api?foo[a]=bar&foo[b]=fuzz&foo[c]=buzz
// is parsed into the following object:
const queryOld: ReturnType<QuerystringParserOld> = { foo: { a: 'bar', b: 'fuzz', c: 'buzz' } };
const queryNew: ReturnType<QuerystringParserNew> = { foo: { a: 'bar', b: 'fuzz', c: 'buzz' } };
```
With `queryOld` a type error is thrown and with `queryNew` not

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)