### PR TITLE
docs: Fix encapsulation decorators example

### DIFF
--- a/docs/Encapsulation.md
+++ b/docs/Encapsulation.md
@@ -51,9 +51,7 @@ fastify.register(async function authenticatedContext (childServer) {
     method: 'GET',
     handler (request, response) {
       response.send({
-        answer: request.answer,
-        foo: request.foo,
-        bar: request.bar
+        answer: request.answer
       })
     }
   })
@@ -68,8 +66,7 @@ fastify.register(async function publicContext (childServer) {
     handler (request, response) {
       response.send({
         answer: request.answer,
-        foo: request.foo,
-        bar: request.bar
+        foo: request.foo
       })
     }
   })

--- a/docs/Encapsulation.md
+++ b/docs/Encapsulation.md
@@ -51,7 +51,11 @@ fastify.register(async function authenticatedContext (childServer) {
     method: 'GET',
     handler (request, response) {
       response.send({
-        answer: request.answer
+        answer: request.answer,
+        // request.foo will be undefined as it's only defined in publicContext
+        foo: request.foo,
+        // request.bar will be undefined as it's only defined in grandchildContext
+        bar: request.bar
       })
     }
   })
@@ -66,7 +70,9 @@ fastify.register(async function publicContext (childServer) {
     handler (request, response) {
       response.send({
         answer: request.answer,
-        foo: request.foo
+        foo: request.foo,
+        // request.bar will be undefined as it's only defined in grandchildContext
+        bar: request.bar
       })
     }
   })


### PR DESCRIPTION
Encapsulation documentation uses decorators (`foo`, `bar`) that are available on different levels but uses all of these at these different levels.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
