### PR TITLE
fix: doc typo, added 'to'.

### DIFF
--- a/docs/LTS.md
+++ b/docs/LTS.md
@@ -4,7 +4,7 @@
 
 ## Long Term Support
 
-Fastify's Long Term Support (LTS) is provided according the schedule laid
+Fastify's Long Term Support (LTS) is provided according to the schedule laid
 out in this document:
 
 1. Major releases, "X" release of [semantic versioning][semver] X.Y.Z release


### PR DESCRIPTION
This is just a minor documentation fix I noticed while reading through the site.