### PR TITLE
ci: automerge only minor semver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,4 @@ jobs:
       - uses: fastify/github-action-merge-dependabot@v2.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          target: minor


### PR DESCRIPTION
We should not merge major into the project if the ci is green because a module may drop a Node.js supported by fastify

examples:
https://github.com/fastify/fastify/pull/3263
https://github.com/fastify/light-my-request/pull/132


#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
