### PR TITLE
fix generic constraint type

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -122,7 +122,7 @@ export type FastifyServerOptions<
     deriveVersion<Context>(req: Object, ctx?: Context): string // not a fan of using Object here. Also what is Context? Can either of these be better defined?
   },
   constraints?: {
-    [name: string]: ConstraintStrategy<FindMyWayVersion<RawServer>>,
+    [name: string]: ConstraintStrategy<FindMyWayVersion<RawServer>, unknown>,
   },
   return503OnClosing?: boolean,
   ajv?: {

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -135,6 +135,18 @@ expectAssignable<FastifyInstance>(fastify({
       }),
       validate () {},
       deriveConstraint: () => 'foo'
+    },
+    withObjectValue: {
+      name: 'withObjectValue',
+      storage: () => ({
+        get: () => () => {},
+        set: () => { },
+        del: () => { },
+        empty: () => { }
+      }),
+      validate () {},
+      deriveConstraint: () => {}
+
     }
   }
 }))


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Since `find-my-way` version 4.1 it is possible to specify a generic type for the value of a constraint. The default type of this generic parameter is `string`. This makes it impossible to register constraints that have a value type other than string. The following example produces the error `Type 'ConstraintStrategy<HTTPVersion.V1, number>' is not assignable to type 'ConstraintStrategy<HTTPVersion.V1, string>'. Type 'number' is not assignable to type 'string'.`.

```typescript
import fastify from 'fastify'
import { ConstraintStrategy, HTTPVersion, Req, Handler} from 'find-my-way'

const constraintStrategy: ConstraintStrategy<HTTPVersion.V1, number> = {
  deriveConstraint<Context>(req: Req<HTTPVersion.V1>, ctx: Context | undefined): number {
    return 0
  },
  mustMatchWhenDerived: false,
  name: "myStrategy",
  storage() {
    return {
      get(value: number): Handler<HTTPVersion.V1> | null {
        return null
      },
      set(value: number, handler: Handler<HTTPVersion.V1>): void {},
      del(value: number): void {},
      empty(): void {}
    }
  },
  validate(value: unknown): void {
  }
}

const app = fastify({
  constraints: {
    constraintStrategy
  }
})
```
Setting the generic type to `unknown` solves this issue.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
