### PR TITLE
Deem everything thrown as an error

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -13,7 +13,8 @@ const {
   kBodyLimit,
   kRequestPayloadStream,
   kState,
-  kTestInternals
+  kTestInternals,
+  kReplyIsError
 } = require('./symbols')
 
 const {
@@ -138,6 +139,7 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
 
   function done (error, body) {
     if (error) {
+      reply[kReplyIsError] = true
       reply.send(error)
     } else {
       request.body = body
@@ -197,6 +199,7 @@ function rawBody (request, reply, options, parser, done) {
 
     if (err !== undefined) {
       err.statusCode = 400
+      reply[kReplyIsError] = true
       reply.code(err.statusCode).send(err)
       return
     }

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -3,10 +3,14 @@
 const { validate: validateSchema } = require('./validation')
 const { hookRunner, hookIterator } = require('./hooks')
 const wrapThenable = require('./wrapThenable')
+const {
+  kReplyIsError
+} = require('./symbols')
 
 function handleRequest (err, request, reply) {
   if (reply.sent === true) return
   if (err != null) {
+    reply[kReplyIsError] = true
     reply.send(err)
     return
   }
@@ -78,6 +82,7 @@ function preValidationCallback (err, request, reply) {
   if (reply.sent === true) return
 
   if (err != null) {
+    reply[kReplyIsError] = true
     reply.send(err)
     return
   }
@@ -110,6 +115,7 @@ function preHandlerCallback (err, request, reply) {
   if (reply.sent) return
 
   if (err != null) {
+    reply[kReplyIsError] = true
     reply.send(err)
     return
   }
@@ -119,6 +125,7 @@ function preHandlerCallback (err, request, reply) {
   try {
     result = reply.context.handler(request, reply)
   } catch (err) {
+    reply[kReplyIsError] = true
     reply.send(err)
     return
   }

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -28,7 +28,6 @@ const {
 } = require('./errors')
 
 const {
-  kReplyIsError,
   kChildren,
   kHooks
 } = require('./symbols')
@@ -189,8 +188,6 @@ function hookRunner (functions, runner, request, reply, cb) {
   function handleReject (err) {
     if (!err) {
       err = new FST_ERR_SEND_UNDEFINED_ERR()
-    } else if (!(err instanceof Error)) {
-      reply[kReplyIsError] = true
     }
 
     cb(err, request, reply)

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -126,6 +126,7 @@ Reply.prototype.send = function (payload) {
   }
 
   if (payload instanceof Error || this[kReplyIsError] === true) {
+    this[kReplyIsError] = false
     onErrorHook(this, payload, onSendHook)
     return this
   }
@@ -528,7 +529,6 @@ function handleError (reply, error, cb) {
 
   const errorHandler = reply.context.errorHandler
   if (errorHandler && reply[kReplyErrorHandlerCalled] === false) {
-    reply[kReplyIsError] = false
     reply[kReplyErrorHandlerCalled] = true
     reply[kReplyHeaders]['content-length'] = undefined
     const result = errorHandler(error, reply.request, reply)
@@ -646,8 +646,6 @@ function buildReply (R) {
 }
 
 function notFound (reply) {
-  reply[kReplyIsError] = false
-
   if (reply.context[kFourOhFourContext] === null) {
     reply.log.warn('Trying to send a NotFound error inside a 404 handler. Sending basic 404 response.')
     reply.code(404).send('404 Not Found')

--- a/lib/route.js
+++ b/lib/route.js
@@ -394,6 +394,7 @@ function validateBodyLimitOption (bodyLimit) {
 function runPreParsing (err, request, reply) {
   if (reply.sent === true) return
   if (err != null) {
+    reply[kReplyIsError] = true
     reply.send(err)
     return
   }
@@ -420,10 +421,6 @@ function preParsingHookRunner (functions, request, reply, cb) {
     }
 
     if (err || i === functions.length) {
-      if (err && !(err instanceof Error)) {
-        reply[kReplyIsError] = true
-      }
-
       cb(err, request, reply)
       return
     }

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -186,3 +186,35 @@ test('add', t => {
 
   t.end()
 })
+
+test('non-Error thrown from content parser is properly handled', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  const throwable = 'test'
+  const payload = 'error'
+
+  fastify.addContentTypeParser('text/test', (request, payload, done) => {
+    done(throwable)
+  })
+
+  fastify.post('/', (req, reply) => {
+  })
+
+  fastify.setErrorHandler((err, req, res) => {
+    t.equal(err, throwable)
+
+    res.send(payload)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    headers: { 'Content-Type': 'text/test' },
+    body: 'some text'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.payload, payload)
+  })
+})

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -540,3 +540,59 @@ invalidErrorCodes.forEach((invalidCode) => {
     })
   })
 })
+
+test('error handler is triggered when a string is thrown from sync handler', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  const throwable = 'test'
+  const payload = 'error'
+
+  fastify.get('/', function (req, reply) {
+    // eslint-disable-next-line no-throw-literal
+    throw throwable
+  })
+
+  fastify.setErrorHandler((err, req, res) => {
+    t.equal(err, throwable)
+
+    res.send(payload)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.payload, payload)
+  })
+})
+
+test('error handler is triggered when a string is thrown from async handler', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  const throwable = 'test'
+  const payload = 'error'
+
+  fastify.get('/', function async (req, reply) {
+    // eslint-disable-next-line no-throw-literal
+    throw throwable
+  })
+
+  fastify.setErrorHandler((err, req, res) => {
+    t.equal(err, throwable)
+
+    res.send(payload)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.payload, payload)
+  })
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This is the first in line of PRs that will address issues outlined in https://github.com/fastify/fastify/issues/2860.

Firstly, I modified how kReplyIsError is tracked. The property is automatically set to false when reply.send() is used. This way there's no way that the reply would be considered an error longer than needed.

Secondly, I went through the code base and properly marked all replies as errors where appropriate. In the current version of Fastify there are huge inconsistencies of how non Errors are handled when thrown. Javascript supports throwing anything, so Fastify must take such cases into consideration. 
This PR ensures that you can safely throw anything in hooks or handlers regardless of them being sync or async. The error handler will be properly called in all such cases.
