### PR TITLE
fix: server.maxRequestsPerSocket miss

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -14,20 +14,20 @@ function createServer (options, httpHandler) {
   let server = null
   if (options.serverFactory) {
     server = options.serverFactory(httpHandler, options)
-  } else if (options.https) {
-    if (options.http2) {
-      server = http2().createSecureServer(options.https, httpHandler)
-      server.on('session', sessionTimeout(options.http2SessionTimeout))
-    } else {
-      server = https.createServer(options.https, httpHandler)
-      server.keepAliveTimeout = options.keepAliveTimeout
-      server.requestTimeout = options.requestTimeout
-    }
   } else if (options.http2) {
-    server = http2().createServer(httpHandler)
+    if (options.https) {
+      server = http2().createSecureServer(options.https, httpHandler)
+    } else {
+      server = http2().createServer(httpHandler)
+    }
     server.on('session', sessionTimeout(options.http2SessionTimeout))
   } else {
-    server = http.createServer(httpHandler)
+    // this is http1
+    if (options.https) {
+      server = https.createServer(options.https, httpHandler)
+    } else {
+      server = http.createServer(httpHandler)
+    }
     server.keepAliveTimeout = options.keepAliveTimeout
     server.requestTimeout = options.requestTimeout
     // we treat zero as null

--- a/test/maxRequestsPerSocket.test.js
+++ b/test/maxRequestsPerSocket.test.js
@@ -102,3 +102,13 @@ test('maxRequestsPerSocket should 0', async (t) => {
   const initialConfig = Fastify().initialConfig
   t.same(initialConfig.maxRequestsPerSocket, 0)
 })
+
+test('requestTimeout passed to server', t => {
+  t.plan(2)
+
+  const httpServer = Fastify({ maxRequestsPerSocket: 5 }).server
+  t.equal(httpServer.maxRequestsPerSocket, 5)
+
+  const httpsServer = Fastify({ maxRequestsPerSocket: 5, https: true }).server
+  t.equal(httpsServer.maxRequestsPerSocket, 5)
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
server.maxRequestsPerSocket is missing when https.I change the logic of the condition of http2,https and http to avoid server's property missing after now.Because this is my second time to fix thing like this..Do you agree that

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
