### PR TITLE
Fix(2788): by preventing invalid route creation

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -249,7 +249,7 @@ function buildRouting (options) {
 
       if (shouldExposeHead && options.method === 'GET' && !headRouteExists) {
         const onSendHandlers = parseHeadOnSendHandlers(opts.onSend)
-        prepareRoute.call(this, 'HEAD', path, { ...opts, onSend: onSendHandlers })
+        prepareRoute.call(this, 'HEAD', !path.length ? '/' : path, { ...opts, onSend: onSendHandlers })
       } else if (headRouteExists && exposeHeadRoute) {
         warning.emit('FSTDEP007')
       }

--- a/lib/route.js
+++ b/lib/route.js
@@ -112,6 +112,7 @@ function buildRouting (options) {
     options = Object.assign({}, options, {
       method,
       url,
+      path: url,
       handler: handler || (options && options.handler)
     })
 
@@ -152,7 +153,7 @@ function buildRouting (options) {
 
     this.after((notHandledErr, done) => {
       const path = opts.url || opts.path
-      if (path === '/' && prefix.length > 0) {
+      if (path === '/' && prefix.length > 0 && opts.method !== 'HEAD') {
         switch (opts.prefixTrailingSlash) {
           case 'slash':
             afterRouteAdded.call(this, { path }, notHandledErr, done)
@@ -249,7 +250,7 @@ function buildRouting (options) {
 
       if (shouldExposeHead && options.method === 'GET' && !headRouteExists) {
         const onSendHandlers = parseHeadOnSendHandlers(opts.onSend)
-        prepareRoute.call(this, 'HEAD', !path.length ? '/' : path, { ...opts, onSend: onSendHandlers })
+        prepareRoute.call(this, 'HEAD', path, { ...opts, onSend: onSendHandlers })
       } else if (headRouteExists && exposeHeadRoute) {
         warning.emit('FSTDEP007')
       }

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -1034,3 +1034,56 @@ test('Set a custom HEAD route before GET one without disabling exposeHeadRoutes 
     t.strictEqual(res.body, '')
   })
 })
+
+test('HEAD routes properly auto created for GET routes when prefixTrailingSlash: \'no-slash\'', t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  fastify.register(function routes (f, opts, next) {
+    f.route({
+      method: 'GET',
+      url: '/',
+      exposeHeadRoute: true,
+      prefixTrailingSlash: 'no-slash',
+      handler: (req, reply) => {
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    next()
+  }, { prefix: '/prefix' })
+
+  fastify.inject({ url: '/prefix/prefix', method: 'HEAD' }, (err, res) => {
+    t.error(err)
+    t.strictEquals(res.statusCode, 404)
+  })
+})
+
+test('HEAD routes properly auto created for GET routes when prefixTrailingSlash: \'both\'', async t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  fastify.register(function routes (f, opts, next) {
+    f.route({
+      method: 'GET',
+      url: '/',
+      exposeHeadRoute: true,
+      prefixTrailingSlash: 'both',
+      handler: (req, reply) => {
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    next()
+  }, { prefix: '/prefix' })
+
+  const doublePrefixReply = await fastify.inject({ url: '/prefix/prefix', method: 'HEAD' })
+  const trailingSlashReply = await fastify.inject({ url: '/prefix/', method: 'HEAD' })
+  const noneTrailingReply = await fastify.inject({ url: '/prefix', method: 'HEAD' })
+
+  t.ok(doublePrefixReply.statusCode === 404)
+  t.ok(trailingSlashReply.statusCode === 200)
+  t.ok(noneTrailingReply.statusCode === 200)
+})

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -1083,7 +1083,7 @@ test('HEAD routes properly auto created for GET routes when prefixTrailingSlash:
   const trailingSlashReply = await fastify.inject({ url: '/prefix/', method: 'HEAD' })
   const noneTrailingReply = await fastify.inject({ url: '/prefix', method: 'HEAD' })
 
-  t.ok(doublePrefixReply.statusCode === 404)
-  t.ok(trailingSlashReply.statusCode === 200)
-  t.ok(noneTrailingReply.statusCode === 200)
+  t.equals(doublePrefixReply.statusCode, 404)
+  t.equals(trailingSlashReply.statusCode, 200)
+  t.equals(noneTrailingReply.statusCode, 200)
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### Note

This PR fixes #2788, when `prefixTrailingSlash` is set to `'both'` fastify will generate two routes, one that has a trailing slash and the prefix and the other without the trailing slash it will also auto generate generate `HEAD` routes (if `exposeHeadRoute` is set to `true`) for both of the new endpoints which was the primary source of the duplication bug, setting `exposeHeadRoute` to `false` when attempting to add the second route seems to fix this issue.

if `prefixTrailingSlash` is set to `'no-slash'` then fastify will create a `GET` route and (if `exposeHeadRoute` is set to `true`) fastify will generate one `HEAD` route however it actually create a route where the prefix is concatenated twice, this is due to the fact that the path passed is an empty string `''` and the options object used to create the `HEAD` route is the "same" one that was used to create the original route, `''` empty strings are not truthy so the `path` string which is found on the `GET` options object is used to create the `HEAD` route, this is fixed by using `/` as a path to create the the `HEAD` route instead of of `''`
