### PR TITLE
docs: fix a few typos

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -32,7 +32,7 @@ They are split into the following teams:
 | `@fastify/benchmarks`   |  Build and maintain our benchmarks suite  |  `benchmarks` |
 | `@fastify/docs-chinese`   |  Translate the Fastify documentation in Chinese  |  `docs-chinese` |
 
-Every memeber of the org is also part of `@fastify/fastify`.
+Every member of the org is also part of `@fastify/fastify`.
 
 Collaborators have:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,9 +7,9 @@ This document describes the management of vulnerabilities for the Fastify projec
 
 Individuals who find potential vulnerabilities in Fastify are invited to complete a vulnerability report via the dedicated HackerOne tool for Node.js modules: [https://hackerone.com/nodejs-ecosystem](https://hackerone.com/nodejs-ecosystem).
 
-### How to report a vulnerabiliy
+### How to report a vulnerability
 
-It is of the utmost importance that you read carefully [**HOW TO REPORT A VULNERABILIY**](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md) written by the Security Working Group of Node.js.
+It is of the utmost importance that you read carefully [**HOW TO REPORT A VULNERABILITY**](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md) written by the Security Working Group of Node.js.
 
 
 ## Handling vulnerability reports

--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -94,7 +94,7 @@ Plugins maintained by the fastify team are listed under [Core](#core) while plug
 - [`fastify-http-context`](https://github.com/thorough-developer/fastify-http-context) Fastify plugin for "simulating" a thread of execution to allow for true http context to take place per api call within the fastify lifecycle of calls.
 - [`fastify-https-redirect`](https://github.com/tomsvogel/fastify-https-redirect) Fastify plugin for auto redirect from http to https
 - [`fastify-http-client`](https://github.com/kenuyx/fastify-http-client) Plugin to send HTTP(s) requests. Built upon [urllib](https://github.com/node-modules/urllib).
-- [`fastify-http-errors-enhanced`](https://github.com/ShogunPanda/fastify-http-errors-enhanced) A error handling plugin for Fastify that uses enhanced HTTP errors.
+- [`fastify-http-errors-enhanced`](https://github.com/ShogunPanda/fastify-http-errors-enhanced) An error handling plugin for Fastify that uses enhanced HTTP errors.
 - [`fastify-influxdb`](https://github.com/alex-ppg/fastify-influxdb) Fastify InfluxDB plugin connecting to an InfluxDB instance via the Influx default package.
 - [`fastify-jwt-authz`](https://github.com/Ethan-Arrowood/fastify-jwt-authz) JWT user scope verifier.
 - [`fastify-jwt-webapp`](https://github.com/charlesread/fastify-jwt-webapp) JWT authentication for fastify-based web apps.

--- a/docs/Encapsulation.md
+++ b/docs/Encapsulation.md
@@ -124,7 +124,7 @@ To see this, start the server and issue requests:
 
 Notice that each context in the prior example inherits _only_ from the parent
 contexts. Parent contexts cannot access any entities within its descendent
-contexts. This default is occassionally not desired. In such cases, the
+contexts. This default is occasionally not desired. In such cases, the
 encapsulation context can be broken through the usage of
 [fastify-plugin][fastify-plugin] such that anything registered in a descendent
 context is available to the containing parent context.

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -456,7 +456,7 @@ Warn: if you declare the function with an [arrow function](https://developer.moz
 <a name="route-hooks"></a>
 
 ## Route level hooks
-You can declare one or more custom [onRequest](#onrequest), [onReponse](#onresponse), [preParsing](#preparsing), [preValidation](#prevalidation), [preHandler](#prehandler) and [preSerialization](#preserialization) hook(s) that will be **unique** for the route.
+You can declare one or more custom [onRequest](#onrequest), [onResponse](#onresponse), [preParsing](#preparsing), [preValidation](#prevalidation), [preHandler](#prehandler) and [preSerialization](#preserialization) hook(s) that will be **unique** for the route.
 If you do so, those hooks are always executed as the last hook in their category. <br/>
 This can be useful if you need to implement authentication, where the [preParsing](#preparsing) or [preValidation](#prevalidation) hooks are exactly what you need.
 Multiple route-level hooks can also be specified as an array.

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -351,7 +351,7 @@ fastify.get('/', {
 ```
 
 If you want to completely customize the error handling, checkout [`setErrorHandler`](Server.md#seterrorhandler) API.<br>
-*Note: you are responsibile for logging when customizing the error handler*
+*Note: you are responsible for logging when customizing the error handler*
 
 API:
 
@@ -409,14 +409,14 @@ fastify.get('/async-await', options, async function (request, reply) {
 Rejected promises default to a `500` HTTP status code. Reject the promise, or `throw` in an `async function`, with an object that has `statusCode` (or `status`) and `message` properties to modify the reply.
 
 ```js
-fastify.get('/teapot', async function (request, reply) => {
+fastify.get('/teapot', async function (request, reply) {
   const err = new Error()
   err.statusCode = 418
   err.message = 'short and stout'
   throw err
 })
 
-fastify.get('/botnet', async function (request, reply) => {
+fastify.get('/botnet', async function (request, reply) {
   throw { statusCode: 418, message: 'short and stout' }
   // will return to the client the same json
 })

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -737,7 +737,7 @@ Name of the current plugin. There are three ways to define a name (in order).
 2. If you `module.exports` a plugin the filename is used.
 3. If you use a regular [function declaration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions#Defining_functions) the function name is used.
 
-*Fallback*: The first two lines of your plugin will represent the plugin name. Newlines are replaced by ` -- `. This will help to indentify the root cause when you deal with many plugins.
+*Fallback*: The first two lines of your plugin will represent the plugin name. Newlines are replaced by ` -- `. This will help to identify the root cause when you deal with many plugins.
 
 Important: If you have to deal with nested plugins the name differs with the usage of the [fastify-plugin](https://github.com/fastify/fastify-plugin) because no new scope is created and therefore we have no place to attach contextual data. In that case the plugin name will represent the boot order of all involved plugins in the format of `plugin-A -> plugin-B`.
 

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -229,7 +229,7 @@ In the last example we used interfaces to define the types for the request query
    ```
    Pay special attention to the imports at the top of this file. It might seem redundant, but you need to import both the schema files and the generated interfaces.
 
-Great work! Now you can make use of both JSON Schemas and TypeScript definitions. If you didn't know already, defining schemas for your Fastify routes can increase their throughput! Check out the [Validation and Serialization](Validation-and-Serialization.md) documenation for more info.
+Great work! Now you can make use of both JSON Schemas and TypeScript definitions. If you didn't know already, defining schemas for your Fastify routes can increase their throughput! Check out the [Validation and Serialization](Validation-and-Serialization.md) documentation for more info.
 
 Some additional notes:
 - Currently, there is no type definition support for inline JSON schemas. If you can come up with a solution please open a PR!


### PR DESCRIPTION
Fixed typos in several `md` files

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
