### PR TITLE
Update v2.x docs compatibility with Docusaurus

### DIFF
--- a/docs/Benchmarking.md
+++ b/docs/Benchmarking.md
@@ -1,6 +1,9 @@
-<h1 align="center">Fastify</h1>
+---
+title: Benchmarking
+sidebar_label: Benchmarking
+hide_title: false
+---
 
-## Benchmarking
 Benchmarking is important if you want to measure how a change can impact the performance of your application. We provide a simple way to benchmark your application from the point of view of a user and contributor. The setup allows you to automate benchmarks in different branches and on different Node.js versions.
 
 The modules we'll use:

--- a/docs/ContentTypeParser.md
+++ b/docs/ContentTypeParser.md
@@ -1,11 +1,14 @@
-<h1 align="center">Fastify</h1>
+---
+title: Content-Type Parser
+sidebar_label: Content-Type Parser
+hide_title: false
+---
 
-## `Content-Type` Parser
 Natively, Fastify only supports `'application/json'` and `'text/plain'` content types. The default charset is `utf-8`. If you need to support different content types, you can use the `addContentTypeParser` API. *The default JSON and/or plain text parser can be changed.*
 
 As with the other APIs, `addContentTypeParser` is encapsulated in the scope in which it is declared. This means that if you declare it in the root scope it will be available everywhere, while if you declare it inside a plugin it will be available only in that scope and its children.
 
