### PR TITLE
add types for default parser

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -13,6 +13,7 @@ import * as ajv from 'ajv'
 import { FastifyError } from 'fastify-error'
 import { FastifyReply } from './types/reply'
 import { FastifySchemaValidationError } from './types/schema'
+import { ConstructorAction, ProtoAction } from "./types/content-type-parser";
 
 /**
  * Fastify factory function for the standard fastify http, https, or http2 server instance.
@@ -88,8 +89,8 @@ export type FastifyServerOptions<
   maxParamLength?: number,
   disableRequestLogging?: boolean,
   exposeHeadRoutes?: boolean,
-  onProtoPoisoning?: 'error' | 'remove' | 'ignore',
-  onConstructorPoisoning?: 'error' | 'remove' | 'ignore',
+  onProtoPoisoning?: ProtoAction,
+  onConstructorPoisoning?: ConstructorAction,
   logger?: boolean | FastifyLoggerOptions<RawServer> | Logger,
   serverFactory?: FastifyServerFactory<RawServer>,
   caseSensitive?: boolean,
@@ -152,7 +153,7 @@ export { FastifyLoggerOptions, FastifyLoggerInstance, FastifyLogFn, LogLevel } f
 export { FastifyContext } from './types/context'
 export { RouteHandler, RouteHandlerMethod, RouteOptions, RouteShorthandMethod, RouteShorthandOptions, RouteShorthandOptionsWithHandler } from './types/route'
 export * from './types/register'
-export { FastifyBodyParser, FastifyContentTypeParser, AddContentTypeParser, hasContentTypeParser } from './types/content-type-parser'
+export { FastifyBodyParser, FastifyContentTypeParser, AddContentTypeParser, hasContentTypeParser, getDefaultJsonParser, ProtoAction, ConstructorAction } from './types/content-type-parser'
 export { FastifyError } from 'fastify-error'
 export { FastifySchema, FastifySchemaCompiler } from './types/schema'
 export { HTTPMethods, RawServerBase, RawRequestDefaultExpression, RawReplyDefaultExpression, RawServerDefault, ContextConfigDefault, RequestBodyDefault, RequestQuerystringDefault, RequestParamsDefault, RequestHeadersDefault } from './types/utils'

--- a/test/types/content-type-parser.test-d.ts
+++ b/test/types/content-type-parser.test-d.ts
@@ -1,5 +1,5 @@
-import fastify from '../../fastify'
-import { expectType } from 'tsd'
+import fastify, { FastifyContentTypeParser } from '../../fastify'
+import { expectError, expectType } from 'tsd'
 import { IncomingMessage } from 'http'
 import { FastifyRequest } from '../../types/request'
 
@@ -56,3 +56,9 @@ expectType<void>(fastify().addContentTypeParser<Buffer>('bodyContentType', { par
   expectType<Buffer>(body)
   return null
 }))
+
+expectType<FastifyContentTypeParser>(fastify().getDefaultJsonParser('error', 'ignore'))
+
+expectError(fastify().getDefaultJsonParser('error', 'skip'))
+
+expectError(fastify().getDefaultJsonParser('nothing', 'ignore'))

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -1,4 +1,4 @@
-import fastify, { FastifyError, FastifyInstance, ValidationResult } from '../../fastify'
+import fastify, { FastifyContentTypeParser, FastifyError, FastifyInstance, ValidationResult } from '../../fastify'
 import { expectAssignable, expectError, expectType } from 'tsd'
 
 const server = fastify()
@@ -106,3 +106,7 @@ type InitialConfig = Readonly<{
 }>
 
 expectType<InitialConfig>(fastify().initialConfig)
+
+expectType<FastifyContentTypeParser>(server.defaultTextParser)
+
+expectType<FastifyContentTypeParser>(server.getDefaultJsonParser('ignore', 'error'))

--- a/types/content-type-parser.d.ts
+++ b/types/content-type-parser.d.ts
@@ -54,3 +54,9 @@ export interface AddContentTypeParser<
  * Checks for a type parser of a content type
  */
 export type hasContentTypeParser = (contentType: string | RegExp) => boolean
+
+export type ProtoAction = 'error' | 'remove' | 'ignore'
+
+export type ConstructorAction = 'error' | 'remove' | 'ignore'
+
+export type getDefaultJsonParser = (onProtoPoisoning: ProtoAction, onConstructorPoisoning: ConstructorAction) => FastifyContentTypeParser

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -8,7 +8,14 @@ import { onRequestHookHandler, preParsingHookHandler, onSendHookHandler, preVali
 import { FastifyRequest } from './request'
 import { FastifyReply } from './reply'
 import { FastifyError } from 'fastify-error'
-import { AddContentTypeParser, hasContentTypeParser } from './content-type-parser'
+import {
+  AddContentTypeParser,
+  hasContentTypeParser,
+  getDefaultJsonParser,
+  FastifyContentTypeParser,
+  ProtoAction,
+  ConstructorAction
+} from './content-type-parser'
 
 /**
  * Fastify server instance. Returned by the core `fastify()` method.
@@ -352,6 +359,14 @@ export interface FastifyInstance<
    */
   addContentTypeParser: AddContentTypeParser<RawServer, RawRequest>;
   hasContentTypeParser: hasContentTypeParser;
+  /**
+   * Fastify default JSON parser
+   */
+  getDefaultJsonParser: getDefaultJsonParser;
+  /**
+   * Fastify default plain text parser
+   */
+  defaultTextParser: FastifyContentTypeParser;
 
   /**
    * Prints the representation of the internal radix tree used by the router
@@ -376,8 +391,8 @@ export interface FastifyInstance<
     ignoreTrailingSlash?: boolean,
     disableRequestLogging?: boolean,
     maxParamLength?: number,
-    onProtoPoisoning?: 'error' | 'remove' | 'ignore',
-    onConstructorPoisoning?: 'error' | 'remove' | 'ignore',
+    onProtoPoisoning?: ProtoAction,
+    onConstructorPoisoning?: ConstructorAction,
     pluginTimeout?: number,
     requestIdHeader?: string,
     requestIdLogLabel?: string,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Closes #2930

I have added types for the default json and the default plain text parser. I have also created types for the `onProtoPoisoning` and the `onConstructorPoisoning` options.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
