### PR TITLE
feat: make version field deterministic and reliable

### DIFF
--- a/build/sync-version.js
+++ b/build/sync-version.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+// package.json:version -> fastify.js:VERSION
+const { version } = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json')).toString('utf8'))
+
+const fastifyJs = path.join(__dirname, '..', 'fastify.js')
+
+fs.writeFileSync(fastifyJs, fs.readFileSync(fastifyJs).toString('utf8').replace(/const\s*VERSION\s*=.*/, `const VERSION = '${version}'`))

--- a/fastify.js
+++ b/fastify.js
@@ -1,11 +1,11 @@
 'use strict'
 
+const VERSION = '3.23.1'
+
 const Avvio = require('avvio')
 const http = require('http')
 const querystring = require('querystring')
 let lightMyRequest
-let version
-let versionLoaded = false
 
 const {
   kAvvioBoot,
@@ -326,12 +326,7 @@ function fastify (options) {
       get () { return this[kSchemaController].getSerializerCompiler() }
     },
     version: {
-      get () {
-        if (versionLoaded === false) {
-          version = loadVersion()
-        }
-        return version
-      }
+      get () { return VERSION }
     },
     errorHandler: {
       get () {
@@ -690,20 +685,6 @@ function wrapRouting (httpHandler, { rewriteUrl, logger }) {
       }
     }
     httpHandler(req, res)
-  }
-}
-
-function loadVersion () {
-  versionLoaded = true
-  const fs = require('fs')
-  const path = require('path')
-  try {
-    const pkgPath = path.join(__dirname, 'package.json')
-    fs.accessSync(pkgPath, fs.constants.R_OK)
-    const pkg = JSON.parse(fs.readFileSync(pkgPath))
-    return pkg.name === 'fastify' ? pkg.version : undefined
-  } catch (e) {
-    return undefined
   }
 }
 

--- a/lib/pluginUtils.js
+++ b/lib/pluginUtils.js
@@ -113,9 +113,7 @@ function registerPluginName (fn) {
 
 function registerPlugin (fn) {
   registerPluginName.call(this, fn)
-  if (this.version !== undefined) {
-    checkVersion.call(this, fn)
-  }
+  checkVersion.call(this, fn)
   checkDecorators.call(this, fn)
   checkDependencies.call(this, fn)
   return shouldSkipOverride(fn)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint:fix": "standard --fix",
     "lint:standard": "standard --verbose | snazzy",
     "lint:typescript": "eslint -c types/.eslintrc.json types/**/*.d.ts test/types/**/*.test-d.ts",
+    "prepublishOnly": "tap --no-check-coverage test/internals/version.test.js",
     "test": "npm run lint && npm run unit && npm run test:typescript",
     "test:ci": "npm run lint && npm run unit -- --cov --coverage-report=lcovonly && npm run test:typescript",
     "test:report": "npm run lint && npm run unit:report && npm run test:typescript",

--- a/test/bundler/webpack/bundler-test.js
+++ b/test/bundler/webpack/bundler-test.js
@@ -3,22 +3,10 @@
 const t = require('tap')
 const test = t.test
 const fastifySuccess = require('./dist/success')
-const fastifyFailPlugin = require('./dist/failPlugin')
 
 test('Bundled package should work', t => {
   t.plan(1)
   fastifySuccess.ready((err) => {
-    t.error(err)
-  })
-})
-
-// In the webpack bundle context the fastify package.json is not read
-// Because of this the version is set to `undefined`, this makes the plugin
-// version check not able to work properly. By then this test shouldn't work
-// in non-bundled environment but works in bundled environment
-test('Bundled package should work with bad plugin version, undefined version fallback', t => {
-  t.plan(1)
-  fastifyFailPlugin.ready((err) => {
     t.error(err)
   })
 })

--- a/test/bundler/webpack/bundler-test.js
+++ b/test/bundler/webpack/bundler-test.js
@@ -3,10 +3,18 @@
 const t = require('tap')
 const test = t.test
 const fastifySuccess = require('./dist/success')
+const fastifyFailPlugin = require('./dist/failPlugin')
 
 test('Bundled package should work', t => {
   t.plan(1)
   fastifySuccess.ready((err) => {
     t.error(err)
+  })
+})
+
+test('Bundled package should not work with bad plugin version', t => {
+  t.plan(1)
+  fastifyFailPlugin.ready((err) => {
+    t.ok(err)
   })
 })

--- a/test/internals/version.test.js
+++ b/test/internals/version.test.js
@@ -1,43 +1,15 @@
 'use strict'
 
+const fs = require('fs')
+const path = require('path')
 const t = require('tap')
 const test = t.test
-const proxyquire = require('proxyquire')
+const fastify = require('../..')()
 
-test('should output an undefined version in case of package.json not available', t => {
-  const Fastify = proxyquire('../..', { fs: { accessSync: () => { throw Error('error') } } })
+test('should be the same as package.json', t => {
   t.plan(1)
-  const srv = Fastify()
-  t.equal(srv.version, undefined)
-})
 
-test('should output an undefined version in case of package.json is not the fastify one', t => {
-  const Fastify = proxyquire('../..', { fs: { accessSync: () => { }, readFileSync: () => JSON.stringify({ name: 'foo', version: '6.6.6' }) } })
-  t.plan(1)
-  const srv = Fastify()
-  t.equal(srv.version, undefined)
-})
+  const json = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', 'package.json')).toString('utf8'))
 
-test('should skip the version check if the version is undefined', t => {
-  const Fastify = proxyquire('../..', { fs: { accessSync: () => { }, readFileSync: () => JSON.stringify({ name: 'foo', version: '6.6.6' }) } })
-  t.plan(3)
-  const srv = Fastify()
-  t.equal(srv.version, undefined)
-
-  plugin[Symbol.for('skip-override')] = false
-  plugin[Symbol.for('plugin-meta')] = {
-    name: 'plugin',
-    fastify: '>=99.0.0'
-  }
-
-  srv.register(plugin)
-
-  srv.ready((err) => {
-    t.error(err)
-    t.pass('everything right')
-  })
-
-  function plugin (instance, opts, done) {
-    done()
-  }
+  t.equal(fastify.version, json.version)
 })

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -27,7 +27,7 @@ export interface FastifyInstance<
 > {
   server: RawServer;
   prefix: string;
-  version: string | undefined;
+  version: string;
   log: Logger;
 
   addSchema(schema: unknown): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;


### PR DESCRIPTION
This change makes the "version" a reliable field, instead of
one that might be "undefined". Some issues with bundlers such
as "a wild package.json appears" are resolved as well.

Maintainers would have to ensure that versions in fastify.js
and package.json are in sync. That would be relatively trivial,
compared to the benefits, when it comes to such an essential
package.

To avoid errors and reduce maintenance burden, a test has been
added to ensure that the versions are in sync. It is configured
to run before publish.

Refs: #3110, #3113, #3155, #3185, #3191
Signed-off-by: Jesse Chan \<jc@linux.com>

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
