### PR TITLE
Update type defs to include new `server` req/rep property

### DIFF
--- a/test/types/reply.test-d.ts
+++ b/test/types/reply.test-d.ts
@@ -3,6 +3,7 @@ import fastify, { RouteHandlerMethod, RouteHandler, RawRequestDefaultExpression,
 import { RawServerDefault, RawReplyDefaultExpression, ContextConfigDefault } from '../../types/utils'
 import { FastifyLoggerInstance } from '../../types/logger'
 import { RouteGenericInterface } from '../../types/route'
+import { FastifyInstance } from '../../types/instance'
 
 const getHandler: RouteHandlerMethod = function (_request, reply) {
   expectType<RawReplyDefaultExpression>(reply.raw)
@@ -29,6 +30,7 @@ const getHandler: RouteHandlerMethod = function (_request, reply) {
   expectType<(fn: (payload: any) => string) => FastifyReply>(reply.serializer)
   expectType<(payload: any) => string>(reply.serialize)
   expectType<(fulfilled: () => void, rejected: (err: Error) => void) => void>(reply.then)
+  expectType<FastifyInstance>(reply.server)
 }
 
 interface ReplyPayload {

--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -4,6 +4,7 @@ import { RawServerDefault, RequestParamsDefault, RequestHeadersDefault, RequestQ
 import { FastifyLoggerInstance } from '../../types/logger'
 import { FastifyRequest } from '../../types/request'
 import { FastifyReply } from '../../types/reply'
+import { FastifyInstance } from '../../types/instance'
 
 interface RequestBody {
   content: string;
@@ -55,6 +56,7 @@ const getHandler: RouteHandler = function (request, _reply) {
   expectType<FastifyLoggerInstance>(request.log)
   expectType<RawRequestDefaultExpression['socket']>(request.socket)
   expectType<Error & { validation: any; validationContext: string } | undefined>(request.validationError)
+  expectType<FastifyInstance>(request.server)
 }
 
 const postHandler: Handler = function (request) {
@@ -66,6 +68,7 @@ const postHandler: Handler = function (request) {
   expectType<string>(request.query.from)
   expectType<number>(request.params.id)
   expectType<string>(request.headers['x-foobar'])
+  expectType<FastifyInstance>(request.server)
 }
 
 function putHandler (request: CustomRequest, reply: FastifyReply) {
@@ -77,6 +80,7 @@ function putHandler (request: CustomRequest, reply: FastifyReply) {
   expectType<string>(request.query.from)
   expectType<number>(request.params.id)
   expectType<string>(request.headers['x-foobar'])
+  expectType<FastifyInstance>(request.server)
 }
 
 const server = fastify()

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -3,6 +3,7 @@ import { FastifyContext } from './context'
 import { FastifyLoggerInstance } from './logger'
 import { FastifyRequest } from './request'
 import { RouteGenericInterface } from './route'
+import { FastifyInstance } from './instance'
 
 export interface ReplyGenericInterface {
   Reply?: ReplyDefault;
@@ -23,6 +24,7 @@ export interface FastifyReply<
   context: FastifyContext<ContextConfig>;
   log: FastifyLoggerInstance;
   request: FastifyRequest<RouteGeneric, RawServer, RawRequest>;
+  server: FastifyInstance;
   code(statusCode: number): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
   status(statusCode: number): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
   statusCode: number;

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -1,6 +1,7 @@
 import { FastifyLoggerInstance } from './logger'
 import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RequestBodyDefault, RequestQuerystringDefault, RequestParamsDefault, RequestHeadersDefault } from './utils'
 import { RouteGenericInterface } from './route'
+import { FastifyInstance } from './instance'
 
 export interface RequestGenericInterface {
   Body?: RequestBodyDefault;
@@ -23,6 +24,7 @@ export interface FastifyRequest<
   raw: RawRequest;
   query: RouteGeneric['Querystring'];
   log: FastifyLoggerInstance;
+  server: FastifyInstance;
   body: RouteGeneric['Body'];
 
   /** in order for this to be used the user should ensure they have set the attachValidation option. */


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### Description

Closes #3202 

Update typescript type definitions for the `request` and `reply` object to include the new `server` property introduced in #3102.
