### PR TITLE
Adjust existing PRs for the new reply.sent handing

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -4,7 +4,7 @@ const FJS = require('fast-json-stringify')
 const statusCodes = require('http').STATUS_CODES
 const wrapThenable = require('./wrapThenable')
 const {
-  kReplyHeaders, kReplyNextErrorHandler, kReplyIsRunningOnErrorHook, kReplySent, kReplyHasStatusCode
+  kReplyHeaders, kReplyNextErrorHandler, kReplyIsRunningOnErrorHook, kReplyHasStatusCode
 } = require('./symbols.js')
 
 const {
@@ -121,8 +121,6 @@ function fallbackErrorHandler (error, reply, cb) {
 
   reply[kReplyHeaders]['content-type'] = 'application/json; charset=utf-8'
   reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)
-
-  reply[kReplySent] = true
 
   cb(reply, payload)
 }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -13,7 +13,6 @@ const {
   kReplyHasStatusCode,
   kReplyIsRunningOnErrorHook,
   kReplyNextErrorHandler,
-  kReplySent,
   kDisableRequestLogging
 } = require('./symbols.js')
 const { hookRunner, hookIterator, onSendHookRunner } = require('./hooks')
@@ -415,8 +414,6 @@ function onSendEnd (reply, payload) {
   }
 
   if (typeof payload.pipe === 'function') {
-    reply[kReplySent] = true
-
     sendStream(payload, res, reply)
     return
   }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -374,7 +374,6 @@ function preserializeHookEnd (err, request, reply, payload) {
 
 function onSendHook (reply, payload) {
   if (reply.context.onSend !== null) {
-    reply[kReplySent] = true
     onSendHookRunner(
       reply.context.onSend,
       reply.request,

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -14,7 +14,7 @@ const JSONStream = require('JSONStream')
 const send = require('send')
 const Readable = require('stream').Readable
 const split = require('split2')
-const { kDisableRequestLogging, kReplySent } = require('../lib/symbols.js')
+const { kDisableRequestLogging } = require('../lib/symbols.js')
 
 test('should respond with a stream (success)', t => {
   t.plan(6)
@@ -653,7 +653,7 @@ test('should mark reply as sent before pumping the payload stream into response 
   const handleRequest = proxyquire('../lib/handleRequest', {
     './wrapThenable': (thenable, reply) => {
       thenable.then(function (payload) {
-        t.equal(reply[kReplySent], true)
+        t.equal(reply.sent, true)
       })
     }
   })
@@ -670,7 +670,7 @@ test('should mark reply as sent before pumping the payload stream into response 
 
   fastify.get('/', async function (req, reply) {
     const stream = fs.createReadStream(__filename, 'utf8')
-    reply.code(200).send(stream)
+    return reply.code(200).send(stream)
   })
 
   fastify.inject({


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This PR adjusts some of the already merged PRs, so they are in line with the new way that reply.sent is handled (introduced in https://github.com/fastify/fastify/pull/3072).

https://github.com/fastify/fastify/pull/3261 & https://github.com/fastify/fastify/pull/3285: kReplySent does not exist anymore. We can simply delete those lines since they don't have any effect.

https://github.com/fastify/fastify/pull/3318: With the new way that the reply is handled, we do not have to do anything manually any more. Only the test had to be adjusted because of the reasoning explained in https://github.com/fastify/fastify/pull/3132.