### PR TITLE
chore: add stream type to logger

### DIFF
--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -2,6 +2,7 @@ import { expectType, expectError } from 'tsd'
 import fastify, { FastifyLogFn, LogLevel, FastifyLoggerInstance, FastifyError, FastifyRequest, FastifyReply } from '../../fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
 import * as pino from 'pino'
+import * as fs from 'fs'
 
 expectType<FastifyLoggerInstance>(fastify().log)
 
@@ -154,3 +155,9 @@ const serverAutoInferredSerializerObjectOption = fastify({
 })
 
 expectType<FastifyLoggerInstance>(serverAutoInferredSerializerObjectOption.log)
+
+const passStreamAsOption = fastify({
+  logger: {
+    stream: fs.createWriteStream('/tmp/stream.out')
+  }
+})

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -109,6 +109,10 @@ export interface PrettyOptions {
   suppressFlushSyncWarning?: boolean;
 }
 
+export interface FastifyLoggerStreamDestination {
+  write(msg: string): void;
+}
+
 /**
  * Fastify Custom Logger options. To enable configuration of all Pino options,
  * refer to this example:
@@ -143,4 +147,5 @@ export interface FastifyLoggerOptions<
   level?: string;
   genReqId?: (req: RawRequest) => string;
   prettyPrint?: boolean | PrettyOptions;
+  stream?: FastifyLoggerStreamDestination;
 }


### PR DESCRIPTION
I see the discussion about it on #2715 and I think that if `stream` is a valid option in `fastify`. At least, we should make it possible to pass this options without problem.

The types is copy from `@types/pino` currently and I think that it support most of the case and well tested by the wide range of `pino` users.

I look forward to `pino@7`, it seems that it will provide official types and we won't have discrete behavior between Javascript and Typescript users in logger anymore.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
