### PR TITLE
Skip encapsulation of Request and Reply when not needed

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -4,7 +4,7 @@ const { kFourOhFourContext, kReplySerializerDefault } = require('./symbols.js')
 
 // Objects that holds the context of every request
 // Every route holds an instance of this object.
-function Context (schema, handler, Reply, Request, contentTypeParser, config, errorHandler, bodyLimit, logLevel, logSerializers, attachValidation, replySerializer, schemaErrorFormatter) {
+function Context (schema, handler, Reply, Request, contentTypeParser, config, errorHandler, bodyLimit, logLevel, logSerializers, attachValidation, replySerializer, schemaErrorFormatter, server) {
   this.schema = schema
   this.handler = handler
   this.Reply = Reply
@@ -26,6 +26,8 @@ function Context (schema, handler, Reply, Request, contentTypeParser, config, er
   this.attachValidation = attachValidation
   this[kReplySerializerDefault] = replySerializer
   this.schemaErrorFormatter = schemaErrorFormatter || defaultSchemaErrorFormatter
+  // TODO simplify the arguments, we can pass way less arguments if we pass server
+  this.server = server
 }
 
 function defaultSchemaErrorFormatter (errors, dataVar) {

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -5,7 +5,8 @@
 const {
   kReply,
   kRequest,
-  kState
+  kState,
+  kHasBeenDecorated
 } = require('./symbols.js')
 
 const {
@@ -39,6 +40,8 @@ function decorateConstructor (konstructor, name, fn, dependencies) {
   if (instance.hasOwnProperty(name) || konstructor.props.includes(name)) {
     throw new FST_ERR_DEC_ALREADY_PRESENT(name)
   }
+
+  konstructor[kHasBeenDecorated] = true
 
   checkDependencies(instance, name, dependencies)
 

--- a/lib/pluginOverride.js
+++ b/lib/pluginOverride.js
@@ -12,7 +12,8 @@ const {
   kReply,
   kRequest,
   kFourOhFour,
-  kPluginNameChain
+  kPluginNameChain,
+  kHasBeenDecorated
 } = require('./symbols.js')
 
 const Reply = require('./reply')
@@ -39,10 +40,7 @@ module.exports = function override (old, fn, opts) {
   instance[kChildren] = []
 
   instance[kReply] = Reply.buildReply(instance[kReply])
-  instance[kReply].prototype.server = instance
-
   instance[kRequest] = Request.buildRequest(instance[kRequest])
-  instance[kRequest].prototype.server = instance
 
   instance[kContentTypeParser] = ContentTypeParser.helpers.buildContentTypeParser(instance[kContentTypeParser])
   instance[kHooks] = buildHooks(instance[kHooks])

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -71,6 +71,17 @@ Object.defineProperties(Reply.prototype, {
       return this.request.context
     }
   },
+  server: {
+    get () {
+      return this.request.context.server
+    },
+    set (value) {
+      Object.defineProperty(this, 'server', {
+        value,
+        writable: true
+      })
+    }
+  },
   res: {
     get () {
       warning.emit('FSTDEP002')
@@ -102,10 +113,6 @@ Object.defineProperties(Reply.prototype, {
     set (value) {
       this.code(value)
     }
-  },
-  server: {
-    value: null,
-    writable: true
   }
 })
 
@@ -676,7 +683,9 @@ function buildReply (R) {
       this[props[i]] = null
     }
   }
-  _Reply.prototype = new R()
+  Object.setPrototypeOf(_Reply.prototype, R.prototype)
+  Object.setPrototypeOf(_Reply, R)
+  _Reply.parent = R
   _Reply.props = props
   return _Reply
 }

--- a/lib/request.js
+++ b/lib/request.js
@@ -3,6 +3,9 @@
 const proxyAddr = require('proxy-addr')
 const semver = require('semver')
 const warning = require('./warnings')
+const {
+  kHasBeenDecorated
+} = require('./symbols')
 
 function Request (id, params, req, query, log, context) {
   this.id = id
@@ -59,8 +62,10 @@ function buildRegularRequest (R) {
       this[props[i]] = null
     }
   }
-  _Request.prototype = new R()
+  Object.setPrototypeOf(_Request.prototype, Request.prototype)
+  Object.setPrototypeOf(_Request, Request)
   _Request.props = props
+  _Request.parent = R
 
   return _Request
 }
@@ -74,6 +79,9 @@ function getLastEntryInMultiHeaderValue (headerValue) {
 function buildRequestWithTrustProxy (R, trustProxy) {
   const _Request = buildRegularRequest(R)
   const proxyFn = getTrustProxyFn(trustProxy)
+
+  // This is a more optimized version of decoration
+  _Request[kHasBeenDecorated] = true
 
   Object.defineProperties(_Request.prototype, {
     ip: {
@@ -108,6 +116,17 @@ function buildRequestWithTrustProxy (R, trustProxy) {
 }
 
 Object.defineProperties(Request.prototype, {
+  server: {
+    get () {
+      return this.context.server
+    },
+    set (value) {
+      Object.defineProperty(this, 'server', {
+        value,
+        writable: true
+      })
+    }
+  },
   req: {
     get () {
       warning.emit('FSTDEP001')
@@ -178,10 +197,6 @@ Object.defineProperties(Request.prototype, {
     set (headers) {
       this.additionalHeaders = headers
     }
-  },
-  server: {
-    value: null,
-    writable: true
   }
 })
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -36,7 +36,8 @@ const {
   kRequestPayloadStream,
   kDisableRequestLogging,
   kSchemaErrorFormatter,
-  kErrorHandler
+  kErrorHandler,
+  kHasBeenDecorated
 } = require('./symbols.js')
 
 function buildRouting (options) {
@@ -245,7 +246,8 @@ function buildRouting (options) {
         opts.logSerializers,
         opts.attachValidation,
         this[kReplySerializerDefault],
-        opts.schemaErrorFormatter || this[kSchemaErrorFormatter]
+        opts.schemaErrorFormatter || this[kSchemaErrorFormatter],
+        this
       )
 
       const headRouteExists = router.find('HEAD', url) != null
@@ -290,6 +292,14 @@ function buildRouting (options) {
               return bound
             })
           context[hook] = toSet.length ? toSet : null
+        }
+
+        // Optimization: avoid encapsulation if no decoration has been done.
+        while (!context.Request[kHasBeenDecorated] && context.Request.parent) {
+          context.Request = context.Request.parent
+        }
+        while (!context.Reply[kHasBeenDecorated] && context.Reply.parent) {
+          context.Reply = context.Reply.parent
         }
 
         // Must store the 404 Context in 'preReady' because it is only guaranteed to

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -20,7 +20,7 @@ const keys = {
   kContentTypeParser: Symbol('fastify.contentTypeParser'),
   kReply: Symbol('fastify.Reply'),
   kRequest: Symbol('fastify.Request'),
-  kRequestPayloadStream: Symbol('fastify.RequestPayloadStream'),
+kRequestPayloadStream: Symbol('fastify.RequestPayloadStream'),
   kCanSetNotFoundHandler: Symbol('fastify.canSetNotFoundHandler'),
   kFourOhFour: Symbol('fastify.404'),
   kFourOhFourLevelInstance: Symbol('fastify.404LogLevelInstance'),
@@ -42,7 +42,8 @@ const keys = {
   kPluginNameChain: Symbol('fastify.pluginNameChain'),
   // This symbol is only meant to be used for fastify tests and should not be used for any other purpose
   kTestInternals: Symbol('fastify.testInternals'),
-  kErrorHandler: Symbol('fastify.errorHandler')
+  kErrorHandler: Symbol('fastify.errorHandler'),
+  kHasBeenDecorated: Symbol('fastify.hasBeenDecorated')
 }
 
 module.exports = keys


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This is a tentative optimization that drops the encapsulation if `decorateRequest` and `decorateReply` has not been called. In common scenarios where most of the decorations happen top-level it can guarantee an improvement of 10% of throughput.

Fixes #3341 

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
