### PR TITLE
Fix promise parameter name

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -434,14 +434,14 @@ fastify.get('/botnet', async function (request, reply) {
 If you want to know more please review [Routes#async-await](Routes.md#async-await).
 
 <a name="then"></a>
-### .then(fullfilled, rejected)
+### .then(fulfilled, rejected)
 
 As the name suggests, a `Reply` object can be awaited upon, i.e. `await reply` will wait until the reply is sent.
 The `await` syntax calls the `reply.then()`.
 
-`reply.then(fullfilled, rejected)` accepts two parameters:
+`reply.then(fulfilled, rejected)` accepts two parameters:
 
-- `fullfilled` will be called when a response has been fully sent,
+- `fulfilled` will be called when a response has been fully sent,
 - `rejected` will be called if the underlying stream had an error, e.g.
 the socket has been destroyed.
 

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -1598,7 +1598,7 @@ test('reply.then', t => {
     const reply = new Reply(response, request)
 
     reply.then(function () {
-      t.pass('fullfilled called')
+      t.pass('fulfilled called')
     })
 
     response.destroy()
@@ -1612,7 +1612,7 @@ test('reply.then', t => {
     const _err = new Error('kaboom')
 
     reply.then(function () {
-      t.fail('fullfilled called')
+      t.fail('fulfilled called')
     }, function (err) {
       t.equal(err, _err)
     })

--- a/test/types/reply.test-d.ts
+++ b/test/types/reply.test-d.ts
@@ -27,7 +27,7 @@ const getHandler: RouteHandlerMethod = function (_request, reply) {
   expectType<(contentType: string) => FastifyReply>(reply.type)
   expectType<(fn: (payload: any) => string) => FastifyReply>(reply.serializer)
   expectType<(payload: any) => string>(reply.serialize)
-  expectType<(fullfilled: () => void, rejected: (err: Error) => void) => void>(reply.then)
+  expectType<(fulfilled: () => void, rejected: (err: Error) => void) => void>(reply.then)
 }
 
 interface ReplyPayload {

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -46,5 +46,5 @@ export interface FastifyReply<
   type(contentType: string): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
   serializer(fn: (payload: any) => string): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
   serialize(payload: any): string;
-  then(fullfilled: () => void, rejected: (err: Error) => void): void;
+  then(fulfilled: () => void, rejected: (err: Error) => void): void;
 }


### PR DESCRIPTION
I didn't change `FST_ERR_PROMISE_NOT_FULLFILLED`, assuming that'd be semver-major.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