-Fastify automatically adds the parsed request payload to the [Fastify request](https://github.com/fastify/fastify/blob/master/docs/Request.md) object which you can access with `request.body`.
+Fastify automatically adds the parsed request payload to the [Fastify request](./Request.md) object which you can access with `request.body`.
 
 ### Usage
 ```js
@@ -40,7 +43,7 @@ if (!fastify.hasContentTypeParser('application/jsoff')){
 ```
 
 #### Body Parser
-You can parse the body of a request in two ways. The first one is shown above: you add a custom content type parser and handle the request stream. In the second one, you should pass a `parseAs` option to the `addContentTypeParser` API, where you declare how you want to get the body. It could be of type `'string'` or `'buffer'`. If you use the `parseAs` option, Fastify will internally handle the stream and perform some checks, such as the [maximum size](https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-body-limit) of the body and the content length. If the limit is exceeded the custom parser will not be invoked.
+You can parse the body of a request in two ways. The first one is shown above: you add a custom content type parser and handle the request stream. In the second one, you should pass a `parseAs` option to the `addContentTypeParser` API, where you declare how you want to get the body. It could be of type `'string'` or `'buffer'`. If you use the `parseAs` option, Fastify will internally handle the stream and perform some checks, such as the [maximum size](./Server.md#factory-body-limit) of the body and the content length. If the limit is exceeded the custom parser will not be invoked.
 ```js
 fastify.addContentTypeParser('application/json', { parseAs: 'string' }, function (req, body, done) {
   try {
@@ -58,7 +61,7 @@ See [`example/parser.js`](https://github.com/fastify/fastify/blob/master/example
 
 ##### Custom Parser Options
 + `parseAs` (string): Either `'string'` or `'buffer'` to designate how the incoming data should be collected. Default: `'buffer'`.
-+ `bodyLimit` (number): The maximum payload size, in bytes, that the custom parser will accept. Defaults to the global body limit passed to the [`Fastify factory function`](https://github.com/fastify/fastify/blob/master/docs/Server.md#bodylimit).
++ `bodyLimit` (number): The maximum payload size, in bytes, that the custom parser will accept. Defaults to the global body limit passed to the [`Fastify factory function`](./Server.md#bodylimit).
 
 #### Catch-All
 There are some cases where you need to catch all requests regardless of their content type. With Fastify, you can just use the `'*'` content type.

--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -1,6 +1,8 @@
-<h1 align="center">Fastify</h1>
-
-## Decorators
+---
+title: Decorators
+sidebar_label: Decorators
+hide_title: false
+---
 
 The decorators API allows customization of the core Fastify objects, such as
 the server instance itself and any request and reply objects used during the

--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -1,6 +1,8 @@
-<h1 align="center">Fastify</h1>
-
-## Ecosystem
+---
+title: Ecosystem
+sidebar_label: Ecosystem
+hide_title: false
+---
 
 Plugins maintained by the fastify team are listed under [Core](#core) while plugins maintained by the community are listed in the [Community](#community) section.
 

--- a/docs/Errors.md
+++ b/docs/Errors.md
@@ -1,132 +1,133 @@
-<h1 align="center">Fastify</h1>
+---
+title: Errors
+sidebar_label: Errors
+hide_title: false
+---
 
-<a id="errors"></a>
-## Errors
-
-<a name="error-handling"></a>
 ### Error Handling
+<a name="error-handling"></a>
 
 Uncaught errors are likely to cause memory leaks, file descriptor leaks and other major production issues. [Domains](https://nodejs.org/en/docs/guides/domain-postmortem/) were introduced to try fixing this issue, but they did not. Given the fact that it is not possible to process all uncaught errors sensibly, the best way to deal with them at the moment is to [crash](https://nodejs.org/api/process.html#process_warning_using_uncaughtexception_correctly). In case of promises, make sure to [handle](https://nodejs.org/dist/latest-v8.x/docs/api/deprecations.html#deprecations_dep0018_unhandled_promise_rejections) errors [correctly](https://github.com/mcollina/make-promises-safe).
 
-Fastify follows an all-or-nothing approach and aims to be lean and optimal as much as possible. Thus, the developer is responsible for making sure that the errors are handled properly. Most of the errors are usually a result of unexpected input data, so we recommend specifying a [JSON.schema validation](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) for your input data.
+Fastify follows an all-or-nothing approach and aims to be lean and optimal as much as possible. Thus, the developer is responsible for making sure that the errors are handled properly. Most of the errors are usually a result of unexpected input data, so we recommend specifying a [JSON.schema validation](./Validation-and-Serialization.md) for your input data.
 
 Note that Fastify doesn't catch uncaught errors within callback-based routes for you, so any uncaught errors will result in a crash.
-If routes are declared as `async` though - the error will safely be caught by the promise and routed to the default error handler of Fastify for a generic `Internal Server Error` response. For customizing this behaviour, you should use [setErrorHandler](https://github.com/fastify/fastify/blob/master/docs/Server.md#seterrorhandler).
+If routes are declared as `async` though - the error will safely be caught by the promise and routed to the default error handler of Fastify for a generic `Internal Server Error` response. For customizing this behaviour, you should use [setErrorHandler](./Server.md#seterrorhandler).
 
-<a name="fastify-error-codes"></a>
 ### Fastify Error Codes
+<a name="fastify-error-codes"></a>
 
-<a name="FST_ERR_BAD_URL"></a>
 #### FST_ERR_BAD_URL
+<a name="FST_ERR_BAD_URL"></a>
 
 The router received an invalid url.
 
-<a name="FST_ERR_CTP_ALREADY_PRESENT"></a>
 #### FST_ERR_CTP_ALREADY_PRESENT
+<a name="FST_ERR_CTP_ALREADY_PRESENT"></a>
 
 The parser for this content type was already registered.
 
-<a name="FST_ERR_CTP_INVALID_TYPE"></a>
 #### FST_ERR_CTP_INVALID_TYPE
+<a name="FST_ERR_CTP_INVALID_TYPE"></a>
 
 The `Content-Type` should be a string.
 
-<a name="FST_ERR_CTP_EMPTY_TYPE"></a>
 #### FST_ERR_CTP_EMPTY_TYPE
+<a name="FST_ERR_CTP_EMPTY_TYPE"></a>
 
 The content type cannot be an empty string.
 
-<a name="FST_ERR_CTP_INVALID_HANDLER"></a>
 #### FST_ERR_CTP_INVALID_HANDLER
+<a name="FST_ERR_CTP_INVALID_HANDLER"></a>
 
 An invalid handler was passed for the content type.
 
-<a name="FST_ERR_CTP_INVALID_PARSE_TYPE"></a>
 #### FST_ERR_CTP_INVALID_PARSE_TYPE
+<a name="FST_ERR_CTP_INVALID_PARSE_TYPE"></a>
 
 The provided parse type is not supported. Accepted values are `string` or `buffer`.
 
-<a name="FST_ERR_CTP_BODY_TOO_LARGE"></a>
 #### FST_ERR_CTP_BODY_TOO_LARGE
+<a name="FST_ERR_CTP_BODY_TOO_LARGE"></a>
 
 The request body is larger than the provided limit.
 
-<a name="FST_ERR_CTP_INVALID_MEDIA_TYPE"></a>
 #### FST_ERR_CTP_INVALID_MEDIA_TYPE
+<a name="FST_ERR_CTP_INVALID_MEDIA_TYPE"></a>
 
 The received media type is not supported (i.e. there is no suitable `Content-Type` parser for it).
 
-<a name="FST_ERR_CTP_INVALID_CONTENT_LENGTH"></a>
 #### FST_ERR_CTP_INVALID_CONTENT_LENGTH
+<a name="FST_ERR_CTP_INVALID_CONTENT_LENGTH"></a>
 
 Request body size did not match Content-Length.
 
-<a name="FST_ERR_DEC_ALREADY_PRESENT"></a>
 #### FST_ERR_DEC_ALREADY_PRESENT
+<a name="FST_ERR_DEC_ALREADY_PRESENT"></a>
 
 A decorator with the same name is already registered.
 
-<a name="FST_ERR_DEC_MISSING_DEPENDENCY"></a>
 #### FST_ERR_DEC_MISSING_DEPENDENCY
+<a name="FST_ERR_DEC_MISSING_DEPENDENCY"></a>
 
 The decorator cannot be registered due to a missing dependency.
 
-<a name="FST_ERR_HOOK_INVALID_TYPE"></a>
 #### FST_ERR_HOOK_INVALID_TYPE
+<a name="FST_ERR_HOOK_INVALID_TYPE"></a>
 
 The hook name must be a string.
 
-<a name="FST_ERR_HOOK_INVALID_HANDLER"></a>
 #### FST_ERR_HOOK_INVALID_HANDLER
+<a name="FST_ERR_HOOK_INVALID_HANDLER"></a>
 
 The hook callback must be a function.
 
-<a name="FST_ERR_LOG_INVALID_DESTINATION"></a>
 #### FST_ERR_LOG_INVALID_DESTINATION
+<a name="FST_ERR_LOG_INVALID_DESTINATION"></a>
 
 The logger accepts either a `'stream'` or a `'file'` as the destination.
 
-<a id="FST_ERR_REP_ALREADY_SENT"></a>
-### FST_ERR_REP_ALREADY_SENT
+#### FST_ERR_REP_ALREADY_SENT
+<a name="FST_ERR_REP_ALREADY_SENT"></a>
 
 A response was already sent.
 
-<a id="FST_ERR_SEND_INSIDE_ONERR"></a>
 #### FST_ERR_SEND_INSIDE_ONERR
+<a name="FST_ERR_SEND_INSIDE_ONERR"></a>
 
 You cannot use `send` inside the `onError` hook.
 
-<a name="FST_ERR_REP_INVALID_PAYLOAD_TYPE"></a>
 #### FST_ERR_REP_INVALID_PAYLOAD_TYPE
+<a name="FST_ERR_REP_INVALID_PAYLOAD_TYPE"></a>
 
 Reply payload can either be a `string` or a `Buffer`.
 
-<a name="FST_ERR_SCH_MISSING_ID"></a>
 #### FST_ERR_SCH_MISSING_ID
+<a name="FST_ERR_SCH_MISSING_ID"></a>
 
 The schema provided does not have `$id` property.
 
-<a name="FST_ERR_SCH_ALREADY_PRESENT"></a>
 #### FST_ERR_SCH_ALREADY_PRESENT
+<a name="FST_ERR_SCH_ALREADY_PRESENT"></a>
 
 A schema with the same `$id` already exists.
 
-<a name="FST_ERR_SCH_NOT_PRESENT"></a>
 #### FST_ERR_SCH_NOT_PRESENT
+<a name="FST_ERR_SCH_NOT_PRESENT"></a>
 
 No schema with the provided `$id` exists.
 
-<a name="FST_ERR_SCH_BUILD"></a>
 #### FST_ERR_SCH_BUILD
+<a name="FST_ERR_SCH_BUILD"></a>
 
 The JSON schema provided to one route is not valid.
 
-<a name="FST_ERR_PROMISE_NOT_FULLFILLED"></a>
 #### FST_ERR_PROMISE_NOT_FULLFILLED
+<a name="FST_ERR_PROMISE_NOT_FULLFILLED"></a>
 
 A promise may not be fulfilled with 'undefined' when statusCode is not 204.
 
-<a name="FST_ERR_SEND_UNDEFINED_ERR"></a>
 #### FST_ERR_SEND_UNDEFINED_ERR
+<a name="FST_ERR_SEND_UNDEFINED_ERR"></a>
 
 Undefined error has occured.

--- a/docs/Fluent-Schema.md
+++ b/docs/Fluent-Schema.md
@@ -1,8 +1,11 @@
-<h1 align="center">Fastify</h1>
+---
+title: Fluent Schema
+sidebar_label: Fluent Schema
+hide_title: false
+---
 
-## Fluent Schema
 
-The [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) documentation outlines all parameters accepted by Fastify to set up JSON Schema Validation in order to validate the input, and JSON Schema Serialization in order to optimize the output.
+The [Validation and Serialization](./Validation-and-Serialization.md) documentation outlines all parameters accepted by Fastify to set up JSON Schema Validation in order to validate the input, and JSON Schema Serialization in order to optimize the output.
 
 [`fluent-schema`](https://github.com/fastify/fluent-schema) can be used to simplify this task while allowing the reuse of constants.
 

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -1,12 +1,16 @@
-<h1 align="center">Fastify</h1>
+---
+title: Getting Started
+sidebar_label: Getting Started
+hide_title: false
+---
 
-## Getting Started
-Hello! Thank you for checking out Fastify!<br>
-This document aims to be a gentle introduction to the framework and its features. It is an elementary preface with examples and links to other parts of the documentation.<br>
+Hello! Thank you for checking out Fastify!<br/>
+This document aims to be a gentle introduction to the framework and its features. It is an elementary preface with examples and links to other parts of the documentation.<br/>
 Let's start!
 
-<a name="install"></a>
 ### Install
+<a name="install"></a>
+
 Install with npm:
 ```
 npm i fastify --save
@@ -16,8 +20,9 @@ Install with yarn:
 yarn add fastify
 ```
 
-<a name="first-server"></a>
 ### Your first server
+<a name="first-server"></a>
+
 Let's write our first server:
 ```js
 // Require the framework and instantiate it
@@ -40,7 +45,7 @@ fastify.listen(3000, function (err, address) {
 })
 ```
 
-Do you prefer to use `async/await`? Fastify supports it out-of-the-box.<br>
+Do you prefer to use `async/await`? Fastify supports it out-of-the-box.<br/>
 *(We also suggest using [make-promises-safe](https://github.com/mcollina/make-promises-safe) to avoid file descriptor and memory leaks.)*
 ```js
 const fastify = require('fastify')()
@@ -60,8 +65,8 @@ const start = async () => {
 start()
 ```
 
-Awesome, that was easy.<br>
-Unfortunately, writing a complex application requires significantly more code than this example. A classic problem when you are building a new application is how to handle multiple files, asynchronous bootstrapping and the architecture of your code.<br>
+Awesome, that was easy.<br/>
+Unfortunately, writing a complex application requires significantly more code than this example. A classic problem when you are building a new application is how to handle multiple files, asynchronous bootstrapping and the architecture of your code.<br/>
 Fastify offers an easy platform that helps to solve all of the problems outlined above, and more!
 
 > ## Note
@@ -81,11 +86,12 @@ Fastify offers an easy platform that helps to solve all of the problems outlined
 >
 > When deploying to a Docker (or other type of) container using `0.0.0.0` or `::` would be the easiest method for exposing the application.
 
-<a name="first-plugin"></a>
 ### Your first plugin
-As with JavaScript, where everything is an object, with Fastify everything is a plugin.<br>
-Before digging into it, let's see how it works!<br>
-Let's declare our basic server, but instead of declaring the route inside the entry point, we'll declare it in an external file (check out the [route declaration](https://github.com/fastify/fastify/blob/master/docs/Routes.md) docs).
+<a name="first-plugin"></a>
+
+As with JavaScript, where everything is an object, with Fastify everything is a plugin.<br/>
+Before digging into it, let's see how it works!<br/>
+Let's declare our basic server, but instead of declaring the route inside the entry point, we'll declare it in an external file (check out the [route declaration](./Routes.md) docs).
 ```js
 const fastify = require('fastify')({
   logger: true
@@ -116,12 +122,12 @@ module.exports = routes
 In this example, we used the `register` API, which is the core of the Fastify framework. It is the only way to add routes, plugins, et cetera.
 
 At the beginning of this guide, we noted that Fastify provides a foundation that assists with asynchronous bootstrapping of your application. Why is this important?
-Consider the scenario where a database connection is needed to handle data storage. Obviously, the database connection needs to be available before the server is accepting connections. How do we address this problem?<br>
-A typical solution is to use a complex callback, or promises - a system that will mix the framework API with other libraries and the application code.<br>
+Consider the scenario where a database connection is needed to handle data storage. Obviously, the database connection needs to be available before the server is accepting connections. How do we address this problem?<br/>
+A typical solution is to use a complex callback, or promises - a system that will mix the framework API with other libraries and the application code.<br/>
 Fastify handles this internally, with minimum effort!
 
-Let's rewrite the above example with a database connection.<br>
-*(we will use a simple example, for a robust solution consider using [`fastify-mongo`](https://github.com/fastify/fastify-mongodb) or another in the Fastify [ecosystem](https://github.com/fastify/fastify/blob/master/docs/Ecosystem.md))*
+Let's rewrite the above example with a database connection.<br/>
+*(we will use a simple example, for a robust solution consider using [`fastify-mongo`](https://github.com/fastify/fastify-mongodb) or another in the Fastify [ecosystem](./Ecosystem.md))*
 
 First, install `fastify-plugin`:
 
@@ -189,18 +195,19 @@ async function routes (fastify, options) {
 module.exports = routes
 ```
 
-Wow, that was fast!<br>
-Let's recap what we have done here since we've introduced some new concepts.<br>
+Wow, that was fast!<br/>
+Let's recap what we have done here since we've introduced some new concepts.<br/>
 As you can see, we used `register` both for the database connector and the registration of the routes.
-This is one of the best features of Fastify, it will load your plugins in the same order you declare them, and it will load the next plugin only once the current one has been loaded. In this way, we can register the database connector in the first plugin and use it in the second *(read [here](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#handle-the-scope) to understand how to handle the scope of a plugin)*.
+This is one of the best features of Fastify, it will load your plugins in the same order you declare them, and it will load the next plugin only once the current one has been loaded. In this way, we can register the database connector in the first plugin and use it in the second *(read [here](./Plugins.md#handle-the-scope) to understand how to handle the scope of a plugin)*.
 Plugin loading starts when you call `fastify.listen()`, `fastify.inject()` or `fastify.ready()`
 
 We have also used the `decorate` API to add custom objects to the Fastify namespace, making them available for use everywhere. Use of this API is encouraged to faciliate easy code reuse and to decrease code or logic duplication.
 
-To dig deeper into how Fastify plugins work, how to develop new plugins, and for details on how to use the whole Fastify API to deal with the complexity of asynchronously bootstrapping an application, read [the hitchhiker's guide to plugins](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md).
+To dig deeper into how Fastify plugins work, how to develop new plugins, and for details on how to use the whole Fastify API to deal with the complexity of asynchronously bootstrapping an application, read [the hitchhiker's guide to plugins](./Plugins-Guide.md).
 
-<a name="plugin-loading-order"></a>
 ### Loading order of your plugins
+<a name="plugin-loading-order"></a>
+
 To guarantee a consistent and predictable behaviour of your application, we highly recommend to always load your code as shown below:
 ```
 └── plugins (from the Fastify ecosystem)
@@ -233,9 +240,10 @@ As discussed previously, Fastify offers a solid encapsulation model, to help you
           └── your services
 ```
 
-<a name="validate-data"></a>
 ### Validate your data
-Data validation is extremely important and a core concept of the framework.<br>
+<a name="validate-data"></a>
+
+Data validation is extremely important and a core concept of the framework.<br/>
 To validate incoming requests, Fastify uses [JSON Schema](http://json-schema.org/).
 Let's look at an example demonstrating validation for routes:
 ```js
@@ -255,12 +263,13 @@ fastify.post('/', opts, async (request, reply) => {
   return { hello: 'world' }
 })
 ```
-This example shows how to pass an options object to the route, which accepts a `schema` key, that contains all of the schemas for route, `body`, `querystring`, `params` and `headers`.<br>
-Read [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) to learn more.
+This example shows how to pass an options object to the route, which accepts a `schema` key, that contains all of the schemas for route, `body`, `querystring`, `params` and `headers`.<br/>
+Read [Validation and Serialization](./Validation-and-Serialization.md) to learn more.
 
-<a name="serialize-data"></a>
 ### Serialize your data
-Fastify has first class support for JSON. It is extremely optimized to parse JSON bodies and to serialize JSON output.<br>
+<a name="serialize-data"></a>
+
+Fastify has first class support for JSON. It is extremely optimized to parse JSON bodies and to serialize JSON output.<br/>
 To speed up JSON serialization (yes, it is slow!) use the `response` key of the schema option as shown in the following example:
 ```js
 const opts = {
@@ -281,20 +290,23 @@ fastify.get('/', opts, async (request, reply) => {
 })
 ```
 Simply by specifying a schema as shown, you can speed up serialization by a factor of 2-3. This also helps to protect against leakage of potentially sensitive data, since Fastify will serialize only the data present in the response schema.
-Read [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) to learn more.
+Read [Validation and Serialization](./Validation-and-Serialization.md) to learn more.
 
-<a name="extend-server"></a>
 ### Extend your server
-Fastify is built to be extremely extensible and minimal, we believe that a bare bones framework is all that is necessary to make great applications possible.<br>
-In other words, Fastify is not a "batteries included" framework, and relies on an amazing [ecosystem](https://github.com/fastify/fastify/blob/master/docs/Ecosystem.md)!
+<a name="extend-server"></a>
 
-<a name="test-server"></a>
+Fastify is built to be extremely extensible and minimal, we believe that a bare bones framework is all that is necessary to make great applications possible.<br/>
+In other words, Fastify is not a "batteries included" framework, and relies on an amazing [ecosystem](./Ecosystem.md)!
+
 ### Test your server
-Fastify does not offer a testing framework, but we do recommend a way to write your tests that uses the features and architecture of Fastify.<br>
-Read the [testing](https://github.com/fastify/fastify/blob/master/docs/Testing.md) documentation to learn more!
+<a name="test-server"></a>
 
-<a name="cli"></a>
+Fastify does not offer a testing framework, but we do recommend a way to write your tests that uses the features and architecture of Fastify.<br/>
+Read the [testing](./Testing.md) documentation to learn more!
+
 ### Run your server from CLI
+<a name="cli"></a>
+
 Fastify also has CLI integration thanks to [fastify-cli](https://github.com/fastify/fastify-cli).
 
 First, install `fastify-cli`:
@@ -331,8 +343,9 @@ Then run your server with:
 npm start
 ```
 
-<a name="slides"></a>
 ### Slides and Videos
+<a name="slides"></a>
+
 - Slides
   - [Take your HTTP server to ludicrous speed](https://mcollina.github.io/take-your-http-server-to-ludicrous-speed) by [@mcollina](https://github.com/mcollina)
   - [What if I told you that HTTP can be fast](https://delvedor.github.io/What-if-I-told-you-that-HTTP-can-be-fast) by [@delvedor](https://github.com/delvedor)

--- a/docs/HTTP2.md
+++ b/docs/HTTP2.md
@@ -1,6 +1,8 @@
-<h1 align="center">Fastify</h1>
-
-## HTTP2
+---
+title: HTTP2
+sidebar_label: HTTP2
+hide_title: false
+---
 
 _Fastify_ offers **experimental support** for HTTP2 starting from Node
 8.8.0, which includes HTTP2 without a flag. _Fastify_ supports HTTP2

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -1,6 +1,8 @@
-<h1 align="center">Fastify</h1>
-
-## Hooks
+---
+title: Hooks
+sidebar_label: Hooks
+hide_title: false
+---
 
 Hooks are registered with the `fastify.addHook` method and allow you to listen to specific events in the application or request/response lifecycle. You have to register a hook before the event is triggered, otherwise the event is lost.
 
@@ -22,15 +24,17 @@ By using hooks you can interact directly with the lifecycle of Fastify. There ar
   - [onClose](#onclose)
   - [onRoute](#onroute)
   - [onRegister](#onregister)
+  - [Scope](#scope)
+- [Route level hooks](#route-level-hooks)
 
 **Notice:** the `done` callback is not available when using `async`/`await` or returning a `Promise`. If you do invoke a `done` callback in this situation unexpected behaviour may occur, e.g. duplicate invocation of handlers.
 
 ## Request/Reply Hooks
 
-[Request](https://github.com/fastify/fastify/blob/master/docs/Request.md) and [Reply](https://github.com/fastify/fastify/blob/master/docs/Reply.md) are the core Fastify objects.<br/>
-`done` is the function to continue with the [lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md).
+[Request](./Request.md) and [Reply](./Reply.md) are the core Fastify objects.<br/>
+`done` is the function to continue with the [lifecycle](./Lifecycle.md).
 
-It is pretty easy to understand where each hook is executed by looking at the [lifecycle page](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md).<br>
+It is pretty easy to understand where each hook is executed by looking at the [lifecycle page](./Lifecycle.md).<br/>
 Hooks are affected by Fastify's encapsulation, and can thus be applied to selected routes. See the [Scopes](#scope) section for more information.
 
 There are eight different hooks that you can use in Request/Reply *(in order of execution)*:
@@ -209,7 +213,7 @@ fastify.addHook('preHandler', (request, reply, done) => {
   done(new Error('Some error'))
 })
 ```
-*The error will be handled by [`Reply`](https://github.com/fastify/fastify/blob/master/docs/Reply.md#errors).*
+*The error will be handled by [`Reply`](./Reply.md#errors).*
 
 Or if you're using `async/await` you can just throw an error:
 ```js
@@ -310,9 +314,10 @@ fastify.addHook('onReady', async function () {
 })
 ```
 
-<a name="on-close"></a>
 ### onClose
-Triggered when `fastify.close()` is invoked to stop the server. It is useful when [plugins](https://github.com/fastify/fastify/blob/master/docs/Plugins.md) need a "shutdown" event, for example to close an open connection to a database.<br>
+<a name="on-close"></a>
+
+Triggered when `fastify.close()` is invoked to stop the server. It is useful when [plugins](./Plugins.md) need a "shutdown" event, for example to close an open connection to a database.<br/>
 The first argument is the Fastify instance, the second one the `done` callback.
 ```js
 fastify.addHook('onClose', (instance, done) => {
@@ -321,8 +326,9 @@ fastify.addHook('onClose', (instance, done) => {
 })
 ```
 
-<a name="on-route"></a>
 ### onRoute
+<a name="on-route"></a>
+
 Triggered when a new route is registered. Listeners are passed a `routeOptions` object as the sole parameter. The interface is synchronous, and, as such, the listeners do not get passed a callback.
 ```js
 fastify.addHook('onRoute', (routeOptions) => {
@@ -350,8 +356,9 @@ fastify.addHook('onRoute', (routeOptions) => {
 })
 ```
 
-<a name="on-register"></a>
 ### onRegister
+<a name="on-register"></a>
+
 Triggered when a new plugin is registered and a new encapsulation context is created. The hook will be executed **before** the registered code.<br/>
 This hook can be useful if you are developing a plugin that needs to know when a plugin context is formed, and you want to operate in that specific context.<br/>
 **Note:** This hook will not be called if a plugin is wrapped inside [`fastify-plugin`](https://github.com/fastify/fastify-plugin).
@@ -384,9 +391,10 @@ fastify.addHook('onRegister', (instance, opts) => {
 })
 ```
 
-<a name="scope"></a>
 ### Scope
-Except for [Application Hooks](#application-hooks), all hooks are encapsulated. This means that you can decide where your hooks should run by using `register` as explained in the [plugins guide](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md). If you pass a function, that function is bound to the right Fastify context and from there you have full access to the Fastify API.
+<a name="scope"></a>
+
+Except for [Application Hooks](#application-hooks), all hooks are encapsulated. This means that you can decide where your hooks should run by using `register` as explained in the [plugins guide](./Plugins-Guide.md). If you pass a function, that function is bound to the right Fastify context and from there you have full access to the Fastify API.
 
 ```js
 fastify.addHook('onRequest', function (request, reply, done) {
@@ -396,9 +404,9 @@ fastify.addHook('onRequest', function (request, reply, done) {
 ```
 Note: using an arrow function will break the binding of this to the Fastify instance.
 
+## Route level hooks
 <a name="route-hooks"></a>
 
-## Route level hooks
 You can declare one or more custom [onRequest](#onRequest), [onReponse](#onResponse), [preParsing](#preParsing), [preValidation](#preValidation), [preHandler](#preHandler) and [preSerialization](#preSerialization) hook(s) that will be **unique** for the route.
 If you do so, those hooks are always executed as the last hook in their category. <br/>
 This can be useful if you need to implement authentication, where the [preParsing](#preParsing) or [preValidation](#preValidation) hooks are exactly what you need.

--- a/docs/LTS.md
+++ b/docs/LTS.md
@@ -1,8 +1,8 @@
-<h1 align="center">Fastify</h1>
-
-<a name="lts"></a>
-
-## Long Term Support
+---
+title: Long Term Support
+sidebar_label: Long Term Support
+hide_title: false
+---
 
 Fastify's Long Term Support (LTS) is provided according the schedule laid
 out in this document:

--- a/docs/Lifecycle.md
+++ b/docs/Lifecycle.md
@@ -1,7 +1,10 @@
-<h1 align="center">Fastify</h1>
+---
+title: Lifecycle
+sidebar_label: Lifecycle
+hide_title: false
+---
 
-## Lifecycle
-Following the schema of the internal lifecycle of Fastify.<br>
+Following the schema of the internal lifecycle of Fastify.<br/>
 On the right branch of every section there is the next phase of the lifecycle, on the left branch there is the corresponding error code that will be generated if the parent throws an error *(note that all the errors are automatically handled by Fastify)*.
 ```
 Incoming Request

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -1,6 +1,8 @@
-<h1 align="center">Fastify</h1>
-
-## Logging
+---
+title: Logging
+sidebar_label: Logging
+hide_title: false
+---
 
 Logging is disabled by default, and you can enable it by passing
 `{ logger: true }` or `{ logger: { level: 'info' } }` when you create
@@ -57,7 +59,7 @@ const fastify = require('fastify')({
 
 <a name="logging-request-id"></a>
 
-By default, fastify adds an id to every request for easier tracking. If the "request-id" header is present its value is used, otherwise a new incremental id is generated. See Fastify Factory [`requestIdHeader`](https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-request-id-header) and Fastify Factory [`genReqId`](https://github.com/fastify/fastify/blob/master/docs/Server.md#gen-request-id) for customization options.
+By default, fastify adds an id to every request for easier tracking. If the "request-id" header is present its value is used, otherwise a new incremental id is generated. See Fastify Factory [`requestIdHeader`](./Server.md#factory-request-id-header) and Fastify Factory [`genReqId`](./Server.md#gen-request-id) for customization options.
 
 The default logger is configured with a set of standard serializers that serialize objects with `req`, `res`, and `err` properties. This behaviour can be customized by specifying custom serializers.
 ```js
@@ -135,7 +137,7 @@ fastify.get('/', function (request, reply) {
 })
 ```
 
-*The logger instance for the current request is available in every part of the [lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md).*
+*The logger instance for the current request is available in every part of the [lifecycle](./Lifecycle.md).*
 
 ## Log Redaction
 

--- a/docs/Middleware.md
+++ b/docs/Middleware.md
@@ -1,10 +1,12 @@
-<h1 align="center">Fastify</h1>
-
-## Middleware
+---
+title: Middleware
+sidebar_label: Middleware
+hide_title: false
+---
 
 Fastify provides an asynchronous [middleware engine](https://github.com/fastify/middie) out-of-the-box, which is compatible with [Express](https://expressjs.com/) and [Restify](http://restify.com/) middleware.
 
-*For help with understanding when middleware is executed, take a look at the [lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md) page.*
+*For help with understanding when middleware is executed, take a look at the [lifecycle](./Lifecycle.md) page.*
 
 Fastify middleware don't support the full syntax `middleware(err, req, res, next)`, because error handling is done inside Fastify.
 Furthermore, methods added by Express and Restify to the enhanced versions of `req` and `res` are not supported in Fastify middlewares.
@@ -30,12 +32,13 @@ const helmet = require('fastify-helmet')
 fastify.register(helmet)
 ```
 
-Remember that middleware can be encapsulated, this means that you can decide where your middleware should run by using `register` as explained in the [plugins guide](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md).
+Remember that middleware can be encapsulated, this means that you can decide where your middleware should run by using `register` as explained in the [plugins guide](./Plugins-Guide.md).
 
 Fastify middleware also do not expose the `send` method or other methods specific to the Fastify [Reply](./Reply.md#reply) instance. This is because Fastify wraps the incoming `req` and `res` Node instances using the [Request](./Request.md#request) and [Reply](./Reply.md#reply) objects internally, but this is done after the middleware phase. If you need to create middleware, you have to use the Node `req` and `res` instances. Otherwise, you can use the `preHandler` hook which already has the [Request](./Request.md#request) and [Reply](./Reply.md#reply) Fastify instances. For more information, see [Hooks](./Hooks.md#hooks).
 
-<a name="restrict-usage"></a>
 #### Restrict middleware execution to a certain path(s)
+<a name="restrict-usage"></a>
+
 If you need to run a middleware only under certain path(s), just pass the path as first parameter to `use` and you are done!
 
 *Note that this does not support routes with parameters, (eg: `/user/:id/comments`) and wildcards are not supported in multiple paths.*
@@ -54,6 +57,7 @@ fastify.use('/css/*', serveStatic(path.join(__dirname, '/assets')))
 fastify.use(['/css', '/js'], serveStatic(path.join(__dirname, '/assets')))
 ```
 
-<a name="express-middleware"></a>
 #### Express middleware compatibility
+<a name="express-middleware"></a>
+
 Express modifies the prototype of the node core Request and Response objects heavily so Fastify cannot guarantee full middleware compatibility. Express specific functionality such as `res.sendFile()`, `res.send()` or `express.Router()` instances will not work with Fastify. For example, [cors](https://github.com/expressjs/cors) is compatible while [passport](https://github.com/jaredhanson/passport) is not.

--- a/docs/Plugins-Guide.md
+++ b/docs/Plugins-Guide.md
@@ -1,4 +1,8 @@
-<h1 align="center">Fastify</h1>
+---
+title: Plugins Guide
+sidebar_label: Plugins Guide
+hide_title: false
+---
 
 # The hitchhiker's guide to plugins
 First of all, `DON'T PANIC`!
@@ -6,19 +10,21 @@ First of all, `DON'T PANIC`!
 Fastify was built from the beginning to be an extremely modular system. We built a powerful API that allows you to add methods and utilities to Fastify by creating a namespace. We built a system that creates an encapsulation model that allows you to split your application in multiple microservices at any moment, without the need to refactor the entire application.
 
 **Table of contents**
-- [Register](#register)
-- [Decorators](#decorators)
-- [Hooks](#hooks)
-- [Middlewares](#middlewares)
-- [How to handle encapsulation and distribution](#distribution)
-- [ESM support](#esm-support)
-- [Handle errors](#handle-errors)
-- [Let's start!](#start)
+- [The hitchhiker's guide to plugins](#the-hitchhikers-guide-to-plugins)
+  - [Register](#register)
+  - [Decorators](#decorators)
+  - [Hooks](#hooks)
+  - [Middleware](#middleware)
+  - [How to handle encapsulation and distribution](#how-to-handle-encapsulation-and-distribution)
+  - [ESM support](#esm-support)
+  - [Handle errors](#handle-errors)
+  - [Let's start!](#lets-start)
 
-<a name="register"></a>
 ## Register
-As with JavaScript, where everything is an object, in Fastify everything is a plugin.<br>
-Your routes, your utilities and so on are all plugins. To add a new plugin, whatever its functionality may be, in Fastify you have a nice and unique API: [`register`](https://github.com/fastify/fastify/blob/master/docs/Plugins.md).
+<a name="register"></a>
+
+As with JavaScript, where everything is an object, in Fastify everything is a plugin.<br/>
+Your routes, your utilities and so on are all plugins. To add a new plugin, whatever its functionality may be, in Fastify you have a nice and unique API: [`register`](./Plugins.md).
 ```js
 fastify.register(
   require('./my-plugin'),
@@ -27,12 +33,12 @@ fastify.register(
 ```
 `register` creates a new Fastify context, which means that if you perform any changes on the Fastify instance, those changes will not be reflected in the context's ancestors. In other words, encapsulation!
 
-*Why is encapsulation important?*<br>
-Well, let's say you are creating a new disruptive startup, what do you do? You create an API server with all your stuff, everything in the same place, a monolith!<br>
-Ok, you are growing very fast and you want to change your architecture and try microservices. Usually, this implies a huge amount of work, because of cross dependencies and a lack of separation of concerns in the codebase.<br>
+*Why is encapsulation important?*<br/>
+Well, let's say you are creating a new disruptive startup, what do you do? You create an API server with all your stuff, everything in the same place, a monolith!<br/>
+Ok, you are growing very fast and you want to change your architecture and try microservices. Usually, this implies a huge amount of work, because of cross dependencies and a lack of separation of concerns in the codebase.<br/>
 Fastify helps you in that regard. Thanks to the encapsulation model it will completely avoid cross dependencies, and will help you structure your code into cohesive blocks.
 
-*Let's return to how to correctly use `register`.*<br>
+*Let's return to how to correctly use `register`.*<br/>
 As you probably know, the required plugins must expose a single function with the following signature
 ```js
 module.exports = function (fastify, options, done) {}
@@ -54,8 +60,9 @@ module.exports = function (fastify, options, done) {
 
 Well, now you know how to use the `register` API and how it works, but how do we add new functionality to Fastify and even better, share them with other developers?
 
-<a name="decorators"></a>
 ## Decorators
+<a name="decorators"></a>
+
 Okay, let's say that you wrote a utility that is so good that you decided to make it available along with all your code. How would you do it? Probably something like the following:
 ```js
 // your-awesome-utility.js
@@ -70,11 +77,11 @@ console.log(util('that is ', 'awesome'))
 And now you will import your utility in every file you need it in. (And don't forget that you will probably also need it in your tests).
 
 Fastify offers you a more elegant and comfortable way to do this, *decorators*.
-Creating a decorator is extremely easy, just use the [`decorate`](https://github.com/fastify/fastify/blob/master/docs/Decorators.md) API:
+Creating a decorator is extremely easy, just use the [`decorate`](./Decorators.md) API:
 ```js
 fastify.decorate('util', (a, b) => a + b)
 ```
-Now you can access your utility just by calling `fastify.util` whenever you need it - even inside your test.<br>
+Now you can access your utility just by calling `fastify.util` whenever you need it - even inside your test.<br/>
 And here starts the magic; do you remember how just now we were talking about encapsulation? Well, using `register` and `decorate` in conjunction enable exactly that, let me show you an example to clarify this:
 ```js
 fastify.register((instance, opts, done) => {
@@ -90,7 +97,7 @@ fastify.register((instance, opts, done) => {
   done()
 })
 ```
-Inside the second register call `instance.util` will throw an error, because `util` exists only inside the first register context.<br>
+Inside the second register call `instance.util` will throw an error, because `util` exists only inside the first register context.<br/>
 Let's step back for a moment and dig deeper into this: every time you use the `register` API, a new context is created which avoids the negative situations mentioned above.
 
 Do note that encapsulation applies to the ancestors and siblings, but not the children.
@@ -117,7 +124,7 @@ fastify.register((instance, opts, done) => {
 
 `decorate` is not the only API that you can use to extend the server functionality, you can also use `decorateRequest` and `decorateReply`.
 
-*`decorateRequest` and `decorateReply`? Why do we need them if we already have `decorate`?*<br>
+*`decorateRequest` and `decorateReply`? Why do we need them if we already have `decorate`?*<br/>
 Good question, we added them to make Fastify more developer-friendly. Let's see an example:
 ```js
 fastify.decorate('html', payload => {
@@ -175,10 +182,11 @@ fastify.get('/happiness', (request, reply) => {
 })
 ```
 
-We've seen how to extend server functionality and how to handle the encapsulation system, but what if you need to add a function that must be executed every time when the server "[emits](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md)" an event?
+We've seen how to extend server functionality and how to handle the encapsulation system, but what if you need to add a function that must be executed every time when the server "[emits](./Lifecycle.md)" an event?
 
-<a name="hooks"></a>
 ## Hooks
+<a name="hooks"></a>
+
 You just built an amazing utility, but now you need to execute that for every request, this is what you will likely do:
 ```js
 fastify.decorate('util', (request, key, value) => { request[key] = value })
@@ -195,7 +203,7 @@ fastify.get('/plugin2', (request, reply) => {
 ```
 I think we all agree that this is terrible. Repeated code, awful readability and it cannot scale.
 
-So what can you do to avoid this annoying issue? Yes, you are right, use a [hook](https://github.com/fastify/fastify/blob/master/docs/Hooks.md)!<br>
+So what can you do to avoid this annoying issue? Yes, you are right, use a [hook](./Hooks.md)!<br/>
 ```js
 fastify.decorate('util', (request, key, value) => { request[key] = value })
 
@@ -212,7 +220,7 @@ fastify.get('/plugin2', (request, reply) => {
   reply.send(request)
 })
 ```
-Now for every request, you will run your utility. Obviously you can register as many hooks as you need.<br>
+Now for every request, you will run your utility. Obviously you can register as many hooks as you need.<br/>
 Sometimes you want a hook that should be executed for just a subset of routes, how can you do that? Yep, encapsulation!
 
 ```js
@@ -237,11 +245,12 @@ fastify.get('/plugin2', (request, reply) => {
 ```
 Now your hook will run just for the first route!
 
-As you probably noticed by now, `request` and `reply` are not the standard Nodejs *request* and *response* objects, but Fastify's objects.<br>
+As you probably noticed by now, `request` and `reply` are not the standard Nodejs *request* and *response* objects, but Fastify's objects.<br/>
 
-<a name="middleware"></a>
 ## Middleware
-Fastify [supports](https://github.com/fastify/fastify/blob/master/docs/Middleware.md) Express/Restify/Connect middleware out-of-the-box, which means that you can just drop-in your old code and it will work! *(faster, by the way)*<br>
+<a name="middleware"></a>
+
+Fastify [supports](./Middleware.md) Express/Restify/Connect middleware out-of-the-box, which means that you can just drop-in your old code and it will work! *(faster, by the way)*<br/>
 Let's say that you are arriving from Express, and you already have some Middleware which does exactly what you need, and you don't want to redo all the work.
 How we can do that? Check out our middleware engine, [middie](https://github.com/fastify/middie).
 ```js
@@ -249,13 +258,14 @@ const yourMiddleware = require('your-middleware')
 fastify.use(yourMiddleware)
 ```
 
-<a name="distribution"></a>
 ## How to handle encapsulation and distribution
+<a name="distribution"></a>
+
 Perfect, now you know (almost) all of the tools that you can use to extend Fastify. But chances are that you came across one big issue: how is distribution handled?
 
 The preferred way to distribute a utility is to wrap all your code inside a `register`, in this way your plugin can support asynchronous bootstrapping *(since `decorate` is a synchronous API)*, in the case of a database connection for example.
 
-*Wait, what? Didn't you tell me that `register` creates an encapsulation and that the stuff I create inside will not be available outside?*<br>
+*Wait, what? Didn't you tell me that `register` creates an encapsulation and that the stuff I create inside will not be available outside?*<br/>
 Yes, I said that. But what I didn't tell you, is that you can tell to Fastify to avoid this behaviour, with the [`fastify-plugin`](https://github.com/fastify/fastify-plugin) module.
 ```js
 const fp = require('fastify-plugin')
@@ -272,7 +282,7 @@ module.exports = fp(dbPlugin)
 ```
 You can also tell `fastify-plugin` to check the installed version of Fastify, in case you need a specific API.
 
-As we mentioned earlier, Fastify starts loading its plugins __after__ `.listen()`, `.inject()` or `.ready()` are called and as such, __after__ they have been declared. This means that, even though the plugin may inject variables to the external fastify instance via [`decorate`](https://github.com/fastify/fastify/blob/master/docs/Decorators.md), the decorated variables will not be accessible before calling `.listen()`, `.inject()` or `.ready()`.
+As we mentioned earlier, Fastify starts loading its plugins __after__ `.listen()`, `.inject()` or `.ready()` are called and as such, __after__ they have been declared. This means that, even though the plugin may inject variables to the external fastify instance via [`decorate`](./Decorators.md), the decorated variables will not be accessible before calling `.listen()`, `.inject()` or `.ready()`.
 
 In case you rely on a variable injected by a preceding plugin and want to pass that in the `options` argument of `register`, you can do so by using a function instead of an object:
 ```js
@@ -294,8 +304,8 @@ fastify.register(require('your-plugin'), parent => {
 ```
 In the above example, the `parent` variable of the function passed in as the second argument of `register` is a copy of the **external fastify instance** that the plugin was registered at. This means that we are able to access any variables that were injected by preceding plugins in the order of declaration.
 
-<a name="esm-support"></a>
 ## ESM support
+<a name="esm-support"></a>
 
 ESM is supported as well from [Node.js `v13.3.0`](https://nodejs.org/api/esm.html) and above! Just export your plugin as ESM module and you are good to go!
 
@@ -310,10 +320,11 @@ async function plugin (fastify, opts) {
 export default plugin
 ```
 
-<a name="handle-errors"></a>
 ## Handle errors
+<a name="handle-errors"></a>
+
 It can happen that one of your plugins fails during startup. Maybe you expect it and you have a custom logic that will be triggered in that case. How can you implement this?
-The `after` API is what you need. `after` simply registers a callback that will be executed just after a register, and it can take up to three parameters.<br>
+The `after` API is what you need. `after` simply registers a callback that will be executed just after a register, and it can take up to three parameters.<br/>
 The callback changes based on the parameters you are giving:
 
 1. If no parameter is given to the callback and there is an error, that error will be passed to the next error handler.
@@ -330,8 +341,9 @@ fastify
   })
 ```
 
-<a name="start"></a>
 ## Let's start!
+<a name="start"></a>
+
 Awesome, now you know everything you need to know about Fastify and its plugin system to start building your first plugin, and please if you do, tell us! We will add it to the [*ecosystem*](https://github.com/fastify/fastify#ecosystem) section of our documentation!
 
 If you want to see some real-world example, check out:

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -1,23 +1,27 @@
-<h1 align="center">Fastify</h1>
+---
+title: Plugins
+sidebar_label: Plugins
+hide_title: false
+---
 
-## Plugins
 Fastify allows the user to extend its functionalities with plugins.
-A plugin can be a set of routes, a server [decorator](https://github.com/fastify/fastify/blob/master/docs/Decorators.md) or whatever. The API that you will need to use one or more plugins, is `register`.<br>
+A plugin can be a set of routes, a server [decorator](./Decorators.md) or whatever. The API that you will need to use one or more plugins, is `register`.<br/>
 
 By default, `register` creates a *new scope*, this means that if you do some changes to the Fastify instance (via `decorate`), this change will not be reflected to the current context ancestors, but only to its sons. This feature allows us to achieve plugin *encapsulation* and *inheritance*, in this way we create a *direct acyclic graph* (DAG) and we will not have issues caused by cross dependencies.
 
-You already see in the [getting started](https://github.com/fastify/fastify/blob/master/docs/Getting-Started.md#register) section how using this API is pretty straightforward.
+You already see in the [getting started](./Getting-Started.md#register) section how using this API is pretty straightforward.
 ```
 fastify.register(plugin, [options])
 ```
 
-<a name="plugin-options"></a>
 ### Plugin Options
+<a name="plugin-options"></a>
+
 The optional `options` parameter for `fastify.register` supports a predefined set of options that Fastify itself will use, except when the plugin has been wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This options object will also be passed to the plugin upon invocation, regardless of whether or not the plugin has been wrapped. The currently supported list of Fastify specific options is:
 
-+ [`logLevel`](https://github.com/fastify/fastify/blob/master/docs/Routes.md#custom-log-level)
-+ [`logSerializers`](https://github.com/fastify/fastify/blob/master/docs/Routes.md#custom-log-serializer)
-+ [`prefix`](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#route-prefixing-options)
++ [`logLevel`](./Routes.md#custom-log-level)
++ [`logSerializers`](./Routes.md#custom-log-serializer)
++ [`prefix`](./Plugins.md#route-prefixing-options)
 
 **Note: Those options will be ignored when used with fastify-plugin**
 
@@ -58,18 +62,20 @@ fastify.register(fp((fastify, opts, done) => {
 fastify.register(require('fastify-foo'), parent => parent.foo_bar)
 ```
 
-The fastify instance passed on to the function is the latest state of the **external fastify instance** the plugin was declared on, allowing access to variables injected via [`decorate`](https://github.com/fastify/fastify/blob/master/docs/Decorators.md) by preceding plugins according to the **order of registration**. This is useful in case a plugin depends on changes made to the Fastify instance by a preceding plugin f.e. utilizing an existing database connection to wrap around it.
+The fastify instance passed on to the function is the latest state of the **external fastify instance** the plugin was declared on, allowing access to variables injected via [`decorate`](./Decorators.md) by preceding plugins according to the **order of registration**. This is useful in case a plugin depends on changes made to the Fastify instance by a preceding plugin f.e. utilizing an existing database connection to wrap around it.
 
 Keep in mind that the fastify instance passed on to the function is the same as the one that will be passed in to the plugin, a copy of the external fastify instance rather than a reference. Any usage of the instance will behave the same as it would if called within the plugin's function i.e. if `decorate` is called, the decorated variables will be available within the plugin's function unless it was wrapped with [`fastify-plugin`](https://github.com/fastify/fastify-plugin).
 
-<a name="route-prefixing-option"></a>
 #### Route Prefixing option
-If you pass an option with the key `prefix` with a `string` value, Fastify will use it to prefix all the routes inside the register, for more info check [here](https://github.com/fastify/fastify/blob/master/docs/Routes.md#route-prefixing).<br>
+<a name="route-prefixing-option"></a>
+
+If you pass an option with the key `prefix` with a `string` value, Fastify will use it to prefix all the routes inside the register, for more info check [here](./Routes.md#route-prefixing).<br/>
 Be aware that if you use [`fastify-plugin`](https://github.com/fastify/fastify-plugin) this option won't work.
 
-<a name="error-handling"></a>
 #### Error handling
-The error handling is done by [avvio](https://github.com/mcollina/avvio#error-handling).<br>
+<a name="error-handling"></a>
+
+The error handling is done by [avvio](https://github.com/mcollina/avvio#error-handling).<br/>
 As general rule, it is highly recommended that you handle your errors in the next `after` or `ready` block, otherwise you will get them inside the `listen` callback.
 
 ```js
@@ -99,8 +105,8 @@ await fastify.ready()
 await fastify.listen(3000)
 ```
 
-<a name="esm-support"></a>
 #### ESM support
+<a name="esm-support"></a>
 
 ESM is supported as well from [Node.js `v13.3.0`](https://nodejs.org/api/esm.html) and above!
 
@@ -124,9 +130,10 @@ async function plugin (fastify, opts) {
 export default plugin
 ```
 
-<a name="create-plugin"></a>
 ### Create a plugin
-Creating a plugin is very easy, you just need to create a function that takes three parameters, the `fastify` instance, an `options` object and the `done` callback.<br>
+<a name="create-plugin"></a>
+
+Creating a plugin is very easy, you just need to create a function that takes three parameters, the `fastify` instance, an `options` object and the `done` callback.<br/>
 Example:
 ```js
 module.exports = function (fastify, opts, done) {
@@ -149,13 +156,14 @@ module.exports = function (fastify, opts, done) {
   done()
 }
 ```
-Sometimes, you will need to know when the server is about to close, for example because you must close a connection to a database. To know when this is going to happen, you can use the [`'onClose'`](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#on-close) hook.
+Sometimes, you will need to know when the server is about to close, for example because you must close a connection to a database. To know when this is going to happen, you can use the [`'onClose'`](./Hooks.md#on-close) hook.
 
 Do not forget that `register` will always create a new Fastify scope, if you don't need that, read the following section.
 
-<a name="handle-scope"></a>
 ### Handle the scope
-If you are using `register` only for extending the functionality of the server with  [`decorate`](https://github.com/fastify/fastify/blob/master/docs/Decorators.md), it is your responsibility to tell Fastify to not create a new scope, otherwise your changes will not be accessible by the user in the upper scope.
+<a name="handle-scope"></a>
+
+If you are using `register` only for extending the functionality of the server with  [`decorate`](./Decorators.md), it is your responsibility to tell Fastify to not create a new scope, otherwise your changes will not be accessible by the user in the upper scope.
 
 You have two ways to tell Fastify to avoid the creation of a new context:
 - Use the [`fastify-plugin`](https://github.com/fastify/fastify-plugin) module

--- a/docs/Recommendations.md
+++ b/docs/Recommendations.md
@@ -1,14 +1,16 @@
-<h1 align="center">Fastify</h1>
-
-## Recommendations
+---
+title: Recommendations
+sidebar_label: Recommendations
+hide_title: false
+---
 
 This document contains a set recommendations, or best practices, when using
 Fastify.
 
-* [Use A Reverse Proxy](#reverseproxy)
+- [Use A Reverse Proxy](#use-a-reverse-proxy)
 
 ## Use A Reverse Proxy
-<a id="reverseproxy"></a>
+<a name="reverseproxy"></a>
 
 Node.js is an early adopter of frameworks shipping with an easy to use web
 server within the standard library. Previously, with languages like PHP or

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -1,33 +1,36 @@
-<h1 align="center">Fastify</h1>
+---
+title: Reply
+sidebar_label: Reply
+hide_title: false
+---
 
-## Reply
-- [Reply](#reply)
-  - [Introduction](#introduction)
-  - [.code(statusCode)](#codestatuscode)
-  - [.statusCode](#statusCode)
-  - [.header(key, value)](#headerkey-value)
-  - [.headers(object)](#headersobject)
-  - [.getHeader(key)](#getheaderkey)
-  - [.removeHeader(key)](#removeheaderkey)
-  - [.hasHeader(key)](#hasheaderkey)
-  - [.redirect(dest)](#redirectdest)
-  - [.callNotFound()](#callnotfound)
-  - [.getResponseTime()](#getresponsetime)
-  - [.type(contentType)](#typecontenttype)
-  - [.serializer(func)](#serializerfunc)
-  - [.sent](#sent)
-  - [.send(data)](#senddata)
-    - [Objects](#objects)
-    - [Strings](#strings)
-    - [Streams](#streams)
-    - [Buffers](#buffers)
-    - [Errors](#errors)
-    - [Type of the final payload](#type-of-the-final-payload)
-    - [Async-Await and Promises](#async-await-and-promises)
-  - [.then](#then)
+- [Introduction](#introduction)
+- [.code(statusCode)](#codestatuscode)
+- [.statusCode](#statuscode)
+- [.header(key, value)](#headerkey-value)
+- [.headers(object)](#headersobject)
+- [.getHeader(key)](#getheaderkey)
+- [.removeHeader(key)](#removeheaderkey)
+- [.hasHeader(key)](#hasheaderkey)
+- [.redirect([code ,] dest)](#redirectcode--dest)
+- [.callNotFound()](#callnotfound)
+- [.getResponseTime()](#getresponsetime)
+- [.type(contentType)](#typecontenttype)
+- [.serializer(func)](#serializerfunc)
+- [.sent](#sent)
+- [.send(data)](#senddata)
+  - [Objects](#objects)
+  - [Strings](#strings)
+  - [Streams](#streams)
+  - [Buffers](#buffers)
+  - [Errors](#errors)
+  - [Type of the final payload](#type-of-the-final-payload)
+  - [Async-Await and Promises](#async-await-and-promises)
+- [.then(fullfilled, rejected)](#thenfullfilled-rejected)
 
-<a name="introduction"></a>
 ### Introduction
+<a name="introduction"></a>
+
 The second parameter of the handler function is `Reply`.
 Reply is a core Fastify object that exposes the following functions
 and properties:
@@ -69,12 +72,14 @@ fastify.get('/', {config: {foo: 'bar'}}, function (request, reply) {
 })
 ```
 
-<a name="code"></a>
 ### .code(statusCode)
+<a name="code"></a>
+
 If not set via `reply.code`, the resulting `statusCode` will be `200`.
 
-<a name="statusCode"></a>
 ### .statusCode
+<a name="statusCode"></a>
+
 This property reads and sets the HTTP status code. It is an alias for `reply.code()` when used as a setter.
 ```js
 if (reply.statusCode >= 299) {
@@ -82,15 +87,17 @@ if (reply.statusCode >= 299) {
 }
 ```
 
-<a name="header"></a>
 ### .header(key, value)
+<a name="header"></a>
+
 Sets a response header. If the value is omitted or undefined it is coerced
 to `''`.
 
 For more information, see [`http.ServerResponse#setHeader`](https://nodejs.org/dist/latest/docs/api/http.html#http_response_setheader_name_value).
 
-<a name="headers"></a>
 ### .headers(object)
+<a name="headers"></a>
+
 Sets all the keys of the object as response headers. [`.header`](#headerkey-value) will be called under the hood.
 ```js
 reply.headers({
@@ -99,16 +106,17 @@ reply.headers({
 })
 ```
 
-<a name="getHeader"></a>
 ### .getHeader(key)
+<a name="getHeader"></a>
+
 Retrieves the value of a previously set header.
 ```js
 reply.header('x-foo', 'foo') // setHeader: key, value
 reply.getHeader('x-foo') // 'foo'
 ```
 
-<a name="getHeader"></a>
 ### .removeHeader(key)
+<a name="getHeader"></a>
 
 Remove the value of a previously set header.
 ```js
@@ -117,12 +125,14 @@ reply.removeHeader('x-foo')
 reply.getHeader('x-foo') // undefined
 ```
 
-<a name="hasHeader"></a>
 ### .hasHeader(key)
+<a name="hasHeader"></a>
+
 Returns a boolean indicating if the specified header has been set.
 
-<a name="redirect"></a>
 ### .redirect([code ,] dest)
+<a name="redirect"></a>
+
 Redirects a request to the specified url, the status code is optional, default to `302` (if status code is not already set by calling `code`).
 
 Example (no `reply.code()` call) sets status code to `302` and redirects to `/home`
@@ -145,24 +155,27 @@ Example (`reply.code()` call) sets status code to `302` and redirects to `/home`
 reply.code(303).redirect(302, '/home')
 ```
 
-<a name="call-not-found"></a>
 ### .callNotFound()
-Invokes the custom not found handler. Note that it will only call `preHandler` hook specified in [`setNotFoundHandler`](https://github.com/fastify/fastify/blob/master/docs/Server.md#set-not-found-handler).
+<a name="call-not-found"></a>
+
+Invokes the custom not found handler. Note that it will only call `preHandler` hook specified in [`setNotFoundHandler`](./Server.md#set-not-found-handler).
 
 ```js
 reply.callNotFound()
 ```
 
-<a name="getResponseTime"></a>
 ### .getResponseTime()
+<a name="getResponseTime"></a>
+
 Invokes the custom response time getter to calculate the amount of time passed since the request was started.
 
 ```js
 const milliseconds = reply.getResponseTime()
 ```
 
-<a name="type"></a>
 ### .type(contentType)
+<a name="type"></a>
+
 Sets the content type for the response.
 This is a shortcut for `reply.header('Content-Type', 'the/type')`.
 
@@ -170,8 +183,9 @@ This is a shortcut for `reply.header('Content-Type', 'the/type')`.
 reply.type('text/html')
 ```
 
-<a name="serializer"></a>
 ### .serializer(func)
+<a name="serializer"></a>
+
 `.send()` will by default JSON-serialize any value that is not one of: `Buffer`, `stream`, `string`, `undefined`, `Error`. If you need to replace the default serializer with a custom serializer for a particular request, you can do so with the `.serializer()` utility. Be aware that if you are using a custom serializer, you must set a custom `'Content-Type'` header.
 
 ```js
@@ -190,8 +204,8 @@ reply
 
 See [`.send()`](#send) for more information on sending different types of values.
 
-<a name="sent"></a>
 ### .sent
+<a name="sent"></a>
 
 As the name suggests, `.sent` is a property to indicate if
 a response has been sent via `reply.send()`.
@@ -216,12 +230,14 @@ app.get('/', (req, reply) => {
 
 If the handler rejects, the error will be logged.
 
-<a name="send"></a>
 ### .send(data)
+<a name="send"></a>
+
 As the name suggests, `.send()` is the function that sends the payload to the end user.
 
-<a name="send-object"></a>
 #### Objects
+<a name="send-object"></a>
+
 As noted above, if you are sending JSON objects, `send` will serialize the object with [fast-json-stringify](https://www.npmjs.com/package/fast-json-stringify) if you set an output schema, otherwise `JSON.stringify()` will be used.
 ```js
 fastify.get('/json', options, function (request, reply) {
@@ -229,8 +245,9 @@ fastify.get('/json', options, function (request, reply) {
 })
 ```
 
-<a name="send-string"></a>
 #### Strings
+<a name="send-string"></a>
+
 If you pass a string to `send` without a `Content-Type`, it will be sent as `text/plain; charset=utf-8`. If you set the `Content-Type` header and pass a string to `send`, it will be serialized with the custom serializer if one is set, otherwise it will be sent unmodified (unless the `Content-Type` header is set to `application/json; charset=utf-8`, in which case it will be JSON-serialized like an object — see the section above).
 ```js
 fastify.get('/json', options, function (request, reply) {
@@ -238,8 +255,9 @@ fastify.get('/json', options, function (request, reply) {
 })
 ```
 
-<a name="send-streams"></a>
 #### Streams
+<a name="send-streams"></a>
+
 *send* can also handle streams out of the box, internally uses [pump](https://www.npmjs.com/package/pump) to avoid leaks of file descriptors. If you are sending a stream and you have not set a `'Content-Type'` header, *send* will set it at `'application/octet-stream'`.
 ```js
 fastify.get('/streams', function (request, reply) {
@@ -249,8 +267,9 @@ fastify.get('/streams', function (request, reply) {
 })
 ```
 
-<a name="send-buffers"></a>
 #### Buffers
+<a name="send-buffers"></a>
+
 If you are sending a buffer and you have not set a `'Content-Type'` header, *send* will set it to `'application/octet-stream'`.
 ```js
 const fs = require('fs')
@@ -261,8 +280,9 @@ fastify.get('/streams', function (request, reply) {
 })
 ```
 
-<a name="errors"></a>
 #### Errors
+<a name="errors"></a>
+
 If you pass to *send* an object that is an instance of *Error*, Fastify will automatically create an error structured as the following:
 ```js
 {
@@ -272,7 +292,7 @@ If you pass to *send* an object that is an instance of *Error*, Fastify will aut
   statusCode: Number   // the http status code
 }
 ```
-You can add some custom property to the Error object, such as `headers`, that will be used to enhance the http response.<br>
+You can add some custom property to the Error object, such as `headers`, that will be used to enhance the http response.<br/>
 *Note: If you are passing an error to `send` and the statusCode is less than 400, Fastify will automatically set it at 500.*
 
 Tip: you can simplify errors by using the [`http-errors`](https://npm.im/http-errors) module or [`fastify-sensible`](https://github.com/fastify/fastify-sensible) plugin to generate errors:
@@ -283,7 +303,7 @@ fastify.get('/', function (request, reply) {
 })
 ```
 
-If you want to completely customize the error handling, checkout [`setErrorHandler`](https://github.com/fastify/fastify/blob/master/docs/Server.md#seterrorhandler) API.<br>
+If you want to completely customize the error handling, checkout [`setErrorHandler`](./Server.md#seterrorhandler) API.<br/>
 *Note: you are responsibile for logging when customizing the error handler*
 
 API:
@@ -299,7 +319,7 @@ fastify.setErrorHandler(function (error, request, reply) {
 })
 ```
 
-The not found errors generated by the router will use the  [`setNotFoundHandler`](https://github.com/fastify/fastify/blob/master/docs/Server.md#setnotfoundhandler)
+The not found errors generated by the router will use the  [`setNotFoundHandler`](./Server.md#setnotfoundhandler)
 
 API:
 
@@ -312,9 +332,10 @@ fastify.setNotFoundHandler(function (request, reply) {
 })
 ```
 
-<a name="payload-type"></a>
 #### Type of the final payload
-The type of the sent payload (after serialization and going through any [`onSend` hooks](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#the-onsend-hook)) must be one of the following types, otherwise an error will be thrown:
+<a name="payload-type"></a>
+
+The type of the sent payload (after serialization and going through any [`onSend` hooks](./Hooks.md#the-onsend-hook)) must be one of the following types, otherwise an error will be thrown:
 
 - `string`
 - `Buffer`
@@ -322,9 +343,10 @@ The type of the sent payload (after serialization and going through any [`onSend
 - `undefined`
 - `null`
 
-<a name="async-await-promise"></a>
 #### Async-Await and Promises
-Fastify natively handles promises and supports async-await.<br>
+<a name="async-await-promise"></a>
+
+Fastify natively handles promises and supports async-await.<br/>
 *Note that in the following examples we are not using reply.send.*
 ```js
 const delay = promisify(setTimeout)
@@ -350,10 +372,10 @@ fastify.get('/teapot', async function (request, reply) => {
 })
 ```
 
-If you want to know more please review [Routes#async-await](https://github.com/fastify/fastify/blob/master/docs/Routes.md#async-await).
+If you want to know more please review [Routes#async-await](./Routes.md#async-await).
 
-<a name="then"></a>
 ### .then(fullfilled, rejected)
+<a name="then"></a>
 
 As the name suggests, a `Reply` object can be awaited upon, i.e. `await reply` will wait until the reply is sent.
 The `await` syntax calls the `reply.then()`.

--- a/docs/Request.md
+++ b/docs/Request.md
@@ -1,7 +1,10 @@
-<h1 align="center">Fastify</h1>
+---
+title: Request
+sidebar_label: Request
+hide_title: false
+---
 
-## Request
-The first parameter of the handler function is `Request`.<br>
+The first parameter of the handler function is `Request`.<br/>
 Request is a core Fastify object containing the following fields:
 - `query` - the parsed querystring
 - `body` - the body
@@ -11,7 +14,7 @@ Request is a core Fastify object containing the following fields:
 - `id` - the request id
 - `log` - the logger instance of the incoming request
 - `ip` - the IP address of the incoming request
-- `ips` - an array of the IP addresses in the `X-Forwarded-For` header of the incoming request (only when the [`trustProxy`](https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-trust-proxy) option is enabled)
+- `ips` - an array of the IP addresses in the `X-Forwarded-For` header of the incoming request (only when the [`trustProxy`](./Server.md#factory-trust-proxy) option is enabled)
 - `hostname` - the hostname of the incoming request
 
 ```js

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -1,38 +1,42 @@
-<h1 align="center">Fastify</h1>
-
-## Routes
+---
+title: Routes
+sidebar_label: Routes
+hide_title: false
+---
 
 The routes methods will configure the endpoints of your application. 
 You have two ways to declare a route with Fastify, the shorthand method and the full declaration.
 
-- [Full Declaration](#full-declaration)
-- [Route Options](#options)
-- [Shorthand Declaration](#shorthand-declaration)
-- [URL Parameters](#url-building)
-- [Use `async`/`await`](#async-await)
+- [Full declaration](#full-declaration)
+- [Routes option](#routes-option)
+- [Shorthand declaration](#shorthand-declaration)
+- [Url building](#url-building)
+- [Async Await](#async-await)
 - [Promise resolution](#promise-resolution)
 - [Route Prefixing](#route-prefixing)
-- Logs
-  - [Custom Log Level](#custom-log-level)
-  - [Custom Log Serializer](#custom-log-serializer)
-- [Route handler configuration](#routes-config)
-- [Route's Versioning](#version)
+  - [Handling of / route inside prefixed plugins](#handling-of--route-inside-prefixed-plugins)
+- [Custom Log Level](#custom-log-level)
+- [Custom Log Serializer](#custom-log-serializer)
+- [Config](#config)
+- [Version](#version)
+  - [Default](#default)
+  - [Custom](#custom)
 
-<a name="full-declaration"></a>
 ### Full declaration
+<a name="full-declaration"></a>
 
 ```js
 fastify.route(options)
 ```
 
-<a name="options"></a>
 ### Routes option
+<a name="options"></a>
 
 * `method`: currently it supports `'DELETE'`, `'GET'`, `'HEAD'`, `'PATCH'`, `'POST'`, `'PUT'` and `'OPTIONS'`. It could also be an array of methods.
 * `url`: the path of the url to match this route (alias: `path`).
 * `schema`: an object containing the schemas for the request and response.
 They need to be in
-  [JSON Schema](http://json-schema.org/) format, check [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) for more info.
+  [JSON Schema](http://json-schema.org/) format, check [here](./Validation-and-Serialization.md) for more info.
 
   * `body`: validates the body of the request if it is a POST or a
     PUT.
@@ -43,28 +47,28 @@ They need to be in
   * `response`: filter and generate a schema for the response, setting a
     schema allows us to have 10-20% more throughput.
 * `attachValidation`: attach `validationError` to request, if there is a schema validation error, instead of sending the error to the error handler.
-* `onRequest(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#onrequest) as soon that a request is received, it could also be an array of functions.
-* `preParsing(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#preparsing) called before parsing the request, it could also be an array of functions.
-* `preValidation(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#prevalidation) called after the shared `preValidation` hooks, useful if you need to perform authentication at route level for example, it could also be an array of functions.
-* `preHandler(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#prehandler) called just before the request handler, it could also be an array of functions.
-* `preSerialization(request, reply, payload, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#preserialization) called just before the serialization, it could also be an array of functions.
-* `onSend(request, reply, payload, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#route-hooks) called right before a response is sent, it could also be an array of functions.
-* `onResponse(request, reply, done)`: a [function](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#onresponse) called when a response has been sent, so you will not be able to send more data to the client. It could also be an array of functions.
+* `onRequest(request, reply, done)`: a [function](./Hooks.md#onrequest) as soon that a request is received, it could also be an array of functions.
+* `preParsing(request, reply, done)`: a [function](./Hooks.md#preparsing) called before parsing the request, it could also be an array of functions.
+* `preValidation(request, reply, done)`: a [function](./Hooks.md#prevalidation) called after the shared `preValidation` hooks, useful if you need to perform authentication at route level for example, it could also be an array of functions.
+* `preHandler(request, reply, done)`: a [function](./Hooks.md#prehandler) called just before the request handler, it could also be an array of functions.
+* `preSerialization(request, reply, payload, done)`: a [function](./Hooks.md#preserialization) called just before the serialization, it could also be an array of functions.
+* `onSend(request, reply, payload, done)`: a [function](./Hooks.md#route-hooks) called right before a response is sent, it could also be an array of functions.
+* `onResponse(request, reply, done)`: a [function](./Hooks.md#onresponse) called when a response has been sent, so you will not be able to send more data to the client. It could also be an array of functions.
 * `handler(request, reply)`: the function that will handle this request.
-* `schemaCompiler(schema)`: the function that build the schema for the validations. See [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-compiler)
+* `schemaCompiler(schema)`: the function that build the schema for the validations. See [here](./Validation-and-Serialization.md#schema-compiler)
 * `bodyLimit`: prevents the default JSON body parser from parsing request bodies larger than this number of bytes. Must be an integer. You may also set this option globally when first creating the Fastify instance with `fastify(options)`. Defaults to `1048576` (1 MiB).
 * `logLevel`: set log level for this route. See below.
 * `logSerializers`: set serializers to log for this route.
 * `config`: object used to store custom configuration.
-* `version`: a [semver](http://semver.org/) compatible string that defined the version of the endpoint. [Example](https://github.com/fastify/fastify/blob/master/docs/Routes.md#version).
+* `version`: a [semver](http://semver.org/) compatible string that defined the version of the endpoint. [Example](./Routes.md#version).
 * `prefixTrailingSlash`: string used to determine how to handle passing `/` as a route with a prefix.
   * `both` (default): Will register both `/prefix` and `/prefix/`.
   * `slash`: Will register only `/prefix/`.
   * `no-slash`: Will register only `/prefix`.
 
-  `request` is defined in [Request](https://github.com/fastify/fastify/blob/master/docs/Request.md).
+  `request` is defined in [Request](./Request.md).
 
-  `reply` is defined in [Reply](https://github.com/fastify/fastify/blob/master/docs/Reply.md).
+  `reply` is defined in [Reply](./Reply.md).
 
 
 Example:
@@ -92,15 +96,16 @@ fastify.route({
 })
 ```
 
-<a name="shorthand-declaration"></a>
 ### Shorthand declaration
-The above route declaration is more *Hapi*-like, but if you prefer an *Express/Restify* approach, we support it as well:<br>
-`fastify.get(path, [options], handler)`<br>
-`fastify.head(path, [options], handler)`<br>
-`fastify.post(path, [options], handler)`<br>
-`fastify.put(path, [options], handler)`<br>
-`fastify.delete(path, [options], handler)`<br>
-`fastify.options(path, [options], handler)`<br>
+<a name="shorthand-declaration"></a>
+
+The above route declaration is more *Hapi*-like, but if you prefer an *Express/Restify* approach, we support it as well:<br/>
+`fastify.get(path, [options], handler)`<br/>
+`fastify.head(path, [options], handler)`<br/>
+`fastify.post(path, [options], handler)`<br/>
+`fastify.put(path, [options], handler)`<br/>
+`fastify.delete(path, [options], handler)`<br/>
+`fastify.options(path, [options], handler)`<br/>
 `fastify.patch(path, [options], handler)`
 
 Example:
@@ -146,9 +151,10 @@ fastify.get('/', opts)
 
 > Note: if the handler is specified in both the `options` and as the third parameter to the shortcut method then throws duplicate `handler` error.
 
-<a name="url-building"></a>
 ### Url building
-Fastify supports both static and dynamic urls.<br>
+<a name="url-building"></a>
+
+Fastify supports both static and dynamic urls.<br/>
 To register a **parametric** path, use the *colon* before the parameter name. For **wildcard** use the *star*.
 *Remember that static routes are always checked before parametric and wildcard.*
 
@@ -182,8 +188,9 @@ In this case as parameter separator it's possible to use whatever character is n
 Having a route with multiple parameters may affect negatively the performance, so prefer single parameter approach whenever possible, especially on routes which are on the hot path of your application.
 If you are interested in how we handle the routing, checkout [find-my-way](https://github.com/delvedor/find-my-way).
 
-<a name="async-await"></a>
 ### Async Await
+<a name="async-await"></a>
+
 Are you an `async/await` user? We have you covered!
 ```js
 fastify.get('/', options, async function (request, reply) {
@@ -231,8 +238,8 @@ fastify.get('/', options, async function (request, reply) {
 * When using both `return value` and `reply.send(value)` at the same time, the first one that happens takes precedence, the second value will be discarded, and a *warn* log will also be emitted because you tried to send a response twice.
 * You can't return `undefined`. For more details read [promise-resolution](#promise-resolution).
 
-<a name="promise-resolution"></a>
 ### Promise resolution
+<a name="promise-resolution"></a>
 
 If your handler is an `async` function or returns a promise, you should be aware of a special behaviour which is necessary to support the callback and promise control-flow. If the handler's promise is resolved with `undefined`, it will be ignored causing the request to hang and an *error* log to be emitted.
 
@@ -247,8 +254,9 @@ In this way, we can support both `callback-style` and `async-await`, with the mi
 
 **Notice**: Every async function returns a promise by itself.
 
-<a name="route-prefixing"></a>
 ### Route Prefixing
+<a name="route-prefixing"></a>
+
 Sometimes you need to maintain two or more different versions of the same api, a classic approach is to prefix all the routes with the api version number, `/v1/user` for example.
 Fastify offers you a fast and smart way to create different version of the same api without changing all the route names by hand, *route prefixing*. Let's see how it works:
 
@@ -296,12 +304,13 @@ and `/something/`.
 
 See the `prefixTrailingSlash` route option above to change this behaviour.
 
-<a name="custom-log-level"></a>
 ### Custom Log Level
+<a name="custom-log-level"></a>
+
 It could happen that you need different log levels in your routes, Fastify achieves this in a very straightforward way.<br/>
 You just need to pass the option `logLevel` to the plugin option or the route option with the [value](https://github.com/pinojs/pino/blob/master/docs/API.md#discussion-3) that you need.
 
-Be aware that if you set the `logLevel` at plugin level, also the [`setNotFoundHandler`](https://github.com/fastify/fastify/blob/master/docs/Server.md#setnotfoundhandler) and [`setErrorHandler`](https://github.com/fastify/fastify/blob/master/docs/Server.md#seterrorhandler) will be affected.
+Be aware that if you set the `logLevel` at plugin level, also the [`setNotFoundHandler`](./Server.md#setnotfoundhandler) and [`setErrorHandler`](./Server.md#seterrorhandler) will be affected.
 
 ```js
 // server.js
@@ -321,8 +330,8 @@ fastify.get('/', { logLevel: 'warn' }, (request, reply) => {
 ```
 *Remember that the custom log level is applied only to the routes, and not to the global Fastify Logger, accessible with `fastify.log`*
 
-<a name="custom-log-serializer"></a>
 ### Custom Log Serializer
+<a name="custom-log-serializer"></a>
 
 In some context, you may need to log a large object but it could be a waste of resources for some routes. In this case, you can define some [`serializer`](https://github.com/pinojs/pino/blob/master/docs/api.md#bindingsserializers-object) and attach them in the right context!
 
@@ -381,8 +390,9 @@ async function context1 (fastify, opts) {
 fastify.listen(3000)
 ```
 
-<a name="routes-config"></a>
 ### Config
+<a name="routes-config"></a>
+
 Registering a new handler, you can pass a configuration object to it and retrieve it in the handler.
 
 ```js
@@ -399,8 +409,8 @@ fastify.get('/it', { config: { output: 'ciao mondo!' } }, handler)
 fastify.listen(3000)
 ```
 
-<a name="version"></a>
 ### Version
+<a name="version"></a>
 
 #### Default
 If needed you can provide a version option, which will allow you to declare multiple versions of the same route. The versioning should follow the [semver](http://semver.org/) specification.<br/>
@@ -432,4 +442,4 @@ If you declare multiple versions with the same major or minor, Fastify will alwa
 If the request will not have the `Accept-Version` header, a 404 error will be returned.
 
 #### Custom
-It's possible to define a custom versioning logic. This can be done through the [`versioning`](https://github.com/fastify/fastify/blob/master/docs/Server.md#versioning) configuration, when creating a fastify server instance.
+It's possible to define a custom versioning logic. This can be done through the [`versioning`](./Server.md#versioning) configuration, when creating a fastify server instance.

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -1,38 +1,37 @@
-<h1 align="center">Fastify</h1>
+---
+title: Server
+sidebar_label: Server
+hide_title: false
+---
 
-<a name="factory"></a>
 ## Factory
+<a name="factory"></a>
 
-The Fastify module exports a factory function that is used to create new
-<a href="https://github.com/fastify/fastify/blob/master/docs/Server.md"><code><b>Fastify server</b></code></a>
-instances. This factory function accepts an options object which is used to
+The Fastify module exports a factory function that is used to create new [`Fastify server`](./Server.md) instances. This factory function accepts an options object which is used to
 customize the resulting instance. This document describes the properties
 available in that options object.
 
-<a name="factory-http2"></a>
 ### `http2`
+<a name="factory-http2"></a>
 
 If `true` Node.js core's [HTTP/2](https://nodejs.org/dist/latest-v8.x/docs/api/http2.html) module is used for binding the socket.
 
 + Default: `false`
 
-<a name="factory-https"></a>
 ### `https`
+<a name="factory-https"></a>
 
 An object used to configure the server's listening socket for TLS. The options
 are the same as the Node.js core
 [`createServer` method](https://nodejs.org/dist/latest-v8.x/docs/api/https.html#https_https_createserver_options_requestlistener).
 When this property is `null`, the socket will not be configured for TLS.
 
-This option also applies when the
-<a href="https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-http2">
-<code><b>http2</b></code>
-</a> option is set.
+This option also applies when the [`http2`](./Server.md#factory-http2) option is set.
 
 + Default: `null`
 
-<a name="factory-ignore-slash"></a>
 ### `ignoreTrailingSlash`
+<a name="factory-ignore-slash"></a>
 
 Fastify uses [find-my-way](https://github.com/delvedor/find-my-way) to handle
 routing. This option may be set to `true` to ignore trailing slashes in routes.
@@ -57,21 +56,22 @@ fastify.get('/bar', function (req, reply) {
 })
 ```
 
-<a name="factory-max-param-length"></a>
 ### `maxParamLength`
-You can set a custom length for parameters in parametric (standard, regex and multi) routes by using `maxParamLength` option, the default value is 100 characters.<br>
-This can be useful especially if you have some regex based route, protecting you against [DoS attacks](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS).<br>
+<a name="factory-max-param-length"></a>
+
+You can set a custom length for parameters in parametric (standard, regex and multi) routes by using `maxParamLength` option, the default value is 100 characters.<br/>
+This can be useful especially if you have some regex based route, protecting you against [DoS attacks](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS).<br/>
 *If the maximum length limit is reached, the not found route will be invoked.*
 
-<a name="factory-body-limit"></a>
 ### `bodyLimit`
+<a name="factory-body-limit"></a>
 
 Defines the maximum payload, in bytes, the server is allowed to accept.
 
 + Default: `1048576` (1MiB)
 
-<a name="factory-on-proto-poisoning"></a>
 ### `onProtoPoisoning`
+<a name="factory-on-proto-poisoning"></a>
 
 Defines what action the framework must take when parsing a JSON object
 with `__proto__`. This functionality is provided by
@@ -83,8 +83,8 @@ Possible values are `'error'`, `'remove'` and `'ignore'`.
 
 + Default: `'error'`
 
-<a name="factory-on-constructor-poisoning"></a>
 ### `onConstructorPoisoning`
+<a name="factory-on-constructor-poisoning"></a>
 
 Defines what action the framework must take when parsing a JSON object
 with `constructor`. This functionality is provided by
@@ -96,8 +96,8 @@ Possible values are `'error'`, `'remove'` and `'ignore'`.
 
 + Default: `'ignore'`
 
-<a name="factory-logger"></a>
 ### `logger`
+<a name="factory-logger"></a>
 
 Fastify includes built-in logging via the [Pino](https://getpino.io/) logger.
 This property is used to configure the internal logger instance.
@@ -151,8 +151,9 @@ interface by having the following methods: `info`, `error`, `debug`, `fatal`, `w
   const fastify = require('fastify')({logger: customLogger});
   ```
 
-<a name="factory-disable-request-logging"></a>
 ### `disableRequestLogging`
+<a name="factory-disable-request-logging"></a>
+
 By default, when logging is enabled, Fastify will issue an `info` level log
 message when a request is received and when the response for that request has
 been sent. By setting this option to `true`, these log messages will be disabled.
@@ -174,8 +175,9 @@ fastify.addHook('onResponse', (req, reply, done) => {
 })
 ```
 
-<a name="custom-http-server"></a>
 ### `serverFactory`
+<a name="custom-http-server"></a>
+
 You can pass a custom http server to Fastify by using the `serverFactory` option.<br/>
 `serverFactory` is a function that takes an `handler` parameter, which takes the `request` and `response` objects as parameters, and an options object, which is the same you have passed to Fastify.
 
@@ -200,8 +202,8 @@ fastify.listen(3000)
 Internally Fastify uses the API of Node core http server, so if you are using a custom server you must be sure to have the same API exposed. If not, you can enhance the server instance inside the `serverFactory` function before the `return` statement.<br/>
 *Note that we have also added `modifyCoreObjects: false` because in some serverless environments such as Google Cloud Functions, some Node.js core properties are not writable.*
 
-<a name="factory-case-sensitive"></a>
 ### `caseSensitive`
+<a name="factory-case-sensitive"></a>
 
 By default, value equal to `true`, routes are registered as case sensitive. That is, `/foo` is not equivalent to `/Foo`. When set to `false`, routes are registered in a fashion such that `/foo` is equivalent to `/Foo` which is equivalent to `/FOO`.
 
@@ -217,22 +219,22 @@ fastify.get('/user/:username', (request, reply) => {
 Please note this setting this option to `false` goes against
 [RFC3986](https://tools.ietf.org/html/rfc3986#section-6.2.2.1).
 
-<a name="factory-request-id-header"></a>
 ### `requestIdHeader`
+<a name="factory-request-id-header"></a>
 
-The header name used to know the request id. See [the request id](https://github.com/fastify/fastify/blob/master/docs/Logging.md#logging-request-id) section.
+The header name used to know the request id. See [the request id](./Logging.md#logging-request-id) section.
 
 + Default: `'request-id'`
 
-<a name="factory-request-id-log-label"></a>
 ### `requestIdLogLabel`
+<a name="factory-request-id-log-label"></a>
 
 Defines the label used for the request identifier when logging the request.
 
 + Default: `'reqId'`
 
-<a name="factory-gen-request-id"></a>
 ### `genReqId`
+<a name="factory-gen-request-id"></a>
 
 Function for generating the request id. It will receive the incoming request as a parameter.
 
@@ -249,8 +251,8 @@ const fastify = require('fastify')({
 
 **Note: genReqId will _not_ be called if the header set in <code>[requestIdHeader](#requestidheader)</code> is available (defaults to 'request-id').**
 
-<a name="factory-trust-proxy"></a>
 ### `trustProxy`
+<a name="factory-trust-proxy"></a>
 
 By enabling the `trustProxy` option, Fastify will have knowledge that it's sitting behind a proxy and that the `X-Forwarded-*` header fields may be trusted, which otherwise may be easily spoofed.
 
@@ -272,7 +274,7 @@ const fastify = Fastify({ trustProxy: true })
 
 For more examples refer to [proxy-addr](https://www.npmjs.com/package/proxy-addr) package.
 
-You may access the `ip`, `ips`, and `hostname` values on the [`request`](https://github.com/fastify/fastify/blob/master/docs/Request.md) object.
+You may access the `ip`, `ips`, and `hostname` values on the [`request`](./Request.md) object.
 
 ```js
 fastify.get('/', (request, reply) => {
@@ -282,17 +284,17 @@ fastify.get('/', (request, reply) => {
 })
 ```
 
-<a name="plugin-timeout"></a>
 ### `pluginTimeout`
+<a name="plugin-timeout"></a>
 
 The maximum amount of time in *milliseconds* in which a plugin can load.
-If not, [`ready`](https://github.com/fastify/fastify/blob/master/docs/Server.md#ready)
+If not, [`ready`](./Server.md#ready)
 will complete with an `Error` with code `'ERR_AVVIO_PLUGIN_TIMEOUT'`.
 
 + Default: `10000`
 
-<a name="factory-querystring-parser"></a>
 ### `querystringParser`
+<a name="factory-querystring-parser"></a>
 
 The default query string parser that Fastify uses is the Node.js's core `querystring` module.<br/>
 You can change this default setting by passing the option `querystringParser` and use a custom one, such as [`qs`](https://www.npmjs.com/package/qs).
@@ -304,10 +306,10 @@ const fastify = require('fastify')({
 })
 ```
 
-<a name="versioning"></a>
 ### `versioning`
+<a name="versioning"></a>
 
-By default you can version your routes with [semver versioning](https://github.com/fastify/fastify/blob/master/docs/Routes.md#version), which is provided by `find-my-way`. There is still an option to provide custom versioning strategy. You can find more information in the [find-my-way](https://github.com/delvedor/find-my-way#versioned-routes) documentation.
+By default you can version your routes with [semver versioning](./Routes.md#version), which is provided by `find-my-way`. There is still an option to provide custom versioning strategy. You can find more information in the [find-my-way](https://github.com/delvedor/find-my-way#versioned-routes) documentation.
 
 ```js
 const versioning = {
@@ -330,12 +332,12 @@ const fastify = require('fastify')({
 })
 ```
 
-<a name="factory-modify-core-objects"></a>
 ### `modifyCoreObjects`
+<a name="factory-modify-core-objects"></a>
 
 + Default: `true`
 
-By default, Fastify will add the `ip`, `ips`, `hostname`, and `log` properties to Node's raw request object (see [`Request`](https://github.com/fastify/fastify/blob/master/docs/Request.md)) and the `log` property to Node's raw response object. Set to `false` to prevent these properties from being added to the Node core objects.
+By default, Fastify will add the `ip`, `ips`, `hostname`, and `log` properties to Node's raw request object (see [`Request`](./Request.md)) and the `log` property to Node's raw response object. Set to `false` to prevent these properties from being added to the Node core objects.
 
 ```js
 const fastify = Fastify({ modifyCoreObjects: true }) // the default
@@ -351,7 +353,7 @@ fastify.get('/', (request, reply) => {
 
 Disable this option could help in serverless environments such as Google Cloud Functions, where `ip` and `ips` are not writable properties.
 
-**Note that these properties are deprecated and will be removed in the next major version of Fastify along with this option.** It is recommended to use the same properties on Fastify's [`Request`](https://github.com/fastify/fastify/blob/master/docs/Request.md) and [`Reply`](https://github.com/fastify/fastify/blob/master/docs/Reply.md) objects instead.
+**Note that these properties are deprecated and will be removed in the next major version of Fastify along with this option.** It is recommended to use the same properties on Fastify's [`Request`](./Request.md) and [`Reply`](./Reply.md) objects instead.
 
 ```js
 const fastify = Fastify({ modifyCoreObjects: false })
@@ -365,16 +367,16 @@ fastify.get('/', (request, reply) => {
 })
 ```
 
-<a name="factory-return-503-on-closing"></a>
 ### `return503OnClosing`
+<a name="factory-return-503-on-closing"></a>
 
 Returns 503 after calling `close` server method.
 If `false`, the server routes the incoming request as usual.
 
 + Default: `true`
 
-<a name="factory-ajv"></a>
 ### `ajv`
+<a name="factory-ajv"></a>
 
 Configure the ajv instance used by Fastify without providing a custom one.
 
@@ -409,8 +411,8 @@ const fastify = require('fastify')({
 })
 ```
 
-<a name="http2-session-timeout"></a>
 ### `http2SessionTimeout`
+<a name="http2-session-timeout"></a>
 
 Set a default
 [timeout](https://nodejs.org/api/http2.html#http2_http2session_settimeout_msecs_callback) to every incoming http2 session. The session will be closed on the timeout. Default: `5000` ms.
@@ -418,8 +420,8 @@ Set a default
 Note that this is needed to offer the graceful "close" experience when
 using http2. Node core defaults this to `0`.
 
-<a name="framework-errors"></a>
 ### `frameworkErrors`
+<a name="framework-errors"></a>
 
 + Default: `null`
 
@@ -446,12 +448,14 @@ const fastify = require('fastify')({
 
 ### Server Methods
 
-<a name="server"></a>
 #### server
-`fastify.server`: The Node core [server](https://nodejs.org/api/http.html#http_class_http_server) object as returned by the [**`Fastify factory function`**](https://github.com/fastify/fastify/blob/master/docs/Server.md).
+<a name="server"></a>
 
-<a name="after"></a>
+`fastify.server`: The Node core [server](https://nodejs.org/api/http.html#http_class_http_server) object as returned by the [**`Fastify factory function`**](./Server.md).
+
 #### after
+<a name="after"></a>
+
 Invoked when the current plugin and all the plugins
 that have been registered within it have finished loading.
 It is always executed before the method `fastify.ready`.
@@ -474,8 +478,9 @@ fastify
   })
 ```
 
-<a name="ready"></a>
 #### ready
+<a name="ready"></a>
+
 Function called when all the plugins have been loaded.
 It takes an error parameter if something went wrong.
 ```js
@@ -493,8 +498,9 @@ fastify.ready().then(() => {
 })
 ```
 
-<a name="listen"></a>
 #### listen
+<a name="listen"></a>
+
 Starts the server on the given port after all the plugins are loaded, internally waits for the `.ready()` event. The callback is the same as the Node core. By default, the server will listen on the address resolved by `localhost` when no specific address is provided (`127.0.0.1` or `::1` depending on the operating system). If listening on any available interface is desired, then specifying `0.0.0.0` for the address will listen on all IPv4 address. Using `::` for the address will listen on all IPv6 addresses, and, depending on OS, may also listen on all IPv4 addresses. Be careful when deciding to listen on all interfaces; it comes with inherent [security risks](https://web.archive.org/web/20170831174611/https://snyk.io/blog/mongodb-hack-and-secure-defaults/).
 
 ```js
@@ -598,15 +604,17 @@ fastify.listen({
 }, (err) => {})
 ```
 
-<a name="route"></a>
 #### route
-Method to add routes to the server, it also has shorthand functions, check [here](https://github.com/fastify/fastify/blob/master/docs/Routes.md).
+<a name="route"></a>
 
-<a name="close"></a>
+Method to add routes to the server, it also has shorthand functions, check [here](./Routes.md).
+
 #### close
-`fastify.close(callback)`: call this function to close the server instance and run the [`'onClose'`](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#on-close) hook.<br>
+<a name="close"></a>
+
+`fastify.close(callback)`: call this function to close the server instance and run the [`'onClose'`](./Hooks.md#on-close) hook.<br/>
 Calling `close` will also cause the server to respond to every new incoming request with a `503` error and destroy that request.
-See [`return503OnClosing` flags](https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-return-503-on-closing) for changing this behaviour.
+See [`return503OnClosing` flags](./Server.md#factory-return-503-on-closing) for changing this behaviour.
 
 If it is called without any arguments, it will return a Promise:
 
@@ -618,25 +626,30 @@ fastify.close().then(() => {
 })
 ```
 
+#### decorate
 <a name="decorate"></a>
-#### decorate*
-Function useful if you need to decorate the fastify instance, Reply or Request, check [here](https://github.com/fastify/fastify/blob/master/docs/Decorators.md).
 
-<a name="register"></a>
+Function useful if you need to decorate the fastify instance, Reply or Request, check [here](./Decorators.md).
+
 #### register
+<a name="register"></a>
+
 Fastify allows the user to extend its functionality with plugins.
-A plugin can be a set of routes, a server decorator or whatever, check [here](https://github.com/fastify/fastify/blob/master/docs/Plugins.md).
+A plugin can be a set of routes, a server decorator or whatever, check [here](./Plugins.md).
 
-<a name="use"></a>
 #### use
-Function to add middlewares to Fastify, check [here](https://github.com/fastify/fastify/blob/master/docs/Middleware.md).
+<a name="use"></a>
 
-<a name="addHook"></a>
+Function to add middlewares to Fastify, check [here](./Middleware.md).
+
 #### addHook
-Function to add a specific hook in the lifecycle of Fastify, check [here](https://github.com/fastify/fastify/blob/master/docs/Hooks.md).
+<a name="addHook"></a>
 
-<a name="prefix"></a>
+Function to add a specific hook in the lifecycle of Fastify, check [here](./Hooks.md).
+
 #### prefix
+<a name="prefix"></a>
+
 The full path that will be prefixed to a route.
 
 Example:
@@ -663,8 +676,9 @@ fastify.register(function (instance, opts, done) {
 }, { prefix: '/v1' })
 ```
 
-<a name="pluginName"></a>
 #### pluginName
+<a name="pluginName"></a>
+
 Name of the current plugin. There are three ways to define a name (in order).
 
 1. If you use [fastify-plugin](https://github.com/fastify/fastify-plugin) the metadata `name` is used.
@@ -675,23 +689,27 @@ Name of the current plugin. There are three ways to define a name (in order).
 
 Important: If you have to deal with nested plugins the name differs with the usage of the [fastify-plugin](https://github.com/fastify/fastify-plugin) because no new scope is created and therefore we have no place to attach contextual data. In that case the plugin name will represent the boot order of all involved plugins in the format of `plugin-A -> plugin-B`.
 
-<a name="log"></a>
 #### log
-The logger instance, check [here](https://github.com/fastify/fastify/blob/master/docs/Logging.md).
+<a name="log"></a>
 
-<a name="inject"></a>
+The logger instance, check [here](./Logging.md).
+
 #### inject
-Fake http injection (for testing purposes) [here](https://github.com/fastify/fastify/blob/master/docs/Testing.md#inject).
+<a name="inject"></a>
 
-<a name="add-schema"></a>
+Fake http injection (for testing purposes) [here](./Testing.md#inject).
+
 #### addSchema
-`fastify.addSchema(schemaObj)`, adds a shared schema to the Fastify instance. This allows you to reuse it everywhere in your application just by writing the schema id that you need.<br/>
-To learn more, see [shared schema example](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#shared-schema) in the [Validation and Serialization](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md) documentation.
+<a name="add-schema"></a>
 
-<a name="set-reply-serializer"></a>
+`fastify.addSchema(schemaObj)`, adds a shared schema to the Fastify instance. This allows you to reuse it everywhere in your application just by writing the schema id that you need.<br/>
+To learn more, see [shared schema example](./Validation-and-Serialization.md#shared-schema) in the [Validation and Serialization](./Validation-and-Serialization.md) documentation.
+
 #### setReplySerializer
-Set the reply serializer for all the routes. This will used as default if a [Reply.serializer(func)](https://github.com/fastify/fastify/blob/master/docs/Reply.md#serializerfunc) has not been set. The handler is fully encapsulated, so different plugins can set different error handlers.
-Note: the function parameter is called only for status `2xx`. Checkout the [`setErrorHandler`](https://github.com/fastify/fastify/blob/master/docs/Server.md#seterrorhandler) for errors.
+<a name="set-reply-serializer"></a>
+
+Set the reply serializer for all the routes. This will used as default if a [Reply.serializer(func)](./Reply.md#serializerfunc) has not been set. The handler is fully encapsulated, so different plugins can set different error handlers.
+Note: the function parameter is called only for status `2xx`. Checkout the [`setErrorHandler`](./Server.md#seterrorhandler) for errors.
 
 ```js
 fastify.setReplySerializer(function (payload, statusCode){
@@ -700,27 +718,30 @@ fastify.setReplySerializer(function (payload, statusCode){
 })
 ```
 
-<a name="set-schema-compiler"></a>
 #### setSchemaCompiler
-Set the schema compiler for all routes [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-compiler).
+<a name="set-schema-compiler"></a>
 
-<a name="set-schema-resolver"></a>
+Set the schema compiler for all routes [here](./Validation-and-Serialization.md#schema-compiler).
+
 #### setSchemaResolver
-Set the schema `$ref` resolver for all routes [here](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md#schema-resolver).
+<a name="set-schema-resolver"></a>
+
+Set the schema `$ref` resolver for all routes [here](./Validation-and-Serialization.md#schema-resolver).
 
 
-<a name="schema-compiler"></a>
 #### schemaCompiler
+<a name="schema-compiler"></a>
+
 This property can be used to set the schema compiler, it is a shortcut for the `setSchemaCompiler` method, and get the schema compiler back for all routes.
 
-<a name="set-not-found-handler"></a>
 #### setNotFoundHandler
+<a name="set-not-found-handler"></a>
 
-`fastify.setNotFoundHandler(handler(request, reply))`: set the 404 handler. This call is encapsulated by prefix, so different plugins can set different not found handlers if a different [`prefix` option](https://github.com/fastify/fastify/blob/master/docs/Plugins.md#route-prefixing-option) is passed to `fastify.register()`. The handler is treated like a regular route handler so requests will go through the full [Fastify lifecycle](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md#lifecycle).
+`fastify.setNotFoundHandler(handler(request, reply))`: set the 404 handler. This call is encapsulated by prefix, so different plugins can set different not found handlers if a different [`prefix` option](./Plugins.md#route-prefixing-option) is passed to `fastify.register()`. The handler is treated like a regular route handler so requests will go through the full [Fastify lifecycle](./Lifecycle.md#lifecycle).
 
 You can also register a [`preValidation`](https://www.fastify.io/docs/latest/Hooks/#route-hooks) and [preHandler](https://www.fastify.io/docs/latest/Hooks/#route-hooks) hook for the 404 handler.
 
-_Note: The `preValidation` hook registered using this method will run for a route that Fastify does not recognize and **not** when a route handler manually calls [`reply.callNotFound`](https://github.com/fastify/fastify/blob/master/docs/Reply.md#call-not-found)_. In which case only preHandler will be run.
+_Note: The `preValidation` hook registered using this method will run for a route that Fastify does not recognize and **not** when a route handler manually calls [`reply.callNotFound`](./Reply.md#call-not-found)_. In which case only preHandler will be run.
 
 ```js
 fastify.setNotFoundHandler({
@@ -745,10 +766,10 @@ fastify.register(function (instance, options, done) {
 }, { prefix: '/v1' })
 ```
 
-<a name="set-error-handler"></a>
 #### setErrorHandler
+<a name="set-error-handler"></a>
 
-`fastify.setErrorHandler(handler(error, request, reply))`: Set a function that will be called whenever an error happens. The handler is bound to the Fastify instance, and is fully encapsulated, so different plugins can set different error handlers. *async-await* is supported as well.<br>
+`fastify.setErrorHandler(handler(error, request, reply))`: Set a function that will be called whenever an error happens. The handler is bound to the Fastify instance, and is fully encapsulated, so different plugins can set different error handlers. *async-await* is supported as well.<br/>
 *Note: If the error `statusCode` is less than 400, Fastify will automatically set it at 500 before calling the error handler.*
 
 ```js
@@ -773,8 +794,8 @@ if (statusCode >= 500) {
 }
 ```
 
-<a name="print-routes"></a>
 #### printRoutes
+<a name="print-routes"></a>
 
 `fastify.printRoutes()`: Prints the representation of the internal radix tree used by the router, useful for debugging.<br/>
 *Remember to call it inside or after a `ready` call.*
@@ -793,8 +814,8 @@ fastify.ready(() => {
 })
 ```
 
-<a name="initial-config"></a>
 #### initialConfig
+<a name="initial-config"></a>
 
 `fastify.initialConfig`: Exposes a frozen read-only object registering the initial
 options passed down by the user to the fastify instance.

--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -1,11 +1,24 @@
-<h1 align="center">Serverless</h1>
+---
+title: Serverless
+sidebar_label: Serverless
+hide_title: false
+---
 
 Run serverless applications and REST APIs using your existing Fastify application.
 
 ### Contents
 
 - [AWS Lambda](#aws-lambda)
+  - [app.js](#appjs)
+  - [lambda.js](#lambdajs)
+  - [Example](#example)
+  - [Considerations](#considerations)
 - [Google Cloud Run](#google-cloud-run)
+  - [Adjust Fastify server](#adjust-fastify-server)
+  - [Add a Dockerfile](#add-a-dockerfile)
+  - [Add a .dockerignore](#add-a-dockerignore)
+  - [Submit build](#submit-build)
+  - [Deploy Image](#deploy-image)
 - [Vercel](#vercel)
 
 ### Attention Readers:

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,10 +1,14 @@
-<h1 align="center">Fastify</h1>
+---
+title: Testing
+sidebar_label: Testing
+hide_title: false
+---
 
-## Testing
 Testing is one of the most important parts of developing an application. Fastify is very flexible when it comes to testing and is compatible with most testing frameworks (such as [Tap](https://www.npmjs.com/package/tap), which is used in the examples below).
 
-<a name="inject"></a>
 ### Testing with http injection
+<a name="inject"></a>
+
 Fastify comes with built-in support for fake http injection thanks to [`light-my-request`](https://github.com/fastify/light-my-request).
 
 To inject a fake http request, use the `inject` method:

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -1,7 +1,9 @@
-<h1 align="center">Fastify</h1>
+---
+title: TypeScript
+sidebar_label: TypeScript
+hide_title: false
+---
 
-<a id="typescript"></a>
-## TypeScript
 Fastify is shipped with a typings file, but you may need to install `@types/node`, depending on the Node.js version you are using.
 
 ## Types support
@@ -45,8 +47,9 @@ server.get('/ping', opts, (request, reply) => {
 })
 ```
 
-<a id="generic-parameters"></a>
 ## Generic Parameters
+<a name="generic-parameters"></a>
+
 Since you can validate the querystring, params, body, and headers, you can also override the default types of those values on the request interface:
 
 ```ts
@@ -161,8 +164,9 @@ server.get<unknown, Params, unknown, unknown>('/ping/:bar', opts, (request, repl
 })
 ```
 
-<a id="http-prototypes"></a>
 ## HTTP Prototypes
+<a name="http-prototypes"></a>
+
 By default, fastify will determine which version of http is being used based on the options you pass to it. If for any
 reason you need to override this you can do so as shown below:
 
@@ -186,8 +190,9 @@ In this example we pass a modified `http.IncomingMessage` interface since it has
 application.
 
 
-<a id="contributing"></a>
 ## Contributing
+<a name="contributing"></a>
+
 TypeScript related changes can be considered to fall into one of two categories:
 
 * [`Core`](#core-types) - The typings bundled with fastify
@@ -195,15 +200,16 @@ TypeScript related changes can be considered to fall into one of two categories:
 
 Make sure to read our [`CONTRIBUTING.md`](https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md) file before getting started to make sure things go smoothly!
 
-<a id="core-types"></a>
 ### Core Types
+<a name="core-types"></a>
+
 When updating core types you should make a PR to this repository. Ensure you:
 
 1. Update `examples/typescript-server.ts` to reflect the changes (if necessary)
 2. Update `test/types/index.ts` to validate changes work as expected
 
-<a id="plugin-types"></a>
 ### Plugin Types
+<a name="plugin-types"></a>
 
 Plugins maintained by and organized under the fastify organization on GitHub should ship with typings just like fastify itself does.
 Some plugins already include typings but many do not. We are happy to accept contributions to those plugins without any typings, see [fastify-cors](https://github.com/fastify/fastify-cors) for an example of a plugin that comes with it's own typings.
@@ -212,8 +218,9 @@ Typings for third-party-plugins may either be included with the plugin or hosted
 
 Some types might not be available yet, so don't be shy about contributing.
 
-<a id="authoring-plugin-types"></a>
 ### Authoring Plugin Types
+<a name="authoring-plugin-types"></a>
+
 Typings for many plugins that extend the `FastifyRequest`, `FastifyReply` or `FastifyInstance` objects can be achieved as shown below.
 
 This code shows the typings for the [`fastify-static`](https://github.com/fastify/fastify-static) plugin.

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -1,6 +1,9 @@
-<h1 align="center">Fastify</h1>
+---
+title: Validation and Serialization
+sidebar_label: Validation and Serialization
+hide_title: false
+---
 
-## Validation and Serialization
 Fastify uses a schema-based approach, and even if it is not mandatory we recommend using [JSON Schema](http://json-schema.org/) to validate your routes and serialize your outputs. Internally, Fastify compiles the schema into a highly performant function.
 
 > ## ⚠  Security Notice
@@ -11,8 +14,9 @@ Fastify uses a schema-based approach, and even if it is not mandatory we recomme
 > [fast-json-stringify](http://npm.im/fast-json-stringify) for more
 > details.
 
-<a name="validation"></a>
 ### Validation
+<a name="validation"></a>
+
 The route validation internally relies upon [Ajv](https://www.npmjs.com/package/ajv), which is a high-performance JSON schema validator. Validating the input is very easy: just add the fields that you need inside the route schema, and you are done! The supported validations are:
 - `body`: validates the body of the request if it is a POST, a PATCH or a PUT.
 - `querystring` or `query`: validates the query string. This can be a complete JSON Schema object (with a `type` property of `'object'` and a `'properties'` object containing parameters) or a simpler variation in which the `type` and `properties` attributes are forgone and the query parameters are listed at the top level (see the example below).
@@ -100,8 +104,9 @@ fastify.post('/the/url', { schema }, handler)
 ```
 *Note that Ajv will try to [coerce](https://github.com/epoberezkin/ajv#coercing-data-types) the values to the types specified in your schema `type` keywords, both to pass the validation and to use the correctly typed data afterwards.*
 
-<a name="shared-schema"></a>
 #### Adding a shared schema
+<a name="shared-schema"></a>
+
 Thanks to the `addSchema` API, you can add multiple schemas to the Fastify instance and then reuse them in multiple parts of your application. As usual, this API is encapsulated.
 
 There are two ways to reuse your shared schemas:
@@ -227,8 +232,8 @@ fastify.route({
 })
 ```
 
-<a name="get-shared-schema"></a>
 #### Retrieving a copy of shared schemas
+<a name="get-shared-schema"></a>
 
 The function `getSchemas` returns the shared schemas available in the selected scope:
 ```js
@@ -255,12 +260,12 @@ This example will returns:
 | /sub  | one, two        |
 | /deep | one, two, three |
 
-<a name="ajv-plugins"></a>
 #### Ajv Plugins
+<a name="ajv-plugins"></a>
 
 You can provide a list of plugins you want to use with Ajv:
 
-> Refer to [`ajv options`](https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-ajv) to check plugins format
+> Refer to [`ajv options`](./Server.md#factory-ajv) to check plugins format
 
 ```js
 const fastify = require('fastify')({
@@ -326,8 +331,8 @@ fastify.route({
 })
 ```
 
-<a name="schema-compiler"></a>
 #### Schema Compiler
+<a name="schema-compiler"></a>
 
 The `schemaCompiler` is a function that returns a function that validates the body, url parameters, headers, and query string. The default `schemaCompiler` returns a function that implements the [ajv](https://ajv.js.org/) validation interface. Fastify uses it internally to speed the validation up.
 
@@ -342,7 +347,7 @@ Fastify's [baseline ajv configuration](https://github.com/epoberezkin/ajv#option
 }
 ```
 
-This baseline configuration can be modified by providing [`ajv.customOptions`](https://github.com/fastify/fastify/blob/master/docs/Server.md#factory-ajv) to your Fastify factory.
+This baseline configuration can be modified by providing [`ajv.customOptions`](./Server.md#factory-ajv) to your Fastify factory.
 
 If you want to change or set additional config options, you will need to create your own instance and override the existing one like:
 
@@ -368,8 +373,8 @@ fastify.schemaCompiler = function (schema) { return ajv.compile(schema) })
 ```
 _**Note:** If you use a custom instance of any validator (even Ajv), you have to add schemas to the validator instead of fastify, since fastify's default validator is no longer used, and fastify's `addSchema` method has no idea what validator you are using._
 
-<a name="using-other-validation-libraries"></a>
 #### Using other validation libraries
+<a name="using-other-validation-libraries"></a>
 
 The `schemaCompiler` function makes it easy to substitute `ajv` with almost any Javascript validation library ([joi](https://github.com/hapijs/joi/), [yup](https://github.com/jquense/yup/), ...).
 
@@ -499,8 +504,8 @@ const errorHandler = (error, request, reply) => {
 }
 ```
 
-<a name="schema-resolver"></a>
 #### Schema Resolver
+<a name="schema-resolver"></a>
 
 The `schemaResolver` is a function that works together with the `schemaCompiler`: you can't use it
 with the default schema compiler. This feature is useful when you use complex schemas with `$ref` keyword
@@ -561,8 +566,9 @@ fastify.route({
 })
 ```
 
-<a name="serialization"></a>
 ### Serialization
+<a name="serialization"></a>
+
 Usually you will send your data to the clients via JSON, and Fastify has a powerful tool to help you, [fast-json-stringify](https://www.npmjs.com/package/fast-json-stringify), which is used if you have provided an output schema in the route options. We encourage you to use an output schema, as it will increase your throughput by 100-400% depending on your payload and will prevent accidental disclosure of sensitive information.
 
 Example:
@@ -863,8 +869,9 @@ const refToSharedSchemaDefinitions = {
 }
 ```
 
-<a name="resources"></a>
 ### Resources
+<a name="resources"></a>
+
 - [JSON Schema](http://json-schema.org/)
 - [Understanding JSON schema](https://spacetelescope.github.io/understanding-json-schema/)
 - [fast-json-stringify documentation](https://github.com/fastify/fast-json-stringify)

--- a/docs/Write-Plugin.md
+++ b/docs/Write-Plugin.md
@@ -1,20 +1,24 @@
-<h1 align="center">Fastify</h1>
+---
+title: Write Plugin
+sidebar_label: Write Plugin
+hide_title: false
+---
 
 # How to write a good plugin
-First, thank you for deciding to write a plugin for Fastify. Fastify is a minimal framework and plugins are its strength, so thank you.<br>
+First, thank you for deciding to write a plugin for Fastify. Fastify is a minimal framework and plugins are its strength, so thank you.<br/>
 The core principles of Fastify are performance, low overhead and providing a good experience to our users. When writing a plugin, it is important to keep these principles in mind. Therefore, in this document we will analyze what characterizes a quality plugin.
 
 *Need some inspiration? You can use the label ["plugin suggestion"](https://github.com/fastify/fastify/issues?q=is%3Aissue+is%3Aopen+label%3A%22plugin+suggestion%22) in our issue tracker!*
 
 ## Code
-Fastify uses different techniques to optimize its code, many of them are documented in our Guides. We highly recommend you read [the hitchhiker's guide to plugins](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md) to discover all the APIs you can use to build your plugin and learn how use them.
+Fastify uses different techniques to optimize its code, many of them are documented in our Guides. We highly recommend you read [the hitchhiker's guide to plugins](./Plugins-Guide.md) to discover all the APIs you can use to build your plugin and learn how use them.
 
 Have you got some question or are you seeking for a suggestion? We are more than happy to help you! Just open an issue in our [help repository](https://github.com/fastify/help).
 
-Once you submit a plugin to our [ecosystem list](https://github.com/fastify/fastify/blob/master/docs/Ecosystem.md), we will review your code and help you improve it if necessary.
+Once you submit a plugin to our [ecosystem list](./Ecosystem.md), we will review your code and help you improve it if necessary.
 
 ## Documentation
-Documentation is extremely important. If your plugin is not well documented we will not accept it to the ecosystem list. Lack of quality documentation makes it more difficult for people to use your plugin, and will likely result in it going unused.<br>
+Documentation is extremely important. If your plugin is not well documented we will not accept it to the ecosystem list. Lack of quality documentation makes it more difficult for people to use your plugin, and will likely result in it going unused.<br/>
 If you want to see some good examples on how to document a plugin take a look at:
 - [`fastify-caching`](https://github.com/fastify/fastify-caching)
 - [`fastify-compress`](https://github.com/fastify/fastify-compress)
@@ -23,14 +27,14 @@ If you want to see some good examples on how to document a plugin take a look at
 - [`under-pressure`](https://github.com/fastify/under-pressure)
 
 ## License
-You can license your plugin as you prefer, we do not enforce any kind of license.<br>
+You can license your plugin as you prefer, we do not enforce any kind of license.<br/>
 We prefer the [MIT license](https://choosealicense.com/licenses/mit/) because we think it allows more people to use the code freely. For a list of alternative licenses see the [OSI list](https://opensource.org/licenses) or GitHub's [choosealicense.com](https://choosealicense.com/).
 
 ## Examples
 Always put an example file in your repository. Examples are very helpful for users and give a very fast way to test your plugin. Your users will be grateful.
 
 ## Test
-It is extremely important that a plugin is thoroughly tested to verify that is working properly.<br>
+It is extremely important that a plugin is thoroughly tested to verify that is working properly.<br/>
 A plugin without tests will not be accepted to the ecosystem list. A lack of tests does not inspire trust nor guarantee that the code will continue to work among different versions of its dependencies.
 
 We do not enforce any testing library. We use [`tap`](http://www.node-tap.org/) since it offers out of the box parallel testing and code coverage, but it is up to you to choose your library of preference.
@@ -41,7 +45,7 @@ It is not mandatory, but we highly recommend you use a code linter in your plugi
 We use [`standard`](https://standardjs.com/) since it works without the need to configure it and is very easy integrate in a test suite.
 
 ## Continuous Integration
-It is not mandatory, but if you release your code as open source it helps to use Continuous Integration to ensure contributions do not break your plugin and to show that the plugin works as intended. [Travis](https://travis-ci.org/) is free for open source projects and easy to setup.<br>
+It is not mandatory, but if you release your code as open source it helps to use Continuous Integration to ensure contributions do not break your plugin and to show that the plugin works as intended. [Travis](https://travis-ci.org/) is free for open source projects and easy to setup.<br/>
 In addition you can enable services like [Greenkeeper](https://greenkeeper.io/), that will help you keep your dependencies up to date and discover if a new release of Fastify has some issues with your plugin.
 
 ## Let's start!


### PR DESCRIPTION
These changes are in line with the discussion at fastify/fastify#3492. These tweaks are being pushed to the `2.x` branch so that it will maintain compatibility with modern Markdown processors such as Docusaurus. Please note that the current website does not compile from this branch but rather from releases, so merging this will not break the current website.

#### Changes
- Use relative links rather than absolute links
- Ensure Markdown headers have newline directly above
- Add Markdown metadata to each file
- Replace `<br>` tags with `<br/>`

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
