### PR TITLE
Extend content type parser

### DIFF
--- a/docs/ContentTypeParser.md
+++ b/docs/ContentTypeParser.md
@@ -1,7 +1,7 @@
 <h1 align="center">Fastify</h1>
 
 ## `Content-Type` Parser
-Natively, Fastify only supports `'application/json'` and `'text/plain'` content types. The default charset is `utf-8`. If you need to support different content types, you can use the `addContentTypeParser` API. *The default JSON and/or plain text parser can be changed.*
+Natively, Fastify only supports `'application/json'` and `'text/plain'` content types. The default charset is `utf-8`. If you need to support different content types, you can use the `addContentTypeParser` API. *The default JSON and/or plain text parser can be changed or removed.*
 
 *Note: If you decide to specify your own content type with the `Content-Type` header, UTF-8 will not be the default. Be sure to include UTF-8 like this `text/html; charset=utf-8`.*
 
@@ -56,7 +56,11 @@ fastify.addContentTypeParser('application/vnd.custom', (request, body, done) => 
 fastify.addContentTypeParser('application/vnd.custom+xml', (request, body, done) => {} )
 ```
 
-You can also use the `hasContentTypeParser` API to find if a specific content type parser already exists.
+Besides the `addContentTypeParser` API there are further APIs that can be used. These are `hasContentTypeParser`, `removeContentTypeParser` and `resetContentTypeParsers`.
+
+#### hasContentTypeParser
+
+You can use the `hasContentTypeParser` API to find if a specific content type parser already exists.
 
 ```js
 if (!fastify.hasContentTypeParser('application/jsoff')){
@@ -66,6 +70,40 @@ if (!fastify.hasContentTypeParser('application/jsoff')){
     })
   })
 }
