### PR TITLE
Fix requires in the benchmark scripts

### DIFF
--- a/examples/benchmark/hooks-benchmark-async-await.js
+++ b/examples/benchmark/hooks-benchmark-async-await.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const fastify = require('../fastify')({ logger: false })
+const fastify = require('../../fastify')({ logger: false })
 
 const opts = {
   schema: {

--- a/examples/benchmark/hooks-benchmark.js
+++ b/examples/benchmark/hooks-benchmark.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const fastify = require('../fastify')({ logger: false })
+const fastify = require('../../fastify')({ logger: false })
 
 const opts = {
   schema: {

--- a/examples/benchmark/simple.js
+++ b/examples/benchmark/simple.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const fastify = require('../fastify')({
+const fastify = require('../../fastify')({
   logger: false
 })
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

The https://github.com/fastify/fastify/pull/3048 moved the benchmark scripts, but the requires were not adapted to the new path, so they do not work in the current state. This PR fixes these paths.