### PR TITLE
chore: remove events.once devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^5.0.0",
-    "events.once": "^2.0.2",
     "fast-json-body": "^1.1.0",
     "fastify-plugin": "^3.0.0",
     "fluent-json-schema": "^2.0.1",

--- a/test/http2/closing.test.js
+++ b/test/http2/closing.test.js
@@ -6,7 +6,7 @@ const http2 = require('http2')
 const semver = require('semver')
 const { promisify } = require('util')
 const connect = promisify(http2.connect)
-const once = require('events.once')
+const { once } = require('events')
 
 t.test('http/2 request while fastify closing', t => {
   let fastify


### PR DESCRIPTION
There is not need of this polyfill module since the minimum node.js version supported by fastify is 10.16.x that has this feature included.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
