### PR TITLE
Fix responding from a hook doc

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -256,8 +256,8 @@ Replying from a hook implies that the hook chain is __stopped__ and
 the rest of the hooks and handlers are not executed. If the hook is
 using the callback approach, i.e. it is not an `async` function or it
 returns a `Promise`, it is as simple as calling `reply.send()` and avoiding
-calling the callback. If the hook is `async`, `reply.send()` __must__ be
-called _before_ the function returns or the promise resolves, otherwise, the
+calling the callback. If the hook is `async`, `reply` __must__ be
+awaited or returned, otherwise the
 request will proceed. When `reply.send()` is called outside of the
 promise chain, it is important to `return reply` otherwise the request
 will be executed twice.
@@ -276,7 +276,7 @@ fastify.addHook('onRequest', (request, reply, done) => {
 fastify.addHook('preHandler', async (request, reply) => {
   await something()
   reply.send({ hello: 'world' })
-  return reply // optional in this case, but it is a good practice
+  return reply // mandatory, so the request is not executed further
 })
 ```
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

I found another place in the docs that needed to be slightly adjusted due to the new way that tracking reply.sent state is handled.