### PR TITLE
fix(typescript): define instance listen callback error nullable

### DIFF
--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -90,6 +90,12 @@ expectAssignable<void>(server.listen('3000', '', (err, address) => {}))
 expectAssignable<void>(server.listen(3000, (err, address) => {}))
 expectAssignable<void>(server.listen('3000', (err, address) => {}))
 
+// test listen method callback types
+expectAssignable<void>(server.listen('3000', (err, address) => {
+  expectAssignable<Error|null>(err)
+  expectAssignable<string>(address)
+}))
+
 // test listen method promise
 expectAssignable<PromiseLike<string>>(server.listen(3000))
 expectAssignable<PromiseLike<string>>(server.listen('3000'))

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -70,11 +70,11 @@ export interface FastifyInstance<
   inject(opts: InjectOptions | string): Promise<LightMyRequestResponse>;
   inject(): LightMyRequestChain;
 
-  listen(port: number | string, address: string, backlog: number, callback: (err: Error, address: string) => void): void;
-  listen(port: number | string, address: string, callback: (err: Error, address: string) => void): void;
-  listen(port: number | string, callback: (err: Error, address: string) => void): void;
+  listen(port: number | string, address: string, backlog: number, callback: (err: Error|null, address: string) => void): void;
+  listen(port: number | string, address: string, callback: (err: Error|null, address: string) => void): void;
+  listen(port: number | string, callback: (err: Error|null, address: string) => void): void;
   listen(port: number | string, address?: string, backlog?: number): Promise<string>;
-  listen(opts: { port: number; host?: string; backlog?: number }, callback: (err: Error, address: string) => void): void;
+  listen(opts: { port: number; host?: string; backlog?: number }, callback: (err: Error|null, address: string) => void): void;
   listen(opts: { port: number; host?: string; backlog?: number }): Promise<string>;
 
   ready(): FastifyInstance<RawServer, RawRequest, RawReply> & PromiseLike<undefined>;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Description
Fixes #3448 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
