### PR TITLE
afterRouteAdded: fixed `headRouteExists` lookup argument

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -247,7 +247,7 @@ function buildRouting (options) {
         opts.schemaErrorFormatter || this[kSchemaErrorFormatter]
       )
 
-      const headRouteExists = router.find('HEAD', path) != null
+      const headRouteExists = router.find('HEAD', url) != null
 
       try {
         router.on(opts.method, opts.url, { constraints }, routeHandler, context)

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -1190,3 +1190,33 @@ test('HEAD routes properly auto created for GET routes when prefixTrailingSlash:
   t.equal(trailingSlashReply.statusCode, 200)
   t.equal(noneTrailingReply.statusCode, 200)
 })
+
+test('Will not try to re-createprefixed HEAD route if it already exists and exposeHeadRoutes is true', async (t) => {
+  t.plan(1)
+
+  const fastify = Fastify({ exposeHeadRoutes: true })
+
+  fastify.register((scope, opts, next) => {
+    scope.route({
+      method: 'HEAD',
+      path: '/route',
+      handler: (req, reply) => {
+        reply.header('content-type', 'text/plain')
+        reply.send('custom HEAD response')
+      }
+    })
+    scope.route({
+      method: 'GET',
+      path: '/route',
+      handler: (req, reply) => {
+        reply.send({ ok: true })
+      }
+    })
+
+    next()
+  }, { prefix: '/prefix' })
+
+  await fastify.ready()
+
+  t.ok(true)
+})


### PR DESCRIPTION
Fixes https://github.com/fastify/fastify-swagger/issues/425

Problem: when checking if a scoped GET route's matching HEAD route already exists, Fastify looks it up by method and path, omitting the scope's prefix. When `exposeHeadRoutes` is true, this results is a false negative and an error when it tries to create a HEAD route that already exists.

Solution: look up the route by method and full path/url

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
