### PR TITLE
test: move build certificate to the file it need only

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -3,4 +3,3 @@ jsx: false
 flow: false
 check-coverage: false
 coverage: true
-before: test/before-tests.js

--- a/test/build-certificate.js
+++ b/test/build-certificate.js
@@ -6,9 +6,9 @@ const pem = require('pem')
 const createCertificate = util.promisify(pem.createCertificate)
 
 async function buildCertificate () {
-  if (!globalThis.context || !globalThis.context.cert || !globalThis.context.key) {
+  if (!global.context || !global.context.cert || !global.context.key) {
     const keys = await createCertificate({ days: 1, selfSigned: true })
-    globalThis.context = {
+    global.context = {
       cert: keys.certificate,
       key: keys.serviceKey
     }

--- a/test/build-certificate.js
+++ b/test/build-certificate.js
@@ -7,7 +7,7 @@ const pem = require('pem')
 
 const createCertificate = util.promisify(pem.createCertificate)
 
-(async () => {
+async function buildCertificate () {
   try {
     const keys = await createCertificate({ days: 1, selfSigned: true })
     const certFile = path.join(__dirname, 'https', 'fastify.cert')
@@ -22,4 +22,6 @@ const createCertificate = util.promisify(pem.createCertificate)
     console.log(error)
     process.exit(1)
   }
-})()
+}
+
+module.exports = { buildCertificate }

--- a/test/build-certificate.js
+++ b/test/build-certificate.js
@@ -6,6 +6,9 @@ const pem = require('pem')
 const createCertificate = util.promisify(pem.createCertificate)
 
 async function buildCertificate () {
+  // "global" is used in here because "t.context" is only supported by "t.beforeEach" and "t.afterEach"
+  // For the test case which execute this code which will be using `t.before` and it can reduce the
+  // number of times executing it.
   if (!global.context || !global.context.cert || !global.context.key) {
     const keys = await createCertificate({ days: 1, selfSigned: true })
     global.context = {

--- a/test/build-certificate.js
+++ b/test/build-certificate.js
@@ -1,26 +1,17 @@
 'use strict'
 
 const util = require('util')
-const fs = require('fs')
-const path = require('path')
 const pem = require('pem')
 
 const createCertificate = util.promisify(pem.createCertificate)
 
 async function buildCertificate () {
-  try {
+  if (!globalThis.context || !globalThis.context.cert || !globalThis.context.key) {
     const keys = await createCertificate({ days: 1, selfSigned: true })
-    const certFile = path.join(__dirname, 'https', 'fastify.cert')
-    const keyFile = path.join(__dirname, 'https', 'fastify.key')
-    if (!fs.existsSync(certFile) || !fs.existsSync(keyFile)) {
-      await Promise.all([
-        fs.promises.writeFile(certFile, keys.certificate),
-        fs.promises.writeFile(keyFile, keys.serviceKey)
-      ])
+    globalThis.context = {
+      cert: keys.certificate,
+      key: keys.serviceKey
     }
-  } catch (error) {
-    console.log(error)
-    process.exit(1)
   }
 }
 

--- a/test/http2/closing.test.js
+++ b/test/http2/closing.test.js
@@ -128,8 +128,8 @@ t.test('https/2 closes successfully with async await', { skip: semver.lt(process
     http2SessionTimeout: 100,
     http2: true,
     https: {
-      key: globalThis.context.key,
-      cert: globalThis.context.cert
+      key: global.context.key,
+      cert: global.context.cert
     }
   })
 

--- a/test/http2/closing.test.js
+++ b/test/http2/closing.test.js
@@ -4,8 +4,6 @@ const t = require('tap')
 const Fastify = require('../..')
 const http2 = require('http2')
 const semver = require('semver')
-const fs = require('fs')
-const path = require('path')
 const { promisify } = require('util')
 const connect = promisify(http2.connect)
 const { once } = require('events')
@@ -130,8 +128,8 @@ t.test('https/2 closes successfully with async await', { skip: semver.lt(process
     http2SessionTimeout: 100,
     http2: true,
     https: {
-      key: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.key')),
-      cert: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.cert'))
+      key: globalThis.context.key,
+      cert: globalThis.context.cert
     }
   })
 

--- a/test/http2/closing.test.js
+++ b/test/http2/closing.test.js
@@ -10,6 +10,9 @@ const { promisify } = require('util')
 const connect = promisify(http2.connect)
 const { once } = require('events')
 
+const { buildCertificate } = require('../build-certificate')
+t.before(buildCertificate)
+
 t.test('http/2 request while fastify closing', t => {
   let fastify
   try {

--- a/test/http2/secure-with-fallback.test.js
+++ b/test/http2/secure-with-fallback.test.js
@@ -9,6 +9,9 @@ const h2url = require('h2url')
 const sget = require('simple-get').concat
 const msg = { hello: 'world' }
 
+const { buildCertificate } = require('../build-certificate')
+t.before(buildCertificate)
+
 let fastify
 try {
   fastify = Fastify({

--- a/test/http2/secure-with-fallback.test.js
+++ b/test/http2/secure-with-fallback.test.js
@@ -19,8 +19,8 @@ test('secure with fallback', (t) => {
       http2: true,
       https: {
         allowHTTP1: true,
-        key: globalThis.context.key,
-        cert: globalThis.context.cert
+        key: global.context.key,
+        cert: global.context.cert
       }
     })
     t.pass('Key/cert successfully loaded')

--- a/test/http2/secure-with-fallback.test.js
+++ b/test/http2/secure-with-fallback.test.js
@@ -2,8 +2,6 @@
 
 const t = require('tap')
 const test = t.test
-const fs = require('fs')
-const path = require('path')
 const Fastify = require('../..')
 const h2url = require('h2url')
 const sget = require('simple-get').concat
@@ -21,8 +19,8 @@ test('secure with fallback', (t) => {
       http2: true,
       https: {
         allowHTTP1: true,
-        key: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.key')),
-        cert: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.cert'))
+        key: globalThis.context.key,
+        cert: globalThis.context.cert
       }
     })
     t.pass('Key/cert successfully loaded')

--- a/test/http2/secure-with-fallback.test.js
+++ b/test/http2/secure-with-fallback.test.js
@@ -10,7 +10,11 @@ const sget = require('simple-get').concat
 const msg = { hello: 'world' }
 
 const { buildCertificate } = require('../build-certificate')
-buildCertificate().then(function () {
+t.before(buildCertificate)
+
+test('secure with fallback', (t) => {
+  t.plan(7)
+
   let fastify
   try {
     fastify = Fastify({
@@ -42,7 +46,7 @@ buildCertificate().then(function () {
     t.error(err)
     fastify.server.unref()
 
-    test('https get error', async (t) => {
+    t.test('https get error', async (t) => {
       t.plan(1)
 
       const url = `https://localhost:${fastify.server.address().port}/error`
@@ -51,7 +55,7 @@ buildCertificate().then(function () {
       t.equal(res.headers[':status'], 500)
     })
 
-    test('https post', async (t) => {
+    t.test('https post', async (t) => {
       t.plan(2)
 
       const url = `https://localhost:${fastify.server.address().port}`
@@ -68,7 +72,7 @@ buildCertificate().then(function () {
       t.same(JSON.parse(res.body), { hello: 'http2' })
     })
 
-    test('https get request', async (t) => {
+    t.test('https get request', async (t) => {
       t.plan(3)
 
       const url = `https://localhost:${fastify.server.address().port}`
@@ -79,7 +83,7 @@ buildCertificate().then(function () {
       t.same(JSON.parse(res.body), msg)
     })
 
-    test('http1 get request', t => {
+    t.test('http1 get request', t => {
       t.plan(4)
       sget({
         method: 'GET',
@@ -93,7 +97,7 @@ buildCertificate().then(function () {
       })
     })
 
-    test('http1 get error', (t) => {
+    t.test('http1 get error', (t) => {
       t.plan(2)
       sget({
         method: 'GET',

--- a/test/http2/secure-with-fallback.test.js
+++ b/test/http2/secure-with-fallback.test.js
@@ -10,99 +10,99 @@ const sget = require('simple-get').concat
 const msg = { hello: 'world' }
 
 const { buildCertificate } = require('../build-certificate')
-t.before(buildCertificate)
-
-let fastify
-try {
-  fastify = Fastify({
-    http2: true,
-    https: {
-      allowHTTP1: true,
-      key: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.key')),
-      cert: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.cert'))
-    }
-  })
-  t.pass('Key/cert successfully loaded')
-} catch (e) {
-  t.fail('Key/cert loading failed', e)
-}
-
-fastify.get('/', function (req, reply) {
-  reply.code(200).send(msg)
-})
-
-fastify.post('/', function (req, reply) {
-  reply.code(200).send(req.body)
-})
-
-fastify.get('/error', async function (req, reply) {
-  throw new Error('kaboom')
-})
-
-fastify.listen(0, err => {
-  t.error(err)
-  fastify.server.unref()
-
-  test('https get error', async (t) => {
-    t.plan(1)
-
-    const url = `https://localhost:${fastify.server.address().port}/error`
-    const res = await h2url.concat({ url })
-
-    t.equal(res.headers[':status'], 500)
-  })
-
-  test('https post', async (t) => {
-    t.plan(2)
-
-    const url = `https://localhost:${fastify.server.address().port}`
-    const res = await h2url.concat({
-      url,
-      method: 'POST',
-      body: JSON.stringify({ hello: 'http2' }),
-      headers: {
-        'content-type': 'application/json'
+buildCertificate().then(function () {
+  let fastify
+  try {
+    fastify = Fastify({
+      http2: true,
+      https: {
+        allowHTTP1: true,
+        key: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.key')),
+        cert: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.cert'))
       }
     })
+    t.pass('Key/cert successfully loaded')
+  } catch (e) {
+    t.fail('Key/cert loading failed', e)
+  }
 
-    t.equal(res.headers[':status'], 200)
-    t.same(JSON.parse(res.body), { hello: 'http2' })
+  fastify.get('/', function (req, reply) {
+    reply.code(200).send(msg)
   })
 
-  test('https get request', async (t) => {
-    t.plan(3)
-
-    const url = `https://localhost:${fastify.server.address().port}`
-    const res = await h2url.concat({ url })
-
-    t.equal(res.headers[':status'], 200)
-    t.equal(res.headers['content-length'], '' + JSON.stringify(msg).length)
-    t.same(JSON.parse(res.body), msg)
+  fastify.post('/', function (req, reply) {
+    reply.code(200).send(req.body)
   })
 
-  test('http1 get request', t => {
-    t.plan(4)
-    sget({
-      method: 'GET',
-      url: 'https://localhost:' + fastify.server.address().port,
-      rejectUnauthorized: false
-    }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.equal(response.headers['content-length'], '' + body.length)
-      t.same(JSON.parse(body), { hello: 'world' })
+  fastify.get('/error', async function (req, reply) {
+    throw new Error('kaboom')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
+
+    test('https get error', async (t) => {
+      t.plan(1)
+
+      const url = `https://localhost:${fastify.server.address().port}/error`
+      const res = await h2url.concat({ url })
+
+      t.equal(res.headers[':status'], 500)
     })
-  })
 
-  test('http1 get error', (t) => {
-    t.plan(2)
-    sget({
-      method: 'GET',
-      url: 'https://localhost:' + fastify.server.address().port + '/error',
-      rejectUnauthorized: false
-    }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 500)
+    test('https post', async (t) => {
+      t.plan(2)
+
+      const url = `https://localhost:${fastify.server.address().port}`
+      const res = await h2url.concat({
+        url,
+        method: 'POST',
+        body: JSON.stringify({ hello: 'http2' }),
+        headers: {
+          'content-type': 'application/json'
+        }
+      })
+
+      t.equal(res.headers[':status'], 200)
+      t.same(JSON.parse(res.body), { hello: 'http2' })
+    })
+
+    test('https get request', async (t) => {
+      t.plan(3)
+
+      const url = `https://localhost:${fastify.server.address().port}`
+      const res = await h2url.concat({ url })
+
+      t.equal(res.headers[':status'], 200)
+      t.equal(res.headers['content-length'], '' + JSON.stringify(msg).length)
+      t.same(JSON.parse(res.body), msg)
+    })
+
+    test('http1 get request', t => {
+      t.plan(4)
+      sget({
+        method: 'GET',
+        url: 'https://localhost:' + fastify.server.address().port,
+        rejectUnauthorized: false
+      }, (err, response, body) => {
+        t.error(err)
+        t.equal(response.statusCode, 200)
+        t.equal(response.headers['content-length'], '' + body.length)
+        t.same(JSON.parse(body), { hello: 'world' })
+      })
+    })
+
+    test('http1 get error', (t) => {
+      t.plan(2)
+      sget({
+        method: 'GET',
+        url: 'https://localhost:' + fastify.server.address().port + '/error',
+        rejectUnauthorized: false
+      }, (err, response, body) => {
+        t.error(err)
+        t.equal(response.statusCode, 500)
+      })
     })
   })
 })

--- a/test/http2/secure.test.js
+++ b/test/http2/secure.test.js
@@ -9,49 +9,49 @@ const h2url = require('h2url')
 const msg = { hello: 'world' }
 
 const { buildCertificate } = require('../build-certificate')
-t.before(buildCertificate)
+buildCertificate().then(function () {
+  let fastify
+  try {
+    fastify = Fastify({
+      http2: true,
+      https: {
+        key: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.key')),
+        cert: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.cert'))
+      }
+    })
+    t.pass('Key/cert successfully loaded')
+  } catch (e) {
+    t.fail('Key/cert loading failed', e)
+  }
 
-let fastify
-try {
-  fastify = Fastify({
-    http2: true,
-    https: {
-      key: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.key')),
-      cert: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.cert'))
-    }
+  fastify.get('/', function (req, reply) {
+    reply.code(200).send(msg)
   })
-  t.pass('Key/cert successfully loaded')
-} catch (e) {
-  t.fail('Key/cert loading failed', e)
-}
-
-fastify.get('/', function (req, reply) {
-  reply.code(200).send(msg)
-})
-fastify.get('/proto', function (req, reply) {
-  reply.code(200).send({ proto: req.protocol })
-})
-
-fastify.listen(0, err => {
-  t.error(err)
-  fastify.server.unref()
-
-  test('https get request', async (t) => {
-    t.plan(3)
-
-    const url = `https://localhost:${fastify.server.address().port}`
-    const res = await h2url.concat({ url })
-
-    t.equal(res.headers[':status'], 200)
-    t.equal(res.headers['content-length'], '' + JSON.stringify(msg).length)
-    t.same(JSON.parse(res.body), msg)
+  fastify.get('/proto', function (req, reply) {
+    reply.code(200).send({ proto: req.protocol })
   })
 
-  test('https get request without trust proxy - protocol', async (t) => {
-    t.plan(2)
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
 
-    const url = `https://localhost:${fastify.server.address().port}/proto`
-    t.same(JSON.parse((await h2url.concat({ url })).body), { proto: 'https' })
-    t.same(JSON.parse((await h2url.concat({ url, headers: { 'X-Forwarded-Proto': 'lorem' } })).body), { proto: 'https' })
+    test('https get request', async (t) => {
+      t.plan(3)
+
+      const url = `https://localhost:${fastify.server.address().port}`
+      const res = await h2url.concat({ url })
+
+      t.equal(res.headers[':status'], 200)
+      t.equal(res.headers['content-length'], '' + JSON.stringify(msg).length)
+      t.same(JSON.parse(res.body), msg)
+    })
+
+    test('https get request without trust proxy - protocol', async (t) => {
+      t.plan(2)
+
+      const url = `https://localhost:${fastify.server.address().port}/proto`
+      t.same(JSON.parse((await h2url.concat({ url })).body), { proto: 'https' })
+      t.same(JSON.parse((await h2url.concat({ url, headers: { 'X-Forwarded-Proto': 'lorem' } })).body), { proto: 'https' })
+    })
   })
 })

--- a/test/http2/secure.test.js
+++ b/test/http2/secure.test.js
@@ -9,7 +9,11 @@ const h2url = require('h2url')
 const msg = { hello: 'world' }
 
 const { buildCertificate } = require('../build-certificate')
-buildCertificate().then(function () {
+t.before(buildCertificate)
+
+test('secure', (t) => {
+  t.plan(4)
+
   let fastify
   try {
     fastify = Fastify({
@@ -35,7 +39,7 @@ buildCertificate().then(function () {
     t.error(err)
     fastify.server.unref()
 
-    test('https get request', async (t) => {
+    t.test('https get request', async (t) => {
       t.plan(3)
 
       const url = `https://localhost:${fastify.server.address().port}`
@@ -46,7 +50,7 @@ buildCertificate().then(function () {
       t.same(JSON.parse(res.body), msg)
     })
 
-    test('https get request without trust proxy - protocol', async (t) => {
+    t.test('https get request without trust proxy - protocol', async (t) => {
       t.plan(2)
 
       const url = `https://localhost:${fastify.server.address().port}/proto`

--- a/test/http2/secure.test.js
+++ b/test/http2/secure.test.js
@@ -17,8 +17,8 @@ test('secure', (t) => {
     fastify = Fastify({
       http2: true,
       https: {
-        key: globalThis.context.key,
-        cert: globalThis.context.cert
+        key: global.context.key,
+        cert: global.context.cert
       }
     })
     t.pass('Key/cert successfully loaded')

--- a/test/http2/secure.test.js
+++ b/test/http2/secure.test.js
@@ -8,6 +8,9 @@ const Fastify = require('../..')
 const h2url = require('h2url')
 const msg = { hello: 'world' }
 
+const { buildCertificate } = require('../build-certificate')
+t.before(buildCertificate)
+
 let fastify
 try {
   fastify = Fastify({

--- a/test/http2/secure.test.js
+++ b/test/http2/secure.test.js
@@ -2,8 +2,6 @@
 
 const t = require('tap')
 const test = t.test
-const fs = require('fs')
-const path = require('path')
 const Fastify = require('../..')
 const h2url = require('h2url')
 const msg = { hello: 'world' }
@@ -19,8 +17,8 @@ test('secure', (t) => {
     fastify = Fastify({
       http2: true,
       https: {
-        key: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.key')),
-        cert: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.cert'))
+        key: globalThis.context.key,
+        cert: globalThis.context.cert
       }
     })
     t.pass('Key/cert successfully loaded')

--- a/test/https/custom-https-server.test.js
+++ b/test/https/custom-https-server.test.js
@@ -16,8 +16,8 @@ test('Should support a custom https server', t => {
     t.ok(opts.serverFactory)
 
     const options = {
-      key: globalThis.context.key,
-      cert: globalThis.context.cert
+      key: global.context.key,
+      cert: global.context.cert
     }
 
     const server = https.createServer(options, (req, res) => {

--- a/test/https/custom-https-server.test.js
+++ b/test/https/custom-https-server.test.js
@@ -8,6 +8,9 @@ const fs = require('fs')
 const path = require('path')
 const sget = require('simple-get').concat
 
+const { buildCertificate } = require('../build-certificate')
+t.before(buildCertificate)
+
 test('Should support a custom https server', t => {
   t.plan(6)
 

--- a/test/https/custom-https-server.test.js
+++ b/test/https/custom-https-server.test.js
@@ -4,8 +4,6 @@ const t = require('tap')
 const test = t.test
 const Fastify = require('../..')
 const https = require('https')
-const fs = require('fs')
-const path = require('path')
 const sget = require('simple-get').concat
 
 const { buildCertificate } = require('../build-certificate')
@@ -18,8 +16,8 @@ test('Should support a custom https server', t => {
     t.ok(opts.serverFactory)
 
     const options = {
-      key: fs.readFileSync(path.join(__dirname, 'fastify.key')),
-      cert: fs.readFileSync(path.join(__dirname, 'fastify.cert'))
+      key: globalThis.context.key,
+      cert: globalThis.context.cert
     }
 
     const server = https.createServer(options, (req, res) => {

--- a/test/https/https.test.js
+++ b/test/https/https.test.js
@@ -15,8 +15,8 @@ test('https', (t) => {
   try {
     fastify = Fastify({
       https: {
-        key: globalThis.context.key,
-        cert: globalThis.context.cert
+        key: global.context.key,
+        cert: global.context.cert
       }
     })
     t.pass('Key/cert successfully loaded')

--- a/test/https/https.test.js
+++ b/test/https/https.test.js
@@ -8,74 +8,74 @@ const path = require('path')
 const Fastify = require('../..')
 
 const { buildCertificate } = require('../build-certificate')
-t.before(buildCertificate)
+buildCertificate().then(function () {
+  let fastify
+  try {
+    fastify = Fastify({
+      https: {
+        key: fs.readFileSync(path.join(__dirname, 'fastify.key')),
+        cert: fs.readFileSync(path.join(__dirname, 'fastify.cert'))
+      }
+    })
+    t.pass('Key/cert successfully loaded')
+  } catch (e) {
+    t.fail('Key/cert loading failed', e)
+  }
 
-let fastify
-try {
-  fastify = Fastify({
-    https: {
-      key: fs.readFileSync(path.join(__dirname, 'fastify.key')),
-      cert: fs.readFileSync(path.join(__dirname, 'fastify.cert'))
+  test('https get', t => {
+    t.plan(1)
+    try {
+      fastify.get('/', function (req, reply) {
+        reply.code(200).send({ hello: 'world' })
+      })
+      fastify.get('/proto', function (req, reply) {
+        reply.code(200).send({ proto: req.protocol })
+      })
+      t.pass()
+    } catch (e) {
+      t.fail()
     }
   })
-  t.pass('Key/cert successfully loaded')
-} catch (e) {
-  t.fail('Key/cert loading failed', e)
-}
 
-test('https get', t => {
-  t.plan(1)
-  try {
-    fastify.get('/', function (req, reply) {
-      reply.code(200).send({ hello: 'world' })
-    })
-    fastify.get('/proto', function (req, reply) {
-      reply.code(200).send({ proto: req.protocol })
-    })
-    t.pass()
-  } catch (e) {
-    t.fail()
-  }
-})
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
 
-fastify.listen(0, err => {
-  t.error(err)
-  fastify.server.unref()
-
-  test('https get request', t => {
-    t.plan(4)
-    sget({
-      method: 'GET',
-      url: 'https://localhost:' + fastify.server.address().port,
-      rejectUnauthorized: false
-    }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.equal(response.headers['content-length'], '' + body.length)
-      t.same(JSON.parse(body), { hello: 'world' })
+    test('https get request', t => {
+      t.plan(4)
+      sget({
+        method: 'GET',
+        url: 'https://localhost:' + fastify.server.address().port,
+        rejectUnauthorized: false
+      }, (err, response, body) => {
+        t.error(err)
+        t.equal(response.statusCode, 200)
+        t.equal(response.headers['content-length'], '' + body.length)
+        t.same(JSON.parse(body), { hello: 'world' })
+      })
     })
-  })
 
-  test('https get request without trust proxy - protocol', t => {
-    t.plan(4)
-    sget({
-      method: 'GET',
-      url: 'https://localhost:' + fastify.server.address().port + '/proto',
-      rejectUnauthorized: false
-    }, (err, response, body) => {
-      t.error(err)
-      t.same(JSON.parse(body), { proto: 'https' })
-    })
-    sget({
-      method: 'GET',
-      url: 'https://localhost:' + fastify.server.address().port + '/proto',
-      rejectUnauthorized: false,
-      headers: {
-        'x-forwarded-proto': 'lorem'
-      }
-    }, (err, response, body) => {
-      t.error(err)
-      t.same(JSON.parse(body), { proto: 'https' })
+    test('https get request without trust proxy - protocol', t => {
+      t.plan(4)
+      sget({
+        method: 'GET',
+        url: 'https://localhost:' + fastify.server.address().port + '/proto',
+        rejectUnauthorized: false
+      }, (err, response, body) => {
+        t.error(err)
+        t.same(JSON.parse(body), { proto: 'https' })
+      })
+      sget({
+        method: 'GET',
+        url: 'https://localhost:' + fastify.server.address().port + '/proto',
+        rejectUnauthorized: false,
+        headers: {
+          'x-forwarded-proto': 'lorem'
+        }
+      }, (err, response, body) => {
+        t.error(err)
+        t.same(JSON.parse(body), { proto: 'https' })
+      })
     })
   })
 })

--- a/test/https/https.test.js
+++ b/test/https/https.test.js
@@ -8,7 +8,11 @@ const path = require('path')
 const Fastify = require('../..')
 
 const { buildCertificate } = require('../build-certificate')
-buildCertificate().then(function () {
+t.before(buildCertificate)
+
+test('https', (t) => {
+  t.plan(4)
+
   let fastify
   try {
     fastify = Fastify({
@@ -22,26 +26,19 @@ buildCertificate().then(function () {
     t.fail('Key/cert loading failed', e)
   }
 
-  test('https get', t => {
-    t.plan(1)
-    try {
-      fastify.get('/', function (req, reply) {
-        reply.code(200).send({ hello: 'world' })
-      })
-      fastify.get('/proto', function (req, reply) {
-        reply.code(200).send({ proto: req.protocol })
-      })
-      t.pass()
-    } catch (e) {
-      t.fail()
-    }
+  fastify.get('/', function (req, reply) {
+    reply.code(200).send({ hello: 'world' })
+  })
+
+  fastify.get('/proto', function (req, reply) {
+    reply.code(200).send({ proto: req.protocol })
   })
 
   fastify.listen(0, err => {
     t.error(err)
     fastify.server.unref()
 
-    test('https get request', t => {
+    t.test('https get request', t => {
       t.plan(4)
       sget({
         method: 'GET',
@@ -55,7 +52,7 @@ buildCertificate().then(function () {
       })
     })
 
-    test('https get request without trust proxy - protocol', t => {
+    t.test('https get request without trust proxy - protocol', t => {
       t.plan(4)
       sget({
         method: 'GET',

--- a/test/https/https.test.js
+++ b/test/https/https.test.js
@@ -3,8 +3,6 @@
 const t = require('tap')
 const test = t.test
 const sget = require('simple-get').concat
-const fs = require('fs')
-const path = require('path')
 const Fastify = require('../..')
 
 const { buildCertificate } = require('../build-certificate')
@@ -17,8 +15,8 @@ test('https', (t) => {
   try {
     fastify = Fastify({
       https: {
-        key: fs.readFileSync(path.join(__dirname, 'fastify.key')),
-        cert: fs.readFileSync(path.join(__dirname, 'fastify.cert'))
+        key: globalThis.context.key,
+        cert: globalThis.context.cert
       }
     })
     t.pass('Key/cert successfully loaded')

--- a/test/https/https.test.js
+++ b/test/https/https.test.js
@@ -7,6 +7,9 @@ const fs = require('fs')
 const path = require('path')
 const Fastify = require('../..')
 
+const { buildCertificate } = require('../build-certificate')
+t.before(buildCertificate)
+
 let fastify
 try {
   fastify = Fastify({

--- a/test/internals/initialConfig.test.js
+++ b/test/internals/initialConfig.test.js
@@ -2,8 +2,6 @@
 
 const { test, before } = require('tap')
 const Fastify = require('../..')
-const fs = require('fs')
-const path = require('path')
 const http = require('http')
 const pino = require('pino')
 const split = require('split2')
@@ -74,8 +72,8 @@ test('Fastify.initialConfig should expose all options', t => {
   const options = {
     http2: true,
     https: {
-      key: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.key')),
-      cert: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.cert'))
+      key: globalThis.context.key,
+      cert: globalThis.context.cert
     },
     ignoreTrailingSlash: true,
     maxParamLength: 200,
@@ -144,8 +142,8 @@ test('We must avoid shallow freezing and ensure that the whole object is freezed
   const fastify = Fastify({
     https: {
       allowHTTP1: true,
-      key: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.key')),
-      cert: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.cert'))
+      key: globalThis.context.key,
+      cert: globalThis.context.cert
     }
   })
 
@@ -183,8 +181,8 @@ test('Original options must not be frozen', t => {
   const originalOptions = {
     https: {
       allowHTTP1: true,
-      key: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.key')),
-      cert: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.cert'))
+      key: globalThis.context.key,
+      cert: globalThis.context.cert
     }
   }
 
@@ -202,8 +200,8 @@ test('Original options must not be altered (test deep cloning)', t => {
   const originalOptions = {
     https: {
       allowHTTP1: true,
-      key: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.key'), 'utf8').toString('base64'),
-      cert: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.cert'), 'utf8').toString('base64')
+      key: globalThis.context.key,
+      cert: globalThis.context.cert
     }
   }
 
@@ -295,7 +293,7 @@ test('deepFreezeObject() should not throw on TypedArray', t => {
   t.plan(5)
 
   const object = {
-    buffer: fs.readFileSync(path.join(__dirname, '..', 'https', 'fastify.key')),
+    buffer: Buffer.from(globalThis.context.key),
     dataView: new DataView(new ArrayBuffer(16)),
     float: 1.1,
     integer: 1,

--- a/test/internals/initialConfig.test.js
+++ b/test/internals/initialConfig.test.js
@@ -72,8 +72,8 @@ test('Fastify.initialConfig should expose all options', t => {
   const options = {
     http2: true,
     https: {
-      key: globalThis.context.key,
-      cert: globalThis.context.cert
+      key: global.context.key,
+      cert: global.context.cert
     },
     ignoreTrailingSlash: true,
     maxParamLength: 200,
@@ -142,8 +142,8 @@ test('We must avoid shallow freezing and ensure that the whole object is freezed
   const fastify = Fastify({
     https: {
       allowHTTP1: true,
-      key: globalThis.context.key,
-      cert: globalThis.context.cert
+      key: global.context.key,
+      cert: global.context.cert
     }
   })
 
@@ -181,8 +181,8 @@ test('Original options must not be frozen', t => {
   const originalOptions = {
     https: {
       allowHTTP1: true,
-      key: globalThis.context.key,
-      cert: globalThis.context.cert
+      key: global.context.key,
+      cert: global.context.cert
     }
   }
 
@@ -200,8 +200,8 @@ test('Original options must not be altered (test deep cloning)', t => {
   const originalOptions = {
     https: {
       allowHTTP1: true,
-      key: globalThis.context.key,
-      cert: globalThis.context.cert
+      key: global.context.key,
+      cert: global.context.cert
     }
   }
 
@@ -293,7 +293,7 @@ test('deepFreezeObject() should not throw on TypedArray', t => {
   t.plan(5)
 
   const object = {
-    buffer: Buffer.from(globalThis.context.key),
+    buffer: Buffer.from(global.context.key),
     dataView: new DataView(new ArrayBuffer(16)),
     float: 1.1,
     integer: 1,

--- a/test/internals/initialConfig.test.js
+++ b/test/internals/initialConfig.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test, before } = require('tap')
 const Fastify = require('../..')
 const fs = require('fs')
 const path = require('path')
@@ -9,6 +9,9 @@ const pino = require('pino')
 const split = require('split2')
 const deepClone = require('rfdc')({ circles: true, proto: false })
 const { deepFreezeObject } = require('../../lib/initialConfigValidation').utils
+
+const { buildCertificate } = require('../build-certificate')
+before(buildCertificate)
 
 process.removeAllListeners('warning')
 


### PR DESCRIPTION
Resolve: #3029
Duplicated and Closes #3031 

Changes:
- Remove the before script file
- Remove before script from tap
- Run build certificate inside the file it needed

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
