### PR TITLE
Fix: use case when route defined without a url

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -173,7 +173,7 @@ function buildRouting (options) {
               afterRouteAdded.call(this, { path, prefixing: true }, notHandledErr, done)
             }
         }
-      } else if (path[0] === '/' && prefix.endsWith('/')) {
+      } else if (path && path[0] === '/' && prefix.endsWith('/')) {
         // Ensure that '/prefix/' + '/route' gets registered as '/prefix/route'
         afterRouteAdded.call(this, { path: path.slice(1) }, notHandledErr, done)
       } else {

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -547,6 +547,20 @@ test('throws when route with empty url', async t => {
   }
 })
 
+test('throws when route with empty url in shorthand declaration', async t => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  try {
+    await fastify.get(
+      '',
+      async function handler () { return {} }
+    ).ready()
+  } catch (err) {
+    t.equal(err.message, 'The path could not be empty')
+  }
+})
+
 test('throws when route-level error handler is not a function', t => {
   t.plan(1)
 

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -530,6 +530,23 @@ test('route error handler overrides global custom error handler', t => {
   })
 })
 
+test('throws when route with empty url', async t => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  try {
+    await fastify.route({
+      method: 'GET',
+      url: '',
+      handler: (req, res) => {
+        res.send('hi!')
+      }
+    }).ready()
+  } catch (err) {
+    t.equal(err.message, 'The first character of a path should be `/` or `*`')
+  }
+})
+
 test('throws when route-level error handler is not a function', t => {
   t.plan(1)
 


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This merge is intended to fix the bug #3047.

in case of empty url in route - throw error