### PR TITLE
`FastifyInstance#setErrorHandler` supports async handlers

### DIFF
--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -42,8 +42,14 @@ expectAssignable<FastifyInstance>(
 function fastifyErrorHandler (this: FastifyInstance, error: FastifyError) {}
 server.setErrorHandler(fastifyErrorHandler)
 
+async function asyncFastifyErrorHandler (this: FastifyInstance, error: FastifyError) {}
+server.setErrorHandler(asyncFastifyErrorHandler)
+
 function nodeJSErrorHandler (error: NodeJS.ErrnoException) {}
 server.setErrorHandler(nodeJSErrorHandler)
+
+function asyncNodeJSErrorHandler (error: NodeJS.ErrnoException) {}
+server.setErrorHandler(asyncNodeJSErrorHandler)
 
 function notFoundHandler (request: FastifyRequest, reply: FastifyReply) {}
 function notFoundpreHandlerHandler (request: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction) { done() }

--- a/types/.eslintrc.json
+++ b/types/.eslintrc.json
@@ -35,7 +35,8 @@
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/no-unused-vars": "off",
-        "@typescript-eslint/no-non-null-assertion": "off"
+        "@typescript-eslint/no-non-null-assertion": "off",
+        "@typescript-eslint/no-misused-promises": ["error"]
       },
       "globals": {
         "NodeJS": "readonly"

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -357,7 +357,7 @@ export interface FastifyInstance<
    * Set a function that will be called whenever an error happens
    */
   setErrorHandler<TError extends Error = FastifyError, RouteGeneric extends RouteGenericInterface = RouteGenericInterface>(
-    handler: (this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>, error: TError, request: FastifyRequest<RouteGeneric, RawServer, RawRequest>, reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric>) => void
+    handler: (this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>, error: TError, request: FastifyRequest<RouteGeneric, RawServer, RawRequest>, reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric>) => void | Promise<void>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**


### PR DESCRIPTION
As far as I can tell, error handlers that return Promises are already handled: https://github.com/fastify/fastify/blob/0109643d76c578e389cf173c87402d7df30cd62a/lib/reply.js#L550-L557