### PR TITLE
Update v1.x docs compatibility with Docusaurus

### DIFF
--- a/docs/Benchmarking.md
+++ b/docs/Benchmarking.md
@@ -1,7 +1,5 @@
 ---
 title: Benchmarking
-sidebar_label: Benchmarking
-hide_title: false
 ---
 
 Benchmarking is important if you want to measure how a change can impact your application performance. We provide a simple way to benchmark your application from the point of view of a user and contributor. The setup allows you to automate benchmarks in different branches on different Node.js versions.

--- a/docs/Benchmarking.md
+++ b/docs/Benchmarking.md
@@ -1,6 +1,9 @@
-<h1 align="center">Fastify</h1>
+---
+title: Benchmarking
+sidebar_label: Benchmarking
+hide_title: false
+---
 
-## Benchmarking
 Benchmarking is important if you want to measure how a change can impact your application performance. We provide a simple way to benchmark your application from the point of view of a user and contributor. The setup allows you to automate benchmarks in different branches on different Node.js versions.
 
 The modules we'll use:

--- a/docs/ContentTypeParser.md
+++ b/docs/ContentTypeParser.md
@@ -1,7 +1,5 @@
 ---
 title: Content-Type Parser
-sidebar_label: Content-Type Parser
-hide_title: false
 ---
 
 Natively, Fastify only supports the `'application/json'` content type. The default charset is `utf-8`. If you need to support different content types, you can use the `addContentTypeParser` API. *The default JSON parser can be changed.*

--- a/docs/ContentTypeParser.md
+++ b/docs/ContentTypeParser.md
@@ -1,11 +1,14 @@
-<h1 align="center">Fastify</h1>
+---
+title: Content-Type Parser
+sidebar_label: Content-Type Parser
+hide_title: false
+---
 
-## Content Type Parser
 Natively, Fastify only supports the `'application/json'` content type. The default charset is `utf-8`. If you need to support different content types, you can use the `addContentTypeParser` API. *The default JSON parser can be changed.*
 
 As with the other APIs, `addContentTypeParser` is encapsulated in the scope in which it is declared. This means that if you declare it in the root scope it will be available everywhere, while if you declare it inside a register it will be available only in that scope and its children.
 
