### PR TITLE
docs(errors): sort error list alphabetically ascending

### DIFF
--- a/docs/Errors.md
+++ b/docs/Errors.md
@@ -63,40 +63,40 @@ The router received an invalid url.
 
 The parser for this content type was already registered.
 
-<a name="FST_ERR_CTP_INVALID_TYPE"></a>
-#### FST_ERR_CTP_INVALID_TYPE
+<a name="FST_ERR_CTP_BODY_TOO_LARGE"></a>
+#### FST_ERR_CTP_BODY_TOO_LARGE
 
-The `Content-Type` should be a string.
+The request body is larger than the provided limit.
 
 <a name="FST_ERR_CTP_EMPTY_TYPE"></a>
 #### FST_ERR_CTP_EMPTY_TYPE
 
 The content type cannot be an empty string.
 
+<a name="FST_ERR_CTP_INVALID_CONTENT_LENGTH"></a>
+#### FST_ERR_CTP_INVALID_CONTENT_LENGTH
+
+Request body size did not match Content-Length.
+
 <a name="FST_ERR_CTP_INVALID_HANDLER"></a>
 #### FST_ERR_CTP_INVALID_HANDLER
 
 An invalid handler was passed for the content type.
-
-<a name="FST_ERR_CTP_INVALID_PARSE_TYPE"></a>
-#### FST_ERR_CTP_INVALID_PARSE_TYPE
-
-The provided parse type is not supported. Accepted values are `string` or `buffer`.
-
-<a name="FST_ERR_CTP_BODY_TOO_LARGE"></a>
-#### FST_ERR_CTP_BODY_TOO_LARGE
-
-The request body is larger than the provided limit.
 
 <a name="FST_ERR_CTP_INVALID_MEDIA_TYPE"></a>
 #### FST_ERR_CTP_INVALID_MEDIA_TYPE
 
 The received media type is not supported (i.e. there is no suitable `Content-Type` parser for it).
 
-<a name="FST_ERR_CTP_INVALID_CONTENT_LENGTH"></a>
-#### FST_ERR_CTP_INVALID_CONTENT_LENGTH
+<a name="FST_ERR_CTP_INVALID_PARSE_TYPE"></a>
+#### FST_ERR_CTP_INVALID_PARSE_TYPE
 
-Request body size did not match Content-Length.
+The provided parse type is not supported. Accepted values are `string` or `buffer`.
+
+<a name="FST_ERR_CTP_INVALID_TYPE"></a>
+#### FST_ERR_CTP_INVALID_TYPE
+
+The `Content-Type` should be a string.
 
 <a name="FST_ERR_DEC_ALREADY_PRESENT"></a>
 #### FST_ERR_DEC_ALREADY_PRESENT
@@ -108,60 +108,60 @@ A decorator with the same name is already registered.
 
 The decorator cannot be registered due to a missing dependency.
 
-<a name="FST_ERR_HOOK_INVALID_TYPE"></a>
-#### FST_ERR_HOOK_INVALID_TYPE
-
-The hook name must be a string.
-
 <a name="FST_ERR_HOOK_INVALID_HANDLER"></a>
 #### FST_ERR_HOOK_INVALID_HANDLER
 
 The hook callback must be a function.
+
+<a name="FST_ERR_HOOK_INVALID_TYPE"></a>
+#### FST_ERR_HOOK_INVALID_TYPE
+
+The hook name must be a string.
 
 <a name="FST_ERR_LOG_INVALID_DESTINATION"></a>
 #### FST_ERR_LOG_INVALID_DESTINATION
 
 The logger accepts either a `'stream'` or a `'file'` as the destination.
 
+<a name="FST_ERR_PROMISE_NOT_FULFILLED"></a>
+#### FST_ERR_PROMISE_NOT_FULFILLED
+
+A promise may not be fulfilled with 'undefined' when statusCode is not 204.
+
 <a id="FST_ERR_REP_ALREADY_SENT"></a>
 #### FST_ERR_REP_ALREADY_SENT
 
 A response was already sent.
