### PR TITLE
fix headers no longer readonly

### DIFF
--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd'
 import fastify, { RouteHandler, RawRequestDefaultExpression, RequestBodyDefault, RequestGenericInterface } from '../../fastify'
-import { RawServerDefault, RequestParamsDefault, RequestHeadersDefault, RequestQuerystringDefault, RawReplyDefaultExpression } from '../../types/utils'
+import { RequestParamsDefault, RequestHeadersDefault, RequestQuerystringDefault } from '../../types/utils'
 import { FastifyLoggerInstance } from '../../types/logger'
 import { FastifyRequest } from '../../types/request'
 import { FastifyReply } from '../../types/reply'
@@ -50,7 +50,10 @@ const getHandler: RouteHandler = function (request, _reply) {
   expectType<RawRequestDefaultExpression>(request.raw)
   expectType<RequestBodyDefault>(request.body)
   expectType<RequestParamsDefault>(request.params)
+
   expectType<RequestHeadersDefault & RawRequestDefaultExpression['headers']>(request.headers)
+  request.headers = {}
+
   expectType<RequestQuerystringDefault>(request.query)
   expectType<any>(request.id)
   expectType<FastifyLoggerInstance>(request.log)

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -23,6 +23,7 @@ export interface FastifyRequest<
   params: RouteGeneric['Params'];
   raw: RawRequest;
   query: RouteGeneric['Querystring'];
+  headers: RawRequest['headers'] & RouteGeneric['Headers']; // this enables the developer to extend the existing http(s|2) headers list
   log: FastifyLoggerInstance;
   server: FastifyInstance;
   body: RouteGeneric['Body'];
@@ -34,7 +35,6 @@ export interface FastifyRequest<
    * @deprecated Use `raw` property
    */
   readonly req: RawRequest;
-  readonly headers: RawRequest['headers'] & RouteGeneric['Headers']; // this enables the developer to extend the existing http(s|2) headers list
   readonly ip: string;
   readonly ips?: string[];
   readonly hostname: string;


### PR DESCRIPTION
Fixing types declaration for `request.headers` - its no longer a readonly property following #2817 which added the ability to set custom headers

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
