### PR TITLE
Remove broken link from Server documentation

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -4,10 +4,9 @@
 ## Factory
 
 The Fastify module exports a factory function that is used to create new
-<a href="./Server.md"><code><b>Fastify server</b></code></a>
-instances. This factory function accepts an options object which is used to
-customize the resulting instance. This document describes the properties
-available in that options object.
+<code><b>Fastify server</b></code> instances. This factory function accepts
+an options object which is used to customize the resulting instance. This
+document describes the properties available in that options object.
 
 <a name="factory-http2"></a>
 ### `http2`


### PR DESCRIPTION
If this link was working it seems that the page would have been linking to itself, so I've removed it completely.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
