### PR TITLE
fix: reply.d.ts missing hijack function

### DIFF
--- a/test/types/reply.test-d.ts
+++ b/test/types/reply.test-d.ts
@@ -21,6 +21,7 @@ const getHandler: RouteHandlerMethod = function (_request, reply) {
   expectType<(key: string) => void>(reply.removeHeader)
   expectType<(key: string) => boolean>(reply.hasHeader)
   expectType<{(statusCode: number, url: string): FastifyReply; (url: string): FastifyReply }>(reply.redirect)
+  expectType<() => FastifyReply>(reply.hijack)
   expectType<() => void>(reply.callNotFound)
   expectType<() => number>(reply.getResponseTime)
   expectType<(contentType: string) => FastifyReply>(reply.type)

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -40,6 +40,7 @@ export interface FastifyReply<
   // Note: should consider refactoring the argument order for redirect. statusCode is optional so it should be after the required url param
   redirect(statusCode: number, url: string): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
   redirect(url: string): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
+  hijack(): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
   callNotFound(): void;
   getResponseTime(): number;
   type(contentType: string): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;


### PR DESCRIPTION
fix reply.d.ts missing hijack funciton

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
