### PR TITLE
Fix request hanging when synchronously returning a value in setErrorHandler

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -548,8 +548,12 @@ function handleError (reply, error, cb) {
     reply[kReplyErrorHandlerCalled] = true
     reply[kReplyHeaders]['content-length'] = undefined
     const result = errorHandler(error, reply.request, reply)
-    if (result && typeof result.then === 'function') {
-      wrapThenable(result, reply)
+    if (result !== undefined) {
+      if (result !== null && typeof result.then === 'function') {
+        wrapThenable(result, reply)
+      } else {
+        reply.send(result)
+      }
     }
     return
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### Comments

Resolves #3209 

Make setErrorHandler consistent in handling return values, like in lib/handleRequest.js https://github.com/fastify/fastify/blob/7db55d47a80607f97c4fd8e3e54c649abcd78f2f/lib/handleRequest.js#L136-L142