### PR TITLE
fix: check existence

### DIFF
--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -75,10 +75,12 @@ function checkExistence (instance, name) {
 }
 
 function checkRequestExistence (name) {
+  if (name && this[kRequest].props.includes(name)) return true
   return checkExistence(this[kRequest].prototype, name)
 }
 
 function checkReplyExistence (name) {
+  if (name && this[kReply].props.includes(name)) return true
   return checkExistence(this[kReply].prototype, name)
 }
 

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -17,6 +17,15 @@ test('server methods should exist', t => {
   t.ok(fastify.hasDecorator)
 })
 
+test('should check if the given decoration already exist when null', t => {
+  t.plan(1)
+  const fastify = Fastify()
+  fastify.decorate('null', null)
+  fastify.ready(() => {
+    t.ok(fastify.hasDecorator('null'))
+  })
+})
+
 test('server methods should be encapsulated via .register', t => {
   t.plan(2)
   const fastify = Fastify()
@@ -425,6 +434,15 @@ test('hasRequestDecorator', t => {
     t.ok(fastify.hasRequestDecorator(requestDecoratorName))
   })
 
+  t.test('should check if the given request decoration already exist when null', t => {
+    t.plan(2)
+    const fastify = Fastify()
+
+    t.notOk(fastify.hasRequestDecorator(requestDecoratorName))
+    fastify.decorateRequest(requestDecoratorName, null)
+    t.ok(fastify.hasRequestDecorator(requestDecoratorName))
+  })
+
   t.test('should be plugin encapsulable', t => {
     t.plan(4)
     const fastify = Fastify()
@@ -478,6 +496,15 @@ test('hasReplyDecorator', t => {
 
     t.notOk(fastify.hasReplyDecorator(replyDecoratorName))
     fastify.decorateReply(replyDecoratorName, 42)
+    t.ok(fastify.hasReplyDecorator(replyDecoratorName))
+  })
+
+  t.test('should check if the given reply decoration already exist when null', t => {
+    t.plan(2)
+    const fastify = Fastify()
+
+    t.notOk(fastify.hasReplyDecorator(replyDecoratorName))
+    fastify.decorateReply(replyDecoratorName, null)
     t.ok(fastify.hasReplyDecorator(replyDecoratorName))
   })
 

--- a/test/same-shape.test.js
+++ b/test/same-shape.test.js
@@ -33,6 +33,36 @@ test('same shape on Request', async (t) => {
   await app.inject('/')
 })
 
+test('same shape on Request when object', async (t) => {
+  t.plan(1)
+
+  const app = fastify()
+
+  let request
+
+  app.decorateRequest('object', null)
+
+  app.addHook('preHandler', (req, reply, done) => {
+    if (request) {
+      req.object = {}
+    }
+    done()
+  })
+
+  app.get('/', (req, reply) => {
+    if (request) {
+      t.equal(%HaveSameMap(request, req), true)
+    }
+
+    request = req
+
+    return 'hello world'
+  })
+
+  await app.inject('/')
+  await app.inject('/')
+})
+
 test('same shape on Reply', async (t) => {
   t.plan(1)
 
@@ -45,6 +75,36 @@ test('same shape on Reply', async (t) => {
   app.addHook('preHandler', (req, reply, done) => {
     if (_reply) {
       reply.user = 'User'
+    }
+    done()
+  })
+
+  app.get('/', (req, reply) => {
+    if (_reply) {
+      t.equal(%HaveSameMap(_reply, reply), true)
+    }
+
+    _reply = reply
+
+    return 'hello world'
+  })
+
+  await app.inject('/')
+  await app.inject('/')
+})
+
+test('same shape on Reply when object', async (t) => {
+  t.plan(1)
+
+  const app = fastify()
+
+  let _reply
+
+  app.decorateReply('object', null)
+
+  app.addHook('preHandler', (req, reply, done) => {
+    if (_reply) {
+      reply.object = {}
     }
     done()
   })


### PR DESCRIPTION
Fixes: #3323 

When we `decorate` something that is not truthy, e.g. `null`. It will fall into `<k>.props` but not the `prototype`.
Currently, both `checkRequestExistence` and `checkReplyExistence` only check for `prototype` but not checking the new `<k>.props`.

Why I do not change `checkExistence` because it will fail the test for `instance` decoration.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
