### PR TITLE
fix: verify request socket before access attributes

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -102,7 +102,9 @@ function buildRequestWithTrustProxy (R, trustProxy) {
         if (this.headers['x-forwarded-proto']) {
           return getLastEntryInMultiHeaderValue(this.headers['x-forwarded-proto'])
         }
-        return this.socket.encrypted ? 'https' : 'http'
+        if (this.socket) {
+          return this.socket.encrypted ? 'https' : 'http'
+        }
       }
     }
   })
@@ -158,7 +160,9 @@ Object.defineProperties(Request.prototype, {
   },
   ip: {
     get () {
-      return this.socket.remoteAddress
+      if (this.socket) {
+        return this.socket.remoteAddress
+      }
     }
   },
   hostname: {
@@ -168,7 +172,9 @@ Object.defineProperties(Request.prototype, {
   },
   protocol: {
     get () {
-      return this.socket.encrypted ? 'https' : 'http'
+      if (this.socket) {
+        return this.socket.encrypted ? 'https' : 'http'
+      }
     }
   },
   headers: {

--- a/test/internals/request.test.js
+++ b/test/internals/request.test.js
@@ -213,3 +213,50 @@ test('Request with trust proxy - plain', t => {
   const request = new TpRequest('id', 'params', req, 'query', 'log')
   t.same(request.protocol, 'http')
 })
+
+test('Request with undefined socket', t => {
+  t.plan(15)
+  const headers = {
+    host: 'hostname'
+  }
+  const req = {
+    method: 'GET',
+    url: '/',
+    socket: undefined,
+    headers
+  }
+  const request = new Request('id', 'params', req, 'query', 'log')
+  t.type(request, Request)
+  t.equal(request.id, 'id')
+  t.equal(request.params, 'params')
+  t.same(request.raw, req)
+  t.equal(request.query, 'query')
+  t.equal(request.headers, headers)
+  t.equal(request.log, 'log')
+  t.equal(request.ip, undefined)
+  t.equal(request.ips, undefined)
+  t.equal(request.hostname, 'hostname')
+  t.equal(request.body, null)
+  t.equal(request.method, 'GET')
+  t.equal(request.url, '/')
+  t.equal(request.protocol, undefined)
+  t.same(request.socket, req.socket)
+})
+
+test('Request with trust proxy and undefined socket', t => {
+  t.plan(1)
+  const headers = {
+    'x-forwarded-for': '2.2.2.2, 1.1.1.1',
+    'x-forwarded-host': 'example.com'
+  }
+  const req = {
+    method: 'GET',
+    url: '/',
+    socket: undefined,
+    headers
+  }
+
+  const TpRequest = Request.buildRequest(Request, true)
+  const request = new TpRequest('id', 'params', req, 'query', 'log')
+  t.same(request.protocol, undefined)
+})


### PR DESCRIPTION
Adds a check on the existence of the request `socket` before accessing the attributes.

It should fix #3419

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

```
Suites:   96 passed, 96 of 96 completed
Asserts:  5497 passed, 2 skip, of 5499
Time:     28s
-----------------------------|---------|----------|---------|---------|-------------------
File                         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------------|---------|----------|---------|---------|-------------------
All files                    |     100 |      100 |     100 |     100 |                   
 fastify                     |     100 |      100 |     100 |     100 |                   
  fastify.js                 |     100 |      100 |     100 |     100 |                   
 fastify/lib                 |     100 |      100 |     100 |     100 |                   
  contentTypeParser.js       |     100 |      100 |     100 |     100 |                   
  context.js                 |     100 |      100 |     100 |     100 |                   
  decorate.js                |     100 |      100 |     100 |     100 |                   
  errors.js                  |     100 |      100 |     100 |     100 |                   
  fourOhFour.js              |     100 |      100 |     100 |     100 |                   
  handleRequest.js           |     100 |      100 |     100 |     100 |                   
  headRoute.js               |     100 |      100 |     100 |     100 |                   
  hooks.js                   |     100 |      100 |     100 |     100 |                   
  initialConfigValidation.js |     100 |      100 |     100 |     100 |                   
  logger.js                  |     100 |      100 |     100 |     100 |                   
  pluginOverride.js          |     100 |      100 |     100 |     100 |                   
  pluginUtils.js             |     100 |      100 |     100 |     100 |                   
  reply.js                   |     100 |      100 |     100 |     100 |                   
  reqIdGenFactory.js         |     100 |      100 |     100 |     100 |                   
  request.js                 |     100 |      100 |     100 |     100 |                   
  route.js                   |     100 |      100 |     100 |     100 |                   
  schema-compilers.js        |     100 |      100 |     100 |     100 |                   
  schema-controller.js       |     100 |      100 |     100 |     100 |                   
  schemas.js                 |     100 |      100 |     100 |     100 |                   
  server.js                  |     100 |      100 |     100 |     100 |                   
  symbols.js                 |     100 |      100 |     100 |     100 |                   
  validation.js              |     100 |      100 |     100 |     100 |                   
  warnings.js                |     100 |      100 |     100 |     100 |                   
  wrapThenable.js            |     100 |      100 |     100 |     100 |                   
-----------------------------|---------|----------|---------|---------|-------------------

```

```
 npm run benchmark

> fastify@3.22.1 benchmark /Users/davide/Work/nearForm/bench/fastify
> npx concurrently -k -s first "node ./examples/benchmark/simple.js" "npx autocannon -c 100 -d 30 -p 10 localhost:3000/"

npx: installed 27 in 4.023s
[1] Running 30s test @ http://localhost:3000/
[1] 100 connections with 10 pipelining factor
[1] 
[1] ┌─────────┬──────┬──────┬───────┬───────┬─────────┬────────┬───────────┐
[1] │ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%   │ Avg     │ Stdev  │ Max       │
[1] ├─────────┼──────┼──────┼───────┼───────┼─────────┼────────┼───────────┤
[1] │ Latency │ 0 ms │ 0 ms │ 10 ms │ 11 ms │ 1.49 ms │ 3.7 ms │ 224.03 ms │
[1] └─────────┴──────┴──────┴───────┴───────┴─────────┴────────┴───────────┘
[1] ┌───────────┬─────────┬─────────┬─────────┬─────────┬─────────┬────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg     │ Stdev  │ Min     │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼────────┼─────────┤
[1] │ Req/Sec   │ 35359   │ 35359   │ 65599   │ 71423   │ 63308.8 │ 8538.6 │ 35351   │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼────────┼─────────┤
[1] │ Bytes/Sec │ 6.61 MB │ 6.61 MB │ 12.3 MB │ 13.4 MB │ 11.8 MB │ 1.6 MB │ 6.61 MB │
[1] └───────────┴─────────┴─────────┴─────────┴─────────┴─────────┴────────┴─────────┘
[1] 
[1] Req/Bytes counts sampled once per second.
[1] 
[1] 1899k requests in 30.08s, 355 MB read
[1] npx autocannon -c 100 -d 30 -p 10 localhost:3000/ exited with code 0
--> Sending SIGTERM to other processes..
[0] node ./examples/benchmark/simple.js exited with code SIGTERM

```