### PR TITLE
Increase http2SessionTimeout and keepAliveTimeout to 72 seconds

### DIFF
--- a/build/build-validation.js
+++ b/build/build-validation.js
@@ -23,7 +23,7 @@ module.exports.defaultInitOptions = ${JSON.stringify(defaultInitOptions)}
 
 const defaultInitOptions = {
   connectionTimeout: 0, // 0 sec
-  keepAliveTimeout: 5000, // 5 sec
+  keepAliveTimeout: 72000, // 72 seconds
   bodyLimit: 1024 * 1024, // 1 MiB
   caseSensitive: true,
   disableRequestLogging: false,
@@ -35,7 +35,7 @@ const defaultInitOptions = {
   pluginTimeout: 10000,
   requestIdHeader: 'request-id',
   requestIdLogLabel: 'reqId',
-  http2SessionTimeout: 5000,
+  http2SessionTimeout: 72000, // 72 seconds
   exposeHeadRoutes: true
 }
 

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -48,7 +48,7 @@ Defines the server keep-alive timeout in milliseconds. See documentation for
 to understand the effect of this option. This option only applies when HTTP/1
 is in use. Also, when `serverFactory` option is specified, this option is ignored.
 
-+ Default: `5000` (5 seconds)
++ Default: `72000` (72 seconds)
 
 <a name="factory-ignore-slash"></a>
 ### `ignoreTrailingSlash`
@@ -438,7 +438,7 @@ const fastify = require('fastify')({
 ### `http2SessionTimeout`
 
 Set a default
-[timeout](https://nodejs.org/api/http2.html#http2_http2session_settimeout_msecs_callback) to every incoming HTTP/2 session. The session will be closed on the timeout. Default: `5000` ms.
+[timeout](https://nodejs.org/api/http2.html#http2_http2session_settimeout_msecs_callback) to every incoming HTTP/2 session. The session will be closed on the timeout. Default: `72000` ms.
 
 Note that this is needed to offer the graceful "close" experience when using HTTP/2. 
 The low default has been chosen to mitigate denial of service attacks. 

--- a/lib/configValidator.js
+++ b/lib/configValidator.js
@@ -3,7 +3,7 @@
 "use strict";
 module.exports = validate10;
 module.exports.default = validate10;
-const schema11 = {"type":"object","additionalProperties":false,"properties":{"connectionTimeout":{"type":"integer","default":0},"keepAliveTimeout":{"type":"integer","default":5000},"bodyLimit":{"type":"integer","default":1048576},"caseSensitive":{"type":"boolean","default":true},"http2":{"type":"boolean"},"https":{"if":{"not":{"oneOf":[{"type":"boolean"},{"type":"null"},{"type":"object","additionalProperties":false,"required":["allowHTTP1"],"properties":{"allowHTTP1":{"type":"boolean"}}}]}},"then":{"setDefaultValue":true}},"ignoreTrailingSlash":{"type":"boolean","default":false},"disableRequestLogging":{"type":"boolean","default":false},"jsonShorthand":{"type":"boolean","default":true},"maxParamLength":{"type":"integer","default":100},"onProtoPoisoning":{"type":"string","default":"error"},"onConstructorPoisoning":{"type":"string","default":"error"},"pluginTimeout":{"type":"integer","default":10000},"requestIdHeader":{"type":"string","default":"request-id"},"requestIdLogLabel":{"type":"string","default":"reqId"},"http2SessionTimeout":{"type":"integer","default":5000},"exposeHeadRoutes":{"type":"boolean","default":true},"versioning":{"type":"object","additionalProperties":true,"required":["storage","deriveVersion"],"properties":{"storage":{},"deriveVersion":{}}},"constraints":{"type":"object","additionalProperties":{"type":"object","required":["name","storage","validate","deriveConstraint"],"additionalProperties":true,"properties":{"name":{"type":"string"},"storage":{},"validate":{},"deriveConstraint":{}}}}}};
+const schema11 = {"type":"object","additionalProperties":false,"properties":{"connectionTimeout":{"type":"integer","default":0},"keepAliveTimeout":{"type":"integer","default":72000},"bodyLimit":{"type":"integer","default":1048576},"caseSensitive":{"type":"boolean","default":true},"http2":{"type":"boolean"},"https":{"if":{"not":{"oneOf":[{"type":"boolean"},{"type":"null"},{"type":"object","additionalProperties":false,"required":["allowHTTP1"],"properties":{"allowHTTP1":{"type":"boolean"}}}]}},"then":{"setDefaultValue":true}},"ignoreTrailingSlash":{"type":"boolean","default":false},"disableRequestLogging":{"type":"boolean","default":false},"jsonShorthand":{"type":"boolean","default":true},"maxParamLength":{"type":"integer","default":100},"onProtoPoisoning":{"type":"string","default":"error"},"onConstructorPoisoning":{"type":"string","default":"error"},"pluginTimeout":{"type":"integer","default":10000},"requestIdHeader":{"type":"string","default":"request-id"},"requestIdLogLabel":{"type":"string","default":"reqId"},"http2SessionTimeout":{"type":"integer","default":72000},"exposeHeadRoutes":{"type":"boolean","default":true},"versioning":{"type":"object","additionalProperties":true,"required":["storage","deriveVersion"],"properties":{"storage":{},"deriveVersion":{}}},"constraints":{"type":"object","additionalProperties":{"type":"object","required":["name","storage","validate","deriveConstraint"],"additionalProperties":true,"properties":{"name":{"type":"string"},"storage":{},"validate":{},"deriveConstraint":{}}}}}};
 const func4 = Object.prototype.hasOwnProperty;
 
 function validate10(data, {instancePath="", parentData, parentDataProperty, rootData=data}={}){
@@ -15,7 +15,7 @@ if(data.connectionTimeout === undefined){
 data.connectionTimeout = 0;
 }
 if(data.keepAliveTimeout === undefined){
-data.keepAliveTimeout = 5000;
+data.keepAliveTimeout = 72000;
 }
 if(data.bodyLimit === undefined){
 data.bodyLimit = 1048576;
@@ -51,7 +51,7 @@ if(data.requestIdLogLabel === undefined){
 data.requestIdLogLabel = "reqId";
 }
 if(data.http2SessionTimeout === undefined){
-data.http2SessionTimeout = 5000;
+data.http2SessionTimeout = 72000;
 }
 if(data.exposeHeadRoutes === undefined){
 data.exposeHeadRoutes = true;
@@ -816,4 +816,4 @@ return errors === 0;
 }
 
 
-module.exports.defaultInitOptions = {"connectionTimeout":0,"keepAliveTimeout":5000,"bodyLimit":1048576,"caseSensitive":true,"disableRequestLogging":false,"jsonShorthand":true,"ignoreTrailingSlash":false,"maxParamLength":100,"onProtoPoisoning":"error","onConstructorPoisoning":"error","pluginTimeout":10000,"requestIdHeader":"request-id","requestIdLogLabel":"reqId","http2SessionTimeout":5000,"exposeHeadRoutes":true}
+module.exports.defaultInitOptions = {"connectionTimeout":0,"keepAliveTimeout":72000,"bodyLimit":1048576,"caseSensitive":true,"disableRequestLogging":false,"jsonShorthand":true,"ignoreTrailingSlash":false,"maxParamLength":100,"onProtoPoisoning":"error","onConstructorPoisoning":"error","pluginTimeout":10000,"requestIdHeader":"request-id","requestIdLogLabel":"reqId","http2SessionTimeout":72000,"exposeHeadRoutes":true}

--- a/test/internals/initialConfig.test.js
+++ b/test/internals/initialConfig.test.js
@@ -23,7 +23,7 @@ test('without options passed to Fastify, initialConfig should expose default val
 
   const fastifyDefaultOptions = {
     connectionTimeout: 0,
-    keepAliveTimeout: 5000,
+    keepAliveTimeout: 72000,
     bodyLimit: 1024 * 1024,
     caseSensitive: true,
     disableRequestLogging: false,
@@ -35,7 +35,7 @@ test('without options passed to Fastify, initialConfig should expose default val
     pluginTimeout: 10000,
     requestIdHeader: 'request-id',
     requestIdLogLabel: 'reqId',
-    http2SessionTimeout: 5000,
+    http2SessionTimeout: 72000,
     exposeHeadRoutes: true
   }
 
@@ -80,7 +80,7 @@ test('Fastify.initialConfig should expose all options', t => {
     ignoreTrailingSlash: true,
     maxParamLength: 200,
     connectionTimeout: 0,
-    keepAliveTimeout: 5000,
+    keepAliveTimeout: 72000,
     bodyLimit: 1049600,
     onProtoPoisoning: 'remove',
     serverFactory,
@@ -106,7 +106,7 @@ test('Fastify.initialConfig should expose all options', t => {
   t.equal(fastify.initialConfig.ignoreTrailingSlash, true)
   t.equal(fastify.initialConfig.maxParamLength, 200)
   t.equal(fastify.initialConfig.connectionTimeout, 0)
-  t.equal(fastify.initialConfig.keepAliveTimeout, 5000)
+  t.equal(fastify.initialConfig.keepAliveTimeout, 72000)
   t.equal(fastify.initialConfig.bodyLimit, 1049600)
   t.equal(fastify.initialConfig.onProtoPoisoning, 'remove')
   t.equal(fastify.initialConfig.caseSensitive, true)
@@ -249,7 +249,7 @@ test('Should not have issues when passing stream options to Pino.js', t => {
     t.type(fastify, 'object')
     t.same(fastify.initialConfig, {
       connectionTimeout: 0,
-      keepAliveTimeout: 5000,
+      keepAliveTimeout: 72000,
       bodyLimit: 1024 * 1024,
       caseSensitive: true,
       disableRequestLogging: false,
@@ -261,7 +261,7 @@ test('Should not have issues when passing stream options to Pino.js', t => {
       pluginTimeout: 10000,
       requestIdHeader: 'request-id',
       requestIdLogLabel: 'reqId',
-      http2SessionTimeout: 5000,
+      http2SessionTimeout: 72000,
       exposeHeadRoutes: true
     })
   } catch (error) {

--- a/test/request-error.test.js
+++ b/test/request-error.test.js
@@ -132,10 +132,7 @@ test('default clientError handler ignores sockets in destroyed state', t => {
 
   const fastify = Fastify({
     bodyLimit: 1,
-    keepAliveTimeout: 100,
-    logger: {
-      level: 'trace'
-    }
+    keepAliveTimeout: 100
   })
   fastify.server.on('clientError', () => {
     // this handler is called after default handler, so we can make sure end was not called
@@ -157,10 +154,7 @@ test('default clientError handler destroys sockets in writable state', t => {
 
   const fastify = Fastify({
     bodyLimit: 1,
-    keepAliveTimeout: 100,
-    logger: {
-      level: 'trace'
-    }
+    keepAliveTimeout: 100
   })
 
   fastify.server.emit('clientError', new Error(), {
@@ -181,10 +175,7 @@ test('default clientError handler destroys http sockets in non-writable state', 
 
   const fastify = Fastify({
     bodyLimit: 1,
-    keepAliveTimeout: 100,
-    logger: {
-      level: 'trace'
-    }
+    keepAliveTimeout: 100
   })
 
   fastify.server.emit('clientError', new Error(), {


### PR DESCRIPTION
Fixes https://github.com/fastify/fastify/issues/3282

I picked 72 seconds because bad things happen when two timeouts are the same on different machines. In this way things would work correctly on all platforms.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
