### PR TITLE
fix: content-length 0 although explicitly set

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -409,7 +409,7 @@ function onSendEnd (reply, payload) {
     // we cannot send a content-length for 304 and 204, and all status code
     // < 200.
     // For HEAD we don't overwrite the `content-length`
-    if (statusCode >= 200 && statusCode !== 204 && statusCode !== 304 && req.method !== 'HEAD') {
+    if ((statusCode < 200 || statusCode === 204 || statusCode === 304) && req.method !== 'HEAD') {
       reply[kReplyHeaders]['content-length'] = '0'
     }
 


### PR DESCRIPTION
#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

### The issue:

Setting explicitly a `Content-Length` header will reply with `Content-Length: 0`. Example code:

```javascript
            reply
                .code(200)
                .type("video/mp4")
                .header("content-length", fileSize)
                .send();
```

*Use-Case:* I am implementing a service for video streaming. When the client requests the resource without a `Range` header the service is expected to respond with the content length, while the reply body/payload is empty.

### The solution

The if condition seemed not to do what the comment claimed it should to. I changed that and now the above code is working. 
