### PR TITLE
Typed decorators

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -403,6 +403,7 @@ One of Fastify's most distinguishable features is its extensive plugin ecosystem
    import fp from 'fastify-plugin'
 
    // using declaration merging, add your plugin props to the appropriate fastify interfaces
+   // if prop type is defined here, the value will be typechecked when you call decorate{,Request,Reply}
    declare module 'fastify' {
      interface FastifyRequest {
        myPluginProp: string

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -24,17 +24,17 @@ declare module '../../fastify' {
 expectError(server.decorate('functionWithTypeDefinition', (foo: any, bar: any) => {})) // error because invalid return type
 expectError(server.decorate('functionWithTypeDefinition', (foo: any, bar: any) => true)) // error because doesn't return a promise
 expectError(server.decorate('functionWithTypeDefinition', async (foo: any, bar: any, qwe: any) => true)) // error because too many args
-server.decorate('functionWithTypeDefinition', async (foo, bar) => {
+expectAssignable<FastifyInstance>(server.decorate('functionWithTypeDefinition', async (foo, bar) => {
   expectType<string>(foo)
   expectType<number>(bar)
   return true
-})
+}))
 
 expectError(server.decorateRequest('numberWithTypeDefinition', 'not a number')) // error because invalid type
-server.decorateRequest('numberWithTypeDefinition', 10)
+expectAssignable<FastifyInstance>(server.decorateRequest('numberWithTypeDefinition', 10))
 
 expectError(server.decorateReply('stringWithTypeDefinition', 'not in enum')) // error because invalid type
-server.decorateReply('stringWithTypeDefinition', 'foo')
+expectAssignable<FastifyInstance>(server.decorateReply('stringWithTypeDefinition', 'foo'))
 
 expectAssignable<FastifyInstance>(server.addSchema({
   type: 'null'

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -8,7 +8,7 @@ const server = fastify()
 
 server.decorate('nonexistent', () => {})
 
-declare module "../../fastify" {
+declare module '../../fastify' {
   interface FastifyInstance {
     functionWithTypeDefinition: (foo: string, bar: number) => Promise<boolean>
   }

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -24,7 +24,11 @@ declare module '../../fastify' {
 expectError(server.decorate('functionWithTypeDefinition', (foo: any, bar: any) => {})) // error because invalid return type
 expectError(server.decorate('functionWithTypeDefinition', (foo: any, bar: any) => true)) // error because doesn't return a promise
 expectError(server.decorate('functionWithTypeDefinition', async (foo: any, bar: any, qwe: any) => true)) // error because too many args
-server.decorate('functionWithTypeDefinition', async (foo, bar) => true)
+server.decorate('functionWithTypeDefinition', async (foo, bar) => {
+  expectType<string>(foo)
+  expectType<number>(bar)
+  return true
+})
 
 expectError(server.decorateRequest('numberWithTypeDefinition', 'not a number')) // error because invalid type
 server.decorateRequest('numberWithTypeDefinition', 10)

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -6,6 +6,18 @@ import { HookHandlerDoneFunction } from '../../types/hooks'
 
 const server = fastify()
 
+server.decorate('nonexistent', () => {})
+
+declare module "../../fastify" {
+  interface FastifyInstance {
+    functionWithTypeDefinition: (foo: string, bar: number) => Promise<boolean>
+  }
+}
+expectError(server.decorate('functionWithTypeDefinition', (foo: any, bar: any) => {})) // error because invalid return type
+expectError(server.decorate('functionWithTypeDefinition', (foo: any, bar: any) => true)) // error because doesn't return a promise
+expectError(server.decorate('functionWithTypeDefinition', async (foo: any, bar: any, qwe: any) => true)) // error because too many args
+server.decorate('functionWithTypeDefinition', async (foo, bar) => true)
+
 expectAssignable<FastifyInstance>(server.addSchema({
   type: 'null'
 }))

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -7,16 +7,30 @@ import { HookHandlerDoneFunction } from '../../types/hooks'
 const server = fastify()
 
 server.decorate('nonexistent', () => {})
+server.decorateRequest('nonexistent', () => {})
+server.decorateReply('nonexistent', () => {})
 
 declare module '../../fastify' {
   interface FastifyInstance {
     functionWithTypeDefinition: (foo: string, bar: number) => Promise<boolean>
+  }
+  interface FastifyRequest {
+    numberWithTypeDefinition: number
+  }
+  interface FastifyReply {
+    stringWithTypeDefinition: 'foo' | 'bar'
   }
 }
 expectError(server.decorate('functionWithTypeDefinition', (foo: any, bar: any) => {})) // error because invalid return type
 expectError(server.decorate('functionWithTypeDefinition', (foo: any, bar: any) => true)) // error because doesn't return a promise
 expectError(server.decorate('functionWithTypeDefinition', async (foo: any, bar: any, qwe: any) => true)) // error because too many args
 server.decorate('functionWithTypeDefinition', async (foo, bar) => true)
+
+expectError(server.decorateRequest('numberWithTypeDefinition', 'not a number')) // error because invalid type
+server.decorateRequest('numberWithTypeDefinition', 10)
+
+expectError(server.decorateReply('stringWithTypeDefinition', 'not in enum')) // error because invalid type
+server.decorateReply('stringWithTypeDefinition', 'foo')
 
 expectAssignable<FastifyInstance>(server.addSchema({
   type: 'null'

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -17,6 +17,8 @@ import {
   ConstructorAction
 } from './content-type-parser'
 
+type NotInInterface<T, IFACE> = T extends keyof IFACE ? never : T
+
 /**
  * Fastify server instance. Returned by the core `fastify()` method.
  */
@@ -42,9 +44,14 @@ export interface FastifyInstance<
   close(closeListener: () => void): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   // should be able to define something useful with the decorator getter/setter pattern using Generics to enfore the users function returns what they expect it to
-  decorate(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
-  decorateRequest(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
-  decorateReply(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+  decorate<K extends keyof FastifyInstance>(property: K, value: FastifyInstance[K], dependencies?: string): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+  decorate<K extends string | symbol>(property: NotInInterface<K, FastifyInstance>, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+
+  decorateRequest<K extends keyof FastifyRequest>(property: K, value: FastifyRequest[K], dependencies?: string): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+  decorateRequest<K extends string | symbol>(property: NotInInterface<K, FastifyRequest>, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+
+  decorateReply<K extends keyof FastifyReply>(property: K, value: FastifyReply[K], dependencies?: string): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+  decorateReply<K extends string | symbol>(property: NotInInterface<K, FastifyReply>, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   hasDecorator(decorator: string | symbol): boolean;
   hasRequestDecorator(decorator: string | symbol): boolean;

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -17,7 +17,7 @@ import {
   ConstructorAction
 } from './content-type-parser'
 
-type NotInInterface<T, IFACE> = T extends keyof IFACE ? never : T
+type NotInInterface<Key, _Interface> = Key extends keyof _Interface ? never : Key
 
 /**
  * Fastify server instance. Returned by the core `fastify()` method.

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -44,13 +44,13 @@ export interface FastifyInstance<
   close(closeListener: () => void): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   // should be able to define something useful with the decorator getter/setter pattern using Generics to enfore the users function returns what they expect it to
-  decorate<K extends keyof FastifyInstance>(property: K, value: FastifyInstance[K], dependencies?: string): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+  decorate<K extends keyof FastifyInstance>(property: K, value: FastifyInstance[K], dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
   decorate<K extends string | symbol>(property: NotInInterface<K, FastifyInstance>, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
-  decorateRequest<K extends keyof FastifyRequest>(property: K, value: FastifyRequest[K], dependencies?: string): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+  decorateRequest<K extends keyof FastifyRequest>(property: K, value: FastifyRequest[K], dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
   decorateRequest<K extends string | symbol>(property: NotInInterface<K, FastifyRequest>, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
-  decorateReply<K extends keyof FastifyReply>(property: K, value: FastifyReply[K], dependencies?: string): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+  decorateReply<K extends keyof FastifyReply>(property: K, value: FastifyReply[K], dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
   decorateReply<K extends string | symbol>(property: NotInInterface<K, FastifyReply>, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   hasDecorator(decorator: string | symbol): boolean;


### PR DESCRIPTION
Again a quite strong type change, but I think an important one as well for type safety. This would mean that all decorators must be explicitly typed in the interface to go through without `as any` hacks. Looking for comments about this approach

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
