### PR TITLE
Expose the avvio pretty printer for printing the plugin tree

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -961,6 +961,26 @@ fastify.ready(() => {
 })
 ```
 
+<a name="print-plugins"></a>
+#### printPlugins
+
+`fastify.printPlugins()`: Prints the representation of the internal plugin tree used by the avvio, useful for debugging require order issues.<br/>
+*Remember to call it inside or after a `ready` call.*
+
+```js
+fastify.get('/test', () => {})
+fastify.get('/test/hello', () => {})
+fastify.get('/hello/world', () => {})
+
+fastify.ready(() => {
+  console.log(fastify.printPlugins())
+  // └── root
+  //   ├── foo
+  //   │   └── bar
+  //   └── baz
+})
+```
+
 <a name="addContentTypeParser"></a>
 #### addContentTypeParser
 

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -968,12 +968,14 @@ fastify.ready(() => {
 *Remember to call it inside or after a `ready` call.*
 
 ```js
-fastify.get('/test', () => {})
-fastify.get('/test/hello', () => {})
-fastify.get('/hello/world', () => {})
+fastify.register(async function foo (instance) {
+  instance.register(async function bar () {})
+})
+fastify.register(async function baz () {})
 
 fastify.ready(() => {
-  console.log(fastify.printPlugins())
+  console.error(fastify.printPlugins())
+  // will output the following to stderr:
   // └── root
   //   ├── foo
   //   │   └── bar

--- a/fastify.js
+++ b/fastify.js
@@ -268,6 +268,7 @@ function fastify (options) {
     ready: null,
     onClose: null,
     close: null,
+    printPlugins: null,
     // http server
     listen: listen,
     server: server,
@@ -351,6 +352,8 @@ function fastify (options) {
   avvio.on('start', () => (fastify[kState].started = true))
   fastify[kAvvioBoot] = fastify.ready // the avvio ready function
   fastify.ready = ready // overwrite the avvio ready function
+  fastify.printPlugins = avvio.prettyPrint.bind(avvio)
+
   // cache the closing value, since we are checking it in an hot path
   avvio.once('preReady', () => {
     fastify.onClose((instance, done) => {

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -93,3 +93,31 @@ test('pretty print - wildcard routes', t => {
     t.equal(tree, expected)
   })
 })
+
+test('pretty print - empty plugins', t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  fastify.ready(() => {
+    const tree = fastify.printPlugins()
+    t.is(typeof tree, 'string')
+    t.match(tree, 'bound root')
+  })
+})
+
+test('pretty print - nested plugins', t => {
+  t.plan(4)
+
+  const fastify = Fastify()
+  fastify.register(async function foo (instance) {
+    instance.register(async function bar () {})
+    instance.register(async function baz () {})
+  })
+  fastify.ready(() => {
+    const tree = fastify.printPlugins()
+    t.is(typeof tree, 'string')
+    t.match(tree, 'foo')
+    t.match(tree, 'bar')
+    t.match(tree, 'baz')
+  })
+})

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -15,6 +15,8 @@ expectAssignable<FastifyInstance>(server.addSchema({
 
 expectType<Record<string, unknown>>(server.getSchemas())
 expectType<unknown>(server.getSchema('SchemaId'))
+expectType<string>(server.printRoutes())
+expectType<string>(server.printPlugins())
 
 expectAssignable<FastifyInstance>(
   server.setErrorHandler(function (error, request, reply) {

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -358,6 +358,11 @@ export interface FastifyInstance<
   printRoutes(): string;
 
   /**
+   * Prints the representation of the plugin tree used by avvio, the plugin registration system
+   */
+  printPlugins(): string;
+
+  /**
    *  Frozen read-only object registering the initial options passed down by the user to the fastify instance
    */
   initialConfig: Readonly<{


### PR DESCRIPTION
This is useful when debugging require order issues, especially if using something that loads plugins for you like `fastify-autoload`

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
