### PR TITLE
docs: Extend TypeBox documentation

### DIFF
--- a/docs/Type-Providers.md
+++ b/docs/Type-Providers.md
@@ -85,6 +85,6 @@ server.get('/route', {
 })
 ```
 
-TypeBox uses the properties `kind` and `modifier` internally. These properties are not strictly valid JSON schema which will cause AJV to throw an invalid schema error. To remove the error it's either necessary to omit the properties by using [`Type.Strict()`](https://github.com/sinclairzx81/typebox#strict) or use the AJV options for adding custom keywords.
+TypeBox uses the properties `kind` and `modifier` internally. These properties are not strictly valid JSON schema which will cause `AJV@7` to throw an invalid schema error. To remove the error it's either necessary to omit the properties by using [`Type.Strict()`](https://github.com/sinclairzx81/typebox#strict) or use the AJV options for adding custom keywords.
 
 See also the [TypeBox documentation](https://github.com/sinclairzx81/typebox#validation) on how to set up AJV to work with TypeBox.

--- a/docs/Type-Providers.md
+++ b/docs/Type-Providers.md
@@ -85,4 +85,6 @@ server.get('/route', {
 })
 ```
 
+TypeBox uses the properties `kind` and `modifier` internally. Those are not strictly valid JSON schema and will throw an AJV error. To remove the error it's either necessary to omit the properties by using [`Type.strict()`](https://github.com/sinclairzx81/typebox#strict) or use the AJV options for adding custom keywords.
+
 See also the [TypeBox documentation](https://github.com/sinclairzx81/typebox#validation) on how to set up AJV to work with TypeBox.

--- a/docs/Type-Providers.md
+++ b/docs/Type-Providers.md
@@ -61,7 +61,14 @@ import { TypeBoxTypeProvider, Type } from 'fastify-type-provider-typebox'
 
 import fastify from 'fastify'
 
-const server = fastify().withTypeProvider<TypeBoxTypeProvider>()
+const server = fastify({
+    ajv: {
+        customOptions: {
+            strict: 'log',
+            keywords: ['kind', 'modifier'],
+        },
+    },
+}).withTypeProvider<TypeBoxTypeProvider>()
 
 server.get('/route', {
     schema: {
@@ -77,3 +84,5 @@ server.get('/route', {
     const { foo, bar } = request.query // type safe!
 })
 ```
+
+See also the [TypeBox documentation](https://github.com/sinclairzx81/typebox#validation) on how to set up AJV to work with TypeBox.

--- a/docs/Type-Providers.md
+++ b/docs/Type-Providers.md
@@ -85,6 +85,6 @@ server.get('/route', {
 })
 ```
 
-TypeBox uses the properties `kind` and `modifier` internally. These properties are not strictly valid JSON schema which will cause `AJV@7` to throw an invalid schema error. To remove the error it's either necessary to omit the properties by using [`Type.Strict()`](https://github.com/sinclairzx81/typebox#strict) or use the AJV options for adding custom keywords.
+TypeBox uses the properties `kind` and `modifier` internally. These properties are not strictly valid JSON schema which will cause `AJV@7` and newer versions to throw an invalid schema error. To remove the error it's either necessary to omit the properties by using [`Type.Strict()`](https://github.com/sinclairzx81/typebox#strict) or use the AJV options for adding custom keywords.
 
 See also the [TypeBox documentation](https://github.com/sinclairzx81/typebox#validation) on how to set up AJV to work with TypeBox.

--- a/docs/Type-Providers.md
+++ b/docs/Type-Providers.md
@@ -85,6 +85,6 @@ server.get('/route', {
 })
 ```
 
-TypeBox uses the properties `kind` and `modifier` internally. Those are not strictly valid JSON schema and will throw an AJV error. To remove the error it's either necessary to omit the properties by using [`Type.strict()`](https://github.com/sinclairzx81/typebox#strict) or use the AJV options for adding custom keywords.
+TypeBox uses the properties `kind` and `modifier` internally. These properties are not strictly valid JSON schema which will cause AJV to throw an invalid schema error. To remove the error it's either necessary to omit the properties by using [`Type.Strict()`](https://github.com/sinclairzx81/typebox#strict) or use the AJV options for adding custom keywords.
 
 See also the [TypeBox documentation](https://github.com/sinclairzx81/typebox#validation) on how to set up AJV to work with TypeBox.


### PR DESCRIPTION
Hi,

the following PR closes https://github.com/fastify/fastify/issues/3421 and adds additional documentation how to use TypeBox with fastify v4.

#### Checklist
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
