### PR TITLE
Deprecate modifying reply.sent property

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -19,7 +19,7 @@
   - [.raw](#raw)
   - [.serializer(func)](#serializerfunc)
   - [.sent](#sent)
-  - [.hijack](#hijack)
+  - [.hijack()](#hijack)
   - [.send(data)](#senddata)
     - [Objects](#objects)
     - [Strings](#strings)
@@ -53,6 +53,7 @@ and properties:
 - `.serializer(function)` - Sets a custom serializer for the payload.
 - `.send(payload)` - Sends the payload to the user, could be a plain text, a buffer, JSON, stream, or an Error object.
 - `.sent` - A boolean value that you can use if you need to know if `send` has already been called.
+- `.hijack()` - interrupt the normal request lifecycle.
 - `.raw` - The [`http.ServerResponse`](https://nodejs.org/dist/latest/docs/api/http.html#http_class_http_serverresponse) from Node core.
 - `.log` - The logger instance of the incoming request.
 - `.request` - The incoming request.
@@ -245,33 +246,24 @@ Another example of the misuse of `Reply.raw` is explained in [Reply](Reply.md#ge
 ### .sent
 
 As the name suggests, `.sent` is a property to indicate if
-a response has been sent via `reply.send()`.
+a response has been sent via `reply.send()`. It will also be `true` in case `reply.hijack()` was used.
 
-In case a route handler is defined as an async function or it
-returns a promise, it is possible to set `reply.sent = true`
-to indicate that the automatic invocation of `reply.send()` once the
-handler promise resolve should be skipped. By setting `reply.sent =
-true`, an application claims full responsibility for the low-level
-request and response. Moreover, hooks will not be invoked.
-
-As an example:
-
-```js
-app.get('/', (req, reply) => {
-  reply.sent = true
-  reply.raw.end('hello world')
-
-  return Promise.resolve('this will be skipped')
-})
-```
-
-If the handler rejects, the error will be logged.
+*Modifying the `.sent` property directly is deprecated. Please use the aformentioned `.hijack()` method to achieve the same effect.*
 
 <a name="hijack"></a>
 ### .hijack()
 Sometimes you might need to halt the execution of the normal request lifecycle and handle sending the response manually.
 
 To achieve this, Fastify provides the `reply.hijack()` method that can be called during the request lifecycle (At any point before `reply.send()` is called), and allows you to prevent Fastify from sending the response, and from running the remaining hooks (and user handler if the reply was hijacked before).
+
+```js
+app.get('/', (req, reply) => {
+  reply.hijack()
+  reply.raw.end('hello world')
+
+  return Promise.resolve('this will be skipped')
+})
+```
 
 NB (*): If `reply.raw` is used to send a response back to the user, `onResponse` hooks will still be executed
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -47,6 +47,7 @@ const {
   FST_ERR_SEND_INSIDE_ONERR,
   FST_ERR_BAD_STATUS_CODE
 } = require('./errors')
+const warning = require('./warnings')
 
 function Reply (res, request, log) {
   this.raw = res
@@ -81,6 +82,8 @@ Object.defineProperties(Reply.prototype, {
       return (this[kReplySentOverwritten] || (typeof this.raw.writableEnded !== 'undefined' ? this.raw.writableEnded : (this.raw.headersSent && this.raw.finished))) === true
     },
     set (value) {
+      warning.emit('FSTDEP010')
+
       if (value !== true) {
         throw new FST_ERR_REP_SENT_VALUE()
       }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -7,7 +7,7 @@ const {
   kSchemaResponse,
   kFourOhFourContext,
   kReplyErrorHandlerCalled,
-  kReplySentOverwritten,
+  kReplyHijacked,
   kReplyStartTime,
   kReplySerializer,
   kReplySerializerDefault,
@@ -71,15 +71,15 @@ Object.defineProperties(Reply.prototype, {
   sent: {
     enumerable: true,
     get () {
-      // We are checking whether reply was manually marked as sent or the
-      // response has ended. The response.writableEnded property was added in
-      // Node.js v12.9.0. Since fastify supports older Node.js versions as well,
-      // we have to take response.finished property in consideration when
-      // applicable. The response.finished will be always true when the request
-      // method is HEAD and http2 is used, so we have to combine that with
+      // We are checking whether reply was hijacked or the response has ended.
+      // The response.writableEnded property was added in Node.js v12.9.0. Since
+      // fastify supports older Node.js versions as well, we have to take
+      // response.finished property in consideration when applicable. The
+      // response.finished will be always true when the request method is HEAD
+      // and http2 is used, so we have to combine that with
       // response.headersSent.
       // TODO: remove fallback when the lowest supported Node.js version >= v12.9.0
-      return (this[kReplySentOverwritten] || (typeof this.raw.writableEnded !== 'undefined' ? this.raw.writableEnded : (this.raw.headersSent && this.raw.finished))) === true
+      return (this[kReplyHijacked] || (typeof this.raw.writableEnded !== 'undefined' ? this.raw.writableEnded : (this.raw.headersSent && this.raw.finished))) === true
     },
     set (value) {
       warning.emit('FSTDEP010')
@@ -89,11 +89,11 @@ Object.defineProperties(Reply.prototype, {
       }
 
       // We throw only if sent was overwritten from Fastify
-      if (this.sent && this[kReplySentOverwritten]) {
+      if (this.sent && this[kReplyHijacked]) {
         throw new FST_ERR_REP_ALREADY_SENT()
       }
 
-      this[kReplySentOverwritten] = true
+      this[kReplyHijacked] = true
     }
   },
   statusCode: {
@@ -111,7 +111,7 @@ Object.defineProperties(Reply.prototype, {
 })
 
 Reply.prototype.hijack = function () {
-  this[kReplySentOverwritten] = true
+  this[kReplyHijacked] = true
   return this
 }
 
@@ -634,7 +634,7 @@ function buildReply (R) {
     this.raw = res
     this[kReplyIsError] = false
     this[kReplyErrorHandlerCalled] = false
-    this[kReplySentOverwritten] = false
+    this[kReplyHijacked] = false
     this[kReplySerializer] = null
     this.request = request
     this[kReplyHeaders] = {}

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -29,7 +29,7 @@ const keys = {
   kReplyIsError: Symbol('fastify.reply.isError'),
   kReplyHeaders: Symbol('fastify.reply.headers'),
   kReplyHasStatusCode: Symbol('fastify.reply.hasStatusCode'),
-  kReplySentOverwritten: Symbol('fastify.reply.sentOverwritten'),
+  kReplyHijacked: Symbol('fastify.reply.hijacked'),
   kReplyStartTime: Symbol('fastify.reply.startTime'),
   kReplyErrorHandlerCalled: Symbol('fastify.reply.errorHandlerCalled'),
   kReplyIsRunningOnErrorHook: Symbol('fastify.reply.isRunningOnErrorHook'),

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -17,4 +17,6 @@ warning.create('FastifyDeprecation', 'FSTDEP008', 'You are using route constrain
 
 warning.create('FastifyDeprecation', 'FSTDEP009', 'You are using a custom route versioning strategy via the server { versioning: "..." } option, use { constraints: { version: "..." } } option instead.')
 
+warning.create('FastifyDeprecation', 'FSTDEP010', 'Modifying the "reply.sent" property is deprecated. Use the "reply.hijack()" method instead.')
+
 module.exports = warning

--- a/lib/wrapThenable.js
+++ b/lib/wrapThenable.js
@@ -2,12 +2,12 @@
 
 const {
   kReplyIsError,
-  kReplySentOverwritten
+  kReplyHijacked
 } = require('./symbols')
 
 function wrapThenable (thenable, reply) {
   thenable.then(function (payload) {
-    if (reply[kReplySentOverwritten] === true) {
+    if (reply[kReplyHijacked] === true) {
       return
     }
 

--- a/test/wrapThenable.test.js
+++ b/test/wrapThenable.test.js
@@ -2,22 +2,22 @@
 
 const t = require('tap')
 const test = t.test
-const { kReplySentOverwritten } = require('../lib/symbols')
+const { kReplyHijacked } = require('../lib/symbols')
 const wrapThenable = require('../lib/wrapThenable')
 const Reply = require('../lib/reply')
 
-test('should resolve immediately when reply[kReplySentOverwritten] is true', t => {
+test('should resolve immediately when reply[kReplyHijacked] is true', t => {
   const reply = {}
-  reply[kReplySentOverwritten] = true
+  reply[kReplyHijacked] = true
   const thenable = Promise.resolve()
   wrapThenable(thenable, reply)
   t.end()
 })
 
-test('should reject immediately when reply[kReplySentOverwritten] is true', t => {
+test('should reject immediately when reply[kReplyHijacked] is true', t => {
   t.plan(1)
   const reply = new Reply({}, {}, {})
-  reply[kReplySentOverwritten] = true
+  reply[kReplyHijacked] = true
   reply.log = {
     error: ({ err }) => {
       t.equal(err.message, 'Reply sent already')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This PR deprecates the ability to modify `reply.sent` property directly. Fastify already includes the `reply.hijack()` method that does exactly the same thing. I believe that using a method fits the Nodejs ecosystem much better than modifying the property directly.

Additionally kReplySentOverwritten symbol is renamed to kReplyHijacked to make it more understandable.
