### PR TITLE
Refactor to ES6 classes

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -29,126 +29,128 @@ const {
 } = require('./errors')
 const warning = require('./warnings')
 
-function ContentTypeParser (bodyLimit, onProtoPoisoning, onConstructorPoisoning) {
-  this[kDefaultJsonParse] = getDefaultJsonParser(onProtoPoisoning, onConstructorPoisoning)
-  this.customParsers = {}
-  this.customParsers['application/json'] = new Parser(true, false, bodyLimit, this[kDefaultJsonParse])
-  this.customParsers['text/plain'] = new Parser(true, false, bodyLimit, defaultPlainTextParser)
-  this.parserList = ['application/json', 'text/plain']
-  this.parserRegExpList = []
-  this.cache = lru(100)
-}
-
-ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
-  const contentTypeIsString = typeof contentType === 'string'
-
-  if (!contentTypeIsString && !(contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()
-  if (contentTypeIsString && contentType.length === 0) throw new FST_ERR_CTP_EMPTY_TYPE()
-  if (typeof parserFn !== 'function') throw new FST_ERR_CTP_INVALID_HANDLER()
-
-  if (this.existingParser(contentType)) {
-    throw new FST_ERR_CTP_ALREADY_PRESENT(contentType)
+class ContentTypeParser {
+  constructor (bodyLimit, onProtoPoisoning, onConstructorPoisoning) {
+    this[kDefaultJsonParse] = getDefaultJsonParser(onProtoPoisoning, onConstructorPoisoning)
+    this.customParsers = {}
+    this.customParsers['application/json'] = new Parser(true, false, bodyLimit, this[kDefaultJsonParse])
+    this.customParsers['text/plain'] = new Parser(true, false, bodyLimit, defaultPlainTextParser)
+    this.parserList = ['application/json', 'text/plain']
+    this.parserRegExpList = []
+    this.cache = lru(100)
   }
 
-  if (opts.parseAs !== undefined) {
-    if (opts.parseAs !== 'string' && opts.parseAs !== 'buffer') {
-      throw new FST_ERR_CTP_INVALID_PARSE_TYPE(opts.parseAs)
+  add (contentType, opts, parserFn) {
+    const contentTypeIsString = typeof contentType === 'string'
+
+    if (!contentTypeIsString && !(contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()
+    if (contentTypeIsString && contentType.length === 0) throw new FST_ERR_CTP_EMPTY_TYPE()
+    if (typeof parserFn !== 'function') throw new FST_ERR_CTP_INVALID_HANDLER()
+
+    if (this.existingParser(contentType)) {
+      throw new FST_ERR_CTP_ALREADY_PRESENT(contentType)
     }
-  }
 
-  const parser = new Parser(
-    opts.parseAs === 'string',
-    opts.parseAs === 'buffer',
-    opts.bodyLimit,
-    parserFn
-  )
-
-  if (contentTypeIsString && contentType === '*') {
-    this.customParsers[''] = parser
-  } else {
-    if (contentTypeIsString) {
-      if (contentType !== 'application/json' && contentType !== 'text/plain') {
-        this.parserList.unshift(contentType)
+    if (opts.parseAs !== undefined) {
+      if (opts.parseAs !== 'string' && opts.parseAs !== 'buffer') {
+        throw new FST_ERR_CTP_INVALID_PARSE_TYPE(opts.parseAs)
       }
-    } else {
-      this.parserRegExpList.unshift(contentType)
     }
-    this.customParsers[contentType] = parser
-  }
-}
 
-ContentTypeParser.prototype.hasParser = function (contentType) {
-  return contentType in this.customParsers
-}
-
-ContentTypeParser.prototype.existingParser = function (contentType) {
-  if (contentType === 'application/json') {
-    return this.customParsers['application/json'].fn !== this[kDefaultJsonParse]
-  }
-  if (contentType === 'text/plain') {
-    return this.customParsers['text/plain'].fn !== defaultPlainTextParser
-  }
-
-  return contentType in this.customParsers
-}
-
-ContentTypeParser.prototype.getParser = function (contentType) {
-  // eslint-disable-next-line no-var
-  for (var i = 0; i !== this.parserList.length; ++i) {
-    const parserName = this.parserList[i]
-    if (contentType.indexOf(parserName) > -1) {
-      const parser = this.customParsers[parserName]
-      this.cache.set(contentType, parser)
-      return parser
-    }
-  }
-
-  // eslint-disable-next-line no-var
-  for (var j = 0; j !== this.parserRegExpList.length; ++j) {
-    const parserRegExp = this.parserRegExpList[j]
-    if (parserRegExp.test(contentType)) {
-      const parser = this.customParsers[parserRegExp]
-      this.cache.set(contentType, parser)
-      return parser
-    }
-  }
-
-  return this.customParsers['']
-}
-
-ContentTypeParser.prototype.run = function (contentType, handler, request, reply) {
-  const parser = this.cache.get(contentType) || this.getParser(contentType)
-
-  if (parser === undefined) {
-    reply.send(new FST_ERR_CTP_INVALID_MEDIA_TYPE(contentType))
-  } else if (parser.asString === true || parser.asBuffer === true) {
-    rawBody(
-      request,
-      reply,
-      reply.context._parserOptions,
-      parser,
-      done
+    const parser = new Parser(
+      opts.parseAs === 'string',
+      opts.parseAs === 'buffer',
+      opts.bodyLimit,
+      parserFn
     )
-  } else {
-    let result
 
-    if (parser.isDeprecatedSignature) {
-      result = parser.fn(request[kRequestPayloadStream], done)
+    if (contentTypeIsString && contentType === '*') {
+      this.customParsers[''] = parser
     } else {
-      result = parser.fn(request, request[kRequestPayloadStream], done)
-    }
-
-    if (result && typeof result.then === 'function') {
-      result.then(body => done(null, body), done)
+      if (contentTypeIsString) {
+        if (contentType !== 'application/json' && contentType !== 'text/plain') {
+          this.parserList.unshift(contentType)
+        }
+      } else {
+        this.parserRegExpList.unshift(contentType)
+      }
+      this.customParsers[contentType] = parser
     }
   }
 
-  function done (error, body) {
-    if (error) {
-      reply.send(error)
+  hasParser (contentType) {
+    return contentType in this.customParsers
+  }
+
+  existingParser (contentType) {
+    if (contentType === 'application/json') {
+      return this.customParsers['application/json'].fn !== this[kDefaultJsonParse]
+    }
+    if (contentType === 'text/plain') {
+      return this.customParsers['text/plain'].fn !== defaultPlainTextParser
+    }
+
+    return contentType in this.customParsers
+  }
+
+  getParser (contentType) {
+    // eslint-disable-next-line no-var
+    for (var i = 0; i !== this.parserList.length; ++i) {
+      const parserName = this.parserList[i]
+      if (contentType.indexOf(parserName) > -1) {
+        const parser = this.customParsers[parserName]
+        this.cache.set(contentType, parser)
+        return parser
+      }
+    }
+
+    // eslint-disable-next-line no-var
+    for (var j = 0; j !== this.parserRegExpList.length; ++j) {
+      const parserRegExp = this.parserRegExpList[j]
+      if (parserRegExp.test(contentType)) {
+        const parser = this.customParsers[parserRegExp]
+        this.cache.set(contentType, parser)
+        return parser
+      }
+    }
+
+    return this.customParsers['']
+  }
+
+  run (contentType, handler, request, reply) {
+    const parser = this.cache.get(contentType) || this.getParser(contentType)
+
+    if (parser === undefined) {
+      reply.send(new FST_ERR_CTP_INVALID_MEDIA_TYPE(contentType))
+    } else if (parser.asString === true || parser.asBuffer === true) {
+      rawBody(
+        request,
+        reply,
+        reply.context._parserOptions,
+        parser,
+        done
+      )
     } else {
-      request.body = body
-      handler(request, reply)
+      let result
+
+      if (parser.isDeprecatedSignature) {
+        result = parser.fn(request[kRequestPayloadStream], done)
+      } else {
+        result = parser.fn(request, request[kRequestPayloadStream], done)
+      }
+
+      if (result && typeof result.then === 'function') {
+        result.then(body => done(null, body), done)
+      }
+    }
+
+    function done (error, body) {
+      if (error) {
+        reply.send(error)
+      } else {
+        request.body = body
+        handler(request, reply)
+      }
     }
   }
 }

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -30,32 +30,34 @@ const {
   kHooks
 } = require('./symbols')
 
-function Hooks () {
-  this.onRequest = []
-  this.preParsing = []
-  this.preValidation = []
-  this.preSerialization = []
-  this.preHandler = []
-  this.onResponse = []
-  this.onSend = []
-  this.onError = []
-  this.onRoute = []
-  this.onRegister = []
-  this.onReady = []
-  this.onTimeout = []
-}
-
-Hooks.prototype.validate = function (hook, fn) {
-  if (typeof hook !== 'string') throw new FST_ERR_HOOK_INVALID_TYPE()
-  if (typeof fn !== 'function') throw new FST_ERR_HOOK_INVALID_HANDLER()
-  if (supportedHooks.indexOf(hook) === -1) {
-    throw new Error(`${hook} hook not supported!`)
+class Hooks {
+  constructor () {
+    this.onRequest = []
+    this.preParsing = []
+    this.preValidation = []
+    this.preSerialization = []
+    this.preHandler = []
+    this.onResponse = []
+    this.onSend = []
+    this.onError = []
+    this.onRoute = []
+    this.onRegister = []
+    this.onReady = []
+    this.onTimeout = []
   }
-}
 
-Hooks.prototype.add = function (hook, fn) {
-  this.validate(hook, fn)
-  this[hook].push(fn)
+  validate (hook, fn) {
+    if (typeof hook !== 'string') throw new FST_ERR_HOOK_INVALID_TYPE()
+    if (typeof fn !== 'function') throw new FST_ERR_HOOK_INVALID_HANDLER()
+    if (supportedHooks.indexOf(hook) === -1) {
+      throw new Error(`${hook} hook not supported!`)
+    }
+  }
+
+  add (hook, fn) {
+    this.validate(hook, fn)
+    this[hook].push(fn)
+  }
 }
 
 function buildHooks (h) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -50,20 +50,256 @@ const {
 } = require('./errors')
 const warning = require('./warnings')
 
-function Reply (res, request, log) {
-  this.raw = res
-  this[kReplySent] = false
-  this[kReplySerializer] = null
-  this[kReplyErrorHandlerCalled] = false
-  this[kReplyIsError] = false
-  this[kReplyIsRunningOnErrorHook] = false
-  this.request = request
-  this[kReplyHeaders] = {}
-  this[kReplyHasStatusCode] = false
-  this[kReplyStartTime] = undefined
-  this.log = log
+class Reply {
+  constructor (res, request, log) {
+    this.raw = res
+    this[kReplySent] = false
+    this[kReplySerializer] = null
+    this[kReplyErrorHandlerCalled] = false
+    this[kReplyIsError] = false
+    this[kReplyIsRunningOnErrorHook] = false
+    this.request = request
+    this[kReplyHeaders] = {}
+    this[kReplyHasStatusCode] = false
+    this[kReplyStartTime] = undefined
+    this.log = log
+  }
+
+  hijack () {
+    this[kReplySent] = true
+    return this
+  }
+
+  send (payload) {
+    if (this[kReplyIsRunningOnErrorHook] === true) {
+      throw new FST_ERR_SEND_INSIDE_ONERR()
+    }
+
+    if (this[kReplySent]) {
+      this.log.warn({ err: new FST_ERR_REP_ALREADY_SENT() }, 'Reply already sent')
+      return this
+    }
+
+    if (payload instanceof Error || this[kReplyIsError] === true) {
+      onErrorHook(this, payload, onSendHook)
+      return this
+    }
+
+    if (payload === undefined) {
+      onSendHook(this, payload)
+      return this
+    }
+
+    const contentType = this.getHeader('content-type')
+    const hasContentType = contentType !== undefined
+
+    if (payload !== null) {
+      if (Buffer.isBuffer(payload) || typeof payload.pipe === 'function') {
+        if (hasContentType === false) {
+          this[kReplyHeaders]['content-type'] = CONTENT_TYPE.OCTET
+        }
+        onSendHook(this, payload)
+        return this
+      }
+
+      if (hasContentType === false && typeof payload === 'string') {
+        this[kReplyHeaders]['content-type'] = CONTENT_TYPE.PLAIN
+        onSendHook(this, payload)
+        return this
+      }
+    }
+
+    if (this[kReplySerializer] !== null) {
+      if (typeof payload !== 'string') {
+        preserializeHook(this, payload)
+        return this
+      } else {
+        payload = this[kReplySerializer](payload)
+      }
+
+    // The indexOf below also matches custom json mimetypes such as 'application/hal+json' or 'application/ld+json'
+    } else if (hasContentType === false || contentType.indexOf('json') > -1) {
+      if (hasContentType === false) {
+        this[kReplyHeaders]['content-type'] = CONTENT_TYPE.JSON
+      } else {
+        // If hasContentType === true, we have a JSON mimetype
+        if (contentType.indexOf('charset') === -1) {
+          // If we have simply application/json instead of a custom json mimetype
+          if (contentType.indexOf('/json') > -1) {
+            this[kReplyHeaders]['content-type'] = CONTENT_TYPE.JSON
+          } else {
+            const currContentType = this[kReplyHeaders]['content-type']
+            // We extract the custom mimetype part (e.g. 'hal+' from 'application/hal+json')
+            const customJsonType = currContentType.substring(
+              currContentType.indexOf('/'),
+              currContentType.indexOf('json') + 4
+            )
+
+            // We ensure we set the header to the proper JSON content-type if necessary
+            // (e.g. 'application/hal+json' instead of 'application/json')
+            this[kReplyHeaders]['content-type'] = CONTENT_TYPE.JSON.replace('/json', customJsonType)
+          }
+        }
+      }
+      if (typeof payload !== 'string') {
+        preserializeHook(this, payload)
+        return this
+      }
+    }
+
+    onSendHook(this, payload)
+
+    return this
+  }
+
+  getHeader (key) {
+    key = key.toLowerCase()
+    const res = this.raw
+    let value = this[kReplyHeaders][key]
+    if (value === undefined && res.hasHeader(key)) {
+      value = res.getHeader(key)
+    }
+    return value
+  }
+
+  getHeaders () {
+    return {
+      ...this.raw.getHeaders(),
+      ...this[kReplyHeaders]
+    }
+  }
+
+  hasHeader (key) {
+    key = key.toLowerCase()
+    if (this[kReplyHeaders][key] !== undefined) {
+      return true
+    }
+    return this.raw.hasHeader(key)
+  }
+
+  removeHeader (key) {
+    // Node.js does not like headers with keys set to undefined,
+    // so we have to delete the key.
+    delete this[kReplyHeaders][key.toLowerCase()]
+    return this
+  }
+
+  header (key, value) {
+    const _key = key.toLowerCase()
+
+    // default the value to ''
+    value = value === undefined ? '' : value
+
+    if (this[kReplyHeaders][_key] && _key === 'set-cookie') {
+      // https://tools.ietf.org/html/rfc7230#section-3.2.2
+      if (typeof this[kReplyHeaders][_key] === 'string') {
+        this[kReplyHeaders][_key] = [this[kReplyHeaders][_key]]
+      }
+      if (Array.isArray(value)) {
+        Array.prototype.push.apply(this[kReplyHeaders][_key], value)
+      } else {
+        this[kReplyHeaders][_key].push(value)
+      }
+    } else {
+      this[kReplyHeaders][_key] = value
+    }
+    return this
+  }
+
+  headers (headers) {
+    const keys = Object.keys(headers)
+    /* eslint-disable no-var */
+    for (var i = 0; i !== keys.length; ++i) {
+      const key = keys[i]
+      this.header(key, headers[key])
+    }
+    return this
+  }
+
+  code (code) {
+    const intValue = parseInt(code)
+    if (isNaN(intValue) || intValue < 100 || intValue > 600) {
+      throw new FST_ERR_BAD_STATUS_CODE(code || String(code))
+    }
+
+    this.raw.statusCode = intValue
+    this[kReplyHasStatusCode] = true
+    return this
+  }
+
+  serialize (payload) {
+    if (this[kReplySerializer] !== null) {
+      return this[kReplySerializer](payload)
+    } else {
+      if (this.context && this.context[kReplySerializerDefault]) {
+        return this.context[kReplySerializerDefault](payload, this.raw.statusCode)
+      } else {
+        return serialize(this.context, payload, this.raw.statusCode)
+      }
+    }
+  }
+
+  serializer (fn) {
+    this[kReplySerializer] = fn
+    return this
+  }
+
+  type (type) {
+    this[kReplyHeaders]['content-type'] = type
+    return this
+  }
+
+  redirect (code, url) {
+    if (typeof code === 'string') {
+      url = code
+      code = this[kReplyHasStatusCode] ? this.raw.statusCode : 302
+    }
+
+    this.header('location', url).code(code).send()
+  }
+
+  callNotFound () {
+    notFound(this)
+  }
+
+  getResponseTime () {
+    let responseTime = 0
+
+    if (this[kReplyStartTime] !== undefined) {
+      responseTime = now() - this[kReplyStartTime]
+    }
+
+    return responseTime
+  }
+
+  // Make reply a thenable, so it could be used with async/await.
+  // See
+  // - https://github.com/fastify/fastify/issues/1864 for the discussions
+  // - https://promisesaplus.com/ for the definition of thenable
+  // - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then for the signature
+  then (fulfilled, rejected) {
+    if (this.sent) {
+      fulfilled()
+      return
+    }
+
+    eos(this.raw, (err) => {
+      // We must not treat ERR_STREAM_PREMATURE_CLOSE as
+      // an error because it is created by eos, not by the stream.
+      if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
+        if (rejected) {
+          rejected(err)
+        } else {
+          this.log && this.log.warn('unhandled rejection on reply.then')
+        }
+      } else {
+        fulfilled()
+      }
+    })
+  }
 }
 
+Reply.prototype.status = Reply.prototype.code
 Object.defineProperties(Reply.prototype, {
   context: {
     get () {
@@ -107,241 +343,6 @@ Object.defineProperties(Reply.prototype, {
     writable: true
   }
 })
-
-Reply.prototype.hijack = function () {
-  this[kReplySent] = true
-  return this
-}
-
-Reply.prototype.send = function (payload) {
-  if (this[kReplyIsRunningOnErrorHook] === true) {
-    throw new FST_ERR_SEND_INSIDE_ONERR()
-  }
-
-  if (this[kReplySent]) {
-    this.log.warn({ err: new FST_ERR_REP_ALREADY_SENT() }, 'Reply already sent')
-    return this
-  }
-
-  if (payload instanceof Error || this[kReplyIsError] === true) {
-    onErrorHook(this, payload, onSendHook)
-    return this
-  }
-
-  if (payload === undefined) {
-    onSendHook(this, payload)
-    return this
-  }
-
-  const contentType = this.getHeader('content-type')
-  const hasContentType = contentType !== undefined
-
-  if (payload !== null) {
-    if (Buffer.isBuffer(payload) || typeof payload.pipe === 'function') {
-      if (hasContentType === false) {
-        this[kReplyHeaders]['content-type'] = CONTENT_TYPE.OCTET
-      }
-      onSendHook(this, payload)
-      return this
-    }
-
-    if (hasContentType === false && typeof payload === 'string') {
-      this[kReplyHeaders]['content-type'] = CONTENT_TYPE.PLAIN
-      onSendHook(this, payload)
-      return this
-    }
-  }
-
-  if (this[kReplySerializer] !== null) {
-    if (typeof payload !== 'string') {
-      preserializeHook(this, payload)
-      return this
-    } else {
-      payload = this[kReplySerializer](payload)
-    }
-
-  // The indexOf below also matches custom json mimetypes such as 'application/hal+json' or 'application/ld+json'
-  } else if (hasContentType === false || contentType.indexOf('json') > -1) {
-    if (hasContentType === false) {
-      this[kReplyHeaders]['content-type'] = CONTENT_TYPE.JSON
-    } else {
-      // If hasContentType === true, we have a JSON mimetype
-      if (contentType.indexOf('charset') === -1) {
-        // If we have simply application/json instead of a custom json mimetype
-        if (contentType.indexOf('/json') > -1) {
-          this[kReplyHeaders]['content-type'] = CONTENT_TYPE.JSON
-        } else {
-          const currContentType = this[kReplyHeaders]['content-type']
-          // We extract the custom mimetype part (e.g. 'hal+' from 'application/hal+json')
-          const customJsonType = currContentType.substring(
-            currContentType.indexOf('/'),
-            currContentType.indexOf('json') + 4
-          )
-
-          // We ensure we set the header to the proper JSON content-type if necessary
-          // (e.g. 'application/hal+json' instead of 'application/json')
-          this[kReplyHeaders]['content-type'] = CONTENT_TYPE.JSON.replace('/json', customJsonType)
-        }
-      }
-    }
-    if (typeof payload !== 'string') {
-      preserializeHook(this, payload)
-      return this
-    }
-  }
-
-  onSendHook(this, payload)
-
-  return this
-}
-
-Reply.prototype.getHeader = function (key) {
-  key = key.toLowerCase()
-  const res = this.raw
-  let value = this[kReplyHeaders][key]
-  if (value === undefined && res.hasHeader(key)) {
-    value = res.getHeader(key)
-  }
-  return value
-}
-
-Reply.prototype.getHeaders = function () {
-  return {
-    ...this.raw.getHeaders(),
-    ...this[kReplyHeaders]
-  }
-}
-
-Reply.prototype.hasHeader = function (key) {
-  key = key.toLowerCase()
-  if (this[kReplyHeaders][key] !== undefined) {
-    return true
-  }
-  return this.raw.hasHeader(key)
-}
-
-Reply.prototype.removeHeader = function (key) {
-  // Node.js does not like headers with keys set to undefined,
-  // so we have to delete the key.
-  delete this[kReplyHeaders][key.toLowerCase()]
-  return this
-}
-
-Reply.prototype.header = function (key, value) {
-  const _key = key.toLowerCase()
-
-  // default the value to ''
-  value = value === undefined ? '' : value
-
-  if (this[kReplyHeaders][_key] && _key === 'set-cookie') {
-    // https://tools.ietf.org/html/rfc7230#section-3.2.2
-    if (typeof this[kReplyHeaders][_key] === 'string') {
-      this[kReplyHeaders][_key] = [this[kReplyHeaders][_key]]
-    }
-    if (Array.isArray(value)) {
-      Array.prototype.push.apply(this[kReplyHeaders][_key], value)
-    } else {
-      this[kReplyHeaders][_key].push(value)
-    }
-  } else {
-    this[kReplyHeaders][_key] = value
-  }
-  return this
-}
-
-Reply.prototype.headers = function (headers) {
-  const keys = Object.keys(headers)
-  /* eslint-disable no-var */
-  for (var i = 0; i !== keys.length; ++i) {
-    const key = keys[i]
-    this.header(key, headers[key])
-  }
-  return this
-}
-
-Reply.prototype.code = function (code) {
-  const intValue = parseInt(code)
-  if (isNaN(intValue) || intValue < 100 || intValue > 600) {
-    throw new FST_ERR_BAD_STATUS_CODE(code || String(code))
-  }
-
-  this.raw.statusCode = intValue
-  this[kReplyHasStatusCode] = true
-  return this
-}
-
-Reply.prototype.status = Reply.prototype.code
-
-Reply.prototype.serialize = function (payload) {
-  if (this[kReplySerializer] !== null) {
-    return this[kReplySerializer](payload)
-  } else {
-    if (this.context && this.context[kReplySerializerDefault]) {
-      return this.context[kReplySerializerDefault](payload, this.raw.statusCode)
-    } else {
-      return serialize(this.context, payload, this.raw.statusCode)
-    }
-  }
-}
-
-Reply.prototype.serializer = function (fn) {
-  this[kReplySerializer] = fn
-  return this
-}
-
-Reply.prototype.type = function (type) {
-  this[kReplyHeaders]['content-type'] = type
-  return this
-}
-
-Reply.prototype.redirect = function (code, url) {
-  if (typeof code === 'string') {
-    url = code
-    code = this[kReplyHasStatusCode] ? this.raw.statusCode : 302
-  }
-
-  this.header('location', url).code(code).send()
-}
-
-Reply.prototype.callNotFound = function () {
-  notFound(this)
-}
-
-Reply.prototype.getResponseTime = function () {
-  let responseTime = 0
-
-  if (this[kReplyStartTime] !== undefined) {
-    responseTime = now() - this[kReplyStartTime]
-  }
-
-  return responseTime
-}
-
-// Make reply a thenable, so it could be used with async/await.
-// See
-// - https://github.com/fastify/fastify/issues/1864 for the discussions
-// - https://promisesaplus.com/ for the definition of thenable
-// - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then for the signature
-Reply.prototype.then = function (fulfilled, rejected) {
-  if (this.sent) {
-    fulfilled()
-    return
-  }
-
-  eos(this.raw, (err) => {
-    // We must not treat ERR_STREAM_PREMATURE_CLOSE as
-    // an error because it is created by eos, not by the stream.
-    if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
-      if (rejected) {
-        rejected(err)
-      } else {
-        this.log && this.log.warn('unhandled rejection on reply.then')
-      }
-    } else {
-      fulfilled()
-    }
-  })
-}
 
 function preserializeHook (reply, payload) {
   if (reply.context.preSerialization !== null) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -4,14 +4,16 @@ const proxyAddr = require('proxy-addr')
 const semver = require('semver')
 const warning = require('./warnings')
 
-function Request (id, params, req, query, log, context) {
-  this.id = id
-  this.context = context
-  this.params = params
-  this.raw = req
-  this.query = query
-  this.log = log
-  this.body = null
+class Request {
+  constructor (id, params, req, query, log, context) {
+    this.id = id
+    this.context = context
+    this.params = params
+    this.raw = req
+    this.query = query
+    this.log = log
+    this.body = null
+  }
 }
 
 function getTrustProxyFn (tp) {

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -12,35 +12,37 @@ const {
 
 const SCHEMAS_SOURCE = ['params', 'body', 'querystring', 'query', 'headers']
 
-function Schemas (initStore) {
-  this.store = initStore || {}
-}
-
-Schemas.prototype.add = function (inputSchema) {
-  const schema = fastClone((inputSchema.isFluentSchema || inputSchema.isFluentJSONSchema || inputSchema[kFluentSchema])
-    ? inputSchema.valueOf()
-    : inputSchema
-  )
-
-  // devs can add schemas without $id, but with $def instead
-  const id = schema.$id
-  if (!id) {
-    throw new FST_ERR_SCH_MISSING_ID()
+class Schemas {
+  constructor (initStore) {
+    this.store = initStore || {}
   }
 
-  if (this.store[id]) {
-    throw new FST_ERR_SCH_ALREADY_PRESENT(id)
+  add (inputSchema) {
+    const schema = fastClone((inputSchema.isFluentSchema || inputSchema.isFluentJSONSchema || inputSchema[kFluentSchema])
+      ? inputSchema.valueOf()
+      : inputSchema
+    )
+
+    // devs can add schemas without $id, but with $def instead
+    const id = schema.$id
+    if (!id) {
+      throw new FST_ERR_SCH_MISSING_ID()
+    }
+
+    if (this.store[id]) {
+      throw new FST_ERR_SCH_ALREADY_PRESENT(id)
+    }
+
+    this.store[id] = schema
   }
 
-  this.store[id] = schema
-}
+  getSchemas () {
+    return Object.assign({}, this.store)
+  }
 
-Schemas.prototype.getSchemas = function () {
-  return Object.assign({}, this.store)
-}
-
-Schemas.prototype.getSchema = function (schemaId) {
-  return this.store[schemaId]
+  getSchema (schemaId) {
+    return this.store[schemaId]
+  }
 }
 
 function normalizeSchema (routeSchemas) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This PR only introduces a syntax change; it refactors constructor functions and modifying prototypes to using ES6 classes. I ran benchmarks a few times there isn't any noticable difference since benchmarks are very inconsistent.

These were ran using nodejs v10.17.0.
"main"

```
[1] ┌─────────┬──────┬───────┬───────┬───────┬──────────┬─────────┬────────┐
[1] │ Stat    │ 2.5% │ 50%   │ 97.5% │ 99%   │ Avg      │ Stdev   │ Max    │
[1] ├─────────┼──────┼───────┼───────┼───────┼──────────┼─────────┼────────┤
[1] │ Latency │ 9 ms │ 20 ms │ 41 ms │ 61 ms │ 19.67 ms │ 10.3 ms │ 182 ms │
[1] └─────────┴──────┴───────┴───────┴───────┴──────────┴─────────┴────────┘
[1] ┌───────────┬─────────┬─────────┬─────────┬────────┬─────────┬─────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%  │ Avg     │ Stdev   │ Min     │
[1] ├───────────┼─────────┼─────────┼─────────┼────────┼─────────┼─────────┼─────────┤
[1] │ Req/Sec   │ 35263   │ 35263   │ 55583   │ 56063  │ 49622.4 │ 8279.23 │ 35239   │
[1] ├───────────┼─────────┼─────────┼─────────┼────────┼─────────┼─────────┼─────────┤
[1] │ Bytes/Sec │ 5.78 MB │ 5.78 MB │ 9.12 MB │ 9.2 MB │ 8.14 MB │ 1.36 MB │ 5.78 MB │
[1] └───────────┴─────────┴─────────┴─────────┴────────┴─────────┴─────────┴─────────┘
```

```
[1] ┌─────────┬───────┬───────┬───────┬───────┬──────────┬──────────┬────────┐
[1] │ Stat    │ 2.5%  │ 50%   │ 97.5% │ 99%   │ Avg      │ Stdev    │ Max    │
[1] ├─────────┼───────┼───────┼───────┼───────┼──────────┼──────────┼────────┤
[1] │ Latency │ 10 ms │ 21 ms │ 43 ms │ 63 ms │ 20.41 ms │ 10.25 ms │ 176 ms │
[1] └─────────┴───────┴───────┴───────┴───────┴──────────┴──────────┴────────┘
[1] ┌───────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg     │ Stdev   │ Min     │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
[1] │ Req/Sec   │ 34623   │ 34623   │ 52927   │ 53983   │ 47856   │ 7489.29 │ 34616   │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
[1] │ Bytes/Sec │ 5.68 MB │ 5.68 MB │ 8.68 MB │ 8.86 MB │ 7.85 MB │ 1.23 MB │ 5.68 MB │
[1] └───────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
```

"pr/refactor-to-es6-classes"

```
[1] ┌─────────┬───────┬───────┬───────┬───────┬──────────┬──────────┬────────┐
[1] │ Stat    │ 2.5%  │ 50%   │ 97.5% │ 99%   │ Avg      │ Stdev    │ Max    │
[1] ├─────────┼───────┼───────┼───────┼───────┼──────────┼──────────┼────────┤
[1] │ Latency │ 10 ms │ 22 ms │ 43 ms │ 59 ms │ 21.05 ms │ 10.93 ms │ 151 ms │
[1] └─────────┴───────┴───────┴───────┴───────┴──────────┴──────────┴────────┘
[1] ┌───────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg     │ Stdev   │ Min     │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
[1] │ Req/Sec   │ 34047   │ 34047   │ 50143   │ 52511   │ 46460.8 │ 7062.01 │ 34021   │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
[1] │ Bytes/Sec │ 5.58 MB │ 5.58 MB │ 8.22 MB │ 8.61 MB │ 7.62 MB │ 1.16 MB │ 5.58 MB │
[1] └───────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
```

```
[1] ┌─────────┬──────┬───────┬───────┬───────┬──────────┬─────────┬────────┐
[1] │ Stat    │ 2.5% │ 50%   │ 97.5% │ 99%   │ Avg      │ Stdev   │ Max    │
[1] ├─────────┼──────┼───────┼───────┼───────┼──────────┼─────────┼────────┤
[1] │ Latency │ 9 ms │ 20 ms │ 37 ms │ 60 ms │ 19.04 ms │ 9.52 ms │ 174 ms │
[1] └─────────┴──────┴───────┴───────┴───────┴──────────┴─────────┴────────┘
[1] ┌───────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg     │ Stdev   │ Min     │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
[1] │ Req/Sec   │ 36895   │ 36895   │ 54527   │ 58079   │ 51190.4 │ 7966.28 │ 36895   │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
[1] │ Bytes/Sec │ 6.05 MB │ 6.05 MB │ 8.95 MB │ 9.53 MB │ 8.4 MB  │ 1.31 MB │ 6.05 MB │
[1] └───────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
```