### PR TITLE
add clientErrorHandler in fastify ts definition

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -14,7 +14,7 @@ import { FastifyError } from 'fastify-error'
 import { FastifyReply } from './types/reply'
 import { FastifySchemaValidationError } from './types/schema'
 import { ConstructorAction, ProtoAction } from "./types/content-type-parser";
-import { Socket } from 'node:net'
+import { Socket } from 'net'
 
 /**
  * Fastify factory function for the standard fastify http, https, or http2 server instance.

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -14,6 +14,7 @@ import { FastifyError } from 'fastify-error'
 import { FastifyReply } from './types/reply'
 import { FastifySchemaValidationError } from './types/schema'
 import { ConstructorAction, ProtoAction } from "./types/content-type-parser";
+import { Socket } from 'node:net'
 
 /**
  * Fastify factory function for the standard fastify http, https, or http2 server instance.
@@ -74,6 +75,15 @@ export type FastifyHttpsOptions<
 
 type FindMyWayVersion<RawServer extends RawServerBase> = RawServer extends http.Server ? HTTPVersion.V1 : HTTPVersion.V2
 
+export interface ConnectionError extends Error {
+  code: string,
+  bytesParsed: number,
+  rawPacket: {
+    type: string,
+    data: number[]
+  }
+}
+
 /**
  * Options for a fastify server instance. Utilizes conditional logic on the generic server parameter to enforce certain https and http2
  */
@@ -125,7 +135,11 @@ export type FastifyServerOptions<
     res: FastifyReply<RawServer, RawRequestDefaultExpression<RawServer>, RawReplyDefaultExpression<RawServer>>
   ) => void,
   rewriteUrl?: (req: RawRequestDefaultExpression<RawServer>) => string,
-  schemaErrorFormatter?: (errors: FastifySchemaValidationError[], dataVar: string) => Error
+  schemaErrorFormatter?: (errors: FastifySchemaValidationError[], dataVar: string) => Error,
+  /**
+   * listener to error events emitted by client connections
+   */
+  clientErrorHandler?: (error: ConnectionError, socket: Socket) => void
 }
 
 type TrustProxyFunction = (address: string, hop: number) => boolean

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -11,7 +11,7 @@ import * as http2 from 'http2'
 import { Chain as LightMyRequestChain } from 'light-my-request'
 import { expectType, expectError, expectAssignable } from 'tsd'
 import { FastifyLoggerInstance } from '../../types/logger'
-import { Socket } from 'node:net'
+import { Socket } from 'net'
 
 // FastifyInstance
 // http server

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -1,4 +1,5 @@
 import fastify, {
+  ConnectionError,
   FastifyInstance,
   FastifyPlugin,
   FastifyPluginAsync,
@@ -10,6 +11,7 @@ import * as http2 from 'http2'
 import { Chain as LightMyRequestChain } from 'light-my-request'
 import { expectType, expectError, expectAssignable } from 'tsd'
 import { FastifyLoggerInstance } from '../../types/logger'
+import { Socket } from 'node:net'
 
 // FastifyInstance
 // http server
@@ -139,6 +141,12 @@ expectAssignable<FastifyInstance>(fastify({
   rewriteUrl: (req) => req.url === '/hi' ? '/hello' : req.url!
 }))
 expectAssignable<FastifyInstance>(fastify({ schemaErrorFormatter: (errors, dataVar) => new Error() }))
+expectAssignable<FastifyInstance>(fastify({
+  clientErrorHandler: (err, socket) => {
+    expectType<ConnectionError>(err)
+    expectType<Socket>(socket)
+  }
+}))
 
 // Thenable
 expectAssignable<PromiseLike<FastifyInstance>>(fastify({ return503OnClosing: true }))


### PR DESCRIPTION
#### Checklist

- [X] run `npm run test`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Added the clientErrorHandler option in the fastify server definition, according to the official doc.

This is intended to solve the issue https://github.com/fastify/fastify/issues/3062 