### PR TITLE
fix: remove invalid assertion

### DIFF
--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -33,8 +33,6 @@ expectAssignable<FastifyInstance>(
   })
 )
 
-expectType<ValidationResult[] | undefined>(FastifyError().validation)
-
 function fastifyErrorHandler (this: FastifyInstance, error: FastifyError) {}
 server.setErrorHandler(fastifyErrorHandler)
 


### PR DESCRIPTION
Ref #3017 

I removed the assertion since it does not seem useful, `FastifyError` is an interface and in the test are being called as a function. 
@Ethan-Arrowood I'm asking review for you since you've implemented it a long time ago.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
