### PR TITLE
fix: pipe stream inside error handler

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -549,7 +549,9 @@ function handleError (reply, error, cb) {
     reply[kReplySent] = false
     reply[kReplyIsError] = false
     reply[kReplyErrorHandlerCalled] = true
-    reply[kReplyHeaders]['content-length'] = undefined
+    // remove header is needed in here, because when we pipe to a stream
+    // `undefined` value header will directly passed to node response
+    reply.removeHeader('content-length')
     const result = errorHandler(error, reply.request, reply)
     if (result !== undefined) {
       if (result !== null && typeof result.then === 'function') {


### PR DESCRIPTION
Fix when pipe stream inside custom handler, it will cause an error because of `undefined` header being set.

This issue is found by `poloniumcz` in Discord Server.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
