### PR TITLE
docs: improve preValidation docs

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -86,18 +86,21 @@ fastify.addHook('preParsing', async (request, reply, payload) => {
 
 ### preValidation
 ```js
+If you are using the `preValidation` hook, you can change the payload before it is validated. For example:
+
 fastify.addHook('preValidation', (request, reply, done) => {
-  // Some code
+  req.body = { ...req.body, importantKey: 'randomString' }
   done()
 })
 ```
 Or `async/await`:
 ```js
 fastify.addHook('preValidation', async (request, reply) => {
-  // Some code
-  await asyncMethod()
+  const importantKey = await generateRandomString()
+  req.body = { ...req.body, importantKey }
 })
 ```
+
 ### preHandler
 ```js
 fastify.addHook('preHandler', (request, reply, done) => {


### PR DESCRIPTION
Add an example of `preValidation` usage in the documentation and also add a test for this behavior.

I've noticed that `preSerialization` has a good use-case in our documentation (See [here](https://www.fastify.io/docs/latest/Hooks/#preserialization)) and I think that would be great to have an example in `preValidation` hook as well.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
