### PR TITLE
fix: setSchemaController not inheriting Schemas from root parent

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -635,7 +635,7 @@ function fastify (options) {
   function setSchemaController (schemaControllerOpts) {
     throwIfAlreadyStarted('Cannot call "setSchemaController" when fastify instance is already started!')
     const old = this[kSchemaController]
-    const parent = old.parent != null ? old.parent : old
+    const parent = old.parent || old
     const schemaController = SchemaController.buildSchemaController(parent, Object.assign({}, old.opts, schemaControllerOpts))
     this[kSchemaController] = schemaController
     this.getSchema = schemaController.getSchema.bind(schemaController)

--- a/fastify.js
+++ b/fastify.js
@@ -635,7 +635,8 @@ function fastify (options) {
   function setSchemaController (schemaControllerOpts) {
     throwIfAlreadyStarted('Cannot call "setSchemaController" when fastify instance is already started!')
     const old = this[kSchemaController]
-    const schemaController = SchemaController.buildSchemaController(old.parent, Object.assign({}, old.opts, schemaControllerOpts))
+    const parent = old.parent != null ? old.parent : old
+    const schemaController = SchemaController.buildSchemaController(parent, Object.assign({}, old.opts, schemaControllerOpts))
     this[kSchemaController] = schemaController
     this.getSchema = schemaController.getSchema.bind(schemaController)
     this.getSchemas = schemaController.getSchemas.bind(schemaController)

--- a/lib/schema-controller.js
+++ b/lib/schema-controller.js
@@ -79,11 +79,12 @@ class SchemaController {
     return this.serializerCompiler || (this.parent && this.parent.getSerializerCompiler())
   }
 
-  getCompilersFactory () {
-    return {
-      buildSerializer: this.compilersFactory.buildSerializer || (this.parent && this.parent.getCompilersFactory().buildSerializer),
-      buildValidator: this.compilersFactory.buildValidator || (this.parent && this.parent.getCompilersFactory().buildValidator)
-    }
+  getSerializerBuilder () {
+    return this.compilersFactory.buildSerializer || (this.parent && this.parent.getSerializerBuilder())
+  }
+
+  getValidatorBuilder () {
+    return this.compilersFactory.buildValidator || (this.parent && this.parent.getValidatorBuilder())
   }
 
   /**
@@ -96,7 +97,7 @@ class SchemaController {
     if (isReady) {
       return
     }
-    this.validatorCompiler = this.getCompilersFactory().buildValidator(this.schemaBucket.getSchemas(), serverOption.ajv)
+    this.validatorCompiler = this.getValidatorBuilder()(this.schemaBucket.getSchemas(), serverOption.ajv)
   }
 
   /**
@@ -110,7 +111,7 @@ class SchemaController {
       return
     }
 
-    this.serializerCompiler = this.getCompilersFactory().buildSerializer(this.schemaBucket.getSchemas(), serverOption.serializerOpts)
+    this.serializerCompiler = this.getSerializerBuilder()(this.schemaBucket.getSchemas(), serverOption.serializerOpts)
   }
 }
 

--- a/lib/schema-controller.js
+++ b/lib/schema-controller.js
@@ -79,6 +79,13 @@ class SchemaController {
     return this.serializerCompiler || (this.parent && this.parent.getSerializerCompiler())
   }
 
+  getCompilersFactory () {
+    return {
+      buildSerializer: this.compilersFactory.buildSerializer || (this.parent && this.parent.getCompilersFactory().buildSerializer),
+      buildValidator: this.compilersFactory.buildValidator || (this.parent && this.parent.getCompilersFactory().buildValidator)
+    }
+  }
+
   /**
    * This method will be called when a validator must be setup.
    * Do not setup the compiler more than once
@@ -89,7 +96,7 @@ class SchemaController {
     if (isReady) {
       return
     }
-    this.validatorCompiler = this.compilersFactory.buildValidator(this.schemaBucket.getSchemas(), serverOption.ajv)
+    this.validatorCompiler = this.getCompilersFactory().buildValidator(this.schemaBucket.getSchemas(), serverOption.ajv)
   }
 
   /**
@@ -102,7 +109,8 @@ class SchemaController {
     if (isReady) {
       return
     }
-    this.serializerCompiler = this.compilersFactory.buildSerializer(this.schemaBucket.getSchemas(), serverOption.serializerOpts)
+
+    this.serializerCompiler = this.getCompilersFactory().buildSerializer(this.schemaBucket.getSchemas(), serverOption.serializerOpts)
   }
 }
 

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -1487,7 +1487,7 @@ test('setSchemaController: Inherits buildSerializer from parent if not present w
   t.equal(rootSerializerCalled, 1, 'Should be called from the child')
   t.equal(rootValidatorCalled, 0, 'Should not be called from the child')
   t.equal(childValidatorCalled, 1, 'Should be called from the child')
-  t.equal(res.statusCode, 400, 'Should not coearce the string into array')
+  t.equal(res.statusCode, 400, 'Should not coerce the string into array')
 })
 
 test('setSchemaController: Inherits buildValidator from parent if not present within the instance', async t => {

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -1296,6 +1296,7 @@ test('setSchemaController: Inherits correctly parent schemas', async t => {
   const customAjv = new Ajv({ coerceTypes: false })
   const server = Fastify()
 
+  // this schema must be added before calling setSchemaController()
   server.addSchema({
     $id: 'some',
     type: 'array',

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -1315,7 +1315,6 @@ test('setSchemaController: Inherits correctly parent schemas with a customized v
     }
   }
 
-  // these schemas must be added before calling setSchemaController()
   server.addSchema(someSchema)
   server.addSchema(errorResponseSchema)
 
@@ -1427,7 +1426,6 @@ test('setSchemaController: Inherits buildSerializer from parent if not present w
     }
   })
 
-  // these schemas must be added before calling setSchemaController()
   server.addSchema(someSchema)
   server.addSchema(errorResponseSchema)
 
@@ -1542,10 +1540,6 @@ test('setSchemaController: Inherits buildValidator from parent if not present wi
     }
   })
 
-  // these schemas must be added before calling setSchemaController()
-  server.addSchema(someSchema)
-  server.addSchema(errorResponseSchema)
-
   server.register((instance, _, done) => {
     instance.register((subInstance, _, subDone) => {
       subInstance.setSchemaController({
@@ -1590,6 +1584,9 @@ test('setSchemaController: Inherits buildValidator from parent if not present wi
 
     done()
   })
+
+  server.addSchema(someSchema)
+  server.addSchema(errorResponseSchema)
 
   const res = await server.inject({
     method: 'GET',

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -1366,7 +1366,7 @@ test('setSchemaController: Inherits correctly parent schemas with a customized v
     method: 'GET',
     url: '/',
     query: {
-      msg: ['string']
+      msg: 'string'
     }
   })
   const json = res.json()

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -1477,7 +1477,7 @@ test('setSchemaController: Inherits buildSerializer from parent if not present w
     method: 'GET',
     url: '/',
     query: {
-      msg: ['string']
+      msg: 'string'
     }
   })
   const json = res.json()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

As stated in #3121, during the development of the plugin I noticed that when setting up a custom `SchemaController` on the second level of encapsulation (root -> instance), the custom Validator is not correctly inheriting the schemas defined on the root layer of encapsulation. Causing the following error:

`Failed building the validation schema for POST: /, due to error can't resolve reference some# from id #`

**Full Reproduction in the test case added**.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
