### PR TITLE
Regexp support content type parser

### DIFF
--- a/docs/ContentTypeParser.md
+++ b/docs/ContentTypeParser.md
@@ -40,6 +40,7 @@ fastify.addContentTypeParser(/^image\/.*/, function (request, payload, done) {
 fastify.addContentTypeParser('text/json', { parseAs: 'string' }, fastify.getDefaultJsonParser('ignore', 'ignore'))
 ```
 
+Fastify first tries to match a content-type parser with a `string` value before trying to find a matching `RegExp`.
 If you provide overlapping content types, fastify tries to find a matching content type by starting with the last one passed and ending with the first one.
 So if you want to specify a general content type more precisely, first specify the general content type and then the more specific one, like in the example below.
 

--- a/docs/ContentTypeParser.md
+++ b/docs/ContentTypeParser.md
@@ -41,7 +41,7 @@ fastify.addContentTypeParser('text/json', { parseAs: 'string' }, fastify.getDefa
 ```
 
 Fastify first tries to match a content-type parser with a `string` value before trying to find a matching `RegExp`.
-If you provide overlapping content types, fastify tries to find a matching content type by starting with the last one passed and ending with the first one.
+If you provide overlapping content types, Fastify tries to find a matching content type by starting with the last one passed and ending with the first one.
 So if you want to specify a general content type more precisely, first specify the general content type and then the more specific one, like in the example below.
 
 ```js

--- a/docs/ContentTypeParser.md
+++ b/docs/ContentTypeParser.md
@@ -29,8 +29,28 @@ fastify.addContentTypeParser('application/jsoff', async function (request, paylo
   return res
 })
 
+// Handle all content types that matches RegExp 
+fastify.addContentTypeParser(/^image\/.*/, function (request, payload, done) {
+  imageParser(payload, function (err, body) {
+    done(err, body)
+  })
+})
+
 // Can use default JSON/Text parser for different content Types
 fastify.addContentTypeParser('text/json', { parseAs: 'string' }, fastify.getDefaultJsonParser('ignore', 'ignore'))
+```
+
+If you provide overlapping content types, fastify tries to find a matching content type by starting with the last one passed and ending with the first one.
+So if you want to specify a general content type more precisely, first specify the general content type and then the more specific one, like in the example below.
+
+```js
+// Here only the second content type parser is called because its value also matches the first one
+fastify.addContentTypeParser('application/vnd.custom+xml', (request, body, done) => {} )
+fastify.addContentTypeParser('application/vnd.custom', (request, body, done) => {} )
+
+// Here the desired behavior is achieved because fastify first tries to match the `application/vnd.custom+xml` content type parser 
+fastify.addContentTypeParser('application/vnd.custom', (request, body, done) => {} )
+fastify.addContentTypeParser('application/vnd.custom+xml', (request, body, done) => {} )
 ```
 
 You can also use the `hasContentTypeParser` API to find if a specific content type parser already exists.

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -30,12 +30,15 @@ function ContentTypeParser (bodyLimit, onProtoPoisoning, onConstructorPoisoning)
   this.customParsers['application/json'] = new Parser(true, false, bodyLimit, this[kDefaultJsonParse])
   this.customParsers['text/plain'] = new Parser(true, false, bodyLimit, defaultPlainTextParser)
   this.parserList = ['application/json', 'text/plain']
+  this.parserRegExpList = []
   this.cache = lru(100)
 }
 
 ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
-  if (typeof contentType !== 'string') throw new FST_ERR_CTP_INVALID_TYPE()
-  if (contentType.length === 0) throw new FST_ERR_CTP_EMPTY_TYPE()
+  const contentTypeIsString = typeof contentType === 'string'
+
+  if (!contentTypeIsString && !(contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()
+  if (contentTypeIsString && contentType.length === 0) throw new FST_ERR_CTP_EMPTY_TYPE()
   if (typeof parserFn !== 'function') throw new FST_ERR_CTP_INVALID_HANDLER()
 
   if (this.existingParser(contentType)) {
@@ -55,12 +58,15 @@ ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
     parserFn
   )
 
-  if (contentType === '*') {
-    this.parserList.push('')
+  if (contentTypeIsString && contentType === '*') {
     this.customParsers[''] = parser
   } else {
-    if (contentType !== 'application/json') {
-      this.parserList.unshift(contentType)
+    if (contentTypeIsString) {
+      if (contentType !== 'application/json' && contentType !== 'text/plain') {
+        this.parserList.unshift(contentType)
+      }
+    } else {
+      this.parserRegExpList.unshift(contentType)
     }
     this.customParsers[contentType] = parser
   }
@@ -77,6 +83,7 @@ ContentTypeParser.prototype.existingParser = function (contentType) {
   if (contentType === 'text/plain') {
     return this.customParsers['text/plain'].fn !== defaultPlainTextParser
   }
+
   return contentType in this.customParsers
 }
 
@@ -85,6 +92,15 @@ ContentTypeParser.prototype.getParser = function (contentType) {
   for (var i = 0; i < this.parserList.length; i++) {
     if (contentType.indexOf(this.parserList[i]) > -1) {
       const parser = this.customParsers[this.parserList[i]]
+      this.cache.set(contentType, parser)
+      return parser
+    }
+  }
+
+  /* eslint-disable no-var */
+  for (var j = 0; j < this.parserRegExpList.length; j++) {
+    if (this.parserRegExpList[j].test(contentType)) {
+      const parser = this.customParsers[this.parserRegExpList[j]]
       this.cache.set(contentType, parser)
       return parser
     }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -20,7 +20,7 @@ const codes = {
   ),
   FST_ERR_CTP_INVALID_TYPE: createError(
     'FST_ERR_CTP_INVALID_TYPE',
-    'The content type should be a string',
+    'The content type should be a string or a RegExp',
     500,
     TypeError
   ),

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -3,14 +3,188 @@
 const t = require('tap')
 const test = t.test
 const Fastify = require('..')
+const keys = require('../lib/symbols')
+const { FST_ERR_CTP_ALREADY_PRESENT, FST_ERR_CTP_INVALID_TYPE } = require('../lib/errors')
 
-test('hasContentTypeParser should know about internal parsers', t => {
-  t.plan(4)
-  const fastify = Fastify()
-  fastify.ready(err => {
-    t.error(err)
-    t.ok(fastify.hasContentTypeParser('application/json'))
-    t.ok(fastify.hasContentTypeParser('text/plain'))
-    t.notOk(fastify.hasContentTypeParser('application/jsoff'))
+const first = function (req, payload, done) {}
+const second = function (req, payload, done) {}
+const third = function (req, payload, done) {}
+
+test('hasContentTypeParser', t => {
+  test('should know about internal parsers', t => {
+    t.plan(4)
+
+    const fastify = Fastify()
+    fastify.ready(err => {
+      t.error(err)
+      t.ok(fastify.hasContentTypeParser('application/json'))
+      t.ok(fastify.hasContentTypeParser('text/plain'))
+      t.notOk(fastify.hasContentTypeParser('application/jsoff'))
+    })
   })
+
+  test('should work with string and RegExp', t => {
+    t.plan(7)
+
+    const fastify = Fastify()
+    fastify.addContentTypeParser(/^image\/.*/, first)
+    fastify.addContentTypeParser(/^application\/.+\+xml/, first)
+    fastify.addContentTypeParser('image/gif', first)
+
+    t.ok(fastify.hasContentTypeParser('application/json'))
+    t.ok(fastify.hasContentTypeParser(/^image\/.*/))
+    t.ok(fastify.hasContentTypeParser(/^application\/.+\+xml/))
+    t.ok(fastify.hasContentTypeParser('image/gif'))
+    t.notOk(fastify.hasContentTypeParser(/^image\/.+\+xml/))
+    t.notOk(fastify.hasContentTypeParser('image/png'))
+    t.notOk(fastify.hasContentTypeParser('*'))
+  })
+
+  t.end()
+})
+
+test('getParser', t => {
+  test('should return matching parser', t => {
+    t.plan(3)
+
+    const fastify = Fastify()
+
+    fastify.addContentTypeParser(/^image\/.*/, first)
+    fastify.addContentTypeParser(/^application\/.+\+xml/, second)
+    fastify.addContentTypeParser('text/html', third)
+
+    t.strictEqual(fastify[keys.kContentTypeParser].getParser('application/t+xml').fn, second)
+    t.strictEqual(fastify[keys.kContentTypeParser].getParser('image/png').fn, first)
+    t.strictEqual(fastify[keys.kContentTypeParser].getParser('text/html').fn, third)
+  })
+
+  test('should prefer content type parser with string value', t => {
+    t.plan(2)
+
+    const fastify = Fastify()
+
+    fastify.addContentTypeParser(/^image\/.*/, first)
+    fastify.addContentTypeParser('image/gif', second)
+
+    t.strictEqual(fastify[keys.kContentTypeParser].getParser('image/gif').fn, second)
+    t.strictEqual(fastify[keys.kContentTypeParser].getParser('image/png').fn, first)
+  })
+
+  test('should return parser that catches all if no other is set', t => {
+    t.plan(3)
+
+    const fastify = Fastify()
+
+    fastify.addContentTypeParser('*', first)
+    fastify.addContentTypeParser(/^text\/.*/, second)
+
+    t.strictEqual(fastify[keys.kContentTypeParser].getParser('image/gif').fn, first)
+    t.strictEqual(fastify[keys.kContentTypeParser].getParser('text/html').fn, second)
+    t.strictEqual(fastify[keys.kContentTypeParser].getParser('text').fn, first)
+  })
+
+  test('should return undefined if no matching parser exist', t => {
+    t.plan(2)
+
+    const fastify = Fastify()
+
+    fastify.addContentTypeParser(/^weirdType\/.+/, first)
+    fastify.addContentTypeParser('application/javascript', first)
+
+    t.notOk(fastify[keys.kContentTypeParser].getParser('application/xml'))
+    t.notOk(fastify[keys.kContentTypeParser].getParser('weirdType/'))
+  })
+
+  t.end()
+})
+
+test('existingParser', t => {
+  test('returns always false for "*" and ".*"', t => {
+    t.plan(4)
+
+    const fastify = Fastify()
+
+    fastify.addContentTypeParser(/^image\/.*/, first)
+    fastify.addContentTypeParser(/^application\/.+\+xml/, first)
+    fastify.addContentTypeParser('text/html', first)
+
+    t.notOk(fastify[keys.kContentTypeParser].existingParser('*'))
+    t.notOk(fastify[keys.kContentTypeParser].existingParser(/.*/))
+
+    fastify.addContentTypeParser('*', first)
+
+    t.notOk(fastify[keys.kContentTypeParser].existingParser('*'))
+    t.notOk(fastify[keys.kContentTypeParser].existingParser(/.*/))
+  })
+
+  test('let you override the default parser once', t => {
+    t.plan(2)
+
+    const fastify = Fastify()
+
+    fastify.addContentTypeParser('application/json', first)
+    fastify.addContentTypeParser('text/plain', first)
+
+    t.throws(
+      () => fastify.addContentTypeParser('application/json', first),
+      FST_ERR_CTP_ALREADY_PRESENT,
+      "Content type parser 'application/json' already present"
+    )
+    t.throws(
+      () => fastify.addContentTypeParser('text/plain', first),
+      FST_ERR_CTP_ALREADY_PRESENT,
+      "Content type parser 'text/plain' already present"
+    )
+  })
+
+  const fastify = Fastify()
+  const contentTypeParser = fastify[keys.kContentTypeParser]
+
+  fastify.addContentTypeParser(/^image\/.*/, first)
+  fastify.addContentTypeParser(/^application\/.+\+xml/, first)
+  fastify.addContentTypeParser('text/html', first)
+
+  t.ok(contentTypeParser.existingParser(/^image\/.*/))
+  t.ok(contentTypeParser.existingParser('text/html'))
+  t.ok(contentTypeParser.existingParser(/^application\/.+\+xml/))
+  t.notOk(contentTypeParser.existingParser('application/json'))
+  t.notOk(contentTypeParser.existingParser('text/plain'))
+  t.notOk(contentTypeParser.existingParser('image/png'))
+  t.notOk(contentTypeParser.existingParser(/^application\/.+\+json/))
+
+  t.end()
+})
+
+test('add', t => {
+  test('should only accept string and RegExp', t => {
+    t.plan(4)
+
+    const fastify = Fastify()
+    const contentTypeParser = fastify[keys.kContentTypeParser]
+
+    t.error(contentTypeParser.add('test', {}, first))
+    t.error(contentTypeParser.add(/test/, {}, first))
+    t.throws(
+      () => contentTypeParser.add({}, {}, first),
+      FST_ERR_CTP_INVALID_TYPE,
+      'The content type should be a string or a RegExp'
+    )
+    t.throws(
+      () => contentTypeParser.add(1, {}, first),
+      FST_ERR_CTP_INVALID_TYPE,
+      'The content type should be a string or a RegExp'
+    )
+  })
+
+  test('should set "*" as parser that catches all', t => {
+    t.plan(1)
+
+    const fastify = Fastify()
+    const contentTypeParser = fastify[keys.kContentTypeParser]
+
+    contentTypeParser.add('*', {}, first)
+    t.strictEqual(contentTypeParser.customParsers[''].fn, first)
+  })
+
+  t.end()
 })

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -99,7 +99,7 @@ test('getParser', t => {
 })
 
 test('existingParser', t => {
-  test('returns always false for "*" and ".*"', t => {
+  test('returns always false for "*"', t => {
     t.plan(4)
 
     const fastify = Fastify()
@@ -109,12 +109,10 @@ test('existingParser', t => {
     fastify.addContentTypeParser('text/html', first)
 
     t.notOk(fastify[keys.kContentTypeParser].existingParser('*'))
-    t.notOk(fastify[keys.kContentTypeParser].existingParser(/.*/))
 
     fastify.addContentTypeParser('*', first)
 
     t.notOk(fastify[keys.kContentTypeParser].existingParser('*'))
-    t.notOk(fastify[keys.kContentTypeParser].existingParser(/.*/))
   })
 
   test('let you override the default parser once', t => {

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -100,7 +100,7 @@ test('getParser', t => {
 
 test('existingParser', t => {
   test('returns always false for "*"', t => {
-    t.plan(4)
+    t.plan(2)
 
     const fastify = Fastify()
 

--- a/types/content-type-parser.d.ts
+++ b/types/content-type-parser.d.ts
@@ -33,15 +33,15 @@ export interface AddContentTypeParser<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>
 > {
   (
-    contentType: string | string[],
+    contentType: string | string[] | RegExp,
     opts: {
       bodyLimit?: number;
     },
     parser: FastifyContentTypeParser<RawServer, RawRequest>
   ): void;
-  (contentType: string | string[], parser: FastifyContentTypeParser<RawServer, RawRequest>): void;
+  (contentType: string | string[] | RegExp, parser: FastifyContentTypeParser<RawServer, RawRequest>): void;
   <parseAs extends string | Buffer>(
-    contentType: string | string[],
+    contentType: string | string[] | RegExp,
     opts: {
       parseAs: parseAs extends Buffer ? 'buffer' : 'string';
       bodyLimit?: number;
@@ -53,4 +53,4 @@ export interface AddContentTypeParser<
 /**
  * Checks for a type parser of a content type
  */
-export type hasContentTypeParser = (contentType: string) => boolean
+export type hasContentTypeParser = (contentType: string | RegExp) => boolean


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
Closes #2885.

Create the possibility to provide a RegExp to the `addContentTypeParser` API.

```js
fastify.addContentTypeParser(/^image\/.*/, function (request, payload, done) {
  imageParser(payload, function (err, body) {
    done(err, body)
  })
})
```

In the current implementation, fastify first tries to match a content-type parser with a string value before trying to find a matching RegExp.
Additionally, I updated the documentation to demonstrate the user in which order fastify searches for a matching content type parser.
I can provide benchmark results if necessary.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