-
-<a id="FST_ERR_SEND_INSIDE_ONERR"></a>
-#### FST_ERR_SEND_INSIDE_ONERR
-
-You cannot use `send` inside the `onError` hook.
 
 <a name="FST_ERR_REP_INVALID_PAYLOAD_TYPE"></a>
 #### FST_ERR_REP_INVALID_PAYLOAD_TYPE
 
 Reply payload can be either a `string` or a `Buffer`.
 
-<a name="FST_ERR_SCH_MISSING_ID"></a>
-#### FST_ERR_SCH_MISSING_ID
-
-The schema provided does not have `$id` property.
-
 <a name="FST_ERR_SCH_ALREADY_PRESENT"></a>
 #### FST_ERR_SCH_ALREADY_PRESENT
 
 A schema with the same `$id` already exists.
 
-<a name="FST_ERR_SCH_VALIDATION_BUILD"></a>
-#### FST_ERR_SCH_VALIDATION_BUILD
+<a name="FST_ERR_SCH_MISSING_ID"></a>
+#### FST_ERR_SCH_MISSING_ID
 
-The JSON schema provided for validation to a route is not valid.
+The schema provided does not have `$id` property.
 
 <a name="FST_ERR_SCH_SERIALIZATION_BUILD"></a>
 #### FST_ERR_SCH_SERIALIZATION_BUILD
 
 The JSON schema provided for serialization of a route response is not valid.
 
-<a name="FST_ERR_PROMISE_NOT_FULFILLED"></a>
-#### FST_ERR_PROMISE_NOT_FULFILLED
+<a name="FST_ERR_SCH_VALIDATION_BUILD"></a>
+#### FST_ERR_SCH_VALIDATION_BUILD
 
-A promise may not be fulfilled with 'undefined' when statusCode is not 204.
+The JSON schema provided for validation to a route is not valid.
+
+<a id="FST_ERR_SEND_INSIDE_ONERR"></a>
+#### FST_ERR_SEND_INSIDE_ONERR
+
+You cannot use `send` inside the `onError` hook.
 
 <a name="FST_ERR_SEND_UNDEFINED_ERR"></a>
 #### FST_ERR_SEND_UNDEFINED_ERR

--- a/docs/Errors.md
+++ b/docs/Errors.md
@@ -7,7 +7,7 @@
 ### Error Handling In Node.js
 
 #### Uncaught Errors
-In Node.js, uncaught errors are likely to cause memory leaks, file descriptor leaks and other major production issues. [Domains](https://nodejs.org/en/docs/guides/domain-postmortem/) were introduced to try fix this issue, but did not. 
+In Node.js, uncaught errors are likely to cause memory leaks, file descriptor leaks and other major production issues. [Domains](https://nodejs.org/en/docs/guides/domain-postmortem/) were introduced to try to fix this issue, but did not. 
 
 Given that it is not possible to process all uncaught errors sensibly, the best way to deal with them is to [crash](https://nodejs.org/api/process.html#process_warning_using_uncaughtexception_correctly). 
 
@@ -136,7 +136,7 @@ You cannot use `send` inside the `onError` hook.
 <a name="FST_ERR_REP_INVALID_PAYLOAD_TYPE"></a>
 #### FST_ERR_REP_INVALID_PAYLOAD_TYPE
 
-Reply payload can either be a `string` or a `Buffer`.
+Reply payload can be either a `string` or a `Buffer`.
 
 <a name="FST_ERR_SCH_MISSING_ID"></a>
 #### FST_ERR_SCH_MISSING_ID


### PR DESCRIPTION
Creating this as a draft first, as I had a quick question: is it worth converting the list of errors into a table composed of  `code` and `description` column headers? It would compress the data into an easier to reference format.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
