### PR TITLE
Create shallow copy of the route context config

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -227,9 +227,11 @@ function buildRouting (options) {
         }
       }
 
-      const config = opts.config || {}
-      config.url = url
-      config.method = opts.method
+      const config = {
+        ...opts.config,
+        url,
+        method: opts.method
+      }
 
       const context = new Context(
         opts.schema,

--- a/test/context-config.test.js
+++ b/test/context-config.test.js
@@ -67,3 +67,55 @@ test('config', t => {
     t.deepEquals(JSON.parse(response.payload), { url: '/no-config', method: 'GET' })
   })
 })
+
+test('config with exposeHeadRoutes', t => {
+  t.plan(9)
+  const fastify = Fastify({ exposeHeadRoutes: true })
+
+  fastify.get('/get', {
+    schema: schema.schema,
+    config: Object.assign({}, schema.config)
+  }, handler)
+
+  fastify.route({
+    method: 'GET',
+    url: '/route',
+    schema: schema.schema,
+    handler: handler,
+    config: Object.assign({}, schema.config)
+  })
+
+  fastify.route({
+    method: 'GET',
+    url: '/no-config',
+    schema: schema.schema,
+    handler: handler
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/get'
+  }, (err, response) => {
+    t.error(err)
+    t.strictEqual(response.statusCode, 200)
+    t.deepEquals(JSON.parse(response.payload), Object.assign({ url: '/get', method: 'GET' }, schema.config))
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/route'
+  }, (err, response) => {
+    t.error(err)
+    t.strictEqual(response.statusCode, 200)
+    t.deepEquals(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/no-config'
+  }, (err, response) => {
+    t.error(err)
+    t.strictEqual(response.statusCode, 200)
+    t.deepEquals(JSON.parse(response.payload), { url: '/no-config', method: 'GET' })
+  })
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

If `exposeHeadRoutes` is set to `true` (introduced in https://github.com/fastify/fastify/pull/2700), the route `config` property will be wrongly altered. This PR fixes it.
I've discovered this when working on #2826.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
