### PR TITLE
feat: error on wrong decorator dependency type

### DIFF
--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -11,7 +11,8 @@ const {
 const {
   FST_ERR_DEC_ALREADY_PRESENT,
   FST_ERR_DEC_MISSING_DEPENDENCY,
-  FST_ERR_DEC_AFTER_START
+  FST_ERR_DEC_AFTER_START,
+  FST_ERR_DEC_DEPENDENCY_INVALID_TYPE
 } = require('./errors')
 
 const warning = require('./warnings')
@@ -22,6 +23,10 @@ function decorate (instance, name, fn, dependencies) {
   }
 
   if (dependencies) {
+    if (!Array.isArray(dependencies)) {
+      throw new FST_ERR_DEC_DEPENDENCY_INVALID_TYPE(name)
+    }
+
     checkDependencies(instance, dependencies)
   }
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -72,6 +72,10 @@ const codes = {
     'FST_ERR_DEC_ALREADY_PRESENT',
     "The decorator '%s' has already been added!"
   ),
+  FST_ERR_DEC_DEPENDENCY_INVALID_TYPE: createError(
+    'FST_ERR_DEC_DEPENDENCY_INVALID_TYPE',
+    "The dependencies of decorator '%s' must be of type Array."
+  ),
   FST_ERR_DEC_MISSING_DEPENDENCY: createError(
     'FST_ERR_DEC_MISSING_DEPENDENCY',
     "The decorator is missing dependency '%s'."

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -56,8 +56,26 @@ test('decorate should throw if a declared dependency is not present', t => {
       instance.decorate('test', () => {}, ['dependency'])
       t.fail()
     } catch (e) {
-      t.ok(e.code, 'FST_ERR_DEC_MISSING_DEPENDENCY')
-      t.ok(e.message, 'The decorator is missing dependency \'dependency\'.')
+      t.same(e.code, 'FST_ERR_DEC_MISSING_DEPENDENCY')
+      t.same(e.message, 'The decorator is missing dependency \'dependency\'.')
+    }
+    done()
+  })
+
+  fastify.ready(() => t.pass())
+})
+
+test('decorate should throw if declared dependency is not array', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.register((instance, opts, done) => {
+    try {
+      instance.decorate('test', () => {}, {})
+      t.fail()
+    } catch (e) {
+      t.same(e.code, 'FST_ERR_DEC_DEPENDENCY_INVALID_TYPE')
+      t.same(e.message, 'The dependencies of decorator \'test\' must be of type Array.')
     }
     done()
   })
@@ -726,22 +744,22 @@ test('decorate* should throw if called after ready', async t => {
     fastify.decorate('test', true)
     t.fail('should not decorate')
   } catch (err) {
-    t.ok(err.code, 'FST_ERR_DEC_AFTER_START')
-    t.ok(err.message, "The decorator 'test' has been added after start!")
+    t.same(err.code, 'FST_ERR_DEC_AFTER_START')
+    t.same(err.message, "The decorator 'test' has been added after start!")
   }
   try {
     fastify.decorateRequest('test', true)
     t.fail('should not decorate')
   } catch (e) {
-    t.ok(e.code, 'FST_ERR_DEC_AFTER_START')
-    t.ok(e.message, "The decorator 'test' has been added after start!")
+    t.same(e.code, 'FST_ERR_DEC_AFTER_START')
+    t.same(e.message, "The decorator 'test' has been added after start!")
   }
   try {
     fastify.decorateReply('test', true)
     t.fail('should not decorate')
   } catch (e) {
-    t.ok(e.code, 'FST_ERR_DEC_AFTER_START')
-    t.ok(e.message, "The decorator 'test' has been added after start!")
+    t.same(e.code, 'FST_ERR_DEC_AFTER_START')
+    t.same(e.message, "The decorator 'test' has been added after start!")
   }
   await fastify.close()
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Throws a meaningful error if a server decorator dependency is specified and it is not an array. The code assumes an array and will fail with misleading errors in case something else is provided.

Also fixes a few assertions in the `decorator.test.js` file where `t.ok` was mistakenly used to do an equality check. Replaced with `t.same`.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
