### PR TITLE
Skip encapsulation of Request and Reply when not needed

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -296,9 +296,6 @@ function fastify (options) {
     initialConfig
   }
 
-  fastify[kReply].prototype.server = fastify
-  fastify[kRequest].prototype.server = fastify
-
   Object.defineProperties(fastify, {
     pluginName: {
       get () {

--- a/lib/context.js
+++ b/lib/context.js
@@ -4,7 +4,7 @@ const { kFourOhFourContext, kReplySerializerDefault } = require('./symbols.js')
 
 // Objects that holds the context of every request
 // Every route holds an instance of this object.
-function Context (schema, handler, Reply, Request, contentTypeParser, config, errorHandler, bodyLimit, logLevel, logSerializers, attachValidation, replySerializer, schemaErrorFormatter) {
+function Context (schema, handler, Reply, Request, contentTypeParser, config, errorHandler, bodyLimit, logLevel, logSerializers, attachValidation, replySerializer, schemaErrorFormatter, server) {
   this.schema = schema
   this.handler = handler
   this.Reply = Reply
@@ -26,6 +26,8 @@ function Context (schema, handler, Reply, Request, contentTypeParser, config, er
   this.attachValidation = attachValidation
   this[kReplySerializerDefault] = replySerializer
   this.schemaErrorFormatter = schemaErrorFormatter || defaultSchemaErrorFormatter
+  // TODO simplify the arguments, we can pass way less arguments if we pass server
+  this.server = server
 }
 
 function defaultSchemaErrorFormatter (errors, dataVar) {

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -5,7 +5,8 @@
 const {
   kReply,
   kRequest,
-  kState
+  kState,
+  kHasBeenDecorated
 } = require('./symbols.js')
 
 const {
@@ -39,6 +40,8 @@ function decorateConstructor (konstructor, name, fn, dependencies) {
   if (instance.hasOwnProperty(name) || hasKey(konstructor, name)) {
     throw new FST_ERR_DEC_ALREADY_PRESENT(name)
   }
+
+  konstructor[kHasBeenDecorated] = true
 
   checkDependencies(instance, name, dependencies)
 

--- a/lib/pluginOverride.js
+++ b/lib/pluginOverride.js
@@ -39,10 +39,7 @@ module.exports = function override (old, fn, opts) {
   instance[kChildren] = []
 
   instance[kReply] = Reply.buildReply(instance[kReply])
-  instance[kReply].prototype.server = instance
-
   instance[kRequest] = Request.buildRequest(instance[kRequest])
-  instance[kRequest].prototype.server = instance
 
   instance[kContentTypeParser] = ContentTypeParser.helpers.buildContentTypeParser(instance[kContentTypeParser])
   instance[kHooks] = buildHooks(instance[kHooks])

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -59,6 +59,11 @@ Object.defineProperties(Reply.prototype, {
       return this.request.context
     }
   },
+  server: {
+    get () {
+      return this.request.context.server
+    }
+  },
   sent: {
     enumerable: true,
     get () {
@@ -94,10 +99,6 @@ Object.defineProperties(Reply.prototype, {
     set (value) {
       this.code(value)
     }
-  },
-  server: {
-    value: null,
-    writable: true
   }
 })
 
@@ -589,7 +590,9 @@ function buildReply (R) {
       this[prop.key] = prop.value
     }
   }
-  _Reply.prototype = new R()
+  Object.setPrototypeOf(_Reply.prototype, R.prototype)
+  Object.setPrototypeOf(_Reply, R)
+  _Reply.parent = R
   _Reply.props = props
   return _Reply
 }

--- a/lib/request.js
+++ b/lib/request.js
@@ -3,6 +3,9 @@
 const proxyAddr = require('proxy-addr')
 const semver = require('semver')
 const warning = require('./warnings')
+const {
+  kHasBeenDecorated
+} = require('./symbols')
 
 function Request (id, params, req, query, log, context) {
   this.id = id
@@ -62,8 +65,10 @@ function buildRegularRequest (R) {
       this[prop.key] = prop.value
     }
   }
-  _Request.prototype = new R()
+  Object.setPrototypeOf(_Request.prototype, Request.prototype)
+  Object.setPrototypeOf(_Request, Request)
   _Request.props = props
+  _Request.parent = R
 
   return _Request
 }
@@ -77,6 +82,9 @@ function getLastEntryInMultiHeaderValue (headerValue) {
 function buildRequestWithTrustProxy (R, trustProxy) {
   const _Request = buildRegularRequest(R)
   const proxyFn = getTrustProxyFn(trustProxy)
+
+  // This is a more optimized version of decoration
+  _Request[kHasBeenDecorated] = true
 
   Object.defineProperties(_Request.prototype, {
     ip: {
@@ -113,6 +121,11 @@ function buildRequestWithTrustProxy (R, trustProxy) {
 }
 
 Object.defineProperties(Request.prototype, {
+  server: {
+    get () {
+      return this.context.server
+    }
+  },
   url: {
     get () {
       return this.raw.url
@@ -181,10 +194,6 @@ Object.defineProperties(Request.prototype, {
     set (headers) {
       this.additionalHeaders = headers
     }
-  },
-  server: {
-    value: null,
-    writable: true
   }
 })
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -36,7 +36,8 @@ const {
   kRequestPayloadStream,
   kDisableRequestLogging,
   kSchemaErrorFormatter,
-  kErrorHandler
+  kErrorHandler,
+  kHasBeenDecorated
 } = require('./symbols.js')
 const { buildErrorHandler } = require('./error-handler')
 
@@ -216,7 +217,15 @@ function buildRouting (options) {
         this[kReply],
         this[kRequest],
         this[kContentTypeParser],
-        config
+        config,
+        opts.errorHandler || this[kErrorHandler],
+        opts.bodyLimit,
+        opts.logLevel,
+        opts.logSerializers,
+        opts.attachValidation,
+        this[kReplySerializerDefault],
+        opts.schemaErrorFormatter || this[kSchemaErrorFormatter],
+        this
       )
 
       if (opts.version) {
@@ -257,6 +266,14 @@ function buildRouting (options) {
               .concat(opts[hook] || [])
               .map(h => h.bind(this))
             context[hook] = toSet.length ? toSet : null
+          }
+
+          // Optimization: avoid encapsulation if no decoration has been done.
+          while (!context.Request[kHasBeenDecorated] && context.Request.parent) {
+            context.Request = context.Request.parent
+          }
+          while (!context.Reply[kHasBeenDecorated] && context.Reply.parent) {
+            context.Reply = context.Reply.parent
           }
 
           // Must store the 404 Context in 'preReady' because it is only guaranteed to

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -42,7 +42,8 @@ const keys = {
   kPluginNameChain: Symbol('fastify.pluginNameChain'),
   // This symbol is only meant to be used for fastify tests and should not be used for any other purpose
   kTestInternals: Symbol('fastify.testInternals'),
-  kErrorHandler: Symbol('fastify.errorHandler')
+  kErrorHandler: Symbol('fastify.errorHandler'),
+  kHasBeenDecorated: Symbol('fastify.hasBeenDecorated')
 }
 
 module.exports = keys

--- a/test/500s.test.js
+++ b/test/500s.test.js
@@ -40,7 +40,7 @@ test('custom 500', t => {
 
   fastify.setErrorHandler(function (err, request, reply) {
     t.type(request, 'object')
-    t.type(request, fastify[symbols.kRequest])
+    t.type(request, fastify[symbols.kRequest].parent)
     reply
       .code(500)
       .type('text/plain')
@@ -74,7 +74,7 @@ test('encapsulated 500', t => {
 
     f.setErrorHandler(function (err, request, reply) {
       t.type(request, 'object')
-      t.type(request, f[symbols.kRequest])
+      t.type(request, fastify[symbols.kRequest].parent)
       reply
         .code(500)
         .type('text/plain')

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -864,7 +864,7 @@ test('decorate* should not emit warning if string,bool,numbers are passed', t =>
   t.end('Done')
 })
 
-test('Request/reply decorators should be able to access the server instance', { only: true }, async t => {
+test('Request/reply decorators should be able to access the server instance', async t => {
   t.plan(6)
 
   const server = require('..')({ logger: false })

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -864,7 +864,7 @@ test('decorate* should not emit warning if string,bool,numbers are passed', t =>
   t.end('Done')
 })
 
-test('Request/reply decorators should be able to access the server instance', async t => {
+test('Request/reply decorators should be able to access the server instance', { only: true }, async t => {
   t.plan(6)
 
   const server = require('..')({ logger: false })

--- a/test/helper.js
+++ b/test/helper.js
@@ -16,7 +16,7 @@ module.exports.payloadMethod = function (method, t, isSetErrorHandler = false) {
   if (isSetErrorHandler) {
     fastify.setErrorHandler(function (err, request, reply) {
       t.type(request, 'object')
-      t.type(request, fastify[symbols.kRequest])
+      t.type(request, fastify[symbols.kRequest].parent)
       reply
         .code(err.statusCode)
         .type('application/json; charset=utf-8')

--- a/test/request-error.test.js
+++ b/test/request-error.test.js
@@ -43,7 +43,7 @@ test('default 400 on request error with custom error handler', t => {
 
   fastify.setErrorHandler(function (err, request, reply) {
     t.type(request, 'object')
-    t.type(request, fastify[kRequest])
+    t.type(request, fastify[kRequest].parent)
     reply
       .code(err.statusCode)
       .type('application/json; charset=utf-8')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This is an optimization that drops the encapsulation if decorateRequest and decorateReply has not been called. In common scenarios where most of the decorations happen top-level it can guarantee an improvement of 10% of throughput.

Fixes #3341

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
