### PR TITLE
fix: Add typings for log redaction options

### DIFF
--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -183,3 +183,11 @@ const passStreamAsOption = fastify({
     stream: fs.createWriteStream('/tmp/stream.out')
   }
 })
+
+const serverWithRedaction = fastify({
+  logger: {
+    redact: ['req.headers.authorization']
+  }
+})
+
+expectType<FastifyLoggerInstance>(serverWithRedaction.log)

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -113,6 +113,12 @@ export interface FastifyLoggerStreamDestination {
   write(msg: string): void;
 }
 
+interface RedactOptions {
+  paths: string[];
+  censor?: string | ((v: any) => any) | undefined;
+  remove?: boolean | undefined;
+}
+
 /**
  * Fastify Custom Logger options. To enable configuration of all Pino options,
  * refer to this example:
@@ -149,4 +155,5 @@ export interface FastifyLoggerOptions<
   genReqId?: (req: RawRequest) => string;
   prettyPrint?: boolean | PrettyOptions;
   stream?: FastifyLoggerStreamDestination;
+  redact?: string[] | RedactOptions | undefined;
 }


### PR DESCRIPTION
Fixes #3329

The typings are copied from the typings in Pino 16.13.2. I just changed the case of the interface to match the rest of the typings file.

Not sure how this related to the certifiication of origin. Both projects are MIT licensed.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
