### PR TITLE
Do not coerce undefined to null, always set it to decorated value.

### DIFF
--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -36,7 +36,7 @@ function decorate (instance, name, fn, dependencies) {
 
 function decorateConstructor (konstructor, name, fn, dependencies) {
   const instance = konstructor.prototype
-  if (instance.hasOwnProperty(name) || konstructor.props.includes(name)) {
+  if (instance.hasOwnProperty(name) || hasKey(konstructor, name)) {
     throw new FST_ERR_DEC_ALREADY_PRESENT(name)
   }
 
@@ -47,10 +47,10 @@ function decorateConstructor (konstructor, name, fn, dependencies) {
       get: fn.getter,
       set: fn.setter
     })
-  } else if (fn !== undefined && fn !== null) {
+  } else if (typeof fn === 'function') {
     instance[name] = fn
   } else {
-    konstructor.props.push(name)
+    konstructor.props.push({ key: name, value: fn })
   }
 }
 
@@ -74,13 +74,17 @@ function checkExistence (instance, name) {
   return instance in this
 }
 
+function hasKey (fn, name) {
+  return fn.props.find(({ key }) => key === name)
+}
+
 function checkRequestExistence (name) {
-  if (name && this[kRequest].props.includes(name)) return true
+  if (name && hasKey(this[kRequest], name)) return true
   return checkExistence(this[kRequest].prototype, name)
 }
 
 function checkReplyExistence (name) {
-  if (name && this[kReply].props.includes(name)) return true
+  if (name && hasKey(this[kReply], name)) return true
   return checkExistence(this[kReply].prototype, name)
 }
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -674,8 +674,11 @@ function buildReply (R) {
     this.log = log
 
     // eslint-disable-next-line no-var
+    var prop
+    // eslint-disable-next-line no-var
     for (var i = 0; i < props.length; i++) {
-      this[props[i]] = null
+      prop = props[i]
+      this[prop.key] = prop.value
     }
   }
   _Reply.prototype = new R()

--- a/lib/request.js
+++ b/lib/request.js
@@ -55,8 +55,11 @@ function buildRegularRequest (R) {
     this.body = null
 
     // eslint-disable-next-line no-var
+    var prop
+    // eslint-disable-next-line no-var
     for (var i = 0; i < props.length; i++) {
-      this[props[i]] = null
+      prop = props[i]
+      this[prop.key] = prop.value
     }
   }
   _Request.prototype = new R()

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -113,12 +113,11 @@ test('should pass error for missing request decorator', t => {
 })
 
 test('decorateReply inside register', t => {
-  t.plan(12)
+  t.plan(11)
   const fastify = Fastify()
 
   fastify.register((instance, opts, done) => {
     instance.decorateReply('test', 'test')
-    t.ok(instance[symbols.kReply].prototype.test)
 
     instance.get('/yes', (req, reply) => {
       t.ok(reply.test, 'test exists')
@@ -256,12 +255,11 @@ test('decorateReply as plugin (outside .after)', t => {
 })
 
 test('decorateRequest inside register', t => {
-  t.plan(12)
+  t.plan(11)
   const fastify = Fastify()
 
   fastify.register((instance, opts, done) => {
     instance.decorateRequest('test', 'test')
-    t.ok(instance[symbols.kRequest].prototype.test)
 
     instance.get('/yes', (req, reply) => {
       t.ok(req.test, 'test exists')
@@ -976,8 +974,8 @@ test('decorateRequest/decorateReply is undefined', t => {
   fastify.decorateRequest('test', undefined)
   fastify.decorateReply('test2', undefined)
   fastify.get('/yes', (req, reply) => {
-    t.equal(req.test, null)
-    t.equal(reply.test2, null)
+    t.equal(req.test, undefined)
+    t.equal(reply.test2, undefined)
     reply.send({ hello: 'world' })
   })
   t.teardown(fastify.close.bind(fastify))
@@ -1005,8 +1003,8 @@ test('decorateRequest/decorateReply is not set to a value', t => {
   fastify.decorateRequest('test')
   fastify.decorateReply('test2')
   fastify.get('/yes', (req, reply) => {
-    t.equal(req.test, null)
-    t.equal(reply.test2, null)
+    t.equal(req.test, undefined)
+    t.equal(reply.test2, undefined)
     reply.send({ hello: 'world' })
   })
   t.teardown(fastify.close.bind(fastify))


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This is another followup from #3334.
This PR restore the optimization for all set values and remove a breaking change that was introduced in #3334, the coercion between `undefined` and `null`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
