### PR TITLE
[WIP] feat: group server options

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -68,14 +68,14 @@ function buildRouting (options) {
       setupResponseListeners = fastifyArgs.setupResponseListeners
       throwIfAlreadyStarted = fastifyArgs.throwIfAlreadyStarted
 
-      globalExposeHeadRoutes = options.exposeHeadRoutes
+      globalExposeHeadRoutes = options.routing.exposeHeadRoutes
       requestIdHeader = options.requestIdHeader
       querystringParser = options.querystringParser
       requestIdLogLabel = options.requestIdLogLabel
       genReqId = options.genReqId
       disableRequestLogging = options.disableRequestLogging
-      ignoreTrailingSlash = options.ignoreTrailingSlash
-      return503OnClosing = Object.prototype.hasOwnProperty.call(options, 'return503OnClosing') ? options.return503OnClosing : true
+      ignoreTrailingSlash = options.routing.ignoreTrailingSlash
+      return503OnClosing = Object.prototype.hasOwnProperty.call(options.errorManagement, 'return503OnClosing') ? options.errorManagement.return503OnClosing : true
     },
     routing: router.lookup.bind(router), // router func to find the right handler to call
     route, // configure a route in the fastify instance

--- a/lib/server.js
+++ b/lib/server.js
@@ -17,21 +17,21 @@ function createServer (options, httpHandler) {
   } else if (options.https) {
     if (options.http2) {
       server = http2().createSecureServer(options.https, httpHandler)
-      server.on('session', sessionTimeout(options.http2SessionTimeout))
+      server.on('session', sessionTimeout(options.timeouts.http2SessionTimeout))
     } else {
       server = https.createServer(options.https, httpHandler)
-      server.keepAliveTimeout = options.keepAliveTimeout
+      server.keepAliveTimeout = options.timeouts.keepAliveTimeout
     }
   } else if (options.http2) {
     server = http2().createServer(httpHandler)
-    server.on('session', sessionTimeout(options.http2SessionTimeout))
+    server.on('session', sessionTimeout(options.timeouts.http2SessionTimeout))
   } else {
     server = http.createServer(httpHandler)
-    server.keepAliveTimeout = options.keepAliveTimeout
+    server.keepAliveTimeout = options.timeouts.keepAliveTimeout
   }
 
   if (!options.serverFactory) {
-    server.setTimeout(options.connectionTimeout)
+    server.setTimeout(options.timeouts.connectionTimeout)
   }
 
   return { server, listen }


### PR DESCRIPTION
#### Description

This PR closes #3074

TODOS:

- [x] Add a helper function that normalizes options to the new grouped format
- [ ] Display deprecation warnings for old format of the options
- [x] Fix setting of default values post normalization
- [x] Fix schema for server options in build-validation.js 
- [x] Fix corresponding type definitions if any
- [x] Update tests to use the new grouped version for options 
- [ ] Update docs
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
