### PR TITLE
docs: update description for onReady hooks

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -321,7 +321,7 @@ You can hook into the application-lifecycle as well.
 - [onRegister](#onregister)
 
 ### onReady
-Triggered before the server starts listening for requests. It cannot change the routes or add new hooks.
+Triggered before the server starts listening for requests and calling `.ready()`. It cannot change the routes or add new hooks.
 Registered hook functions are executed serially.
 Only after all `onReady` hook functions have completed will the server start listening for requests.
 Hook functions accept one argument: a callback, `done`, to be invoked after the hook function is complete.

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -321,7 +321,7 @@ You can hook into the application-lifecycle as well.
 - [onRegister](#onregister)
 
 ### onReady
-Triggered before the server starts listening for requests and calling `.ready()`. It cannot change the routes or add new hooks.
+Triggered before the server starts listening for requests and when `.ready()` is invoked. It cannot change the routes or add new hooks.
 Registered hook functions are executed serially.
 Only after all `onReady` hook functions have completed will the server start listening for requests.
 Hook functions accept one argument: a callback, `done`, to be invoked after the hook function is complete.


### PR DESCRIPTION
Just to make it more clear.
`onReady` hooks will execute every time when calling `.ready` and `.listen`

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
