### PR TITLE
docs: add Google Cloud Functions example to Serverless Documentation

### DIFF
--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -192,7 +192,7 @@ Than you can run your function locally with Functions Framework:
 npx @google-cloud/functions-framework --target=fastifyFunction
 ```
 
-or add this command to your `package.json` scripts 
+Or add this command to your `package.json` scripts:
 ```json
 "scripts": {
 ...

--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -328,8 +328,6 @@ export default async (req, res) => {
 
 ## Google Cloud Functions
 
-You can easly use Fastify inside your Google Cloud Functions.
-
 ### Creation of Fastify instance
 ```js
 const fastify = require("fastify")({

--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -328,23 +328,18 @@ export default async (req, res) => {
 
 ## Google Cloud Functions
 
-You can run Fastify as a Google Cloud Functions using [`serverFactory`](https://www.fastify.io/docs/v1.13.x/Server/#serverfactory) option to pass the cloud function HTTP request to Fastify `handler`.
+You can easly use Fastify inside your Google Cloud Functions.
 
-### Creation of Fastify instance with `serverFactory`
+### Creation of Fastify instance
 ```js
 const fastify = require("fastify")({
-  serverFactory: (handler, opts) => {
-    const server = require("http").createServer((req, res) => {
-      handler(req, res);
-    });
-    return server;
-  },
+  logger: true // you can also define the level passing an object configuration to logger: {level: 'debug'}
 });
 ```
 
-### Add Custom `contentTypeParse` to Fastyfy instance
+### Add Custom `contentTypeParser` to Fastyfy instance
 
-As explained [here](https://github.com/fastify/fastify/issues/946#issuecomment-766319521), since Google Cloud Functions platform perform the parsing of the body request before it arrives into Fastify instance, troubling the body request in case of `POST` and `PATCH` methods, you need to add a custom [`ContentTypeParser`](https://www.fastify.io/docs/v1.13.x/ContentTypeParser/) to mitigate this behavior.
+As explained [here](https://github.com/fastify/fastify/issues/946#issuecomment-766319521), since Google Cloud Functions platform perform the parsing of the body request before it arrives into Fastify instance, troubling the body request in case of `POST` and `PATCH` methods, you need to add a custom [`ContentTypeParser`](https://www.fastify.io/docs/latest/ContentTypeParser/) to mitigate this behavior.
 
 ```js
 fastify.addContentTypeParser('application/json', {}, (req, body, done) => {
@@ -394,7 +389,7 @@ fastify.route({
 
 ### Implement and export the function
 
-Final step, implement the function to handle the request with Fastify and export it
+Final step, implement the function to handle the request and passing it to Fastify by emitting `request` event to `fastify.server`
 
 ```js
 const fastifyFunction = async (request, reply) => {
@@ -448,7 +443,8 @@ gcloud functions logs read
 
 #### Example request to `/hello` endpoint
 ```bash
-curl -X POST $GOOGLE_CLOUD_FUNCTION_URL/me -H "Content-Type: application/json" -d '{ "name": "Fastify" }'
+curl -X POST https://$GOOGLE_REGION-$GOOGLE_PROJECT.cloudfunctions.net/me -H "Content-Type: application/json" -d '{ "name": "Fastify" }'
+{"message":"Hello Fastify!"}
 ```
 
 ### References

--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -162,7 +162,7 @@ fastify.route({
 
 ### Implement and export the function
 
-Final step, implement the function to handle the request and passing it to Fastify by emitting `request` event to `fastify.server`
+Final step, implement the function to handle the request and pass it to Fastify by emitting `request` event to `fastify.server`:
 
 ```js
 const fastifyFunction = async (request, reply) => {

--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -177,7 +177,7 @@ export.fastifyFunction = fastifyFunction;
 
 Install [Google Functions Framework for Node.js](https://github.com/GoogleCloudPlatform/functions-framework-nodejs).
 
-You can install it globally
+You can install it globally:
 ```bash
 npm i -g @google-cloud/functions-framework
 ```

--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -187,7 +187,7 @@ Or as a development library:
 npm i --save-dev @google-cloud/functions-framework
 ```
 
-Than you can run your function locally with Functions Framework
+Than you can run your function locally with Functions Framework:
 ``` bash
 npx @google-cloud/functions-framework --target=fastifyFunction
 ```

--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -110,7 +110,7 @@ const fastify = require("fastify")({
 });
 ```
 
-### Add Custom `contentTypeParser` to Fastyfy instance
+### Add Custom `contentTypeParser` to Fastify instance
 
 As explained [here](https://github.com/fastify/fastify/issues/946#issuecomment-766319521), since the Google Cloud Functions platform parses the body of the request before it arrives into Fastify instance, troubling the body request in case of `POST` and `PATCH` methods, you need to add a custom [`ContentTypeParser`](https://www.fastify.io/docs/latest/ContentTypeParser/) to mitigate this behavior.
 

--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -337,7 +337,7 @@ const fastify = require("fastify")({
 
 ### Add Custom `contentTypeParser` to Fastyfy instance
 
-As explained [here](https://github.com/fastify/fastify/issues/946#issuecomment-766319521), since Google Cloud Functions platform perform the parsing of the body request before it arrives into Fastify instance, troubling the body request in case of `POST` and `PATCH` methods, you need to add a custom [`ContentTypeParser`](https://www.fastify.io/docs/latest/ContentTypeParser/) to mitigate this behavior.
+As explained [here](https://github.com/fastify/fastify/issues/946#issuecomment-766319521), since the Google Cloud Functions platform parses the body of the request before it arrives into Fastify instance, troubling the body request in case of `POST` and `PATCH` methods, you need to add a custom [`ContentTypeParser`](https://www.fastify.io/docs/latest/ContentTypeParser/) to mitigate this behavior.
 
 ```js
 fastify.addContentTypeParser('application/json', {}, (req, body, done) => {

--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -22,10 +22,10 @@ choice with an additional snippet of code.
 ### Contents
 
 - [AWS Lambda](#aws-lambda)
+- [Google Cloud Functions](#google-cloud-functions)
 - [Google Cloud Run](#google-cloud-run)
 - [Netlify Lambda](#netlify-lambda)
 - [Vercel](#vercel)
-- [Google Cloud Functions](#google-cloud-functions)
 
 ## AWS Lambda
 
@@ -100,6 +100,128 @@ An example deployable with [claudia.js](https://claudiajs.com/tutorials/serverle
 
 - API Gateway does not support streams yet, so you are not able to handle [streams](https://www.fastify.io/docs/latest/Reply/#streams).
 - API Gateway has a timeout of 29 seconds, so it is important to provide a reply during this time.
+
+## Google Cloud Functions
+
+### Creation of Fastify instance
+```js
+const fastify = require("fastify")({
+  logger: true // you can also define the level passing an object configuration to logger: {level: 'debug'}
+});
+```
+
+### Add Custom `contentTypeParser` to Fastyfy instance
+
+As explained [here](https://github.com/fastify/fastify/issues/946#issuecomment-766319521), since the Google Cloud Functions platform parses the body of the request before it arrives into Fastify instance, troubling the body request in case of `POST` and `PATCH` methods, you need to add a custom [`ContentTypeParser`](https://www.fastify.io/docs/latest/ContentTypeParser/) to mitigate this behavior.
+
+```js
+fastify.addContentTypeParser('application/json', {}, (req, body, done) => {
+  done(null, body.body);
+});
+```
+
+### Define your endpoint (examples)
+
+A simple `GET` endpoint
+```js
+fastify.get('/', async (request, reply) => {
+  reply.send({message: 'Hello World!'})
+})
+```
+
+Or a more complete `POST` endpoint with schema validation 
+```JS
+fastify.route({
+  method: 'POST',
+  url: '/hello',
+  schema: {
+    body: {
+      type: 'object',
+      properties: {
+        name: { type: 'string'}
+      },
+      required: ['name']
+    },
+    response: {
+      200: {
+        type: 'object', 
+        properties: {
+          message: {type: 'string'}
+        }
+      }
+    },
+  },
+  handler: async (request, reply) => {
+    const { name } = request.body;
+    reply.code(200).send({
+      message: `Hello ${name}!`
+    })
+  }
+})
+```
+
+### Implement and export the function
+
+Final step, implement the function to handle the request and passing it to Fastify by emitting `request` event to `fastify.server`
+
+```js
+const fastifyFunction = async (request, reply) => {
+  await fastify.ready();
+  fastify.server.emit('request', request, reply)
+}
+
+export.fastifyFunction = fastifyFunction;
+```
+
+### Local test
+
+Install [Google Functions Framework for Node.js](https://github.com/GoogleCloudPlatform/functions-framework-nodejs).
+
+You can install it globally
+```bash
+npm i -g @google-cloud/functions-framework
+```
+
+or as a development library.
+```bash
+npm i --save-dev @google-cloud/functions-framework
+```
+
+Than you can run your function locally with Functions Framework
+``` bash
+npx @google-cloud/functions-framework --target=fastifyFunction
+```
+
+or add this command to your `package.json` scripts 
+```json
+"scripts": {
+...
+"dev": "npx @google-cloud/functions-framework --target=fastifyFunction"
+...
+}
+```
+and run it with `npm run dev`.
+
+
+### Deploy
+```bash
+gcloud functions deploy fastifyFunction \
+--runtime nodejs14 --trigger-http --region $GOOGLE_REGION --allow-unauthenticated
+```
+
+#### Read logs
+```bash
+gcloud functions logs read
+```
+
+#### Example request to `/hello` endpoint
+```bash
+curl -X POST https://$GOOGLE_REGION-$GOOGLE_PROJECT.cloudfunctions.net/me -H "Content-Type: application/json" -d '{ "name": "Fastify" }'
+{"message":"Hello Fastify!"}
+```
+
+### References
+- [Google Cloud Functions - Node.js Quickstart ](https://cloud.google.com/functions/docs/quickstart-nodejs)
 
 ## Google Cloud Run
 
@@ -325,125 +447,3 @@ export default async (req, res) => {
     app.server.emit('request', req, res);
 }
 ```
-
-## Google Cloud Functions
-
-### Creation of Fastify instance
-```js
-const fastify = require("fastify")({
-  logger: true // you can also define the level passing an object configuration to logger: {level: 'debug'}
-});
-```
-
-### Add Custom `contentTypeParser` to Fastyfy instance
-
-As explained [here](https://github.com/fastify/fastify/issues/946#issuecomment-766319521), since the Google Cloud Functions platform parses the body of the request before it arrives into Fastify instance, troubling the body request in case of `POST` and `PATCH` methods, you need to add a custom [`ContentTypeParser`](https://www.fastify.io/docs/latest/ContentTypeParser/) to mitigate this behavior.
-
-```js
-fastify.addContentTypeParser('application/json', {}, (req, body, done) => {
-  done(null, body.body);
-});
-```
-
-### Define your endpoint (examples)
-
-A simple `GET` endpoint
-```js
-fastify.get('/', async (request, reply) => {
-  reply.send({message: 'Hello World!'})
-})
-```
-
-Or a more complete `POST` endpoint with schema validation 
-```JS
-fastify.route({
-  method: 'POST',
-  url: '/hello',
-  schema: {
-    body: {
-      type: 'object',
-      properties: {
-        name: { type: 'string'}
-      },
-      required: ['name']
-    },
-    response: {
-      200: {
-        type: 'object', 
-        properties: {
-          message: {type: 'string'}
-        }
-      }
-    },
-  },
-  handler: async (request, reply) => {
-    const { name } = request.body;
-    reply.code(200).send({
-      message: `Hello ${name}!`
-    })
-  }
-})
-```
-
-### Implement and export the function
-
-Final step, implement the function to handle the request and passing it to Fastify by emitting `request` event to `fastify.server`
-
-```js
-const fastifyFunction = async (request, reply) => {
-  await fastify.ready();
-  fastify.server.emit('request', request, reply)
-}
-
-export.fastifyFunction = fastifyFunction;
-```
-
-### Local test
-
-Install [Google Functions Framework for Node.js](https://github.com/GoogleCloudPlatform/functions-framework-nodejs).
-
-You can install it globally
-```bash
-npm i -g @google-cloud/functions-framework
-```
-
-or as a development library.
-```bash
-npm i --save-dev @google-cloud/functions-framework
-```
-
-Than you can run your function locally with Functions Framework
-``` bash
-npx @google-cloud/functions-framework --target=fastifyFunction
-```
-
-or add this command to your `package.json` scripts 
-```json
-"scripts": {
-...
-"dev": "npx @google-cloud/functions-framework --target=fastifyFunction"
-...
-}
-```
-and run it with `npm run dev`.
-
-
-### Deploy
-```bash
-gcloud functions deploy fastifyFunction \
---runtime nodejs14 --trigger-http --region $GOOGLE_REGION --allow-unauthenticated
-```
-
-#### Read logs
-```bash
-gcloud functions logs read
-```
-
-#### Example request to `/hello` endpoint
-```bash
-curl -X POST https://$GOOGLE_REGION-$GOOGLE_PROJECT.cloudfunctions.net/me -H "Content-Type: application/json" -d '{ "name": "Fastify" }'
-{"message":"Hello Fastify!"}
-```
-
-### References
-- [Google Cloud Functions - Node.js Quickstart ](https://cloud.google.com/functions/docs/quickstart-nodejs)

--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -129,7 +129,7 @@ fastify.get('/', async (request, reply) => {
 })
 ```
 
-Or a more complete `POST` endpoint with schema validation 
+Or a more complete `POST` endpoint with schema validation: 
 ```js
 fastify.route({
   method: 'POST',

--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -122,7 +122,7 @@ fastify.addContentTypeParser('application/json', {}, (req, body, done) => {
 
 ### Define your endpoint (examples)
 
-A simple `GET` endpoint
+A simple `GET` endpoint:
 ```js
 fastify.get('/', async (request, reply) => {
   reply.send({message: 'Hello World!'})

--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -345,7 +345,7 @@ fastify.addContentTypeParser('application/json', {}, (req, body, done) => {
 });
 ```
 
-### Defines your endpoint (examples)
+### Define your endpoint (examples)
 
 A simple `GET` endpoint
 ```js

--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -130,7 +130,7 @@ fastify.get('/', async (request, reply) => {
 ```
 
 Or a more complete `POST` endpoint with schema validation 
-```JS
+```js
 fastify.route({
   method: 'POST',
   url: '/hello',

--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -112,7 +112,7 @@ const fastify = require("fastify")({
 
 ### Add Custom `contentTypeParser` to Fastify instance
 
-As explained [here](https://github.com/fastify/fastify/issues/946#issuecomment-766319521), since the Google Cloud Functions platform parses the body of the request before it arrives into Fastify instance, troubling the body request in case of `POST` and `PATCH` methods, you need to add a custom [`ContentTypeParser`](https://www.fastify.io/docs/latest/ContentTypeParser/) to mitigate this behavior.
+As explained [in issue #946](https://github.com/fastify/fastify/issues/946#issuecomment-766319521), since the Google Cloud Functions platform parses the body of the request before it arrives into Fastify instance, troubling the body request in case of `POST` and `PATCH` methods, you need to add a custom [`ContentTypeParser`](https://www.fastify.io/docs/latest/ContentTypeParser/) to mitigate this behavior.
 
 ```js
 fastify.addContentTypeParser('application/json', {}, (req, body, done) => {

--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -182,7 +182,7 @@ You can install it globally:
 npm i -g @google-cloud/functions-framework
 ```
 
-or as a development library.
+Or as a development library:
 ```bash
 npm i --save-dev @google-cloud/functions-framework
 ```

--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -350,7 +350,7 @@ fastify.addContentTypeParser('application/json', {}, (req, body, done) => {
 A simple `GET` endpoint
 ```js
 fastify.get('/', async (request, reply) => {
-  replay.send({message: 'Hello World!'})
+  reply.send({message: 'Hello World!'})
 })
 ```
 


### PR DESCRIPTION
Added Google Cloud Functions example to use Fastify as requests handler. (Related to https://github.com/fastify/fastify/issues/3382)

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
