### PR TITLE
src: change request.context to use a symbol

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -17,7 +17,8 @@ const {
   kReplyHeaders,
   kReplyHasStatusCode,
   kReplyIsRunningOnErrorHook,
-  kDisableRequestLogging
+  kDisableRequestLogging,
+  kContext
 } = require('./symbols.js')
 const { hookRunner, hookIterator, onSendHookRunner } = require('./hooks')
 
@@ -67,7 +68,7 @@ function Reply (res, request, log) {
 Object.defineProperties(Reply.prototype, {
   context: {
     get () {
-      return this.request.context
+      return this.request[kContext]
     }
   },
   res: {
@@ -657,7 +658,7 @@ function notFound (reply) {
     return
   }
 
-  reply.request.context = reply.context[kFourOhFourContext]
+  reply.request[kContext] = reply.context[kFourOhFourContext]
 
   // preHandler hook
   if (reply.context.preHandler !== null) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -3,10 +3,11 @@
 const proxyAddr = require('@fastify/proxy-addr')
 const semver = require('semver')
 const warning = require('./warnings')
+const { kContext } = require('./symbols')
 
 function Request (id, params, req, query, log, context) {
   this.id = id
-  this.context = context
+  this[kContext] = context
   this.params = params
   this.raw = req
   this.query = query
@@ -45,7 +46,7 @@ function buildRequest (R, trustProxy) {
 function buildRegularRequest (R) {
   function _Request (id, params, req, query, log, context) {
     this.id = id
-    this.context = context
+    this[kContext] = context
     this.params = params
     this.raw = req
     this.query = query
@@ -118,17 +119,17 @@ Object.defineProperties(Request.prototype, {
   },
   routerPath: {
     get () {
-      return this.context.config.url
+      return this[kContext].config.url
     }
   },
   routerMethod: {
     get () {
-      return this.context.config.method
+      return this[kContext].config.method
     }
   },
   is404: {
     get () {
-      return this.context.config.url === undefined
+      return this[kContext].config.url === undefined
     }
   },
   connection: {

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -42,7 +42,8 @@ const keys = {
   kPluginNameChain: Symbol('fastify.pluginNameChain'),
   // This symbol is only meant to be used for fastify tests and should not be used for any other purpose
   kTestInternals: Symbol('fastify.testInternals'),
-  kErrorHandler: Symbol('fastify.errorHandler')
+  kErrorHandler: Symbol('fastify.errorHandler'),
+  kContext: Symbol('fastify.context')
 }
 
 module.exports = keys

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -4,6 +4,7 @@ const { test } = require('tap')
 const semver = require('semver')
 const handleRequest = require('../../lib/handleRequest')
 const internals = require('../../lib/handleRequest')[Symbol.for('internals')]
+const { kContext } = require('../../lib/symbols')
 const Request = require('../../lib/request')
 const Reply = require('../../lib/reply')
 const buildSchema = require('../../lib/validation').compileSchemasForValidation
@@ -74,7 +75,7 @@ test('handler function - invalid schema', t => {
   buildSchema(context, schemaValidator)
   const request = {
     body: { hello: 'world' },
-    context
+    [kContext]: context
   }
   internals.handler(request, new Reply(res, request))
 })
@@ -101,7 +102,7 @@ test('handler function - reply', t => {
     onError: []
   }
   buildSchema(context, schemaValidator)
-  internals.handler({}, new Reply(res, { context }))
+  internals.handler({}, new Reply(res, { [kContext]: context }))
 })
 
 test('handler function - preValidationCallback with finished response', t => {

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -13,14 +13,15 @@ const {
   kReplyHeaders,
   kReplySerializer,
   kReplyIsError,
-  kReplySerializerDefault
+  kReplySerializerDefault,
+  kContext
 } = require('../../lib/symbols')
 
 test('Once called, Reply should return an object with methods', t => {
   t.plan(13)
   const response = { res: 'res' }
   const context = {}
-  const request = { context }
+  const request = { [kContext]: context }
   const reply = new Reply(response, request)
   t.is(typeof reply, 'object')
   t.is(typeof reply[kReplyIsError], 'boolean')
@@ -61,7 +62,7 @@ test('reply.send will logStream error and destroy the stream', { only: true }, t
     pipe: () => {},
     destroy: () => {}
   })
-  const reply = new Reply(response, { context: { onSend: null } }, log)
+  const reply = new Reply(response, { [kContext]: { onSend: null } }, log)
   reply.send(payload)
   payload.emit('error', new Error('stream error'))
 
@@ -94,7 +95,7 @@ test('reply.send returns itself', t => {
     writeHead: () => {},
     end: () => {}
   }
-  const reply = new Reply(response, { context: { onSend: [] } })
+  const reply = new Reply(response, { [kContext]: { onSend: [] } })
   t.equal(reply.send('hello'), reply)
 })
 
@@ -135,7 +136,7 @@ test('reply.serialize should serialize payload', t => {
   t.plan(1)
   const response = { statusCode: 200 }
   const context = {}
-  const reply = new Reply(response, { context })
+  const reply = new Reply(response, { [kContext]: context })
   t.equal(reply.serialize({ foo: 'bar' }), '{"foo":"bar"}')
 })
 
@@ -155,7 +156,7 @@ test('reply.serialize should serialize payload with a context default serializer
   let customSerializerCalled = false
   const response = { statusCode: 200 }
   const context = { [kReplySerializerDefault]: (x) => (customSerializerCalled = true) && JSON.stringify(x) }
-  const reply = new Reply(response, { context })
+  const reply = new Reply(response, { [kContext]: context })
   t.equal(reply.serialize({ foo: 'bar' }), '{"foo":"bar"}')
   t.equal(customSerializerCalled, true, 'custom serializer not called')
 })


### PR DESCRIPTION
Many of the other properties in fastify objects use a Symbol as the property key in order to hide these properties, preventing them from becoming a part of the public API. The `context` property on `request` was essentially an undocumented breaking change to the API.

See: https://github.com/fastify/fastify/pull/2506

This commit removes the `context` property from `Request` and replaces it with a `Symbol` to both revert this breaking change, and to remove the `context` property from the API surface area.

This is potentially a breaking change, however, the `Request#context` property has never been documented, and is - based on my understanding of the intent in #2506 - not meant to be a part of the public API.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
