### PR TITLE
chore: go back to the original proxy-addr module instead of @fastify/proxy-addr

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -288,7 +288,7 @@ const fastify = Fastify({ trustProxy: true })
     }
     ```
 
-For more examples, refer to the [`@fastify/proxy-addr`](https://www.npmjs.com/package/@fastify/proxy-addr) package.
+For more examples, refer to the [`proxy-addr`](https://www.npmjs.com/package/proxy-addr) package.
 
 You may access the `ip`, `ips`, `hostname` and `protocol` values on the [`request`](Request.md) object.
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const proxyAddr = require('@fastify/proxy-addr')
+const proxyAddr = require('proxy-addr')
 const semver = require('semver')
 const warning = require('./warnings')
 

--- a/package.json
+++ b/package.json
@@ -177,7 +177,6 @@
   },
   "dependencies": {
     "@fastify/ajv-compiler": "^1.0.0",
-    "@fastify/proxy-addr": "^3.0.0",
     "abstract-logging": "^2.0.0",
     "avvio": "^7.1.2",
     "fast-json-stringify": "^2.5.2",
@@ -187,6 +186,7 @@
     "flatstr": "^1.0.12",
     "light-my-request": "^4.2.0",
     "pino": "^6.2.1",
+    "proxy-addr": "^2.0.7",
     "readable-stream": "^3.4.0",
     "rfdc": "^1.1.4",
     "secure-json-parse": "^2.0.0",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Hi there! :wave:

Fastify has maintained its own fork of the `proxy-addr` module to address an issue in one of its dependencies. That issue has now been resolved in the original package and released in `proxy-addr@2.0.7`.

I mentioned this in https://github.com/fastify/proxy-addr/issues/9, and was asked to submit a PR here to go back to using the original `proxy-addr` package for consideration.

I couldn't find anywhere to put a changelog entry, but maybe the commit message is enough?

Tests all pass:

![image](https://user-images.githubusercontent.com/1404650/120459044-19c94c00-c398-11eb-9ac3-a9b58b71ed42.png)

I verified that several tests fail with `proxy-addr@2.0.6`:

![image](https://user-images.githubusercontent.com/1404650/120459587-978d5780-c398-11eb-9b1d-dbdacb8fb695.png)

Benchmarks:

![image](https://user-images.githubusercontent.com/1404650/120458996-10d87a80-c398-11eb-9c53-16cae8bca917.png)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
