### PR TITLE
Remove content type coercion for response streams

### DIFF
--- a/examples/simple-stream.js
+++ b/examples/simple-stream.js
@@ -6,23 +6,8 @@ const fastify = require('../fastify')({
 
 const Readable = require('stream').Readable
 
-const schema = {
-  schema: {
-    response: {
-      200: {
-        type: 'object',
-        properties: {
-          hello: {
-            type: 'string'
-          }
-        }
-      }
-    }
-  }
-}
-
 fastify
-  .get('/', schema, function (req, reply) {
+  .get('/', function (req, reply) {
     const stream = Readable.from(['hello world'])
     reply.send(stream)
   })

--- a/examples/simple-stream.js
+++ b/examples/simple-stream.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const fastify = require('../fastify')({
+  logger: false
+})
+
+const Readable = require('stream').Readable
+
+const schema = {
+  schema: {
+    response: {
+      200: {
+        type: 'object',
+        properties: {
+          hello: {
+            type: 'string'
+          }
+        }
+      }
+    }
+  }
+}
+
+fastify
+  .get('/', schema, function (req, reply) {
+    const stream = Readable.from(['hello world'])
+    reply.send(stream)
+  })
+
+fastify.listen(3000, (err, address) => {
+  if (err) throw err
+  fastify.log.info(`server listening on ${address}`)
+})

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -126,7 +126,12 @@ Reply.prototype.send = function (payload) {
   const hasContentType = contentType !== undefined
 
   if (payload !== null) {
-    if (Buffer.isBuffer(payload) || typeof payload.pipe === 'function') {
+    if (typeof payload.pipe === 'function') {
+      onSendHook(this, payload)
+      return this
+    }
+
+    if (Buffer.isBuffer(payload)) {
       if (hasContentType === false) {
         this[kReplyHeaders]['content-type'] = CONTENT_TYPE.OCTET
       }

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -1073,7 +1073,7 @@ test('onSend hook is called after payload is serialized and headers are set', t 
 
     instance.addHook('onSend', function (request, reply, payload, done) {
       t.equal(payload, thePayload)
-      t.equal(reply[symbols.kReplyHeaders]['content-type'], 'application/octet-stream')
+      t.same(reply[symbols.kReplyHeaders]['content-type'], null)
       done()
     })
 

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -1073,11 +1073,12 @@ test('onSend hook is called after payload is serialized and headers are set', t 
 
     instance.addHook('onSend', function (request, reply, payload, done) {
       t.equal(payload, thePayload)
-      t.same(reply[symbols.kReplyHeaders]['content-type'], null)
+      t.equal(reply[symbols.kReplyHeaders]['content-type'], 'application/octet-stream')
       done()
     })
 
     instance.get('/stream', (request, reply) => {
+      reply.header('content-type', 'application/octet-stream')
       reply.send(thePayload)
     })
 

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -15,6 +15,8 @@ const {
   kReplyIsError,
   kReplySerializerDefault
 } = require('../../lib/symbols')
+const fs = require('fs')
+const path = require('path')
 
 test('Once called, Reply should return an object with methods', t => {
   t.plan(13)
@@ -452,8 +454,6 @@ test('stream with content type should not send application/octet-stream', t => {
   t.plan(4)
 
   const fastify = require('../..')()
-  const fs = require('fs')
-  const path = require('path')
 
   const streamPath = path.join(__dirname, '..', '..', 'package.json')
   const stream = fs.createReadStream(streamPath)
@@ -481,12 +481,9 @@ test('stream without content type should not send application/octet-stream', t =
   t.plan(4)
 
   const fastify = require('../..')()
-  const fs = require('fs')
-  const path = require('path')
 
-  const streamPath = path.join(__dirname, '..', '..', 'package.json')
-  const stream = fs.createReadStream(streamPath)
-  const buf = fs.readFileSync(streamPath)
+  const stream = fs.createReadStream(__filename)
+  const buf = fs.readFileSync(__filename)
 
   fastify.get('/', function (req, reply) {
     reply.send(stream)
@@ -500,7 +497,7 @@ test('stream without content type should not send application/octet-stream', t =
       url: 'http://localhost:' + fastify.server.address().port
     }, (err, response, body) => {
       t.error(err)
-      t.same(response.headers['content-type'], null)
+      t.equal(response.headers['content-type'], undefined)
       t.same(body, buf)
     })
   })

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -477,6 +477,35 @@ test('stream with content type should not send application/octet-stream', t => {
   })
 })
 
+test('stream without content type should not send application/octet-stream', t => {
+  t.plan(4)
+
+  const fastify = require('../..')()
+  const fs = require('fs')
+  const path = require('path')
+
+  const streamPath = path.join(__dirname, '..', '..', 'package.json')
+  const stream = fs.createReadStream(streamPath)
+  const buf = fs.readFileSync(streamPath)
+
+  fastify.get('/', function (req, reply) {
+    reply.send(stream)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.same(response.headers['content-type'], null)
+      t.same(body, buf)
+    })
+  })
+})
+
 test('stream using reply.raw.writeHead should return customize headers', t => {
   t.plan(6)
 

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -859,7 +859,7 @@ test('HEAD route should handle properly each response type', t => {
   }, (error, res) => {
     t.error(error)
     t.equal(res.statusCode, 200)
-    t.equal(res.headers['content-type'], 'application/octet-stream')
+    t.same(res.headers['content-type'], null)
     t.equal(res.headers['content-length'], undefined)
     t.equal(res.body, '')
   })
@@ -1007,7 +1007,7 @@ test("HEAD route should handle stream.on('error')", t => {
   }, (error, res) => {
     t.error(error)
     t.equal(res.statusCode, 200)
-    t.equal(res.headers['content-type'], 'application/octet-stream')
+    t.same(res.headers['content-type'], null)
   })
 })
 

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -859,7 +859,7 @@ test('HEAD route should handle properly each response type', t => {
   }, (error, res) => {
     t.error(error)
     t.equal(res.statusCode, 200)
-    t.same(res.headers['content-type'], null)
+    t.equal(res.headers['content-type'], undefined)
     t.equal(res.headers['content-length'], undefined)
     t.equal(res.body, '')
   })
@@ -1007,7 +1007,7 @@ test("HEAD route should handle stream.on('error')", t => {
   }, (error, res) => {
     t.error(error)
     t.equal(res.statusCode, 200)
-    t.same(res.headers['content-type'], null)
+    t.equal(res.headers['content-type'], undefined)
   })
 })
 

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -34,7 +34,7 @@ test('should respond with a stream', t => {
 
     sget(`http://localhost:${fastify.server.address().port}`, function (err, response, data) {
       t.error(err)
-      t.same(response.headers['content-type'], null)
+      t.equal(response.headers['content-type'], undefined)
       t.equal(response.statusCode, 200)
 
       fs.readFile(__filename, (err, expected) => {
@@ -446,11 +446,11 @@ test('return a 404 if the stream emits a 404 error', t => {
 })
 
 test('should support send module 200 and 404', t => {
-  t.plan(7)
+  t.plan(8)
   const fastify = Fastify()
 
   fastify.get('/', function (req, reply) {
-    const stream = Readable.from(['Text stream'])
+    const stream = send(req.raw, __filename)
     reply.code(200).send(stream)
   })
 
@@ -465,9 +465,13 @@ test('should support send module 200 and 404', t => {
 
     sget(`http://localhost:${fastify.server.address().port}`, function (err, response, data) {
       t.error(err)
-      t.same(response.headers['content-type'], null)
+      t.equal(response.headers['content-type'], 'application/javascript; charset=UTF-8')
       t.equal(response.statusCode, 200)
-      t.equal('Text stream', data.toString())
+
+      fs.readFile(__filename, (err, expected) => {
+        t.error(err)
+        t.equal(expected.toString(), data.toString())
+      })
     })
 
     sget(`http://localhost:${fastify.server.address().port}/error`, function (err, response) {

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -34,7 +34,7 @@ test('should respond with a stream', t => {
 
     sget(`http://localhost:${fastify.server.address().port}`, function (err, response, data) {
       t.error(err)
-      t.equal(response.headers['content-type'], 'application/octet-stream')
+      t.same(response.headers['content-type'], null)
       t.equal(response.statusCode, 200)
 
       fs.readFile(__filename, (err, expected) => {
@@ -446,11 +446,11 @@ test('return a 404 if the stream emits a 404 error', t => {
 })
 
 test('should support send module 200 and 404', t => {
-  t.plan(8)
+  t.plan(7)
   const fastify = Fastify()
 
   fastify.get('/', function (req, reply) {
-    const stream = send(req.raw, __filename)
+    const stream = Readable.from(['Text stream'])
     reply.code(200).send(stream)
   })
 
@@ -465,13 +465,9 @@ test('should support send module 200 and 404', t => {
 
     sget(`http://localhost:${fastify.server.address().port}`, function (err, response, data) {
       t.error(err)
-      t.equal(response.headers['content-type'], 'application/octet-stream')
+      t.same(response.headers['content-type'], null)
       t.equal(response.statusCode, 200)
-
-      fs.readFile(__filename, (err, expected) => {
-        t.error(err)
-        t.equal(expected.toString(), data.toString())
-      })
+      t.equal('Text stream', data.toString())
     })
 
     sget(`http://localhost:${fastify.server.address().port}/error`, function (err, response) {


### PR DESCRIPTION
Resolves #3085, resolves fastify/fastify-reply-from#174

Adjusts the handling of response streams so that we no longer apply a default `content-type` header. As discussed on the original issue the current behaviour can cause issues with specific responses e.g. 204 - empty response.

This change will be included in v3 as well behind a option, but wanted to confirm the approach in v4 first. 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
