### PR TITLE
Feature: Add Typescript type checking of replies based on the status code.

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -27,7 +27,7 @@
     - [Errors](#errors)
     - [Type of the final payload](#type-of-the-final-payload)
     - [Async-Await and Promises](#async-await-and-promises)
-  - [.sendWithStatus(code, data)](#send-reply-typed)
+  - [.sendWithStatus(code, data)](#send-with-status)
   - [.then](#then)
 
 <a name="introduction"></a>
@@ -436,11 +436,11 @@ fastify.get('/botnet', async function (request, reply) {
 If you want to know more please review [Routes#async-await](Routes.md#async-await).
 
 
-<a name="send-reply-typed"></a>
+<a name="send-with-status"></a>
 ### .sendWithStatus(code, data)
 
-As the name suggests, `.sendWithStatus()` is a function that sends a reply to the user along with a status code. When used in combination
-Typescript this method performs type validation of the response.
+Sends a reply with a specific status code.  When used in combination
+with Typescript this method can perform type checking of the response.
 
 <a name="then"></a>
 ### .then(fulfilled, rejected)

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -27,7 +27,7 @@
     - [Errors](#errors)
     - [Type of the final payload](#type-of-the-final-payload)
     - [Async-Await and Promises](#async-await-and-promises)
-  - [.sendReplyTyped(code, data)](#send-reply-typed)
+  - [.sendWithStatus(code, data)](#send-reply-typed)
   - [.then](#then)
 
 <a name="introduction"></a>
@@ -51,7 +51,7 @@ and properties:
 - `.serialize(payload)` - Serializes the specified payload using the default JSON serializer or using the custom serializer (if one is set) and returns the serialized payload.
 - `.serializer(function)` - Sets a custom serializer for the payload.
 - `.send(payload)` - Sends the payload to the user, could be a plain text, a buffer, JSON, stream, or an Error object.
-- `.sendReplyTyped(code, payload)` - Combines the calls to status and payload together with type checking for TypeScript.
+- `.sendWithStatus(code, payload)` - Combines the calls to status and payload together with type checking for TypeScript.
 - `.sent` - A boolean value that you can use if you need to know if `send` has already been called.
 - `.raw` - The [`http.ServerResponse`](https://nodejs.org/dist/latest/docs/api/http.html#http_class_http_serverresponse) from Node core.
 - `.res` *(deprecated, use `.raw` instead)* - The [`http.ServerResponse`](https://nodejs.org/dist/latest/docs/api/http.html#http_class_http_serverresponse) from Node core.
@@ -437,9 +437,9 @@ If you want to know more please review [Routes#async-await](Routes.md#async-awai
 
 
 <a name="send-reply-typed"></a>
-### .sendReplyTyped(code, data)
+### .sendWithStatus(code, data)
 
-As the name suggests, `.sendReplyTyped()` is a function that sends a reply to the user along with a status code. When used in combination
+As the name suggests, `.sendWithStatus()` is a function that sends a reply to the user along with a status code. When used in combination
 Typescript this method performs type validation of the response.
 
 <a name="then"></a>

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -27,6 +27,7 @@
     - [Errors](#errors)
     - [Type of the final payload](#type-of-the-final-payload)
     - [Async-Await and Promises](#async-await-and-promises)
+  - [.sendReplyTyped(code, data)](#send-reply-typed)
   - [.then](#then)
 
 <a name="introduction"></a>
@@ -50,6 +51,7 @@ and properties:
 - `.serialize(payload)` - Serializes the specified payload using the default JSON serializer or using the custom serializer (if one is set) and returns the serialized payload.
 - `.serializer(function)` - Sets a custom serializer for the payload.
 - `.send(payload)` - Sends the payload to the user, could be a plain text, a buffer, JSON, stream, or an Error object.
+- `.sendReplyTyped(code, payload)` - Combines the calls to status and payload together with type checking for TypeScript.
 - `.sent` - A boolean value that you can use if you need to know if `send` has already been called.
 - `.raw` - The [`http.ServerResponse`](https://nodejs.org/dist/latest/docs/api/http.html#http_class_http_serverresponse) from Node core.
 - `.res` *(deprecated, use `.raw` instead)* - The [`http.ServerResponse`](https://nodejs.org/dist/latest/docs/api/http.html#http_class_http_serverresponse) from Node core.
@@ -432,6 +434,13 @@ fastify.get('/botnet', async function (request, reply) {
 ```
 
 If you want to know more please review [Routes#async-await](Routes.md#async-await).
+
+
+<a name="send-reply-typed"></a>
+### .sendReplyTyped(code, data)
+
+As the name suggests, `.sendReplyTyped()` is a function that sends a reply to the user along with a status code. When used in combination
+Typescript this method performs type validation of the response.
 
 <a name="then"></a>
 ### .then(fulfilled, rejected)

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -127,7 +127,7 @@ The type system heavily relies on generic properties to provide the most accurat
 
 ### Type checking responses based on the status code
 
-If you would like to be strict about the responses that are returned to the caller of a route. You can use the RepliesType when creating a route this key allows a type to be specified for any status code.  When `.sendReplyTyped` is called on the reply object, both the status code and the payload data is type scheduled to match.
+If you would like to be strict about the responses that are returned to the caller of a route. You can use the RepliesType when creating a route this key allows a type to be specified for any status code.  When `.sendWithStatus` is called on the reply object, both the status code and the payload data is type scheduled to match.
 
    ```typescript
    server.get<{
@@ -143,9 +143,9 @@ If you would like to be strict about the responses that are returned to the call
    }>('/get-user-data', async (request, reply) => {
      const wasUserFound = false;
      if(wasUserFound) {
-       reply.sendReplyTyped(200, { username: 'Example User' })
+       reply.sendWithStatus(200, { username: 'Example User' })
      } else {
-       reply.sendReplyTyped(404, { resultMessage: 'Not Found', retryable: false })
+       reply.sendWithStatus(404, { resultMessage: 'Not Found', retryable: false })
      }
      return
    })
@@ -158,7 +158,6 @@ To validate your requests and responses you can use JSON Schema files. If you di
 Also it has the advantage to use the defined type within your handlers (including pre-validation, etc.).
 
 Here are some options how to achieve this.
-
 
 #### typebox
 

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -125,6 +125,32 @@ The type system heavily relies on generic properties to provide the most accurat
 
 🎉 Good work, now you can define interfaces for each route and have strictly typed request and reply instances. Other parts of the Fastify type system rely on generic properties. Make sure to reference the detailed type system documentation below to learn more about what is available.
 
+### Type checking responses based on the status code
+
+If you would like to be strict about the responses that are returned to the caller of a route. You can use the RepliesType when creating a route this key allows a type to be specified for any status code.  When `.sendReplyTyped` is called on the reply object, both the status code and the payload data is type scheduled to match.
+
+   ```typescript
+   server.get<{
+    RepliesTyped: {
+      200: {
+        username: string,
+      },
+      404: {
+        resultMessage: 'Not Found'
+        retryable: boolean,
+      }
+     };
+   }>('/get-user-data', async (request, reply) => {
+     const wasUserFound = false;
+     if(wasUserFound) {
+       reply.sendReplyTyped(200, { username: 'Example User' })
+     } else {
+       reply.sendReplyTyped(404, { resultMessage: 'Not Found', retryable: false })
+     }
+     return
+   })
+   ```
+
 ### JSON Schema
 
 To validate your requests and responses you can use JSON Schema files. If you didn't know already, defining schemas for your Fastify routes can increase their throughput! Check out the [Validation and Serialization](Validation-and-Serialization.md) documentation for more info.
@@ -148,7 +174,7 @@ When you want to use it for validation of some payload in a fastify route you ca
     ```
 
 2. Define the schema you need with `Type` and create the respective type  with `Static`.
-  
+
     ```typescript
     import { Static, Type } from '@sinclair/typebox'
 
@@ -346,7 +372,7 @@ fastify.post<{ Body: FromSchema<typeof todo> }>(
   async (request, reply): Promise<void> => {
 
     /*
-    request.body has type 
+    request.body has type
     {
       [x: string]: unknown;
       description?: string;
@@ -357,7 +383,7 @@ fastify.post<{ Body: FromSchema<typeof todo> }>(
 
     request.body.name // will not throw type error
     request.body.notthere // will throw type error
-    
+
     reply.status(201).send();
   },
 );

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -196,7 +196,7 @@ Reply.prototype.send = function (payload) {
   return this
 }
 
-Reply.prototype.sendReplyTyped = function (statusCode, payload) {
+Reply.prototype.sendWithStatus = function (statusCode, payload) {
   return this.status(statusCode).send(payload)
 }
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -196,6 +196,10 @@ Reply.prototype.send = function (payload) {
   return this
 }
 
+Reply.prototype.sendReplyTyped = function (statusCode, payload) {
+  return this.status(statusCode).send(payload)
+}
+
 Reply.prototype.getHeader = function (key) {
   key = key.toLowerCase()
   const res = this.raw

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -90,16 +90,12 @@ const headersSchema = {
   }
 }
 
-test('shorthand - get sendReplyTyped', t => {
+test('shorthand - get sendWithStatus', t => {
   t.plan(1)
-  try {
-    fastify.get('/combined-reply', schema, function (req, reply) {
-      reply.sendReplyTyped(200, { hello: 'world' })
-    })
-    t.pass()
-  } catch (e) {
-    t.fail()
-  }
+  fastify.get('/combined-reply', schema, function (req, reply) {
+    reply.sendWithStatus(200, { hello: 'world' })
+  })
+  t.pass()
 })
 
 test('shorthand - get', t => {
@@ -232,7 +228,7 @@ fastify.listen(0, err => {
     })
   })
 
-  test('shorthand - request get sendReplyTyped', t => {
+  test('shorthand - request get sendWithStatus', t => {
     t.plan(4)
     sget({
       method: 'GET',

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -90,6 +90,18 @@ const headersSchema = {
   }
 }
 
+test('shorthand - get sendReplyTyped', t => {
+  t.plan(1)
+  try {
+    fastify.get('/combined-reply', schema, function (req, reply) {
+      reply.sendReplyTyped(200, { hello: 'world' })
+    })
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+})
+
 test('shorthand - get', t => {
   t.plan(1)
   try {
@@ -212,6 +224,19 @@ fastify.listen(0, err => {
     sget({
       method: 'GET',
       url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers['content-length'], '' + body.length)
+      t.same(JSON.parse(body), { hello: 'world' })
+    })
+  })
+
+  test('shorthand - request get sendReplyTyped', t => {
+    t.plan(4)
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port + '/combined-reply'
     }, (err, response, body) => {
       t.error(err)
       t.equal(response.statusCode, 200)

--- a/test/types/reply.test-d.ts
+++ b/test/types/reply.test-d.ts
@@ -35,6 +35,15 @@ interface ReplyPayload {
   Reply: {
     test: boolean;
   };
+  RepliesTyped: {
+    200: {
+      resultMessage: string,
+    },
+    404: {
+      resultMessage: 'Not Found'
+      retryable: boolean,
+    }
+  }
 }
 
 const typedHandler: RouteHandler<ReplyPayload> = async (request, reply) => {
@@ -55,4 +64,13 @@ expectError(server.get<ReplyPayload>('/get-generic-return-error', async function
 }))
 expectError(server.get<ReplyPayload>('/get-generic-return-error', async function handler (request, reply) {
   return { foo: 'bar' }
+}))
+server.get<ReplyPayload>('/get-generic-return-typed', async function handler (request, reply) {
+  reply.sendReplyTyped(200, { resultMessage: 'hello world' })
+})
+server.get<ReplyPayload>('/get-generic-return-typed-second', async function handler (request, reply) {
+  reply.sendReplyTyped(404, { resultMessage: 'Not Found', retryable: false })
+})
+expectError(server.get<ReplyPayload>('/get-typed-return-error', async function handler (request, reply) {
+  reply.sendReplyTyped(200, false)
 }))

--- a/test/types/reply.test-d.ts
+++ b/test/types/reply.test-d.ts
@@ -66,11 +66,11 @@ expectError(server.get<ReplyPayload>('/get-generic-return-error', async function
   return { foo: 'bar' }
 }))
 server.get<ReplyPayload>('/get-generic-return-typed', async function handler (request, reply) {
-  reply.sendReplyTyped(200, { resultMessage: 'hello world' })
+  reply.sendWithStatus(200, { resultMessage: 'hello world' })
 })
 server.get<ReplyPayload>('/get-generic-return-typed-second', async function handler (request, reply) {
-  reply.sendReplyTyped(404, { resultMessage: 'Not Found', retryable: false })
+  reply.sendWithStatus(404, { resultMessage: 'Not Found', retryable: false })
 })
 expectError(server.get<ReplyPayload>('/get-typed-return-error', async function handler (request, reply) {
-  reply.sendReplyTyped(200, false)
+  reply.sendWithStatus(200, false)
 }))

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -6,6 +6,9 @@ import { RouteGenericInterface } from './route'
 
 export interface ReplyGenericInterface {
   Reply?: ReplyDefault;
+  RepliesTyped?: {
+    [statusCode: string]: ReplyDefault
+  }
 }
 
 /**
@@ -28,6 +31,8 @@ export interface FastifyReply<
   statusCode: number;
   sent: boolean;
   send(payload?: RouteGeneric['Reply']): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
+  // Send a reply with a status code and the type fully specified.
+  sendReplyTyped<T extends keyof RouteGeneric['RepliesTyped']>(statusCode: T, payload: RouteGeneric['RepliesTyped'][T]): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
   header(key: string, value: any): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
   headers(values: {[key: string]: any}): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
   getHeader(key: string): string | undefined;

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -32,7 +32,7 @@ export interface FastifyReply<
   sent: boolean;
   send(payload?: RouteGeneric['Reply']): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
   // Send a reply with a status code and the type fully specified.
-  sendReplyTyped<T extends keyof RouteGeneric['RepliesTyped']>(statusCode: T, payload: RouteGeneric['RepliesTyped'][T]): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
+  sendWithStatus<T extends keyof RouteGeneric['RepliesTyped']>(statusCode: T, payload: RouteGeneric['RepliesTyped'][T]): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
   header(key: string, value: any): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
   headers(values: {[key: string]: any}): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
   getHeader(key: string): string | undefined;


### PR DESCRIPTION
Currently the type of replies for routes are the amalgamation of all possible
responses.  This leaves much to be desired for Typescript based type checking
of responses.  This PR attempts to remedy this by adding the ability to specify
response type information for every HTTP status code of the route and check that
the data being sent matches the expressed type.

Adds a new sendReplyTyped() method to FastifyReplies which takes a status code
along with a payload.   In Javascript this simply is reply.statusCode().send().

Add support for RepliesTyped in the ReplyPayload interface which allows a separate
Typescript type to be specified per status code.

Adds associated tests.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
