### PR TITLE
fix error messages

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -143,12 +143,14 @@ function buildRouting (options) {
       }
     }
 
+    const path = opts.url || opts.path
+
     if (!opts.handler) {
-      throw new Error(`Missing handler function for ${opts.method}:${opts.url} route.`)
+      throw new Error(`Missing handler function for ${opts.method}:${path} route.`)
     }
 
     if (opts.errorHandler !== undefined && typeof opts.errorHandler !== 'function') {
-      throw new Error(`Error Handler for ${opts.method}:${opts.url} route, if defined, must be a function`)
+      throw new Error(`Error Handler for ${opts.method}:${path} route, if defined, must be a function`)
     }
 
     validateBodyLimitOption(opts.bodyLimit)
@@ -156,7 +158,6 @@ function buildRouting (options) {
     const prefix = this[kRoutePrefix]
 
     this.after((notHandledErr, done) => {
-      const path = opts.url || opts.path
       if (path === '/' && prefix.length && opts.method !== 'HEAD') {
         switch (opts.prefixTrailingSlash) {
           case 'slash':

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -1246,3 +1246,25 @@ test('Will not try to re-createprefixed HEAD route if it already exists and expo
 
   t.ok(true)
 })
+
+test('Correct error message is produced if "path" option is used', t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  t.throws(() => {
+    fastify.route({
+      method: 'GET',
+      path: '/test'
+    })
+  }, new Error('Missing handler function for GET:/test route.'))
+
+  t.throws(() => {
+    fastify.route({
+      method: 'POST',
+      url: '/test',
+      handler: function () {},
+      errorHandler: ''
+    })
+  }, new Error('Error Handler for POST:/test route, if defined, must be a function'))
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Fixes a bug where incorrect error messages were produced when using the `path` option instead of the `url` option for the route declaration with `route`method.

So
```javascript
fastify.route({
      method: 'GET',
      path: '/test'
    })
```
would produce the error message: `Missing handler function for GET:undefined route.`

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
