### PR TITLE
Fix positioning of <a> tags relative to headers

### DIFF
--- a/docs/Errors.md
+++ b/docs/Errors.md
@@ -1,10 +1,10 @@
 <h1 align="center">Fastify</h1>
 
-<a id="errors"></a>
 ## Errors
+<a id="errors"></a>
 
-<a name="error-handling"></a>
 ### Error Handling In Node.js
+<a name="error-handling"></a>
 
 #### Uncaught Errors
 In Node.js, uncaught errors are likely to cause memory leaks, file descriptor leaks, and other major production issues. [Domains](https://nodejs.org/en/docs/guides/domain-postmortem/) were a failed attempt to fix this.
@@ -50,122 +50,122 @@ Some things to consider in your custom error handler:
 	- an error will not be triggered twice from a lifecycle hook - Fastify internally monitors the error invocation to avoid infinite loops for errors thrown in the reply phases of the lifecycle. (those after the route handler)
 
 
-<a name="fastify-error-codes"></a>
 ### Fastify Error Codes
+<a name="fastify-error-codes"></a>
 
-<a name="FST_ERR_BAD_URL"></a>
 #### FST_ERR_BAD_URL
+<a name="FST_ERR_BAD_URL"></a>
 
 The router received an invalid url.
 
-<a name="FST_ERR_CTP_ALREADY_PRESENT"></a>
 #### FST_ERR_CTP_ALREADY_PRESENT
+<a name="FST_ERR_CTP_ALREADY_PRESENT"></a>
 
 The parser for this content type was already registered.
 
-<a name="FST_ERR_CTP_BODY_TOO_LARGE"></a>
 #### FST_ERR_CTP_BODY_TOO_LARGE
+<a name="FST_ERR_CTP_BODY_TOO_LARGE"></a>
 
 The request body is larger than the provided limit.
 
 This setting can be defined in the Fastify server instance: [`bodyLimit`](./Reference/Server.md#bodyLimit)
 
-<a name="FST_ERR_CTP_EMPTY_TYPE"></a>
 #### FST_ERR_CTP_EMPTY_TYPE
+<a name="FST_ERR_CTP_EMPTY_TYPE"></a>
 
 The content type cannot be an empty string.
 
-<a name="FST_ERR_CTP_INVALID_CONTENT_LENGTH"></a>
 #### FST_ERR_CTP_INVALID_CONTENT_LENGTH
+<a name="FST_ERR_CTP_INVALID_CONTENT_LENGTH"></a>
 
 Request body size did not match Content-Length.
 
-<a name="FST_ERR_CTP_INVALID_HANDLER"></a>
 #### FST_ERR_CTP_INVALID_HANDLER
+<a name="FST_ERR_CTP_INVALID_HANDLER"></a>
 
 An invalid handler was passed for the content type.
 
-<a name="FST_ERR_CTP_INVALID_MEDIA_TYPE"></a>
 #### FST_ERR_CTP_INVALID_MEDIA_TYPE
+<a name="FST_ERR_CTP_INVALID_MEDIA_TYPE"></a>
 
 The received media type is not supported (i.e. there is no suitable `Content-Type` parser for it).
 
-<a name="FST_ERR_CTP_INVALID_PARSE_TYPE"></a>
 #### FST_ERR_CTP_INVALID_PARSE_TYPE
+<a name="FST_ERR_CTP_INVALID_PARSE_TYPE"></a>
 
 The provided parse type is not supported. Accepted values are `string` or `buffer`.
 
-<a name="FST_ERR_CTP_INVALID_TYPE"></a>
 #### FST_ERR_CTP_INVALID_TYPE
+<a name="FST_ERR_CTP_INVALID_TYPE"></a>
 
 The `Content-Type` should be a string.
 
-<a name="FST_ERR_DEC_ALREADY_PRESENT"></a>
 #### FST_ERR_DEC_ALREADY_PRESENT
+<a name="FST_ERR_DEC_ALREADY_PRESENT"></a>
 
 A decorator with the same name is already registered.
 
-<a name="FST_ERR_DEC_MISSING_DEPENDENCY"></a>
 #### FST_ERR_DEC_MISSING_DEPENDENCY
+<a name="FST_ERR_DEC_MISSING_DEPENDENCY"></a>
 
 The decorator cannot be registered due to a missing dependency.
 
-<a name="FST_ERR_HOOK_INVALID_HANDLER"></a>
 #### FST_ERR_HOOK_INVALID_HANDLER
+<a name="FST_ERR_HOOK_INVALID_HANDLER"></a>
 
 The hook callback must be a function.
 
-<a name="FST_ERR_HOOK_INVALID_TYPE"></a>
 #### FST_ERR_HOOK_INVALID_TYPE
+<a name="FST_ERR_HOOK_INVALID_TYPE"></a>
 
 The hook name must be a string.
 
-<a name="FST_ERR_LOG_INVALID_DESTINATION"></a>
 #### FST_ERR_LOG_INVALID_DESTINATION
+<a name="FST_ERR_LOG_INVALID_DESTINATION"></a>
 
 The logger accepts either a `'stream'` or a `'file'` as the destination.
 
-<a name="FST_ERR_PROMISE_NOT_FULFILLED"></a>
 #### FST_ERR_PROMISE_NOT_FULFILLED
+<a name="FST_ERR_PROMISE_NOT_FULFILLED"></a>
 
 A promise may not be fulfilled with 'undefined' when statusCode is not 204.
 
-<a id="FST_ERR_REP_ALREADY_SENT"></a>
 #### FST_ERR_REP_ALREADY_SENT
+<a id="FST_ERR_REP_ALREADY_SENT"></a>
 
 A response was already sent.
 
-<a name="FST_ERR_REP_INVALID_PAYLOAD_TYPE"></a>
 #### FST_ERR_REP_INVALID_PAYLOAD_TYPE
+<a name="FST_ERR_REP_INVALID_PAYLOAD_TYPE"></a>
 
 Reply payload can be either a `string` or a `Buffer`.
 
-<a name="FST_ERR_SCH_ALREADY_PRESENT"></a>
 #### FST_ERR_SCH_ALREADY_PRESENT
+<a name="FST_ERR_SCH_ALREADY_PRESENT"></a>
 
 A schema with the same `$id` already exists.
 
-<a name="FST_ERR_SCH_MISSING_ID"></a>
 #### FST_ERR_SCH_MISSING_ID
+<a name="FST_ERR_SCH_MISSING_ID"></a>
 
 The schema provided does not have `$id` property.
 
-<a name="FST_ERR_SCH_SERIALIZATION_BUILD"></a>
 #### FST_ERR_SCH_SERIALIZATION_BUILD
+<a name="FST_ERR_SCH_SERIALIZATION_BUILD"></a>
 
 The JSON schema provided for serialization of a route response is not valid.
 
-<a name="FST_ERR_SCH_VALIDATION_BUILD"></a>
 #### FST_ERR_SCH_VALIDATION_BUILD
+<a name="FST_ERR_SCH_VALIDATION_BUILD"></a>
 
 The JSON schema provided for validation to a route is not valid.
 
-<a id="FST_ERR_SEND_INSIDE_ONERR"></a>
 #### FST_ERR_SEND_INSIDE_ONERR
+<a id="FST_ERR_SEND_INSIDE_ONERR"></a>
 
 You cannot use `send` inside the `onError` hook.
 
-<a name="FST_ERR_SEND_UNDEFINED_ERR"></a>
 #### FST_ERR_SEND_UNDEFINED_ERR
+<a name="FST_ERR_SEND_UNDEFINED_ERR"></a>
 
 Undefined error has occurred.

--- a/docs/Guides/Getting-Started.md
+++ b/docs/Guides/Getting-Started.md
@@ -5,8 +5,9 @@ Hello! Thank you for checking out Fastify!<br>
 This document aims to be a gentle introduction to the framework and its features. It is an elementary preface with examples and links to other parts of the documentation.<br>
 Let's start!
 
-<a name="install"></a>
 ### Install
+<a name="install"></a>
+
 Install with npm:
 ```
 npm i fastify --save
@@ -16,8 +17,9 @@ Install with yarn:
 yarn add fastify
 ```
 
-<a name="first-server"></a>
 ### Your first server
+<a name="first-server"></a>
+
 Let's write our first server:
 ```js
 // Require the framework and instantiate it
@@ -96,8 +98,9 @@ Fastify offers an easy platform that helps to solve all of the problems outlined
 >
 > When deploying to a Docker (or another type of) container using `0.0.0.0` or `::` would be the easiest method for exposing the application.
 
-<a name="first-plugin"></a>
 ### Your first plugin
+<a name="first-plugin"></a>
+
 As with JavaScript, where everything is an object, with Fastify everything is a plugin.<br>
 Before digging into it, let's see how it works!<br>
 Let's declare our basic server, but instead of declaring the route inside the entry point, we'll declare it in an external file (check out the [route declaration](Routes.md) docs).
@@ -295,8 +298,9 @@ The MongoDB plugin uses the `decorate` API to add custom objects to the Fastify 
 
 To dig deeper into how Fastify plugins work, how to develop new plugins, and for details on how to use the whole Fastify API to deal with the complexity of asynchronously bootstrapping an application, read [the hitchhiker's guide to plugins](Plugins-Guide.md).
 
-<a name="plugin-loading-order"></a>
 ### Loading order of your plugins
+<a name="plugin-loading-order"></a>
+
 To guarantee consistent and predictable behavior of your application, we highly recommend to always load your code as shown below:
 ```
 └── plugins (from the Fastify ecosystem)
@@ -329,8 +333,9 @@ As discussed previously, Fastify offers a solid encapsulation model, to help you
           └── your services
 ```
 
-<a name="validate-data"></a>
 ### Validate your data
+<a name="validate-data"></a>
+
 Data validation is extremely important and a core concept of the framework.<br>
 To validate incoming requests, Fastify uses [JSON Schema](https://json-schema.org/).
 (JTD schemas are loosely supported, but `jsonShorthand` must be disabled first)
@@ -356,8 +361,9 @@ fastify.post('/', opts, async (request, reply) => {
 This example shows how to pass an options object to the route, which accepts a `schema` key that contains all of the schemas for route, `body`, `querystring`, `params`, and `headers`.<br>
 Read [Validation and Serialization](Validation-and-Serialization.md) to learn more.
 
-<a name="serialize-data"></a>
 ### Serialize your data
+<a name="serialize-data"></a>
+
 Fastify has first class support for JSON. It is extremely optimized to parse JSON bodies and to serialize JSON output.<br>
 To speed up JSON serialization (yes, it is slow!) use the `response` key of the schema option as shown in the following example:
 ```js
@@ -381,8 +387,9 @@ fastify.get('/', opts, async (request, reply) => {
 By specifying a schema as shown, you can speed up serialization by a factor of 2-3. This also helps to protect against leakage of potentially sensitive data, since Fastify will serialize only the data present in the response schema.
 Read [Validation and Serialization](Validation-and-Serialization.md) to learn more.
 
-<a name="request-payload"></a>
 ### Parsing request payloads
+<a name="request-payload"></a>
+
 Fastify parses `'application/json'` and `'text/plain'` request payloads natively, with the result accessible from the [Fastify request](Request.md) object at `request.body`.<br>
 The following example returns the parsed body of a request back to the client:
 
@@ -395,18 +402,21 @@ fastify.post('/', opts, async (request, reply) => {
 
 Read [Content Type Parser](ContentTypeParser.md) to learn more about Fastify's default parsing functionality and how to support other content types.
 
-<a name="extend-server"></a>
 ### Extend your server
+<a name="extend-server"></a>
+
 Fastify is built to be extremely extensible and minimal, we believe that a bare-bones framework is all that is necessary to make great applications possible.<br>
 In other words, Fastify is not a "batteries included" framework, and relies on an amazing [ecosystem](Ecosystem.md)!
 
-<a name="test-server"></a>
 ### Test your server
+<a name="test-server"></a>
+
 Fastify does not offer a testing framework, but we do recommend a way to write your tests that uses the features and architecture of Fastify.<br>
 Read the [testing](Testing.md) documentation to learn more!
 
-<a name="cli"></a>
 ### Run your server from CLI
+<a name="cli"></a>
+
 Fastify also has CLI integration thanks to [fastify-cli](https://github.com/fastify/fastify-cli).
 
 First, install `fastify-cli`:
@@ -443,8 +453,9 @@ Then run your server with:
 npm start
 ```
 
-<a name="slides"></a>
 ### Slides and Videos
+<a name="slides"></a>
+
 - Slides
   - [Take your HTTP server to ludicrous speed](https://mcollina.github.io/take-your-http-server-to-ludicrous-speed) by [@mcollina](https://github.com/mcollina)
   - [What if I told you that HTTP can be fast](https://delvedor.github.io/What-if-I-told-you-that-HTTP-can-be-fast) by [@delvedor](https://github.com/delvedor)

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -342,8 +342,9 @@ fastify.addHook('onReady', async function () {
 })
 ```
 
-<a name="on-close"></a>
 ### onClose
+<a name="on-close"></a>
+
 Triggered when `fastify.close()` is invoked to stop the server. It is useful when [plugins](Plugins.md) need a "shutdown" event, for example, to close an open connection to a database.<br>
 The first argument is the Fastify instance, the second one the `done` callback.
 ```js
@@ -353,8 +354,9 @@ fastify.addHook('onClose', (instance, done) => {
 })
 ```
 
-<a name="on-route"></a>
 ### onRoute
+<a name="on-route"></a>
+
 Triggered when a new route is registered. Listeners are passed a `routeOptions` object as the sole parameter. The interface is synchronous, and, as such, the listeners are not passed a callback. This hook is encapsulated.
 ```js
 fastify.addHook('onRoute', (routeOptions) => {
@@ -384,8 +386,9 @@ fastify.addHook('onRoute', (routeOptions) => {
 })
 ```
 
-<a name="on-register"></a>
 ### onRegister
+<a name="on-register"></a>
+
 Triggered when a new plugin is registered and a new encapsulation context is created. The hook will be executed **before** the registered code.<br/>
 This hook can be useful if you are developing a plugin that needs to know when a plugin context is formed, and you want to operate in that specific context, thus this hook is encapsulated.<br/>
 **Note:** This hook will not be called if a plugin is wrapped inside [`fastify-plugin`](https://github.com/fastify/fastify-plugin).
@@ -418,8 +421,9 @@ fastify.addHook('onRegister', (instance, opts) => {
 })
 ```
 
-<a name="scope"></a>
 ## Scope
+<a name="scope"></a>
+
 Except for [onClose](#onclose), all hooks are encapsulated. This means that you can decide where your hooks should run by using `register` as explained in the [plugins guide](Plugins-Guide.md). If you pass a function, that function is bound to the right Fastify context and from there you have full access to the Fastify API.
 
 ```js
@@ -457,9 +461,10 @@ fastify.register(async function plugin (fastify, opts) {
 
 Warn: if you declare the function with an [arrow function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), the `this` will not be Fastify, but the one of the current scope.
 
-<a name="route-hooks"></a>
 
 ## Route level hooks
+<a name="route-hooks"></a>
+
 You can declare one or more custom lifecycle hooks ([onRequest](#onrequest), [onResponse](#onresponse), [preParsing](#preparsing), [preValidation](#prevalidation), [preHandler](#prehandler), [preSerialization](#preserialization), [onSend](#onsend), [onTimeout](#ontimeout), and [onError](#onerror)) hook(s) that will be **unique** for the route.
 If you do so, those hooks are always executed as the last hook in their category. <br/>
 This can be useful if you need to implement authentication, where the [preParsing](#preparsing) or [preValidation](#prevalidation) hooks are exactly what you need.

--- a/docs/LTS.md
+++ b/docs/LTS.md
@@ -1,8 +1,7 @@
 <h1 align="center">Fastify</h1>
 
-<a name="lts"></a>
-
 ## Long Term Support
+<a name="lts"></a>
 
 Fastify's Long Term Support (LTS) is provided according to the schedule laid
 out in this document:
@@ -41,9 +40,8 @@ A "month" is defined as 30 consecutive days.
 
 [semver]: https://semver.org/
 
-<a name="lts-schedule"></a>
-
 ### Schedule
+<a name="lts-schedule"></a>
 
 | Version | Release Date | End Of LTS Date | Node.js              |
 | :------ | :----------- | :-------------- | :------------------- |
@@ -51,9 +49,8 @@ A "month" is defined as 30 consecutive days.
 | 2.0.0   | 2019-02-25   | 2021-01-31      | 6, 8, 10, 12, 14     |
 | 3.0.0   | 2020-07-07   | TBD             | 10, 12, 14, 16       |
 
-<a name="supported-os"></a>
-
 ### CI tested operating systems
+<a name="supported-os"></a>
 
 Fastify uses GitHub Actions for CI testing, please refer to
 [GitHub's documentation regarding workflow runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)

--- a/docs/Middleware.md
+++ b/docs/Middleware.md
@@ -28,8 +28,9 @@ Remember that middleware can be encapsulated; this means that you can decide whe
 
 Fastify middleware do not expose the `send` method or other methods specific to the Fastify [Reply](Reply.md#reply) instance. This is because Fastify wraps the incoming `req` and `res` Node instances using the [Request](Request.md#request) and [Reply](Reply.md#reply) objects internally, but this is done after the middleware phase. If you need to create middleware, you have to use the Node `req` and `res` instances. Otherwise, you can use the `preHandler` hook that already has the [Request](Request.md#request) and [Reply](Reply.md#reply) Fastify instances. For more information, see [Hooks](Hooks.md#hooks).
 
-<a name="restrict-usage"></a>
 #### Restrict middleware execution to certain paths
+<a name="restrict-usage"></a>
+
 If you need to only run middleware under certain paths, just pass the path as the first parameter to `use` and you are done!
 
 *Note that this does not support routes with parameters, (e.g. `/user/:id/comments`) and wildcards are not supported in multiple paths.*

--- a/docs/Plugins-Guide.md
+++ b/docs/Plugins-Guide.md
@@ -16,8 +16,9 @@ Fastify was built from the beginning to be an extremely modular system. We built
 - [Emit warnings](#emit-warnings)
 - [Let's start!](#start)
 
-<a name="register"></a>
 ## Register
+<a name="register"></a>
+
 As with JavaScript, where everything is an object, in Fastify everything is a plugin.<br>
 Your routes, your utilities, and so on are all plugins. To add a new plugin, whatever its functionality may be, in Fastify you have a nice and unique API: [`register`](Plugins.md).
 ```js
@@ -55,8 +56,9 @@ module.exports = function (fastify, options, done) {
 
 Well, now you know how to use the `register` API and how it works, but how do we add new functionality to Fastify and even better, share them with other developers?
 
-<a name="decorators"></a>
 ## Decorators
+<a name="decorators"></a>
+
 Okay, let's say that you wrote a utility that is so good that you decided to make it available along with all your code. How would you do it? Probably something like the following:
 ```js
 // your-awesome-utility.js
@@ -178,8 +180,9 @@ fastify.get('/happiness', (request, reply) => {
 
 We have seen how to extend server functionality and how to handle the encapsulation system, but what if you need to add a function that must be executed every time when the server "[emits](Lifecycle.md)" an event?
 
-<a name="hooks"></a>
 ## Hooks
+<a name="hooks"></a>
+
 You just built an amazing utility, but now you need to execute that for every request, this is what you will likely do:
 ```js
 fastify.decorate('util', (request, key, value) => { request[key] = value })
@@ -240,8 +243,9 @@ Now your hook will run just for the first route!
 
 As you probably noticed by now, `request` and `reply` are not the standard Nodejs *request* and *response* objects, but Fastify's objects.<br>
 
-<a name="distribution"></a>
 ## How to handle encapsulation and distribution
+<a name="distribution"></a>
+
 Perfect, now you know (almost) all of the tools that you can use to extend Fastify. Nevertheless, chances are that you came across one big issue: how is distribution handled?
 
 The preferred way to distribute a utility is to wrap all your code inside a `register`. Using this, your plugin can support asynchronous bootstrapping *(since `decorate` is a synchronous API)*, in the case of a database connection for example.
@@ -285,8 +289,8 @@ fastify.register(require('your-plugin'), parent => {
 ```
 In the above example, the `parent` variable of the function passed in as the second argument of `register` is a copy of the **external Fastify instance** that the plugin was registered at. This means that we are able to access any variables that were injected by preceding plugins in the order of declaration.
 
-<a name="esm-support"></a>
 ## ESM support
+<a name="esm-support"></a>
 
 ESM is supported as well from [Node.js `v13.3.0`](https://nodejs.org/api/esm.html) and above! Just export your plugin as ESM module and you are good to go!
 
@@ -318,8 +322,9 @@ fastify.listen(3000, (err, address) => {
 })
 ```
 
-<a name="handle-errors"></a>
 ## Handle errors
+<a name="handle-errors"></a>
+
 It can happen that one of your plugins fails during startup. Maybe you expect it and you have a custom logic that will be triggered in that case. How can you implement this?
 The `after` API is what you need. `after` simply registers a callback that will be executed just after a register, and it can take up to three parameters.<br>
 The callback changes based on the parameters you are giving:
@@ -338,8 +343,9 @@ fastify
   })
 ```
 
-<a name="custom-errors"></a>
 ## Custom errors
+<a name="custom-errors"></a>
+
 If your plugin needs to expose custom errors, you can easily generate consistent error objects across your codebase and plugins with the [`fastify-error`](https://github.com/fastify/fastify-error) module.
 
 ```js
@@ -348,8 +354,9 @@ const CustomError = createError('ERROR_CODE', 'message')
 console.log(new CustomError())
 ```
 
-<a name="emit-warnings"></a>
 ## Emit Warnings
+<a name="emit-warnings"></a>
+
 If you want to deprecate an API, or you want to warn the user about a specific use case, you can use the [`fastify-warning`](https://github.com/fastify/fastify-warning) module.
 
 ```js
@@ -358,8 +365,9 @@ warning.create('FastifyDeprecation', 'FST_ERROR_CODE', 'message')
 warning.emit('FST_ERROR_CODE')
 ```
 
-<a name="start"></a>
 ## Let's start!
+<a name="start"></a>
+
 Awesome, now you know everything you need to know about Fastify and its plugin system to start building your first plugin, and please if you do, tell us! We will add it to the [*ecosystem*](https://github.com/fastify/fastify#ecosystem) section of our documentation!
 
 If you want to see some real-world examples, check out:

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -11,8 +11,9 @@ You already see in the [getting started](./Guides/Getting-Started.md#register) s
 fastify.register(plugin, [options])
 ```
 
-<a name="plugin-options"></a>
 ### Plugin Options
+<a name="plugin-options"></a>
+
 The optional `options` parameter for `fastify.register` supports a predefined set of options that Fastify itself will use, except when the plugin has been wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This options object will also be passed to the plugin upon invocation, regardless of whether or not the plugin has been wrapped. The currently supported list of Fastify specific options is:
 
 + [`logLevel`](Routes.md#custom-log-level)
@@ -62,13 +63,15 @@ The Fastify instance passed on to the function is the latest state of the **exte
 
 Keep in mind that the Fastify instance passed on to the function is the same as the one that will be passed into the plugin, a copy of the external Fastify instance rather than a reference. Any usage of the instance will behave the same as it would if called within the plugins function i.e. if `decorate` is called, the decorated variables will be available within the plugins function unless it was wrapped with [`fastify-plugin`](https://github.com/fastify/fastify-plugin).
 
-<a name="route-prefixing-option"></a>
 #### Route Prefixing option
+<a name="route-prefixing-option"></a>
+
 If you pass an option with the key `prefix` with a `string` value, Fastify will use it to prefix all the routes inside the register, for more info check [here](Routes.md#route-prefixing).<br>
 Be aware that if you use [`fastify-plugin`](https://github.com/fastify/fastify-plugin) this option will not work.
 
-<a name="error-handling"></a>
 #### Error handling
+<a name="error-handling"></a>
+
 The error handling is done by [avvio](https://github.com/mcollina/avvio#error-handling).<br>
 As a general rule, it is highly recommended that you handle your errors in the next `after` or `ready` block, otherwise you will get them inside the `listen` callback.
 
@@ -90,8 +93,8 @@ fastify.listen(3000, (err, address) => {
 })
 ```
 
-<a name="async-await"></a>
 ### async/await
+<a name="async-await"></a>
 
 *async/await* is supported by `after`, `ready` and `listen`, as well as
 `fastify` being a [Thenable](https://promisesaplus.com/).
@@ -106,8 +109,8 @@ await fastify.ready()
 await fastify.listen(3000)
 ```
 
-<a name="esm-support"></a>
 #### ESM support
+<a name="esm-support"></a>
 
 ESM is supported as well from [Node.js `v13.3.0`](https://nodejs.org/api/esm.html) and above!
 
@@ -131,8 +134,9 @@ async function plugin (fastify, opts) {
 export default plugin
 ```
 
-<a name="create-plugin"></a>
 ### Create a plugin
+<a name="create-plugin"></a>
+
 Creating a plugin is very easy, you just need to create a function that takes three parameters, the `fastify` instance, an `options` object, and the `done` callback.<br>
 Example:
 ```js
@@ -160,8 +164,9 @@ Sometimes, you will need to know when the server is about to close, for example,
 
 Do not forget that `register` will always create a new Fastify scope, if you do not need that, read the following section.
 
-<a name="handle-scope"></a>
 ### Handle the scope
+<a name="handle-scope"></a>
+
 If you are using `register` only for extending the functionality of the server with  [`decorate`](Decorators.md), it is your responsibility to tell Fastify not to create a new scope. Otherwise, your changes will not be accessible by the user in the upper scope.
 
 You have two ways to tell Fastify to avoid the creation of a new context:

--- a/docs/Reference/Encapsulation.md
+++ b/docs/Reference/Encapsulation.md
@@ -1,7 +1,7 @@
 <h1 align="center">Fastify</h1>
 
-<a id="encapsulation"></a>
 ## Encapsulation
+<a id="encapsulation"></a>
 
 A fundamental feature of Fastify is the "encapsulation context." The
 encapsulation context governs which [decorators](./Decorators.md), registered
@@ -122,8 +122,8 @@ To see this, start the server and issue requests:
 
 [bearer]: https://github.com/fastify/fastify-bearer-auth
 
-<a id="shared-context"></a>
 ## Sharing Between Contexts
+<a id="shared-context"></a>
 
 Notice that each context in the prior example inherits _only_ from the parent
 contexts. Parent contexts cannot access any entities within their descendent

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1,7 +1,7 @@
 <h1 align="center">Fastify</h1>
 
-<a name="factory"></a>
 ## Factory
+<a name="factory"></a>
 
 The Fastify module exports a factory function that is used to create new
 <code><b>Fastify server</b></code> instances. This factory function accepts
@@ -42,30 +42,27 @@ document describes the properties available in that options object.
 - [initialConfig](./Server.md#initialConfig)
 
 
-<a name="factory-http2"></a>
 ### `http2`
+<a name="factory-http2"></a>
 
 If `true` Node.js core's [HTTP/2](https://nodejs.org/dist/latest-v14.x/docs/api/http2.html) module is used for binding the socket.
 
 + Default: `false`
 
-<a name="factory-https"></a>
 ### `https`
+<a name="factory-https"></a>
 
 An object used to configure the server's listening socket for TLS. The options
 are the same as the Node.js core
 [`createServer` method](https://nodejs.org/dist/latest-v14.x/docs/api/https.html#https_https_createserver_options_requestlistener).
 When this property is `null`, the socket will not be configured for TLS.
 
-This option also applies when the
-<a href="./Server.md#factory-http2">
-<code><b>http2</b></code>
-</a> option is set.
+This option also applies when the [`http2`](./Server.md#factory-http2) option is set.
 
 + Default: `null`
 
-<a name="factory-connection-timeout"></a>
 ### `connectionTimeout`
+<a name="factory-connection-timeout"></a>
 
 Defines the server timeout in milliseconds. See documentation for
 [`server.timeout` property](https://nodejs.org/api/http.html#http_server_timeout)
@@ -74,8 +71,8 @@ specified, this option is ignored.
 
 + Default: `0` (no timeout)
 
-<a name="factory-keep-alive-timeout"></a>
 ### `keepAliveTimeout`
+<a name="factory-keep-alive-timeout"></a>
 
 Defines the server keep-alive timeout in milliseconds. See documentation for
 [`server.keepAliveTimeout` property](https://nodejs.org/api/http.html#http_server_keepalivetimeout)
@@ -84,8 +81,8 @@ is in use. Also, when `serverFactory` option is specified, this option is ignore
 
 + Default: `5000` (5 seconds)
 
-<a name="factory-max-requests-per-socket"></a>
 ### `maxRequestsPerSocket`
+<a name="factory-max-requests-per-socket"></a>
 
 Defines the maximum number of requests socket can handle before closing keep alive connection. See documentation for
 [`server.maxRequestsPerSocket` property](https://nodejs.org/dist/latest/docs/api/http.html#http_server_maxrequestspersocket)
@@ -95,8 +92,8 @@ is in use. Also, when `serverFactory` option is specified, this option is ignore
 
 + Default: `0` (no limit)
 
-<a name="factory-request-timeout"></a>
 ### `requestTimeout`
+<a name="factory-request-timeout"></a>
 
 Defines the maximum number of milliseconds for receiving the entire request from the client.
 [`server.requestTimeout` property](https://nodejs.org/dist/latest/docs/api/http.html#http_server_requesttimeout)
@@ -106,8 +103,8 @@ It must be set to a non-zero value (e.g. 120 seconds) to protect against potenti
 
 + Default: `0` (no limit)
 
-<a name="factory-ignore-slash"></a>
 ### `ignoreTrailingSlash`
+<a name="factory-ignore-slash"></a>
 
 Fastify uses [find-my-way](https://github.com/delvedor/find-my-way) to handle
 routing. This option may be set to `true` to ignore trailing slashes in routes.
@@ -132,21 +129,22 @@ fastify.get('/bar', function (req, reply) {
 })
 ```
 
-<a name="factory-max-param-length"></a>
 ### `maxParamLength`
+<a name="factory-max-param-length"></a>
+
 You can set a custom length for parameters in parametric (standard, regex, and multi) routes by using `maxParamLength` option; the default value is 100 characters.<br>
 This can be useful especially if you have some regex based route, protecting you against [DoS attacks](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS).<br>
 *If the maximum length limit is reached, the not found route will be invoked.*
 
-<a name="factory-body-limit"></a>
 ### `bodyLimit`
+<a name="factory-body-limit"></a>
 
 Defines the maximum payload, in bytes, the server is allowed to accept.
 
 + Default: `1048576` (1MiB)
 
-<a name="factory-on-proto-poisoning"></a>
 ### `onProtoPoisoning`
+<a name="factory-on-proto-poisoning"></a>
 
 Defines what action the framework must take when parsing a JSON object
 with `__proto__`. This functionality is provided by
@@ -158,8 +156,8 @@ Possible values are `'error'`, `'remove'` and `'ignore'`.
 
 + Default: `'error'`
 
-<a name="factory-on-constructor-poisoning"></a>
 ### `onConstructorPoisoning`
+<a name="factory-on-constructor-poisoning"></a>
 
 Defines what action the framework must take when parsing a JSON object
 with `constructor`. This functionality is provided by
@@ -171,8 +169,8 @@ Possible values are `'error'`, `'remove'` and `'ignore'`.
 
 + Default: `'error'`
 
-<a name="factory-logger"></a>
 ### `logger`
+<a name="factory-logger"></a>
 
 Fastify includes built-in logging via the [Pino](https://getpino.io/) logger.
 This property is used to configure the internal logger instance.
@@ -224,8 +222,9 @@ interface by having the following methods: `info`, `error`, `debug`, `fatal`, `w
   const fastify = require('fastify')({logger: customLogger});
   ```
 
-<a name="factory-disable-request-logging"></a>
 ### `disableRequestLogging`
+<a name="factory-disable-request-logging"></a>
+
 By default, when logging is enabled, Fastify will issue an `info` level log
 message when a request is received and when the response for that request has
 been sent. By setting this option to `true`, these log messages will be disabled.
@@ -249,8 +248,9 @@ fastify.addHook('onResponse', (req, reply, done) => {
 
 Please note that this setting will also disable an error log written by the default `onResponse` hook on reply callback errors.
 
-<a name="custom-http-server"></a>
 ### `serverFactory`
+<a name="custom-http-server"></a>
+
 You can pass a custom HTTP server to Fastify by using the `serverFactory` option.<br/>
 `serverFactory` is a function that takes a `handler` parameter, which takes the `request` and `response` objects as parameters, and an options object, which is the same you have passed to Fastify.
 
@@ -274,8 +274,8 @@ fastify.listen(3000)
 
 Internally Fastify uses the API of Node core HTTP server, so if you are using a custom server you must be sure to have the same API exposed. If not, you can enhance the server instance inside the `serverFactory` function before the `return` statement.<br/>
 
-<a name="schema-json-shorthand"></a>
 ### `jsonShorthand`
+<a name="schema-json-shorthand"></a>
 
 + Default: `true`
 
@@ -305,8 +305,8 @@ fastify.post('/', {
 
 **Note: Fastify does not currently throw on invalid schemas, so if you turn this off in an existing project, you need to be careful that none of your existing schemas become invalid as a result, since they will be treated as a catch-all.**
 
-<a name="factory-case-sensitive"></a>
 ### `caseSensitive`
+<a name="factory-case-sensitive"></a>
 
 By default, value equal to `true`, routes are registered as case sensitive. That is, `/foo` is not equivalent to `/Foo`. When set to `false`, routes are registered in a fashion such that `/foo` is equivalent to `/Foo` which is equivalent to `/FOO`.
 
@@ -324,22 +324,22 @@ Please note that setting this option to `false` goes against
 
 Also note, this setting will not affect query strings. If you want to change the way query strings are handled take a look at [`querystringParser`](./Server.md#querystringparser).
 
-<a name="factory-request-id-header"></a>
 ### `requestIdHeader`
+<a name="factory-request-id-header"></a>
 
 The header name used to know the request-id. See [the request-id](Logging.md#logging-request-id) section.
 
 + Default: `'request-id'`
 
-<a name="factory-request-id-log-label"></a>
 ### `requestIdLogLabel`
+<a name="factory-request-id-log-label"></a>
 
 Defines the label used for the request identifier when logging the request.
 
 + Default: `'reqId'`
 
-<a name="factory-gen-request-id"></a>
 ### `genReqId`
+<a name="factory-gen-request-id"></a>
 
 Function for generating the request-id. It will receive the incoming request as a parameter.
 
@@ -356,8 +356,8 @@ const fastify = require('fastify')({
 
 **Note: genReqId will _not_ be called if the header set in <code>[requestIdHeader](#requestidheader)</code> is available (defaults to 'request-id').**
 
-<a name="factory-trust-proxy"></a>
 ### `trustProxy`
+<a name="factory-trust-proxy"></a>
 
 By enabling the `trustProxy` option, Fastify will know that it is sitting behind a proxy and that the `X-Forwarded-*` header fields may be trusted, which otherwise may be easily spoofed.
 
@@ -392,8 +392,8 @@ fastify.get('/', (request, reply) => {
 
 **Note: if a request contains multiple <code>x-forwarded-host</code> or <code>x-forwarded-proto</code> headers, it is only the last one that is used to derive <code>request.hostname</code> and <code>request.protocol</code>**
 
-<a name="plugin-timeout"></a>
 ### `pluginTimeout`
+<a name="plugin-timeout"></a>
 
 The maximum amount of time in *milliseconds* in which a plugin can load.
 If not, [`ready`](./Server.md#ready)
@@ -401,8 +401,8 @@ will complete with an `Error` with code `'ERR_AVVIO_PLUGIN_TIMEOUT'`.
 
 + Default: `10000`
 
-<a name="factory-querystring-parser"></a>
 ### `querystringParser`
+<a name="factory-querystring-parser"></a>
 
 The default query string parser that Fastify uses is the Node.js's core `querystring` module.<br/>
 You can change this default setting by passing the option `querystringParser` and use a custom one, such as [`qs`](https://www.npmjs.com/package/qs).
@@ -425,15 +425,15 @@ const fastify = require('fastify')({
 
 Note, if you only want the keys (and not the values) to be case insensitive we recommend using a custom parser to convert only the keys to lowercase.
 
-<a name="exposeHeadRoutes"></a>
 ### `exposeHeadRoutes`
+<a name="exposeHeadRoutes"></a>
 
 Automatically creates a sibling `HEAD` route for each `GET` route defined. If you want a custom `HEAD` handler without disabling this option, make sure to define it before the `GET` route.
 
 + Default: `false`
 
-<a name="constraints"></a>
 ### `constraints`
+<a name="constraints"></a>
 
 Fastify's built in route constraints are provided by `find-my-way`, which allow constraining routes by `version` or `host`. You are able to add new constraint strategies, or override the built in strategies by providing a `constraints` object with strategies for `find-my-way`. You can find more information on constraint strategies in the [find-my-way](https://github.com/delvedor/find-my-way) documentation.
 
@@ -460,16 +460,16 @@ const fastify = require('fastify')({
 })
 ```
 
-<a name="factory-return-503-on-closing"></a>
 ### `return503OnClosing`
+<a name="factory-return-503-on-closing"></a>
 
 Returns 503 after calling `close` server method.
 If `false`, the server routes the incoming request as usual.
 
 + Default: `true`
 
-<a name="factory-ajv"></a>
 ### `ajv`
+<a name="factory-ajv"></a>
 
 Configure the Ajv v6 instance used by Fastify without providing a custom one.
 
@@ -504,8 +504,8 @@ const fastify = require('fastify')({
 })
 ```
 
-<a name="serializer-opts"></a>
 ### `serializerOpts`
+<a name="serializer-opts"></a>
 
 Customize the options of the default [`fast-json-stringify`](https://github.com/fastify/fast-json-stringify#options) instance that serialize the response's payload:
 
@@ -517,8 +517,8 @@ const fastify = require('fastify')({
 })
 ```
 
-<a name="http2-session-timeout"></a>
 ### `http2SessionTimeout`
+<a name="http2-session-timeout"></a>
 
 Set a default
 [timeout](https://nodejs.org/api/http2.html#http2_http2session_settimeout_msecs_callback) to every incoming HTTP/2 session. The session will be closed on the timeout. Default: `5000` ms.
@@ -528,8 +528,8 @@ The low default has been chosen to mitigate denial of service attacks.
 When the server is behind a load balancer or can scale automatically this value can be
 increased to fit the use case. Node core defaults this to `0`. `
 
-<a name="framework-errors"></a>
 ### `frameworkErrors`
+<a name="framework-errors"></a>
 
 + Default: `null`
 
@@ -551,8 +551,8 @@ const fastify = require('fastify')({
 })
 ```
 
-<a name="client-error-handler"></a>
 ### `clientErrorHandler`
+<a name="client-error-handler"></a>
 
 Set a [clientErrorHandler](https://nodejs.org/api/http.html#http_event_clienterror) that listens to `error` events emitted by client connections and responds with a `400`.
 
@@ -599,8 +599,8 @@ const fastify = require('fastify')({
 })
 ```
 
-<a name="rewrite-url"></a>
 ### `rewriteUrl`
+<a name="rewrite-url"></a>
 
 Set a sync callback function that must return a string that allows rewriting URLs.
 
@@ -618,12 +618,14 @@ Note that `rewriteUrl` is called _before_ routing, it is not encapsulated and it
 
 ### Server Methods
 
-<a name="server"></a>
 #### server
+<a name="server"></a>
+
 `fastify.server`: The Node core [server](https://nodejs.org/api/http.html#http_class_http_server) object as returned by the [**`Fastify factory function`**](./Server.md).
 
-<a name="after"></a>
 #### after
+<a name="after"></a>
+
 Invoked when the current plugin and all the plugins
 that have been registered within it have finished loading.
 It is always executed before the method `fastify.ready`.
@@ -665,8 +667,9 @@ await fastify.ready()
 console.log('Everything has been loaded')
 ```
 
-<a name="ready"></a>
 #### ready
+<a name="ready"></a>
+
 Function called when all the plugins have been loaded.
 It takes an error parameter if something went wrong.
 ```js
@@ -684,8 +687,9 @@ fastify.ready().then(() => {
 })
 ```
 
-<a name="listen"></a>
 #### listen
+<a name="listen"></a>
+
 Starts the server on the given port after all the plugins are loaded, internally waits for the `.ready()` event. The callback is the same as the Node core. By default, the server will listen on the address resolved by `localhost` when no specific address is provided (`127.0.0.1` or `::1` depending on the operating system). If listening on any available interface is desired, then specifying `0.0.0.0` for the address will listen on all IPv4 addresses. Using `::` for the address will listen on all IPv6 addresses and, depending on OS, may also listen on all IPv4 addresses. Be careful when deciding to listen on all interfaces; it comes with inherent [security risks](https://web.archive.org/web/20170831174611/https://snyk.io/blog/mongodb-hack-and-secure-defaults/).
 
 ```js
@@ -789,16 +793,18 @@ fastify.listen({
 }, (err) => {})
 ```
 
-<a name="getDefaultRoute"></a>
 #### getDefaultRoute
+<a name="getDefaultRoute"></a>
+
 Method to get the `defaultRoute` for the server:
 
 ```js
 const defaultRoute = fastify.getDefaultRoute()
 ```
 
-<a name="setDefaultRoute"></a>
 #### setDefaultRoute
+<a name="setDefaultRoute"></a>
+
 Method to set the `defaultRoute` for the server:
 
 ```js
@@ -809,20 +815,23 @@ const defaultRoute = function (req, res) {
 fastify.setDefaultRoute(defaultRoute)
 ```
 
-<a name="routing"></a>
 #### routing
+<a name="routing"></a>
+
 Method to access the `lookup` method of the internal router and match the request to the appropriate handler:
 
 ```js
 fastify.routing(req, res)
 ```
 
-<a name="route"></a>
 #### route
+<a name="route"></a>
+
 Method to add routes to the server, it also has shorthand functions, check [here](Routes.md).
 
-<a name="close"></a>
 #### close
+<a name="close"></a>
+
 `fastify.close(callback)`: call this function to close the server instance and run the [`'onClose'`](Hooks.md#on-close) hook.<br>
 Calling `close` will also cause the server to respond to every new incoming request with a `503` error and destroy that request.
 See [`return503OnClosing` flags](./Server.md#factory-return-503-on-closing) for changing this behavior.
@@ -837,21 +846,25 @@ fastify.close().then(() => {
 })
 ```
 
-<a name="decorate"></a>
 #### decorate*
+<a name="decorate"></a>
+
 Function useful if you need to decorate the fastify instance, Reply or Request, check [here](Decorators.md).
 
-<a name="register"></a>
 #### register
+<a name="register"></a>
+
 Fastify allows the user to extend its functionality with plugins.
 A plugin can be a set of routes, a server decorator, or whatever, check [here](Plugins.md).
 
-<a name="addHook"></a>
 #### addHook
+<a name="addHook"></a>
+
 Function to add a specific hook in the lifecycle of Fastify, check [here](Hooks.md).
 
-<a name="prefix"></a>
 #### prefix
+<a name="prefix"></a>
+
 The full path that will be prefixed to a route.
 
 Example:
@@ -878,8 +891,9 @@ fastify.register(function (instance, opts, done) {
 }, { prefix: '/v1' })
 ```
 
-<a name="pluginName"></a>
 #### pluginName
+<a name="pluginName"></a>
+
 Name of the current plugin. There are three ways to define a name (in order).
 
 1. If you use [fastify-plugin](https://github.com/fastify/fastify-plugin) the metadata `name` is used.
@@ -890,33 +904,40 @@ Name of the current plugin. There are three ways to define a name (in order).
 
 Important: If you have to deal with nested plugins, the name differs with the usage of the [fastify-plugin](https://github.com/fastify/fastify-plugin) because no new scope is created and therefore we have no place to attach contextual data. In that case, the plugin name will represent the boot order of all involved plugins in the format of `plugin-A -> plugin-B`.
 
-<a name="log"></a>
 #### log
+<a name="log"></a>
+
 The logger instance, check [here](Logging.md).
 
-<a name="version"></a>
 #### version
+<a name="version"></a>
+
 Fastify version of the instance. Used for plugin support. See [Plugins](Plugins.md#handle-the-scope) for information on how the version is used by plugins.
 
-<a name="inject"></a>
 #### inject
+<a name="inject"></a>
+
 Fake HTTP injection (for testing purposes) [here](Testing.md#inject).
 
-<a name="add-schema"></a>
 #### addSchema
+<a name="add-schema"></a>
+
 `fastify.addSchema(schemaObj)`, adds a JSON schema to the Fastify instance. This allows you to reuse it everywhere in your application just by using the standard `$ref` keyword.<br/>
 To learn more, read the [Validation and Serialization](Validation-and-Serialization.md) documentation.
 
-<a name="get-schemas"></a>
 #### getSchemas
+<a name="get-schemas"></a>
+
 `fastify.getSchemas()`, returns a hash of all schemas added via `.addSchema`. The keys of the hash are the `$id`s of the JSON Schema provided.
 
-<a name="get-schema"></a>
 #### getSchema
+<a name="get-schema"></a>
+
 `fastify.getSchema(id)`, return the JSON schema added with `.addSchema` and the matching `id`. It returns `undefined` if it is not found.
 
-<a name="set-reply-serializer"></a>
 #### setReplySerializer
+<a name="set-reply-serializer"></a>
+
 Set the reply serializer for all the routes. This will be used as default if a [Reply.serializer(func)](Reply.md#serializerfunc) has not been set. The handler is fully encapsulated, so different plugins can set different error handlers.
 Note: the function parameter is called only for status `2xx`. Check out the [`setErrorHandler`](./Server.md#seterrorhandler) for errors.
 
@@ -927,35 +948,42 @@ fastify.setReplySerializer(function (payload, statusCode){
 })
 ```
 
-<a name="set-validator-compiler"></a>
 #### setValidatorCompiler
+<a name="set-validator-compiler"></a>
+
 Set the schema validator compiler for all routes. See [#schema-validator](Validation-and-Serialization.md#schema-validator).
 
-<a name="set-schema-error-formatter"></a>
 #### setSchemaErrorFormatter
+<a name="set-schema-error-formatter"></a>
+
 Set the schema error formatter for all routes. See [#error-handling](Validation-and-Serialization.md#schemaerrorformatter).
 
-<a name="set-serializer-resolver"></a>
 #### setSerializerCompiler
+<a name="set-serializer-resolver"></a>
+
 Set the schema serializer compiler for all routes. See [#schema-serializer](Validation-and-Serialization.md#schema-serializer).
 **Note:** [`setReplySerializer`](#set-reply-serializer) has priority if set!
 
-<a name="validator-compiler"></a>
 #### validatorCompiler
+<a name="validator-compiler"></a>
+
 This property can be used to get the schema validator. If not set, it will be `null` until the server starts, then it will be a function with the signature `function ({ schema, method, url, httpPart })` that returns the input `schema` compiled to a function for validating data.
 The input `schema` can access all the shared schemas added with [`.addSchema`](#add-schema) function.
 
-<a name="serializer-compiler"></a>
 #### serializerCompiler
+<a name="serializer-compiler"></a>
+
 This property can be used to get the schema serializer. If not set, it will be `null` until the server starts, then it will be a function with the signature `function ({ schema, method, url, httpPart })` that returns the input `schema` compiled to a function for validating data.
 The input `schema` can access all the shared schemas added with [`.addSchema`](#add-schema) function.
 
-<a name="schema-error-formatter"></a>
 #### schemaErrorFormatter
+<a name="schema-error-formatter"></a>
+
 This property can be used to set a function to format errors that happen while the `validationCompiler` fails to validate the schema. See [#error-handling](Validation-and-Serialization.md#schemaerrorformatter).
 
-<a name="schema-controller"></a>
 #### schemaController
+<a name="schema-controller"></a>
+
 This property can be used to fully manage:
 - `bucket`: where the schemas of your application will be stored
 - `compilersFactory`: what module must compile the JSON schemas
@@ -1071,8 +1099,8 @@ const app = fastify({
 // Done! You can now use Ajv 8 options and keywords in your schemas!
 ```
 
-<a name="set-not-found-handler"></a>
 #### setNotFoundHandler
+<a name="set-not-found-handler"></a>
 
 `fastify.setNotFoundHandler(handler(request, reply))`: set the 404 handler. This call is encapsulated by prefix, so different plugins can set different not found handlers if a different [`prefix` option](Plugins.md#route-prefixing-option) is passed to `fastify.register()`. The handler is treated as a regular route handler so requests will go through the full [Fastify lifecycle](Lifecycle.md#lifecycle).
 
@@ -1105,8 +1133,8 @@ fastify.register(function (instance, options, done) {
 
 Fastify calls setNotFoundHandler to add a default 404 handler at startup before plugins are registered. If you would like to augment the behavior of the default 404 handler, for example with plugins, you can call setNotFoundHandler with no arguments `fastify.setNotFoundHandler()` within the context of these registered plugins.
 
-<a name="set-error-handler"></a>
 #### setErrorHandler
+<a name="set-error-handler"></a>
 
 `fastify.setErrorHandler(handler(error, request, reply))`: Set a function that will be called whenever an error happens. The handler is bound to the Fastify instance and is fully encapsulated, so different plugins can set different error handlers. *async-await* is supported as well.<br>
 *Note: If the error `statusCode` is less than 400, Fastify will automatically set it at 500 before calling the error handler.*
@@ -1133,8 +1161,8 @@ if (statusCode >= 500) {
 }
 ```
 
-<a name="print-routes"></a>
 #### printRoutes
+<a name="print-routes"></a>
 
 `fastify.printRoutes()`: Prints the representation of the internal radix tree used by the router, useful for debugging. Alternatively, `fastify.printRoutes({ commonPrefix: false })` can be used to print the flattened routes tree.<br/>
 *Remember to call it inside or after a `ready` call.*
@@ -1189,8 +1217,8 @@ fastify.ready(() => {
   //         └── licopter (GET)
 ```
 
-<a name="print-plugins"></a>
 #### printPlugins
+<a name="print-plugins"></a>
 
 `fastify.printPlugins()`: Prints the representation of the internal plugin tree used by the avvio, useful for debugging require order issues.<br/>
 *Remember to call it inside or after a `ready` call.*
@@ -1211,8 +1239,8 @@ fastify.ready(() => {
 })
 ```
 
-<a name="addContentTypeParser"></a>
 #### addContentTypeParser
+<a name="addContentTypeParser"></a>
 
 `fastify.addContentTypeParser(content-type, options, parser)` is used to pass custom parser for a given content type. Useful for adding parsers for custom content types, e.g. `text/json, application/vnd.oasis.opendocument.text`. `content-type` can be a string, string array or RegExp.
 
@@ -1222,14 +1250,14 @@ fastify.ready(() => {
 fastify.addContentTypeParser('text/json', { asString: true }, fastify.getDefaultJsonParser('ignore', 'ignore'))
 ```
 
-<a name="getDefaultJsonParser"></a>
 #### getDefaultJsonParser
+<a name="getDefaultJsonParser"></a>
 
 `fastify.getDefaultJsonParser(onProtoPoisoning, onConstructorPoisoning)` takes two arguments. First argument is ProtoType poisoning configuration and second argument is constructor poisoning configuration. See the <a href="https://github.com/fastify/secure-json-parse#api">`secure-json-parse` documentation</a> for more information.
 
 
-<a name="defaultTextParser"></a>
 #### defaultTextParser
+<a name="defaultTextParser"></a>
 
 `fastify.defaultTextParser()` can be used to parse content as plain text.
 
@@ -1237,8 +1265,8 @@ fastify.addContentTypeParser('text/json', { asString: true }, fastify.getDefault
 fastify.addContentTypeParser('text/json', { asString: true }, fastify.defaultTextParser())
 ```
 
-<a name="errorHandler"></a>
 #### errorHandler
+<a name="errorHandler"></a>
 
 `fastify.errorHandler` can be used to handle errors using fastify's default error handler.
 
@@ -1255,8 +1283,8 @@ fastify.get('/', {
 }, handler)
 ```
 
-<a name="initial-config"></a>
 #### initialConfig
+<a name="initial-config"></a>
 
 `fastify.initialConfig`: Exposes a frozen read-only object registering the initial
 options passed down by the user to the Fastify instance.

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -31,8 +31,9 @@
     - [Async-Await and Promises](#async-await-and-promises)
   - [.then](#then)
 
-<a name="introduction"></a>
 ### Introduction
+<a name="introduction"></a>
+
 The second parameter of the handler function is `Reply`.
 Reply is a core Fastify object that exposes the following functions
 and properties:
@@ -78,12 +79,14 @@ fastify.get('/', {config: {foo: 'bar'}}, function (request, reply) {
 })
 ```
 
-<a name="code"></a>
 ### .code(statusCode)
+<a name="code"></a>
+
 If not set via `reply.code`, the resulting `statusCode` will be `200`.
 
-<a name="statusCode"></a>
 ### .statusCode
+<a name="statusCode"></a>
+
 This property reads and sets the HTTP status code. It is an alias for `reply.code()` when used as a setter.
 ```js
 if (reply.statusCode >= 299) {
@@ -91,8 +94,9 @@ if (reply.statusCode >= 299) {
 }
 ```
 
-<a name="server"></a>
 ### .server
+<a name="server"></a>
+
 The Fastify server instance, scoped to the current [encapsulation context](./Reference/Encapsulation.md).
 
 ```js
@@ -105,12 +109,14 @@ fastify.get('/', async function (req, rep) {
 })
 ```
 
-<a name="header"></a>
 ### .header(key, value)
+<a name="header"></a>
+
 Sets a response header. If the value is omitted or undefined, it is coerced
 to `''`.
 
 <a name="set-cookie"></a>
+
 - ### set-cookie
     - While sending different values as cookie with `set-cookie` as the key, every value will be sent as cookie instead of replacing the previous value.
 
@@ -124,8 +130,9 @@ to `''`.
 
 For more information, see [`http.ServerResponse#setHeader`](https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_response_setheader_name_value).
 
-<a name="headers"></a>
 ### .headers(object)
+<a name="headers"></a>
+
 Sets all the keys of the object as response headers. [`.header`](#headerkey-value) will be called under the hood.
 ```js
 reply.headers({
@@ -134,16 +141,17 @@ reply.headers({
 })
 ```
 
-<a name="getHeader"></a>
 ### .getHeader(key)
+<a name="getHeader"></a>
+
 Retrieves the value of a previously set header.
 ```js
 reply.header('x-foo', 'foo') // setHeader: key, value
 reply.getHeader('x-foo') // 'foo'
 ```
 
-<a name="getHeaders"></a>
 ### .getHeaders()
+<a name="getHeaders"></a>
 
 Gets a shallow copy of all current response headers, including those set via the raw `http.ServerResponse`. Note that headers set via Fastify take precedence over those set via `http.ServerResponse`.
 
@@ -154,8 +162,8 @@ reply.raw.setHeader('x-foo', 'foo2')
 reply.getHeaders() // { 'x-foo': 'foo', 'x-bar': 'bar' }
 ```
 
-<a name="getHeader"></a>
 ### .removeHeader(key)
+<a name="getHeader"></a>
 
 Remove the value of a previously set header.
 ```js
@@ -164,12 +172,14 @@ reply.removeHeader('x-foo')
 reply.getHeader('x-foo') // undefined
 ```
 
-<a name="hasHeader"></a>
 ### .hasHeader(key)
+<a name="hasHeader"></a>
+
 Returns a boolean indicating if the specified header has been set.
 
-<a name="redirect"></a>
 ### .redirect([code ,] dest)
+<a name="redirect"></a>
+
 Redirects a request to the specified URL, the status code is optional, default to `302` (if status code is not already set by calling `code`).
 
 Example (no `reply.code()` call) sets status code to `302` and redirects to `/home`
@@ -192,16 +202,18 @@ Example (`reply.code()` call) sets status code to `302` and redirects to `/home`
 reply.code(303).redirect(302, '/home')
 ```
 
-<a name="call-not-found"></a>
 ### .callNotFound()
+<a name="call-not-found"></a>
+
 Invokes the custom not found handler. Note that it will only call `preHandler` hook specified in [`setNotFoundHandler`](./Reference/Server.md#set-not-found-handler).
 
 ```js
 reply.callNotFound()
 ```
 
-<a name="getResponseTime"></a>
 ### .getResponseTime()
+<a name="getResponseTime"></a>
+
 Invokes the custom response time getter to calculate the amount of time passed since the request was started.
 
 Note that unless this function is called in the [`onResponse` hook](Hooks.md#onresponse) it will always return `0`.
@@ -210,8 +222,9 @@ Note that unless this function is called in the [`onResponse` hook](Hooks.md#onr
 const milliseconds = reply.getResponseTime()
 ```
 
-<a name="type"></a>
 ### .type(contentType)
+<a name="type"></a>
+
 Sets the content type for the response.
 This is a shortcut for `reply.header('Content-Type', 'the/type')`.
 
@@ -219,8 +232,9 @@ This is a shortcut for `reply.header('Content-Type', 'the/type')`.
 reply.type('text/html')
 ```
 
-<a name="serializer"></a>
 ### .serializer(func)
+<a name="serializer"></a>
+
 `.send()` will by default JSON-serialize any value that is not one of: `Buffer`, `stream`, `string`, `undefined`, `Error`. If you need to replace the default serializer with a custom serializer for a particular request, you can do so with the `.serializer()` utility. Be aware that if you are using a custom serializer, you must set a custom `'Content-Type'` header.
 
 ```js
@@ -239,8 +253,9 @@ reply
 
 See [`.send()`](#send) for more information on sending different types of values.
 
-<a name="raw"></a>
 ### .raw
+<a name="raw"></a>
+
 This is the [`http.ServerResponse`](https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_class_http_serverresponse) from Node core. Whilst you are using the Fastify `Reply` object, the use of `Reply.raw` functions is at your own risk as you are skipping all the Fastify
 logic of handling the HTTP response. e.g.:
 
@@ -256,8 +271,8 @@ app.get('/cookie-2', (req, reply) => {
 ```
 Another example of the misuse of `Reply.raw` is explained in [Reply](Reply.md#getheaders).
 
-<a name="sent"></a>
 ### .sent
+<a name="sent"></a>
 
 As the name suggests, `.sent` is a property to indicate if
 a response has been sent via `reply.send()`.
@@ -282,20 +297,23 @@ app.get('/', (req, reply) => {
 
 If the handler rejects, the error will be logged.
 
-<a name="hijack"></a>
 ### .hijack()
+<a name="hijack"></a>
+
 Sometimes you might need to halt the execution of the normal request lifecycle and handle sending the response manually.
 
 To achieve this, Fastify provides the `reply.hijack()` method that can be called during the request lifecycle (At any point before `reply.send()` is called), and allows you to prevent Fastify from sending the response, and from running the remaining hooks (and user handler if the reply was hijacked before).
 
 NB (*): If `reply.raw` is used to send a response back to the user, `onResponse` hooks will still be executed
 
-<a name="send"></a>
 ### .send(data)
+<a name="send"></a>
+
 As the name suggests, `.send()` is the function that sends the payload to the end user.
 
-<a name="send-object"></a>
 #### Objects
+<a name="send-object"></a>
+
 As noted above, if you are sending JSON objects, `send` will serialize the object with [fast-json-stringify](https://www.npmjs.com/package/fast-json-stringify) if you set an output schema, otherwise, `JSON.stringify()` will be used.
 ```js
 fastify.get('/json', options, function (request, reply) {
@@ -303,8 +321,9 @@ fastify.get('/json', options, function (request, reply) {
 })
 ```
 
-<a name="send-string"></a>
 #### Strings
+<a name="send-string"></a>
+
 If you pass a string to `send` without a `Content-Type`, it will be sent as `text/plain; charset=utf-8`. If you set the `Content-Type` header and pass a string to `send`, it will be serialized with the custom serializer if one is set, otherwise, it will be sent unmodified (unless the `Content-Type` header is set to `application/json; charset=utf-8`, in which case it will be JSON-serialized like an object — see the section above).
 ```js
 fastify.get('/json', options, function (request, reply) {
@@ -312,8 +331,9 @@ fastify.get('/json', options, function (request, reply) {
 })
 ```
 
-<a name="send-streams"></a>
 #### Streams
+<a name="send-streams"></a>
+
 *send* can also handle streams out of the box. If you are sending a stream and you have not set a `'Content-Type'` header, *send* will set it at `'application/octet-stream'`.
 ```js
 fastify.get('/streams', function (request, reply) {
@@ -323,8 +343,9 @@ fastify.get('/streams', function (request, reply) {
 })
 ```
 
-<a name="send-buffers"></a>
 #### Buffers
+<a name="send-buffers"></a>
+
 If you are sending a buffer and you have not set a `'Content-Type'` header, *send* will set it to `'application/octet-stream'`.
 ```js
 const fs = require('fs')
@@ -335,8 +356,9 @@ fastify.get('/streams', function (request, reply) {
 })
 ```
 
-<a name="errors"></a>
 #### Errors
+<a name="errors"></a>
+
 If you pass to *send* an object that is an instance of *Error*, Fastify will automatically create an error structured as the following:
 
 ```js
@@ -418,8 +440,9 @@ fastify.setNotFoundHandler(function (request, reply) {
 })
 ```
 
-<a name="payload-type"></a>
 #### Type of the final payload
+<a name="payload-type"></a>
+
 The type of the sent payload (after serialization and going through any [`onSend` hooks](Hooks.md#the-onsend-hook)) must be one of the following types, otherwise, an error will be thrown:
 
 - `string`
@@ -428,8 +451,9 @@ The type of the sent payload (after serialization and going through any [`onSend
 - `undefined`
 - `null`
 
-<a name="async-await-promise"></a>
 #### Async-Await and Promises
+<a name="async-await-promise"></a>
+
 Fastify natively handles promises and supports async-await.<br>
 *Note that in the following examples we are not using reply.send.*
 ```js
@@ -463,8 +487,8 @@ fastify.get('/botnet', async function (request, reply) {
 
 If you want to know more please review [Routes#async-await](Routes.md#async-await).
 
-<a name="then"></a>
 ### .then(fulfilled, rejected)
+<a name="then"></a>
 
 As the name suggests, a `Reply` object can be awaited upon, i.e. `await reply` will wait until the reply is sent.
 The `await` syntax calls the `reply.then()`.

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -18,15 +18,15 @@ You have two ways to declare a route with Fastify, the shorthand method and the 
 - [Route handler configuration](#routes-config)
 - [Route constraints](#constraints)
 
-<a name="full-declaration"></a>
 ### Full declaration
+<a name="full-declaration"></a>
 
 ```js
 fastify.route(options)
 ```
 
-<a name="options"></a>
 ### Routes options
+<a name="options"></a>
 
 * `method`: currently it supports `'DELETE'`, `'GET'`, `'HEAD'`, `'PATCH'`, `'POST'`, `'PUT'` and `'OPTIONS'`. It could also be an array of methods.
 * `url`: the path of the URL to match this route (alias: `path`).
@@ -102,8 +102,9 @@ fastify.route({
 })
 ```
 
-<a name="shorthand-declaration"></a>
 ### Shorthand declaration
+<a name="shorthand-declaration"></a>
+
 The above route declaration is more *Hapi*-like, but if you prefer an *Express/Restify* approach, we support it as well:<br>
 `fastify.get(path, [options], handler)`<br>
 `fastify.head(path, [options], handler)`<br>
@@ -156,8 +157,9 @@ fastify.get('/', opts)
 
 > Note: if the handler is specified in both the `options` and as the third parameter to the shortcut method then throws duplicate `handler` error.
 
-<a name="url-building"></a>
 ### Url building
+<a name="url-building"></a>
+
 Fastify supports both static and dynamic URLs.<br>
 To register a **parametric** path, use the *colon* before the parameter name. For **wildcard**, use the *star*.
 *Remember that static routes are always checked before parametric and wildcard.*
@@ -197,8 +199,9 @@ If you want a path containing a colon without declaring a parameter, use a doubl
 fastify.post('/name::verb') // will be interpreted as /name:verb
 ```
 
-<a name="async-await"></a>
 ### Async Await
+<a name="async-await"></a>
+
 Are you an `async/await` user? We have you covered!
 ```js
 fastify.get('/', options, async function (request, reply) {
@@ -246,8 +249,8 @@ fastify.get('/', options, async function (request, reply) {
 * When using both `return value` and `reply.send(value)` at the same time, the first one that happens takes precedence, the second value will be discarded, and a *warn* log will also be emitted because you tried to send a response twice.
 * You cannot return `undefined`. For more details read [promise-resolution](#promise-resolution).
 
-<a name="promise-resolution"></a>
 ### Promise resolution
+<a name="promise-resolution"></a>
 
 If your handler is an `async` function or returns a promise, you should be aware of a special behavior that is necessary to support the callback and promise control-flow. If the handler's promise is resolved with `undefined`, it will be ignored causing the request to hang and an *error* log to be emitted.
 
@@ -262,8 +265,9 @@ In this way, we can support both `callback-style` and `async-await`, with the mi
 
 **Notice**: Every async function returns a promise by itself.
 
-<a name="route-prefixing"></a>
 ### Route Prefixing
+<a name="route-prefixing"></a>
+
 Sometimes you need to maintain two or more different versions of the same API; a classic approach is to prefix all the routes with the API version number, `/v1/user` for example.
 Fastify offers you a fast and smart way to create different versions of the same API without changing all the route names by hand, *route prefixing*. Let's see how it works:
 
@@ -311,8 +315,9 @@ and `/something/`.
 
 See the `prefixTrailingSlash` route option above to change this behavior.
 
-<a name="custom-log-level"></a>
 ### Custom Log Level
+<a name="custom-log-level"></a>
+
 It could happen that you need different log levels in your routes; Fastify achieves this in a very straightforward way.<br/>
 You just need to pass the option `logLevel` to the plugin option or the route option with the [value](https://github.com/pinojs/pino/blob/master/docs/api.md#level-string) that you need.
 
@@ -336,8 +341,8 @@ fastify.get('/', { logLevel: 'warn' }, (request, reply) => {
 ```
 *Remember that the custom log level is applied only to the routes, and not to the global Fastify Logger, accessible with `fastify.log`*
 
-<a name="custom-log-serializer"></a>
 ### Custom Log Serializer
+<a name="custom-log-serializer"></a>
 
 In some context, you may need to log a large object but it could be a waste of resources for some routes. In this case, you can define some [`serializer`](https://github.com/pinojs/pino/blob/master/docs/api.md#bindingsserializers-object) and attach them in the right context!
 
@@ -396,8 +401,9 @@ async function context1 (fastify, opts) {
 fastify.listen(3000)
 ```
 
-<a name="routes-config"></a>
 ### Config
+<a name="routes-config"></a>
+
 Registering a new handler, you can pass a configuration object to it and retrieve it in the handler.
 
 ```js
@@ -414,8 +420,8 @@ fastify.get('/it', { config: { output: 'ciao mondo!' } }, handler)
 fastify.listen(3000)
 ```
 
-<a name="constraints"></a>
 ### Constraints
+<a name="constraints"></a>
 
 Fastify supports constraining routes to match only certain requests based on some property of the request, like the `Host` header, or any other value via [`find-my-way`](https://github.com/delvedor/find-my-way) constraints. Constraints are specified in the `constraints` property of the route options. Fastify has two built-in constraints ready for use: the `version` constraint and the `host` constraint, and you can add your own custom constraint strategies to inspect other parts of a request to decide if a route should be executed for a request.
 

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -23,8 +23,9 @@ The validation and the serialization tasks are processed by two different, and c
 
 These two separate entities share only the JSON schemas added to Fastify's instance through `.addSchema(schema)`.
 
-<a name="shared-schema"></a>
 #### Adding a shared schema
+<a name="shared-schema"></a>
+
 Thanks to the `addSchema` API, you can add multiple schemas to the Fastify instance and then reuse them in multiple parts of your application.
 As usual, this API is encapsulated.
 
@@ -80,8 +81,8 @@ fastify.post('/', {
 })
 ```
 
-<a name="get-shared-schema"></a>
 #### Retrieving the shared schemas
+<a name="get-shared-schema"></a>
 
 If the validator and the serializer are customized, the `.addSchema` method will not be useful since the actors are no longer
 controlled by Fastify.
@@ -301,8 +302,8 @@ server.setValidatorCompiler(req => {
 
 For further information see [here](https://ajv.js.org/coercion.html)
 
-<a name="ajv-plugins"></a>
 #### Ajv Plugins
+<a name="ajv-plugins"></a>
 
 You can provide a list of plugins you want to use with the default `ajv` instance.
 Note that the plugin must be **compatible with Ajv v6**.
@@ -365,8 +366,8 @@ fastify.post('/foo', {
 })
 ```
 
-<a name="schema-validator"></a>
 #### Validator Compiler
+<a name="schema-validator"></a>
 
 The `validatorCompiler` is a function that returns a function that validates the body, URL  parameters, headers, and query string.
 The default `validatorCompiler` returns a function that implements the [ajv](https://ajv.js.org/) validation interface.
@@ -405,8 +406,8 @@ fastify.setValidatorCompiler(({ schema, method, url, httpPart }) => {
 ```
 _**Note:** If you use a custom instance of any validator (even Ajv), you have to add schemas to the validator instead of Fastify, since Fastify's default validator is no longer used, and Fastify's `addSchema` method has no idea what validator you are using._
 
-<a name="using-other-validation-libraries"></a>
 ##### Using other validation libraries
+<a name="using-other-validation-libraries"></a>
 
 The `setValidatorCompiler` function makes it easy to substitute `ajv` with almost any Javascript validation library ([joi](https://github.com/hapijs/joi/), [yup](https://github.com/jquense/yup/), ...) or a custom one:
 
@@ -503,8 +504,9 @@ const errorHandler = (error, request, reply) => {
 }
 ```
 
-<a name="serialization"></a>
 ### Serialization
+<a name="serialization"></a>
+
 Usually, you will send your data to the clients as JSON, and Fastify has a powerful tool to help you, [fast-json-stringify](https://www.npmjs.com/package/fast-json-stringify), which is used if you have provided an output schema in the route options.
 We encourage you to use an output schema, as it can drastically increase throughput and help prevent accidental disclosure of sensitive information.
 
@@ -546,8 +548,8 @@ const schema = {
 fastify.post('/the/url', { schema }, handler)
 ```
 
-<a name="schema-serializer"></a>
 #### Serializer Compiler
+<a name="schema-serializer"></a>
 
 The `serializerCompiler` is a function that returns a function that must return a string from an input object. You must provide a function to serialize every route where you have defined a `response` JSON Schema.
 
@@ -836,8 +838,9 @@ const refToSharedSchemaDefinitions = {
 }
 ```
 
-<a name="resources"></a>
 ### Resources
+<a name="resources"></a>
+
 - [JSON Schema](https://json-schema.org/)
 - [Understanding JSON Schema](https://spacetelescope.github.io/understanding-json-schema/)
 - [fast-json-stringify documentation](https://github.com/fastify/fast-json-stringify)


### PR DESCRIPTION
No new line above Markdown headings is considered invalid in some compilers, including Docusaurus. This PR simply moves the `<a>` tags below the headers, which was already the format used in some files (such as `Decorators.md`).

![image](https://user-images.githubusercontent.com/1667261/143663399-7a01b4f6-3fcc-4a1a-966d-595b8b3a3753.png)

EDIT: I also fixed an `<a>` link which could have been written as a Markdown (`[text](url)`) link in `Server.md`.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
