### PR TITLE
Clarification for "Simplify reply sent monitoring (#3072)"

### DIFF
--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -203,12 +203,12 @@ fastify.get('/', options, async function (request, reply) {
 
 As you can see, we are not calling `reply.send` to send back the data to the user. You just need to return the body and you are done!
 
-If you need it you can also send back the data to the user with `reply.send`.
+If you need it you can also send back the data to the user with `reply.send`. In this case do not forget to `return reply` or `await reply` in your `async` handler or you will introduce a race condition in certain situations.
 ```js
 fastify.get('/', options, async function (request, reply) {
   var data = await getData()
   var processed = await processData(data)
-  reply.send(processed)
+  return reply.send(processed)
 })
 ```
 

--- a/test/async-await.test.js
+++ b/test/async-await.test.js
@@ -79,7 +79,7 @@ test('ignore the result of the promise if reply.send is called beforehand (undef
   const payload = { hello: 'world' }
 
   server.get('/', async function awaitMyFunc (req, reply) {
-    reply.send(payload)
+    await reply.send(payload)
   })
 
   t.teardown(server.close.bind(server))
@@ -104,7 +104,7 @@ test('ignore the result of the promise if reply.send is called beforehand (objec
   const payload = { hello: 'world2' }
 
   server.get('/', async function awaitMyFunc (req, reply) {
-    reply.send(payload)
+    await reply.send(payload)
     return { hello: 'world' }
   })
 
@@ -139,7 +139,7 @@ test('server logs an error if reply.send is called and a value is returned via a
   })
 
   fastify.get('/', async (req, reply) => {
-    reply.send({ hello: 'world' })
+    await reply.send({ hello: 'world' })
     return { hello: 'world2' }
   })
 
@@ -160,7 +160,7 @@ test('ignore the result of the promise if reply.send is called beforehand (undef
   const payload = { hello: 'world' }
 
   server.get('/', async function awaitMyFunc (req, reply) {
-    reply.send(payload)
+    await reply.send(payload)
   })
 
   t.teardown(server.close.bind(server))
@@ -185,7 +185,7 @@ test('ignore the result of the promise if reply.send is called beforehand (objec
   const payload = { hello: 'world2' }
 
   server.get('/', async function awaitMyFunc (req, reply) {
-    reply.send(payload)
+    await reply.send(payload)
     return { hello: 'world' }
   })
 
@@ -478,7 +478,7 @@ test('customErrorHandler support without throwing', t => {
 
   fastify.setErrorHandler(async (err, req, reply) => {
     t.equal(err.message, 'ouch')
-    reply.code(401).send('kaboom')
+    await reply.code(401).send('kaboom')
     reply.send = t.fail.bind(t, 'should not be called')
   })
 

--- a/test/hooks-async.test.js
+++ b/test/hooks-async.test.js
@@ -132,7 +132,7 @@ test('onRequest hooks should be able to block a request', t => {
   const fastify = Fastify()
 
   fastify.addHook('onRequest', async (req, reply) => {
-    reply.send('hello')
+    await reply.send('hello')
   })
 
   fastify.addHook('onRequest', async (req, reply) => {
@@ -224,7 +224,7 @@ test('preHandler hooks should be able to block a request', t => {
   const fastify = Fastify()
 
   fastify.addHook('preHandler', async (req, reply) => {
-    reply.send('hello')
+    await reply.send('hello')
   })
 
   fastify.addHook('preHandler', async (req, reply) => {
@@ -258,7 +258,7 @@ test('preValidation hooks should be able to block a request', t => {
   const fastify = Fastify()
 
   fastify.addHook('preValidation', async (req, reply) => {
-    reply.send('hello')
+    await reply.send('hello')
   })
 
   fastify.addHook('preValidation', async (req, reply) => {
@@ -383,7 +383,7 @@ test('preValidation hooks should handle throwing null', t => {
 
   fastify.setErrorHandler(async (error, request, reply) => {
     t.ok(error instanceof Error)
-    reply.send(error)
+    await reply.send(error)
   })
 
   fastify.addHook('preValidation', async () => {
@@ -434,7 +434,7 @@ test('onRequest hooks should be able to block a request (last hook)', t => {
   const fastify = Fastify()
 
   fastify.addHook('onRequest', async (req, reply) => {
-    reply.send('hello')
+    await reply.send('hello')
   })
 
   fastify.addHook('preHandler', async (req, reply) => {
@@ -468,7 +468,7 @@ test('preHandler hooks should be able to block a request (last hook)', t => {
   const fastify = Fastify()
 
   fastify.addHook('preHandler', async (req, reply) => {
-    reply.send('hello')
+    await reply.send('hello')
   })
 
   fastify.addHook('onSend', async (req, reply, payload) => {
@@ -502,8 +502,9 @@ test('onRequest respond with a stream', t => {
       const stream = fs.createReadStream(process.cwd() + '/test/stream.test.js', 'utf8')
       // stream.pipe(res)
       // res.once('finish', resolve)
-      reply.send(stream)
-      reply.raw.once('finish', () => resolve())
+      reply.send(stream).then(() => {
+        reply.raw.once('finish', () => resolve())
+      })
     })
   })
 
@@ -551,10 +552,11 @@ test('preHandler respond with a stream', t => {
   fastify.addHook('preHandler', async (req, reply) => {
     return new Promise((resolve, reject) => {
       const stream = fs.createReadStream(process.cwd() + '/test/stream.test.js', 'utf8')
-      reply.send(stream)
-      reply.raw.once('finish', () => {
-        t.equal(order.shift(), 2)
-        resolve()
+      reply.send(stream).then(() => {
+        reply.raw.once('finish', () => {
+          t.equal(order.shift(), 2)
+          resolve()
+        })
       })
     })
   })

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -3173,7 +3173,7 @@ test('onTimeout should be triggered', t => {
   })
 
   fastify.get('/', async (req, reply) => {
-    reply.send({ hello: 'world' })
+    await reply.send({ hello: 'world' })
   })
 
   fastify.get('/timeout', async (req, reply) => {
@@ -3212,7 +3212,7 @@ test('onTimeout should be triggered and socket _meta is set', t => {
 
   fastify.get('/', async (req, reply) => {
     req.raw.socket._meta = {}
-    reply.send({ hello: 'world' })
+    return reply.send({ hello: 'world' })
   })
 
   fastify.get('/timeout', async (req, reply) => {

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -459,7 +459,7 @@ test('should not set headers or status code for custom error handler', t => {
   fastify.setErrorHandler(async (err, req, res) => {
     t.equal(res.statusCode, 200)
     t.equal('fake-random-header' in res.headers, false)
-    res.code(500).send(err.message)
+    return res.code(500).send(err.message)
   })
 
   fastify.inject({
@@ -495,7 +495,7 @@ test('error thrown by custom error handler routes to default error handler', t =
     t.equal('fake-random-header' in res.headers, false)
     t.same(err.headers, error.headers)
 
-    res.send(newError)
+    return res.send(newError)
   })
 
   fastify.inject({

--- a/test/route-hooks.test.js
+++ b/test/route-hooks.test.js
@@ -220,7 +220,7 @@ function testBeforeHandlerHook (hook) {
 
     fastify.setErrorHandler(async (error, request, reply) => {
       t.same(error, myError, 'the error object throws by the user')
-      reply.code(500).send({ this: 'is', my: 'error' })
+      return reply.code(500).send({ this: 'is', my: 'error' })
     })
 
     fastify.get('/', {

--- a/test/skip-reply-send.test.js
+++ b/test/skip-reply-send.test.js
@@ -297,7 +297,7 @@ function testHandlerOrBeforeHandlerHook (test, hookOrHandler) {
       } else {
         app.addHook(hookOrHandler, async (req, reply) => {
           reply.hijack()
-          reply.send('hello from reply.send()')
+          return reply.send('hello from reply.send()')
         })
         app.get('/', (req, reply) => t.fail('Handler should not be called'))
       }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

After studying the reasoning behind https://github.com/fastify/fastify/issues/3107, I found out that the reply.send() will behave like synchronous method most of the time, but in rare situations it will not fully complete before async function is resolved. Therefore, not awaiting the reply will introduce a race condition. This is already the case in current version, but since marking reply as sent is done manually, it was very hard to notice this problem. Now that the reply is marked as sent only after response is actually sent, such situation can occur more frequently.

I updated the docs to warn users to await (or return) for reply in their async handlers when using reply.send() manually. I also updated the tests, so they cannot fail due to this race condition.

The example that could trigger such situation:
```js
  fastify.addHook('onSend', async (request, reply, payload) => {
    if (payload === 'OK') {
      await new Promise((resolve) => {
        setImmediate(resolve)
      })
    }

    return payload
  })


  fastify.get('/', async (req, reply) => {
    reply.send('OK')
  })
```
The handler will resolve and send reply before reply.send() called from within handler has finished its operation. 