### PR TITLE
Add this types to decorator functions

### DIFF
--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -117,6 +117,9 @@ upon "greet" and "log" decorators:
 fastify.decorate('utility', fn, ['greet', 'log'])
 ```
 
+Note: using an arrow function will break the binding of `this` to the
+`FastifyInstance`.
+
 If a dependency is not satisfied, the `decorate` method will throw an exception.
 The dependency check is performed before the server instance is booted. Thus,
 it cannot occur during runtime.

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -140,14 +140,22 @@ expectType<string>(server.printRoutes())
 server.decorate<(x: string) => void>('test', function (x: string): void {
   expectType<FastifyInstance>(this)
 })
+server.decorate('test', function (x: string): void {
+  expectType<FastifyInstance>(this)
+})
+
 server.decorateRequest<(x: string, y: number) => void>('test', function (x: string, y: number): void {
   expectType<FastifyRequest>(this)
 })
+server.decorateRequest('test', function (x: string, y: number): void {
+  expectType<FastifyRequest>(this)
+})
+
 server.decorateReply<(x: string) => void>('test', function (x: string): void {
   expectType<FastifyReply>(this)
 })
-server.decorate('test', function (x: string): void {
-  expectType<FastifyInstance>(this)
+server.decorateReply('test', function (x: string): void {
+  expectType<FastifyReply>(this)
 })
 
 expectError(server.decorate<string>('test', true))

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -5,7 +5,7 @@ import fastify, {
   FastifyLoggerInstance,
   ValidationResult
 } from '../../fastify'
-import { expectAssignable, expectError, expectType } from 'tsd'
+import { expectAssignable, expectError, expectNotAssignable, expectType } from 'tsd'
 import { FastifyRequest } from '../../types/request'
 import { FastifyReply } from '../../types/reply'
 import { HookHandlerDoneFunction } from '../../types/hooks'
@@ -137,12 +137,17 @@ expectType<string>(server.printRoutes({ includeMeta: ['key1', Symbol('key2')] })
 
 expectType<string>(server.printRoutes())
 
-server.decorate('test', function (x: string) {
-  expectType<FastifyInstance | any>(this)
+server.decorate<(x: string) => void>('test', function (x: string): void {
+  expectType<FastifyInstance>(this)
 })
-server.decorateRequest('test', function (x: string, y: number) {
-  expectType<FastifyRequest | any>(this)
+server.decorateRequest<(x: string, y: number) => void>('test', function (x: string, y: number): void {
+  expectType<FastifyRequest>(this)
 })
-server.decorateReply('test', function (x: string) {
-  expectType<FastifyReply | any>(this)
+server.decorateReply<(x: string) => void>('test', function (x: string): void {
+  expectType<FastifyReply>(this)
 })
+
+expectError(server.decorate<string>('test', true))
+expectError(server.decorate<(myNumber: number) => number>('test', function (myNumber: number): string {
+  return ''
+}))

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -1,4 +1,10 @@
-import fastify, { FastifyBodyParser, FastifyError, FastifyInstance, ValidationResult } from '../../fastify'
+import fastify, {
+  FastifyBodyParser,
+  FastifyError,
+  FastifyInstance,
+  FastifyLoggerInstance,
+  ValidationResult
+} from '../../fastify'
 import { expectAssignable, expectError, expectType } from 'tsd'
 import { FastifyRequest } from '../../types/request'
 import { FastifyReply } from '../../types/reply'
@@ -130,3 +136,13 @@ expectType<string>(server.printRoutes({ includeHooks: true, commonPrefix: false,
 expectType<string>(server.printRoutes({ includeMeta: ['key1', Symbol('key2')] }))
 
 expectType<string>(server.printRoutes())
+
+server.decorate('test', function (x: string) {
+  expectType<FastifyInstance | any>(this)
+})
+server.decorateRequest('test', function (x: string, y: number) {
+  expectType<FastifyRequest | any>(this)
+})
+server.decorateReply('test', function (x: string) {
+  expectType<FastifyReply | any>(this)
+})

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -146,6 +146,9 @@ server.decorateRequest<(x: string, y: number) => void>('test', function (x: stri
 server.decorateReply<(x: string) => void>('test', function (x: string): void {
   expectType<FastifyReply>(this)
 })
+server.decorate('test', function (x: string): void {
+  expectType<FastifyInstance>(this)
+})
 
 expectError(server.decorate<string>('test', true))
 expectError(server.decorate<(myNumber: number) => number>('test', function (myNumber: number): string {

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -40,9 +40,12 @@ export interface FastifyInstance<
   close(): FastifyInstance<RawServer, RawRequest, RawReply, Logger> & PromiseLike<undefined>;
   close(closeListener: () => void): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
-  // should be able to define something useful with the decorator getter/setter pattern using Generics to enfore the users function returns what they expect it to
+  // should be able to define something useful with the decorator getter/setter pattern using Generics to enforce the users function returns what they expect it to
+  decorate(property: string | symbol, value: (this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>, ...args: any[]) => any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
   decorate(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+  decorateRequest(property: string | symbol, value: (this: FastifyRequest, ...args: any[]) => any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
   decorateRequest(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+  decorateReply(property: string | symbol, value: (this: FastifyReply, ...args: any[]) => any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
   decorateReply(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   hasDecorator(decorator: string | symbol): boolean;

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -41,12 +41,26 @@ export interface FastifyInstance<
   close(closeListener: () => void): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   // should be able to define something useful with the decorator getter/setter pattern using Generics to enforce the users function returns what they expect it to
-  decorate(property: string | symbol, value: (this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>, ...args: any[]) => any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
-  decorate(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
-  decorateRequest(property: string | symbol, value: (this: FastifyRequest, ...args: any[]) => any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
-  decorateRequest(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
-  decorateReply(property: string | symbol, value: (this: FastifyReply, ...args: any[]) => any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
-  decorateReply(property: string | symbol, value: any, dependencies?: string[]): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+  decorate<T>(property: string | symbol,
+    value: T extends (...args: any[]) => any
+      ? (this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>, ...args: Parameters<T>) => ReturnType<T>
+      : T,
+    dependencies?: string[]
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+
+  decorateRequest<T>(property: string | symbol,
+    value: T extends (...args: any[]) => any
+      ? (this: FastifyRequest, ...args: Parameters<T>) => ReturnType<T>
+      : T,
+    dependencies?: string[]
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+
+  decorateReply<T>(property: string | symbol,
+    value: T extends (...args: any[]) => any
+      ? (this: FastifyReply, ...args: Parameters<T>) => ReturnType<T>
+      : T,
+    dependencies?: string[]
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   hasDecorator(decorator: string | symbol): boolean;
   hasRequestDecorator(decorator: string | symbol): boolean;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Just added the correct type for the ``this`` binding in the decorator functions. Additionally I added a note in the documentation that an arrow function in the ``decorate`` function would break the this binding.