### PR TITLE
docs(ecosystem): add fastify-api-key to community plugins

### DIFF
--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -69,6 +69,7 @@ Plugins maintained by the Fastify team are listed under [Core](#core) while plug
 - [`fastify-405`](https://github.com/Eomm/fastify-405) Fastify plugin that adds 405 HTTP status to your routes
 - [`fastify-amqp`](https://github.com/RafaelGSS/fastify-amqp) Fastify AMQP connection plugin, to use with RabbitMQ or another connector. Just a wrapper to [`amqplib`](https://github.com/squaremo/amqp.node).
 - [`fastify-angular-universal`](https://github.com/exequiel09/fastify-angular-universal) Angular server-side rendering support using [`@angular/platform-server`](https://github.com/angular/angular/tree/master/packages/platform-server) for Fastify
+- [`fastify-api-key`](https://github.com/arkerone/fastify-api-key) Fastify plugin to authenticate HTTP requests based on api key and signature
 - [`fastify-auth0-verify`](https://github.com/nearform/fastify-auth0-verify): Auth0 verification plugin for Fastify, internally uses [fastify-jwt](https://npm.im/fastify-jwt) and [jsonwebtoken](https://npm.im/jsonwebtoken).
 - [`fastify-autocrud`](https://github.com/paranoiasystem/fastify-autocrud) Plugin to autogenerate CRUD routes as fast as possible.
 - [`fastify-autoroutes`](https://github.com/GiovanniCardamone/fastify-autoroutes) Plugin to scan and load routes based on filesystem path from custom directory.


### PR DESCRIPTION
Hi,

I've developed a plugin used to authenticate HTTP requests based on api key and signature. I thought that's a good idea to share it with the community.

Note: Sorry for my previous PR [#2957](https://github.com/fastify/fastify/pull/2957), I had a problem with my IDE when I commited then I've prefered to recreate a clean PR... my bad

### Checklist

- [ ]  run `npm run test` and `npm run benchmark`
- [ ]  tests and/or benchmarks are included
- [x]  documentation is changed or added
- [x]  commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)