### PR TITLE
Add types for printRoutes

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -163,7 +163,7 @@ export type { Chain as LightMyRequestChain, InjectOptions, Response as LightMyRe
 export { FastifyRequest, RequestGenericInterface } from './types/request'
 export { FastifyReply } from './types/reply'
 export { FastifyPluginCallback, FastifyPluginAsync, FastifyPluginOptions, FastifyPlugin } from './types/plugin'
-export { FastifyInstance } from './types/instance'
+export { FastifyInstance, PrintRoutesOptions } from './types/instance'
 export { FastifyLoggerOptions, FastifyLoggerInstance, FastifyLogFn, LogLevel } from './types/logger'
 export { FastifyContext, FastifyContextConfig } from './types/context'
 export { RouteHandler, RouteHandlerMethod, RouteOptions, RouteShorthandMethod, RouteShorthandOptions, RouteShorthandOptionsWithHandler } from './types/route'

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -124,3 +124,9 @@ expectType<InitialConfig>(fastify().initialConfig)
 expectType<FastifyBodyParser<string>>(server.defaultTextParser)
 
 expectType<FastifyBodyParser<string>>(server.getDefaultJsonParser('ignore', 'error'))
+
+expectType<string>(server.printRoutes({ includeHooks: true, commonPrefix: false, includeMeta: true }))
+
+expectType<string>(server.printRoutes({ includeMeta: ['key1', Symbol('key2')] }))
+
+expectType<string>(server.printRoutes())

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -10,6 +10,12 @@ import { FastifyReply } from './reply'
 import { FastifyError } from 'fastify-error'
 import { AddContentTypeParser, hasContentTypeParser, getDefaultJsonParser, ProtoAction, ConstructorAction, FastifyBodyParser } from './content-type-parser'
 
+export interface PrintRoutesOptions {
+  includeMeta?: boolean | (string | symbol)[]
+  commonPrefix?: boolean
+  includeHooks?: boolean
+}
+
 /**
  * Fastify server instance. Returned by the core `fastify()` method.
  */
@@ -372,7 +378,7 @@ export interface FastifyInstance<
   /**
    * Prints the representation of the internal radix tree used by the router
    */
-  printRoutes(): string;
+  printRoutes(opts?: PrintRoutesOptions): string;
 
   /**
    * Prints the representation of the plugin tree used by avvio, the plugin registration system


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Added types for the ``printRoutes`` method.