### PR TITLE
fix(typescript): use RouteGeneric for setErrorHandler types

### DIFF
--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -357,7 +357,12 @@ export interface FastifyInstance<
    * Set a function that will be called whenever an error happens
    */
   setErrorHandler<TError extends Error = FastifyError, RouteGeneric extends RouteGenericInterface = RouteGenericInterface>(
-    handler: (this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>, error: TError, request: FastifyRequest<RouteGeneric, RawServer, RawRequest>, reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric>) => void | Promise<void>
+    handler: (
+      this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
+      error: TError,
+      request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+      reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric>
+    ) => void | Promise<RouteGeneric['Reply'] | void>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**


### PR DESCRIPTION
Change `FastifyInstance.setErrorHandler` types on the handler to use `RouteGeneric` for the type of the promise return value, matching the typing of `RouteHandler`. This also makes sending a response via returning a value from an async function typecheck properly. The added tests mirror those from #2530.

P.S. This is basically a 1-year-late attempt at properly closing out #2466/#2467 :)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
