### PR TITLE
chore: add benchmark workflow to run by label

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,68 @@
+name: Benchmark
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  benchmark:
+    if: ${{ github.event.label.name == 'benchmark' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10, 12, 14, 16]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install
+        run: |
+          npm install --ignore-scripts
+
+      - name: Run benchmark
+        id: benchmark-pr
+        run: |
+          npm run --silent benchmark > ./bench-result.md
+          result=$(awk '/requests in/' ./bench-result.md)
+          echo "::set-output name=BENCH_RESULT::$result"
+
+      # main benchmark
+      - uses: actions/checkout@v2
+        with:
+          ref: 'main'
+
+      - name: Install
+        run: |
+          npm install --ignore-scripts
+
+      - name: Run benchmark
+        id: benchmark-main
+        run: |
+          npm run --silent benchmark > ./bench-result.md
+          result=$(awk '/requests in/' ./bench-result.md)
+          echo "::set-output name=BENCH_RESULT::$result"
+
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          message: |
+            **Node**: ${{ matrix.node-version }}
+            **PR**: ${{ steps.benchmark-pr.outputs.BENCH_RESULT }}
+            **MAIN**: ${{ steps.benchmark-main.outputs.BENCH_RESULT }}
+
+  remove-label:
+    needs: [benchmark]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: |
+            benchmark
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,6 +8,15 @@ jobs:
   benchmark:
     if: ${{ github.event.label.name == 'benchmark' }}
     runs-on: ubuntu-latest
+    outputs:
+      PR-BENCH-10: ${{ steps.benchmark-pr.outputs.BENCH_RESULT10 }}
+      PR-BENCH-12: ${{ steps.benchmark-pr.outputs.BENCH_RESULT12 }}
+      PR-BENCH-14: ${{ steps.benchmark-pr.outputs.BENCH_RESULT14 }}
+      PR-BENCH-16: ${{ steps.benchmark-pr.outputs.BENCH_RESULT16 }}
+      MAIN-BENCH-10: ${{ steps.benchmark-main.outputs.BENCH_RESULT10 }}
+      MAIN-BENCH-12: ${{ steps.benchmark-main.outputs.BENCH_RESULT12 }}
+      MAIN-BENCH-14: ${{ steps.benchmark-main.outputs.BENCH_RESULT14 }}
+      MAIN-BENCH-16: ${{ steps.benchmark-main.outputs.BENCH_RESULT16 }}
     strategy:
       matrix:
         node-version: [10, 12, 14, 16]
@@ -30,7 +39,7 @@ jobs:
         run: |
           npm run --silent benchmark > ./bench-result.md
           result=$(awk '/requests in/' ./bench-result.md)
-          echo "::set-output name=BENCH_RESULT::$result"
+          echo "::set-output name=BENCH_RESULT${{matrix.node-version}}::$result"
 
       # main benchmark
       - uses: actions/checkout@v2
@@ -46,21 +55,39 @@ jobs:
         run: |
           npm run --silent benchmark > ./bench-result.md
           result=$(awk '/requests in/' ./bench-result.md)
-          echo "::set-output name=BENCH_RESULT::$result"
+          echo "::set-output name=BENCH_RESULT${{matrix.node-version}}::$result"
 
+  output-benchmark:
+    needs: [benchmark]
+    runs-on: ubuntu-latest
+    steps:
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@master
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: |
-            **Node**: ${{ matrix.node-version }}
-            **PR**: ${{ steps.benchmark-pr.outputs.BENCH_RESULT }}
-            **MAIN**: ${{ steps.benchmark-main.outputs.BENCH_RESULT }}
-
-  remove-label:
-    needs: [benchmark]
-    runs-on: ubuntu-latest
-    steps:
+            **Node**: 10
+            **PR**: ${{ needs.benchmark.outputs.PR-BENCH-10 }}
+            **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-10 }}
+            
+            ---
+            
+            **Node**: 12
+            **PR**: ${{ needs.benchmark.outputs.PR-BENCH-12 }}
+            **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-12 }}
+            
+            ---
+            
+            **Node**: 14
+            **PR**: ${{ needs.benchmark.outputs.PR-BENCH-14 }}
+            **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-14 }}
+            
+            ---
+            
+            **Node**: 16
+            **PR**: ${{ needs.benchmark.outputs.PR-BENCH-16 }}
+            **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-16 }}
+            
       - uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,17 +9,15 @@ jobs:
     if: ${{ github.event.label.name == 'benchmark' }}
     runs-on: ubuntu-latest
     outputs:
-      PR-BENCH-10: ${{ steps.benchmark-pr.outputs.BENCH_RESULT10 }}
       PR-BENCH-12: ${{ steps.benchmark-pr.outputs.BENCH_RESULT12 }}
       PR-BENCH-14: ${{ steps.benchmark-pr.outputs.BENCH_RESULT14 }}
       PR-BENCH-16: ${{ steps.benchmark-pr.outputs.BENCH_RESULT16 }}
-      MAIN-BENCH-10: ${{ steps.benchmark-main.outputs.BENCH_RESULT10 }}
       MAIN-BENCH-12: ${{ steps.benchmark-main.outputs.BENCH_RESULT12 }}
       MAIN-BENCH-14: ${{ steps.benchmark-main.outputs.BENCH_RESULT14 }}
       MAIN-BENCH-16: ${{ steps.benchmark-main.outputs.BENCH_RESULT16 }}
     strategy:
       matrix:
-        node-version: [10, 12, 14, 16]
+        node-version: [12, 14, 16]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -66,12 +64,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: |
-            **Node**: 10
-            **PR**: ${{ needs.benchmark.outputs.PR-BENCH-10 }}
-            **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-10 }}
-            
-            ---
-            
             **Node**: 12
             **PR**: ${{ needs.benchmark.outputs.PR-BENCH-12 }}
             **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-12 }}


### PR DESCRIPTION
Finally, we are able to solve: #2497 #2152 #1931.

Sorry to be late with this, I've noticed with a delay the `pull_request_target` feature in GH Actions.

I've created a repository earlier to test the fork permissions and it's working fine:

- https://github.com/RafaelGSS/test-gh-pr-referral/pull/14 (By allowed collaborators)
- https://github.com/RafaelGSS/test-gh-pr-referral/pull/15 (By fork)

Also, I've used my fork of Fastify to test this PR before making this PR:

![image](https://user-images.githubusercontent.com/26234614/122272281-c63a2080-ceb6-11eb-96ee-8899c66b9017.png)

The above result is when I remove the `response` schema in https://github.com/fastify/fastify/blob/main/examples/benchmark/simple.js#L7. The idea was to have a slow PR to check the divergences.

There is an important note that could be solved later or in this PR:

- We'll run the benchmark in GH action using the free tier, which means that the hosted runners use a shared environment that could provide not reliable results. To be honest, we are going to run both benchmarks in the same pipeline and likely a "reliable" metric would be a percentage of the difference between both runs.
- Also, likely we would fit in the free tier in most cloud providers. I would not mind picking one and use.

Note: To achieve better insights probably would be better to increase the duration in our current `benchmark` script: https://github.com/fastify/fastify/blob/main/package.json#L10

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
