### PR TITLE
avoid warning with exposeHeadRoute route option

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -235,6 +235,8 @@ function buildRouting (options) {
         opts.schemaErrorFormatter || this[kSchemaErrorFormatter]
       )
 
+      const headRouteExists = router.find('HEAD', path) != null
+
       try {
         router.on(opts.method, opts.url, { version: opts.version }, routeHandler, context)
       } catch (err) {
@@ -245,7 +247,6 @@ function buildRouting (options) {
       const { exposeHeadRoute } = opts
       const hasRouteExposeHeadRouteFlag = exposeHeadRoute != null
       const shouldExposeHead = hasRouteExposeHeadRouteFlag ? exposeHeadRoute : globalExposeHeadRoutes
-      const headRouteExists = router.find('HEAD', path) != null
 
       if (shouldExposeHead && options.method === 'GET' && !headRouteExists) {
         const onSendHandlers = parseHeadOnSendHandlers(opts.onSend)

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -819,6 +819,32 @@ test('HEAD route should respect custom onSend handlers', t => {
   })
 })
 
+test('no warning for exposeHeadRoute', async t => {
+  const fastify = Fastify()
+
+  fastify.route({
+    method: 'GET',
+    path: '/more-coffee',
+    exposeHeadRoute: true,
+    async handler () {
+      return 'hello world'
+    }
+  })
+
+  const listener = (w) => {
+    console.error(w)
+    t.fail('no warning')
+  }
+
+  process.on('warning', listener)
+
+  await fastify.listen(0)
+
+  process.removeListener('warning', listener)
+
+  await fastify.close()
+})
+
 test("HEAD route should handle stream.on('error')", t => {
   t.plan(6)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Unfortunately we where emitting a warning even if the `HEAD` route was defined.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
