### PR TITLE
Drop readable-stream dependency

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const eos = require('readable-stream').finished
+const eos = require('stream').finished
 const statusCodes = require('http').STATUS_CODES
 const flatstr = require('flatstr')
 const FJS = require('fast-json-stringify')

--- a/package.json
+++ b/package.json
@@ -183,7 +183,6 @@
     "light-my-request": "^4.2.0",
     "pino": "^6.13.0",
     "proxy-addr": "^2.0.7",
-    "readable-stream": "^3.4.0",
     "rfdc": "^1.1.4",
     "secure-json-parse": "^2.0.0",
     "semver": "^7.3.2",

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -7,7 +7,7 @@ const http = require('http')
 const NotFound = require('http-errors').NotFound
 const EventEmitter = require('events').EventEmitter
 const Reply = require('../../lib/reply')
-const { Writable } = require('readable-stream')
+const { Writable } = require('stream')
 const {
   kReplyErrorHandlerCalled,
   kReplyHeaders,

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -145,7 +145,7 @@ test('onSend hook stream should work even if payload is not a proper stream', t 
   t.plan(1)
 
   const reply = proxyquire('../lib/reply', {
-    'readable-stream': {
+    stream: {
       finished: (...args) => {
         if (args.length === 2) { args[1](new Error('test-error')) }
       }
@@ -186,7 +186,7 @@ test('onSend hook stream should work on payload with "close" ending function', t
   t.plan(1)
 
   const reply = proxyquire('../lib/reply', {
-    'readable-stream': {
+    stream: {
       finished: (...args) => {
         if (args.length === 2) { args[1](new Error('test-error')) }
       }


### PR DESCRIPTION
It's not really needed and it's just more dependencies that we are bringing along.

See https://github.com/fastify/fastify/issues/3371

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
