### PR TITLE
fix: reply object not marked as sent for stream payloads

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -423,6 +423,8 @@ function onSendEnd (reply, payload) {
   }
 
   if (typeof payload.pipe === 'function') {
+    reply[kReplySent] = true
+
     sendStream(payload, res, reply)
     return
   }

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -14,7 +14,7 @@ const JSONStream = require('JSONStream')
 const send = require('send')
 const Readable = require('stream').Readable
 const split = require('split2')
-const { kDisableRequestLogging } = require('../lib/symbols.js')
+const { kDisableRequestLogging, kReplySent } = require('../lib/symbols.js')
 
 test('should respond with a stream', t => {
   t.plan(8)
@@ -634,5 +634,41 @@ test('should destroy stream when response is ended', t => {
       t.error(err)
       t.equal(response.statusCode, 200)
     })
+  })
+})
+
+test('should mark reply as sent before pumping the payload stream into response for async route handler', t => {
+  t.plan(3)
+
+  const handleRequest = proxyquire('../lib/handleRequest', {
+    './wrapThenable': (thenable, reply) => {
+      thenable.then(function (payload) {
+        t.equal(reply[kReplySent], true)
+      })
+    }
+  })
+
+  const route = proxyquire('../lib/route', {
+    './handleRequest': handleRequest
+  })
+
+  const Fastify = proxyquire('..', {
+    './lib/route': route
+  })
+
+  const fastify = Fastify()
+
+  fastify.get('/', async function (req, reply) {
+    const stream = fs.createReadStream(__filename, 'utf8')
+    reply.code(200).send(stream)
+  })
+
+  fastify.inject({
+    url: '/',
+    method: 'GET'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.payload, fs.readFileSync(__filename, 'utf8'))
+    fastify.close()
   })
 })


### PR DESCRIPTION
Replication scenario: https://github.com/fastify/fastify-static/issues/232
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
