### PR TITLE
fix: stream should always be destroyed when response is ended

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -462,21 +462,17 @@ function sendStream (payload, res, reply) {
   })
 
   eos(res, function (err) {
-    if (err != null) {
-      if (sourceOpen) {
-        if (res.headersSent) {
-          if (!errorLogged) {
-            errorLogged = true
-            logStreamError(reply.log, err, res)
-          }
-        }
-        if (payload.destroy) {
-          payload.destroy()
-        } else if (typeof payload.close === 'function') {
-          payload.close(noop)
-        } else if (typeof payload.abort === 'function') {
-          payload.abort()
-        }
+    if (sourceOpen) {
+      if (err != null && res.headersSent && !errorLogged) {
+        errorLogged = true
+        logStreamError(reply.log, err, res)
+      }
+      if (payload.destroy) {
+        payload.destroy()
+      } else if (typeof payload.close === 'function') {
+        payload.close(noop)
+      } else if (typeof payload.abort === 'function') {
+        payload.abort()
       }
     }
   })


### PR DESCRIPTION
Currently streams are closed (if it is not closedby itself) only if there is an error in the response.

I think it should always be closed when the response ends.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
