### PR TITLE
fix: socket null in logger

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -53,7 +53,7 @@ const serializers = {
       version: req.headers['accept-version'],
       hostname: req.hostname,
       remoteAddress: req.ip,
-      remotePort: req.socket.remotePort
+      remotePort: req.socket ? req.socket.remotePort : undefined
     }
   },
   err: pino.stdSerializers.err,

--- a/test/internals/logger.test.js
+++ b/test/internals/logger.test.js
@@ -112,3 +112,23 @@ test('The logger should error if both stream and file destination are given', t 
     t.equal(err.message, 'Cannot specify both logger.stream and logger.file options')
   }
 })
+
+test('The serializer prevent fails if the request socket is undefined', t => {
+  t.plan(1)
+
+  const serialized = loggerUtils.serializers.req({
+    method: 'GET',
+    url: '/',
+    socket: undefined,
+    headers: {}
+  })
+
+  t.same(serialized, {
+    method: 'GET',
+    url: '/',
+    version: undefined,
+    hostname: undefined,
+    remoteAddress: undefined,
+    remotePort: undefined
+  })
+})


### PR DESCRIPTION
Adds a check on the existence of the request socket before accessing the attributes, in a previous commit was missed a check.

It should fix #3419

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

```
Suites:   96 passed, 96 of 96 completed
Asserts:  5498 passed, 2 skip, of 5500
Time:     31s
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |                   
 fastify           |     100 |      100 |     100 |     100 |                   
  fastify.js       |     100 |      100 |     100 |     100 |                   
 fastify/lib       |     100 |      100 |     100 |     100 |                   
  ...TypeParser.js |     100 |      100 |     100 |     100 |                   
  context.js       |     100 |      100 |     100 |     100 |                   
  decorate.js      |     100 |      100 |     100 |     100 |                   
  errors.js        |     100 |      100 |     100 |     100 |                   
  fourOhFour.js    |     100 |      100 |     100 |     100 |                   
  handleRequest.js |     100 |      100 |     100 |     100 |                   
  headRoute.js     |     100 |      100 |     100 |     100 |                   
  hooks.js         |     100 |      100 |     100 |     100 |                   
  ...Validation.js |     100 |      100 |     100 |     100 |                   
  logger.js        |     100 |      100 |     100 |     100 |                   
  ...inOverride.js |     100 |      100 |     100 |     100 |                   
  pluginUtils.js   |     100 |      100 |     100 |     100 |                   
  reply.js         |     100 |      100 |     100 |     100 |                   
  ...GenFactory.js |     100 |      100 |     100 |     100 |                   
  request.js       |     100 |      100 |     100 |     100 |                   
  route.js         |     100 |      100 |     100 |     100 |                   
  ...-compilers.js |     100 |      100 |     100 |     100 |                   
  ...controller.js |     100 |      100 |     100 |     100 |                   
  schemas.js       |     100 |      100 |     100 |     100 |                   
  server.js        |     100 |      100 |     100 |     100 |                   
  symbols.js       |     100 |      100 |     100 |     100 |                   
  validation.js    |     100 |      100 |     100 |     100 |                   
  warnings.js      |     100 |      100 |     100 |     100 |                   
  wrapThenable.js  |     100 |      100 |     100 |     100 |                   
-------------------|---------|----------|---------|---------|-------------------
[fix-3419-logger-fail-on-null-socket 0165c12] fix: socket null in logger
 2 files changed, 21 insertions(+), 1 deletion(-)
```

```
➜  fastify git:(fix-3419-logger-fail-on-null-socket) npm run benchmark

> fastify@3.23.0 benchmark /Users/davide/Work/nearForm/bench/fastify
> npx concurrently -k -s first "node ./examples/benchmark/simple.js" "npx autocannon -c 100 -d 30 -p 10 localhost:3000/"

npx: installed 27 in 3.73s
[1] Running 30s test @ http://localhost:3000/
[1] 100 connections with 10 pipelining factor
[1] 
[1] ┌─────────┬──────┬──────┬───────┬───────┬─────────┬─────────┬───────────┐
[1] │ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%   │ Avg     │ Stdev   │ Max       │
[1] ├─────────┼──────┼──────┼───────┼───────┼─────────┼─────────┼───────────┤
[1] │ Latency │ 0 ms │ 0 ms │ 11 ms │ 12 ms │ 1.45 ms │ 3.52 ms │ 142.66 ms │
[1] └─────────┴──────┴──────┴───────┴───────┴─────────┴─────────┴───────────┘
[1] ┌───────────┬────────┬────────┬───────┬─────────┬─────────┬─────────┬────────┐
[1] │ Stat      │ 1%     │ 2.5%   │ 50%   │ 97.5%   │ Avg     │ Stdev   │ Min    │
[1] ├───────────┼────────┼────────┼───────┼─────────┼─────────┼─────────┼────────┤
[1] │ Req/Sec   │ 43327  │ 43327  │ 69439 │ 73151   │ 64702.4 │ 8615.71 │ 43305  │
[1] ├───────────┼────────┼────────┼───────┼─────────┼─────────┼─────────┼────────┤
[1] │ Bytes/Sec │ 8.1 MB │ 8.1 MB │ 13 MB │ 13.7 MB │ 12.1 MB │ 1.61 MB │ 8.1 MB │
[1] └───────────┴────────┴────────┴───────┴─────────┴─────────┴─────────┴────────┘
[1] 
[1] Req/Bytes counts sampled once per second.
[1] 
[1] 1941k requests in 30.09s, 363 MB read
[1] npx autocannon -c 100 -d 30 -p 10 localhost:3000/ exited with code 0
--> Sending SIGTERM to other processes..
[0] node ./examples/benchmark/simple.js exited with code SIGTERM
```