### PR TITLE
fix(types): add missing typings for `this` in encapsulated hooks

### DIFF
--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -15,7 +15,8 @@ type TestPayloadType = {
 
 // Synchronous Tests
 
-server.addHook('onRequest', (request, reply, done) => {
+server.addHook('onRequest', function (request, reply, done) {
+  expectType<FastifyInstance>(this)
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)
   expectAssignable<(err?: FastifyError) => void>(done)
@@ -23,7 +24,8 @@ server.addHook('onRequest', (request, reply, done) => {
   expectType<void>(done(new Error()))
 })
 
-server.addHook('preParsing', (request, reply, payload, done) => {
+server.addHook('preParsing', function (request, reply, payload, done) {
+  expectType<FastifyInstance>(this)
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)
   expectType<RequestPayload>(payload)
@@ -32,7 +34,8 @@ server.addHook('preParsing', (request, reply, payload, done) => {
   expectType<void>(done(new Error()))
 })
 
-server.addHook('preValidation', (request, reply, done) => {
+server.addHook('preValidation', function (request, reply, done) {
+  expectType<FastifyInstance>(this)
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)
   expectAssignable<(err?: FastifyError) => void>(done)
@@ -40,7 +43,8 @@ server.addHook('preValidation', (request, reply, done) => {
   expectType<void>(done(new Error()))
 })
 
-server.addHook('preHandler', (request, reply, done) => {
+server.addHook('preHandler', function (request, reply, done) {
+  expectType<FastifyInstance>(this)
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)
   expectAssignable<(err?: FastifyError) => void>(done)
@@ -49,6 +53,7 @@ server.addHook('preHandler', (request, reply, done) => {
 })
 
 server.addHook<TestPayloadType>('preSerialization', function (request, reply, payload, done) {
+  expectType<FastifyInstance>(this)
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)
   expectType<TestPayloadType>(payload) // we expect this to be unknown when not specified like in the previous test
@@ -58,7 +63,8 @@ server.addHook<TestPayloadType>('preSerialization', function (request, reply, pa
   expectError<void>(done(new Error(), 'foobar'))
 })
 
-server.addHook<TestPayloadType>('onSend', (request, reply, payload, done) => {
+server.addHook<TestPayloadType>('onSend', function (request, reply, payload, done) {
+  expectType<FastifyInstance>(this)
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)
   expectType<TestPayloadType>(payload)
@@ -68,7 +74,8 @@ server.addHook<TestPayloadType>('onSend', (request, reply, payload, done) => {
   expectError<void>(done(new Error(), 'foobar'))
 })
 
-server.addHook('onResponse', (request, reply, done) => {
+server.addHook('onResponse', function (request, reply, done) {
+  expectType<FastifyInstance>(this)
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)
   expectAssignable<(err?: FastifyError) => void>(done)
@@ -76,7 +83,8 @@ server.addHook('onResponse', (request, reply, done) => {
   expectType<void>(done(new Error()))
 })
 
-server.addHook('onTimeout', (request, reply, done) => {
+server.addHook('onTimeout', function (request, reply, done) {
+  expectType<FastifyInstance>(this)
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)
   expectAssignable<(err?: FastifyError) => void>(done)
@@ -84,7 +92,8 @@ server.addHook('onTimeout', (request, reply, done) => {
   expectType<void>(done(new Error()))
 })
 
-server.addHook('onError', (request, reply, error, done) => {
+server.addHook('onError', function (request, reply, error, done) {
+  expectType<FastifyInstance>(this)
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)
   expectType<FastifyError>(error)
@@ -92,7 +101,8 @@ server.addHook('onError', (request, reply, error, done) => {
   expectType<void>(done())
 })
 
-server.addHook('onRoute', (opts) => {
+server.addHook('onRoute', function (opts) {
+  expectType<FastifyInstance>(this)
   expectType<RouteOptions & { routePath: string; path: string; prefix: string}>(opts)
 })
 
@@ -104,6 +114,7 @@ server.addHook('onRegister', (instance, done) => {
 })
 
 server.addHook('onReady', function (done) {
+  expectType<FastifyInstance>(this)
   expectAssignable<(err?: FastifyError) => void>(done)
   expectAssignable<(err?: NodeJS.ErrnoException) => void>(done)
   expectType<void>(done(new Error()))
@@ -118,50 +129,59 @@ server.addHook('onClose', (instance, done) => {
 
 // Asynchronous
 
-server.addHook('onRequest', async (request, reply) => {
+server.addHook('onRequest', async function (request, reply) {
+  expectType<FastifyInstance>(this)
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)
 })
 
-server.addHook('preParsing', async (request, reply, payload) => {
+server.addHook('preParsing', async function (request, reply, payload) {
+  expectType<FastifyInstance>(this)
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)
   expectType<RequestPayload>(payload)
 })
 
-server.addHook('preValidation', async (request, reply) => {
+server.addHook('preValidation', async function (request, reply) {
+  expectType<FastifyInstance>(this)
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)
 })
 
-server.addHook('preHandler', (request, reply) => {
+server.addHook('preHandler', async function (request, reply) {
+  expectType<FastifyInstance>(this)
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)
 })
 
 server.addHook<TestPayloadType>('preSerialization', async function (request, reply, payload) {
+  expectType<FastifyInstance>(this)
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)
   expectType<TestPayloadType>(payload) // we expect this to be unknown when not specified like in the previous test
 })
 
-server.addHook<TestPayloadType>('onSend', async (request, reply, payload) => {
+server.addHook<TestPayloadType>('onSend', async function (request, reply, payload) {
+  expectType<FastifyInstance>(this)
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)
   expectType<TestPayloadType>(payload)
 })
 
-server.addHook('onResponse', async (request, reply) => {
+server.addHook('onResponse', async function (request, reply) {
+  expectType<FastifyInstance>(this)
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)
 })
 
-server.addHook('onTimeout', async (request, reply) => {
+server.addHook('onTimeout', async function (request, reply) {
+  expectType<FastifyInstance>(this)
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)
 })
 
-server.addHook('onError', async (request, reply, error) => {
+server.addHook('onError', async function (request, reply, error) {
+  expectType<FastifyInstance>(this)
   expectType<FastifyRequest>(request)
   expectType<FastifyReply>(reply)
   expectType<FastifyError>(error)
@@ -169,6 +189,10 @@ server.addHook('onError', async (request, reply, error) => {
 
 server.addHook('onRegister', async (instance) => {
   expectType<FastifyInstance>(instance)
+})
+
+server.addHook('onReady', async function () {
+  expectType<FastifyInstance>(this)
 })
 
 server.addHook('onClose', async (instance) => {

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -27,6 +27,7 @@ export interface onRequestHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
@@ -41,6 +42,7 @@ export interface onRequestAsyncHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
   ): Promise<unknown>;
@@ -58,6 +60,7 @@ export interface preParsingHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: RequestPayload,
@@ -73,6 +76,7 @@ export interface preParsingAsyncHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: RequestPayload,
@@ -90,6 +94,7 @@ export interface preValidationHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
@@ -104,6 +109,7 @@ export interface preValidationAsyncHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
   ): Promise<unknown>;
@@ -120,6 +126,7 @@ export interface preHandlerHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
@@ -134,6 +141,7 @@ export interface preHandlerAsyncHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
   ): Promise<unknown>;
@@ -159,6 +167,7 @@ export interface preSerializationHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: PreSerializationPayload,
@@ -175,6 +184,7 @@ export interface preSerializationAsyncHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: PreSerializationPayload
@@ -194,6 +204,7 @@ export interface onSendHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: OnSendPayload,
@@ -210,6 +221,7 @@ export interface onSendAsyncHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: OnSendPayload,
@@ -228,6 +240,7 @@ export interface onResponseHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
@@ -242,6 +255,7 @@ export interface onResponseAsyncHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
   ): Promise<unknown>;
@@ -259,6 +273,7 @@ export interface onTimeoutHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
@@ -273,6 +288,7 @@ export interface onTimeoutAsyncHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
   ): Promise<unknown>;
@@ -293,6 +309,7 @@ export interface onErrorHookHandler<
   TError extends Error = FastifyError
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     error: TError,
@@ -309,6 +326,7 @@ export interface onErrorAsyncHookHandler<
   TError extends Error = FastifyError
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     error: TError
@@ -328,6 +346,7 @@ export interface onRouteHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply>,
     opts: RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> & { routePath: string; path: string; prefix: string }
   ): Promise<unknown> | void;
 }
@@ -354,12 +373,15 @@ export interface onRegisterHookHandler<
  */
 export interface onReadyHookHandler {
   (
+    this: FastifyInstance,
     done: HookHandlerDoneFunction
   ): void;
 }
 
 export interface onReadyAsyncHookHandler {
-  (): Promise<unknown>;
+  (
+    this: FastifyInstance,
+  ): Promise<unknown>;
 }
 /**
  * Triggered when fastify.close() is invoked to stop the server. It is useful when plugins need a "shutdown" event, for example to close an open connection to a database.


### PR DESCRIPTION
TS2683: 'this' implicitly has type 'any' because it does not have a type
annotation.

An outer value of 'this' is shadowed by this container.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
