### PR TITLE
Add `instance` property to req/rep prototypes

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -5,6 +5,7 @@
   - [Introduction](#introduction)
   - [.code(statusCode)](#codestatuscode)
   - [.statusCode](#statusCode)
+  - [.instance](#instance)
   - [.header(key, value)](#headerkey-value)
   - [.headers(object)](#headersobject)
   - [.getHeader(key)](#getheaderkey)
@@ -38,6 +39,7 @@ and properties:
 - `.code(statusCode)` - Sets the status code.
 - `.status(statusCode)` - An alias for `.code(statusCode)`.
 - `.statusCode` - Read and set the HTTP status code.
+- `.instance` - A reference to the fastify instance object.
 - `.header(name, value)` - Sets a response header.
 - `.headers(object)` - Sets all the keys of the object as response headers.
 - `.getHeader(name)` - Retrieve value of already set header.
@@ -85,6 +87,20 @@ This property reads and sets the HTTP status code. It is an alias for `reply.cod
 if (reply.statusCode >= 299) {
   reply.statusCode = 500
 }
+```
+
+<a name="instance"></a>
+### .instance
+Contains a reference to the instance object of the current scope.
+
+```js
+fastify.decorate('util', function util () {
+  return 'foo'
+})
+
+fastify.get('/', async function (req, rep) {
+  return rep.instance.util() // foo
+})
 ```
 
 <a name="header"></a>

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -5,7 +5,7 @@
   - [Introduction](#introduction)
   - [.code(statusCode)](#codestatuscode)
   - [.statusCode](#statusCode)
-  - [.instance](#instance)
+  - [.server](#server)
   - [.header(key, value)](#headerkey-value)
   - [.headers(object)](#headersobject)
   - [.getHeader(key)](#getheaderkey)
@@ -89,9 +89,9 @@ if (reply.statusCode >= 299) {
 }
 ```
 
-<a name="instance"></a>
-### .instance
-Contains a reference to the instance object of the current scope.
+<a name="server"></a>
+### .server
+Contains a reference to the server object of the current scope.
 
 ```js
 fastify.decorate('util', function util () {
@@ -99,7 +99,7 @@ fastify.decorate('util', function util () {
 })
 
 fastify.get('/', async function (req, rep) {
-  return rep.instance.util() // foo
+  return rep.server.util() // foo
 })
 ```
 

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -39,7 +39,7 @@ and properties:
 - `.code(statusCode)` - Sets the status code.
 - `.status(statusCode)` - An alias for `.code(statusCode)`.
 - `.statusCode` - Read and set the HTTP status code.
-- `.instance` - A reference to the fastify instance object.
+- `.server` - A reference to the fastify instance object.
 - `.header(name, value)` - Sets a response header.
 - `.headers(object)` - Sets all the keys of the object as response headers.
 - `.getHeader(name)` - Retrieve value of already set header.

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -91,7 +91,7 @@ if (reply.statusCode >= 299) {
 
 <a name="server"></a>
 ### .server
-Contains a reference to the server object of the current scope.
+The Fastify server instance, scoped to the current [encapsulation context](Encapsulation.md).
 
 ```js
 fastify.decorate('util', function util () {

--- a/docs/Request.md
+++ b/docs/Request.md
@@ -9,7 +9,7 @@ Request is a core Fastify object containing the following fields:
 - `headers` - the headers
 - `raw` - the incoming HTTP request from Node core
 - `req` *(deprecated, use `.raw` instead)* - the incoming HTTP request from Node core
-- `server` - A reference to the fastify server object
+- `server` - The Fastify server instance, scoped to the current [encapsulation context](Encapsulation.md)
 - `id` - the request id
 - `log` - the logger instance of the incoming request
 - `ip` - the IP address of the incoming request

--- a/docs/Request.md
+++ b/docs/Request.md
@@ -9,6 +9,7 @@ Request is a core Fastify object containing the following fields:
 - `headers` - the headers
 - `raw` - the incoming HTTP request from Node core
 - `req` *(deprecated, use `.raw` instead)* - the incoming HTTP request from Node core
+- `instance` - A reference to the fastify instance object
 - `id` - the request id
 - `log` - the logger instance of the incoming request
 - `ip` - the IP address of the incoming request

--- a/docs/Request.md
+++ b/docs/Request.md
@@ -9,7 +9,7 @@ Request is a core Fastify object containing the following fields:
 - `headers` - the headers
 - `raw` - the incoming HTTP request from Node core
 - `req` *(deprecated, use `.raw` instead)* - the incoming HTTP request from Node core
-- `instance` - A reference to the fastify instance object
+- `server` - A reference to the fastify server object
 - `id` - the request id
 - `log` - the logger instance of the incoming request
 - `ip` - the IP address of the incoming request
@@ -32,6 +32,7 @@ fastify.post('/:params', options, function (request, reply) {
   console.log(request.params)
   console.log(request.headers)
   console.log(request.raw)
+  console.log(request.server)
   console.log(request.id)
   console.log(request.ip)
   console.log(request.ips)

--- a/fastify.js
+++ b/fastify.js
@@ -286,6 +286,9 @@ function fastify (options) {
     initialConfig
   }
 
+  fastify[kReply].prototype.instance = fastify
+  fastify[kRequest].prototype.instance = fastify
+
   Object.defineProperties(fastify, {
     pluginName: {
       get () {

--- a/fastify.js
+++ b/fastify.js
@@ -286,8 +286,8 @@ function fastify (options) {
     initialConfig
   }
 
-  fastify[kReply].prototype.instance = fastify
-  fastify[kRequest].prototype.instance = fastify
+  fastify[kReply].prototype.server = fastify
+  fastify[kRequest].prototype.server = fastify
 
   Object.defineProperties(fastify, {
     pluginName: {

--- a/lib/pluginOverride.js
+++ b/lib/pluginOverride.js
@@ -38,7 +38,11 @@ module.exports = function override (old, fn, opts) {
   instance.ready = old[kAvvioBoot].bind(instance)
   instance[kChildren] = []
   instance[kReply] = Reply.buildReply(instance[kReply])
+  instance[kReply].prototype.instance = instance
+
   instance[kRequest] = Request.buildRequest(instance[kRequest])
+  instance[kRequest].prototype.instance = instance
+
   instance[kContentTypeParser] = ContentTypeParser.helpers.buildContentTypeParser(instance[kContentTypeParser])
   instance[kHooks] = buildHooks(instance[kHooks])
   instance[kRoutePrefix] = buildRoutePrefix(instance[kRoutePrefix], opts.prefix)

--- a/lib/pluginOverride.js
+++ b/lib/pluginOverride.js
@@ -37,11 +37,12 @@ module.exports = function override (old, fn, opts) {
   old[kChildren].push(instance)
   instance.ready = old[kAvvioBoot].bind(instance)
   instance[kChildren] = []
+
   instance[kReply] = Reply.buildReply(instance[kReply])
-  instance[kReply].prototype.instance = instance
+  instance[kReply].prototype.server = instance
 
   instance[kRequest] = Request.buildRequest(instance[kRequest])
-  instance[kRequest].prototype.instance = instance
+  instance[kRequest].prototype.server = instance
 
   instance[kContentTypeParser] = ContentTypeParser.helpers.buildContentTypeParser(instance[kContentTypeParser])
   instance[kHooks] = buildHooks(instance[kHooks])

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -108,7 +108,7 @@ Object.defineProperties(Reply.prototype, {
       this.code(value)
     }
   },
-  instance: {
+  server: {
     value: null,
     writable: true
   }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -107,6 +107,10 @@ Object.defineProperties(Reply.prototype, {
     set (value) {
       this.code(value)
     }
+  },
+  instance: {
+    value: null,
+    writable: true
   }
 })
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -165,7 +165,7 @@ Object.defineProperties(Request.prototype, {
       return this.raw.headers
     }
   },
-  instance: {
+  server: {
     value: null,
     writable: true
   }

--- a/lib/request.js
+++ b/lib/request.js
@@ -164,6 +164,10 @@ Object.defineProperties(Request.prototype, {
     get () {
       return this.raw.headers
     }
+  },
+  instance: {
+    value: null,
+    writable: true
   }
 })
 

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -869,11 +869,11 @@ test('Request/reply decorators should be able to access the server instance', as
 
   // ----
   function rootAssert () {
-    t.equal(this.instance, server)
+    t.equal(this.server, server)
   }
 
   function nestedAssert () {
-    t.not(this.instance, server)
-    t.equal(this.instance.foo, 'bar')
+    t.not(this.server, server)
+    t.equal(this.server.foo, 'bar')
   }
 })

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -838,3 +838,42 @@ test('decorate* should not emit warning if string,bool,numbers are passed', t =>
   fastify.decorateReply('test_undefined', undefined)
   t.end('Done')
 })
+
+test('Request/reply decorators should be able to access the server instance', async t => {
+  t.plan(6)
+
+  const server = require('..')({ logger: false })
+  server.decorateRequest('assert', rootAssert)
+  server.decorateReply('assert', rootAssert)
+
+  server.get('/root-assert', async (req, rep) => {
+    req.assert()
+    rep.assert()
+    return 'done'
+  })
+
+  server.register(async instance => {
+    instance.decorateRequest('assert', nestedAssert)
+    instance.decorateReply('assert', nestedAssert)
+    instance.decorate('foo', 'bar')
+
+    instance.get('/nested-assert', async (req, rep) => {
+      req.assert()
+      rep.assert()
+      return 'done'
+    })
+  })
+
+  await server.inject({ method: 'GET', url: '/root-assert' })
+  await server.inject({ method: 'GET', url: '/nested-assert' })
+
+  // ----
+  function rootAssert () {
+    t.equal(this.instance, server)
+  }
+
+  function nestedAssert () {
+    t.not(this.instance, server)
+    t.equal(this.instance.foo, 'bar')
+  }
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This PR implements feature #3094 , which adds a new  `instance` property to the prototypes of the Request/Reply constructors.
