### PR TITLE
add support for running preSerialization hooks for custom reply serializers

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -144,7 +144,12 @@ Reply.prototype.send = function (payload) {
   }
 
   if (this[kReplySerializer] !== null) {
-    payload = this[kReplySerializer](payload)
+    if (typeof payload !== 'string') {
+      preserializeHook(this, payload)
+      return this
+    } else {
+      payload = this[kReplySerializer](payload)
+    }
 
   // The indexOf below also matches custom json mimetypes such as 'application/hal+json' or 'application/ld+json'
   } else if (hasContentType === false || contentType.indexOf('json') > -1) {
@@ -342,7 +347,9 @@ function preserializeHookEnd (err, request, reply, payload) {
     return
   }
 
-  if (reply.context && reply.context[kReplySerializerDefault]) {
+  if (reply[kReplySerializer] !== null) {
+    payload = reply[kReplySerializer](payload)
+  } else if (reply.context && reply.context[kReplySerializerDefault]) {
     payload = reply.context[kReplySerializerDefault](payload, reply.raw.statusCode)
   } else {
     payload = serialize(reply.context, payload, reply.raw.statusCode)

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -106,6 +106,31 @@ test('reply.serializer should set a custom serializer', t => {
   t.equal(reply[kReplySerializer], 'serializer')
 })
 
+test('reply.serializer should support running preSerialization hooks', t => {
+  t.plan(3)
+  const fastify = require('../..')()
+
+  fastify.addHook('preSerialization', async (request, reply, payload) => { t.ok('called', 'preSerialization') })
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    handler: (req, reply) => {
+      reply
+        .type('application/json')
+        .serializer(JSON.stringify)
+        .send({ foo: 'bar' })
+    }
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.payload, '{"foo":"bar"}')
+  })
+})
+
 test('reply.serialize should serialize payload', t => {
   t.plan(1)
   const response = { statusCode: 200 }


### PR DESCRIPTION
closes #2770

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
