### PR TITLE
upgrade fast-json-stringify to 2.7.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "@fastify/ajv-compiler": "^1.0.0",
     "abstract-logging": "^2.0.0",
     "avvio": "^7.1.2",
-    "fast-json-stringify": "^2.5.2",
+    "fast-json-stringify": "^2.7.11",
     "fastify-error": "^0.3.0",
     "fastify-warning": "^0.2.0",
     "find-my-way": "^4.1.0",


### PR DESCRIPTION
The new version 2.7.11 can now use recursion in json schema without problems.

#### Checklist
- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
