### PR TITLE
move validation type to core

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -118,6 +118,20 @@ export type FastifyServerOptions<
 
 type TrustProxyFunction = (address: string, hop: number) => boolean
 
+declare module 'fastify-error' {
+  interface FastifyError {
+    validation?: ValidationResult[];
+  }
+}
+
+export interface ValidationResult {
+  keyword: string;
+  dataPath: string;
+  schemaPath: string;
+  params: Record<string, string | string[]>;
+  message: string;
+}
+
 /* Export all additional types */
 export { FastifyRequest, RequestGenericInterface } from './types/request'
 export { FastifyReply } from './types/reply'
@@ -128,7 +142,7 @@ export { FastifyContext } from './types/context'
 export { RouteHandler, RouteHandlerMethod, RouteOptions, RouteShorthandMethod, RouteShorthandOptions, RouteShorthandOptionsWithHandler } from './types/route'
 export * from './types/register'
 export { FastifyBodyParser, FastifyContentTypeParser, AddContentTypeParser, hasContentTypeParser } from './types/content-type-parser'
-export { FastifyError, ValidationResult } from 'fastify-error'
+export { FastifyError } from 'fastify-error'
 export { FastifySchema, FastifySchemaCompiler } from './types/schema'
 export { HTTPMethods, RawServerBase, RawRequestDefaultExpression, RawReplyDefaultExpression, RawServerDefault, ContextConfigDefault, RequestBodyDefault, RequestQuerystringDefault, RequestParamsDefault, RequestHeadersDefault } from './types/utils'
 export * from './types/hooks'

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "ajv": "^6.12.2",
     "avvio": "^7.1.2",
     "fast-json-stringify": "^2.2.1",
-    "fastify-error": "^0.2.0",
+    "fastify-error": "^0.3.0",
     "fastify-warning": "^0.2.0",
     "find-my-way": "^3.0.0",
     "flatstr": "^1.0.12",

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -1,4 +1,4 @@
-import fastify, { FastifyError, FastifyInstance } from '../../fastify'
+import fastify, { FastifyError, FastifyInstance, ValidationResult } from '../../fastify'
 import { expectAssignable, expectError, expectType } from 'tsd'
 
 const server = fastify()
@@ -30,6 +30,8 @@ expectAssignable<FastifyInstance>(
     expectType<FastifyError>(error)
   })
 )
+
+expectType<ValidationResult[] | undefined>(FastifyError().validation)
 
 function fastifyErrorHandler (this: FastifyInstance, error: FastifyError) {}
 server.setErrorHandler(fastifyErrorHandler)


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


This is blocked until fastify-error module is updated (https://github.com/fastify/fastify-error/pull/9) 