### PR TITLE
fix: use current instance schema controller

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -631,7 +631,7 @@ function fastify (options) {
   function setSchemaController (schemaControllerOpts) {
     throwIfAlreadyStarted('Cannot call "setSchemaController" when fastify instance is already started!')
     const old = this[kSchemaController]
-    const parent = old.parent || old
+    const parent = old
     const schemaController = SchemaController.buildSchemaController(parent, Object.assign({}, old.opts, schemaControllerOpts))
     this[kSchemaController] = schemaController
     this.getSchema = schemaController.getSchema.bind(schemaController)

--- a/fastify.js
+++ b/fastify.js
@@ -631,8 +631,7 @@ function fastify (options) {
   function setSchemaController (schemaControllerOpts) {
     throwIfAlreadyStarted('Cannot call "setSchemaController" when fastify instance is already started!')
     const old = this[kSchemaController]
-    const parent = old
-    const schemaController = SchemaController.buildSchemaController(parent, Object.assign({}, old.opts, schemaControllerOpts))
+    const schemaController = SchemaController.buildSchemaController(old, Object.assign({}, old.opts, schemaControllerOpts))
     this[kSchemaController] = schemaController
     this.getSchema = schemaController.getSchema.bind(schemaController)
     this.getSchemas = schemaController.getSchemas.bind(schemaController)

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -1604,3 +1604,88 @@ test('setSchemaController: Inherits buildValidator from parent if not present wi
   t.equal(childSerializerCalled, 1, 'Should be called from the child')
   t.equal(res.statusCode, 400, 'Should not coearce the string into array')
 })
+
+test('Should throw if not default validator passed', { only: true }, async t => {
+  t.plan(4)
+  const customAjv = new Ajv({ coerceTypes: false })
+  const someSchema = {
+    $id: 'some',
+    type: 'array',
+    items: {
+      type: 'string'
+    }
+  }
+  const anotherSchema = {
+    $id: 'another',
+    type: 'integer'
+  }
+  const plugin = fp(function (pluginInstance, _, pluginDone) {
+    pluginInstance.setSchemaController({
+      compilersFactory: {
+        buildValidator: function (externalSchemas) {
+          const schemaKeys = Object.keys(externalSchemas)
+          t.equal(schemaKeys.length, 2)
+          t.same(schemaKeys, ['some', 'another'])
+
+          for (const key of schemaKeys) {
+            if (customAjv.getSchema(key) == null) {
+              customAjv.addSchema(externalSchemas[key], key)
+            }
+          }
+          return function validatorCompiler ({ schema }) {
+            return customAjv.compile(schema)
+          }
+        }
+      }
+    })
+
+    pluginDone()
+  })
+  const server = Fastify()
+
+  server.addSchema(someSchema)
+
+  server.register((instance, opts, done) => {
+    instance.addSchema(anotherSchema)
+
+    instance.register(plugin, {})
+
+    instance.post(
+      '/',
+      {
+        schema: {
+          query: {
+            msg: {
+              $ref: 'some#'
+            }
+          },
+          headers: {
+            'x-another': {
+              $ref: 'another#'
+            }
+          }
+        }
+      },
+      (req, reply) => {
+        reply.send({ noop: 'noop' })
+      }
+    )
+
+    done()
+  })
+
+  try {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/',
+      query: {
+        msg: ['string']
+      }
+    })
+
+    t.equal(res.json().message, 'querystring.msg should be array')
+    t.equal(res.statusCode, 400, 'Should not coearce the string into array')
+  } catch (err) {
+    t.error(err)
+  }
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

While still working on #3121 noticed when adding Schemas to child instances, these schemas were lost in the middle, causing any nested validation schema to fail the compilation step due to missing the schema(s) reference.

**Note**:
- This only happens when registering plugins (for instance not creating a new context)
- I'm not 100% why of the decision of using the parent of the SchemaController on each new registration instead of the one that belongs to the current instance, so please feel free to correct me if the approach is wrong or you think that can cause any side effect that I'm not considering within this PR 🙂 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