-Fastify adds automatically the parsed request payload to the [Fastify request](https://github.com/fastify/fastify/blob/master/docs/Request.md) object, you can reach it with `request.body`.
+Fastify adds automatically the parsed request payload to the [Fastify request](./Request.md) object, you can reach it with `request.body`.
 
 ### Usage
 ```js
@@ -38,7 +41,7 @@ if (!fastify.hasContentTypeParser('application/jsoff')){
 ```
 
 #### Body Parser
-You can parse the body of the request in two ways. The first one is shown above: you add a custom content type parser and handle the request stream. In the second one you should pass a `parseAs` option to the `addContentTypeParser` API, where you declare how you want to get the body, it could be `'string'` or `'buffer'`. If you use the `parseAs` option Fastify will internally handle the stream and perform some checks, such as the [maximum size](https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-body-limit) of the body and the content length. If the limit is exceeded the custom parser will not be invoked.
+You can parse the body of the request in two ways. The first one is shown above: you add a custom content type parser and handle the request stream. In the second one you should pass a `parseAs` option to the `addContentTypeParser` API, where you declare how you want to get the body, it could be `'string'` or `'buffer'`. If you use the `parseAs` option Fastify will internally handle the stream and perform some checks, such as the [maximum size](./Server.md#factory-body-limit) of the body and the content length. If the limit is exceeded the custom parser will not be invoked.
 ```js
 fastify.addContentTypeParser('application/json', { parseAs: 'string' }, function (req, body, done) {
   try {
@@ -56,7 +59,7 @@ See [`example/parser.js`](https://github.com/fastify/fastify/blob/master/example
 
 ##### Custom Parser Options
 + `parseAs` (string): Either `'string'` or `'buffer'` to designate how the incoming data should be collected. Default: `'buffer'`.
-+ `bodyLimit` (number): The maximum payload size, in bytes, that the custom parser will accept. Defaults to the global body limit passed to the [`Fastify factory function`](https://github.com/fastify/fastify/blob/master/docs/Server.md#bodylimit).
++ `bodyLimit` (number): The maximum payload size, in bytes, that the custom parser will accept. Defaults to the global body limit passed to the [`Fastify factory function`](./Server.md#bodylimit).
 
 #### Catch All
 There are some cases where you need to catch all requests regardless of their content type. With Fastify, you just need to add the `'*'` content type.

--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -1,7 +1,5 @@
 ---
 title: Decorators
-sidebar_label: Decorators
-hide_title: false
 ---
 
 If you need to add functionality to the Fastify instance, the `decorate` API is what you need.
@@ -9,10 +7,10 @@ If you need to add functionality to the Fastify instance, the `decorate` API is 
 The API allows you to add new properties to the Fastify instance. A value is not restricted to a function and could also be an object or a string, for example.
 
 ### Usage
-<a name="usage"></a>
+<a id="usage"></a>
 
 **decorate**
-<a name="decorate"></a>
+<a id="decorate"></a>
 
 Just call the `decorate` API and pass the name of the new property and its value.
 ```js
@@ -37,7 +35,7 @@ console.log(fastify.conf.db)
 ```
 
 **decorateReply**
-<a name="decorate-reply"></a>
+<a id="decorate-reply"></a>
 
 As the name suggests, this API is needed if you want to add new methods to the `Reply` core object. Just call the `decorateReply` API and pass the name of the new property and its value:
 ```js
@@ -49,7 +47,7 @@ fastify.decorateReply('utility', function () {
 Note: using an arrow function will break the binding of `this` to the Fastify `reply` instance.
 
 **decorateRequest**
-<a name="decorate-request"></a>
+<a id="decorate-request"></a>
 
 As above, this API is needed if you want to add new methods to the `Request` core object. Just call the `decorateRequest` API and pass the name of the new property and its value:
 ```js
@@ -61,7 +59,7 @@ fastify.decorateRequest('utility', function () {
 Note: using an arrow function will break the binding of `this` to the Fastify `request` instance.
 
 #### Decorators and encapsulation
-<a name="decorators-encapsulation"></a>
+<a id="decorators-encapsulation"></a>
 
 If you define a decorator (using decorate, decorateRequest or decorateReply) with the same name more than once in the same **encapsulated** plugin, fastify will throw an exception.
 
@@ -114,7 +112,7 @@ server.listen(3000)
 ```
 
 #### Getters and Setters
-<a name="getters-setters"></a>
+<a id="getters-setters"></a>
 
 Decorators accept special "getter/setter" objects. These objects have functions named `getter` and `setter` (though, the `setter` function is optional). This allows defining properties via decorators. For example:
 
@@ -133,7 +131,7 @@ console.log(fastify.foo) // 'a getter'
 ```
 
 #### Usage Notes
-<a name="usage_notes"></a>
+<a id="usage_notes"></a>
 
 `decorateReply` and `decorateRequest` are used to modify the `Reply` and `Request` constructors respectively by adding methods or properties. To update these properties you should directly access the desired property of the `Reply` or `Request` object.
 
@@ -156,12 +154,12 @@ fastify.get('/', (req, reply) => {
 Note: The usage of `decorateReply` and `decorateRequest` is optional in this case but will allow Fastify to optimize for performance.
 
 #### Sync and Async
-<a name="sync-async"></a>
+<a id="sync-async"></a>
 
 `decorate` is a *synchronous* API. If you need to add a decorator that has an *asynchronous* bootstrap, Fastify could boot up before your decorator is ready. To avoid this issue, you must use the `register` API in combination with `fastify-plugin`. To learn more, check out the [Plugins](./Plugins.md) documentation as well.
 
 #### Dependencies
-<a name="dependencies"></a>
+<a id="dependencies"></a>
 
 If your decorator depends on another decorator, you can easily declare the other decorator as a dependency. You just need to add an array of strings (representing the names of the decorators on which yours depends) as the third parameter:
 ```js
@@ -171,7 +169,7 @@ fastify.decorate('utility', fn, ['greet', 'log'])
 If a dependency is not satisfied, `decorate` will throw an exception, but don't worry: the dependency check is executed before the server boots up, so it won't ever happen at runtime.
 
 #### hasDecorator
-<a name="has-decorator"></a>
+<a id="has-decorator"></a>
 
 You can check for the presence of a decorator with the `hasDecorator` API:
 ```js
@@ -179,7 +177,7 @@ fastify.hasDecorator('utility')
 ```
 
 #### hasRequestDecorator
-<a name="has-request-decorator"></a>
+<a id="has-request-decorator"></a>
 
 You can check for the presence of a Request decorator with the `hasRequestDecorator` API:
 ```js
@@ -187,7 +185,7 @@ fastify.hasRequestDecorator('utility')
 ```
 
 #### hasReplyDecorator
-<a name="has-reply-decorator"></a>
+<a id="has-reply-decorator"></a>
 
 You can check for the presence of a Reply decorator with the `hasReplyDecorator` API:
 ```js

--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -1,15 +1,19 @@
-<h1 align="center">Fastify</h1>
-
-## Decorators
+---
+title: Decorators
+sidebar_label: Decorators
+hide_title: false
+---
 
 If you need to add functionality to the Fastify instance, the `decorate` API is what you need.
 
 The API allows you to add new properties to the Fastify instance. A value is not restricted to a function and could also be an object or a string, for example.
 
-<a name="usage"></a>
 ### Usage
-<a name="decorate"></a>
+<a name="usage"></a>
+
 **decorate**
+<a name="decorate"></a>
+
 Just call the `decorate` API and pass the name of the new property and its value.
 ```js
 fastify.decorate('utility', () => {
@@ -32,8 +36,9 @@ fastify.utility()
 console.log(fastify.conf.db)
 ```
 
-<a name="decorate-reply"></a>
 **decorateReply**
+<a name="decorate-reply"></a>
+
 As the name suggests, this API is needed if you want to add new methods to the `Reply` core object. Just call the `decorateReply` API and pass the name of the new property and its value:
 ```js
 fastify.decorateReply('utility', function () {
@@ -43,8 +48,9 @@ fastify.decorateReply('utility', function () {
 
 Note: using an arrow function will break the binding of `this` to the Fastify `reply` instance.
 
-<a name="decorate-request"></a>
 **decorateRequest**
+<a name="decorate-request"></a>
+
 As above, this API is needed if you want to add new methods to the `Request` core object. Just call the `decorateRequest` API and pass the name of the new property and its value:
 ```js
 fastify.decorateRequest('utility', function () {
@@ -54,8 +60,8 @@ fastify.decorateRequest('utility', function () {
 
 Note: using an arrow function will break the binding of `this` to the Fastify `request` instance.
 
-<a name="decorators-encapsulation"></a>
 #### Decorators and encapsulation
+<a name="decorators-encapsulation"></a>
 
 If you define a decorator (using decorate, decorateRequest or decorateReply) with the same name more than once in the same **encapsulated** plugin, fastify will throw an exception.
 
@@ -107,8 +113,8 @@ server.register(async function (server, opts) {
 server.listen(3000)
 ```
 
-<a name="getters-setters"></a>
 #### Getters and Setters
+<a name="getters-setters"></a>
 
 Decorators accept special "getter/setter" objects. These objects have functions named `getter` and `setter` (though, the `setter` function is optional). This allows defining properties via decorators. For example:
 
@@ -126,8 +132,9 @@ Will define the `foo` property on the *Fastify* instance:
 console.log(fastify.foo) // 'a getter'
 ```
 
-<a name="usage_notes"></a>
 #### Usage Notes
+<a name="usage_notes"></a>
+
 `decorateReply` and `decorateRequest` are used to modify the `Reply` and `Request` constructors respectively by adding methods or properties. To update these properties you should directly access the desired property of the `Reply` or `Request` object.
 
 As an example let's add a user property to the `Request` object:
@@ -148,12 +155,14 @@ fastify.get('/', (req, reply) => {
 ```
 Note: The usage of `decorateReply` and `decorateRequest` is optional in this case but will allow Fastify to optimize for performance.
 
-<a name="sync-async"></a>
 #### Sync and Async
-`decorate` is a *synchronous* API. If you need to add a decorator that has an *asynchronous* bootstrap, Fastify could boot up before your decorator is ready. To avoid this issue, you must use the `register` API in combination with `fastify-plugin`. To learn more, check out the [Plugins](https://github.com/fastify/fastify/blob/master/docs/Plugins.md) documentation as well.
+<a name="sync-async"></a>
 
-<a name="dependencies"></a>
+`decorate` is a *synchronous* API. If you need to add a decorator that has an *asynchronous* bootstrap, Fastify could boot up before your decorator is ready. To avoid this issue, you must use the `register` API in combination with `fastify-plugin`. To learn more, check out the [Plugins](./Plugins.md) documentation as well.
+
 #### Dependencies
+<a name="dependencies"></a>
+
 If your decorator depends on another decorator, you can easily declare the other decorator as a dependency. You just need to add an array of strings (representing the names of the decorators on which yours depends) as the third parameter:
 ```js
 fastify.decorate('utility', fn, ['greet', 'log'])
@@ -161,22 +170,25 @@ fastify.decorate('utility', fn, ['greet', 'log'])
 
 If a dependency is not satisfied, `decorate` will throw an exception, but don't worry: the dependency check is executed before the server boots up, so it won't ever happen at runtime.
 
-<a name="has-decorator"></a>
 #### hasDecorator
+<a name="has-decorator"></a>
+
 You can check for the presence of a decorator with the `hasDecorator` API:
 ```js
 fastify.hasDecorator('utility')
 ```
 
-<a name="has-request-decorator"></a>
 #### hasRequestDecorator
+<a name="has-request-decorator"></a>
+
 You can check for the presence of a Request decorator with the `hasRequestDecorator` API:
 ```js
 fastify.hasRequestDecorator('utility')
 ```
 
-<a name="has-reply-decorator"></a>
 #### hasReplyDecorator
+<a name="has-reply-decorator"></a>
+
 You can check for the presence of a Reply decorator with the `hasReplyDecorator` API:
 ```js
 fastify.hasReplyDecorator('utility')

--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -1,7 +1,5 @@
 ---
 title: Ecosystem
-sidebar_label: Ecosystem
-hide_title: false
 ---
 
 Plugins maintained by the fastify team are listed under [Core](#core) while plugins maintained by the community are listed in the [Community](#community) section.

--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -1,6 +1,9 @@
-<h1 align="center">Fastify</h1>
+---
+title: Ecosystem
+sidebar_label: Ecosystem
+hide_title: false
+---
 
-## Ecosystem
 Plugins maintained by the fastify team are listed under [Core](#core) while plugins maintained by the community are listed in the [Community](#community) section.
 
 #### [Core](#core)

--- a/docs/Error-Handling.md
+++ b/docs/Error-Handling.md
@@ -1,7 +1,5 @@
 ---
 title: Error Handling
-sidebar_label: Error Handling
-hide_title: false
 ---
 
 Uncaught errors are likely to cause memory leaks, file descriptor leaks and other major production issues. [Domains](https://nodejs.org/en/docs/guides/domain-postmortem/) were introduced to try fixing this issue, but they did not. Given the fact that it is not possible to process all uncaught errors in a sensible way, the best way to deal with them at the moment is to [crash](https://nodejs.org/api/process.html#process_warning_using_uncaughtexception_correctly). In case of promises, make sure to [handle](https://nodejs.org/dist/latest-v8.x/docs/api/deprecations.html#deprecations_dep0018_unhandled_promise_rejections) errors [correctly](https://github.com/mcollina/make-promises-safe).

--- a/docs/Error-Handling.md
+++ b/docs/Error-Handling.md
@@ -1,9 +1,11 @@
-<h1 align="center">Fastify</h1>
-
-## Error Handling
+---
+title: Error Handling
+sidebar_label: Error Handling
+hide_title: false
+---
 
 Uncaught errors are likely to cause memory leaks, file descriptor leaks and other major production issues. [Domains](https://nodejs.org/en/docs/guides/domain-postmortem/) were introduced to try fixing this issue, but they did not. Given the fact that it is not possible to process all uncaught errors in a sensible way, the best way to deal with them at the moment is to [crash](https://nodejs.org/api/process.html#process_warning_using_uncaughtexception_correctly). In case of promises, make sure to [handle](https://nodejs.org/dist/latest-v8.x/docs/api/deprecations.html#deprecations_dep0018_unhandled_promise_rejections) errors [correctly](https://github.com/mcollina/make-promises-safe).
 
-Fastify follows an all-or-nothing approach and aims to be lean and optimal as much as possible. Thus, the developer is responsible for making sure that the errors are handled properly. Most of the errors are usually a result of unexpected input data, so we recommend specifying a [JSON.schema validation](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) for your input data.
+Fastify follows an all-or-nothing approach and aims to be lean and optimal as much as possible. Thus, the developer is responsible for making sure that the errors are handled properly. Most of the errors are usually a result of unexpected input data, so we recommend specifying a [JSON.schema validation](./Validation-and-Serialization.md) for your input data.
 
-Note that, while Fastify doesn't catch uncaught errors for you, if routes are declared as `async`, the error will safely be caught by the promise and routed to the default error handler of Fastify for a generic `Internal Server Error` response. For customizing this behaviour, you should use [setErrorHandler](https://github.com/fastify/fastify/blob/master/docs/Server.md#seterrorhandler).
+Note that, while Fastify doesn't catch uncaught errors for you, if routes are declared as `async`, the error will safely be caught by the promise and routed to the default error handler of Fastify for a generic `Internal Server Error` response. For customizing this behaviour, you should use [setErrorHandler](./Server.md#seterrorhandler).

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -4,8 +4,10 @@ sidebar_label: Getting Started
 hide_title: false
 ---
 
-Hello! Thank you for checking out Fastify!<br/>
-This document aims to be a gentle introduction to the framework and its features. It is an elementary introduction with examples and links to other parts of the documentation.<br/>
+Hello! Thank you for checking out Fastify!
+
+This document aims to be a gentle introduction to the framework and its features. It is an elementary introduction with examples and links to other parts of the documentation.
+
 Let's start!
 
 ### Install
@@ -45,7 +47,8 @@ fastify.listen(3000, function (err, address) {
 })
 ```
 
-Do you prefer to use `async/await`? Fastify supports it out-of-the-box.<br/>
+Do you prefer to use `async/await`? Fastify supports it out-of-the-box.
+
 *(we also suggest using [make-promises-safe](https://github.com/mcollina/make-promises-safe) to avoid file descriptor and memory leaks)*
 ```js
 const fastify = require('fastify')()
@@ -65,8 +68,10 @@ const start = async () => {
 start()
 ```
 
-Awesome, that was easy.<br/>
-Unfortunately, writing a complex application requires significantly more code than this example. A classic problem when you are building a new application is how handle multiple files, asynchronous bootstrapping and the architecture of your code.<br/>
+Awesome, that was easy.
+
+Unfortunately, writing a complex application requires significantly more code than this example. A classic problem when you are building a new application is how handle multiple files, asynchronous bootstrapping and the architecture of your code.
+
 Fastify offers an easy platform that helps solve all of problems, and more.
 
 > ## Note
@@ -89,8 +94,10 @@ Fastify offers an easy platform that helps solve all of problems, and more.
 ### Your first plugin
 <a name="first-plugin"></a>
 
-As with JavaScript everything is an object, with Fastify everything is a plugin.<br/>
-Before digging into it, let's see how it works!<br/>
+As with JavaScript everything is an object, with Fastify everything is a plugin.
+
+Before digging into it, let's see how it works!
+
 Let's declare our basic server, but instead of declaring the route inside the entry point, we'll declare it in an external file (checkout the [route declaration](./Routes.md) docs).
 ```js
 const fastify = require('fastify')({
@@ -122,11 +129,14 @@ module.exports = routes
 In this example we used the `register` API. This API is the core of the Fastify framework, and is the only way to register routes, plugins and so on.
 
 At the beginning of this guide we noted that Fastify provides a foundation that assists with the asynchronous bootstrapping of your application. Why this is important?
-Consider the scenario where a database connection is needed to handle data storage. Obviously the database connection needs to be available prior to the server accepting connections. How do we address this problem?<br/>
-A typical solution is to use a complex callback, or promises, system that will mix the framework API with other libraries and the application code.<br/>
+Consider the scenario where a database connection is needed to handle data storage. Obviously the database connection needs to be available prior to the server accepting connections. How do we address this problem?
+
+A typical solution is to use a complex callback, or promises, system that will mix the framework API with other libraries and the application code.
+
 Fastify handles this internally, with minimum effort!
 
-Let's rewrite the above example with a database connection.<br/>
+Let's rewrite the above example with a database connection.
+
 *(we will use a simple example, for a robust solution consider using [`fastify-mongo`](https://github.com/fastify/fastify-mongodb) or another in the Fastify [ecosystem](./Ecosystem.md))*
 
 **server.js**
@@ -189,13 +199,16 @@ async function routes (fastify, options) {
 module.exports = routes
 ```
 
-Wow, that was fast!<br/>
-Let's recap what we have done here since we've introduced some new concepts.<br/>
+Wow, that was fast!
+
+Let's recap what we have done here since we've introduced some new concepts.
+
 As you can see, we used `register` both for the database connector and the routes registration.
 This is one of the best features of Fastify, it will load your plugins in the same order you declare them, and it will load the next plugin only once the current one has been loaded. In this way we can register the database connector in the first plugin and use it in the second *(read [here](./Plugins.md#handle-the-scope) to understand how to handle the scope of a plugin)*.
 Plugin loading starts when you call `fastify.listen()`, `fastify.inject()` or `fastify.ready()`
 
-We have used the `decorate` API. Let's take a moment to understand what it is and how it works. A scenario is to use the same code/library in different parts of an application. A solution is to require the code/library that it is needed. This works, but is annoying because of duplicated code repeated and, if needed, long refactors.<br/>
+We have used the `decorate` API. Let's take a moment to understand what it is and how it works. A scenario is to use the same code/library in different parts of an application. A solution is to require the code/library that it is needed. This works, but is annoying because of duplicated code repeated and, if needed, long refactors.
+
 To solve this Fastify offers the `decorate` API, which adds custom objects to the Fastify namespace, so that they can be used everywhere.
 
 To dig deeper into how Fastify plugins work, how to develop new plugins, and for details on how to use the whole Fastify API to deal with the complexity of asynchronously bootstrapping an application, read [the hitchhiker's guide to plugins](./Plugins-Guide.md).
@@ -211,7 +224,8 @@ To guarantee a consistent and predictable behavior of your application, we highl
 └── hooks and middlewares
 └── your services
 ```
-In this way you will always have access to all of the properties declared in the current scope.<br/>
+In this way you will always have access to all of the properties declared in the current scope.
+
 As discussed previously, Fastify offers a solid encapsulation model, to help you build your application as single and independent services. If you want to register a plugin only for a subset of routes, you have just to replicate the above structure.
 ```
 └── plugins (from the Fastify ecosystem)
@@ -238,7 +252,8 @@ As discussed previously, Fastify offers a solid encapsulation model, to help you
 ### Validate your data
 <a name="validate-data"></a>
 
-Data validation is extremely important and is a core concept of the framework.<br/>
+Data validation is extremely important and is a core concept of the framework.
+
 To validate incoming requests, Fastify uses [JSON Schema](http://json-schema.org/).
 Let's look at an example demonstrating validation for routes:
 ```js
@@ -258,13 +273,15 @@ fastify.post('/', opts, async (request, reply) => {
   return { hello: 'world' }
 })
 ```
-This example shows how to pass an options object to the route, which accepts a `schema` key, that contains all of the schemas for route, `body`, `querystring`, `params` and `headers`.<br/>
+This example shows how to pass an options object to the route, which accepts a `schema` key, that contains all of the schemas for route, `body`, `querystring`, `params` and `headers`.
+
 Read [Validation and Serialization](./Validation-and-Serialization.md) to learn more.
 
 ### Serialize your data
 <a name="serialize-data"></a>
 
-Fastify has first class support for JSON. It is extremely optimized to parse a JSON body and to serialize JSON output.<br/>
+Fastify has first class support for JSON. It is extremely optimized to parse a JSON body and to serialize JSON output.
+
 To speed up JSON serialization (yes, it is slow!) use the `response` key of the schema option like so:
 ```js
 const opts = {
@@ -290,13 +307,15 @@ Read [Validation and Serialization](./Validation-and-Serialization.md) to learn 
 ### Extend your server
 <a name="extend-server"></a>
 
-Fastify is built to be extremely extensible and very minimal, We believe that a bare minimum framework is all that is necessary to make great applications possible.<br/>
+Fastify is built to be extremely extensible and very minimal, We believe that a bare minimum framework is all that is necessary to make great applications possible.
+
 In other words, Fastify is not a "batteries included" framework, and relies on an amazing [ecosystem](./Ecosystem.md)!
 
 ### Test your server
 <a name="test-server"></a>
 
-Fastify does not offer a testing framework, but we do recommend a way to write your tests that uses the features and the architecture of Fastify.<br/>
+Fastify does not offer a testing framework, but we do recommend a way to write your tests that uses the features and the architecture of Fastify.
+
 Read the [testing](./Testing.md) documentation to learn more!
 
 ### Run your server from CLI

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -1,7 +1,5 @@
 ---
 title: Getting Started
-sidebar_label: Getting Started
-hide_title: false
 ---
 
 Hello! Thank you for checking out Fastify!
@@ -11,7 +9,7 @@ This document aims to be a gentle introduction to the framework and its features
 Let's start!
 
 ### Install
-<a name="install"></a>
+<a id="install"></a>
 
 Install with npm:
 ```
@@ -23,7 +21,7 @@ yarn add fastify
 ```
 
 ### Your first server
-<a name="first-server"></a>
+<a id="first-server"></a>
 
 Let's write our first server:
 ```js
@@ -92,7 +90,7 @@ Fastify offers an easy platform that helps solve all of problems, and more.
 > When deploying to a Docker, or other type of, container this would be the easiest method for exposing the application.
 
 ### Your first plugin
-<a name="first-plugin"></a>
+<a id="first-plugin"></a>
 
 As with JavaScript everything is an object, with Fastify everything is a plugin.
 
@@ -214,7 +212,7 @@ To solve this Fastify offers the `decorate` API, which adds custom objects to th
 To dig deeper into how Fastify plugins work, how to develop new plugins, and for details on how to use the whole Fastify API to deal with the complexity of asynchronously bootstrapping an application, read [the hitchhiker's guide to plugins](./Plugins-Guide.md).
 
 ### Loading order of your plugins
-<a name="plugin-loading-order"></a>
+<a id="plugin-loading-order"></a>
 
 To guarantee a consistent and predictable behavior of your application, we highly recommend to always load your code as shown below:
 ```
@@ -250,7 +248,7 @@ As discussed previously, Fastify offers a solid encapsulation model, to help you
 ```
 
 ### Validate your data
-<a name="validate-data"></a>
+<a id="validate-data"></a>
 
 Data validation is extremely important and is a core concept of the framework.
 
@@ -278,7 +276,7 @@ This example shows how to pass an options object to the route, which accepts a `
 Read [Validation and Serialization](./Validation-and-Serialization.md) to learn more.
 
 ### Serialize your data
-<a name="serialize-data"></a>
+<a id="serialize-data"></a>
 
 Fastify has first class support for JSON. It is extremely optimized to parse a JSON body and to serialize JSON output.
 
@@ -305,21 +303,21 @@ Simply by specifying a schema as shown, a speed up your of serialization by 2x o
 Read [Validation and Serialization](./Validation-and-Serialization.md) to learn more.
 
 ### Extend your server
-<a name="extend-server"></a>
+<a id="extend-server"></a>
 
 Fastify is built to be extremely extensible and very minimal, We believe that a bare minimum framework is all that is necessary to make great applications possible.
 
 In other words, Fastify is not a "batteries included" framework, and relies on an amazing [ecosystem](./Ecosystem.md)!
 
 ### Test your server
-<a name="test-server"></a>
+<a id="test-server"></a>
 
 Fastify does not offer a testing framework, but we do recommend a way to write your tests that uses the features and the architecture of Fastify.
 
 Read the [testing](./Testing.md) documentation to learn more!
 
 ### Run your server from CLI
-<a name="cli"></a>
+<a id="cli"></a>
 
 Fastify also has CLI integration thanks to
 [fastify-cli](https://github.com/fastify/fastify-cli).
@@ -359,7 +357,7 @@ npm start
 ```
 
 ### Slides and Videos
-<a name="slides"></a>
+<a id="slides"></a>
 
 - Slides
   - [Take your HTTP server to ludicrous speed](https://mcollina.github.io/take-your-http-server-to-ludicrous-speed) by [@mcollina](https://github.com/mcollina)

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -1,12 +1,16 @@
-<h1 align="center">Fastify</h1>
+---
+title: Getting Started
+sidebar_label: Getting Started
+hide_title: false
+---
 
-## Getting Started
-Hello! Thank you for checking out Fastify!<br>
-This document aims to be a gentle introduction to the framework and its features. It is an elementary introduction with examples and links to other parts of the documentation.<br>
+Hello! Thank you for checking out Fastify!<br/>
+This document aims to be a gentle introduction to the framework and its features. It is an elementary introduction with examples and links to other parts of the documentation.<br/>
 Let's start!
 
-<a name="install"></a>
 ### Install
+<a name="install"></a>
+
 Install with npm:
 ```
 npm i fastify --save
@@ -16,8 +20,9 @@ Install with yarn:
 yarn add fastify
 ```
 
-<a name="first-server"></a>
 ### Your first server
+<a name="first-server"></a>
+
 Let's write our first server:
 ```js
 // Require the framework and instantiate it
@@ -40,7 +45,7 @@ fastify.listen(3000, function (err, address) {
 })
 ```
 
-Do you prefer to use `async/await`? Fastify supports it out-of-the-box.<br>
+Do you prefer to use `async/await`? Fastify supports it out-of-the-box.<br/>
 *(we also suggest using [make-promises-safe](https://github.com/mcollina/make-promises-safe) to avoid file descriptor and memory leaks)*
 ```js
 const fastify = require('fastify')()
@@ -60,8 +65,8 @@ const start = async () => {
 start()
 ```
 
-Awesome, that was easy.<br>
-Unfortunately, writing a complex application requires significantly more code than this example. A classic problem when you are building a new application is how handle multiple files, asynchronous bootstrapping and the architecture of your code.<br>
+Awesome, that was easy.<br/>
+Unfortunately, writing a complex application requires significantly more code than this example. A classic problem when you are building a new application is how handle multiple files, asynchronous bootstrapping and the architecture of your code.<br/>
 Fastify offers an easy platform that helps solve all of problems, and more.
 
 > ## Note
@@ -81,11 +86,12 @@ Fastify offers an easy platform that helps solve all of problems, and more.
 >
 > When deploying to a Docker, or other type of, container this would be the easiest method for exposing the application.
 
-<a name="first-plugin"></a>
 ### Your first plugin
-As with JavaScript everything is an object, with Fastify everything is a plugin.<br>
-Before digging into it, let's see how it works!<br>
-Let's declare our basic server, but instead of declaring the route inside the entry point, we'll declare it in an external file (checkout the [route declaration](https://github.com/fastify/fastify/blob/master/docs/Routes.md) docs).
+<a name="first-plugin"></a>
+
+As with JavaScript everything is an object, with Fastify everything is a plugin.<br/>
+Before digging into it, let's see how it works!<br/>
+Let's declare our basic server, but instead of declaring the route inside the entry point, we'll declare it in an external file (checkout the [route declaration](./Routes.md) docs).
 ```js
 const fastify = require('fastify')({
   logger: true
@@ -116,12 +122,12 @@ module.exports = routes
 In this example we used the `register` API. This API is the core of the Fastify framework, and is the only way to register routes, plugins and so on.
 
 At the beginning of this guide we noted that Fastify provides a foundation that assists with the asynchronous bootstrapping of your application. Why this is important?
-Consider the scenario where a database connection is needed to handle data storage. Obviously the database connection needs to be available prior to the server accepting connections. How do we address this problem?<br>
-A typical solution is to use a complex callback, or promises, system that will mix the framework API with other libraries and the application code.<br>
+Consider the scenario where a database connection is needed to handle data storage. Obviously the database connection needs to be available prior to the server accepting connections. How do we address this problem?<br/>
+A typical solution is to use a complex callback, or promises, system that will mix the framework API with other libraries and the application code.<br/>
 Fastify handles this internally, with minimum effort!
 
-Let's rewrite the above example with a database connection.<br>
-*(we will use a simple example, for a robust solution consider using [`fastify-mongo`](https://github.com/fastify/fastify-mongodb) or another in the Fastify [ecosystem](https://github.com/fastify/fastify/blob/master/docs/Ecosystem.md))*
+Let's rewrite the above example with a database connection.<br/>
+*(we will use a simple example, for a robust solution consider using [`fastify-mongo`](https://github.com/fastify/fastify-mongodb) or another in the Fastify [ecosystem](./Ecosystem.md))*
 
 **server.js**
 ```js
@@ -183,19 +189,20 @@ async function routes (fastify, options) {
 module.exports = routes
 ```
 
-Wow, that was fast!<br>
-Let's recap what we have done here since we've introduced some new concepts.<br>
+Wow, that was fast!<br/>
+Let's recap what we have done here since we've introduced some new concepts.<br/>
 As you can see, we used `register` both for the database connector and the routes registration.
-This is one of the best features of Fastify, it will load your plugins in the same order you declare them, and it will load the next plugin only once the current one has been loaded. In this way we can register the database connector in the first plugin and use it in the second *(read [here](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#handle-the-scope) to understand how to handle the scope of a plugin)*.
+This is one of the best features of Fastify, it will load your plugins in the same order you declare them, and it will load the next plugin only once the current one has been loaded. In this way we can register the database connector in the first plugin and use it in the second *(read [here](./Plugins.md#handle-the-scope) to understand how to handle the scope of a plugin)*.
 Plugin loading starts when you call `fastify.listen()`, `fastify.inject()` or `fastify.ready()`
 
-We have used the `decorate` API. Let's take a moment to understand what it is and how it works. A scenario is to use the same code/library in different parts of an application. A solution is to require the code/library that it is needed. This works, but is annoying because of duplicated code repeated and, if needed, long refactors.<br>
+We have used the `decorate` API. Let's take a moment to understand what it is and how it works. A scenario is to use the same code/library in different parts of an application. A solution is to require the code/library that it is needed. This works, but is annoying because of duplicated code repeated and, if needed, long refactors.<br/>
 To solve this Fastify offers the `decorate` API, which adds custom objects to the Fastify namespace, so that they can be used everywhere.
 
-To dig deeper into how Fastify plugins work, how to develop new plugins, and for details on how to use the whole Fastify API to deal with the complexity of asynchronously bootstrapping an application, read [the hitchhiker's guide to plugins](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md).
+To dig deeper into how Fastify plugins work, how to develop new plugins, and for details on how to use the whole Fastify API to deal with the complexity of asynchronously bootstrapping an application, read [the hitchhiker's guide to plugins](./Plugins-Guide.md).
 
-<a name="plugin-loading-order"></a>
 ### Loading order of your plugins
+<a name="plugin-loading-order"></a>
+
 To guarantee a consistent and predictable behavior of your application, we highly recommend to always load your code as shown below:
 ```
 └── plugins (from the Fastify ecosystem)
@@ -228,9 +235,10 @@ As discussed previously, Fastify offers a solid encapsulation model, to help you
           └── your services
 ```
 
-<a name="validate-data"></a>
 ### Validate your data
-Data validation is extremely important and is a core concept of the framework.<br>
+<a name="validate-data"></a>
+
+Data validation is extremely important and is a core concept of the framework.<br/>
 To validate incoming requests, Fastify uses [JSON Schema](http://json-schema.org/).
 Let's look at an example demonstrating validation for routes:
 ```js
@@ -250,12 +258,13 @@ fastify.post('/', opts, async (request, reply) => {
   return { hello: 'world' }
 })
 ```
-This example shows how to pass an options object to the route, which accepts a `schema` key, that contains all of the schemas for route, `body`, `querystring`, `params` and `headers`.<br>
-Read [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) to learn more.
+This example shows how to pass an options object to the route, which accepts a `schema` key, that contains all of the schemas for route, `body`, `querystring`, `params` and `headers`.<br/>
+Read [Validation and Serialization](./Validation-and-Serialization.md) to learn more.
 
-<a name="serialize-data"></a>
 ### Serialize your data
-Fastify has first class support for JSON. It is extremely optimized to parse a JSON body and to serialize JSON output.<br>
+<a name="serialize-data"></a>
+
+Fastify has first class support for JSON. It is extremely optimized to parse a JSON body and to serialize JSON output.<br/>
 To speed up JSON serialization (yes, it is slow!) use the `response` key of the schema option like so:
 ```js
 const opts = {
@@ -276,20 +285,23 @@ fastify.get('/', opts, async (request, reply) => {
 })
 ```
 Simply by specifying a schema as shown, a speed up your of serialization by 2x or even 3x can be achieved. This also helps protect against leaking of sensitive data, since Fastify will serialize only the data present in the response schema.
-Read [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) to learn more.
+Read [Validation and Serialization](./Validation-and-Serialization.md) to learn more.
 
-<a name="extend-server"></a>
 ### Extend your server
-Fastify is built to be extremely extensible and very minimal, We believe that a bare minimum framework is all that is necessary to make great applications possible.<br>
-In other words, Fastify is not a "batteries included" framework, and relies on an amazing [ecosystem](https://github.com/fastify/fastify/blob/master/docs/Ecosystem.md)!
+<a name="extend-server"></a>
 
-<a name="test-server"></a>
+Fastify is built to be extremely extensible and very minimal, We believe that a bare minimum framework is all that is necessary to make great applications possible.<br/>
+In other words, Fastify is not a "batteries included" framework, and relies on an amazing [ecosystem](./Ecosystem.md)!
+
 ### Test your server
-Fastify does not offer a testing framework, but we do recommend a way to write your tests that uses the features and the architecture of Fastify.<br>
-Read the [testing](https://github.com/fastify/fastify/blob/master/docs/Testing.md) documentation to learn more!
+<a name="test-server"></a>
 
-<a name="cli"></a>
+Fastify does not offer a testing framework, but we do recommend a way to write your tests that uses the features and the architecture of Fastify.<br/>
+Read the [testing](./Testing.md) documentation to learn more!
+
 ### Run your server from CLI
+<a name="cli"></a>
+
 Fastify also has CLI integration thanks to
 [fastify-cli](https://github.com/fastify/fastify-cli).
 
@@ -327,8 +339,9 @@ Then run your server with:
 npm start
 ```
 
-<a name="slides"></a>
 ### Slides and Videos
+<a name="slides"></a>
+
 - Slides
   - [Take your HTTP server to ludicrous speed](https://mcollina.github.io/take-your-http-server-to-ludicrous-speed) by [@mcollina](https://github.com/mcollina)
   - [What if I told you that HTTP can be fast](https://delvedor.github.io/What-if-I-told-you-that-HTTP-can-be-fast) by [@delvedor](https://github.com/delvedor)

--- a/docs/HTTP2.md
+++ b/docs/HTTP2.md
@@ -1,7 +1,5 @@
 ---
 title: HTTP2
-sidebar_label: HTTP2
-hide_title: false
 ---
 
 _Fastify_ offers **experimental support** for HTTP2 starting from Node

--- a/docs/HTTP2.md
+++ b/docs/HTTP2.md
@@ -1,6 +1,8 @@
-<h1 align="center">Fastify</h1>
-
-## HTTP2
+---
+title: HTTP2
+sidebar_label: HTTP2
+hide_title: false
+---
 
 _Fastify_ offers **experimental support** for HTTP2 starting from Node
 8.8.0, which includes HTTP2 without a flag. _Fastify_ supports HTTP2

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -90,7 +90,8 @@ fastify.addHook('onResponse', async (res) => {
 | payload | The serialized payload |
 | next | Function to continue with the [lifecycle](./Lifecycle.md) |
 
-It is pretty easy to understand where each hook is executed by looking at the [lifecycle page](./Lifecycle.md).<br/>
+It is pretty easy to understand where each hook is executed by looking at the [lifecycle page](./Lifecycle.md).
+
 Hooks are affected by Fastify's encapsulation, and can thus be applied to selected routes. See the [Scopes](#scope) section for more information.
 
 If you get an error during the execution of your hook, just pass it to `next()` and Fastify will automatically close the request and send the appropriate error code to the user.
@@ -180,7 +181,8 @@ You are able to hook into the application-lifecycle as well. It's important to n
 ### onClose
 <a name="on-close"></a>
 
-Triggered when `fastify.close()` is invoked to stop the server. It is useful when [plugins](./Plugins.md) need a "shutdown" event, such as a connection to a database.<br/>
+Triggered when `fastify.close()` is invoked to stop the server. It is useful when [plugins](./Plugins.md) need a "shutdown" event, such as a connection to a database.
+
 The first argument is the Fastify instance, the second one the `done` callback.
 ```js
 fastify.addHook('onClose', (instance, done) => {
@@ -219,7 +221,8 @@ Note: using an arrow function will break the binding of this to the Fastify inst
 ### beforeHandler
 <a name="before-handler"></a>
 
-Despite the name, `beforeHandler` is not a standard hook like `preHandler`, but is a function that your register right in the route option that will be executed only in the specified route. Can be useful if you need to handle the authentication at route level instead of at hook level (`preHandler` for example), it could also be an array of functions.<br/>
+Despite the name, `beforeHandler` is not a standard hook like `preHandler`, but is a function that your register right in the route option that will be executed only in the specified route. Can be useful if you need to handle the authentication at route level instead of at hook level (`preHandler` for example), it could also be an array of functions.
+
 **`beforeHandler` is executed always after the `preHandler` hook.**
 
 ```js

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -1,7 +1,5 @@
 ---
 title: Hooks
-sidebar_label: Hooks
-hide_title: false
 ---
 
 Hooks are registered with the `fastify.addHook` method and allow you to listen to specific events in the application or request/response lifecycle. You have to register a hook before the event is triggered otherwise the event is lost.
@@ -179,7 +177,7 @@ You are able to hook into the application-lifecycle as well. It's important to n
 - `'onRoute'`
 
 ### onClose
-<a name="on-close"></a>
+<a id="on-close"></a>
 
 Triggered when `fastify.close()` is invoked to stop the server. It is useful when [plugins](./Plugins.md) need a "shutdown" event, such as a connection to a database.
 
@@ -191,7 +189,7 @@ fastify.addHook('onClose', (instance, done) => {
 })
 ```
 ### onRoute
-<a name="on-route"></a>
+<a id="on-route"></a>
 
 Triggered when a new route is registered. Listeners are passed a `routeOptions` object as the sole parameter. The interface is synchronous, and, as such, the listeners do not get passed a callback.
 ```js
@@ -206,7 +204,7 @@ fastify.addHook('onRoute', (routeOptions) => {
 })
 ```
 ### Scope
-<a name="scope"></a>
+<a id="scope"></a>
 
 Except for [Application Hooks](#application-hooks), all hooks are encapsulated. This means that you can decide where your hooks should run by using `register` as explained in the [plugins guide](./Plugins-Guide.md). If you pass a function, that function is bound to the right Fastify context and from there you have full access to the Fastify API.
 
@@ -219,7 +217,7 @@ fastify.addHook('onRequest', function (req, res, next) {
 Note: using an arrow function will break the binding of this to the Fastify instance.
 
 ### beforeHandler
-<a name="before-handler"></a>
+<a id="before-handler"></a>
 
 Despite the name, `beforeHandler` is not a standard hook like `preHandler`, but is a function that your register right in the route option that will be executed only in the specified route. Can be useful if you need to handle the authentication at route level instead of at hook level (`preHandler` for example), it could also be an array of functions.
 

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -1,6 +1,8 @@
-<h1 align="center">Fastify</h1>
-
-## Hooks
+---
+title: Hooks
+sidebar_label: Hooks
+hide_title: false
+---
 
 Hooks are registered with the `fastify.addHook` method and allow you to listen to specific events in the application or request/response lifecycle. You have to register a hook before the event is triggered otherwise the event is lost.
 
@@ -83,12 +85,12 @@ fastify.addHook('onResponse', async (res) => {
 |-------------|-------------|
 | req |  Node.js [IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage) |
 | res | Node.js [ServerResponse](https://nodejs.org/api/http.html#http_class_http_serverresponse) |
-| request | Fastify [Request](https://github.com/fastify/fastify/blob/master/docs/Request.md) interface |
-| reply | Fastify [Reply](https://github.com/fastify/fastify/blob/master/docs/Reply.md) interface |
+| request | Fastify [Request](./Request.md) interface |
+| reply | Fastify [Reply](./Reply.md) interface |
 | payload | The serialized payload |
-| next | Function to continue with the [lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md) |
+| next | Function to continue with the [lifecycle](./Lifecycle.md) |
 
-It is pretty easy to understand where each hook is executed by looking at the [lifecycle page](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md).<br>
+It is pretty easy to understand where each hook is executed by looking at the [lifecycle page](./Lifecycle.md).<br/>
 Hooks are affected by Fastify's encapsulation, and can thus be applied to selected routes. See the [Scopes](#scope) section for more information.
 
 If you get an error during the execution of your hook, just pass it to `next()` and Fastify will automatically close the request and send the appropriate error code to the user.
@@ -107,9 +109,9 @@ fastify.addHook('preHandler', (request, reply, next) => {
 })
 ```
 
-*The error will be handled by [`Reply`](https://github.com/fastify/fastify/blob/master/docs/Reply.md#errors).*
+*The error will be handled by [`Reply`](./Reply.md#errors).*
 
-Note that in the `'preHandler'` and `'onSend'` hook the request and reply objects are different from `'onRequest'`, because the two arguments are [`request`](https://github.com/fastify/fastify/blob/master/docs/Request.md) and [`reply`](https://github.com/fastify/fastify/blob/master/docs/Reply.md) core Fastify objects.
+Note that in the `'preHandler'` and `'onSend'` hook the request and reply objects are different from `'onRequest'`, because the two arguments are [`request`](./Request.md) and [`reply`](./Reply.md) core Fastify objects.
 
 #### The `onSend` Hook
 
@@ -175,9 +177,10 @@ You are able to hook into the application-lifecycle as well. It's important to n
 - `'onClose'`
 - `'onRoute'`
 
+### onClose
 <a name="on-close"></a>
-**'onClose'**<br>
-Triggered when `fastify.close()` is invoked to stop the server. It is useful when [plugins](https://github.com/fastify/fastify/blob/master/docs/Plugins.md) need a "shutdown" event, such as a connection to a database.<br>
+
+Triggered when `fastify.close()` is invoked to stop the server. It is useful when [plugins](./Plugins.md) need a "shutdown" event, such as a connection to a database.<br/>
 The first argument is the Fastify instance, the second one the `done` callback.
 ```js
 fastify.addHook('onClose', (instance, done) => {
@@ -185,8 +188,9 @@ fastify.addHook('onClose', (instance, done) => {
   done()
 })
 ```
+### onRoute
 <a name="on-route"></a>
-**'onRoute'**<br>
+
 Triggered when a new route is registered. Listeners are passed a `routeOptions` object as the sole parameter. The interface is synchronous, and, as such, the listeners do not get passed a callback.
 ```js
 fastify.addHook('onRoute', (routeOptions) => {
@@ -199,9 +203,10 @@ fastify.addHook('onRoute', (routeOptions) => {
   routeOptions.prefix
 })
 ```
-<a name="scope"></a>
 ### Scope
-Except for [Application Hooks](#application-hooks), all hooks are encapsulated. This means that you can decide where your hooks should run by using `register` as explained in the [plugins guide](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md). If you pass a function, that function is bound to the right Fastify context and from there you have full access to the Fastify API.
+<a name="scope"></a>
+
+Except for [Application Hooks](#application-hooks), all hooks are encapsulated. This means that you can decide where your hooks should run by using `register` as explained in the [plugins guide](./Plugins-Guide.md). If you pass a function, that function is bound to the right Fastify context and from there you have full access to the Fastify API.
 
 ```js
 fastify.addHook('onRequest', function (req, res, next) {
@@ -211,9 +216,10 @@ fastify.addHook('onRequest', function (req, res, next) {
 ```
 Note: using an arrow function will break the binding of this to the Fastify instance.
 
-<a name="before-handler"></a>
 ### beforeHandler
-Despite the name, `beforeHandler` is not a standard hook like `preHandler`, but is a function that your register right in the route option that will be executed only in the specified route. Can be useful if you need to handle the authentication at route level instead of at hook level (`preHandler` for example), it could also be an array of functions.<br>
+<a name="before-handler"></a>
+
+Despite the name, `beforeHandler` is not a standard hook like `preHandler`, but is a function that your register right in the route option that will be executed only in the specified route. Can be useful if you need to handle the authentication at route level instead of at hook level (`preHandler` for example), it could also be an array of functions.<br/>
 **`beforeHandler` is executed always after the `preHandler` hook.**
 
 ```js

--- a/docs/LTS.md
+++ b/docs/LTS.md
@@ -1,7 +1,5 @@
 ---
 title: Long Term Support
-sidebar_label: Long Term Support
-hide_title: false
 ---
 
 Fastify's Long Term Support (LTS) is provided according the schedule laid
@@ -19,7 +17,7 @@ A "month" is to be a period of 30 consecutive days.
 
 [semver]: https://semver.org/
 
-<a name="lts-schedule"></a>
+<a id="lts-schedule"></a>
 
 ### Schedule
 
@@ -27,7 +25,7 @@ A "month" is to be a period of 30 consecutive days.
 | :------ | :----------- | :-------------- | :------------------ |
 | 1.0.0   | 2018-03-06   | 2019-09-01      | 6, 8, 9, 10, 11, 12 |
 
-<a name="supported-os"></a>
+<a id="supported-os"></a>
 
 ### CI tested operating systems
 

--- a/docs/LTS.md
+++ b/docs/LTS.md
@@ -1,8 +1,8 @@
-<h1 align="center">Fastify</h1>
-
-<a name="lts"></a>
-
-## Long Term Support
+---
+title: Long Term Support
+sidebar_label: Long Term Support
+hide_title: false
+---
 
 Fastify's Long Term Support (LTS) is provided according the schedule laid
 out in this document:
@@ -12,7 +12,7 @@ out in this document:
    date. The release date of any specific version can be found at
    [https://github.com/fastify/fastify/releases](https://github.com/fastify/fastify/releases).
 
-1. Major releases will receive security updates for an additional six months
+2. Major releases will receive security updates for an additional six months
    from the release of the next major release.
 
 A "month" is to be a period of 30 consecutive days.

--- a/docs/Lifecycle.md
+++ b/docs/Lifecycle.md
@@ -4,7 +4,8 @@ sidebar_label: Lifecycle
 hide_title: false
 ---
 
-Following the schema of the internal lifecycle of Fastify.<br/>
+Following the schema of the internal lifecycle of Fastify.
+
 On the right branch of every section there is the next phase of the lifecycle, on the left branch there is the corresponding error code that will be generated if the parent throws an error *(note that all the errors are automatically handled by Fastify)*.
 ```
 Incoming Request

--- a/docs/Lifecycle.md
+++ b/docs/Lifecycle.md
@@ -1,7 +1,5 @@
 ---
 title: Lifecycle
-sidebar_label: Lifecycle
-hide_title: false
 ---
 
 Following the schema of the internal lifecycle of Fastify.

--- a/docs/Lifecycle.md
+++ b/docs/Lifecycle.md
@@ -1,7 +1,10 @@
-<h1 align="center">Fastify</h1>
+---
+title: Lifecycle
+sidebar_label: Lifecycle
+hide_title: false
+---
 
-## Lifecycle
-Following the schema of the internal lifecycle of Fastify.<br>
+Following the schema of the internal lifecycle of Fastify.<br/>
 On the right branch of every section there is the next phase of the lifecycle, on the left branch there is the corresponding error code that will be generated if the parent throws an error *(note that all the errors are automatically handled by Fastify)*.
 ```
 Incoming Request

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -1,7 +1,5 @@
 ---
 title: Logging
-sidebar_label: Logging
-hide_title: false
 ---
 
 Logging is disabled by default, and you can enable it by passing
@@ -46,7 +44,7 @@ fastify.get('/', options, function (request, reply) {
 })
 ```
 
-<a name="logging-request-id" />
+<a id="logging-request-id" />
 
 By default fastify adds an id to every request for easier tracking. If the "request-id" header is present its value is used, otherwise a new incremental id is generated. See Fastify Factory [`requestIdHeader`](./Server.md#factory-request-id-header) options for customizing that header name.
 Additionally, `genReqId` option can be used for generating the request id by yourself. It will received the incoming request as a parameter.

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -1,6 +1,8 @@
-<h1 align="center">Fastify</h1>
-
-## Logging
+---
+title: Logging
+sidebar_label: Logging
+hide_title: false
+---
 
 Logging is disabled by default, and you can enable it by passing
 `{ logger: true }` or `{ logger: { level: 'info' } }` when you create
@@ -46,7 +48,7 @@ fastify.get('/', options, function (request, reply) {
 
 <a name="logging-request-id" />
 
-By default fastify adds an id to every request for easier tracking. If the "request-id" header is present its value is used, otherwise a new incremental id is generated. See Fastify Factory [`requestIdHeader`](https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-request-id-header) options for customizing that header name.
+By default fastify adds an id to every request for easier tracking. If the "request-id" header is present its value is used, otherwise a new incremental id is generated. See Fastify Factory [`requestIdHeader`](./Server.md#factory-request-id-header) options for customizing that header name.
 Additionally, `genReqId` option can be used for generating the request id by yourself. It will received the incoming request as a parameter.
 
 ```js
@@ -91,4 +93,4 @@ fastify.get('/', function (request, reply) {
 })
 ```
 
-*The logger instance for the current request is available in every part of the [lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md).*
+*The logger instance for the current request is available in every part of the [lifecycle](./Lifecycle.md).*

--- a/docs/Middlewares.md
+++ b/docs/Middlewares.md
@@ -1,7 +1,5 @@
 ---
 title: Middlewares
-sidebar_label: Middlewares
-hide_title: false
 ---
 
 Fastify out of the box provides an asynchronous [middleware engine](https://github.com/fastify/middie) compatible with [Express](https://expressjs.com/) and [Restify](http://restify.com/) middlewares.
@@ -37,7 +35,7 @@ Remember that middlewares can be encapsulated, this means that you can decide wh
 Fastify middlewares also do not expose the `send` method or other methods specific to the Fastify [Reply](./Reply.md) instance. This is because Fastify wraps the incoming `req` and `res` Node instances using the [Request](./Request.md) and [Reply](./Reply.md) objects internally, but this is done after the middlewares phase. If you need to create a middleware you have to use the Node `req` and `res` instances. Otherwise, you can use the `preHandler` hook that has the [Request](./Request.md) and [Reply](./Reply.md) Fastify instances. For more information, see [Hooks](./Hooks.md).
 
 #### Restrict middleware execution to a certain path(s)
-<a name="restrict-usage"></a>
+<a id="restrict-usage"></a>
 
 If you need to run a middleware only under certain path(s), just pass the path as first parameter to `use` and you are done!
 

--- a/docs/Middlewares.md
+++ b/docs/Middlewares.md
@@ -1,10 +1,12 @@
-<h1 align="center">Fastify</h1>
-
-## Middlewares
+---
+title: Middlewares
+sidebar_label: Middlewares
+hide_title: false
+---
 
 Fastify out of the box provides an asynchronous [middleware engine](https://github.com/fastify/middie) compatible with [Express](https://expressjs.com/) and [Restify](http://restify.com/) middlewares.
 
-*If you need a visual feedback to understand when the middlewares are executed take a look to the [lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md) page.*
+*If you need a visual feedback to understand when the middlewares are executed take a look to the [lifecycle](./Lifecycle.md) page.*
 
 Fastify middlewares don't support the full syntax `middleware(err, req, res, next)`, because error handling is done inside Fastify.
 Furthermore methods added by Express and Restify to the enhanced versions of `req` and `res` are not supported in Fastify middlewares.
@@ -30,12 +32,13 @@ const helmet = require('fastify-helmet')
 fastify.register(helmet)
 ```
 
-Remember that middlewares can be encapsulated, this means that you can decide where your middlewares should run by using `register` as explained in the [plugins guide](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md).
+Remember that middlewares can be encapsulated, this means that you can decide where your middlewares should run by using `register` as explained in the [plugins guide](./Plugins-Guide.md).
 
-Fastify middlewares also do not expose the `send` method or other methods specific to the Fastify [Reply]('./Reply.md' "Reply") instance. This is because Fastify wraps the incoming `req` and `res` Node instances using the [Request](./Request.md "Request") and [Reply](./Reply.md "Reply") objects internally, but this is done after the middlewares phase. If you need to create a middleware you have to use the Node `req` and `res` instances. Otherwise, you can use the `preHandler` hook that has the [Request](./Request.md "Request") and [Reply](./Reply.md "Reply") Fastify instances. For more information, see [Hooks](./Hooks.md "Hooks").
+Fastify middlewares also do not expose the `send` method or other methods specific to the Fastify [Reply](./Reply.md) instance. This is because Fastify wraps the incoming `req` and `res` Node instances using the [Request](./Request.md) and [Reply](./Reply.md) objects internally, but this is done after the middlewares phase. If you need to create a middleware you have to use the Node `req` and `res` instances. Otherwise, you can use the `preHandler` hook that has the [Request](./Request.md) and [Reply](./Reply.md) Fastify instances. For more information, see [Hooks](./Hooks.md).
 
-<a name="restrict-usage"></a>
 #### Restrict middleware execution to a certain path(s)
+<a name="restrict-usage"></a>
+
 If you need to run a middleware only under certain path(s), just pass the path as first parameter to `use` and you are done!
 
 *Note that this does not support routes with parameters, (eg: `/user/:id/comments`) and wildcard is not supported in multiple paths.*

--- a/docs/Plugins-Guide.md
+++ b/docs/Plugins-Guide.md
@@ -1,7 +1,5 @@
 ---
 title: Plugins Guide
-sidebar_label: Plugins Guide
-hide_title: false
 ---
 
 # The hitchhiker's guide to plugins
@@ -20,7 +18,7 @@ Fastify was built from the beginning to be an extremely modular system. We built
   - [Let's start!](#lets-start)
 
 ## Register
-<a name="register"></a>
+<a id="register"></a>
 
 As in JavaScript everything is an object, in Fastify everything is a plugin.
 
@@ -66,7 +64,7 @@ module.exports = function (fastify, options, next) {
 Well, now you know how to use the `register` api and how it works, but how do we add new functionality to Fastify and even better, share them with other developers?
 
 ## Decorators
-<a name="decorators"></a>
+<a id="decorators"></a>
 
 Okay, let's say that you wrote an utility that is so good that you decided to make it available along all your code. How would you do it? Probably something like the following:
 ```js
@@ -191,7 +189,7 @@ fastify.get('/happiness', (request, reply) => {
 We've seen how to extend server functionality and how handle the encapsulation system, but what if you need to add a function that must be executed every time that the server "[emits](./Lifecycle.md)" an event?
 
 ## Hooks
-<a name="hooks"></a>
+<a id="hooks"></a>
 
 You just built an amazing utility, but now you need to execute that for every request, this is what you will likely do:
 ```js
@@ -257,7 +255,7 @@ As you probably noticed at this time, `request` and `reply` are not the standard
 
 
 ## Middlewares
-<a name="middlewares"></a>
+<a id="middlewares"></a>
 
 Fastify [supports](./Middlewares.md) out of the box Express/Restify/Connect middlewares, this means that you can just drop-in your old code and it will work! *(faster, by the way)*
 
@@ -269,7 +267,7 @@ fastify.use(yourMiddleware)
 ```
 
 ## How to handle encapsulation and distribution
-<a name="distribution"></a>
+<a id="distribution"></a>
 
 Perfect, now you know (almost) all the tools that you can use to extend Fastify. But probably there is something you noted when trying out your code.
 
@@ -296,7 +294,7 @@ module.exports = fp(dbPlugin)
 You can also tell to `fastify-plugin` to check the installed version of Fastify, in case of you need a specific api.
 
 ## Handle errors
-<a name="handle-errors"></a>
+<a id="handle-errors"></a>
 
 It can happen that one of your plugins could fail during the startup. Maybe you expect it and you have a custom logic that will be triggered in that case. How can you do this?
 The `after` api is what you need. `after` simply registers a callback that will be executed just after a register, and it can take up to three parameters.
@@ -318,7 +316,7 @@ fastify
 ```
 
 ## Let's start!
-<a name="start"></a>
+<a id="start"></a>
 
 Awesome, now you know everything you need to know about Fastify and its plugin system to start building your first plugin, and please if you do, tell us! We will add it to the [*ecosystem*](https://github.com/fastify/fastify#ecosystem) section of our documentation!
 

--- a/docs/Plugins-Guide.md
+++ b/docs/Plugins-Guide.md
@@ -22,7 +22,8 @@ Fastify was built from the beginning to be an extremely modular system. We built
 ## Register
 <a name="register"></a>
 
-As in JavaScript everything is an object, in Fastify everything is a plugin.<br/>
+As in JavaScript everything is an object, in Fastify everything is a plugin.
+
 Your routes, your utilities and so on are all plugins. To add a new plugin, whatever its functionality is, in Fastify you have a nice and unique api to use: [`register`](./Plugins.md).
 ```js
 fastify.register(
@@ -33,12 +34,16 @@ fastify.register(
 `register` creates a new Fastify context, this means that if you do any change to the Fastify instance, those changes will not be reflected in the context's ancestors. In other words, encapsulation!
 
 
-*Why is encapsulation important?*<br/>
-Well, let's say you are creating a new disruptive startup, what do you do? You create an api server with all your stuff, everything in the same place, a monolith!<br/>
-Ok, you are growing very fast and you want to change your architecture and try microservices. Usually this implies a huge amount of work, because of cross dependencies and the lack of separation of concerns.<br/>
+*Why is encapsulation important?*
+
+Well, let's say you are creating a new disruptive startup, what do you do? You create an api server with all your stuff, everything in the same place, a monolith!
+
+Ok, you are growing very fast and you want to change your architecture and try microservices. Usually this implies a huge amount of work, because of cross dependencies and the lack of separation of concerns.
+
 Fastify helps you a lot in this direction, because thanks to the encapsulation model it will completely avoid cross dependencies, and will help you structure your code in cohesive blocks.
 
-*Let's return to how to correctly use `register`.*<br/>
+*Let's return to how to correctly use `register`.*
+
 As you probably know, the required plugins must expose a single function with the following signature
 ```js
 module.exports = function (fastify, options, next) {}
@@ -81,7 +86,8 @@ Create a decorator is extremely easy, just use the [`decorate`](./Decorators.md)
 ```js
 fastify.decorate('util', (a, b) => a + b)
 ```
-Now you can access your utility just by doing `fastify.util` whenever you need it, even inside your test.<br/>
+Now you can access your utility just by doing `fastify.util` whenever you need it, even inside your test.
+
 And here's starts the magic; do you remember that few lines above we talked about encapsulation? Well, using `register` and `decorate` in conjunction enable exactly that, let me show you an example to clarify this:
 ```js
 fastify.register((instance, opts, next) => {
@@ -97,7 +103,8 @@ fastify.register((instance, opts, next) => {
   next()
 })
 ```
-Inside the second register call `instance.util` will throw an error, because `util` exists only inside the first register context.<br/>
+Inside the second register call `instance.util` will throw an error, because `util` exists only inside the first register context.
+
 Let's step back for a moment and get deeper on this: when using the `register` api you will create a new context every time and this avoids situations like the one mentioned few line above. But pay attention, the encapsulation works only for the ancestors and the brothers, but not for the sons.
 ```js
 fastify.register((instance, opts, next) => {
@@ -122,7 +129,8 @@ fastify.register((instance, opts, next) => {
 
 `decorate` is not the unique api that you can use to extend the server functionalities, you can also use `decorateRequest` and `decorateReply`.
 
-*`decorateRequest` and `decorateReply`? Why do we need them if we already have `decorate`?*<br/>
+*`decorateRequest` and `decorateReply`? Why do we need them if we already have `decorate`?*
+
 Good question, we added them to make Fastify more developer-friendly. Let's see an example:
 ```js
 fastify.decorate('html', payload => {
@@ -201,7 +209,8 @@ fastify.get('/plugin2', (request, reply) => {
 ```
 I think we all agree that this is terrible. Code repeat, awful readability and it cannot scale.
 
-So what can you do to avoid this annoying issue? Yes, you are right, use an [hook](./Hooks.md)!<br/>
+So what can you do to avoid this annoying issue? Yes, you are right, use an [hook](./Hooks.md)!
+
 ```js
 fastify.decorate('util', (request, key, value) => { request[key] = value })
 
@@ -218,7 +227,8 @@ fastify.get('/plugin2', (request, reply) => {
   reply.send(request)
 })
 ```
-Now for every request you will run your utility, it is obvious that you can register as many hooks as you need.<br/>
+Now for every request you will run your utility, it is obvious that you can register as many hooks as you need.
+
 It can happen that you want a hook that must be executed just for a subset of routes, how can you do that?  Yep, encapsulation!
 
 ```js
@@ -243,12 +253,14 @@ fastify.get('/plugin2', (request, reply) => {
 ```
 Now your hook will run just for the first route!
 
-As you probably noticed at this time, `request` and `reply` are not the standard Nodejs *request* and *response* objects, but Fastify's objects.<br/>
+As you probably noticed at this time, `request` and `reply` are not the standard Nodejs *request* and *response* objects, but Fastify's objects.
+
 
 ## Middlewares
 <a name="middlewares"></a>
 
-Fastify [supports](./Middlewares.md) out of the box Express/Restify/Connect middlewares, this means that you can just drop-in your old code and it will work! *(faster, by the way)*<br/>
+Fastify [supports](./Middlewares.md) out of the box Express/Restify/Connect middlewares, this means that you can just drop-in your old code and it will work! *(faster, by the way)*
+
 Let's say that you are arriving from Express, and you already have some Middleware that does exactly what you need, and you don't want to redo all the work.
 How we can do that? Checkout our middlewares engine, [middie](https://github.com/fastify/middie).
 ```js
@@ -259,12 +271,14 @@ fastify.use(yourMiddleware)
 ## How to handle encapsulation and distribution
 <a name="distribution"></a>
 
-Perfect, now you know (almost) all the tools that you can use to extend Fastify. But probably there is something you noted when trying out your code.<br/>
+Perfect, now you know (almost) all the tools that you can use to extend Fastify. But probably there is something you noted when trying out your code.
+
 How can you distribute your code?
 
 The preferred way to distribute a utility is to wrap all your code inside a `register`, in this way your plugin can support an asynchronous bootstrap *(since `decorate` is a synchronous api)*, in the case of a database connection for example.
 
-*Wait, what? Didn't you tell me that `register` creates an encapsulation and that what I create inside there will not be available outside?*<br/>
+*Wait, what? Didn't you tell me that `register` creates an encapsulation and that what I create inside there will not be available outside?*
+
 Yes, I said that. But what I didn't tell you, is that you can tell to Fastify to avoid this behavior, with the [`fastify-plugin`](https://github.com/fastify/fastify-plugin) module.
 ```js
 const fp = require('fastify-plugin')
@@ -285,7 +299,8 @@ You can also tell to `fastify-plugin` to check the installed version of Fastify,
 <a name="handle-errors"></a>
 
 It can happen that one of your plugins could fail during the startup. Maybe you expect it and you have a custom logic that will be triggered in that case. How can you do this?
-The `after` api is what you need. `after` simply registers a callback that will be executed just after a register, and it can take up to three parameters.<br/>
+The `after` api is what you need. `after` simply registers a callback that will be executed just after a register, and it can take up to three parameters.
+
 The callback changes based on the parameters your are giving:
 
 1. If no parameter is given to the callback and there is an error, that error will be passed to the next error handler.

--- a/docs/Plugins-Guide.md
+++ b/docs/Plugins-Guide.md
@@ -1,4 +1,8 @@
-<h1 align="center">Fastify</h1>
+---
+title: Plugins Guide
+sidebar_label: Plugins Guide
+hide_title: false
+---
 
 # The hitchhiker's guide to plugins
 First of all, `DON'T PANIC`!
@@ -6,18 +10,20 @@ First of all, `DON'T PANIC`!
 Fastify was built from the beginning to be an extremely modular system. We built a powerful API that allows you to add methods and utilities to Fastify by creating a namespace. We built a system that creates an encapsulation model that allows you to split your application in multiple microservices at any moment, without the need to refactor the entire application.
 
 **Table of contents**
-- [Register](#register)
-- [Decorators](#decorators)
-- [Hooks](#hooks)
-- [Middlewares](#middlewares)
-- [How to handle encapsulation and distribution](#distribution)
-- [Handle errors](#handle-errors)
-- [Let's start!](#start)
+- [The hitchhiker's guide to plugins](#the-hitchhikers-guide-to-plugins)
+  - [Register](#register)
+  - [Decorators](#decorators)
+  - [Hooks](#hooks)
+  - [Middlewares](#middlewares)
+  - [How to handle encapsulation and distribution](#how-to-handle-encapsulation-and-distribution)
+  - [Handle errors](#handle-errors)
+  - [Let's start!](#lets-start)
 
-<a name="register"></a>
 ## Register
-As in JavaScript everything is an object, in Fastify everything is a plugin.<br>
-Your routes, your utilities and so on are all plugins. To add a new plugin, whatever its functionality is, in Fastify you have a nice and unique api to use: [`register`](https://github.com/fastify/fastify/blob/master/docs/Plugins.md).
+<a name="register"></a>
+
+As in JavaScript everything is an object, in Fastify everything is a plugin.<br/>
+Your routes, your utilities and so on are all plugins. To add a new plugin, whatever its functionality is, in Fastify you have a nice and unique api to use: [`register`](./Plugins.md).
 ```js
 fastify.register(
   require('./my-plugin'),
@@ -27,12 +33,12 @@ fastify.register(
 `register` creates a new Fastify context, this means that if you do any change to the Fastify instance, those changes will not be reflected in the context's ancestors. In other words, encapsulation!
 
 
-*Why is encapsulation important?*<br>
-Well, let's say you are creating a new disruptive startup, what do you do? You create an api server with all your stuff, everything in the same place, a monolith!<br>
-Ok, you are growing very fast and you want to change your architecture and try microservices. Usually this implies a huge amount of work, because of cross dependencies and the lack of separation of concerns.<br>
+*Why is encapsulation important?*<br/>
+Well, let's say you are creating a new disruptive startup, what do you do? You create an api server with all your stuff, everything in the same place, a monolith!<br/>
+Ok, you are growing very fast and you want to change your architecture and try microservices. Usually this implies a huge amount of work, because of cross dependencies and the lack of separation of concerns.<br/>
 Fastify helps you a lot in this direction, because thanks to the encapsulation model it will completely avoid cross dependencies, and will help you structure your code in cohesive blocks.
 
-*Let's return to how to correctly use `register`.*<br>
+*Let's return to how to correctly use `register`.*<br/>
 As you probably know, the required plugins must expose a single function with the following signature
 ```js
 module.exports = function (fastify, options, next) {}
@@ -54,8 +60,9 @@ module.exports = function (fastify, options, next) {
 
 Well, now you know how to use the `register` api and how it works, but how do we add new functionality to Fastify and even better, share them with other developers?
 
-<a name="decorators"></a>
 ## Decorators
+<a name="decorators"></a>
+
 Okay, let's say that you wrote an utility that is so good that you decided to make it available along all your code. How would you do it? Probably something like the following:
 ```js
 // your-awesome-utility.js
@@ -70,11 +77,11 @@ console.log(util('that is ', ' awesome'))
 And now you will import your utility in every file you need it. (And don't forget that you will probably also need it in your test).
 
 Fastify offers you a way nicer and elegant way to do this, *decorators*.
-Create a decorator is extremely easy, just use the [`decorate`](https://github.com/fastify/fastify/blob/master/docs/Decorators.md) api:
+Create a decorator is extremely easy, just use the [`decorate`](./Decorators.md) api:
 ```js
 fastify.decorate('util', (a, b) => a + b)
 ```
-Now you can access your utility just by doing `fastify.util` whenever you need it, even inside your test.<br>
+Now you can access your utility just by doing `fastify.util` whenever you need it, even inside your test.<br/>
 And here's starts the magic; do you remember that few lines above we talked about encapsulation? Well, using `register` and `decorate` in conjunction enable exactly that, let me show you an example to clarify this:
 ```js
 fastify.register((instance, opts, next) => {
@@ -90,7 +97,7 @@ fastify.register((instance, opts, next) => {
   next()
 })
 ```
-Inside the second register call `instance.util` will throw an error, because `util` exists only inside the first register context.<br>
+Inside the second register call `instance.util` will throw an error, because `util` exists only inside the first register context.<br/>
 Let's step back for a moment and get deeper on this: when using the `register` api you will create a new context every time and this avoids situations like the one mentioned few line above. But pay attention, the encapsulation works only for the ancestors and the brothers, but not for the sons.
 ```js
 fastify.register((instance, opts, next) => {
@@ -115,7 +122,7 @@ fastify.register((instance, opts, next) => {
 
 `decorate` is not the unique api that you can use to extend the server functionalities, you can also use `decorateRequest` and `decorateReply`.
 
-*`decorateRequest` and `decorateReply`? Why do we need them if we already have `decorate`?*<br>
+*`decorateRequest` and `decorateReply`? Why do we need them if we already have `decorate`?*<br/>
 Good question, we added them to make Fastify more developer-friendly. Let's see an example:
 ```js
 fastify.decorate('html', payload => {
@@ -173,10 +180,11 @@ fastify.get('/happiness', (request, reply) => {
 })
 ```
 
-We've seen how to extend server functionality and how handle the encapsulation system, but what if you need to add a function that must be executed every time that the server "[emits](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md)" an event?
+We've seen how to extend server functionality and how handle the encapsulation system, but what if you need to add a function that must be executed every time that the server "[emits](./Lifecycle.md)" an event?
 
-<a name="hooks"></a>
 ## Hooks
+<a name="hooks"></a>
+
 You just built an amazing utility, but now you need to execute that for every request, this is what you will likely do:
 ```js
 fastify.decorate('util', (request, key, value) => { request.key = value })
@@ -193,7 +201,7 @@ fastify.get('/plugin2', (request, reply) => {
 ```
 I think we all agree that this is terrible. Code repeat, awful readability and it cannot scale.
 
-So what can you do to avoid this annoying issue? Yes, you are right, use an [hook](https://github.com/fastify/fastify/blob/master/docs/Hooks.md)!<br>
+So what can you do to avoid this annoying issue? Yes, you are right, use an [hook](./Hooks.md)!<br/>
 ```js
 fastify.decorate('util', (request, key, value) => { request[key] = value })
 
@@ -210,7 +218,7 @@ fastify.get('/plugin2', (request, reply) => {
   reply.send(request)
 })
 ```
-Now for every request you will run your utility, it is obvious that you can register as many hooks as you need.<br>
+Now for every request you will run your utility, it is obvious that you can register as many hooks as you need.<br/>
 It can happen that you want a hook that must be executed just for a subset of routes, how can you do that?  Yep, encapsulation!
 
 ```js
@@ -235,11 +243,12 @@ fastify.get('/plugin2', (request, reply) => {
 ```
 Now your hook will run just for the first route!
 
-As you probably noticed at this time, `request` and `reply` are not the standard Nodejs *request* and *response* objects, but Fastify's objects.<br>
+As you probably noticed at this time, `request` and `reply` are not the standard Nodejs *request* and *response* objects, but Fastify's objects.<br/>
 
-<a name="middlewares"></a>
 ## Middlewares
-Fastify [supports](https://github.com/fastify/fastify/blob/master/docs/Middlewares.md) out of the box Express/Restify/Connect middlewares, this means that you can just drop-in your old code and it will work! *(faster, by the way)*<br>
+<a name="middlewares"></a>
+
+Fastify [supports](./Middlewares.md) out of the box Express/Restify/Connect middlewares, this means that you can just drop-in your old code and it will work! *(faster, by the way)*<br/>
 Let's say that you are arriving from Express, and you already have some Middleware that does exactly what you need, and you don't want to redo all the work.
 How we can do that? Checkout our middlewares engine, [middie](https://github.com/fastify/middie).
 ```js
@@ -247,14 +256,15 @@ const yourMiddleware = require('your-middleware')
 fastify.use(yourMiddleware)
 ```
 
-<a name="distribution"></a>
 ## How to handle encapsulation and distribution
-Perfect, now you know (almost) all the tools that you can use to extend Fastify. But probably there is something you noted when trying out your code.<br>
+<a name="distribution"></a>
+
+Perfect, now you know (almost) all the tools that you can use to extend Fastify. But probably there is something you noted when trying out your code.<br/>
 How can you distribute your code?
 
 The preferred way to distribute a utility is to wrap all your code inside a `register`, in this way your plugin can support an asynchronous bootstrap *(since `decorate` is a synchronous api)*, in the case of a database connection for example.
 
-*Wait, what? Didn't you tell me that `register` creates an encapsulation and that what I create inside there will not be available outside?*<br>
+*Wait, what? Didn't you tell me that `register` creates an encapsulation and that what I create inside there will not be available outside?*<br/>
 Yes, I said that. But what I didn't tell you, is that you can tell to Fastify to avoid this behavior, with the [`fastify-plugin`](https://github.com/fastify/fastify-plugin) module.
 ```js
 const fp = require('fastify-plugin')
@@ -271,10 +281,11 @@ module.exports = fp(dbPlugin)
 ```
 You can also tell to `fastify-plugin` to check the installed version of Fastify, in case of you need a specific api.
 
-<a name="handle-errors"></a>
 ## Handle errors
+<a name="handle-errors"></a>
+
 It can happen that one of your plugins could fail during the startup. Maybe you expect it and you have a custom logic that will be triggered in that case. How can you do this?
-The `after` api is what you need. `after` simply registers a callback that will be executed just after a register, and it can take up to three parameters.<br>
+The `after` api is what you need. `after` simply registers a callback that will be executed just after a register, and it can take up to three parameters.<br/>
 The callback changes based on the parameters your are giving:
 
 1. If no parameter is given to the callback and there is an error, that error will be passed to the next error handler.
@@ -291,8 +302,9 @@ fastify
   })
 ```
 
-<a name="start"></a>
 ## Let's start!
+<a name="start"></a>
+
 Awesome, now you know everything you need to know about Fastify and its plugin system to start building your first plugin, and please if you do, tell us! We will add it to the [*ecosystem*](https://github.com/fastify/fastify#ecosystem) section of our documentation!
 
 If you want to see some real world example, checkout:

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -5,7 +5,8 @@ hide_title: false
 ---
 
 Fastify allows the user to extend its functionalities with plugins.
-A plugin can be a set of routes, a server [decorator](./Decorators.md) or whatever. The API that you will need to use one or more plugins, is `register`.<br/>
+A plugin can be a set of routes, a server [decorator](./Decorators.md) or whatever. The API that you will need to use one or more plugins, is `register`.
+
 
 By default, `register` creates a *new scope*, this means that if you do some changes to the Fastify instance (via `decorate`), this change will not be reflected to the current context ancestors, but only to its sons. This feature allows us to achieve plugin *encapsulation* and *inheritance*, in this way we create a *direct acyclic graph* (DAG) and we will not have issues caused by cross dependencies.
 
@@ -47,13 +48,15 @@ fastify.register(require('fastify-foo'), {
 #### Route Prefixing option
 <a name="route-prefixing-option"></a>
 
-If you pass an option with the key `prefix` with a `string` value, Fastify will use it to prefix all the routes inside the register, for more info check [here](./Routes.md#route-prefixing).<br/>
+If you pass an option with the key `prefix` with a `string` value, Fastify will use it to prefix all the routes inside the register, for more info check [here](./Routes.md#route-prefixing).
+
 Be aware that if you use [`fastify-plugin`](https://github.com/fastify/fastify-plugin) this option won't work.
 
 #### Error handling
 <a name="error-handling"></a>
 
-The error handling is done by [avvio](https://github.com/mcollina/avvio#error-handling).<br/>
+The error handling is done by [avvio](https://github.com/mcollina/avvio#error-handling).
+
 As general rule, it is highly recommended that you handle your errors in the next `after` or `ready` block, otherwise you will get them inside the `listen` callback.
 
 ```js
@@ -85,7 +88,8 @@ await fastify.listen(3000)
 ### Create a plugin
 <a name="create-plugin"></a>
 
-Creating a plugin is very easy, you just need to create a function that takes three parameters, the `fastify` instance, an options object and the next callback.<br/>
+Creating a plugin is very easy, you just need to create a function that takes three parameters, the `fastify` instance, an options object and the next callback.
+
 Example:
 ```js
 module.exports = function (fastify, opts, next) {

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -1,7 +1,5 @@
 ---
 title: Plugins
-sidebar_label: Plugins
-hide_title: false
 ---
 
 Fastify allows the user to extend its functionalities with plugins.
@@ -16,7 +14,7 @@ fastify.register(plugin, [options])
 ```
 
 ### Plugin Options
-<a name="plugin-options"></a>
+<a id="plugin-options"></a>
 
 The optional `options` parameter for `fastify.register` supports a predefined set of options that Fastify itself will use, except when the plugin has been wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This options object will also be passed to the plugin upon invocation, regardless of whether or not the plugin has been wrapped. The currently supported list of Fastify specific options is:
 
@@ -46,14 +44,14 @@ fastify.register(require('fastify-foo'), {
 ```
 
 #### Route Prefixing option
-<a name="route-prefixing-option"></a>
+<a id="route-prefixing-option"></a>
 
 If you pass an option with the key `prefix` with a `string` value, Fastify will use it to prefix all the routes inside the register, for more info check [here](./Routes.md#route-prefixing).
 
 Be aware that if you use [`fastify-plugin`](https://github.com/fastify/fastify-plugin) this option won't work.
 
 #### Error handling
-<a name="error-handling"></a>
+<a id="error-handling"></a>
 
 The error handling is done by [avvio](https://github.com/mcollina/avvio#error-handling).
 
@@ -86,7 +84,7 @@ await fastify.ready()
 await fastify.listen(3000)
 ```
 ### Create a plugin
-<a name="create-plugin"></a>
+<a id="create-plugin"></a>
 
 Creating a plugin is very easy, you just need to create a function that takes three parameters, the `fastify` instance, an options object and the next callback.
 
@@ -117,7 +115,7 @@ Sometimes, you will need to know when the server is about to close, for example 
 Do not forget that `register` will always create a new Fastify scope, if you don't need that, read the following section.
 
 ### Handle the scope
-<a name="handle-scope"></a>
+<a id="handle-scope"></a>
 
 If you are using `register` only for extending the functionality of the server with  [`decorate`](./Decorators.md), it is your responsibility to tell Fastify to not create a new scope, otherwise your changes will not be accessible by the user in the upper scope.
 

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -1,22 +1,26 @@
-<h1 align="center">Fastify</h1>
+---
+title: Plugins
+sidebar_label: Plugins
+hide_title: false
+---
 
-## Plugins
 Fastify allows the user to extend its functionalities with plugins.
-A plugin can be a set of routes, a server [decorator](https://github.com/fastify/fastify/blob/master/docs/Decorators.md) or whatever. The API that you will need to use one or more plugins, is `register`.<br>
+A plugin can be a set of routes, a server [decorator](./Decorators.md) or whatever. The API that you will need to use one or more plugins, is `register`.<br/>
 
 By default, `register` creates a *new scope*, this means that if you do some changes to the Fastify instance (via `decorate`), this change will not be reflected to the current context ancestors, but only to its sons. This feature allows us to achieve plugin *encapsulation* and *inheritance*, in this way we create a *direct acyclic graph* (DAG) and we will not have issues caused by cross dependencies.
 
-You already see in the [getting started](https://github.com/fastify/fastify/blob/master/docs/Getting-Started.md#register) section how using this API is pretty straightforward.
+You already see in the [getting started](./Getting-Started.md#register) section how using this API is pretty straightforward.
 ```
 fastify.register(plugin, [options])
 ```
 
-<a name="plugin-options"></a>
 ### Plugin Options
+<a name="plugin-options"></a>
+
 The optional `options` parameter for `fastify.register` supports a predefined set of options that Fastify itself will use, except when the plugin has been wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This options object will also be passed to the plugin upon invocation, regardless of whether or not the plugin has been wrapped. The currently supported list of Fastify specific options is:
 
-+ [`logLevel`](https://github.com/fastify/fastify/blob/master/docs/Routes.md#custom-log-level)
-+ [`prefix`](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#route-prefixing-options)
++ [`logLevel`](./Routes.md#custom-log-level)
++ [`prefix`](./Plugins.md#route-prefixing-options)
 
 It is possible that Fastify will directly support other options in the future. Thus, to avoid collisions, a plugin should consider namespacing its options. For example, a plugin `foo` might be registered like so:
 
@@ -40,14 +44,16 @@ fastify.register(require('fastify-foo'), {
 })
 ```
 
-<a name="route-prefixing-option"></a>
 #### Route Prefixing option
-If you pass an option with the key `prefix` with a `string` value, Fastify will use it to prefix all the routes inside the register, for more info check [here](https://github.com/fastify/fastify/blob/master/docs/Routes.md#route-prefixing).<br>
+<a name="route-prefixing-option"></a>
+
+If you pass an option with the key `prefix` with a `string` value, Fastify will use it to prefix all the routes inside the register, for more info check [here](./Routes.md#route-prefixing).<br/>
 Be aware that if you use [`fastify-plugin`](https://github.com/fastify/fastify-plugin) this option won't work.
 
-<a name="error-handling"></a>
 #### Error handling
-The error handling is done by [avvio](https://github.com/mcollina/avvio#error-handling).<br>
+<a name="error-handling"></a>
+
+The error handling is done by [avvio](https://github.com/mcollina/avvio#error-handling).<br/>
 As general rule, it is highly recommended that you handle your errors in the next `after` or `ready` block, otherwise you will get them inside the `listen` callback.
 
 ```js
@@ -76,9 +82,10 @@ await fastify.ready()
 
 await fastify.listen(3000)
 ```
-<a name="create-plugin"></a>
 ### Create a plugin
-Creating a plugin is very easy, you just need to create a function that takes three parameters, the `fastify` instance, an options object and the next callback.<br>
+<a name="create-plugin"></a>
+
+Creating a plugin is very easy, you just need to create a function that takes three parameters, the `fastify` instance, an options object and the next callback.<br/>
 Example:
 ```js
 module.exports = function (fastify, opts, next) {
@@ -101,13 +108,14 @@ module.exports = function (fastify, opts, next) {
   next()
 }
 ```
-Sometimes, you will need to know when the server is about to close, for example because you must close a connection to a database. To know when this is going to happen, you can use the [`'onClose'`](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#on-close) hook.
+Sometimes, you will need to know when the server is about to close, for example because you must close a connection to a database. To know when this is going to happen, you can use the [`'onClose'`](./Hooks.md#on-close) hook.
 
 Do not forget that `register` will always create a new Fastify scope, if you don't need that, read the following section.
 
-<a name="handle-scope"></a>
 ### Handle the scope
-If you are using `register` only for extending the functionality of the server with  [`decorate`](https://github.com/fastify/fastify/blob/master/docs/Decorators.md), it is your responsibility to tell Fastify to not create a new scope, otherwise your changes will not be accessible by the user in the upper scope.
+<a name="handle-scope"></a>
+
+If you are using `register` only for extending the functionality of the server with  [`decorate`](./Decorators.md), it is your responsibility to tell Fastify to not create a new scope, otherwise your changes will not be accessible by the user in the upper scope.
 
 You have two ways to tell Fastify to avoid the creation of a new context:
 - Use the [`fastify-plugin`](https://github.com/fastify/fastify-plugin) module

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -1,7 +1,5 @@
 ---
 title: Reply
-sidebar_label: Reply
-hide_title: false
 ---
 
 The second parameter of the handler function is `Reply`.
@@ -40,12 +38,12 @@ fastify.get('/', {config: {foo: 'bar'}}, function (request, reply) {
 ```
 
 ### .code(statusCode)
-<a name="code"></a>
+<a id="code"></a>
 
 If not set via `reply.code`, the resulting `statusCode` will be `200`.
 
 ### .header(key, value)
-<a name="header"></a>
+<a id="header"></a>
 
 Sets a response header. If the value is omitted or undefined it is coerced
 to `''`.
@@ -53,7 +51,7 @@ to `''`.
 For more information, see [`http.ServerResponse#setHeader`](https://nodejs.org/dist/latest/docs/api/http.html#http_response_setheader_name_value).
 
 ### .getHeader(key)
-<a name="getHeader"></a>
+<a id="getHeader"></a>
 
 Retrieves the value of a previously set header.
 ```js
@@ -62,7 +60,7 @@ reply.getHeader('x-foo') // 'foo'
 ```
 
 ### .removeHeader(key)
-<a name="getHeader"></a>
+<a id="getHeader"></a>
 
 Removed the value of a previously set header.
 ```js
@@ -72,12 +70,12 @@ reply.getHeader('x-foo') // undefined
 ```
 
 ### .hasHeader(key)
-<a name="hasHeader"></a>
+<a id="hasHeader"></a>
 
 Returns a boolean indicating if the specified header has been set.
 
 ### .redirect(dest)
-<a name="redirect"></a>
+<a id="redirect"></a>
 
 Redirects a request to the specified url, the status code is optional, default to `302` (if status code is not already set by calling `code`).
 ```js
@@ -85,7 +83,7 @@ reply.redirect('/home')
 ```
 
 ### .type(contentType)
-<a name="type"></a>
+<a id="type"></a>
 
 Sets the content type for the response.
 This is a shortcut for `reply.header('Content-Type', 'the/type')`.
@@ -95,7 +93,7 @@ reply.type('text/html')
 ```
 
 ### .serializer(func)
-<a name="serializer"></a>
+<a id="serializer"></a>
 
 `.send()` will by default JSON-serialize any value that is not one of: `Buffer`, `stream`, `string`, `undefined`, `Error`. If you need to replace the default serializer with a custom serializer for a particular request, you can do so with the `.serializer()` utility. Be aware that if you are using a custom serializer, you must set a custom `'Content-Type'` header.
 
@@ -116,7 +114,7 @@ reply
 See [`.send()`](#send) for more information on sending different types of values.
 
 ### .sent
-<a name="sent"></a>
+<a id="sent"></a>
 
 As the name suggests, `.sent` is a property to indicate if
 a response has been sent via `reply.send()`.
@@ -142,12 +140,12 @@ app.get('/', (req, reply) => {
 If the handler rejects, the error will be logged.
 
 ### .send(data)
-<a name="send"></a>
+<a id="send"></a>
 
 As the name suggests, `.send()` is the function that sends the payload to the end user.
 
 #### Objects
-<a name="send-object"></a>
+<a id="send-object"></a>
 
 As noted above, if you are sending JSON objects, `send` will serialize the object with [fast-json-stringify](https://www.npmjs.com/package/fast-json-stringify) if you set an output schema, otherwise `JSON.stringify()` will be used.
 ```js
@@ -157,7 +155,7 @@ fastify.get('/json', options, function (request, reply) {
 ```
 
 #### Strings
-<a name="send-string"></a>
+<a id="send-string"></a>
 
 If you pass a string to `send` without a `Content-Type`, it will be sent as `text/plain; charset=utf-8`. If you set the `Content-Type` header and pass a string to `send`, it will be serialized with the custom serializer if one is set, otherwise it will be sent unmodified (unless the `Content-Type` header is set to `application/json; charset=utf-8`, in which case it will be JSON-serialized like an object — see the section above).
 ```js
@@ -167,7 +165,7 @@ fastify.get('/json', options, function (request, reply) {
 ```
 
 #### Streams
-<a name="send-streams"></a>
+<a id="send-streams"></a>
 
 *send* can also handle streams out of the box, internally uses [pump](https://www.npmjs.com/package/pump) to avoid leaks of file descriptors. If you are sending a stream and you have not set a `'Content-Type'` header, *send* will set it at `'application/octet-stream'`.
 ```js
@@ -179,7 +177,7 @@ fastify.get('/streams', function (request, reply) {
 ```
 
 #### Buffers
-<a name="send-buffers"></a>
+<a id="send-buffers"></a>
 
 If you are sending a buffer and you have not set a `'Content-Type'` header, *send* will set it to `'application/octet-stream'`.
 ```js
@@ -192,7 +190,7 @@ fastify.get('/streams', function (request, reply) {
 ```
 
 #### Errors
-<a name="errors"></a>
+<a id="errors"></a>
 
 If you pass to *send* an object that is an instance of *Error*, Fastify will automatically create an error structured as the following:
 ```js
@@ -231,7 +229,7 @@ fastify.get('/', function (request, reply) {
 ```
 
 #### Type of the final payload
-<a name="payload-type"></a>
+<a id="payload-type"></a>
 
 The type of the sent payload (after serialization and going through any [`onSend` hooks](./Hooks.md#the-onsend-hook)) must be one of the following types, otherwise an error will be thrown:
 
@@ -242,7 +240,7 @@ The type of the sent payload (after serialization and going through any [`onSend
 - `null`
 
 #### Async-Await and Promises
-<a name="async-await-promise"></a>
+<a id="async-await-promise"></a>
 
 Fastify natively handles promises and supports async-await.
 

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -202,7 +202,8 @@ If you pass to *send* an object that is an instance of *Error*, Fastify will aut
   statusCode: Number   // the http status code
 }
 ```
-You can add some custom property to the Error object, such as `code` and `headers`, that will be used to enhance the http response.<br/>
+You can add some custom property to the Error object, such as `code` and `headers`, that will be used to enhance the http response.
+
 *Note: If you are passing an error to `send` and the statusCode is less than 400, Fastify will automatically set it at 500.*
 
 Tip: you can simplify errors by using the [`http-errors`](https://npm.im/http-errors) module to generate errors:
@@ -243,7 +244,8 @@ The type of the sent payload (after serialization and going through any [`onSend
 #### Async-Await and Promises
 <a name="async-await-promise"></a>
 
-Fastify natively handles promises and supports async-await.<br/>
+Fastify natively handles promises and supports async-await.
+
 *Note that in the following examples we are not using reply.send.*
 ```js
 fastify.get('/promises', options, function (request, reply) {

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -1,6 +1,9 @@
-<h1 align="center">Fastify</h1>
+---
+title: Reply
+sidebar_label: Reply
+hide_title: false
+---
 
-## Reply
 The second parameter of the handler function is `Reply`.
 Reply is a core Fastify object that exposes the following functions
 and properties:
@@ -36,27 +39,30 @@ fastify.get('/', {config: {foo: 'bar'}}, function (request, reply) {
 })
 ```
 
-<a name="code"></a>
 ### .code(statusCode)
+<a name="code"></a>
+
 If not set via `reply.code`, the resulting `statusCode` will be `200`.
 
-<a name="header"></a>
 ### .header(key, value)
+<a name="header"></a>
+
 Sets a response header. If the value is omitted or undefined it is coerced
 to `''`.
 
 For more information, see [`http.ServerResponse#setHeader`](https://nodejs.org/dist/latest/docs/api/http.html#http_response_setheader_name_value).
 
-<a name="getHeader"></a>
 ### .getHeader(key)
+<a name="getHeader"></a>
+
 Retrieves the value of a previously set header.
 ```js
 reply.header('x-foo', 'foo')
 reply.getHeader('x-foo') // 'foo'
 ```
 
-<a name="getHeader"></a>
 ### .removeHeader(key)
+<a name="getHeader"></a>
 
 Removed the value of a previously set header.
 ```js
@@ -65,19 +71,22 @@ reply.removeHeader('x-foo')
 reply.getHeader('x-foo') // undefined
 ```
 
-<a name="hasHeader"></a>
 ### .hasHeader(key)
+<a name="hasHeader"></a>
+
 Returns a boolean indicating if the specified header has been set.
 
-<a name="redirect"></a>
 ### .redirect(dest)
+<a name="redirect"></a>
+
 Redirects a request to the specified url, the status code is optional, default to `302` (if status code is not already set by calling `code`).
 ```js
 reply.redirect('/home')
 ```
 
-<a name="type"></a>
 ### .type(contentType)
+<a name="type"></a>
+
 Sets the content type for the response.
 This is a shortcut for `reply.header('Content-Type', 'the/type')`.
 
@@ -85,8 +94,9 @@ This is a shortcut for `reply.header('Content-Type', 'the/type')`.
 reply.type('text/html')
 ```
 
-<a name="serializer"></a>
 ### .serializer(func)
+<a name="serializer"></a>
+
 `.send()` will by default JSON-serialize any value that is not one of: `Buffer`, `stream`, `string`, `undefined`, `Error`. If you need to replace the default serializer with a custom serializer for a particular request, you can do so with the `.serializer()` utility. Be aware that if you are using a custom serializer, you must set a custom `'Content-Type'` header.
 
 ```js
@@ -105,8 +115,8 @@ reply
 
 See [`.send()`](#send) for more information on sending different types of values.
 
-<a name="sent"></a>
 ### .sent
+<a name="sent"></a>
 
 As the name suggests, `.sent` is a property to indicate if
 a response has been sent via `reply.send()`.
@@ -131,12 +141,14 @@ app.get('/', (req, reply) => {
 
 If the handler rejects, the error will be logged.
 
-<a name="send"></a>
 ### .send(data)
+<a name="send"></a>
+
 As the name suggests, `.send()` is the function that sends the payload to the end user.
 
-<a name="send-object"></a>
 #### Objects
+<a name="send-object"></a>
+
 As noted above, if you are sending JSON objects, `send` will serialize the object with [fast-json-stringify](https://www.npmjs.com/package/fast-json-stringify) if you set an output schema, otherwise `JSON.stringify()` will be used.
 ```js
 fastify.get('/json', options, function (request, reply) {
@@ -144,8 +156,9 @@ fastify.get('/json', options, function (request, reply) {
 })
 ```
 
-<a name="send-string"></a>
 #### Strings
+<a name="send-string"></a>
+
 If you pass a string to `send` without a `Content-Type`, it will be sent as `text/plain; charset=utf-8`. If you set the `Content-Type` header and pass a string to `send`, it will be serialized with the custom serializer if one is set, otherwise it will be sent unmodified (unless the `Content-Type` header is set to `application/json; charset=utf-8`, in which case it will be JSON-serialized like an object — see the section above).
 ```js
 fastify.get('/json', options, function (request, reply) {
@@ -153,8 +166,9 @@ fastify.get('/json', options, function (request, reply) {
 })
 ```
 
-<a name="send-streams"></a>
 #### Streams
+<a name="send-streams"></a>
+
 *send* can also handle streams out of the box, internally uses [pump](https://www.npmjs.com/package/pump) to avoid leaks of file descriptors. If you are sending a stream and you have not set a `'Content-Type'` header, *send* will set it at `'application/octet-stream'`.
 ```js
 fastify.get('/streams', function (request, reply) {
@@ -164,8 +178,9 @@ fastify.get('/streams', function (request, reply) {
 })
 ```
 
-<a name="send-buffers"></a>
 #### Buffers
+<a name="send-buffers"></a>
+
 If you are sending a buffer and you have not set a `'Content-Type'` header, *send* will set it to `'application/octet-stream'`.
 ```js
 const fs = require('fs')
@@ -176,8 +191,9 @@ fastify.get('/streams', function (request, reply) {
 })
 ```
 
-<a name="errors"></a>
 #### Errors
+<a name="errors"></a>
+
 If you pass to *send* an object that is an instance of *Error*, Fastify will automatically create an error structured as the following:
 ```js
 {
@@ -186,7 +202,7 @@ If you pass to *send* an object that is an instance of *Error*, Fastify will aut
   statusCode: Number   // the http status code
 }
 ```
-You can add some custom property to the Error object, such as `code` and `headers`, that will be used to enhance the http response.<br>
+You can add some custom property to the Error object, such as `code` and `headers`, that will be used to enhance the http response.<br/>
 *Note: If you are passing an error to `send` and the statusCode is less than 400, Fastify will automatically set it at 500.*
 
 Tip: you can simplify errors by using the [`http-errors`](https://npm.im/http-errors) module to generate errors:
@@ -197,10 +213,10 @@ fastify.get('/', function (request, reply) {
 })
 ```
 
-If you want to completely customize the error response, checkout [`setErrorHandler`](https://github.com/fastify/fastify/blob/master/docs/Server.md#seterrorhandler) API.
+If you want to completely customize the error response, checkout [`setErrorHandler`](./Server.md#seterrorhandler) API.
 
 Errors with a `status` or `statusCode` property equal to `404` will be routed to the not found handler.
-See [`server.setNotFoundHandler`](https://github.com/fastify/fastify/blob/master/docs/Server.md#setnotfoundhandler)
+See [`server.setNotFoundHandler`](./Server.md#setnotfoundhandler)
 API to learn more about handling such cases:
 
 ```js
@@ -213,9 +229,10 @@ fastify.get('/', function (request, reply) {
 })
 ```
 
-<a name="payload-type"></a>
 #### Type of the final payload
-The type of the sent payload (after serialization and going through any [`onSend` hooks](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#the-onsend-hook)) must be one of the following types, otherwise an error will be thrown:
+<a name="payload-type"></a>
+
+The type of the sent payload (after serialization and going through any [`onSend` hooks](./Hooks.md#the-onsend-hook)) must be one of the following types, otherwise an error will be thrown:
 
 - `string`
 - `Buffer`
@@ -223,9 +240,10 @@ The type of the sent payload (after serialization and going through any [`onSend
 - `undefined`
 - `null`
 
-<a name="async-await-promise"></a>
 #### Async-Await and Promises
-Fastify natively handles promises and supports async-await.<br>
+<a name="async-await-promise"></a>
+
+Fastify natively handles promises and supports async-await.<br/>
 *Note that in the following examples we are not using reply.send.*
 ```js
 fastify.get('/promises', options, function (request, reply) {
@@ -253,4 +271,4 @@ fastify.get('/teapot', async function (request, reply) => {
 })
 ```
 
-If you want to know more please review [Routes#async-await](https://github.com/fastify/fastify/blob/master/docs/Routes.md#async-await).
+If you want to know more please review [Routes#async-await](./Routes.md#async-await).

--- a/docs/Request.md
+++ b/docs/Request.md
@@ -4,7 +4,8 @@ sidebar_label: Request
 hide_title: false
 ---
 
-The first parameter of the handler function is `Request`.<br/>
+The first parameter of the handler function is `Request`.
+
 Request is a core Fastify object containing the following fields:
 - `query` - the parsed querystring
 - `body` - the body

--- a/docs/Request.md
+++ b/docs/Request.md
@@ -1,7 +1,5 @@
 ---
 title: Request
-sidebar_label: Request
-hide_title: false
 ---
 
 The first parameter of the handler function is `Request`.

--- a/docs/Request.md
+++ b/docs/Request.md
@@ -1,7 +1,10 @@
-<h1 align="center">Fastify</h1>
+---
+title: Request
+sidebar_label: Request
+hide_title: false
+---
 
-## Request
-The first parameter of the handler function is `Request`.<br>
+The first parameter of the handler function is `Request`.<br/>
 Request is a core Fastify object containing the following fields:
 - `query` - the parsed querystring
 - `body` - the body

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -1,13 +1,11 @@
 ---
 title: Routes
-sidebar_label: Routes
-hide_title: false
 ---
 
 You have two ways to declare a route with Fastify, the shorthand method and the full declaration. Let's start with the second one:
 
 ### Full declaration
-<a name="full-declaration"></a>
+<a id="full-declaration"></a>
 
 ```js
 fastify.route(options)
@@ -67,7 +65,7 @@ fastify.route({
 ```
 
 ### Shorthand declaration
-<a name="shorthand-declaration"></a>
+<a id="shorthand-declaration"></a>
 
 The above route declaration is more *Hapi*-like, but if you prefer an *Express/Restify* approach, we support it as well:
 
@@ -129,7 +127,7 @@ fastify.get('/', opts)
 > Note: if the handler is specified in both the `options` and as the third parameter to the shortcut method then throws duplicate `handler` error.
 
 ### Url building
-<a name="url-building"></a>
+<a id="url-building"></a>
 
 Fastify supports both static and dynamic urls.
 
@@ -167,7 +165,7 @@ Having a route with multiple parameters may affect negatively the performance, s
 If you are interested in how we handle the routing, checkout [find-my-way](https://github.com/delvedor/find-my-way).
 
 ### Async Await
-<a name="async-await"></a>
+<a id="async-await"></a>
 
 Are you an `async/await` user? We have you covered!
 ```js
@@ -194,7 +192,7 @@ fastify.get('/', options, async function (request, reply) {
 * You can't return `undefined`. For more details read [promise-resolution](#promise-resolution).
 
 ### Promise resolution
-<a name="promise-resolution"></a>
+<a id="promise-resolution"></a>
 
 If your handler is an `async` function or returns a promise, you should be aware of a special behaviour which is necessary to support the callback and promise control-flow. If the handler's promise is resolved with `undefined`, it will be ignored causing the request to hang and an *error* log to be emitted.
 
@@ -210,7 +208,7 @@ In this way, we can support both `callback-style` and `async-await`, with the mi
 **Notice**: Every async function returns a promise by itself.
 
 ### Route Prefixing
-<a name="route-prefixing"></a>
+<a id="route-prefixing"></a>
 
 Sometimes you need to maintain two or more different versions of the same api, a classic approach is to prefix all the routes with the api version number, `/v1/user` for example.
 Fastify offers you a fast and smart way to create different version of the same api without changing all the route names by hand, *route prefixing*. Let's see how it works:
@@ -248,7 +246,7 @@ You can do this as many times as you want, it works also for nested `register` a
 Be aware that if you use [`fastify-plugin`](https://github.com/fastify/fastify-plugin) this option won't work.
 
 ### Custom Log Level
-<a name="custom-log-level"></a>
+<a id="custom-log-level"></a>
 
 It could happen that you need different log levels in your routes, with Fastify achieve this is very straightforward.
 
@@ -275,7 +273,7 @@ fastify.get('/', { logLevel: 'warn' }, (request, reply) => {
 
 
 ### Config
-<a name="routes-config"></a>
+<a id="routes-config"></a>
 
 Registering a new handler, you can pass a configuration object to it and retrieve it in the handler.
 
@@ -294,7 +292,7 @@ fastify.listen(3000)
 ```
 
 ### Version
-<a name="version"></a>
+<a id="version"></a>
 
 #### Default
 If needed you can provide a version option, which will allow you to declare multiple versions of the same route. The versioning should follow the [semver](http://semver.org/) specification.

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -69,13 +69,20 @@ fastify.route({
 ### Shorthand declaration
 <a name="shorthand-declaration"></a>
 
-The above route declaration is more *Hapi*-like, but if you prefer an *Express/Restify* approach, we support it as well:<br/>
-`fastify.get(path, [options], handler)`<br/>
-`fastify.head(path, [options], handler)`<br/>
-`fastify.post(path, [options], handler)`<br/>
-`fastify.put(path, [options], handler)`<br/>
-`fastify.delete(path, [options], handler)`<br/>
-`fastify.options(path, [options], handler)`<br/>
+The above route declaration is more *Hapi*-like, but if you prefer an *Express/Restify* approach, we support it as well:
+
+`fastify.get(path, [options], handler)`
+
+`fastify.head(path, [options], handler)`
+
+`fastify.post(path, [options], handler)`
+
+`fastify.put(path, [options], handler)`
+
+`fastify.delete(path, [options], handler)`
+
+`fastify.options(path, [options], handler)`
+
 `fastify.patch(path, [options], handler)`
 
 Example:
@@ -124,7 +131,8 @@ fastify.get('/', opts)
 ### Url building
 <a name="url-building"></a>
 
-Fastify supports both static and dynamic urls.<br/>
+Fastify supports both static and dynamic urls.
+
 To register a **parametric** path, use the *colon* before the parameter name. For **wildcard** use the *star*.
 *Remember that static routes are always checked before parametric and wildcard.*
 
@@ -242,7 +250,8 @@ Be aware that if you use [`fastify-plugin`](https://github.com/fastify/fastify-p
 ### Custom Log Level
 <a name="custom-log-level"></a>
 
-It could happen that you need different log levels in your routes, with Fastify achieve this is very straightforward.<br/>
+It could happen that you need different log levels in your routes, with Fastify achieve this is very straightforward.
+
 You just need to pass the option `logLevel` to the plugin option or the route option with the [value](https://github.com/pinojs/pino/blob/master/docs/API.md#discussion-3) that you need.
 
 Be aware that if you set the `logLevel` at plugin level, also the [`setNotFoundHandler`](./Server.md#setnotfoundhandler) and [`setErrorHandler`](./Server.md#seterrorhandler) will be affected.
@@ -288,8 +297,10 @@ fastify.listen(3000)
 <a name="version"></a>
 
 #### Default
-If needed you can provide a version option, which will allow you to declare multiple versions of the same route. The versioning should follow the [semver](http://semver.org/) specification.<br/>
-Fastify will automatically detect the `Accept-Version` header and route the request accordingly (advanced ranges and pre-releases currently are not supported).<br/>
+If needed you can provide a version option, which will allow you to declare multiple versions of the same route. The versioning should follow the [semver](http://semver.org/) specification.
+
+Fastify will automatically detect the `Accept-Version` header and route the request accordingly (advanced ranges and pre-releases currently are not supported).
+
 *Be aware that using this feature will cause a degradation of the overall performances of the router.*
 ```js
 fastify.route({
@@ -311,7 +322,8 @@ fastify.inject({
   // { hello: 'world' }
 })
 ```
-If you declare multiple versions with the same major or minor, Fastify will always choose the highest compatible with the `Accept-Version` header value.<br/>
+If you declare multiple versions with the same major or minor, Fastify will always choose the highest compatible with the `Accept-Version` header value.
+
 If the request will not have the `Accept-Version` header, a 404 error will be returned.
 
 #### Custom

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -1,9 +1,14 @@
-<h1 align="center">Fastify</h1>
+---
+title: Routes
+sidebar_label: Routes
+hide_title: false
+---
 
-## Routes
 You have two ways to declare a route with Fastify, the shorthand method and the full declaration. Let's start with the second one:
-<a name="full-declaration"></a>
+
 ### Full declaration
+<a name="full-declaration"></a>
+
 ```js
 fastify.route(options)
 ```
@@ -12,7 +17,7 @@ fastify.route(options)
 * `url`: the path of the url to match this route (alias: `path`).
 * `schema`: an object containing the schemas for the request and response.
 They need to be in
-  [JSON Schema](http://json-schema.org/) format, check [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) for more info.
+  [JSON Schema](http://json-schema.org/) format, check [here](./Validation-and-Serialization.md) for more info.
 
   * `body`: validates the body of the request if it is a POST or a
     PUT.
@@ -23,17 +28,17 @@ They need to be in
   * `response`: filter and generate a schema for the response, setting a
     schema allows us to have 10-20% more throughput.
 * `attachValidation`: attach `validationError` to request, if there is a schema validation error, instead of sending the error to the error handler.
-* `beforeHandler(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#before-handler) called just before the request handler, useful if you need to perform authentication at route level for example, it could also be and array of functions.
+* `beforeHandler(request, reply, done)`: a [function](./Hooks.md#before-handler) called just before the request handler, useful if you need to perform authentication at route level for example, it could also be and array of functions.
 * `handler(request, reply)`: the function that will handle this request.
-* `schemaCompiler(schema)`: the function that build the schema for the validations. See [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-compiler)
+* `schemaCompiler(schema)`: the function that build the schema for the validations. See [here](./Validation-and-Serialization.md#schema-compiler)
 * `bodyLimit`: prevents the default JSON body parser from parsing request bodies larger than this number of bytes. Must be an integer. You may also set this option globally when first creating the Fastify instance with `fastify(options)`. Defaults to `1048576` (1 MiB).
 * `logLevel`: set log level for this route. See below.
 * `config`: object used to store custom configuration.
 * `version`: a [semver](http://semver.org/) compatible string that defined the version of the endpoint. [Example](https://github.com/fastify/fastify/blob/versioned-routes/docs/Routes.md#version).
 
-  `request` is defined in [Request](https://github.com/fastify/fastify/blob/master/docs/Request.md).
+  `request` is defined in [Request](./Request.md).
 
-  `reply` is defined in [Reply](https://github.com/fastify/fastify/blob/master/docs/Reply.md).
+  `reply` is defined in [Reply](./Reply.md).
 
 
 Example:
@@ -61,15 +66,16 @@ fastify.route({
 })
 ```
 
-<a name="shorthand-declaration"></a>
 ### Shorthand declaration
-The above route declaration is more *Hapi*-like, but if you prefer an *Express/Restify* approach, we support it as well:<br>
-`fastify.get(path, [options], handler)`<br>
-`fastify.head(path, [options], handler)`<br>
-`fastify.post(path, [options], handler)`<br>
-`fastify.put(path, [options], handler)`<br>
-`fastify.delete(path, [options], handler)`<br>
-`fastify.options(path, [options], handler)`<br>
+<a name="shorthand-declaration"></a>
+
+The above route declaration is more *Hapi*-like, but if you prefer an *Express/Restify* approach, we support it as well:<br/>
+`fastify.get(path, [options], handler)`<br/>
+`fastify.head(path, [options], handler)`<br/>
+`fastify.post(path, [options], handler)`<br/>
+`fastify.put(path, [options], handler)`<br/>
+`fastify.delete(path, [options], handler)`<br/>
+`fastify.options(path, [options], handler)`<br/>
 `fastify.patch(path, [options], handler)`
 
 Example:
@@ -115,9 +121,10 @@ fastify.get('/', opts)
 
 > Note: if the handler is specified in both the `options` and as the third parameter to the shortcut method then throws duplicate `handler` error.
 
-<a name="url-building"></a>
 ### Url building
-Fastify supports both static and dynamic urls.<br>
+<a name="url-building"></a>
+
+Fastify supports both static and dynamic urls.<br/>
 To register a **parametric** path, use the *colon* before the parameter name. For **wildcard** use the *star*.
 *Remember that static routes are always checked before parametric and wildcard.*
 
@@ -151,8 +158,9 @@ In this case as parameter separator it's possible to use whatever character is n
 Having a route with multiple parameters may affect negatively the performance, so prefer single parameter approach whenever possible, especially on routes which are on the hot path of your application.
 If you are interested in how we handle the routing, checkout [find-my-way](https://github.com/delvedor/find-my-way).
 
-<a name="async-await"></a>
 ### Async Await
+<a name="async-await"></a>
+
 Are you an `async/await` user? We have you covered!
 ```js
 fastify.get('/', options, async function (request, reply) {
@@ -177,8 +185,8 @@ fastify.get('/', options, async function (request, reply) {
 * If you use `return` and `reply.send` at the same time, the first one that happens takes precedence, the second value will be discarded, a *warn* log will also be emitted because you tried to send a response twice.
 * You can't return `undefined`. For more details read [promise-resolution](#promise-resolution).
 
-<a name="promise-resolution"></a>
 ### Promise resolution
+<a name="promise-resolution"></a>
 
 If your handler is an `async` function or returns a promise, you should be aware of a special behaviour which is necessary to support the callback and promise control-flow. If the handler's promise is resolved with `undefined`, it will be ignored causing the request to hang and an *error* log to be emitted.
 
@@ -193,8 +201,9 @@ In this way, we can support both `callback-style` and `async-await`, with the mi
 
 **Notice**: Every async function returns a promise by itself.
 
-<a name="route-prefixing"></a>
 ### Route Prefixing
+<a name="route-prefixing"></a>
+
 Sometimes you need to maintain two or more different versions of the same api, a classic approach is to prefix all the routes with the api version number, `/v1/user` for example.
 Fastify offers you a fast and smart way to create different version of the same api without changing all the route names by hand, *route prefixing*. Let's see how it works:
 
@@ -230,12 +239,13 @@ Now your clients will have access to the following routes:
 You can do this as many times as you want, it works also for nested `register` and routes parameter are supported as well.
 Be aware that if you use [`fastify-plugin`](https://github.com/fastify/fastify-plugin) this option won't work.
 
-<a name="custom-log-level"></a>
 ### Custom Log Level
+<a name="custom-log-level"></a>
+
 It could happen that you need different log levels in your routes, with Fastify achieve this is very straightforward.<br/>
 You just need to pass the option `logLevel` to the plugin option or the route option with the [value](https://github.com/pinojs/pino/blob/master/docs/API.md#discussion-3) that you need.
 
-Be aware that if you set the `logLevel` at plugin level, also the [`setNotFoundHandler`](https://github.com/fastify/fastify/blob/master/docs/Server.md#setnotfoundhandler) and [`setErrorHandler`](https://github.com/fastify/fastify/blob/master/docs/Server.md#seterrorhandler) will be affected.
+Be aware that if you set the `logLevel` at plugin level, also the [`setNotFoundHandler`](./Server.md#setnotfoundhandler) and [`setErrorHandler`](./Server.md#seterrorhandler) will be affected.
 
 ```js
 // server.js
@@ -255,8 +265,9 @@ fastify.get('/', { logLevel: 'warn' }, (request, reply) => {
 *Remember that the custom log level is applied only to the routes, and not to the global Fastify Logger, accessible with `fastify.log`*
 
 
-<a name="routes-config"></a>
 ### Config
+<a name="routes-config"></a>
+
 Registering a new handler, you can pass a configuration object to it and retrieve it in the handler.
 
 ```js
@@ -273,8 +284,9 @@ fastify.get('/it', { config: { output: 'ciao mondo!' } }, handler)
 fastify.listen(3000)
 ```
 
-<a name="version"></a>
 ### Version
+<a name="version"></a>
+
 #### Default
 If needed you can provide a version option, which will allow you to declare multiple versions of the same route. The versioning should follow the [semver](http://semver.org/) specification.<br/>
 Fastify will automatically detect the `Accept-Version` header and route the request accordingly (advanced ranges and pre-releases currently are not supported).<br/>
@@ -301,5 +313,6 @@ fastify.inject({
 ```
 If you declare multiple versions with the same major or minor, Fastify will always choose the highest compatible with the `Accept-Version` header value.<br/>
 If the request will not have the `Accept-Version` header, a 404 error will be returned.
+
 #### Custom
-It's possible to define a custom versioning logic. This can be done through the [`versioning`](https://github.com/fastify/fastify/blob/master/docs/Server.md#versioning) configuration, when creating a fastify server instance.
+It's possible to define a custom versioning logic. This can be done through the [`versioning`](./Server.md#versioning) configuration, when creating a fastify server instance.

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -59,8 +59,10 @@ fastify.get('/bar', function (req, reply) {
 ### `maxParamLength`
 <a name="factory-max-param-length"></a>
 
-You can set a custom length for parameters in parametric (standard, regex and multi) routes by using `maxParamLength` option, the default value is 100 characters.<br/>
-This can be useful especially if you have some regex based route, protecting you against [DoS attacks](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS).<br/>
+You can set a custom length for parameters in parametric (standard, regex and multi) routes by using `maxParamLength` option, the default value is 100 characters.
+
+This can be useful especially if you have some regex based route, protecting you against [DoS attacks](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS).
+
 *If the maximum length limit is reached, the not found route will be invoked.*
 
 ### `bodyLimit`
@@ -120,7 +122,8 @@ are not present on the object, they will be added accordingly:
 ### `serverFactory`
 <a name="custom-http-server"></a>
 
-You can pass a custom http server to Fastify by using the `serverFactory` option.<br/>
+You can pass a custom http server to Fastify by using the `serverFactory` option.
+
 `serverFactory` is a function that takes an `handler` parameter, which takes the `request` and `response` objects as parameters, and an options object, which is the same you have passed to Fastify.
 
 ```js
@@ -368,7 +371,8 @@ Method to add routes to the server, it also has shorthand functions, check [here
 #### close
 <a name="close"></a>
 
-`fastify.close(callback)`: call this function to close the server instance and run the [`'onClose'`](./Hooks.md#on-close) hook.<br/>
+`fastify.close(callback)`: call this function to close the server instance and run the [`'onClose'`](./Hooks.md#on-close) hook.
+
 Calling `close` will also cause the server to respond to every new incoming request with a `503` error and destroy that request.
 
 #### decorate
@@ -434,7 +438,8 @@ Fake http injection (for testing purposes) [here](./Testing.md#inject).
 #### addSchema
 <a name="add-schema"></a>
 
-`fastify.addSchema(schemaObj)`, adds a shared schema to the Fastify instance. This allows you to reuse it everywhere in your application just by writing the schema id that you need.<br/>
+`fastify.addSchema(schemaObj)`, adds a shared schema to the Fastify instance. This allows you to reuse it everywhere in your application just by writing the schema id that you need.
+
 To learn more, see [shared schema example](./Validation-and-Serialization.md#shared-schema) in the [Validation and Serialization](./Validation-and-Serialization.md) documentation.
 
 #### setSchemaCompiler
@@ -482,7 +487,8 @@ fastify.setErrorHandler(function (error, request, reply) {
 #### printRoutes
 <a name="print-routes"></a>
 
-`fastify.printRoutes()`: Prints the representation of the internal radix tree used by the router, useful for debugging.<br/>
+`fastify.printRoutes()`: Prints the representation of the internal radix tree used by the router, useful for debugging.
+
 *Remember to call it inside or after a `ready` call.*
 
 ```js

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -1,25 +1,23 @@
 ---
 title: Server
-sidebar_label: Server
-hide_title: false
 ---
 
 ## Factory
-<a name="factory"></a>
+<a id="factory"></a>
 
 The Fastify module exports a factory function that is used to create new [`Fastify server`](./Server.md) instances. This factory function accepts an options object which is used to
 customize the resulting instance. This document describes the properties
 available in that options object.
 
 ### `http2` (Status: experimental)
-<a name="factory-http2"></a>
+<a id="factory-http2"></a>
 
 If `true` Node.js core's [HTTP/2](https://nodejs.org/dist/latest-v8.x/docs/api/http2.html) module is used for binding the socket.
 
 + Default: `false`
 
 ### `https`
-<a name="factory-https"></a>
+<a id="factory-https"></a>
 
 An object used to configure the server's listening socket for TLS. The options
 are the same as the Node.js core
@@ -31,7 +29,7 @@ This option also applies when the [`http2`](./Server.md#factory-http2) option is
 + Default: `null`
 
 ### `ignoreTrailingSlash`
-<a name="factory-ignore-slash"></a>
+<a id="factory-ignore-slash"></a>
 
 Fastify uses [find-my-way](https://github.com/delvedor/find-my-way) to handle
 routing. This option may be set to `true` to ignore trailing slashes in routes.
@@ -57,7 +55,7 @@ fastify.get('/bar', function (req, reply) {
 ```
 
 ### `maxParamLength`
-<a name="factory-max-param-length"></a>
+<a id="factory-max-param-length"></a>
 
 You can set a custom length for parameters in parametric (standard, regex and multi) routes by using `maxParamLength` option, the default value is 100 characters.
 
@@ -66,14 +64,14 @@ This can be useful especially if you have some regex based route, protecting you
 *If the maximum length limit is reached, the not found route will be invoked.*
 
 ### `bodyLimit`
-<a name="factory-body-limit"></a>
+<a id="factory-body-limit"></a>
 
 Defines the maximum payload, in bytes, the server is allowed to accept.
 
 + Default: `1048576` (1MiB)
 
 ### `onProtoPoisoning`
-<a name="factory-on-proto-poisoning"></a>
+<a id="factory-on-proto-poisoning"></a>
 
 Defines what action the framework must take when parsing a JSON object
 with `__proto__`. This functionality is provided by
@@ -86,7 +84,7 @@ Possible values are `'error'`, `'remove'` and `'ignore'`.
 + Default: `'error'`
 
 ### `logger`
-<a name="factory-logger"></a>
+<a id="factory-logger"></a>
 
 Fastify includes built-in logging via the [Pino](https://getpino.io/) logger.
 This property is used to configure the internal logger instance.
@@ -120,7 +118,7 @@ are not present on the object, they will be added accordingly:
       corresponding property.
 
 ### `serverFactory`
-<a name="custom-http-server"></a>
+<a id="custom-http-server"></a>
 
 You can pass a custom http server to Fastify by using the `serverFactory` option.
 
@@ -147,7 +145,7 @@ fastify.listen(3000)
 Internally Fastify uses the API of Node core http server, so if you are using a custom server you must be sure to have the same API exposed. If not, you can enhance the server instance inside the `serverFactory` function before the `return` statement.
 
 ### `caseSensitive`
-<a name="factory-case-sensitive"></a>
+<a id="factory-case-sensitive"></a>
 
 By default, value equal to `true`, routes are registered as case sensitive. That is, `/foo` is not equivalent to `/Foo`. When set to `false`, routes are registered in a fashion such that `/foo` is equivalent to `/Foo` which is equivalent to `/FOO`.
 
@@ -165,14 +163,14 @@ Please note this setting this option to `false` goes against
 [RFC3986](https://tools.ietf.org/html/rfc3986#section-6.2.2.1).
 
 ### `requestIdHeader`
-<a name="factory-request-id-header"></a>
+<a id="factory-request-id-header"></a>
 
 The header name used to know the request id. See [the request id](./Logging.md#logging-request-id) section.
 
 + Default: `'request-id'`
 
 ### `trustProxy`
-<a name="factory-trust-proxy"></a>
+<a id="factory-trust-proxy"></a>
 
 By enabling the `trustProxy` option, Fastify will have knowledge that it's sitting behind a proxy and that the `X-Forwarded-*` header fields may be trusted, which otherwise may be easily spoofed.
 
@@ -203,7 +201,7 @@ fastify.get('/', (request, reply) => {
 })
 ```
 
-<a name="plugin-timeout"></a>
+<a id="plugin-timeout"></a>
 ### `pluginTimeout`
 
 The maximum amount of time in milliseconds in which a plugin can load.
@@ -213,7 +211,7 @@ will complete with an `Error` with code `'ERR_AVVIO_PLUGIN_TIMEOUT'`.
 + Default: `0` (disabled)
 
 ### `versioning`
-<a name="versioning"></a>
+<a id="versioning"></a>
 
 By default you can version your routes with [semver versioning](./Routes.md#version), which is provided by `find-my-way`. There is still an option to provide custom versioning strategy. You can find more information in the [find-my-way](https://github.com/delvedor/find-my-way#versioned-routes) documentation.
 
@@ -243,12 +241,12 @@ const fastify = require('fastify')({
 ### Server Methods
 
 #### server
-<a name="server"></a>
+<a id="server"></a>
 
 `fastify.server`: The Node core [server](https://nodejs.org/api/http.html#http_class_http_server) object as returned by the [**`Fastify factory function`**](./Server.md).
 
 #### after
-<a name="after"></a>
+<a id="after"></a>
 
 Invoked when the current plugin and all the plugins
 that have been registered within it have finished loading.
@@ -273,7 +271,7 @@ fastify
 ```
 
 #### ready
-<a name="ready"></a>
+<a id="ready"></a>
 
 Function called when all the plugins have been loaded.
 It takes an error parameter if something went wrong.
@@ -293,7 +291,7 @@ fastify.ready().then(() => {
 ```
 
 #### listen
-<a name="listen"></a>
+<a id="listen"></a>
 
 Starts the server on the given port after all the plugins are loaded, internally waits for the `.ready()` event. The callback is the same as the Node core. By default, the server will listen on the address resolved by `localhost` when no specific address is provided (`127.0.0.1` or `::1` depending on the operating system). If listening on any available interface is desired, then specifying `0.0.0.0` for the address will listen on all IPv4 address. Using `::` for the address will listen on all IPv6 addresses, and, depending on OS, may also listen on all IPv4 addresses. Be careful when deciding to listen on all interfaces; it comes with inherent [security risks](https://web.archive.org/web/20170831174611/https://snyk.io/blog/mongodb-hack-and-secure-defaults/).
 
@@ -364,40 +362,40 @@ fastify.listen(3000, '0.0.0.0', (err, address) => {
 If the `port` is omitted (or is set to zero), a random available port is automatically chosen (later available via `fastify.server.address().port`).
 
 #### route
-<a name="route"></a>
+<a id="route"></a>
 
 Method to add routes to the server, it also has shorthand functions, check [here](./Routes.md).
 
 #### close
-<a name="close"></a>
+<a id="close"></a>
 
 `fastify.close(callback)`: call this function to close the server instance and run the [`'onClose'`](./Hooks.md#on-close) hook.
 
 Calling `close` will also cause the server to respond to every new incoming request with a `503` error and destroy that request.
 
 #### decorate
-<a name="decorate"></a>
+<a id="decorate"></a>
 
 Function useful if you need to decorate the fastify instance, Reply or Request, check [here](./Decorators.md).
 
 #### register
-<a name="register"></a>
+<a id="register"></a>
 
 Fastify allows the user to extend its functionality with plugins.
 A plugin can be a set of routes, a server decorator or whatever, check [here](./Plugins.md).
 
 #### use
-<a name="use"></a>
+<a id="use"></a>
 
 Function to add middlewares to Fastify, check [here](./Middlewares.md).
 
 #### addHook
-<a name="addHook"></a>
+<a id="addHook"></a>
 
 Function to add a specific hook in the lifecycle of Fastify, check [here](./Hooks.md).
 
 #### basepath
-<a name="base-path"></a>
+<a id="base-path"></a>
 
 The full path that will be prefixed to a route.
 
@@ -426,29 +424,29 @@ fastify.register(function (instance, opts, next) {
 ```
 
 #### log
-<a name="log"></a>
+<a id="log"></a>
 
 The logger instance, check [here](./Logging.md).
 
 #### inject
-<a name="inject"></a>
+<a id="inject"></a>
 
 Fake http injection (for testing purposes) [here](./Testing.md#inject).
 
 #### addSchema
-<a name="add-schema"></a>
+<a id="add-schema"></a>
 
 `fastify.addSchema(schemaObj)`, adds a shared schema to the Fastify instance. This allows you to reuse it everywhere in your application just by writing the schema id that you need.
 
 To learn more, see [shared schema example](./Validation-and-Serialization.md#shared-schema) in the [Validation and Serialization](./Validation-and-Serialization.md) documentation.
 
 #### setSchemaCompiler
-<a name="set-schema-compiler"></a>
+<a id="set-schema-compiler"></a>
 
 Set the schema compiler for all routes [here](./Validation-and-Serialization.md#schema-compiler).
 
 #### setNotFoundHandler
-<a name="set-not-found-handler"></a>
+<a id="set-not-found-handler"></a>
 
 `fastify.setNotFoundHandler(handler(request, reply))`: set the 404 handler. This call is encapsulated by prefix, so different plugins can set different not found handlers if a different [`prefix` option](./Plugins.md#route-prefixing-option) is passed to `fastify.register()`. The handler is treated like a regular route handler so requests will go through the full [Fastify lifecycle](./Lifecycle.md#lifecycle).
 
@@ -474,7 +472,7 @@ fastify.register(function (instance, options, next) {
 ```
 
 #### setErrorHandler
-<a name="set-error-handler"></a>
+<a id="set-error-handler"></a>
 
 `fastify.setErrorHandler(handler(error, request, reply))`: Set a function that will be called whenever an error happens. The handler is fully encapsulated, so different plugins can set different error handlers. *async-await* is supported as well.
 
@@ -485,7 +483,7 @@ fastify.setErrorHandler(function (error, request, reply) {
 ```
 
 #### printRoutes
-<a name="print-routes"></a>
+<a id="print-routes"></a>
 
 `fastify.printRoutes()`: Prints the representation of the internal radix tree used by the router, useful for debugging.
 

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -1,38 +1,37 @@
-<h1 align="center">Fastify</h1>
+---
+title: Server
+sidebar_label: Server
+hide_title: false
+---
 
-<a name="factory"></a>
 ## Factory
+<a name="factory"></a>
 
-The Fastify module exports a factory function that is used to create new
-<a href="https://github.com/fastify/fastify/blob/master/docs/Server.md"><code><b>Fastify server</b></code></a>
-instances. This factory function accepts an options object which is used to
+The Fastify module exports a factory function that is used to create new [`Fastify server`](./Server.md) instances. This factory function accepts an options object which is used to
 customize the resulting instance. This document describes the properties
 available in that options object.
 
-<a name="factory-http2"></a>
 ### `http2` (Status: experimental)
+<a name="factory-http2"></a>
 
 If `true` Node.js core's [HTTP/2](https://nodejs.org/dist/latest-v8.x/docs/api/http2.html) module is used for binding the socket.
 
 + Default: `false`
 
-<a name="factory-https"></a>
 ### `https`
+<a name="factory-https"></a>
 
 An object used to configure the server's listening socket for TLS. The options
 are the same as the Node.js core
 [`createServer` method](https://nodejs.org/dist/latest-v8.x/docs/api/https.html#https_https_createserver_options_requestlistener).
 When this property is `null`, the socket will not be configured for TLS.
 
-This option also applies when the
-<a href="https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-http2">
-<code><b>http2</b></code>
-</a> option is set.
+This option also applies when the [`http2`](./Server.md#factory-http2) option is set.
 
 + Default: `null`
 
-<a name="factory-ignore-slash"></a>
 ### `ignoreTrailingSlash`
+<a name="factory-ignore-slash"></a>
 
 Fastify uses [find-my-way](https://github.com/delvedor/find-my-way) to handle
 routing. This option may be set to `true` to ignore trailing slashes in routes.
@@ -57,21 +56,22 @@ fastify.get('/bar', function (req, reply) {
 })
 ```
 
-<a name="factory-max-param-length"></a>
 ### `maxParamLength`
-You can set a custom length for parameters in parametric (standard, regex and multi) routes by using `maxParamLength` option, the default value is 100 characters.<br>
-This can be useful especially if you have some regex based route, protecting you against [DoS attacks](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS).<br>
+<a name="factory-max-param-length"></a>
+
+You can set a custom length for parameters in parametric (standard, regex and multi) routes by using `maxParamLength` option, the default value is 100 characters.<br/>
+This can be useful especially if you have some regex based route, protecting you against [DoS attacks](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS).<br/>
 *If the maximum length limit is reached, the not found route will be invoked.*
 
-<a name="factory-body-limit"></a>
 ### `bodyLimit`
+<a name="factory-body-limit"></a>
 
 Defines the maximum payload, in bytes, the server is allowed to accept.
 
 + Default: `1048576` (1MiB)
 
-<a name="factory-on-proto-poisoning"></a>
 ### `onProtoPoisoning`
+<a name="factory-on-proto-poisoning"></a>
 
 Defines what action the framework must take when parsing a JSON object
 with `__proto__`. This functionality is provided by
@@ -83,8 +83,8 @@ Possible values are `'error'`, `'remove'` and `'ignore'`.
 
 + Default: `'error'`
 
-<a name="factory-logger"></a>
 ### `logger`
+<a name="factory-logger"></a>
 
 Fastify includes built-in logging via the [Pino](https://getpino.io/) logger.
 This property is used to configure the internal logger instance.
@@ -117,8 +117,9 @@ are not present on the object, they will be added accordingly:
       Any user supplied serializer will override the default serializer of the
       corresponding property.
 
-<a name="custom-http-server"></a>
 ### `serverFactory`
+<a name="custom-http-server"></a>
+
 You can pass a custom http server to Fastify by using the `serverFactory` option.<br/>
 `serverFactory` is a function that takes an `handler` parameter, which takes the `request` and `response` objects as parameters, and an options object, which is the same you have passed to Fastify.
 
@@ -142,8 +143,8 @@ fastify.listen(3000)
 
 Internally Fastify uses the API of Node core http server, so if you are using a custom server you must be sure to have the same API exposed. If not, you can enhance the server instance inside the `serverFactory` function before the `return` statement.
 
-<a name="factory-case-sensitive"></a>
 ### `caseSensitive`
+<a name="factory-case-sensitive"></a>
 
 By default, value equal to `true`, routes are registered as case sensitive. That is, `/foo` is not equivalent to `/Foo`. When set to `false`, routes are registered in a fashion such that `/foo` is equivalent to `/Foo` which is equivalent to `/FOO`.
 
@@ -160,15 +161,15 @@ fastify.get('/user/:username', (request, reply) => {
 Please note this setting this option to `false` goes against
 [RFC3986](https://tools.ietf.org/html/rfc3986#section-6.2.2.1).
 
-<a name="factory-request-id-header"></a>
 ### `requestIdHeader`
+<a name="factory-request-id-header"></a>
 
-The header name used to know the request id. See [the request id](https://github.com/fastify/fastify/blob/master/docs/Logging.md#logging-request-id) section.
+The header name used to know the request id. See [the request id](./Logging.md#logging-request-id) section.
 
 + Default: `'request-id'`
 
-<a name="factory-trust-proxy"></a>
 ### `trustProxy`
+<a name="factory-trust-proxy"></a>
 
 By enabling the `trustProxy` option, Fastify will have knowledge that it's sitting behind a proxy and that the `X-Forwarded-*` header fields may be trusted, which otherwise may be easily spoofed.
 
@@ -203,15 +204,15 @@ fastify.get('/', (request, reply) => {
 ### `pluginTimeout`
 
 The maximum amount of time in milliseconds in which a plugin can load.
-If not, [`ready`](https://github.com/fastify/fastify/blob/master/docs/Server.md#ready)
+If not, [`ready`](./Server.md#ready)
 will complete with an `Error` with code `'ERR_AVVIO_PLUGIN_TIMEOUT'`.
 
 + Default: `0` (disabled)
 
-<a name="versioning"></a>
 ### `versioning`
+<a name="versioning"></a>
 
-By default you can version your routes with [semver versioning](https://github.com/fastify/fastify/blob/master/docs/Routes.md#version), which is provided by `find-my-way`. There is still an option to provide custom versioning strategy. You can find more information in the [find-my-way](https://github.com/delvedor/find-my-way#versioned-routes) documentation.
+By default you can version your routes with [semver versioning](./Routes.md#version), which is provided by `find-my-way`. There is still an option to provide custom versioning strategy. You can find more information in the [find-my-way](https://github.com/delvedor/find-my-way#versioned-routes) documentation.
 
 ```js
 const versioning = {
@@ -238,12 +239,14 @@ const fastify = require('fastify')({
 
 ### Server Methods
 
-<a name="server"></a>
 #### server
-`fastify.server`: The Node core [server](https://nodejs.org/api/http.html#http_class_http_server) object as returned by the [**`Fastify factory function`**](https://github.com/fastify/fastify/blob/master/docs/Server.md).
+<a name="server"></a>
 
-<a name="after"></a>
+`fastify.server`: The Node core [server](https://nodejs.org/api/http.html#http_class_http_server) object as returned by the [**`Fastify factory function`**](./Server.md).
+
 #### after
+<a name="after"></a>
+
 Invoked when the current plugin and all the plugins
 that have been registered within it have finished loading.
 It is always executed before the method `fastify.ready`.
@@ -266,8 +269,9 @@ fastify
   })
 ```
 
-<a name="ready"></a>
 #### ready
+<a name="ready"></a>
+
 Function called when all the plugins have been loaded.
 It takes an error parameter if something went wrong.
 ```js
@@ -285,8 +289,9 @@ fastify.ready().then(() => {
 })
 ```
 
-<a name="listen"></a>
 #### listen
+<a name="listen"></a>
+
 Starts the server on the given port after all the plugins are loaded, internally waits for the `.ready()` event. The callback is the same as the Node core. By default, the server will listen on the address resolved by `localhost` when no specific address is provided (`127.0.0.1` or `::1` depending on the operating system). If listening on any available interface is desired, then specifying `0.0.0.0` for the address will listen on all IPv4 address. Using `::` for the address will listen on all IPv6 addresses, and, depending on OS, may also listen on all IPv4 addresses. Be careful when deciding to listen on all interfaces; it comes with inherent [security risks](https://web.archive.org/web/20170831174611/https://snyk.io/blog/mongodb-hack-and-secure-defaults/).
 
 ```js
@@ -355,34 +360,41 @@ fastify.listen(3000, '0.0.0.0', (err, address) => {
 
 If the `port` is omitted (or is set to zero), a random available port is automatically chosen (later available via `fastify.server.address().port`).
 
-<a name="route"></a>
 #### route
-Method to add routes to the server, it also has shorthand functions, check [here](https://github.com/fastify/fastify/blob/master/docs/Routes.md).
+<a name="route"></a>
 
-<a name="close"></a>
+Method to add routes to the server, it also has shorthand functions, check [here](./Routes.md).
+
 #### close
-`fastify.close(callback)`: call this function to close the server instance and run the [`'onClose'`](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#on-close) hook.<br>
+<a name="close"></a>
+
+`fastify.close(callback)`: call this function to close the server instance and run the [`'onClose'`](./Hooks.md#on-close) hook.<br/>
 Calling `close` will also cause the server to respond to every new incoming request with a `503` error and destroy that request.
 
+#### decorate
 <a name="decorate"></a>
-#### decorate*
-Function useful if you need to decorate the fastify instance, Reply or Request, check [here](https://github.com/fastify/fastify/blob/master/docs/Decorators.md).
 
-<a name="register"></a>
+Function useful if you need to decorate the fastify instance, Reply or Request, check [here](./Decorators.md).
+
 #### register
+<a name="register"></a>
+
 Fastify allows the user to extend its functionality with plugins.
-A plugin can be a set of routes, a server decorator or whatever, check [here](https://github.com/fastify/fastify/blob/master/docs/Plugins.md).
+A plugin can be a set of routes, a server decorator or whatever, check [here](./Plugins.md).
 
-<a name="use"></a>
 #### use
-Function to add middlewares to Fastify, check [here](https://github.com/fastify/fastify/blob/master/docs/Middlewares.md).
+<a name="use"></a>
 
-<a name="addHook"></a>
+Function to add middlewares to Fastify, check [here](./Middlewares.md).
+
 #### addHook
-Function to add a specific hook in the lifecycle of Fastify, check [here](https://github.com/fastify/fastify/blob/master/docs/Hooks.md).
+<a name="addHook"></a>
 
-<a name="base-path"></a>
+Function to add a specific hook in the lifecycle of Fastify, check [here](./Hooks.md).
+
 #### basepath
+<a name="base-path"></a>
+
 The full path that will be prefixed to a route.
 
 Example:
@@ -409,27 +421,31 @@ fastify.register(function (instance, opts, next) {
 }, { prefix: '/v1' })
 ```
 
-<a name="log"></a>
 #### log
-The logger instance, check [here](https://github.com/fastify/fastify/blob/master/docs/Logging.md).
+<a name="log"></a>
 
-<a name="inject"></a>
+The logger instance, check [here](./Logging.md).
+
 #### inject
-Fake http injection (for testing purposes) [here](https://github.com/fastify/fastify/blob/master/docs/Testing.md#inject).
+<a name="inject"></a>
 
-<a name="add-schema"></a>
+Fake http injection (for testing purposes) [here](./Testing.md#inject).
+
 #### addSchema
+<a name="add-schema"></a>
+
 `fastify.addSchema(schemaObj)`, adds a shared schema to the Fastify instance. This allows you to reuse it everywhere in your application just by writing the schema id that you need.<br/>
-To learn more, see [shared schema example](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#shared-schema) in the [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) documentation.
+To learn more, see [shared schema example](./Validation-and-Serialization.md#shared-schema) in the [Validation and Serialization](./Validation-and-Serialization.md) documentation.
 
-<a name="set-schema-compiler"></a>
 #### setSchemaCompiler
-Set the schema compiler for all routes [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-compiler).
+<a name="set-schema-compiler"></a>
 
-<a name="set-not-found-handler"></a>
+Set the schema compiler for all routes [here](./Validation-and-Serialization.md#schema-compiler).
+
 #### setNotFoundHandler
+<a name="set-not-found-handler"></a>
 
-`fastify.setNotFoundHandler(handler(request, reply))`: set the 404 handler. This call is encapsulated by prefix, so different plugins can set different not found handlers if a different [`prefix` option](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#route-prefixing-option) is passed to `fastify.register()`. The handler is treated like a regular route handler so requests will go through the full [Fastify lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md#lifecycle).
+`fastify.setNotFoundHandler(handler(request, reply))`: set the 404 handler. This call is encapsulated by prefix, so different plugins can set different not found handlers if a different [`prefix` option](./Plugins.md#route-prefixing-option) is passed to `fastify.register()`. The handler is treated like a regular route handler so requests will go through the full [Fastify lifecycle](./Lifecycle.md#lifecycle).
 
 You can also register [beforeHandler](https://www.fastify.io/docs/latest/Hooks/#beforehandler) hook for the 404 handler.
 
@@ -452,8 +468,8 @@ fastify.register(function (instance, options, next) {
 }, { prefix: '/v1' })
 ```
 
-<a name="set-error-handler"></a>
 #### setErrorHandler
+<a name="set-error-handler"></a>
 
 `fastify.setErrorHandler(handler(error, request, reply))`: Set a function that will be called whenever an error happens. The handler is fully encapsulated, so different plugins can set different error handlers. *async-await* is supported as well.
 
@@ -463,8 +479,8 @@ fastify.setErrorHandler(function (error, request, reply) {
 })
 ```
 
-<a name="print-routes"></a>
 #### printRoutes
+<a name="print-routes"></a>
 
 `fastify.printRoutes()`: Prints the representation of the internal radix tree used by the router, useful for debugging.<br/>
 *Remember to call it inside or after a `ready` call.*

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,13 +1,11 @@
 ---
 title: Testing
-sidebar_label: Testing
-hide_title: false
 ---
 
 Testing is one of the most important parts of developing an application. Fastify is very flexible when it comes to testing and is compatible with most testing frameworks (such as [Tap](https://www.npmjs.com/package/tap), which is used in the examples below).
 
 ### Testing with http injection
-<a name="inject"></a>
+<a id="inject"></a>
 
 Fastify comes with built-in support for fake http injection thanks to [`light-my-request`](https://github.com/fastify/light-my-request).
 

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,10 +1,14 @@
-<h1 align="center">Fastify</h1>
+---
+title: Testing
+sidebar_label: Testing
+hide_title: false
+---
 
-## Testing
 Testing is one of the most important parts of developing an application. Fastify is very flexible when it comes to testing and is compatible with most testing frameworks (such as [Tap](https://www.npmjs.com/package/tap), which is used in the examples below).
 
-<a name="inject"></a>
 ### Testing with http injection
+<a name="inject"></a>
+
 Fastify comes with built-in support for fake http injection thanks to [`light-my-request`](https://github.com/fastify/light-my-request).
 
 To inject a fake http request, use the `inject` method:

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -1,7 +1,5 @@
 ---
 title: TypeScript
-sidebar_label: TypeScript
-hide_title: false
 ---
 
 Fastify is shipped with a typings file, but it still require to install `@types/node`, depending on the Node.js version that you are using.
@@ -48,7 +46,7 @@ server.get('/ping', opts, (request, reply) => {
 ```
 
 ## Generic Parameters
-<a name="generic-parameters"></a>
+<a id="generic-parameters"></a>
 
 Since you can validate the querystring, params, body, and headers, you can also override the default types of those values on the request interface:
 
@@ -165,7 +163,7 @@ server.get<unknown, Params, unknown, unknown>('/ping/:bar', opts, (request, repl
 ```
 
 ## HTTP Prototypes
-<a name="http-prototypes"></a>
+<a id="http-prototypes"></a>
 
 By default, fastify will determine which version of http is being used based on the options you pass to it. If for any
 reason you need to override this you can do so as shown below:
@@ -191,7 +189,7 @@ application.
 
 
 ## Contributing
-<a name="contributing"></a>
+<a id="contributing"></a>
 
 TypeScript related changes can be considered to fall into one of two categories:
 
@@ -201,7 +199,7 @@ TypeScript related changes can be considered to fall into one of two categories:
 Make sure to read our [`CONTRIBUTING.md`](https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md) file before getting started to make sure things go smoothly!
 
 ### Core Types
-<a name="core-types"></a>
+<a id="core-types"></a>
 
 When updating core types you should make a PR to this repository. Ensure you:
 
@@ -209,7 +207,7 @@ When updating core types you should make a PR to this repository. Ensure you:
 2. Update `test/types/index.ts` to validate changes work as expected
 
 ### Plugin Types
-<a name="plugin-types"></a>
+<a id="plugin-types"></a>
 
 Typings for plugins are hosted in DefinitelyTyped. This means when using plugins you should install like so:
 
@@ -220,7 +218,7 @@ npm install fastify-url-data @types/fastify-url-data
 After this you should be good to go. Some types might not be available yet, so don't be shy about contributing.
 
 ### Authoring Plugin Types
-<a name="authoring-plugin-types"></a>
+<a id="authoring-plugin-types"></a>
 
 Typings for many plugins that extend the `FastifyRequest` and `FastifyReply` objects can be achieved as shown below.
 

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -8,7 +8,8 @@ Fastify is shipped with a typings file, but it still require to install `@types/
 
 ## Types support
 We do care about the TypeScript community, but the framework is written in plain JavaScript and currently no one of the core team is a TypeScript user while only one of the collaborators is.
-We do our best to have the typing updated with the latest version of the API, but *it can happen* that the typings are not in sync.<br/>
+We do our best to have the typing updated with the latest version of the API, but *it can happen* that the typings are not in sync.
+
 Luckly this is Open Source and you can contribute to fix them, we will be very happy to accept the fix and release it as soon as possible as a patch release. Checkout the [contributing](#contributing) rules!
 
 Plugins may or may not include typings. See [Plugin Types](#plugin-types) for more information.

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -1,7 +1,9 @@
-<h1 align="center">Fastify</h1>
+---
+title: TypeScript
+sidebar_label: TypeScript
+hide_title: false
+---
 
-<a id="typescript"></a>
-## TypeScript
 Fastify is shipped with a typings file, but it still require to install `@types/node`, depending on the Node.js version that you are using.
 
 ## Types support
@@ -44,8 +46,9 @@ server.get('/ping', opts, (request, reply) => {
 })
 ```
 
-<a id="generic-parameters"></a>
 ## Generic Parameters
+<a name="generic-parameters"></a>
+
 Since you can validate the querystring, params, body, and headers, you can also override the default types of those values on the request interface:
 
 ```ts
@@ -160,8 +163,9 @@ server.get<unknown, Params, unknown, unknown>('/ping/:bar', opts, (request, repl
 })
 ```
 
-<a id="http-prototypes"></a>
 ## HTTP Prototypes
+<a name="http-prototypes"></a>
+
 By default, fastify will determine which version of http is being used based on the options you pass to it. If for any
 reason you need to override this you can do so as shown below:
 
@@ -185,8 +189,9 @@ In this example we pass a modified `http.IncomingMessage` interface since it has
 application.
 
 
-<a id="contributing"></a>
 ## Contributing
+<a name="contributing"></a>
+
 TypeScript related changes can be considered to fall into one of two categories:
 
 * Core - The typings bundled with fastify
@@ -194,15 +199,16 @@ TypeScript related changes can be considered to fall into one of two categories:
 
 Make sure to read our [`CONTRIBUTING.md`](https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md) file before getting started to make sure things go smoothly!
 
-<a id="core-types"></a>
 ### Core Types
+<a name="core-types"></a>
+
 When updating core types you should make a PR to this repository. Ensure you:
 
 1. Update `examples/typescript-server.ts` to reflect the changes (if necessary)
 2. Update `test/types/index.ts` to validate changes work as expected
 
-<a id="plugin-types"></a>
 ### Plugin Types
+<a name="plugin-types"></a>
 
 Typings for plugins are hosted in DefinitelyTyped. This means when using plugins you should install like so:
 
@@ -212,8 +218,9 @@ npm install fastify-url-data @types/fastify-url-data
 
 After this you should be good to go. Some types might not be available yet, so don't be shy about contributing.
 
-<a id="authoring-plugin-types"></a>
 ### Authoring Plugin Types
+<a name="authoring-plugin-types"></a>
+
 Typings for many plugins that extend the `FastifyRequest` and `FastifyReply` objects can be achieved as shown below.
 
 This code demonstrates adding types for `fastify-url-data` to your application.

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -1,13 +1,11 @@
 ---
 title: Validation and Serialization
-sidebar_label: Validation and Serialization
-hide_title: false
 ---
 
 Fastify uses a schema-based approach, and even if it is not mandatory we recommend using [JSON Schema](http://json-schema.org/) to validate your routes and serialize your outputs. Internally, Fastify compiles the schema into a highly performant function.
 
 ### Validation
-<a name="validation"></a>
+<a id="validation"></a>
 
 The route validation internally relies upon [Ajv](https://www.npmjs.com/package/ajv), which is a high-performance JSON schema validator. Validating the input is very easy: just add the fields that you need inside the route schema, and you are done! The supported validations are:
 - `body`: validates the body of the request if it is a POST or a PUT.
@@ -53,7 +51,7 @@ fastify.post('/the/url', { schema }, handler)
 *Note that Ajv will try to [coerce](https://github.com/epoberezkin/ajv#coercing-data-types) the values to the types specified in your schema `type` keywords, both to pass the validation and to use the correctly typed data afterwards.*
 
 #### Adding a shared schema
-<a name="shared-schema"></a>
+<a id="shared-schema"></a>
 
 Thanks to the `addSchema` API, you can add multiple schemas to the Fastify instance and then reuse them in multiple parts of your application. *(Note that this API is not encapsulated)*
 ```js
@@ -106,12 +104,12 @@ fastify.route({
 ```
 
 #### Retrieving a copy of all shared schemas
-<a name="get-shared-schema"></a>
+<a id="get-shared-schema"></a>
 
 The function `getSchemas` returns all shared schemas that were added by `addSchema` method.
 
 #### Schema Compiler
-<a name="schema-compiler"></a>
+<a id="schema-compiler"></a>
 
 The `schemaCompiler` is a function that returns a function that validates the body, url parameters, headers, and query string. The default `schemaCompiler` returns a function that implements the [ajv](https://ajv.js.org/) validation interface. Fastify uses it internally to speed the validation up.
 
@@ -163,7 +161,7 @@ In that case the function returned by `schemaCompiler` returns an object like:
 * `value`: the coerced value that passed the validation
 
 ### Serialization
-<a name="serialization"></a>
+<a id="serialization"></a>
 
 Usually you will send your data to the clients via JSON, and Fastify has a powerful tool to help you, [fast-json-stringify](https://www.npmjs.com/package/fast-json-stringify), which is used if you have provided an output schema in the route options. We encourage you to use an output schema, as it will increase your throughput by 100-400% depending on your payload and will prevent accidental disclosure of sensitive information.
 
@@ -383,7 +381,7 @@ const refToSharedSchemaDefinitions = {
 ```
 
 ### Resources
-<a name="resources"></a>
+<a id="resources"></a>
 
 - [JSON Schema](http://json-schema.org/)
 - [Understanding JSON schema](https://spacetelescope.github.io/understanding-json-schema/)

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -1,10 +1,14 @@
-<h1 align="center">Fastify</h1>
+---
+title: Validation and Serialization
+sidebar_label: Validation and Serialization
+hide_title: false
+---
 
-## Validation and Serialization
 Fastify uses a schema-based approach, and even if it is not mandatory we recommend using [JSON Schema](http://json-schema.org/) to validate your routes and serialize your outputs. Internally, Fastify compiles the schema into a highly performant function.
 
-<a name="validation"></a>
 ### Validation
+<a name="validation"></a>
+
 The route validation internally relies upon [Ajv](https://www.npmjs.com/package/ajv), which is a high-performance JSON schema validator. Validating the input is very easy: just add the fields that you need inside the route schema, and you are done! The supported validations are:
 - `body`: validates the body of the request if it is a POST or a PUT.
 - `querystring`: validates the query string. This can be a complete JSON Schema object (with a `type` property of `'object'` and a `'properties'` object containing parameters) or a simpler variation in which the `type` and `properties` attributes are forgone and the query parameters are listed at the top level (see the example below).
@@ -48,8 +52,9 @@ fastify.post('/the/url', { schema }, handler)
 ```
 *Note that Ajv will try to [coerce](https://github.com/epoberezkin/ajv#coercing-data-types) the values to the types specified in your schema `type` keywords, both to pass the validation and to use the correctly typed data afterwards.*
 
-<a name="shared-schema"></a>
 #### Adding a shared schema
+<a name="shared-schema"></a>
+
 Thanks to the `addSchema` API, you can add multiple schemas to the Fastify instance and then reuse them in multiple parts of your application. *(Note that this API is not encapsulated)*
 ```js
 const fastify = require('fastify')()
@@ -100,13 +105,13 @@ fastify.route({
 })
 ```
 
-<a name="get-shared-schema"></a>
 #### Retrieving a copy of all shared schemas
+<a name="get-shared-schema"></a>
 
 The function `getSchemas` returns all shared schemas that were added by `addSchema` method.
 
-<a name="schema-compiler"></a>
 #### Schema Compiler
+<a name="schema-compiler"></a>
 
 The `schemaCompiler` is a function that returns a function that validates the body, url parameters, headers, and query string. The default `schemaCompiler` returns a function that implements the [ajv](https://ajv.js.org/) validation interface. Fastify uses it internally to speed the validation up.
 
@@ -157,8 +162,9 @@ In that case the function returned by `schemaCompiler` returns an object like:
 * `error`: filled with an instance of `Error` or a string that describes the validation error
 * `value`: the coerced value that passed the validation
 
-<a name="serialization"></a>
 ### Serialization
+<a name="serialization"></a>
+
 Usually you will send your data to the clients via JSON, and Fastify has a powerful tool to help you, [fast-json-stringify](https://www.npmjs.com/package/fast-json-stringify), which is used if you have provided an output schema in the route options. We encourage you to use an output schema, as it will increase your throughput by 100-400% depending on your payload and will prevent accidental disclosure of sensitive information.
 
 Example:
@@ -376,8 +382,9 @@ const refToSharedSchemaDefinitions = {
 }
 ```
 
-<a name="resources"></a>
 ### Resources
+<a name="resources"></a>
+
 - [JSON Schema](http://json-schema.org/)
 - [Understanding JSON schema](https://spacetelescope.github.io/understanding-json-schema/)
 - [fast-json-stringify documentation](https://github.com/fastify/fast-json-stringify)

--- a/docs/Write-Plugin.md
+++ b/docs/Write-Plugin.md
@@ -1,7 +1,5 @@
 ---
 title: Write Plugin
-sidebar_label: Write Plugin
-hide_title: false
 ---
 
 # How to write a good plugin

--- a/docs/Write-Plugin.md
+++ b/docs/Write-Plugin.md
@@ -5,7 +5,8 @@ hide_title: false
 ---
 
 # How to write a good plugin
-First, thank you for deciding to write a plugin for Fastify. Fastify is a minimal framework and plugins are its strength, so thank you.<br/>
+First, thank you for deciding to write a plugin for Fastify. Fastify is a minimal framework and plugins are its strength, so thank you.
+
 The core principles of Fastify are performance, low overhead and providing a good experience to our users. When writing a plugin, it is important to keep these principles in mind. Therefore, in this document we will analyze what characterizes a quality plugin.
 
 *Need some inspiration? You can use the label ["plugin suggestion"](https://github.com/fastify/fastify/issues?q=is%3Aissue+is%3Aopen+label%3A%22plugin+suggestion%22) in our issue tracker!*
@@ -18,7 +19,8 @@ Have you got some question or are you seeking for a suggestion? We are more than
 Once you submit a plugin to our [ecosystem list](./Ecosystem.md), we will review your code and help you improve it if necessary.
 
 ## Documentation
-Documentation is extremely important. If your plugin is not well documented we will not accept it to the ecosystem list. Lack of quality documentation makes it more difficult for people to use your plugin, and will likely result in it going unused.<br/>
+Documentation is extremely important. If your plugin is not well documented we will not accept it to the ecosystem list. Lack of quality documentation makes it more difficult for people to use your plugin, and will likely result in it going unused.
+
 If you want to see some good examples on how to document a plugin take a look at:
 - [`fastify-caching`](https://github.com/fastify/fastify-caching)
 - [`fastify-compress`](https://github.com/fastify/fastify-compress)
@@ -27,14 +29,16 @@ If you want to see some good examples on how to document a plugin take a look at
 - [`under-pressure`](https://github.com/fastify/under-pressure)
 
 ## License
-You can license your plugin as you prefer, we do not enforce any kind of license.<br/>
+You can license your plugin as you prefer, we do not enforce any kind of license.
+
 We prefer the [MIT license](https://choosealicense.com/licenses/mit/) because we think it allows more people to use the code freely. For a list of alternative licenses see the [OSI list](https://opensource.org/licenses) or GitHub's [choosealicense.com](https://choosealicense.com/).
 
 ## Examples
 Always put an example file in your repository. Examples are very helpful for users and give a very fast way to test your plugin. Your users will be grateful.
 
 ## Test
-It is extremely important that a plugin is thoroughly tested to verify that is working properly.<br/>
+It is extremely important that a plugin is thoroughly tested to verify that is working properly.
+
 A plugin without tests will not be accepted to the ecosystem list. A lack of tests does not inspire trust nor guarantee that the code will continue to work among different versions of its dependencies.
 
 We do not enforce any testing library. We use [`tap`](http://www.node-tap.org/) since it offers out of the box parallel testing and code coverage, but it is up to you to choose your library of preference.
@@ -45,7 +49,8 @@ It is not mandatory, but we highly recommend you use a code linter in your plugi
 We use [`standard`](https://standardjs.com/) since it works without the need to configure it and is very easy integrate in a test suite.
 
 ## Continuous Integration
-It is not mandatory, but if you release your code as open source it helps to use Continuous Integration to ensure contributions do not break your plugin and to show that the plugin works as intended. [Travis](https://travis-ci.org/) is free for open source projects and easy to setup.<br/>
+It is not mandatory, but if you release your code as open source it helps to use Continuous Integration to ensure contributions do not break your plugin and to show that the plugin works as intended. [Travis](https://travis-ci.org/) is free for open source projects and easy to setup.
+
 In addition you can enable services like [Greenkeeper](https://greenkeeper.io/), that will help you keep your dependencies up to date and discover if a new release of Fastify has some issues with your plugin.
 
 ## Let's start!

--- a/docs/Write-Plugin.md
+++ b/docs/Write-Plugin.md
@@ -1,20 +1,24 @@
-<h1 align="center">Fastify</h1>
+---
+title: Write Plugin
+sidebar_label: Write Plugin
+hide_title: false
+---
 
 # How to write a good plugin
-First, thank you for deciding to write a plugin for Fastify. Fastify is a minimal framework and plugins are its strength, so thank you.<br>
+First, thank you for deciding to write a plugin for Fastify. Fastify is a minimal framework and plugins are its strength, so thank you.<br/>
 The core principles of Fastify are performance, low overhead and providing a good experience to our users. When writing a plugin, it is important to keep these principles in mind. Therefore, in this document we will analyze what characterizes a quality plugin.
 
 *Need some inspiration? You can use the label ["plugin suggestion"](https://github.com/fastify/fastify/issues?q=is%3Aissue+is%3Aopen+label%3A%22plugin+suggestion%22) in our issue tracker!*
 
 ## Code
-Fastify uses different techniques to optimize its code, many of them are documented in our Guides. We highly recommend you read [the hitchhiker's guide to plugins](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md) to discover all the APIs you can use to build your plugin and learn how use them.
+Fastify uses different techniques to optimize its code, many of them are documented in our Guides. We highly recommend you read [the hitchhiker's guide to plugins](./Plugins-Guide.md) to discover all the APIs you can use to build your plugin and learn how use them.
 
 Have you got some question or are you seeking for a suggestion? We are more than happy to help you! Just open an issue in our [help repository](https://github.com/fastify/help).
 
-Once you submit a plugin to our [ecosystem list](https://github.com/fastify/fastify/blob/master/docs/Ecosystem.md), we will review your code and help you improve it if necessary.
+Once you submit a plugin to our [ecosystem list](./Ecosystem.md), we will review your code and help you improve it if necessary.
 
 ## Documentation
-Documentation is extremely important. If your plugin is not well documented we will not accept it to the ecosystem list. Lack of quality documentation makes it more difficult for people to use your plugin, and will likely result in it going unused.<br>
+Documentation is extremely important. If your plugin is not well documented we will not accept it to the ecosystem list. Lack of quality documentation makes it more difficult for people to use your plugin, and will likely result in it going unused.<br/>
 If you want to see some good examples on how to document a plugin take a look at:
 - [`fastify-caching`](https://github.com/fastify/fastify-caching)
 - [`fastify-compress`](https://github.com/fastify/fastify-compress)
@@ -23,14 +27,14 @@ If you want to see some good examples on how to document a plugin take a look at
 - [`under-pressure`](https://github.com/fastify/under-pressure)
 
 ## License
-You can license your plugin as you prefer, we do not enforce any kind of license.<br>
+You can license your plugin as you prefer, we do not enforce any kind of license.<br/>
 We prefer the [MIT license](https://choosealicense.com/licenses/mit/) because we think it allows more people to use the code freely. For a list of alternative licenses see the [OSI list](https://opensource.org/licenses) or GitHub's [choosealicense.com](https://choosealicense.com/).
 
 ## Examples
 Always put an example file in your repository. Examples are very helpful for users and give a very fast way to test your plugin. Your users will be grateful.
 
 ## Test
-It is extremely important that a plugin is thoroughly tested to verify that is working properly.<br>
+It is extremely important that a plugin is thoroughly tested to verify that is working properly.<br/>
 A plugin without tests will not be accepted to the ecosystem list. A lack of tests does not inspire trust nor guarantee that the code will continue to work among different versions of its dependencies.
 
 We do not enforce any testing library. We use [`tap`](http://www.node-tap.org/) since it offers out of the box parallel testing and code coverage, but it is up to you to choose your library of preference.
@@ -41,7 +45,7 @@ It is not mandatory, but we highly recommend you use a code linter in your plugi
 We use [`standard`](https://standardjs.com/) since it works without the need to configure it and is very easy integrate in a test suite.
 
 ## Continuous Integration
-It is not mandatory, but if you release your code as open source it helps to use Continuous Integration to ensure contributions do not break your plugin and to show that the plugin works as intended. [Travis](https://travis-ci.org/) is free for open source projects and easy to setup.<br>
+It is not mandatory, but if you release your code as open source it helps to use Continuous Integration to ensure contributions do not break your plugin and to show that the plugin works as intended. [Travis](https://travis-ci.org/) is free for open source projects and easy to setup.<br/>
 In addition you can enable services like [Greenkeeper](https://greenkeeper.io/), that will help you keep your dependencies up to date and discover if a new release of Fastify has some issues with your plugin.
 
 ## Let's start!


### PR DESCRIPTION
These changes are in line with the discussion at fastify/fastify#3492. These tweaks are being pushed to the `1.x` branch so that it will maintain compatibility with modern Markdown processors such as Docusaurus. Please note that the current website does not compile from this branch but rather from releases, so merging this will not break the current website.

#### Changes
- Use relative links rather than absolute links
- Ensure Markdown headers have newline directly above
- Add Markdown metadata to each file
- Replace `<br>` tags with `<br/>`

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
