### PR TITLE
fix: logger argument type

### DIFF
--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -5,11 +5,17 @@ import * as pino from 'pino'
 
 expectType<FastifyLoggerInstance>(fastify().log)
 
-;['trace', 'debug', 'info', 'warn', 'error', 'fatal'].forEach(logLevel => {
+class Foo {}
+
+['trace', 'debug', 'info', 'warn', 'error', 'fatal'].forEach(logLevel => {
   expectType<FastifyLogFn>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel])
   expectType<void>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel](''))
   expectType<void>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel]({}))
-  expectError(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel](0))
+  expectType<void>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel]({ foo: 'bar' }))
+  expectType<void>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel](new Error()))
+  expectType<void>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel](new Foo()))
+  // unknown allow number type to be passed.
+  // expectError(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel](0))
 })
 
 interface CustomLogger extends FastifyLoggerInstance {
@@ -20,7 +26,7 @@ class CustomLoggerImpl implements CustomLogger {
   customMethod (msg: string, ...args: unknown[]) { console.log(msg, args) }
 
   // Implementation signature must be compatible with all overloads of FastifyLogFn
-  info (arg1: string | Record<string, unknown>, arg2?: string | unknown, ...args: unknown[]): void {
+  info (arg1: string | unknown, arg2?: string | unknown, ...args: unknown[]): void {
     console.log(arg1, arg2, ...args)
   }
 

--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -14,6 +14,7 @@ class Foo {}
   expectType<void>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel]({ foo: 'bar' }))
   expectType<void>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel](new Error()))
   expectType<void>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel](new Foo()))
+  expectType<void>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel](0))
 })
 
 interface CustomLogger extends FastifyLoggerInstance {
@@ -24,7 +25,7 @@ class CustomLoggerImpl implements CustomLogger {
   customMethod (msg: string, ...args: unknown[]) { console.log(msg, args) }
 
   // Implementation signature must be compatible with all overloads of FastifyLogFn
-  info (arg1: unknown, arg2?: string | unknown, ...args: unknown[]): void {
+  info (arg1: unknown, arg2?: unknown, ...args: unknown[]): void {
     console.log(arg1, arg2, ...args)
   }
 

--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -24,7 +24,7 @@ class CustomLoggerImpl implements CustomLogger {
   customMethod (msg: string, ...args: unknown[]) { console.log(msg, args) }
 
   // Implementation signature must be compatible with all overloads of FastifyLogFn
-  info (arg1:  unknown, arg2?: string | unknown, ...args: unknown[]): void {
+  info (arg1: unknown, arg2?: string | unknown, ...args: unknown[]): void {
     console.log(arg1, arg2, ...args)
   }
 

--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -14,8 +14,6 @@ class Foo {}
   expectType<void>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel]({ foo: 'bar' }))
   expectType<void>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel](new Error()))
   expectType<void>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel](new Foo()))
-  // unknown allow number type to be passed.
-  // expectError(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel](0))
 })
 
 interface CustomLogger extends FastifyLoggerInstance {
@@ -26,7 +24,7 @@ class CustomLoggerImpl implements CustomLogger {
   customMethod (msg: string, ...args: unknown[]) { console.log(msg, args) }
 
   // Implementation signature must be compatible with all overloads of FastifyLogFn
-  info (arg1: string | unknown, arg2?: string | unknown, ...args: unknown[]): void {
+  info (arg1:  unknown, arg2?: string | unknown, ...args: unknown[]): void {
     console.log(arg1, arg2, ...args)
   }
 

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -27,7 +27,7 @@ import { FastifyRequest, RequestGenericInterface } from './request'
  */
 export interface FastifyLogFn {
   (msg: string, ...args: unknown[]): void;
-  (obj: Record<string, unknown>, msg?: string, ...args: unknown[]): void;
+  (obj: unknown, msg?: string, ...args: unknown[]): void;
 }
 
 export type LogLevel = 'info' | 'error' | 'debug' | 'fatal' | 'warn' | 'trace'


### PR DESCRIPTION
Resolve #2902 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
