### PR TITLE
docs: upgrade all http links to https

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Declaring formal releases remains the prerogative of the lead maintainers. Do no
 The contributors to the Fastify's plugins must attend the same rules of the Fastify repository with few adjustments:
 
 1. A release can be published by any member.
-1. The plugin version must follow the [semver](http://semver.org/) specification.
+1. The plugin version must follow the [semver](https://semver.org/) specification.
 1. The Node.js compatibility must match with the Fastify's master branch.
 1. The new release must have the changelog information stored in the GitHub release.
      For this scope we suggest to adopt a tool like [`releasify`](https://github.com/fastify/releasify) to archive this.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ![](https://github.com/fastify/fastify/workflows/website/badge.svg)
 [![Known Vulnerabilities](https://snyk.io/test/github/fastify/fastify/badge.svg)](https://snyk.io/test/github/fastify/fastify)
 [![Coverage Status](https://coveralls.io/repos/github/fastify/fastify/badge.svg?branch=master)](https://coveralls.io/github/fastify/fastify?branch=master)
-[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
 
 </div>
 
@@ -138,7 +138,7 @@ In a similar way, all Fastify **v2.x** related changes should be based on [**`br
 
 - **Highly performant:** as far as we know, Fastify is one of the fastest web frameworks in town, depending on the code complexity we can serve up to 76+ thousand requests per second.
 - **Extendible:** Fastify is fully extensible via its hooks, plugins and decorators.
-- **Schema based:** even if it is not mandatory we recommend to use [JSON Schema](http://json-schema.org/) to validate your routes and serialize your outputs, internally Fastify compiles the schema in a highly performant function.
+- **Schema based:** even if it is not mandatory we recommend to use [JSON Schema](https://json-schema.org/) to validate your routes and serialize your outputs, internally Fastify compiles the schema in a highly performant function.
 - **Logging:** logs are extremely important but are costly; we chose the best logger to almost remove this cost, [Pino](https://github.com/pinojs/pino)!
 - **Developer friendly:** the framework is built to be very expressive and help the developer in their daily use, without sacrificing performance and security.
 
@@ -258,7 +258,7 @@ We are a [Growth Project](https://github.com/openjs-foundation/cross-project-cou
 ## Acknowledgements
 
 This project is kindly sponsored by:
-- [nearForm](http://nearform.com)
+- [nearForm](https://nearform.com)
 
 Past Sponsors:
 - [LetzDoIt](http://www.letzdoitapp.com/)

--- a/docs/ContentTypeParser.md
+++ b/docs/ContentTypeParser.md
@@ -97,7 +97,7 @@ app.post('/hello', (request, reply) => {
 })
 ```
 
-Here is a complete example that logs incoming [json line](http://jsonlines.org/) objects:
+Here is a complete example that logs incoming [json line](https://jsonlines.org/) objects:
 
 ```js
 const split2 = require('split2')

--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -62,7 +62,7 @@ Plugins maintained by the fastify team are listed under [Core](#core) while plug
 - [`fastify-axios`](https://github.com/davidedantonio/fastify-axios) Plugin to send HTTP requests via [axios](https://github.com/axios/axios).
 - [`fastify-babel`](https://github.com/cfware/fastify-babel) Fastify plugin for development servers which require babel transformations of JavaScript sources.
 - [`fastify-blipp`](https://github.com/PavelPolyakov/fastify-blipp) Prints your routes to the console, so you definitely know which endpoints are available.
-- [`fastify-bookshelf`](https://github.com/butlerx/fastify-bookshelfjs) Fastify plugin to add [bookshelf.js](http://bookshelfjs.org/) orm support.
+- [`fastify-bookshelf`](https://github.com/butlerx/fastify-bookshelfjs) Fastify plugin to add [bookshelf.js](https://bookshelfjs.org/) orm support.
 - [`fastify-boom`](https://github.com/jeromemacias/fastify-boom) Fastify plugin to add [boom](https://github.com/hapijs/boom) support.
 - [`fastify-casbin`](https://github.com/nearform/fastify-casbin) Casbin support for Fastify.
 - [`fastify-casbin-rest`](https://github.com/nearform/fastify-casbin-rest) Casbin support for Fastify based on a RESTful model.
@@ -79,7 +79,7 @@ Plugins maintained by the fastify team are listed under [Core](#core) while plug
 - [`fastify-explorer`](https://github.com/Eomm/fastify-explorer) Get control of your decorators across all the encapsulated contexts
 - [`fastify-esso`](https://github.com/patrickpissurno/fastify-esso) The easiest authentication plugin for Fastify, with built-in support for Single sign-on (and great documentation)
 - [`fastify-favicon`](https://github.com/smartiniOnGitHub/fastify-favicon) Fastify plugin to serve default favicon.
-- [`fastify-feature-flags`](https://gitlab.com/m03geek/fastify-feature-flags) Fastify feature flags plugin with multiple providers support (e.g. env, [config](http://lorenwest.github.io/node-config/), [unleash](https://unleash.github.io/)).
+- [`fastify-feature-flags`](https://gitlab.com/m03geek/fastify-feature-flags) Fastify feature flags plugin with multiple providers support (e.g. env, [config](https://lorenwest.github.io/node-config/), [unleash](https://unleash.github.io/)).
 - [`fastify-file-upload`](https://github.com/huangang/fastify-file-upload) Fastify plugin for uploading files.
 - [`fastify-firebase`](https://github.com/now-ims/fastify-firebase) Fastify plugin for [Firebase Admin SDK](https://firebase.google.com/docs/admin/setup) to Fastify so you can easy use Firebase Auth, Firestore, Cloud Storage, Cloud Messaging, and more.
 - [`fastify-firebase-auth`](https://github.com/oxsav/fastify-firebase-auth) Firebase Authentication for Fastify supporting all of the methods relating to the authentication API.
@@ -113,10 +113,10 @@ Plugins maintained by the fastify team are listed under [Core](#core) while plug
 - [`fastify-mongoose-api`](https://github.com/jeka-kiselyov/fastify-mongoose-api) Fastify plugin to create REST API methods based on Mongoose MongoDB models.
 - [`fastify-mongoose-driver`](https://github.com/alex-ppg/fastify-mongoose) Fastify Mongoose plugin that connects to a MongoDB via the Mongoose plugin with support for Models.
 - [`fastify-multer`](https://github.com/fox1t/fastify-multer) Multer is a plugin for handling multipart/form-data, which is primarily used for uploading files.
-- [`fastify-nats`](https://github.com/mahmed8003/fastify-nats) Plugin to share [NATS](http://nats.io) client across Fastify.
+- [`fastify-nats`](https://github.com/mahmed8003/fastify-nats) Plugin to share [NATS](https://nats.io) client across Fastify.
 - [`fastify-no-additional-properties`](https://github.com/greguz/fastify-no-additional-properties) Add `additionalProperties: false` by default to your JSON Schemas.
 - [`fastify-no-icon`](https://github.com/jsumners/fastify-no-icon) Plugin to eliminate thrown errors for `/favicon.ico` requests.
-- [`fastify-nodemailer`](https://github.com/lependu/fastify-nodemailer) Plugin to share [nodemailer](http://nodemailer.com) transporter across Fastify.
+- [`fastify-nodemailer`](https://github.com/lependu/fastify-nodemailer) Plugin to share [nodemailer](https://nodemailer.com) transporter across Fastify.
 - [`fastify-normalize-request-reply`](https://github.com/ericrglass/fastify-normalize-request-reply) Plugin to normalize the request and reply to the Express version 4.x request and response, which allows use of middleware, like swagger-stats, that was originally written for Express.
 - [`fastify-now`](https://github.com/yonathan06/fastify-now) Structure your endpoints in a folder and load them dynamically with fastify
 - [`fastify-oas`](https://gitlab.com/m03geek/fastify-oas) Generates OpenAPI 3.0+ documentation from routes schemas for Fastify.

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -241,7 +241,7 @@ As discussed previously, Fastify offers a solid encapsulation model, to help you
 <a name="validate-data"></a>
 ### Validate your data
 Data validation is extremely important and a core concept of the framework.<br>
-To validate incoming requests, Fastify uses [JSON Schema](http://json-schema.org/).
+To validate incoming requests, Fastify uses [JSON Schema](https://json-schema.org/).
 Let's look at an example demonstrating validation for routes:
 ```js
 const opts = {

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -32,7 +32,7 @@ fastify.route(options)
 * `url`: the path of the url to match this route (alias: `path`).
 * `schema`: an object containing the schemas for the request and response.
 They need to be in
-  [JSON Schema](http://json-schema.org/) format, check [here](Validation-and-Serialization.md) for more info.
+  [JSON Schema](https://json-schema.org/) format, check [here](Validation-and-Serialization.md) for more info.
 
   * `body`: validates the body of the request if it is a POST or a
     PUT.
@@ -59,7 +59,7 @@ They need to be in
 * `logLevel`: set log level for this route. See below.
 * `logSerializers`: set serializers to log for this route.
 * `config`: object used to store custom configuration.
-* `version`: a [semver](http://semver.org/) compatible string that defined the version of the endpoint. [Example](Routes.md#version).
+* `version`: a [semver](https://semver.org/) compatible string that defined the version of the endpoint. [Example](Routes.md#version).
 * `prefixTrailingSlash`: string used to determine how to handle passing `/` as a route with a prefix.
   * `both` (default): Will register both `/prefix` and `/prefix/`.
   * `slash`: Will register only `/prefix/`.
@@ -406,7 +406,7 @@ fastify.listen(3000)
 ### Version
 
 #### Default
-If needed you can provide a version option, which will allow you to declare multiple versions of the same route. The versioning should follow the [semver](http://semver.org/) specification.<br/>
+If needed you can provide a version option, which will allow you to declare multiple versions of the same route. The versioning should follow the [semver](https://semver.org/) specification.<br/>
 Fastify will automatically detect the `Accept-Version` header and route the request accordingly (advanced ranges and pre-releases currently are not supported).<br/>
 *Be aware that using this feature will cause a degradation of the overall performances of the router.*
 

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -588,7 +588,7 @@ server.get('/', async (request, reply) => {
 
 ###### Example 5: Specifying logger types
 
-Fastify uses [Pino](http://getpino.io/#/) logging library under the hood. Some of it's properties can be configured via `logger` field when constructing Fastify's instance. If properties you need aren't exposed, it's also possible to pass a preconfigured external instance of Pino (or any other compatible logger) to Fastify via the same field. This allows creating custom serializers as well, see the [Logging](Logging.md) documentation for more info.
+Fastify uses [Pino](https://getpino.io/#/) logging library under the hood. Some of it's properties can be configured via `logger` field when constructing Fastify's instance. If properties you need aren't exposed, it's also possible to pass a preconfigured external instance of Pino (or any other compatible logger) to Fastify via the same field. This allows creating custom serializers as well, see the [Logging](Logging.md) documentation for more info.
 
 To use an external instance of Pino, add `@types/pino` to devDependencies and pass the instance to `logger` field:
 
@@ -862,7 +862,7 @@ Check out the [Specifying Logger Types](#example-5-specifying-logger-types) exam
 
 [src](../types/logger.d.ts#L17)
 
-An interface definition for the internal Fastify logger. It is emulative of the [Pino.js](http://getpino.io/#/) logger. When enabled through server options, use it following the general [logger](Logging.md) documentation.
+An interface definition for the internal Fastify logger. It is emulative of the [Pino.js](https://getpino.io/#/) logger. When enabled through server options, use it following the general [logger](Logging.md) documentation.
 
 ##### fastify.FastifyLogFn
 

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -1,14 +1,14 @@
 <h1 align="center">Fastify</h1>
 
 ## Validation and Serialization
-Fastify uses a schema-based approach, and even if it is not mandatory we recommend using [JSON Schema](http://json-schema.org/) to validate your routes and serialize your outputs. Internally, Fastify compiles the schema into a highly performant function.
+Fastify uses a schema-based approach, and even if it is not mandatory we recommend using [JSON Schema](https://json-schema.org/) to validate your routes and serialize your outputs. Internally, Fastify compiles the schema into a highly performant function.
 
 > ## ⚠  Security Notice
 > Treat the schema definition as application code.
 > As both validation and serialization features dynamically evaluate
 > code with `new Function()`, it is not safe to use
-> user-provided schemas. See [Ajv](http://npm.im/ajv) and
-> [fast-json-stringify](http://npm.im/fast-json-stringify) for more
+> user-provided schemas. See [Ajv](https://npm.im/ajv) and
+> [fast-json-stringify](https://npm.im/fast-json-stringify) for more
 > details.
 
 
@@ -731,7 +731,7 @@ const refToSharedSchemaDefinitions = {
 
 <a name="resources"></a>
 ### Resources
-- [JSON Schema](http://json-schema.org/)
+- [JSON Schema](https://json-schema.org/)
 - [Understanding JSON Schema](https://spacetelescope.github.io/understanding-json-schema/)
 - [fast-json-stringify documentation](https://github.com/fastify/fast-json-stringify)
 - [Ajv documentation](https://github.com/epoberezkin/ajv/blob/master/README.md)

--- a/docs/Write-Plugin.md
+++ b/docs/Write-Plugin.md
@@ -33,7 +33,7 @@ Always put an example file in your repository. Examples are very helpful for use
 It is extremely important that a plugin is thoroughly tested to verify that is working properly.<br>
 A plugin without tests will not be accepted to the ecosystem list. A lack of tests does not inspire trust nor guarantee that the code will continue to work among different versions of its dependencies.
 
-We do not enforce any testing library. We use [`tap`](http://www.node-tap.org/) since it offers out of the box parallel testing and code coverage, but it is up to you to choose your library of preference.
+We do not enforce any testing library. We use [`tap`](https://www.node-tap.org/) since it offers out of the box parallel testing and code coverage, but it is up to you to choose your library of preference.
 
 ## Code Linter
 It is not mandatory, but we highly recommend you use a code linter in your plugin. It will ensure a consistent code style and help you to avoid many errors.


### PR DESCRIPTION
Upgraded all `http` links to `https` that support the `https` protocol.

<details>
  <summary>All upgraded links</summary>

  Links
  ---

https://standardjs.com
https://json-schema.org
https://nearform.com
https://semver.org
https://bookshelfjs.org
https://lorenwest.github.io/node-config
https://nats.io
https://getpino.io/#/
https://npm.im/ajv
https://npm.im/fast-json-stringify
https://www.node-tap.org/
</details>

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