+```
+
+#### removeContentTypeParser
+
+With `removeContentTypeParser` a single or an array of content types can be removed. The method supports `string` and
+`RegExp` content types.
+
+```js
+fastify.addContentTypeParser('text/xml', function (request, payload, done) {
+  xmlParser(payload, function (err, body) {
+    done(err, body)
+  })
+})
+
+// Removes the both built-in content type parsers so that only the content type parser for text/html is available
+fastiy.removeContentTypeParser(['application/json', 'text/plain'])
+```
+
+#### resetContentTypeParsers
+
+In the example from just above, it is noticeable that we need to specify each content type that we want to remove.
+To solve this problem Fastify provides the `resetContentTypeParsers` API. This can be used to remove all currently existing content type parsers.
+In the example below we achieve exactly the same as in the example above except that we do not need to specify each content type to delete.
+Just like `removeContentTypeParser`, this API supports encapsulation. The API is especially useful if you want to register a 
+[catch-all content type parser](####Catch-All) that should be executed for every content type and the built-in parsers should be ignored as well.
+
+```js
+fastiy.resetContentTypeParsers()
+
+fastify.addContentTypeParser('text/xml', function (request, payload, done) {
+  xmlParser(payload, function (err, body) {
+    done(err, body)
+  })
+})
 ```
 
 **Notice**: The old syntaxes `function(req, done)` and `async function(req)` for the parser are still supported but they are deprecated.
@@ -140,3 +178,19 @@ fastify.route({
  ```
 
 For piping file uploads you may want to check out [this plugin](https://github.com/fastify/fastify-multipart).
+
+If you really want the content type parser to be executed on all content types and not only on those that don't have a 
+specific one, you should call the `resetContentTypeParsers` method first.
+
+```js
+// Without this call, the request body with the content type application/json would be processed by the built in json parser
+fastify.resetContentTypeParsers()
+
+fastify.addContentTypeParser('*', function (request, payload, done) {
+  var data = ''
+  payload.on('data', chunk => { data += chunk })
+  payload.on('end', () => {
+    done(null, data)
+  })
+})
+```

--- a/docs/ContentTypeParser.md
+++ b/docs/ContentTypeParser.md
@@ -56,7 +56,7 @@ fastify.addContentTypeParser('application/vnd.custom', (request, body, done) => 
 fastify.addContentTypeParser('application/vnd.custom+xml', (request, body, done) => {} )
 ```
 
-Besides the `addContentTypeParser` API there are further APIs that can be used. These are `hasContentTypeParser`, `removeContentTypeParser` and `resetContentTypeParsers`.
+Besides the `addContentTypeParser` API there are further APIs that can be used. These are `hasContentTypeParser`, `removeContentTypeParser` and `removeAllContentTypeParsers`.
 
 #### hasContentTypeParser
 
@@ -88,16 +88,16 @@ fastify.addContentTypeParser('text/xml', function (request, payload, done) {
 fastiy.removeContentTypeParser(['application/json', 'text/plain'])
 ```
 
-#### resetContentTypeParsers
+#### removeAllContentTypeParsers
 
 In the example from just above, it is noticeable that we need to specify each content type that we want to remove.
-To solve this problem Fastify provides the `resetContentTypeParsers` API. This can be used to remove all currently existing content type parsers.
+To solve this problem Fastify provides the `removeAllContentTypeParsers` API. This can be used to remove all currently existing content type parsers.
 In the example below we achieve exactly the same as in the example above except that we do not need to specify each content type to delete.
 Just like `removeContentTypeParser`, this API supports encapsulation. The API is especially useful if you want to register a 
 [catch-all content type parser](#Catch-All) that should be executed for every content type and the built-in parsers should be ignored as well.
 
 ```js
-fastiy.resetContentTypeParsers()
+fastiy.removeAllContentTypeParsers()
 
 fastify.addContentTypeParser('text/xml', function (request, payload, done) {
   xmlParser(payload, function (err, body) {
@@ -180,11 +180,11 @@ fastify.route({
 For piping file uploads you may want to check out [this plugin](https://github.com/fastify/fastify-multipart).
 
 If you really want the content type parser to be executed on all content types and not only on those that don't have a 
-specific one, you should call the `resetContentTypeParsers` method first.
+specific one, you should call the `removeAllContentTypeParsers` method first.
 
 ```js
 // Without this call, the request body with the content type application/json would be processed by the built in json parser
-fastify.resetContentTypeParsers()
+fastify.removeAllContentTypeParsers()
 
 fastify.addContentTypeParser('*', function (request, payload, done) {
   var data = ''

--- a/docs/ContentTypeParser.md
+++ b/docs/ContentTypeParser.md
@@ -94,7 +94,7 @@ In the example from just above, it is noticeable that we need to specify each co
 To solve this problem Fastify provides the `resetContentTypeParsers` API. This can be used to remove all currently existing content type parsers.
 In the example below we achieve exactly the same as in the example above except that we do not need to specify each content type to delete.
 Just like `removeContentTypeParser`, this API supports encapsulation. The API is especially useful if you want to register a 
-[catch-all content type parser](####Catch-All) that should be executed for every content type and the built-in parsers should be ignored as well.
+[catch-all content type parser](#Catch-All) that should be executed for every content type and the built-in parsers should be ignored as well.
 
 ```js
 fastiy.resetContentTypeParsers()

--- a/fastify.js
+++ b/fastify.js
@@ -273,7 +273,7 @@ function fastify (options) {
     getDefaultJsonParser: ContentTypeParser.defaultParsers.getDefaultJsonParser,
     defaultTextParser: ContentTypeParser.defaultParsers.defaultTextParser,
     removeContentTypeParser: ContentTypeParser.helpers.removeContentTypeParser,
-    resetContentTypeParsers: ContentTypeParser.helpers.resetContentTypeParsers,
+    removeAllContentTypeParsers: ContentTypeParser.helpers.removeAllContentTypeParsers,
     // Fastify architecture methods (initialized by Avvio)
     register: null,
     after: null,

--- a/fastify.js
+++ b/fastify.js
@@ -272,6 +272,8 @@ function fastify (options) {
     hasContentTypeParser: ContentTypeParser.helpers.hasContentTypeParser,
     getDefaultJsonParser: ContentTypeParser.defaultParsers.getDefaultJsonParser,
     defaultTextParser: ContentTypeParser.defaultParsers.defaultTextParser,
+    removeContentTypeParser: ContentTypeParser.helpers.removeContentTypeParser,
+    resetContentTypeParsers: ContentTypeParser.helpers.resetContentTypeParsers,
     // Fastify architecture methods (initialized by Avvio)
     register: null,
     after: null,

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -116,6 +116,27 @@ ContentTypeParser.prototype.getParser = function (contentType) {
   return this.customParsers['']
 }
 
+ContentTypeParser.prototype.reset = function () {
+  this.customParsers = {}
+  this.parserRegExpList = []
+  this.parserList = []
+  this.cache = lru(100)
+}
+
+ContentTypeParser.prototype.remove = function (contentType) {
+  if (!(typeof contentType === 'string' || contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()
+
+  delete this.customParsers[contentType]
+
+  const parsers = typeof contentType === 'string' ? this.parserList : this.parserRegExpList
+
+  const idx = parsers.findIndex(ct => ct.toString() === contentType.toString())
+
+  if (idx > -1) {
+    parsers.splice(idx, 1)
+  }
+}
+
 ContentTypeParser.prototype.run = function (contentType, handler, request, reply) {
   const parser = this.cache.get(contentType) || this.getParser(contentType)
 
@@ -297,11 +318,33 @@ function hasContentTypeParser (contentType) {
   return this[kContentTypeParser].hasParser(contentType)
 }
 
+function removeContentTypeParser (contentType) {
+  if (this[kState].started) {
+    throw new Error('Cannot call "removeContentTypeParser" when fastify instance is already started!')
+  }
+
+  if (Array.isArray(contentType)) {
+    contentType.forEach((type) => this[kContentTypeParser].remove(type))
+  } else {
+    this[kContentTypeParser].remove(contentType)
+  }
+}
+
+function resetContentTypeParsers () {
+  if (this[kState].started) {
+    throw new Error('Cannot call "resetContentTypeParsers" when fastify instance is already started!')
+  }
+
+  this[kContentTypeParser].reset()
+}
+
 module.exports = ContentTypeParser
 module.exports.helpers = {
   buildContentTypeParser,
   addContentTypeParser,
-  hasContentTypeParser
+  hasContentTypeParser,
+  removeContentTypeParser,
+  resetContentTypeParsers
 }
 module.exports.defaultParsers = {
   getDefaultJsonParser,

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -116,7 +116,7 @@ ContentTypeParser.prototype.getParser = function (contentType) {
   return this.customParsers['']
 }
 
-ContentTypeParser.prototype.reset = function () {
+ContentTypeParser.prototype.removeAll = function () {
   this.customParsers = {}
   this.parserRegExpList = []
   this.parserList = []
@@ -324,18 +324,20 @@ function removeContentTypeParser (contentType) {
   }
 
   if (Array.isArray(contentType)) {
-    contentType.forEach((type) => this[kContentTypeParser].remove(type))
+    for (const type of contentType) {
+      this[kContentTypeParser].remove(type)
+    }
   } else {
     this[kContentTypeParser].remove(contentType)
   }
 }
 
-function resetContentTypeParsers () {
+function removeAllContentTypeParsers () {
   if (this[kState].started) {
-    throw new Error('Cannot call "resetContentTypeParsers" when fastify instance is already started!')
+    throw new Error('Cannot call "removeAllContentTypeParsers" when fastify instance is already started!')
   }
 
-  this[kContentTypeParser].reset()
+  this[kContentTypeParser].removeAll()
 }
 
 module.exports = ContentTypeParser
@@ -344,7 +346,7 @@ module.exports.helpers = {
   addContentTypeParser,
   hasContentTypeParser,
   removeContentTypeParser,
-  resetContentTypeParsers
+  removeAllContentTypeParsers
 }
 module.exports.defaultParsers = {
   getDefaultJsonParser,

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -186,3 +186,79 @@ test('add', t => {
 
   t.end()
 })
+
+test('remove', t => {
+  test('should remove default parser', t => {
+    t.plan(2)
+
+    const fastify = Fastify()
+    const contentTypeParser = fastify[keys.kContentTypeParser]
+
+    contentTypeParser.remove('application/json')
+
+    t.notOk(contentTypeParser.customParsers['application/json'])
+    t.notOk(contentTypeParser.parserList.find(parser => parser === 'application/json'))
+  })
+
+  test('should remove RegExp parser', t => {
+    t.plan(2)
+
+    const fastify = Fastify()
+    fastify.addContentTypeParser(/^text\/*/, first)
+
+    const contentTypeParser = fastify[keys.kContentTypeParser]
+
+    contentTypeParser.remove(/^text\/*/)
+
+    t.notOk(contentTypeParser.customParsers[/^text\/*/])
+    t.notOk(contentTypeParser.parserRegExpList.find(parser => parser.toString() === /^text\/*/.toString()))
+  })
+
+  test('should throw an error if content type is neither string nor RegExp', t => {
+    t.plan(1)
+
+    const fastify = Fastify()
+
+    t.throws(() => fastify[keys.kContentTypeParser].remove(12), FST_ERR_CTP_INVALID_TYPE)
+  })
+
+  test('should not throw error if content type does not exist', t => {
+    t.plan(1)
+
+    const fastify = Fastify()
+
+    t.doesNotThrow(() => fastify[keys.kContentTypeParser].remove('image/png'))
+  })
+
+  test('should not remove any content type parser if content type does not exist', t => {
+    t.plan(1)
+
+    const fastify = Fastify()
+
+    const contentTypeParser = fastify[keys.kContentTypeParser]
+
+    contentTypeParser.remove('image/png')
+
+    t.same(Object.keys(contentTypeParser.customParsers).length, 2)
+  })
+
+  t.end()
+})
+
+test('reset should remove all existing parsers and reset cache', t => {
+  t.plan(4)
+
+  const fastify = Fastify()
+  fastify.addContentTypeParser('application/xml', first)
+  fastify.addContentTypeParser(/^image\/.*/, first)
+
+  const contentTypeParser = fastify[keys.kContentTypeParser]
+
+  contentTypeParser.getParser('application/xml') // fill cache with one entry
+  contentTypeParser.reset()
+
+  t.same(contentTypeParser.cache.size, 0)
+  t.same(contentTypeParser.parserList.length, 0)
+  t.same(contentTypeParser.parserRegExpList.length, 0)
+  t.same(Object.keys(contentTypeParser.customParsers).length, 0)
+})

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -245,7 +245,7 @@ test('remove', t => {
   t.end()
 })
 
-test('reset should remove all existing parsers and reset cache', t => {
+test('remove all should remove all existing parsers and reset cache', t => {
   t.plan(4)
 
   const fastify = Fastify()
@@ -255,7 +255,7 @@ test('reset should remove all existing parsers and reset cache', t => {
   const contentTypeParser = fastify[keys.kContentTypeParser]
 
   contentTypeParser.getParser('application/xml') // fill cache with one entry
-  contentTypeParser.reset()
+  contentTypeParser.removeAll()
 
   t.same(contentTypeParser.cache.size, 0)
   t.same(contentTypeParser.parserList.length, 0)

--- a/test/custom-parser.test.js
+++ b/test/custom-parser.test.js
@@ -1504,3 +1504,206 @@ test('should prefer string content types over RegExp ones', t => {
     })
   })
 })
+
+test('removeContentTypeParser should support arrays of content types to remove', t => {
+  t.plan(8)
+
+  const fastify = Fastify()
+
+  fastify.addContentTypeParser('application/xml', function (req, payload, done) {
+    payload.on('data', () => {})
+    payload.on('end', () => {
+      done(null, 'xml')
+    })
+  })
+
+  fastify.addContentTypeParser(/^image\/.*/, function (req, payload, done) {
+    payload.on('data', () => {})
+    payload.on('end', () => {
+      done(null, 'image')
+    })
+  })
+
+  fastify.removeContentTypeParser([/^image\/.*/, 'application/json'])
+
+  fastify.post('/', (req, reply) => {
+    reply.send(req.body)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'POST',
+      url: 'http://localhost:' + fastify.server.address().port,
+      body: '<?xml version="1.0">',
+      headers: {
+        'Content-Type': 'application/xml'
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.same(body.toString(), 'xml')
+    })
+
+    sget({
+      method: 'POST',
+      url: 'http://localhost:' + fastify.server.address().port,
+      body: '',
+      headers: {
+        'Content-Type': 'image/png'
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 415)
+    })
+
+    sget({
+      method: 'POST',
+      url: 'http://localhost:' + fastify.server.address().port,
+      body: '{test: "test"}',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 415)
+      fastify.close()
+    })
+  })
+})
+
+test('removeContentTypeParser should support encapsulation', t => {
+  t.plan(6)
+
+  const fastify = Fastify()
+
+  fastify.addContentTypeParser('application/xml', function (req, payload, done) {
+    payload.on('data', () => {})
+    payload.on('end', () => {
+      done(null, 'xml')
+    })
+  })
+
+  fastify.post('/', (req, reply) => {
+    reply.send(req.body)
+  })
+
+  fastify.register(function (instance, options, done) {
+    instance.removeContentTypeParser('application/xml')
+
+    instance.post('/encapsulated', (req, reply) => {
+      reply.send(req.body)
+    })
+
+    done()
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'POST',
+      url: 'http://localhost:' + fastify.server.address().port + '/encapsulated',
+      body: '<?xml version="1.0">',
+      headers: {
+        'Content-Type': 'application/xml'
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 415)
+    })
+
+    sget({
+      method: 'POST',
+      url: 'http://localhost:' + fastify.server.address().port,
+      body: '<?xml version="1.0">',
+      headers: {
+        'Content-Type': 'application/xml'
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.same(body.toString(), 'xml')
+      fastify.close()
+    })
+  })
+})
+
+test('resetContentTypeParsers should support encapsulation', t => {
+  t.plan(6)
+
+  const fastify = Fastify()
+
+  fastify.post('/', (req, reply) => {
+    reply.send(req.body)
+  })
+
+  fastify.register(function (instance, options, done) {
+    instance.resetContentTypeParsers()
+
+    instance.post('/encapsulated', (req, reply) => {
+      reply.send(req.body)
+    })
+
+    done()
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'POST',
+      url: 'http://localhost:' + fastify.server.address().port + '/encapsulated',
+      body: '{}',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 415)
+    })
+
+    sget({
+      method: 'POST',
+      url: 'http://localhost:' + fastify.server.address().port,
+      body: '{"test":1}',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.same(JSON.parse(body.toString()).test, 1)
+      fastify.close()
+    })
+  })
+})
+
+test('cannot reset content type parsers after binding', t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.listen(0, function (err) {
+    t.error(err)
+
+    t.throws(() => fastify.resetContentTypeParsers())
+  })
+})
+
+test('cannot remove content type parsers after binding', t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.listen(0, function (err) {
+    t.error(err)
+
+    t.throws(() => fastify.removeContentTypeParser('application/json'))
+  })
+})

--- a/test/custom-parser.test.js
+++ b/test/custom-parser.test.js
@@ -1630,7 +1630,7 @@ test('removeContentTypeParser should support encapsulation', t => {
   })
 })
 
-test('resetContentTypeParsers should support encapsulation', t => {
+test('removeAllContentTypeParsers should support encapsulation', t => {
   t.plan(6)
 
   const fastify = Fastify()
@@ -1640,7 +1640,7 @@ test('resetContentTypeParsers should support encapsulation', t => {
   })
 
   fastify.register(function (instance, options, done) {
-    instance.resetContentTypeParsers()
+    instance.removeAllContentTypeParsers()
 
     instance.post('/encapsulated', (req, reply) => {
       reply.send(req.body)
@@ -1680,7 +1680,7 @@ test('resetContentTypeParsers should support encapsulation', t => {
   })
 })
 
-test('cannot reset content type parsers after binding', t => {
+test('cannot remove all content type parsers after binding', t => {
   t.plan(2)
 
   const fastify = Fastify()
@@ -1690,7 +1690,7 @@ test('cannot reset content type parsers after binding', t => {
   fastify.listen(0, function (err) {
     t.error(err)
 
-    t.throws(() => fastify.resetContentTypeParsers())
+    t.throws(() => fastify.removeAllContentTypeParsers())
   })
 })
 

--- a/test/types/content-type-parser.test-d.ts
+++ b/test/types/content-type-parser.test-d.ts
@@ -62,3 +62,11 @@ expectType<FastifyBodyParser<string>>(fastify().getDefaultJsonParser('error', 'i
 expectError(fastify().getDefaultJsonParser('error', 'skip'))
 
 expectError(fastify().getDefaultJsonParser('nothing', 'ignore'))
+
+expectType<void>(fastify().resetContentTypeParsers())
+expectError(fastify().resetContentTypeParsers('contentType'))
+
+expectType<void>(fastify().removeContentTypeParser('contentType'))
+expectType<void>(fastify().removeContentTypeParser(/contentType+.*/))
+expectType<void>(fastify().removeContentTypeParser(['contentType', /contentType+.*/]))
+expectError(fastify().removeContentTypeParser({}))

--- a/test/types/content-type-parser.test-d.ts
+++ b/test/types/content-type-parser.test-d.ts
@@ -63,8 +63,8 @@ expectError(fastify().getDefaultJsonParser('error', 'skip'))
 
 expectError(fastify().getDefaultJsonParser('nothing', 'ignore'))
 
-expectType<void>(fastify().resetContentTypeParsers())
-expectError(fastify().resetContentTypeParsers('contentType'))
+expectType<void>(fastify().removeAllContentTypeParsers())
+expectError(fastify().removeAllContentTypeParsers('contentType'))
 
 expectType<void>(fastify().removeContentTypeParser('contentType'))
 expectType<void>(fastify().removeContentTypeParser(/contentType+.*/))

--- a/types/content-type-parser.d.ts
+++ b/types/content-type-parser.d.ts
@@ -60,3 +60,7 @@ export type ProtoAction = 'error' | 'remove' | 'ignore'
 export type ConstructorAction = 'error' | 'remove' | 'ignore'
 
 export type getDefaultJsonParser = (onProtoPoisoning: ProtoAction, onConstructorPoisoning: ConstructorAction) => FastifyBodyParser<string>
+
+export type removeContentTypeParser = (contentType: string | RegExp | (string | RegExp)[]) => void
+
+export type resetContentTypeParsers = () => void

--- a/types/content-type-parser.d.ts
+++ b/types/content-type-parser.d.ts
@@ -63,4 +63,4 @@ export type getDefaultJsonParser = (onProtoPoisoning: ProtoAction, onConstructor
 
 export type removeContentTypeParser = (contentType: string | RegExp | (string | RegExp)[]) => void
 
-export type resetContentTypeParsers = () => void
+export type removeAllContentTypeParsers = () => void

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -8,7 +8,7 @@ import { onRequestHookHandler, preParsingHookHandler, onSendHookHandler, preVali
 import { FastifyRequest } from './request'
 import { FastifyReply } from './reply'
 import { FastifyError } from 'fastify-error'
-import { AddContentTypeParser, hasContentTypeParser, getDefaultJsonParser, ProtoAction, ConstructorAction, FastifyBodyParser } from './content-type-parser'
+import { AddContentTypeParser, hasContentTypeParser, getDefaultJsonParser, ProtoAction, ConstructorAction, FastifyBodyParser, removeContentTypeParser, resetContentTypeParsers } from './content-type-parser'
 
 export interface PrintRoutesOptions {
   includeMeta?: boolean | (string | symbol)[]
@@ -383,6 +383,14 @@ export interface FastifyInstance<
    */
   addContentTypeParser: AddContentTypeParser<RawServer, RawRequest>;
   hasContentTypeParser: hasContentTypeParser;
+  /**
+   * Remove an existing content type parser
+   */
+  removeContentTypeParser: removeContentTypeParser
+  /**
+   * Reset all content type parsers, including the default ones
+   */
+  resetContentTypeParsers: resetContentTypeParsers
   /**
    * Fastify default JSON parser
    */

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -8,7 +8,7 @@ import { onRequestHookHandler, preParsingHookHandler, onSendHookHandler, preVali
 import { FastifyRequest } from './request'
 import { FastifyReply } from './reply'
 import { FastifyError } from 'fastify-error'
-import { AddContentTypeParser, hasContentTypeParser, getDefaultJsonParser, ProtoAction, ConstructorAction, FastifyBodyParser, removeContentTypeParser, resetContentTypeParsers } from './content-type-parser'
+import { AddContentTypeParser, hasContentTypeParser, getDefaultJsonParser, ProtoAction, ConstructorAction, FastifyBodyParser, removeContentTypeParser, removeAllContentTypeParsers } from './content-type-parser'
 
 export interface PrintRoutesOptions {
   includeMeta?: boolean | (string | symbol)[]
@@ -388,9 +388,9 @@ export interface FastifyInstance<
    */
   removeContentTypeParser: removeContentTypeParser
   /**
-   * Reset all content type parsers, including the default ones
+   * Remove all content type parsers, including the default ones
    */
-  resetContentTypeParsers: resetContentTypeParsers
+  removeAllContentTypeParsers: removeAllContentTypeParsers
   /**
    * Fastify default JSON parser
    */


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Closes #2994. This PR adds the 2 methods `resetContentTypeParsers` and `removeContentTypeParser` to the Fastify instance. With `resetContentTypeParsers` all current content type parser can be deleted (including the both built-in content type parsers). This is especially useful if you want to implement a catch-all content type parser that should be called even if the content type is `application/json`. With `removeContentTypeParser` a single or an array of content type parsers can be removed. Both APIs support encapsulation.

```javascript

const app = fastify()

app.removeContentTypeParser('application/json')

app.resetContentTypeParsers()

```