### PR TITLE
Docs: Add and clarify query string handling tips

### DIFF
--- a/docs/Request.md
+++ b/docs/Request.md
@@ -3,7 +3,7 @@
 ## Request
 The first parameter of the handler function is `Request`.<br>
 Request is a core Fastify object containing the following fields:
-- `query` - the parsed querystring
+- `query` - the parsed querystring, its format is specified by [`querystringParser`](Server.md#querystringParser)
 - `body` - the body
 - `params` - the params matching the URL
 - [`headers`](#headers) - the headers getter and setter

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -298,7 +298,7 @@ fastify.get('/user/:username', (request, reply) => {
 Please note that setting this option to `false` goes against
 [RFC3986](https://tools.ietf.org/html/rfc3986#section-6.2.2.1).
 
-Also note, this setting will in no way affect query strings. If you want to change the way query strings are handled take a look at [`querystringParser`](./Server.md#querystringParser).
+Also note, this setting will not affect query strings. If you want to change the way query strings are handled take a look at [`querystringParser`](./Server.md#querystringParser).
 
 <a name="factory-request-id-header"></a>
 ### `requestIdHeader`

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -298,6 +298,8 @@ fastify.get('/user/:username', (request, reply) => {
 Please note that setting this option to `false` goes against
 [RFC3986](https://tools.ietf.org/html/rfc3986#section-6.2.2.1).
 
+Also note, this setting will in no way affect query strings. If you want to change the way query strings are handled take a look at [querystringParser](./Server.md#querystringParser).
+
 <a name="factory-request-id-header"></a>
 ### `requestIdHeader`
 
@@ -387,6 +389,17 @@ const fastify = require('fastify')({
   querystringParser: str => qs.parse(str)
 })
 ```
+
+You could also stick with the parser that Fastify uses but change some handling behaviour, like the example below for case insensitive keys and values.
+
+```js
+const querystring = require('querystring')
+const fastify = require('fastify')({
+  querystringParser: str => querystring.parse(str.toLowerCase())
+})
+```
+
+Note, if you only want the keys (and not the values) to be case insensitive we recommend using a custom parser to convert only the keys to lowercase.
 
 <a name="exposeHeadRoutes"></a>
 ### `exposeHeadRoutes`

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -298,7 +298,7 @@ fastify.get('/user/:username', (request, reply) => {
 Please note that setting this option to `false` goes against
 [RFC3986](https://tools.ietf.org/html/rfc3986#section-6.2.2.1).
 
-Also note, this setting will in no way affect query strings. If you want to change the way query strings are handled take a look at [querystringParser](./Server.md#querystringParser).
+Also note, this setting will in no way affect query strings. If you want to change the way query strings are handled take a look at [`querystringParser`](./Server.md#querystringParser).
 
 <a name="factory-request-id-header"></a>
 ### `requestIdHeader`

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -390,7 +390,7 @@ const fastify = require('fastify')({
 })
 ```
 
-You could also stick with the parser that Fastify uses but change some handling behaviour, like the example below for case insensitive keys and values.
+You can also use Fastify's default parser but change some handling behaviour, like the example below for case insensitive keys and values:
 
 ```js
 const querystring = require('querystring')


### PR DESCRIPTION
A simple addition to `Request.md` now neatly mentions what specifies the format of the query property of a request (Fixes #3314).

A more complex addition to `Server.md` now better documents how users can modify query string handling and make query strings case insensitive (Fixes #2644). 

I decided to add this after stumbling upon all the conversations about query string case insensitivity (and the result agreed upon in #2647).

The related issues can be closed, as well as still open pull requests (namely #3235).

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)