### PR TITLE
Fix typescript def for the setNotFoundHandler

### DIFF
--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -36,6 +36,19 @@ server.setErrorHandler(fastifyErrorHandler)
 function nodeJSErrorHandler (error: NodeJS.ErrnoException) {}
 server.setErrorHandler(nodeJSErrorHandler)
 
+function notFoundHandler (request, reply) {}
+function notFoundpreHandlerHandler (request, reply, done) { done() }
+async function notFoundpreHandlerAsyncHandler (request, reply) {}
+function notFoundpreValidationHandler (request, reply, done) { done() }
+async function notFoundpreValidationAsyncHandler (request, reply) {}
+
+server.setNotFoundHandler(notFoundHandler)
+server.setNotFoundHandler({ preHandler: notFoundpreHandlerHandler }, notFoundHandler)
+server.setNotFoundHandler({ preHandler: notFoundpreHandlerAsyncHandler }, notFoundHandler)
+server.setNotFoundHandler({ preValidation: notFoundpreValidationHandler }, notFoundHandler)
+server.setNotFoundHandler({ preValidation: notFoundpreValidationAsyncHandler }, notFoundHandler)
+server.setNotFoundHandler({ preHandler: notFoundpreHandlerHandler, preValidation: notFoundpreValidationHandler }, notFoundHandler)
+
 function invalidErrorHandler (error: number) {}
 expectError(server.setErrorHandler(invalidErrorHandler))
 

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -1,5 +1,8 @@
 import fastify, { FastifyError, FastifyInstance, ValidationResult } from '../../fastify'
 import { expectAssignable, expectError, expectType } from 'tsd'
+import { FastifyRequest } from '../../types/request'
+import { FastifyReply } from '../../types/reply'
+import { HookHandlerDoneFunction } from '../../types/hooks'
 
 const server = fastify()
 
@@ -36,11 +39,11 @@ server.setErrorHandler(fastifyErrorHandler)
 function nodeJSErrorHandler (error: NodeJS.ErrnoException) {}
 server.setErrorHandler(nodeJSErrorHandler)
 
-function notFoundHandler (request, reply) {}
-function notFoundpreHandlerHandler (request, reply, done) { done() }
-async function notFoundpreHandlerAsyncHandler (request, reply) {}
-function notFoundpreValidationHandler (request, reply, done) { done() }
-async function notFoundpreValidationAsyncHandler (request, reply) {}
+function notFoundHandler (request: FastifyRequest, reply: FastifyReply) {}
+function notFoundpreHandlerHandler (request: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction) { done() }
+async function notFoundpreHandlerAsyncHandler (request: FastifyRequest, reply: FastifyReply) {}
+function notFoundpreValidationHandler (request: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction) { done() }
+async function notFoundpreValidationAsyncHandler (request: FastifyRequest, reply: FastifyReply) {}
 
 server.setNotFoundHandler(notFoundHandler)
 server.setNotFoundHandler({ preHandler: notFoundpreHandlerHandler }, notFoundHandler)

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -311,9 +311,17 @@ export interface FastifyInstance<
   /**
    * Set the 404 handler
    */
-  setNotFoundHandler<RouteGeneric extends RouteGenericInterface = RouteGenericInterface>(
+  setNotFoundHandler<RouteGeneric extends RouteGenericInterface = RouteGenericInterface> (
     handler: (request: FastifyRequest<RouteGeneric, RawServer, RawRequest>, reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric>) => void
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+
+  setNotFoundHandler<RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig extends ContextConfigDefault = ContextConfigDefault> (
+    opts: {
+      preValidation?: preValidationHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> | preValidationHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>[];
+      preHandler?: preHandlerHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> | preHandlerHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>[];
+    },
+    handler: (request: FastifyRequest<RouteGeneric, RawServer, RawRequest>, reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric>) => void
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>
 
   /**
    * Fastify default error handler


### PR DESCRIPTION
This adds the typescript definition for the `setNotFoundHandler` given it supports optional `preHandler` and `preValidation` hooks.

The documentation: https://github.com/fastify/fastify/blob/0af94651ee311f9637bed97ab255b4f5173d5837/docs/Server.md#setnotfoundhandler

The JS code handling the optional hooks: https://github.com/fastify/fastify/blob/0af94651ee311f9637bed97ab255b4f5173d5837/lib/fourOhFour.js#L67

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
