### PR TITLE
Fix thrown non-Error values not being treated as errors

### DIFF
--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -4,6 +4,8 @@ const { validate: validateSchema } = require('./validation')
 const { hookRunner, hookIterator } = require('./hooks')
 const wrapThenable = require('./wrapThenable')
 
+const { kReplyIsError } = require('./symbols')
+
 function handleRequest (err, request, reply) {
   if (reply.sent === true) return
   if (err != null) {
@@ -123,6 +125,10 @@ function preHandlerCallback (err, request, reply) {
   try {
     result = reply.context.handler(request, reply)
   } catch (err) {
+    if (!(err instanceof Error)) {
+      reply[kReplyIsError] = true
+    }
+
     reply.send(err)
     return
   }

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -472,3 +472,56 @@ invalidErrorCodes.forEach((invalidCode) => {
     })
   })
 })
+
+test('status code should be set to 500 and return an error json payload if route handler throws any non Error object expression', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.get('/', () => {
+    /* eslint-disable-next-line */
+    throw { foo: 'bar' }
+  })
+
+  // ----
+  const reply = await fastify.inject({ method: 'GET', url: '/' })
+  t.equal(reply.statusCode, 500)
+  t.equal(JSON.parse(reply.body).foo, 'bar')
+})
+
+test('should preserve the status code set by the user if an expression is thrown in a sync route', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.get('/', (_, rep) => {
+    rep.status(501)
+
+    /* eslint-disable-next-line */
+    throw { foo: 'bar' }
+  })
+
+  // ----
+  const reply = await fastify.inject({ method: 'GET', url: '/' })
+  t.equal(reply.statusCode, 501)
+  t.equal(JSON.parse(reply.body).foo, 'bar')
+})
+
+test('should trigger error handlers if a sync route throws any non-error object', async t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  fastify.get('/', () => {
+    /* eslint-disable-next-line */
+    throw { foo: 'bar' }
+  })
+
+  fastify.setErrorHandler(async (error) => {
+    t.ok(error)
+    return error
+  })
+
+  // ----
+  const reply = await fastify.inject({ method: 'GET', url: '/' })
+  t.equal(reply.statusCode, 500)
+  t.equal(JSON.parse(reply.body).foo, 'bar')
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### Description

Closes #3160 

Sets `reply[kReplyIsError]` to `true` if the  thrown value in the  handler is not an error object.

