### PR TITLE
adding type for fastify.routing

### DIFF
--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -2,8 +2,8 @@ import fastify, {
   FastifyBodyParser,
   FastifyError,
   FastifyInstance,
-  FastifyLoggerInstance,
-  ValidationResult
+  RawReplyDefaultExpression,
+  RawRequestDefaultExpression
 } from '../../fastify'
 import { expectAssignable, expectError, expectNotAssignable, expectType } from 'tsd'
 import { FastifyRequest } from '../../types/request'
@@ -99,6 +99,8 @@ expectAssignable<PromiseLike<string>>(server.listen({ port: 3000, host: '0.0.0.0
 expectAssignable<void>(server.listen({ port: 3000 }, () => {}))
 expectAssignable<void>(server.listen({ port: 3000, host: '0.0.0.0' }, () => {}))
 expectAssignable<void>(server.listen({ port: 3000, host: '0.0.0.0', backlog: 42 }, () => {}))
+
+expectAssignable<void>(server.routing({} as RawRequestDefaultExpression, {} as RawReplyDefaultExpression))
 
 expectType<FastifyInstance>(fastify().get('/', {
   handler: () => {},

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -82,6 +82,7 @@ export interface FastifyInstance<
 
   register: FastifyRegister<FastifyInstance<RawServer, RawRequest, RawReply, Logger> & PromiseLike<undefined>>;
 
+  routing(req: RawRequest, res: RawReply): void;
   getDefaultRoute: DefaultRoute<RawRequest, RawReply>;
   setDefaultRoute(defaultRoute: DefaultRoute<RawRequest, RawReply>): void;
 


### PR DESCRIPTION
adding missing type declaration for https://www.fastify.io/docs/latest/Server/#routing