### PR TITLE
Do not trigger errorHandler when reply.sent === true (async handlers)

### DIFF
--- a/lib/wrapThenable.js
+++ b/lib/wrapThenable.js
@@ -30,10 +30,11 @@ function wrapThenable (thenable, reply) {
       reply.log.error({ err: new FST_ERR_PROMISE_NOT_FULFILLED() }, "Promise may not be fulfilled with 'undefined' when statusCode is not 204")
     }
   }, function (err) {
-    if (reply[kReplySentOverwritten] === true) {
+    if (reply[kReplySentOverwritten] === true || reply.sent === true) {
       reply.log.error({ err }, 'Promise errored, but reply.sent = true was set')
       return
     }
+
     reply[kReplySent] = false
     reply[kReplyIsError] = true
     reply.send(err)


### PR DESCRIPTION
This is a fix for issue https://github.com/fastify/fastify/issues/2653

Test is a bit of copy-pasta, I'm not sure I understand exactly how it works so let me know if I should change anything, this is my first contribution. I'm also unsure how to interpret the output of the benchmark tests, let me know if there's a problem 🙃 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
