### PR TITLE
serializer log req and res are now Fastify Objects in type definition

### DIFF
--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -1,5 +1,5 @@
 import { expectType, expectError } from 'tsd'
-import fastify, { FastifyLogFn, LogLevel, FastifyLoggerInstance, FastifyError } from '../../fastify'
+import fastify, { FastifyLogFn, LogLevel, FastifyLoggerInstance, FastifyError, FastifyRequest, FastifyReply } from '../../fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
 import * as pino from 'pino'
 
@@ -124,6 +124,7 @@ const serverAutoInferredSerializerObjectOption = fastify({
   logger: {
     serializers: {
       req (IncomingMessage) {
+        expectType<FastifyRequest>(IncomingMessage)
         return {
           method: 'method',
           url: 'url',
@@ -135,6 +136,7 @@ const serverAutoInferredSerializerObjectOption = fastify({
         }
       },
       res (ServerResponse) {
+        expectType<FastifyReply>(ServerResponse)
         return {
           statusCode: 'statusCode'
         }

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -20,7 +20,9 @@
 
 import { FastifyError } from 'fastify-error'
 import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression } from './utils'
-import { FastifyRequest, RequestGenericInterface } from './request'
+import { RouteGenericInterface } from './route'
+import { FastifyRequest } from './request'
+import { FastifyReply } from './reply'
 
 /**
  * Standard Fastify logging function
@@ -114,8 +116,8 @@ export interface PrettyOptions {
  */
 export interface FastifyLoggerOptions<
   RawServer extends RawServerBase = RawServerDefault,
-  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
-  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>
+  RawRequest extends FastifyRequest<RouteGenericInterface, RawServer, RawRequestDefaultExpression<RawServer>> = FastifyRequest<RouteGenericInterface, RawServer, RawRequestDefaultExpression<RawServer>>,
+  RawReply extends FastifyReply<RawServer, RawRequestDefaultExpression<RawServer>, RawReplyDefaultExpression<RawServer>> = FastifyReply<RawServer, RawRequestDefaultExpression<RawServer>, RawReplyDefaultExpression<RawServer>>
 > {
   serializers?: {
     req?: (req: RawRequest) => {
@@ -139,6 +141,6 @@ export interface FastifyLoggerOptions<
     };
   };
   level?: string;
-  genReqId?: <RequestGeneric extends RequestGenericInterface = RequestGenericInterface>(req: FastifyRequest<RequestGeneric, RawServer, RawRequest>) => string;
+  genReqId?: (req: RawRequest) => string;
   prettyPrint?: boolean | PrettyOptions;
 }


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This merge is intended to fix the bug https://github.com/fastify/fastify/issues/3026

Now the req and res type in the log serializers are typed respectively FastifyRequest and FastifyReply. 