### PR TITLE
docs: fix import wrong statement

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -599,7 +599,7 @@ The Fastify API is powered by the `fastify()` method. In JavaScript you would im
      const f = fastify()
      f.listen(8080, () => { console.log('running') })
      ```
-   - Destructuring is still supported, but will also not resolve types
+   - Destructuring is supported and will resolve types properly
      ```typescript
      const { fastify } = require('fastify')
 


### PR DESCRIPTION
Not solving #3244 , but correct the wrong statement.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
