### PR TITLE
feat(request): adding referrer to request

### DIFF
--- a/docs/Request.md
+++ b/docs/Request.md
@@ -22,7 +22,7 @@ Request is a core Fastify object containing the following fields:
 - `is404` - true if request is being handled by 404 handler, false if it is not
 - `connection` - Deprecated, use `socket` instead. The underlying connection of the incoming request.
 - `socket` - the underlying connection of the incoming request
-
+- `referrer` - the content of the `Referrer` or `Referer` header
 
 ```js
 fastify.post('/:params', options, function (request, reply) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -159,6 +159,11 @@ Object.defineProperties(Request.prototype, {
       return this.socket.encrypted ? 'https' : 'http'
     }
   },
+  referrer: {
+    get () {
+      return this.raw.headers.referrer || this.raw.headers.referer || ''
+    }
+  },
   headers: {
     get () {
       return this.raw.headers

--- a/test/internals/request.test.js
+++ b/test/internals/request.test.js
@@ -174,3 +174,31 @@ test('Request with trust proxy - handles multiple entries in x-forwarded-host/pr
   t.strictEqual(request.hostname, 'example.com')
   t.strictEqual(request.protocol, 'https')
 })
+
+test('referrer - handles Referrer', t => {
+  t.plan(1)
+  const headers = {
+    referrer: 'referrer'
+  }
+  const req = {
+    method: 'GET',
+    url: '/',
+    headers
+  }
+  const request = new Request('id', 'params', req, 'query', 'log')
+  t.strictEqual(request.referrer, 'referrer')
+})
+
+test('referrer - handles Referer', t => {
+  t.plan(1)
+  const headers = {
+    referer: 'referrer'
+  }
+  const req = {
+    method: 'GET',
+    url: '/',
+    headers
+  }
+  const request = new Request('id', 'params', req, 'query', 'log')
+  t.strictEqual(request.referrer, 'referrer')
+})

--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -45,6 +45,7 @@ const getHandler: RouteHandler = function (request, _reply) {
   expectType<boolean>(request.is404)
   expectType<string>(request.hostname)
   expectType<string>(request.ip)
+  expectType<string>(request.referrer)
   expectType<string[] | undefined>(request.ips)
   expectType<RawRequestDefaultExpression>(request.raw)
   expectType<RequestBodyDefault>(request.body)

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -43,6 +43,7 @@ export interface FastifyRequest<
   readonly routerMethod: string;
   readonly is404: boolean;
   readonly socket: RawRequest['socket'];
+  readonly referrer: string;
 
   // Prefer `socket` over deprecated `connection` property in node 13.0.0 or higher
   // @deprecated


### PR DESCRIPTION
This PR adds `referrer` to the fastify request object.  It has the same functionality for accessing the referrer header as found in Express, Hapi and Restify.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
