### PR TITLE
feat: add initialConfig to FastifyInstance

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -1017,10 +1017,14 @@ Currently the properties that can be exposed are:
 - http2
 - https (it will return `false`/`true` or `{ allowHTTP1: true/false }` if explicitly passed)
 - ignoreTrailingSlash
+- disableRequestLogging
 - maxParamLength
 - onProtoPoisoning
+- onConstructorPoisoning
 - pluginTimeout
 - requestIdHeader
+- requestIdLogLabel
+- http2SessionTimeout
 
 ```js
 const { readFileSync } = require('fs')

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -84,3 +84,23 @@ expectType<FastifyInstance>(fastify().get('/', {
     expectAssignable<void>(server.errorHandler(error, request, reply))
   }
 }))
+
+type InitialConfig = Readonly<{
+  connectionTimeout?: number,
+  keepAliveTimeout?: number,
+  bodyLimit?: number,
+  caseSensitive?: boolean,
+  http2?: boolean,
+  https?: boolean | Readonly<{ allowHTTP1: boolean }>,
+  ignoreTrailingSlash?: boolean,
+  disableRequestLogging?: boolean,
+  maxParamLength?: number,
+  onProtoPoisoning?: 'error' | 'remove' | 'ignore',
+  onConstructorPoisoning?: 'error' | 'remove' | 'ignore',
+  pluginTimeout?: number,
+  requestIdHeader?: string,
+  requestIdLogLabel?: string,
+  http2SessionTimeout?: number
+}>
+
+expectType<InitialConfig>(fastify().initialConfig)

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -356,4 +356,25 @@ export interface FastifyInstance<
    * Prints the representation of the internal radix tree used by the router
    */
   printRoutes(): string;
+
+  /**
+   *  Frozen read-only object registering the initial options passed down by the user to the fastify instance
+   */
+  initialConfig: Readonly<{
+    connectionTimeout?: number,
+    keepAliveTimeout?: number,
+    bodyLimit?: number,
+    caseSensitive?: boolean,
+    http2?: boolean,
+    https?: boolean | Readonly<{ allowHTTP1: boolean }>,
+    ignoreTrailingSlash?: boolean,
+    disableRequestLogging?: boolean,
+    maxParamLength?: number,
+    onProtoPoisoning?: 'error' | 'remove' | 'ignore',
+    onConstructorPoisoning?: 'error' | 'remove' | 'ignore',
+    pluginTimeout?: number,
+    requestIdHeader?: string,
+    requestIdLogLabel?: string,
+    http2SessionTimeout?: number
+  }>
 }


### PR DESCRIPTION
`initialConfig` is missing from the `FastifyInstance` type.  The docs are also updated to list all of the fields available in `initialConfig`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x ] documentation is changed or added
- [x ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
