### PR TITLE
Payload validation

### DIFF
--- a/docs/ContentTypeParser.md
+++ b/docs/ContentTypeParser.md
@@ -9,6 +9,9 @@ As with the other APIs, `addContentTypeParser` is encapsulated in the scope in w
 
 Fastify automatically adds the parsed request payload to the [Fastify request](Request.md) object which you can access with `request.body`.
 
+Note that for `GET` and `HEAD` requests the payload is never parsed. For `OPTIONS` and `DELETE` requests the payload is only parsed if 
+the content type is given in the content-type header. If it is not given, the [catch-all](#catch-all) parser is not executed as with `POST`, `PUT` and `PATCH`, but the payload is simply not parsed.
+
 ### Usage
 ```js
 fastify.addContentTypeParser('application/jsoff', function (request, payload, done) {

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -34,7 +34,9 @@ fastify.route(options)
 They need to be in
   [JSON Schema](https://json-schema.org/) format, check [here](Validation-and-Serialization.md) for more info.
 
-  * `body`: validates the body of the request if it is a POST, PUT, or PATCH method.
+  * `body`: validates the body of the request if it is a `'POST'`, `'PUT'`, `'PATCH'`, `'OPTIONS'` or `'DELETE'` method.
+            Validation can only be successful if the request payload has been parsed by a content type parser before.
+            See [here](ContentTypeParser.md) for more details.
   * `querystring` or `query`: validates the querystring. This can be a complete JSON
   Schema object, with the property `type` of `object` and `properties` object of parameters, or
   simply the values of what would be contained in the `properties` object as shown below.

--- a/lib/route.js
+++ b/lib/route.js
@@ -137,10 +137,18 @@ function buildRouting (options) {
         if (supportedMethods.indexOf(method) === -1) {
           throw new Error(`${method} method is not supported!`)
         }
+
+        if ((method === 'GET' || method === 'HEAD') && opts.schema && opts.schema.body) {
+          throw new Error('Body validation schemas for GET and HEAD routes are not supported!')
+        }
       }
     } else {
       if (supportedMethods.indexOf(opts.method) === -1) {
         throw new Error(`${opts.method} method is not supported!`)
+      }
+
+      if ((opts.method === 'GET' || opts.method === 'HEAD') && opts.schema && opts.schema.body) {
+        throw new Error('Body validation schemas for GET and HEAD routes are not supported!')
       }
     }
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -123,6 +123,10 @@ function buildRouting (options) {
     return route.call(this, options)
   }
 
+  function shouldNotContainBodyValidationSchema (method, schema) {
+    return (method === 'GET' || method === 'HEAD') && schema && schema.body
+  }
+
   // Route management
   function route (options) {
     // Since we are mutating/assigning only top level props, it is fine to have a shallow copy using the spread operator
@@ -138,7 +142,7 @@ function buildRouting (options) {
           throw new Error(`${method} method is not supported!`)
         }
 
-        if ((method === 'GET' || method === 'HEAD') && opts.schema && opts.schema.body) {
+        if (shouldNotContainBodyValidationSchema(method, opts.schema)) {
           throw new Error('Body validation schemas for GET and HEAD routes are not supported!')
         }
       }
@@ -147,7 +151,7 @@ function buildRouting (options) {
         throw new Error(`${opts.method} method is not supported!`)
       }
 
-      if ((opts.method === 'GET' || opts.method === 'HEAD') && opts.schema && opts.schema.body) {
+      if (shouldNotContainBodyValidationSchema(opts.method, opts.schema)) {
         throw new Error('Body validation schemas for GET and HEAD routes are not supported!')
       }
     }

--- a/lib/route.js
+++ b/lib/route.js
@@ -123,10 +123,6 @@ function buildRouting (options) {
     return route.call(this, options)
   }
 
-  function shouldNotContainBodyValidationSchema (method, schema) {
-    return (method === 'GET' || method === 'HEAD') && schema && schema.body
-  }
-
   // Route management
   function route (options) {
     // Since we are mutating/assigning only top level props, it is fine to have a shallow copy using the spread operator
@@ -134,41 +130,28 @@ function buildRouting (options) {
 
     throwIfAlreadyStarted('Cannot add route when fastify instance is already started!')
 
+    const path = opts.url || opts.path || ''
+
     if (Array.isArray(opts.method)) {
       // eslint-disable-next-line no-var
       for (var i = 0; i < opts.method.length; ++i) {
-        const method = opts.method[i]
-        if (supportedMethods.indexOf(method) === -1) {
-          throw new Error(`${method} method is not supported!`)
-        }
-
-        if (shouldNotContainBodyValidationSchema(method, opts.schema)) {
-          throw new Error('Body validation schemas for GET and HEAD routes are not supported!')
-        }
+        validateMethodAndSchemaBodyOption(opts.method[i], path, opts.schema)
       }
     } else {
-      if (supportedMethods.indexOf(opts.method) === -1) {
-        throw new Error(`${opts.method} method is not supported!`)
-      }
-
-      if (shouldNotContainBodyValidationSchema(opts.method, opts.schema)) {
-        throw new Error('Body validation schemas for GET and HEAD routes are not supported!')
-      }
+      validateMethodAndSchemaBodyOption(opts.method, path, opts.schema)
     }
 
     if (!opts.handler) {
-      throw new Error(`Missing handler function for ${opts.method}:${opts.url} route.`)
+      throw new Error(`Missing handler function for ${opts.method}:${path} route.`)
     }
 
     if (opts.errorHandler !== undefined && typeof opts.errorHandler !== 'function') {
-      throw new Error(`Error Handler for ${opts.method}:${opts.url} route, if defined, must be a function`)
+      throw new Error(`Error Handler for ${opts.method}:${path} route, if defined, must be a function`)
     }
 
     validateBodyLimitOption(opts.bodyLimit)
 
     const prefix = this[kRoutePrefix]
-
-    const path = opts.url || opts.path || ''
 
     if (path === '/' && prefix.length > 0 && opts.method !== 'HEAD') {
       switch (opts.prefixTrailingSlash) {
@@ -399,6 +382,16 @@ function handleTimeout () {
     reply,
     noop
   )
+}
+
+function validateMethodAndSchemaBodyOption (method, path, schema) {
+  if (supportedMethods.indexOf(method) === -1) {
+    throw new Error(`${method} method is not supported!`)
+  }
+
+  if ((method === 'GET' || method === 'HEAD') && schema && schema.body) {
+    throw new Error(`Body validation schema for ${method}:${path} route is not supported!`)
+  }
 }
 
 function validateBodyLimitOption (bodyLimit) {

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -1383,3 +1383,39 @@ test('[HEAD, GET] route with body schema should throw', t => {
     })
   }, new Error('Body validation schemas for GET and HEAD routes are not supported!'))
 })
+
+test('GET route with body schema should throw - shorthand', t => {
+  t.plan(1)
+
+  const fastify = Fastify()
+
+  t.throws(() => {
+    fastify.get('/shouldThrow', {
+      schema: {
+        body: {}
+      }
+    },
+    function (req, reply) {
+      reply.send({ hello: 'world' })
+    }
+    )
+  }, new Error('Body validation schemas for GET and HEAD routes are not supported!'))
+})
+
+test('HEAD route with body schema should throw - shorthand', t => {
+  t.plan(1)
+
+  const fastify = Fastify()
+
+  t.throws(() => {
+    fastify.head('/shouldThrow', {
+      schema: {
+        body: {}
+      }
+    },
+    function (req, reply) {
+      reply.send({ hello: 'world' })
+    }
+    )
+  }, new Error('Body validation schemas for GET and HEAD routes are not supported!'))
+})

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -1326,3 +1326,60 @@ test('Will not try to re-createprefixed HEAD route if it already exists and expo
 
   t.ok(true)
 })
+
+test('GET route with body schema should throw', t => {
+  t.plan(1)
+
+  const fastify = Fastify()
+
+  t.throws(() => {
+    fastify.route({
+      method: 'GET',
+      path: '/shouldThrow',
+      schema: {
+        body: {}
+      },
+      handler: function (req, reply) {
+        reply.send({ hello: 'world' })
+      }
+    })
+  })
+})
+
+test('HEAD route with body schema should throw', t => {
+  t.plan(1)
+
+  const fastify = Fastify()
+
+  t.throws(() => {
+    fastify.route({
+      method: 'HEAD',
+      path: '/shouldThrow',
+      schema: {
+        body: {}
+      },
+      handler: function (req, reply) {
+        reply.send({ hello: 'world' })
+      }
+    })
+  })
+})
+
+test('[HEAD, GET] route with body schema should throw', t => {
+  t.plan(1)
+
+  const fastify = Fastify()
+
+  t.throws(() => {
+    fastify.route({
+      method: ['HEAD', 'GET'],
+      path: '/shouldThrow',
+      schema: {
+        body: {}
+      },
+      handler: function (req, reply) {
+        reply.send({ hello: 'world' })
+      }
+    })
+  })
+})

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -1335,7 +1335,7 @@ test('GET route with body schema should throw', t => {
   t.throws(() => {
     fastify.route({
       method: 'GET',
-      path: '/shouldThrow',
+      path: '/get',
       schema: {
         body: {}
       },
@@ -1343,7 +1343,7 @@ test('GET route with body schema should throw', t => {
         reply.send({ hello: 'world' })
       }
     })
-  }, new Error('Body validation schemas for GET and HEAD routes are not supported!'))
+  }, new Error('Body validation schema for GET:/get route is not supported!'))
 })
 
 test('HEAD route with body schema should throw', t => {
@@ -1362,7 +1362,7 @@ test('HEAD route with body schema should throw', t => {
         reply.send({ hello: 'world' })
       }
     })
-  }, new Error('Body validation schemas for GET and HEAD routes are not supported!'))
+  }, new Error('Body validation schema for HEAD:/shouldThrow route is not supported!'))
 })
 
 test('[HEAD, GET] route with body schema should throw', t => {
@@ -1373,7 +1373,7 @@ test('[HEAD, GET] route with body schema should throw', t => {
   t.throws(() => {
     fastify.route({
       method: ['HEAD', 'GET'],
-      path: '/shouldThrow',
+      path: '/shouldThrowHead',
       schema: {
         body: {}
       },
@@ -1381,7 +1381,7 @@ test('[HEAD, GET] route with body schema should throw', t => {
         reply.send({ hello: 'world' })
       }
     })
-  }, new Error('Body validation schemas for GET and HEAD routes are not supported!'))
+  }, new Error('Body validation schema for HEAD:/shouldThrowHead route is not supported!'))
 })
 
 test('GET route with body schema should throw - shorthand', t => {
@@ -1399,7 +1399,7 @@ test('GET route with body schema should throw - shorthand', t => {
       reply.send({ hello: 'world' })
     }
     )
-  }, new Error('Body validation schemas for GET and HEAD routes are not supported!'))
+  }, new Error('Body validation schema for GET:/shouldThrow route is not supported!'))
 })
 
 test('HEAD route with body schema should throw - shorthand', t => {
@@ -1408,7 +1408,7 @@ test('HEAD route with body schema should throw - shorthand', t => {
   const fastify = Fastify()
 
   t.throws(() => {
-    fastify.head('/shouldThrow', {
+    fastify.head('/shouldThrow2', {
       schema: {
         body: {}
       }
@@ -1417,5 +1417,5 @@ test('HEAD route with body schema should throw - shorthand', t => {
       reply.send({ hello: 'world' })
     }
     )
-  }, new Error('Body validation schemas for GET and HEAD routes are not supported!'))
+  }, new Error('Body validation schema for HEAD:/shouldThrow2 route is not supported!'))
 })

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -1343,7 +1343,7 @@ test('GET route with body schema should throw', t => {
         reply.send({ hello: 'world' })
       }
     })
-  })
+  }, new Error('Body validation schemas for GET and HEAD routes are not supported!'))
 })
 
 test('HEAD route with body schema should throw', t => {
@@ -1362,7 +1362,7 @@ test('HEAD route with body schema should throw', t => {
         reply.send({ hello: 'world' })
       }
     })
-  })
+  }, new Error('Body validation schemas for GET and HEAD routes are not supported!'))
 })
 
 test('[HEAD, GET] route with body schema should throw', t => {
@@ -1381,5 +1381,5 @@ test('[HEAD, GET] route with body schema should throw', t => {
         reply.send({ hello: 'world' })
       }
     })
-  })
+  }, new Error('Body validation schemas for GET and HEAD routes are not supported!'))
 })

--- a/test/schema-examples.test.js
+++ b/test/schema-examples.test.js
@@ -431,7 +431,7 @@ test('Example - schemas examples', t => {
     }
   }
 
-  fastify.get('/', {
+  fastify.post('/', {
     handler,
     schema: {
       body: refToId,

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -826,7 +826,7 @@ test('Validation context in validation result', t => {
     t.equal(err.validationContext, 'body')
     reply.send()
   })
-  fastify.get('/', {
+  fastify.post('/', {
     handler: echoParams,
     schema: {
       body: {
@@ -839,7 +839,7 @@ test('Validation context in validation result', t => {
     }
   })
   fastify.inject({
-    method: 'GET',
+    method: 'POST',
     url: '/',
     payload: {} // body lacks required field, will fail validation
   }, (err, res) => {
@@ -880,7 +880,7 @@ test('The schema build should not modify the input', t => {
     ]
   })
 
-  fastify.get('/', {
+  fastify.post('/', {
     schema: {
       description: 'get',
       body: { $ref: 'second#' },
@@ -949,14 +949,14 @@ test('Cross schema reference with encapsulation references', t => {
     }
 
     instance.get('/get', { schema: { response: { 200: multipleRef } } }, () => { })
-    instance.get('/double-get', { schema: { body: multipleRef, response: { 200: multipleRef } } }, () => { })
+    instance.get('/double-get', { schema: { querystring: multipleRef, response: { 200: multipleRef } } }, () => { })
     instance.post('/post', { schema: { body: multipleRef, response: { 200: multipleRef } } }, () => { })
     instance.post('/double', { schema: { response: { 200: { $ref: 'encapsulation' } } } }, () => { })
     done()
   }, { prefix: '/foo' })
 
   fastify.post('/post', { schema: { body: refItem, response: { 200: refItem } } }, () => { })
-  fastify.get('/get', { schema: { body: refItem, response: { 200: refItem } } }, () => { })
+  fastify.get('/get', { schema: { params: refItem, response: { 200: refItem } } }, () => { })
 
   fastify.ready(err => {
     t.error(err)
@@ -1008,7 +1008,7 @@ test('onReady hook has the compilers ready', t => {
   fastify.get(`/${Math.random()}`, {
     handler: (req, reply) => reply.send(),
     schema: {
-      body: { type: 'object' },
+      headers: { type: 'object' },
       response: { 200: { type: 'object' } }
     }
   })
@@ -1098,7 +1098,7 @@ test('Check how many AJV instances are built #2 - verify validatorPool', t => {
 })
 
 function addRandomRoute (server) {
-  server.get(`/${Math.random()}`,
+  server.post(`/${Math.random()}`,
     { schema: { body: { type: 'object' } } },
     (req, reply) => reply.send()
   )


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Closes #3266. An error is now thrown if a body validation schema is specified for `GET` or `HEAD` routes. The docs also explain now that the request body validation is only available for `POST, PUT, PATCH, DELETE and OPTION` requests. The content-type parser documentation also now provides a more detailed explanation of when the request payload is parsed and when it is not.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
