### PR TITLE
Fix simplify reply sent monitoring

### DIFF
--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -75,9 +75,7 @@ function handler (request, reply) {
 }
 
 function preValidationCallback (err, request, reply) {
-  if (reply.sent === true ||
-    reply.raw.writableEnded === true ||
-    reply.raw.writable === false) return
+  if (reply.sent === true) return
 
   if (err != null) {
     reply.send(err)
@@ -109,9 +107,7 @@ function preValidationCallback (err, request, reply) {
 }
 
 function preHandlerCallback (err, request, reply) {
-  if (reply.sent ||
-    reply.raw.writableEnded === true ||
-    reply.raw.writable === false) return
+  if (reply.sent) return
 
   if (err != null) {
     reply.send(err)

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -81,9 +81,11 @@ Object.defineProperties(Reply.prototype, {
       // response has ended. The response.writableEnded property was added in
       // Node.js v12.9.0. Since fastify supports older Node.js versions as well,
       // we have to take response.finished property in consideration when
-      // applicable.
+      // applicable. The response.finished will be always true when the request
+      // method is HEAD and http2 is used, so we have to combine that with
+      // response.headersSent.
       // TODO: remove fallback when the lowest supported Node.js version >= v12.9.0
-      return (this[kReplySentOverwritten] || (typeof this.raw.writableEnded !== 'undefined' ? this.raw.writableEnded : this.raw.finished)) === true
+      return (this[kReplySentOverwritten] || (typeof this.raw.writableEnded !== 'undefined' ? this.raw.writableEnded : (this.raw.headersSent && this.raw.finished))) === true
     },
     set (value) {
       if (value !== true) {

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { test } = require('tap')
-const semver = require('semver')
 const handleRequest = require('../../lib/handleRequest')
 const internals = require('../../lib/handleRequest')[Symbol.for('internals')]
 const Request = require('../../lib/request')
@@ -108,12 +107,8 @@ test('handler function - preValidationCallback with finished response', t => {
   t.plan(0)
   const res = {}
   // Be sure to check only `writableEnded` where is available
-  if (semver.gte(process.versions.node, '12.9.0')) {
-    res.writableEnded = true
-  } else {
-    res.writable = false
-    res.finished = true
-  }
+  res.writableEnded = true
+
   res.end = () => {
     t.fail()
   }
@@ -138,7 +133,7 @@ test('handler function - preValidationCallback with finished response (< v12.9.0
   t.plan(0)
   const res = {}
   // Be sure to check only `writableEnded` where is available
-  res.writable = false
+  res.headersSent = true
   res.finished = true
 
   res.end = () => {

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -1694,10 +1694,10 @@ test('reply.sent should read from response.writableEnded if it is defined', t =>
   t.equal(reply.sent, true)
 })
 
-test('reply.sent should read from response.finished if response.writableEnded is not defined', t => {
+test('reply.sent should read from response.headersSent and response.finished if response.writableEnded is not defined', t => {
   t.plan(1)
 
-  const reply = new Reply({ finished: true }, {}, {})
+  const reply = new Reply({ headersSent: true, finished: true }, {}, {})
 
   t.equal(reply.sent, true)
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


After another review, I noticed a problem with my previous PR https://github.com/fastify/fastify/pull/3072.

I figured out that when http2 is used and the request method is "HEAD", `response.finished` will be always true (my understanding after reading https://nodejs.org/api/http2.html#http2_response_finished was that it behaves the same way as `response.writableEnded`, since that is suggested as a replacement). This is problematic with Node.js versions prior to 12.9.0 where `response.writableEnded` does not exist.

https://github.com/fastify/fastify/pull/2233 was made to cope with this problem, but it relied on `response.writable`, which by my testing will stay true even after the response has ended, so we cannot use it as an indicator.

Therefore, I added additional check, so now both `response.finished` as well as `response.headersSent` has to be true in order for reply to be considered sent. This change only applies for Node.js versions prior to 12.9.0 because newer versions will be using `response.writableEnded` which works correctly.

I also removed additional checks from `preValidationCallback` and `preHandlerCallback` that I missed, which were introduced by https://github.com/fastify/fastify/pull/2233. They are not needed any more with the new way that the `reply.sent` works.

PS: The `test/http2/head.test.js` was supposed to fail before on node10, but I only noticed that in my local environment today. Therefore I didn't include any new tests, since the part that this PR targets is already covered by an existing test.

I'm sorry for any inconvenience caused.