### PR TITLE
Revert "fix: #3110 version resolution"

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -4,8 +4,9 @@ const Avvio = require('avvio')
 const http = require('http')
 const querystring = require('querystring')
 let lightMyRequest
+let version
+let versionLoaded = false
 
-const { version } = require('./package.json')
 const {
   kAvvioBoot,
   kChildren,
@@ -322,6 +323,9 @@ function fastify (options) {
     },
     version: {
       get () {
+        if (versionLoaded === false) {
+          version = loadVersion()
+        }
         return version
       }
     },
@@ -668,6 +672,20 @@ function wrapRouting (httpHandler, { rewriteUrl, logger }) {
       }
     }
     httpHandler(req, res)
+  }
+}
+
+function loadVersion () {
+  versionLoaded = true
+  const fs = require('fs')
+  const path = require('path')
+  try {
+    const pkgPath = path.join(__dirname, 'package.json')
+    fs.accessSync(pkgPath, fs.constants.R_OK)
+    const pkg = JSON.parse(fs.readFileSync(pkgPath))
+    return pkg.name === 'fastify' ? pkg.version : undefined
+  } catch (e) {
+    return undefined
   }
 }
 

--- a/lib/pluginUtils.js
+++ b/lib/pluginUtils.js
@@ -109,7 +109,9 @@ function registerPluginName (fn) {
 
 function registerPlugin (fn) {
   registerPluginName.call(this, fn)
-  checkVersion.call(this, fn)
+  if (this.version !== undefined) {
+    checkVersion.call(this, fn)
+  }
   checkDecorators.call(this, fn)
   checkDependencies.call(this, fn)
   return shouldSkipOverride(fn)

--- a/test/internals/version.test.js
+++ b/test/internals/version.test.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const proxyquire = require('proxyquire')
+
+test('should output an undefined version in case of package.json not available', t => {
+  const Fastify = proxyquire('../..', { fs: { accessSync: () => { throw Error('error') } } })
+  t.plan(1)
+  const srv = Fastify()
+  t.equal(srv.version, undefined)
+})
+
+test('should output an undefined version in case of package.json is not the fastify one', t => {
+  const Fastify = proxyquire('../..', { fs: { accessSync: () => { }, readFileSync: () => JSON.stringify({ name: 'foo', version: '6.6.6' }) } })
+  t.plan(1)
+  const srv = Fastify()
+  t.equal(srv.version, undefined)
+})
+
+test('should skip the version check if the version is undefined', t => {
+  const Fastify = proxyquire('../..', { fs: { accessSync: () => { }, readFileSync: () => JSON.stringify({ name: 'foo', version: '6.6.6' }) } })
+  t.plan(3)
+  const srv = Fastify()
+  t.equal(srv.version, undefined)
+
+  plugin[Symbol.for('skip-override')] = false
+  plugin[Symbol.for('plugin-meta')] = {
+    name: 'plugin',
+    fastify: '>=99.0.0'
+  }
+
+  srv.register(plugin)
+
+  srv.ready((err) => {
+    t.error(err)
+    t.pass('everything right')
+  })
+
+  function plugin (instance, opts, done) {
+    done()
+  }
+})


### PR DESCRIPTION
Reverts fastify/fastify#3113

Apparently this is significantly harder than it looks and there is not a better way to do this that will not break webpack.