### PR TITLE
Fixed socket leakage in TLS connection

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -541,9 +541,8 @@ function fastify (options) {
 
   function defaultClientErrorHandler (err, socket) {
     // In case of a connection reset, the socket has been destroyed and there is nothing that needs to be done.
-    // https://github.com/fastify/fastify/issues/2036
-    // https://github.com/nodejs/node/issues/33302
-    if (err.code === 'ECONNRESET') {
+    // https://nodejs.org/api/http.html#http_event_clienterror
+    if (err.code === 'ECONNRESET' || !socket.writable) {
       return
     }
 

--- a/fastify.js
+++ b/fastify.js
@@ -542,7 +542,7 @@ function fastify (options) {
   function defaultClientErrorHandler (err, socket) {
     // In case of a connection reset, the socket has been destroyed and there is nothing that needs to be done.
     // https://nodejs.org/api/http.html#http_event_clienterror
-    if (err.code === 'ECONNRESET' || !socket.writable) {
+    if (err.code === 'ECONNRESET' || socket.destroyed) {
       return
     }
 
@@ -556,11 +556,14 @@ function fastify (options) {
     // In the vast majority of cases, it's a network error and/or some
     // config issue on the load balancer side.
     this.log.trace({ err }, 'client error')
+    // Copying standard node behaviour
+    // https://github.com/nodejs/node/blob/6ca23d7846cb47e84fd344543e394e50938540be/lib/_http_server.js#L666
 
     // If the socket is not writable, there is no reason to try to send data.
-    if (socket.writable) {
-      socket.end(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n${body}`)
+    if (socket.writable && socket.bytesWritten === 0) {
+      socket.write(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n${body}`)
     }
+    socket.destroy(err)
   }
 
   // If the router does not match any route, every request will land here


### PR DESCRIPTION
1. Added check for writable state of the socket before trying to end request gracefully
2. Node.js updated their official documentation, so I changed link to the issue with a link to their official documentation

Fixes #3251

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
