### PR TITLE
Fix language in encapsulation doc

### DIFF
--- a/docs/Encapsulation.md
+++ b/docs/Encapsulation.md
@@ -123,11 +123,11 @@ To see this, start the server and issue requests:
 ## Sharing Between Contexts
 
 Notice that each context in the prior example inherits _only_ from the parent
-contexts. Sibling contexts do not share any entities. This default is
-occassionally not desired. In such cases, the encapsulation context can be
-broken through the usage of [fastify-plugin][fastify-plugin] such that
-anything registered in a descendent context is available to the containing
-parent context.
+contexts. Parent contexts cannot access any entities within its descendent
+contexts. This default is occassionally not desired. In such cases, the
+encapsulation context can be broken through the usage of
+[fastify-plugin][fastify-plugin] such that anything registered in a descendent
+context is available to the containing parent context.
 
 Assuming the `publicContext` needs access to the `bar` decorator defined
 within the `grandchildContext` in the previous example, the code can be


### PR DESCRIPTION
A slight language correction to match the actual behavior.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
