### PR TITLE
Fix: schema compiler for schemas with the same ids.

### DIFF
--- a/lib/schema-compilers.js
+++ b/lib/schema-compilers.js
@@ -55,8 +55,8 @@ function ValidatorCompiler (externalSchemas, options, cache) {
     if (schema.$id) {
       const stored = ajv.getSchema(schema.$id)
       if (stored) {
-        // TODO we might want to validate the fact that a user
-        // could create two schemas with different ids.
+        // TODO we might want to throw if two schemas have
+        // the same id but different content.
         return stored
       }
     }

--- a/lib/schema-compilers.js
+++ b/lib/schema-compilers.js
@@ -55,8 +55,6 @@ function ValidatorCompiler (externalSchemas, options, cache) {
     if (schema.$id) {
       const stored = ajv.getSchema(schema.$id)
       if (stored) {
-        // TODO we might want to throw if two schemas have
-        // the same id but different content.
         return stored
       }
     }

--- a/lib/schema-compilers.js
+++ b/lib/schema-compilers.js
@@ -49,6 +49,17 @@ function ValidatorCompiler (externalSchemas, options, cache) {
   }
 
   return function ({ schema, method, url, httpPart }) {
+    // Ajv does not support compiling two schemas with the same
+    // id inside the same instance. Therefore if we have already
+    // compiled the schema with the given id, we just return it.
+    if (schema.$id) {
+      const stored = ajv.getSchema(schema.$id)
+      if (stored) {
+        // TODO we might want to validate the fact that a user
+        // could create two schemas with different ids.
+        return stored
+      }
+    }
     return ajv.compile(schema)
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

I have found and fixed a bug in the new schema compilers logic that caused it to throw if the same schema was specified twice with the same id. I went ahead and fixed it.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
