### PR TITLE
Note about security releases and LTS

### DIFF
--- a/docs/LTS.md
+++ b/docs/LTS.md
@@ -28,7 +28,7 @@ A "month" is defined as 30 consecutive days.
 > ## Security Releases and Semver
 >
 > As a consequence of providing long-term support for major releases, there
-> are occasions where we need to release a breaking changes as a _minor_
+> are occasions where we need to release breaking changes as a _minor_
 > version release. Such changes will _always_ be noted in the
 > [release notes](https://github.com/fastify/fastify/releases).
 >

--- a/docs/LTS.md
+++ b/docs/LTS.md
@@ -25,6 +25,18 @@ out in this document:
 
 A "month" is defined as 30 consecutive days.
 
+> ## Security Releases and Semver
+>
+> As a consequence of providing long-term support for major releases, there
+> are occasions where we need to release a breaking changes as a _minor_
+> version release. Such changes will _always_ be noted in the
+> [release notes](https://github.com/fastify/fastify/releases).
+>
+> To avoid automatically updating to new patch releases we recommend using
+> a tilde (`~`) range qualifier. For example, to get patches for the 3.15
+> release, and avoid automatically updating to the 3.16 release, specify
+> the dependency as `"fastify": "~3.15.x"`.
+
 [semver]: https://semver.org/
 
 <a name="lts-schedule"></a>
@@ -41,7 +53,10 @@ A "month" is defined as 30 consecutive days.
 
 ### CI tested operating systems
 
-Fastify uses GitHub Actions for CI testing, please refer to [GitHub's documentation regarding workflow runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) for further details on what the latest virtual environment is in relation to the YAML workflow labels below:
+Fastify uses GitHub Actions for CI testing, please refer to
+[GitHub's documentation regarding workflow runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)
+for further details on what the latest virtual environment is in relation to
+the YAML workflow labels below:
 
 | OS      | YAML Workflow Label    | Package Manager           | Node.js      |
 |---------|------------------------|---------------------------|--------------|

--- a/docs/LTS.md
+++ b/docs/LTS.md
@@ -32,10 +32,11 @@ A "month" is defined as 30 consecutive days.
 > version release. Such changes will _always_ be noted in the
 > [release notes](https://github.com/fastify/fastify/releases).
 >
-> To avoid automatically updating to new patch releases we recommend using
-> a tilde (`~`) range qualifier. For example, to get patches for the 3.15
+> To avoid automatically receiving breaking security updates it is possible to use
+> the tilde (`~`) range qualifier. For example, to get patches for the 3.15
 > release, and avoid automatically updating to the 3.16 release, specify
-> the dependency as `"fastify": "~3.15.x"`.
+> the dependency as `"fastify": "~3.15.x"`. This will leave your application vulnerable,
+> so please use with caution.
 
 [semver]: https://semver.org/
 


### PR DESCRIPTION
This PR adds a call out note to the LTS documentation that informs readers of our policy on publishing security releases and how they can avoid automatically installing them.

Bonus: cleans up some line wrapping in the LTS doc.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
