### PR TITLE
feat: update Getting-Started.md

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -176,7 +176,7 @@ async function routes (fastify, options) {
 
   fastify.get('/animals', async (request, reply) => {
     const result = await collection.find().toArray()
-    if (result?.length) {
+    if (result.length === 0) {
       throw new Error('No documents found')
     }
     return result

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -176,7 +176,7 @@ async function routes (fastify, options) {
 
   fastify.get('/animals', async (request, reply) => {
     const result = await collection.find().toArray()
-    if (result.length === 0) {
+    if (result?.length) {
       throw new Error('No documents found')
     }
     return result
@@ -184,7 +184,7 @@ async function routes (fastify, options) {
 
   fastify.get('/animals/:animal', async (request, reply) => {
     const result = await collection.findOne({ animal: request.params.animal })
-    if (result === null) {
+    if (!result) {
       throw new Error('Invalid value')
     }
     return result


### PR DESCRIPTION
- [x] documentation is changed or added

With current example from Getting-started.md, I get this error and server doesn't resolve anything.

"name":"FastifyError"
"code":"FST_ERR_PROMISE_NOT_FULFILLED","statusCode":500}
"msg":"Promise may not be fulfilled with 'undefined' when statusCode is not 204"

Because "result" return undefined with an empty dataset and check only for null values doesn't avoid the exception.