### PR TITLE
Add workflow for labeling PRs by their content

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,7 @@
+# PRs that only touch the docs folder
+documentation:
+- all: [docs/**/*]
+
+# PRs that only touch type files
+typescript:
+- all: [types/**/*]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,4 +4,4 @@ documentation:
 
 # PRs that only touch type files
 typescript:
-- all: ["**/types/**/*"]
+- all: ["**/*[.|-]d.ts"]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,7 @@
 # PRs that only touch the docs folder
 documentation:
-- all: [docs/**/*]
+- all: ["docs/**/*"]
 
 # PRs that only touch type files
 typescript:
-- all: [types/**/*]
+- all: ["**/types/**/*"]

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on: pull_request_target
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/labeler@master
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,10 +3,8 @@ on: pull_request_target
 
 jobs:
   label:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/labeler@master
+    - uses: actions/labeler@main
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION

[Update]:  fixes https://github.com/fastify/fastify/issues/2906

This PR is a partial solution for https://github.com/fastify/fastify/issues/2906

- `documentation` label for PRs touching only the `docs` folder
- `typescript` label for PRs touching only the `types` folder

Outcome: https://github.com/loredanacirstea/fastify/pulls

I tried some approaches for solving `fastify.d.ts`, but none worked. Such as:
- `any: [types/**/*, fastify.d.ts]`
- `./**/*.d.ts` & some other variations; `**/*.d.ts` is unparsable by .yml