### PR TITLE
Docs: Fixes link preview to Reply

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -224,7 +224,7 @@ app.get('/cookie-2', (req, reply) => {
   reply.raw.end()
 })
 ```
-Another example of the misuse of `Reply.raw` is explained in [Reply.md#getheaders](Reply.md#getheaders).
+Another example of the misuse of `Reply.raw` is explained in [Reply](Reply.md#getheaders).
 
 <a name="sent"></a>
 ### .sent


### PR DESCRIPTION
In https://www.fastify.io/docs/latest/Reply/#raw we have a link that looks like:

![Screenshot 2021-02-05 at 09 56 59](https://user-images.githubusercontent.com/205629/107018780-c6a00d80-6798-11eb-9c3e-afc92a79b54f.png)

This PR changes it to:

![Screenshot 2021-02-05 at 10 00 05](https://user-images.githubusercontent.com/205629/107018916-f18a6180-6798-11eb-917a-737c9a0bd521.png)

