### PR TITLE
Correct typo in type declaration file: factory function

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -14,7 +14,7 @@ import { FastifyReply } from './types/reply'
 import { FastifySchemaValidationError } from './types/schema'
 
 /**
- * Fastify factor function for the standard fastify http, https, or http2 server instance.
+ * Fastify factory function for the standard fastify http, https, or http2 server instance.
  *
  * The default function utilizes http
  *


### PR DESCRIPTION
Correct typo in type declaration file: change from 'factor function' to 'factory function'.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
