### PR TITLE
fix: reply hasHeader behavior

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -209,7 +209,8 @@ Reply.prototype.getHeaders = function () {
 }
 
 Reply.prototype.hasHeader = function (key) {
-  if (this[kReplyHeaders][key.toLowerCase()] !== undefined) {
+  key = key.toLowerCase()
+  if (this[kReplyHeaders][key] !== undefined) {
     return true
   }
   return this.raw.hasHeader(key)

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -209,7 +209,10 @@ Reply.prototype.getHeaders = function () {
 }
 
 Reply.prototype.hasHeader = function (key) {
-  return this[kReplyHeaders][key.toLowerCase()] !== undefined
+  if (this[kReplyHeaders][key.toLowerCase()] !== undefined) {
+    return true
+  }
+  return this.raw.hasHeader(key)
 }
 
 Reply.prototype.removeHeader = function (key) {

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -1094,6 +1094,35 @@ test('reply.header can reset the value', t => {
   })
 })
 
+// https://github.com/fastify/fastify/issues/3030
+test('reply.hasHeader computes raw and fastify headers', t => {
+  t.plan(4)
+
+  const fastify = require('../../')()
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/headers', function (req, reply) {
+    reply.header('x-foo', 'foo')
+    reply.raw.setHeader('x-bar', 'bar')
+    t.ok(reply.hasHeader('x-foo'))
+    t.ok(reply.hasHeader('x-bar'))
+
+    reply.send()
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port + '/headers'
+    }, () => {
+      t.pass()
+    })
+  })
+})
+
 test('Reply should handle JSON content type with a charset', t => {
   t.plan(16)
 


### PR DESCRIPTION
fix: https://github.com/fastify/fastify/issues/3030

@matteo said 

> it should be based on the same logic. We can avoid generating the wrapper object.

src: https://github.com/fastify/fastify/issues/3030#issuecomment-825156516

Issue is in a case of a proxyfied reply the nodeJs raw reply still has its own headers so this it's still needed:
https://github.com/fastify/fastify/blob/28febddefce64d91e2618fd14001211130a067ad/lib/reply.js#L204-L209


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
#### Benchmarks
before:
```
[1] ┌─────────┬──────┬───────┬───────┬───────┬──────────┬─────────┬────────┐
[1] │ Stat    │ 2.5% │ 50%   │ 97.5% │ 99%   │ Avg      │ Stdev   │ Max    │
[1] ├─────────┼──────┼───────┼───────┼───────┼──────────┼─────────┼────────┤
[1] │ Latency │ 7 ms │ 17 ms │ 30 ms │ 56 ms │ 18.04 ms │ 8.17 ms │ 158 ms │
[1] └─────────┴──────┴───────┴───────┴───────┴──────────┴─────────┴────────┘
[1] ┌───────────┬─────────┬─────────┬─────────┬───────┬─────────┬─────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5% │ Avg     │ Stdev   │ Min     │
[1] ├───────────┼─────────┼─────────┼─────────┼───────┼─────────┼─────────┼─────────┤
[1] │ Req/Sec   │ 40959   │ 40959   │ 57439   │ 58559 │ 54275.2 │ 6729.92 │ 40957   │
[1] ├───────────┼─────────┼─────────┼─────────┼───────┼─────────┼─────────┼─────────┤
[1] │ Bytes/Sec │ 7.66 MB │ 7.66 MB │ 10.7 MB │ 11 MB │ 10.1 MB │ 1.26 MB │ 7.66 MB │
[1] └───────────┴─────────┴─────────┴─────────┴───────┴─────────┴─────────┴─────────┘
```
after:
```
[1]
[1] ┌─────────┬──────┬───────┬───────┬───────┬──────────┬─────────┬────────┐
[1] │ Stat    │ 2.5% │ 50%   │ 97.5% │ 99%   │ Avg      │ Stdev   │ Max    │
[1] ├─────────┼──────┼───────┼───────┼───────┼──────────┼─────────┼────────┤
[1] │ Latency │ 6 ms │ 17 ms │ 28 ms │ 58 ms │ 17.55 ms │ 8.66 ms │ 131 ms │
[1] └─────────┴──────┴───────┴───────┴───────┴──────────┴─────────┴────────┘
[1] ┌───────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg     │ Stdev   │ Min     │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
[1] │ Req/Sec   │ 41631   │ 41631   │ 59423   │ 60351   │ 55689.6 │ 7093.95 │ 41620   │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
[1] │ Bytes/Sec │ 7.79 MB │ 7.79 MB │ 11.1 MB │ 11.3 MB │ 10.4 MB │ 1.33 MB │ 7.78 MB │
[1] └───────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
[1]
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
