### PR TITLE
docs: add set-cookie special case

### DIFF
--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -115,10 +115,12 @@ to `''`.
     - While sending different values as cookie with `set-cookie` as the key, every value will be sent as cookie instead of replacing the previous value.
 
     ```js
-    res.header('set-cookie', 'foo');
-    res.header('set-cookie', 'bar');
+    reply.header('set-cookie', 'foo');
+    reply.header('set-cookie', 'bar');
     ```
   - The browser will only consider the latest reference of a key for `set-cookie` header. The fact that this is done this way is to avoid parsing the set-cookie header when you add it in the reply and speeds up the serialization of the reply.
+
+  - To reset the `set-cookie`, you need to make an explicit call to `reply.removeHeader('set-cookie')`, read more about `.removeHeader(key)` [here](#removeheaderkey).
 
 For more information, see [`http.ServerResponse#setHeader`](https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_response_setheader_name_value).
 

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -109,6 +109,16 @@ fastify.get('/', async function (req, rep) {
 Sets a response header. If the value is omitted or undefined, it is coerced
 to `''`.
 
+`NOTE:`
+
+- While sending different values as cookie with `set-cookie` as the key, every value will be sent as cookie instead of replacing the previous value.
+
+```js
+res.header('set-cookie', 'foo');
+res.header('set-cookie', 'bar');
+```
+- The browser will only consider the latest reference of a key for `set-cookie` header. The fact that this is done this way is to avoid parsing the set-cookie header when you add it in the reply and speeds up the serialization of the reply.
+
 For more information, see [`http.ServerResponse#setHeader`](https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_response_setheader_name_value).
 
 <a name="headers"></a>

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -7,6 +7,7 @@
   - [.statusCode](#statusCode)
   - [.server](#server)
   - [.header(key, value)](#headerkey-value)
+      - [set-cookie](#set-cookie)
   - [.headers(object)](#headersobject)
   - [.getHeader(key)](#getheaderkey)
   - [.getHeaders()](#getheaders)
@@ -109,15 +110,15 @@ fastify.get('/', async function (req, rep) {
 Sets a response header. If the value is omitted or undefined, it is coerced
 to `''`.
 
-`NOTE:`
+<a name="set-cookie"></a>
+- ### set-cookie
+    - While sending different values as cookie with `set-cookie` as the key, every value will be sent as cookie instead of replacing the previous value.
 
-- While sending different values as cookie with `set-cookie` as the key, every value will be sent as cookie instead of replacing the previous value.
-
-```js
-res.header('set-cookie', 'foo');
-res.header('set-cookie', 'bar');
-```
-- The browser will only consider the latest reference of a key for `set-cookie` header. The fact that this is done this way is to avoid parsing the set-cookie header when you add it in the reply and speeds up the serialization of the reply.
+    ```js
+    res.header('set-cookie', 'foo');
+    res.header('set-cookie', 'bar');
+    ```
+  - The browser will only consider the latest reference of a key for `set-cookie` header. The fact that this is done this way is to avoid parsing the set-cookie header when you add it in the reply and speeds up the serialization of the reply.
 
 For more information, see [`http.ServerResponse#setHeader`](https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_response_setheader_name_value).
 


### PR DESCRIPTION
##  Document special case for setting 'set-cookie' header
- This PR fixes issue [#3409](https://github.com/fastify/fastify/issues/3409) by adding documentation about  `set-cookie` header
#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
