### PR TITLE
fix: should test if destroy is a function

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -467,7 +467,7 @@ function sendStream (payload, res, reply) {
         errorLogged = true
         logStreamError(reply.log, err, res)
       }
-      if (payload.destroy) {
+      if (typeof payload.destroy === 'function') {
         payload.destroy()
       } else if (typeof payload.close === 'function') {
         payload.close(noop)

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -263,6 +263,68 @@ test('Destroying streams prematurely should call close method', t => {
   })
 })
 
+test('Destroying streams prematurely should call close method when destroy is not a function', t => {
+  t.plan(7)
+
+  let fastify = null
+  const logStream = split(JSON.parse)
+  try {
+    fastify = Fastify({
+      logger: {
+        stream: logStream,
+        level: 'info'
+      }
+    })
+  } catch (e) {
+    t.fail()
+  }
+  const stream = require('stream')
+  const http = require('http')
+
+  // Test that "premature close" errors are logged with level warn
+  logStream.on('data', line => {
+    if (line.res) {
+      t.equal(line.msg, 'stream closed prematurely')
+      t.equal(line.level, 30)
+    }
+  })
+
+  fastify.get('/', function (request, reply) {
+    t.pass('Received request')
+
+    let sent = false
+    const reallyLongStream = new stream.Readable({
+      read: function () {
+        if (!sent) {
+          this.push(Buffer.from('hello\n'))
+        }
+        sent = true
+      }
+    })
+    reallyLongStream.destroy = true
+    reallyLongStream.close = () => t.ok('called')
+    reply.send(reallyLongStream)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
+
+    const port = fastify.server.address().port
+
+    http.get(`http://localhost:${port}`, function (response) {
+      t.strictEqual(response.statusCode, 200)
+      response.on('readable', function () {
+        response.destroy()
+      })
+      // Node bug? Node never emits 'close' here.
+      response.on('aborted', function () {
+        t.pass('Response closed')
+      })
+    })
+  })
+})
+
 test('Destroying streams prematurely should call abort method', t => {
   t.plan(7)
 


### PR DESCRIPTION
Ref: https://github.com/fastify/fastify/pull/2915#discussion_r589270613

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
