### PR TITLE
feat: Add hint of which plugin is requesting specific decorator

### DIFF
--- a/lib/pluginUtils.js
+++ b/lib/pluginUtils.js
@@ -67,21 +67,22 @@ function checkDecorators (fn) {
   const meta = getMeta(fn)
   if (!meta) return
 
-  const decorators = meta.decorators
+  const { decorators, name } = meta
   if (!decorators) return
 
-  if (decorators.fastify) _checkDecorators.call(this, 'Fastify', decorators.fastify)
-  if (decorators.reply) _checkDecorators.call(this[kReply], 'Reply', decorators.reply)
-  if (decorators.request) _checkDecorators.call(this[kRequest], 'Request', decorators.request)
+  if (decorators.fastify) _checkDecorators.call(this, 'Fastify', decorators.fastify, name)
+  if (decorators.reply) _checkDecorators.call(this[kReply], 'Reply', decorators.reply, name)
+  if (decorators.request) _checkDecorators.call(this[kRequest], 'Request', decorators.request, name)
 }
 
-function _checkDecorators (instance, decorators) {
+function _checkDecorators (instance, decorators, name) {
   assert(Array.isArray(decorators), 'The decorators should be an array of strings')
 
   decorators.forEach(decorator => {
+    const withPluginName = typeof name === 'string' ? ` required by '${name}'` : ''
     assert(
       instance === 'Fastify' ? decorator in this : decorator in this.prototype,
-      `The decorator '${decorator}' is not present in ${instance}`
+      `The decorator '${decorator}'${withPluginName} is not present in ${instance}`
     )
   })
 }

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -725,6 +725,61 @@ test('plugin metadata - decorators', t => {
   }
 })
 
+test('plugin metadata - decorators - should throw', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  fastify.decorate('plugin1', true)
+  fastify.decorateReply('plugin1', true)
+
+  plugin[Symbol.for('skip-override')] = true
+  plugin[Symbol.for('plugin-meta')] = {
+    decorators: {
+      fastify: ['plugin1'],
+      reply: ['plugin1'],
+      request: ['plugin1']
+    }
+  }
+
+  fastify.register(plugin)
+  fastify.ready((err) => {
+    t.equals(err.message, "The decorator 'plugin1' is not present in Request")
+  })
+
+  function plugin (instance, opts, next) {
+    instance.decorate('plugin', true)
+    next()
+  }
+})
+
+test('plugin metadata - decorators - should throw with plugin name', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  fastify.decorate('plugin1', true)
+  fastify.decorateReply('plugin1', true)
+
+  plugin[Symbol.for('skip-override')] = true
+  plugin[Symbol.for('plugin-meta')] = {
+    name: 'the-plugin',
+    decorators: {
+      fastify: ['plugin1'],
+      reply: ['plugin1'],
+      request: ['plugin1']
+    }
+  }
+
+  fastify.register(plugin)
+  fastify.ready((err) => {
+    t.equals(err.message, "The decorator 'plugin1' required by 'the-plugin' is not present in Request")
+  })
+
+  function plugin (instance, opts, next) {
+    instance.decorate('plugin', true)
+    next()
+  }
+})
+
 test('plugin metadata - dependencies', t => {
   t.plan(1)
   const fastify = Fastify()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
Fixes #2760

The PR introduces now the name of the plugin that requests a specific decorator which is not available at the moment of registering the plugin. For now, only appends the name in the case that name exists.

For plugins that don't provide a name, the name cannot be printed. Assuming that the usage of the fastify-plugin is kinda mandatory, this shouldn't be an issue as it provides an auto-generated plugin name in case none is provided. In case this is not used, we depend on the handmade implementation by the developer.

We can always rely on the `name` property of the `Function` object but don't know how deep we want to go in that direction.

Any feedback is more than welcome!

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
