### PR TITLE
Correct method names in documentation and fix a few typos

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -10,7 +10,7 @@ The type system was changed in Fastify version 3. The new type system introduces
 
 > Plugins may or may not include typings. See [Plugins](#plugins) for more information. We encourage users to send pull requests to improve typings support.
 
-🚨 Don't foget to install `@types/node`
+🚨 Don't forget to install `@types/node`
 
 ## Learn By Example
 
@@ -985,7 +985,7 @@ This interface is passed to instance of FastifyError.
 
 #### Hooks
 
-##### fastify.onRequestHookhandler<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>(request: [FastifyRequest][FastifyRequest], reply: [FastifyReply][FastifyReply], done: (err?: [FastifyError][FastifyError]) => void): Promise\<unknown\> | void
+##### fastify.onRequestHookHandler<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>(request: [FastifyRequest][FastifyRequest], reply: [FastifyReply][FastifyReply], done: (err?: [FastifyError][FastifyError]) => void): Promise\<unknown\> | void
 
 [src](../types/hooks.d.ts#L17)
 
@@ -993,7 +993,7 @@ This interface is passed to instance of FastifyError.
 
 Notice: in the `onRequest` hook, request.body will always be null, because the body parsing happens before the `preHandler` hook.
 
-##### fastify.preParsingHookhandler<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>(request: [FastifyRequest][FastifyRequest], reply: [FastifyReply][FastifyReply], done: (err?: [FastifyError][FastifyError]) => void): Promise\<unknown\> | void
+##### fastify.preParsingHookHandler<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>(request: [FastifyRequest][FastifyRequest], reply: [FastifyReply][FastifyReply], done: (err?: [FastifyError][FastifyError]) => void): Promise\<unknown\> | void
 
 [src](../types/hooks.d.ts#L35)
 

--- a/fastify.js
+++ b/fastify.js
@@ -319,7 +319,7 @@ function fastify (options) {
       use: 'register'
     }
   })
-  // Override to allow the plugin incapsulation
+  // Override to allow the plugin encapsulation
   avvio.override = override
   avvio.on('start', () => (fastify[kState].started = true))
   fastify[kAvvioBoot] = fastify.ready // the avvio ready function

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -1702,7 +1702,7 @@ test('Should fail to invoke callNotFound inside a 404 handler', t => {
 })
 
 test('400 in case of bad url (pre find-my-way v2.2.0 was a 404)', t => {
-  t.test('Dyamic route', t => {
+  t.test('Dynamic route', t => {
     t.plan(3)
     const fastify = Fastify()
     fastify.get('/hello/:id', () => t.fail('we should not be here'))

--- a/test/async-await.test.js
+++ b/test/async-await.test.js
@@ -378,7 +378,7 @@ test('async await plugin', async t => {
   }
 })
 
-test('does not call reply.send() twice if 204 reponse is already sent', t => {
+test('does not call reply.send() twice if 204 response is already sent', t => {
   t.plan(2)
 
   const fastify = Fastify()

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -17,7 +17,7 @@ test('server methods should exist', t => {
   t.ok(fastify.hasDecorator)
 })
 
-test('server methods should be incapsulated via .register', t => {
+test('server methods should be encapsulated via .register', t => {
   t.plan(2)
   const fastify = Fastify()
 

--- a/test/hooks-async.test.js
+++ b/test/hooks-async.test.js
@@ -530,7 +530,7 @@ test('preHandler respond with a stream', t => {
   })
 
   // we are calling `reply.send` inside the `preHandler` hook with a stream,
-  // this triggers the `onSend` hook event if `preHanlder` has not yet finished
+  // this triggers the `onSend` hook event if `preHandler` has not yet finished
   const order = [1, 2]
 
   fastify.addHook('preHandler', async (req, reply) => {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -1619,7 +1619,7 @@ test('preHandler respond with a stream', t => {
   })
 
   // we are calling `reply.send` inside the `preHandler` hook with a stream,
-  // this triggers the `onSend` hook event if `preHanlder` has not yet finished
+  // this triggers the `onSend` hook event if `preHandler` has not yet finished
   const order = [1, 2]
 
   fastify.addHook('preHandler', (req, reply, done) => {

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -450,12 +450,12 @@ test('The logger should accept custom serializer', t => {
       stream.once('data', line => {
         t.ok(line.req, 'req is defined')
         t.equal(line.msg, 'incoming request', 'message is set')
-        t.deepEqual(line.req, { url: '/custom' }, 'custom req serialiser is use')
+        t.deepEqual(line.req, { url: '/custom' }, 'custom req serializer is use')
 
         stream.once('data', line => {
           t.ok(line.res, 'res is defined')
           t.equal(line.msg, 'kaboom', 'message is set')
-          t.deepEqual(line.res, { statusCode: 500 }, 'default res serialiser is use')
+          t.deepEqual(line.res, { statusCode: 500 }, 'default res serializer is use')
         })
       })
     })

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -41,7 +41,7 @@ test('plugin metadata - ignore prefix', t => {
   }
 })
 
-test('fastify.register with fastify-plugin should not incapsulate his code', t => {
+test('fastify.register with fastify-plugin should not encapsulate his code', t => {
   t.plan(10)
   const fastify = Fastify()
 
@@ -483,7 +483,7 @@ test('approximate a plugin name also when fastify-plugin has no meta data', t =>
   })
 })
 
-test('plugin incapsulation', t => {
+test('plugin encapsulation', t => {
   t.plan(10)
   const fastify = Fastify()
 

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -43,8 +43,8 @@ server.setReplySerializer(function (payload, statusCode) {
   return 'serialized'
 })
 
-function invalidReplySerialzer (payload: number, statusCode: string) {}
-expectError(server.setReplySerializer(invalidReplySerialzer))
+function invalidReplySerializer (payload: number, statusCode: string) {}
+expectError(server.setReplySerializer(invalidReplySerializer))
 
 function serializerWithInvalidReturn (payload: unknown, statusCode: number) {}
 expectError(server.setReplySerializer(serializerWithInvalidReturn))

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -219,7 +219,7 @@ test('should respect when attachValidation is explicitly set to false', t => {
   })
 })
 
-test('Attached validation error should take precendence over setErrorHandler', t => {
+test('Attached validation error should take precedence over setErrorHandler', t => {
   t.plan(3)
 
   const fastify = Fastify()

--- a/test/versioned-routes.test.js
+++ b/test/versioned-routes.test.js
@@ -404,7 +404,7 @@ test('test log stream', t => {
   })
 })
 
-test('Should register a versioned route with custome versioning strategy', t => {
+test('Should register a versioned route with custom versioning strategy', t => {
   t.plan(8)
 
   const versioning = {

--- a/types/content-type-parser.d.ts
+++ b/types/content-type-parser.d.ts
@@ -5,7 +5,7 @@ import { RouteGenericInterface } from './route'
 type ContentTypeParserDoneFunction = (err: Error | null, body?: any) => void
 
 /**
- * Body parser method that operatoes on request body
+ * Body parser method that operators on request body
  */
 export type FastifyBodyParser<
   RawBody extends string | Buffer,


### PR DESCRIPTION
Corrected method names in documentation and fix a few typos.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
