### PR TITLE
fix: check serialized payload

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -574,7 +574,7 @@ function handleError (reply, error, cb) {
         statusCode: { value: statusCode }
       }))
 
-    if (typeof payload !== 'string') {
+    if (serializerFn !== false && typeof payload !== 'string') {
       throw new FST_ERR_REP_INVALID_PAYLOAD_TYPE(typeof payload)
     }
   } catch (err) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -573,12 +573,17 @@ function handleError (reply, error, cb) {
         message: { value: error.message || '' },
         statusCode: { value: statusCode }
       }))
+
+    if (typeof payload !== 'string') {
+      throw new FST_ERR_REP_INVALID_PAYLOAD_TYPE(typeof payload)
+    }
   } catch (err) {
     // error is always FST_ERR_SCH_SERIALIZATION_BUILD because this is called from route/compileSchemasForSerialization
     reply.log.error({ err, statusCode: res.statusCode }, 'The serializer for the given status code failed')
     res.statusCode = 500
     payload = serializeError({
       error: statusCodes['500'],
+      code: err.code,
       message: err.message,
       statusCode: 500
     })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

If a custom serializator returns something that is not a string, the request starve till the timeout (if set).

With this fix the response flow will continue as usual with Fastify's controlled error

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
