### PR TITLE
Fix Content-Length not being updated after onSend hook

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -428,6 +428,8 @@ function onSendEnd (reply, payload) {
 
   if (!reply[kReplyHeaders]['content-length']) {
     reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)
+  } else if (req.raw.method !== 'HEAD' && reply[kReplyHeaders]['content-length'] !== Buffer.byteLength(payload)) {
+    reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)
   }
 
   reply[kReplySent] = true

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -1334,6 +1334,30 @@ test('onSend hook should receive valid request and reply objects if a custom con
   })
 })
 
+test('Content-Length header should be updated if onSend hook modifies the payload', t => {
+  t.plan(2)
+
+  const instance = Fastify()
+
+  instance.get('/', async (_, rep) => {
+    rep.header('content-length', 3)
+    return 'foo'
+  })
+
+  instance.addHook('onSend', async () => 'bar12233000')
+
+  instance.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    const payloadLength = Buffer.byteLength(res.body)
+    const contentLength = Number(res.headers['content-length'])
+
+    t.equal(payloadLength, contentLength)
+  })
+})
+
 test('cannot add hook after binding', t => {
   t.plan(2)
   const instance = Fastify()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This PR fixes #3057, `onSendEnd` will now set `Content-length` header to the length of the payload if they're not already equal and if the http method isn't `HEAD`. 
