### PR TITLE
Improve relative links and broken links on docs-reorg

### DIFF
--- a/docs/ContentTypeParser.md
+++ b/docs/ContentTypeParser.md
@@ -7,7 +7,7 @@ Natively, Fastify only supports `'application/json'` and `'text/plain'` content 
 
 As with the other APIs, `addContentTypeParser` is encapsulated in the scope in which it is declared. This means that if you declare it in the root scope it will be available everywhere, while if you declare it inside a plugin it will be available only in that scope and its children.
 
-Fastify automatically adds the parsed request payload to the [Fastify request](Request.md) object which you can access with `request.body`.
+Fastify automatically adds the parsed request payload to the [Fastify request](./Request.md) object which you can access with `request.body`.
 
 ### Usage
 ```js
@@ -122,7 +122,7 @@ fastify.addContentTypeParser('application/json', { parseAs: 'string' }, function
 })
 ```
 
-See [`example/parser.js`](../examples/parser.js) for an example.
+See [`example/parser.js`](https://github.com/fastify/fastify/blob/main/examples/parser.js) for an example.
 
 ##### Custom Parser Options
 + `parseAs` (string): Either `'string'` or `'buffer'` to designate how the incoming data should be collected. Default: `'buffer'`.

--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -12,7 +12,7 @@ asynchronously could result in the Fastify instance booting before the
 decoration completes its initialization. To avoid this issue, and register an
 asynchronous decoration, the `register` API, in combination with
 `fastify-plugin`, must be used instead. To learn more, see the
-[Plugins](Plugins.md) documentation.
+[Plugins](./Plugins.md) documentation.
 
 Decorating core objects with this API allows the underlying JavaScript engine
 to optimize the handling of server, request, and reply objects. This is
@@ -98,7 +98,7 @@ fastify.utility()
 console.log(fastify.conf.db)
 ```
 
-The decorated [Fastify server](./Reference/Server.md) is bound to `this` in route [route](Routes.md) handlers:
+The decorated [Fastify server](./Reference/Server.md) is bound to `this` in route [route](./Routes.md) handlers:
 
 ```js
 fastify.decorate('db', new DbConnection())
@@ -148,7 +148,7 @@ fastify.decorateReply('foo', { bar: 'fizz'})
 In this example, the reference of the object is shared with all the requests: **any
 mutation will impact all requests, potentially creating security vulnerabilities or memory leaks**.
 To achieve proper encapsulation across requests configure a new value for each incoming request
-in the [`'onRequest'` hook](Hooks.md#onrequest). Example:
+in the [`'onRequest'` hook](./Hooks.md#onrequest). Example:
 
 ```js
 const fp = require('fastify-plugin')
@@ -190,7 +190,7 @@ In this example, the reference of the object is shared with all the requests: **
 mutation will impact all requests, potentially creating security vulnerabilities or memory leaks**.
 
 To achieve proper encapsulation across requests configure a new value for each incoming request
-in the [`'onRequest'` hook](Hooks.md#onrequest). Example:
+in the [`'onRequest'` hook](./Hooks.md#onrequest). Example:
 
 ```js
 const fp = require('fastify-plugin')

--- a/docs/Decorators.md
+++ b/docs/Decorators.md
@@ -65,10 +65,10 @@ See
 for more information on this topic.
 
 ### Usage
-<a name="usage"></a>
+<a id="usage"></a>
 
 #### `decorate(name, value, [dependencies])`
-<a name="decorate"></a>
+<a id="decorate"></a>
 
 This method is used to customize the Fastify [server](./Reference/Server.md) instance.
 
@@ -125,7 +125,7 @@ The dependency check is performed before the server instance is booted. Thus,
 it cannot occur during runtime.
 
 #### `decorateReply(name, value, [dependencies])`
-<a name="decorate-reply"></a>
+<a id="decorate-reply"></a>
 
 As the name suggests, this API is used to add new methods/properties to the core
 `Reply` object:
@@ -166,7 +166,7 @@ module.exports = fp(myPlugin)
 See [`decorate`](#decorate) for information about the `dependencies` parameter.
 
 #### `decorateRequest(name, value, [dependencies])`
-<a name="decorate-request"></a>
+<a id="decorate-request"></a>
 
 As above with [`decorateReply`](#decorate-reply), this API is used add new
 methods/properties to the core `Request` object:
@@ -208,7 +208,7 @@ module.exports = fp(myPlugin)
 See [`decorate`](#decorate) for information about the `dependencies` parameter.
 
 #### `hasDecorator(name)`
-<a name="has-decorator"></a>
+<a id="has-decorator"></a>
 
 Used to check for the existence of a server instance decoration:
 
@@ -217,7 +217,7 @@ fastify.hasDecorator('utility')
 ```
 
 #### hasRequestDecorator
-<a name="has-request-decorator"></a>
+<a id="has-request-decorator"></a>
 
 Used to check for the existence of a Request decoration:
 
@@ -226,7 +226,7 @@ fastify.hasRequestDecorator('utility')
 ```
 
 #### hasReplyDecorator
-<a name="has-reply-decorator"></a>
+<a id="has-reply-decorator"></a>
 
 Used to check for the existence of a Reply decoration:
 
@@ -235,7 +235,7 @@ fastify.hasReplyDecorator('utility')
 ```
 
 ### Decorators and Encapsulation
-<a name="decorators-encapsulation"></a>
+<a id="decorators-encapsulation"></a>
 
 Defining a decorator (using `decorate`, `decorateRequest`, or `decorateReply`)
 with the same name more than once in the same **encapsulated** context will
@@ -290,7 +290,7 @@ server.listen(3000)
 ```
 
 ### Getters and Setters
-<a name="getters-setters"></a>
+<a id="getters-setters"></a>
 
 Decorators accept special "getter/setter" objects. These objects have functions
 named `getter` and `setter` (though the `setter` function is optional). This

--- a/docs/Errors.md
+++ b/docs/Errors.md
@@ -20,7 +20,7 @@ If you are using promises, you should attach a `.catch()` handler synchronously.
 Fastify follows an all-or-nothing approach and aims to be lean and optimal as much as possible. The developer is responsible for making sure that the errors are handled properly.
 
 #### Errors In Input Data
-Most errors are a result of unexpected input data, so we recommend [validating your input data against a JSON schema](Validation-and-Serialization.md).
+Most errors are a result of unexpected input data, so we recommend [validating your input data against a JSON schema](./Validation-and-Serialization.md).
 
 #### Catching Uncaught Errors In Fastify
 Fastify tries to catch as many uncaught errors as it can without hindering performance. This includes:
@@ -34,14 +34,14 @@ To customize this behavior you should use [`setErrorHandler`](./Reference/Server
 
 ### Errors In Fastify Lifecycle Hooks And A Custom Error Handler
 
-From the [Hooks documentation](Hooks.md#manage-errors-from-a-hook):
+From the [Hooks documentation](./Hooks.md#manage-errors-from-a-hook):
 > If you get an error during the execution of your hook, just pass it to `done()` and Fastify will automatically close the request and send the appropriate error code to the user.
 
 If you have defined a custom error handler for using `setErrorHandler` the error will be routed there. otherwise, it will be routed to Fastify’s generic error handler.
 
 Some things to consider in your custom error handler:
 
-- you can `reply.send(data)`, which will behave as it would in [regular route handlers](Reply.md#senddata)
+- you can `reply.send(data)`, which will behave as it would in [regular route handlers](./Reply.md#senddata)
 	- objects are serialized, triggering the `preSerialization` lifecycle hook if you have one defined
 	- strings, buffers, and streams are sent to the client, with appropriate headers (no serialization)
 
@@ -131,7 +131,7 @@ The logger accepts either a `'stream'` or a `'file'` as the destination.
 A promise may not be fulfilled with 'undefined' when statusCode is not 204.
 
 #### FST_ERR_REP_ALREADY_SENT
-<a id="FST_ERR_REP_ALREADY_SENT"></a>
+<a name="FST_ERR_REP_ALREADY_SENT"></a>
 
 A response was already sent.
 
@@ -161,7 +161,7 @@ The JSON schema provided for serialization of a route response is not valid.
 The JSON schema provided for validation to a route is not valid.
 
 #### FST_ERR_SEND_INSIDE_ONERR
-<a id="FST_ERR_SEND_INSIDE_ONERR"></a>
+<a name="FST_ERR_SEND_INSIDE_ONERR"></a>
 
 You cannot use `send` inside the `onError` hook.
 

--- a/docs/Errors.md
+++ b/docs/Errors.md
@@ -4,7 +4,7 @@
 <a id="errors"></a>
 
 ### Error Handling In Node.js
-<a name="error-handling"></a>
+<a id="error-handling"></a>
 
 #### Uncaught Errors
 In Node.js, uncaught errors are likely to cause memory leaks, file descriptor leaks, and other major production issues. [Domains](https://nodejs.org/en/docs/guides/domain-postmortem/) were a failed attempt to fix this.
@@ -51,121 +51,121 @@ Some things to consider in your custom error handler:
 
 
 ### Fastify Error Codes
-<a name="fastify-error-codes"></a>
+<a id="fastify-error-codes"></a>
 
 #### FST_ERR_BAD_URL
-<a name="FST_ERR_BAD_URL"></a>
+<a id="FST_ERR_BAD_URL"></a>
 
 The router received an invalid url.
 
 #### FST_ERR_CTP_ALREADY_PRESENT
-<a name="FST_ERR_CTP_ALREADY_PRESENT"></a>
+<a id="FST_ERR_CTP_ALREADY_PRESENT"></a>
 
 The parser for this content type was already registered.
 
 #### FST_ERR_CTP_BODY_TOO_LARGE
-<a name="FST_ERR_CTP_BODY_TOO_LARGE"></a>
+<a id="FST_ERR_CTP_BODY_TOO_LARGE"></a>
 
 The request body is larger than the provided limit.
 
 This setting can be defined in the Fastify server instance: [`bodyLimit`](./Reference/Server.md#bodyLimit)
 
 #### FST_ERR_CTP_EMPTY_TYPE
-<a name="FST_ERR_CTP_EMPTY_TYPE"></a>
+<a id="FST_ERR_CTP_EMPTY_TYPE"></a>
 
 The content type cannot be an empty string.
 
 #### FST_ERR_CTP_INVALID_CONTENT_LENGTH
-<a name="FST_ERR_CTP_INVALID_CONTENT_LENGTH"></a>
+<a id="FST_ERR_CTP_INVALID_CONTENT_LENGTH"></a>
 
 Request body size did not match Content-Length.
 
 #### FST_ERR_CTP_INVALID_HANDLER
-<a name="FST_ERR_CTP_INVALID_HANDLER"></a>
+<a id="FST_ERR_CTP_INVALID_HANDLER"></a>
 
 An invalid handler was passed for the content type.
 
 #### FST_ERR_CTP_INVALID_MEDIA_TYPE
-<a name="FST_ERR_CTP_INVALID_MEDIA_TYPE"></a>
+<a id="FST_ERR_CTP_INVALID_MEDIA_TYPE"></a>
 
 The received media type is not supported (i.e. there is no suitable `Content-Type` parser for it).
 
 #### FST_ERR_CTP_INVALID_PARSE_TYPE
-<a name="FST_ERR_CTP_INVALID_PARSE_TYPE"></a>
+<a id="FST_ERR_CTP_INVALID_PARSE_TYPE"></a>
 
 The provided parse type is not supported. Accepted values are `string` or `buffer`.
 
 #### FST_ERR_CTP_INVALID_TYPE
-<a name="FST_ERR_CTP_INVALID_TYPE"></a>
+<a id="FST_ERR_CTP_INVALID_TYPE"></a>
 
 The `Content-Type` should be a string.
 
 #### FST_ERR_DEC_ALREADY_PRESENT
-<a name="FST_ERR_DEC_ALREADY_PRESENT"></a>
+<a id="FST_ERR_DEC_ALREADY_PRESENT"></a>
 
 A decorator with the same name is already registered.
 
 #### FST_ERR_DEC_MISSING_DEPENDENCY
-<a name="FST_ERR_DEC_MISSING_DEPENDENCY"></a>
+<a id="FST_ERR_DEC_MISSING_DEPENDENCY"></a>
 
 The decorator cannot be registered due to a missing dependency.
 
 #### FST_ERR_HOOK_INVALID_HANDLER
-<a name="FST_ERR_HOOK_INVALID_HANDLER"></a>
+<a id="FST_ERR_HOOK_INVALID_HANDLER"></a>
 
 The hook callback must be a function.
 
 #### FST_ERR_HOOK_INVALID_TYPE
-<a name="FST_ERR_HOOK_INVALID_TYPE"></a>
+<a id="FST_ERR_HOOK_INVALID_TYPE"></a>
 
 The hook name must be a string.
 
 #### FST_ERR_LOG_INVALID_DESTINATION
-<a name="FST_ERR_LOG_INVALID_DESTINATION"></a>
+<a id="FST_ERR_LOG_INVALID_DESTINATION"></a>
 
 The logger accepts either a `'stream'` or a `'file'` as the destination.
 
 #### FST_ERR_PROMISE_NOT_FULFILLED
-<a name="FST_ERR_PROMISE_NOT_FULFILLED"></a>
+<a id="FST_ERR_PROMISE_NOT_FULFILLED"></a>
 
 A promise may not be fulfilled with 'undefined' when statusCode is not 204.
 
 #### FST_ERR_REP_ALREADY_SENT
-<a name="FST_ERR_REP_ALREADY_SENT"></a>
+<a id="FST_ERR_REP_ALREADY_SENT"></a>
 
 A response was already sent.
 
 #### FST_ERR_REP_INVALID_PAYLOAD_TYPE
-<a name="FST_ERR_REP_INVALID_PAYLOAD_TYPE"></a>
+<a id="FST_ERR_REP_INVALID_PAYLOAD_TYPE"></a>
 
 Reply payload can be either a `string` or a `Buffer`.
 
 #### FST_ERR_SCH_ALREADY_PRESENT
-<a name="FST_ERR_SCH_ALREADY_PRESENT"></a>
+<a id="FST_ERR_SCH_ALREADY_PRESENT"></a>
 
 A schema with the same `$id` already exists.
 
 #### FST_ERR_SCH_MISSING_ID
-<a name="FST_ERR_SCH_MISSING_ID"></a>
+<a id="FST_ERR_SCH_MISSING_ID"></a>
 
 The schema provided does not have `$id` property.
 
 #### FST_ERR_SCH_SERIALIZATION_BUILD
-<a name="FST_ERR_SCH_SERIALIZATION_BUILD"></a>
+<a id="FST_ERR_SCH_SERIALIZATION_BUILD"></a>
 
 The JSON schema provided for serialization of a route response is not valid.
 
 #### FST_ERR_SCH_VALIDATION_BUILD
-<a name="FST_ERR_SCH_VALIDATION_BUILD"></a>
+<a id="FST_ERR_SCH_VALIDATION_BUILD"></a>
 
 The JSON schema provided for validation to a route is not valid.
 
 #### FST_ERR_SEND_INSIDE_ONERR
-<a name="FST_ERR_SEND_INSIDE_ONERR"></a>
+<a id="FST_ERR_SEND_INSIDE_ONERR"></a>
 
 You cannot use `send` inside the `onError` hook.
 
 #### FST_ERR_SEND_UNDEFINED_ERR
-<a name="FST_ERR_SEND_UNDEFINED_ERR"></a>
+<a id="FST_ERR_SEND_UNDEFINED_ERR"></a>
 
 Undefined error has occurred.

--- a/docs/Fluent-Schema.md
+++ b/docs/Fluent-Schema.md
@@ -2,7 +2,7 @@
 
 ## Fluent Schema
 
-The [Validation and Serialization](Validation-and-Serialization.md) documentation outlines all parameters accepted by Fastify to set up JSON Schema Validation to validate the input, and JSON Schema Serialization to optimize the output.
+The [Validation and Serialization](./Validation-and-Serialization.md) documentation outlines all parameters accepted by Fastify to set up JSON Schema Validation to validate the input, and JSON Schema Serialization to optimize the output.
 
 [`fluent-json-schema`](https://github.com/fastify/fluent-json-schema) can be used to simplify this task while allowing the reuse of constants.
 
@@ -53,7 +53,7 @@ fastify.post('/the/url', { schema }, handler)
 
 With `fluent-json-schema` you can manipulate your schemas more easily and programmatically and then reuse them
 thanks to the `addSchema()` method. You can refer to the schema in two different manners that are detailed
-in the [Validation-and-Serialization.md](Validation-and-Serialization.md#adding-a-shared-schema) documentation.
+in the [Validation-and-Serialization.md](./Validation-and-Serialization.md#adding-a-shared-schema) documentation.
 
 Here are some usage examples:
 

--- a/docs/Guides/Contributing.md
+++ b/docs/Guides/Contributing.md
@@ -7,20 +7,21 @@ help us.
 
 > ## Note
 > This is an informal guide. Please review the formal
-> [CONTRIBUTING document](/CONTRIBUTING.md) for full details and our
+> [CONTRIBUTING document](https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md) for full details and our
 > [Developer Certificate of Origin](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin).
 
 ## Table Of Contents
-<a id="contributing-toc"></a>
+<a name="contributing-toc"></a>
 
-0. [Types Of Contributions We're Looking For](#contribution-types)
-0. [Ground Rules & Expectations](#contributing-rules)
-0. [How To Contribute](#contributing-how-to)
-0. [Setting Up Your Environment](#contributing-environment)
-  * [Using Visual Studio Code](#contributing-vscode)
+- [Table Of Contents](#table-of-contents)
+- [Types Of Contributions We're Looking For](#types-of-contributions-were-looking-for)
+- [Ground Rules & Expectations](#ground-rules--expectations)
+- [How To Contribute](#how-to-contribute)
+- [Setting Up Your Environment](#setting-up-your-environment)
+  - [Using Visual Studio Code](#using-visual-studio-code)
 
 ## Types Of Contributions We're Looking For
-<a id="contribution-types"></a>
+<a name="contribution-types"></a>
 
 In short, we welcome any type of contribution you are willing to provide. No
 contribution is too small. We gladly accept contributions such as:
@@ -31,7 +32,7 @@ contribution is too small. We gladly accept contributions such as:
 * Reporting previously unknown bugs by opening an issue with a minimal reproduction
 
 ## Ground Rules & Expectations
-<a id="contributing-rules"></a>
+<a name="contributing-rules"></a>
 
 Before we get started, here are a few things we expect from you (and that
 you should expect from others):
@@ -40,14 +41,14 @@ you should expect from others):
   project is maintained by a diverse set of people from all across the globe.
   Each person has their own views and opinions about the project. Try to listen
   to each other and reach an agreement or compromise.
-* We have a [Code of Conduct](/CODE_OF_CONDUCT.md). You must adhere to it to
+* We have a [Code of Conduct](https://github.com/fastify/fastify/blob/main/CODE_OF_CONDUCT.md). You must adhere to it to
   participate in this project.
 * If you open a pull request, please ensure that your contribution passes all
   tests. If there are test failures, you will need to address them before we
   can merge your contribution.
 
 ## How To Contribute
-<a id="contributing-how-to"></a>
+<a name="contributing-how-to"></a>
 
 If you'd like to contribute, start by searching through the
 [issues](https://github.com/fastify/fastify/issues) and
@@ -67,7 +68,7 @@ https://github.com/github/opensource.guide/blob/2868efbf0c14aec821909c19e210c360
 -->
 
 ## Setting Up Your Environment
-<a id="contributing-environment"></a>
+<a name="contributing-environment"></a>
 
 Please adhere to the project's code and documentation style. Some popular tools
 that automatically "correct" code and documentation do not follow a style that
@@ -75,7 +76,8 @@ conforms to the styles this project uses. Notably, this project uses
 [StandardJS](https://standardjs.com) for code formatting.
 
 ### Using Visual Studio Code
-<a id="contributing-vscode"></a>
+<a name="contributing-vscode"></a>
+
 What follows is how to use [Visual Studio Code (VSCode) portable](https://code.visualstudio.com/docs/editor/portable)
 to create a Fastify specific environment. This guide is written as if you are
 setting up the environment on macOS, but the principles are the same across

--- a/docs/Guides/Contributing.md
+++ b/docs/Guides/Contributing.md
@@ -11,7 +11,7 @@ help us.
 > [Developer Certificate of Origin](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin).
 
 ## Table Of Contents
-<a name="contributing-toc"></a>
+<a id="contributing-toc"></a>
 
 - [Table Of Contents](#table-of-contents)
 - [Types Of Contributions We're Looking For](#types-of-contributions-were-looking-for)
@@ -21,7 +21,7 @@ help us.
   - [Using Visual Studio Code](#using-visual-studio-code)
 
 ## Types Of Contributions We're Looking For
-<a name="contribution-types"></a>
+<a id="contribution-types"></a>
 
 In short, we welcome any type of contribution you are willing to provide. No
 contribution is too small. We gladly accept contributions such as:
@@ -32,7 +32,7 @@ contribution is too small. We gladly accept contributions such as:
 * Reporting previously unknown bugs by opening an issue with a minimal reproduction
 
 ## Ground Rules & Expectations
-<a name="contributing-rules"></a>
+<a id="contributing-rules"></a>
 
 Before we get started, here are a few things we expect from you (and that
 you should expect from others):
@@ -48,7 +48,7 @@ you should expect from others):
   can merge your contribution.
 
 ## How To Contribute
-<a name="contributing-how-to"></a>
+<a id="contributing-how-to"></a>
 
 If you'd like to contribute, start by searching through the
 [issues](https://github.com/fastify/fastify/issues) and
@@ -68,7 +68,7 @@ https://github.com/github/opensource.guide/blob/2868efbf0c14aec821909c19e210c360
 -->
 
 ## Setting Up Your Environment
-<a name="contributing-environment"></a>
+<a id="contributing-environment"></a>
 
 Please adhere to the project's code and documentation style. Some popular tools
 that automatically "correct" code and documentation do not follow a style that
@@ -76,7 +76,7 @@ conforms to the styles this project uses. Notably, this project uses
 [StandardJS](https://standardjs.com) for code formatting.
 
 ### Using Visual Studio Code
-<a name="contributing-vscode"></a>
+<a id="contributing-vscode"></a>
 
 What follows is how to use [Visual Studio Code (VSCode) portable](https://code.visualstudio.com/docs/editor/portable)
 to create a Fastify specific environment. This guide is written as if you are

--- a/docs/Guides/Getting-Started.md
+++ b/docs/Guides/Getting-Started.md
@@ -9,7 +9,7 @@ This document aims to be a gentle introduction to the framework and its features
 Let's start!
 
 ### Install
-<a name="install"></a>
+<a id="install"></a>
 
 Install with npm:
 ```
@@ -21,7 +21,7 @@ yarn add fastify
 ```
 
 ### Your first server
-<a name="first-server"></a>
+<a id="first-server"></a>
 
 Let's write our first server:
 ```js
@@ -105,7 +105,7 @@ Fastify offers an easy platform that helps to solve all of the problems outlined
 > When deploying to a Docker (or another type of) container using `0.0.0.0` or `::` would be the easiest method for exposing the application.
 
 ### Your first plugin
-<a name="first-plugin"></a>
+<a id="first-plugin"></a>
 
 As with JavaScript, where everything is an object, with Fastify everything is a plugin.
 
@@ -315,7 +315,7 @@ The MongoDB plugin uses the `decorate` API to add custom objects to the Fastify 
 To dig deeper into how Fastify plugins work, how to develop new plugins, and for details on how to use the whole Fastify API to deal with the complexity of asynchronously bootstrapping an application, read [the hitchhiker's guide to plugins](../Plugins-Guide.md).
 
 ### Loading order of your plugins
-<a name="plugin-loading-order"></a>
+<a id="plugin-loading-order"></a>
 
 To guarantee consistent and predictable behavior of your application, we highly recommend to always load your code as shown below:
 ```
@@ -351,7 +351,7 @@ As discussed previously, Fastify offers a solid encapsulation model, to help you
 ```
 
 ### Validate your data
-<a name="validate-data"></a>
+<a id="validate-data"></a>
 
 Data validation is extremely important and a core concept of the framework.
 
@@ -382,7 +382,7 @@ This example shows how to pass an options object to the route, which accepts a `
 Read [Validation and Serialization](../Validation-and-Serialization.md) to learn more.
 
 ### Serialize your data
-<a name="serialize-data"></a>
+<a id="serialize-data"></a>
 
 Fastify has first class support for JSON. It is extremely optimized to parse JSON bodies and to serialize JSON output.
 
@@ -409,7 +409,7 @@ By specifying a schema as shown, you can speed up serialization by a factor of 2
 Read [Validation and Serialization](../Validation-and-Serialization.md) to learn more.
 
 ### Parsing request payloads
-<a name="request-payload"></a>
+<a id="request-payload"></a>
 
 Fastify parses `'application/json'` and `'text/plain'` request payloads natively, with the result accessible from the [Fastify request](../Request.md) object at `request.body`.
 
@@ -425,21 +425,21 @@ fastify.post('/', opts, async (request, reply) => {
 Read [Content-Type Parser](../ContentTypeParser.md) to learn more about Fastify's default parsing functionality and how to support other content types.
 
 ### Extend your server
-<a name="extend-server"></a>
+<a id="extend-server"></a>
 
 Fastify is built to be extremely extensible and minimal, we believe that a bare-bones framework is all that is necessary to make great applications possible.
 
 In other words, Fastify is not a "batteries included" framework, and relies on an amazing [ecosystem](../Ecosystem.md)!
 
 ### Test your server
-<a name="test-server"></a>
+<a id="test-server"></a>
 
 Fastify does not offer a testing framework, but we do recommend a way to write your tests that uses the features and architecture of Fastify.
 
 Read the [testing](../Testing.md) documentation to learn more!
 
 ### Run your server from CLI
-<a name="cli"></a>
+<a id="cli"></a>
 
 Fastify also has CLI integration thanks to [fastify-cli](https://github.com/fastify/fastify-cli).
 
@@ -478,7 +478,7 @@ npm start
 ```
 
 ### Slides and Videos
-<a name="slides"></a>
+<a id="slides"></a>
 
 - Slides
   - [Take your HTTP server to ludicrous speed](https://mcollina.github.io/take-your-http-server-to-ludicrous-speed) by [@mcollina](https://github.com/mcollina)

--- a/docs/Guides/Getting-Started.md
+++ b/docs/Guides/Getting-Started.md
@@ -1,8 +1,11 @@
 <h1 align="center">Fastify</h1>
 
 ## Getting Started
-Hello! Thank you for checking out Fastify!<br>
-This document aims to be a gentle introduction to the framework and its features. It is an elementary preface with examples and links to other parts of the documentation.<br>
+
+Hello! Thank you for checking out Fastify!
+
+This document aims to be a gentle introduction to the framework and its features. It is an elementary preface with examples and links to other parts of the documentation.
+
 Let's start!
 
 ### Install
@@ -49,7 +52,8 @@ fastify.listen(3000, function (err, address) {
 })
 ```
 
-Do you prefer to use `async/await`? Fastify supports it out-of-the-box.<br>
+Do you prefer to use `async/await`? Fastify supports it out-of-the-box.
+
 *(We also suggest using [make-promises-safe](https://github.com/mcollina/make-promises-safe) to avoid file descriptor and memory leaks.)*
 ```js
 // ESM
@@ -77,8 +81,10 @@ const start = async () => {
 start()
 ```
 
-Awesome, that was easy.<br>
-Unfortunately, writing a complex application requires significantly more code than this example. A classic problem when you are building a new application is how to handle multiple files, asynchronous bootstrapping, and the architecture of your code.<br>
+Awesome, that was easy.
+
+Unfortunately, writing a complex application requires significantly more code than this example. A classic problem when you are building a new application is how to handle multiple files, asynchronous bootstrapping, and the architecture of your code.
+
 Fastify offers an easy platform that helps to solve all of the problems outlined above, and more!
 
 > ## Note
@@ -101,9 +107,11 @@ Fastify offers an easy platform that helps to solve all of the problems outlined
 ### Your first plugin
 <a name="first-plugin"></a>
 
-As with JavaScript, where everything is an object, with Fastify everything is a plugin.<br>
-Before digging into it, let's see how it works!<br>
-Let's declare our basic server, but instead of declaring the route inside the entry point, we'll declare it in an external file (check out the [route declaration](Routes.md) docs).
+As with JavaScript, where everything is an object, with Fastify everything is a plugin.
+
+Before digging into it, let's see how it works!
+
+Let's declare our basic server, but instead of declaring the route inside the entry point, we'll declare it in an external file (check out the [route declaration](../Routes.md) docs).
 ```js
 // ESM
 import Fastify from 'fastify'
@@ -154,11 +162,15 @@ module.exports = routes
 In this example, we used the `register` API, which is the core of the Fastify framework. It is the only way to add routes, plugins, et cetera.
 
 At the beginning of this guide, we noted that Fastify provides a foundation that assists with asynchronous bootstrapping of your application. Why is this important?
-Consider the scenario where a database connection is needed to handle data storage. The database connection needs to be available before the server is accepting connections. How do we address this problem?<br>
-A typical solution is to use a complex callback, or promises - a system that will mix the framework API with other libraries and the application code.<br>
+
+Consider the scenario where a database connection is needed to handle data storage. The database connection needs to be available before the server is accepting connections. How do we address this problem?
+
+A typical solution is to use a complex callback, or promises - a system that will mix the framework API with other libraries and the application code.
+
 Fastify handles this internally, with minimum effort!
 
-Let's rewrite the above example with a database connection.<br>
+Let's rewrite the above example with a database connection.
+
 
 First, install `fastify-plugin` and `fastify-mongodb`:
 
@@ -219,7 +231,7 @@ async function dbConnector (fastify, options) {
   })
 }
 
-// Wrapping a plugin function with fastify-plugin exposes the decorators	
+// Wrapping a plugin function with fastify-plugin exposes the decorators
 // and hooks, declared inside the plugin to the parent scope.
 module.exports = fastifyPlugin(dbConnector)
 
@@ -235,7 +247,7 @@ async function dbConnector (fastify, options) {
   })
 }
 
-// Wrapping a plugin function with fastify-plugin exposes the decorators	
+// Wrapping a plugin function with fastify-plugin exposes the decorators
 // and hooks, declared inside the plugin to the parent scope.
 module.exports = fastifyPlugin(dbConnector)
 
@@ -288,15 +300,19 @@ async function routes (fastify, options) {
 module.exports = routes
 ```
 
-Wow, that was fast!<br>
-Let's recap what we have done here since we've introduced some new concepts.<br>
+Wow, that was fast!
+
+Let's recap what we have done here since we've introduced some new concepts.
+
 As you can see, we used `register` for both the database connector and the registration of the routes.
-This is one of the best features of Fastify, it will load your plugins in the same order you declare them, and it will load the next plugin only once the current one has been loaded. In this way, we can register the database connector in the first plugin and use it in the second *(read [here](Plugins.md#handle-the-scope) to understand how to handle the scope of a plugin)*.
+
+This is one of the best features of Fastify, it will load your plugins in the same order you declare them, and it will load the next plugin only once the current one has been loaded. In this way, we can register the database connector in the first plugin and use it in the second *(read [here](../Plugins.md#handle-the-scope) to understand how to handle the scope of a plugin)*.
+
 Plugin loading starts when you call `fastify.listen()`, `fastify.inject()` or `fastify.ready()`
 
 The MongoDB plugin uses the `decorate` API to add custom objects to the Fastify instance, making them available for use everywhere. Use of this API is encouraged to facilitate easy code reuse and to decrease code or logic duplication.
 
-To dig deeper into how Fastify plugins work, how to develop new plugins, and for details on how to use the whole Fastify API to deal with the complexity of asynchronously bootstrapping an application, read [the hitchhiker's guide to plugins](Plugins-Guide.md).
+To dig deeper into how Fastify plugins work, how to develop new plugins, and for details on how to use the whole Fastify API to deal with the complexity of asynchronously bootstrapping an application, read [the hitchhiker's guide to plugins](../Plugins-Guide.md).
 
 ### Loading order of your plugins
 <a name="plugin-loading-order"></a>
@@ -309,7 +325,8 @@ To guarantee consistent and predictable behavior of your application, we highly 
 └── hooks
 └── your services
 ```
-In this way, you will always have access to all of the properties declared in the current scope.<br/>
+In this way, you will always have access to all of the properties declared in the current scope.
+
 As discussed previously, Fastify offers a solid encapsulation model, to help you build your application as single and independent services. If you want to register a plugin only for a subset of routes, you just have to replicate the above structure.
 ```
 └── plugins (from the Fastify ecosystem)
@@ -336,8 +353,10 @@ As discussed previously, Fastify offers a solid encapsulation model, to help you
 ### Validate your data
 <a name="validate-data"></a>
 
-Data validation is extremely important and a core concept of the framework.<br>
+Data validation is extremely important and a core concept of the framework.
+
 To validate incoming requests, Fastify uses [JSON Schema](https://json-schema.org/).
+
 (JTD schemas are loosely supported, but `jsonShorthand` must be disabled first)
 
 Let's look at an example demonstrating validation for routes:
@@ -358,13 +377,15 @@ fastify.post('/', opts, async (request, reply) => {
   return { hello: 'world' }
 })
 ```
-This example shows how to pass an options object to the route, which accepts a `schema` key that contains all of the schemas for route, `body`, `querystring`, `params`, and `headers`.<br>
-Read [Validation and Serialization](Validation-and-Serialization.md) to learn more.
+This example shows how to pass an options object to the route, which accepts a `schema` key that contains all of the schemas for route, `body`, `querystring`, `params`, and `headers`.
+
+Read [Validation and Serialization](../Validation-and-Serialization.md) to learn more.
 
 ### Serialize your data
 <a name="serialize-data"></a>
 
-Fastify has first class support for JSON. It is extremely optimized to parse JSON bodies and to serialize JSON output.<br>
+Fastify has first class support for JSON. It is extremely optimized to parse JSON bodies and to serialize JSON output.
+
 To speed up JSON serialization (yes, it is slow!) use the `response` key of the schema option as shown in the following example:
 ```js
 const opts = {
@@ -385,12 +406,13 @@ fastify.get('/', opts, async (request, reply) => {
 })
 ```
 By specifying a schema as shown, you can speed up serialization by a factor of 2-3. This also helps to protect against leakage of potentially sensitive data, since Fastify will serialize only the data present in the response schema.
-Read [Validation and Serialization](Validation-and-Serialization.md) to learn more.
+Read [Validation and Serialization](../Validation-and-Serialization.md) to learn more.
 
 ### Parsing request payloads
 <a name="request-payload"></a>
 
-Fastify parses `'application/json'` and `'text/plain'` request payloads natively, with the result accessible from the [Fastify request](Request.md) object at `request.body`.<br>
+Fastify parses `'application/json'` and `'text/plain'` request payloads natively, with the result accessible from the [Fastify request](../Request.md) object at `request.body`.
+
 The following example returns the parsed body of a request back to the client:
 
 ```js
@@ -400,19 +422,21 @@ fastify.post('/', opts, async (request, reply) => {
 })
 ```
 
-Read [Content Type Parser](ContentTypeParser.md) to learn more about Fastify's default parsing functionality and how to support other content types.
+Read [Content-Type Parser](../ContentTypeParser.md) to learn more about Fastify's default parsing functionality and how to support other content types.
 
 ### Extend your server
 <a name="extend-server"></a>
 
-Fastify is built to be extremely extensible and minimal, we believe that a bare-bones framework is all that is necessary to make great applications possible.<br>
-In other words, Fastify is not a "batteries included" framework, and relies on an amazing [ecosystem](Ecosystem.md)!
+Fastify is built to be extremely extensible and minimal, we believe that a bare-bones framework is all that is necessary to make great applications possible.
+
+In other words, Fastify is not a "batteries included" framework, and relies on an amazing [ecosystem](../Ecosystem.md)!
 
 ### Test your server
 <a name="test-server"></a>
 
-Fastify does not offer a testing framework, but we do recommend a way to write your tests that uses the features and architecture of Fastify.<br>
-Read the [testing](Testing.md) documentation to learn more!
+Fastify does not offer a testing framework, but we do recommend a way to write your tests that uses the features and architecture of Fastify.
+
+Read the [testing](../Testing.md) documentation to learn more!
 
 ### Run your server from CLI
 <a name="cli"></a>

--- a/docs/Guides/Index.md
+++ b/docs/Guides/Index.md
@@ -1,6 +1,6 @@
 # Guides
 
 ## General
-<a name="guides-general"></a>
+<a id="guides-general"></a>
 
 * [Contributing To Fastify](./Contributing.md)

--- a/docs/Guides/Index.md
+++ b/docs/Guides/Index.md
@@ -1,6 +1,6 @@
 # Guides
 
 ## General
-<a id="guides-general"></a>
+<a name="guides-general"></a>
 
 * [Contributing To Fastify](./Contributing.md)

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -347,7 +347,7 @@ fastify.addHook('onReady', async function () {
 ```
 
 ### onClose
-<a name="on-close"></a>
+<a id="on-close"></a>
 
 Triggered when `fastify.close()` is invoked to stop the server. It is useful when [plugins](./Plugins.md) need a "shutdown" event, for example, to close an open connection to a database.
 
@@ -360,7 +360,7 @@ fastify.addHook('onClose', (instance, done) => {
 ```
 
 ### onRoute
-<a name="on-route"></a>
+<a id="on-route"></a>
 
 Triggered when a new route is registered. Listeners are passed a `routeOptions` object as the sole parameter. The interface is synchronous, and, as such, the listeners are not passed a callback. This hook is encapsulated.
 ```js
@@ -392,7 +392,7 @@ fastify.addHook('onRoute', (routeOptions) => {
 ```
 
 ### onRegister
-<a name="on-register"></a>
+<a id="on-register"></a>
 
 Triggered when a new plugin is registered and a new encapsulation context is created. The hook will be executed **before** the registered code.
 
@@ -429,7 +429,7 @@ fastify.addHook('onRegister', (instance, opts) => {
 ```
 
 ## Scope
-<a name="scope"></a>
+<a id="scope"></a>
 
 Except for [onClose](#onclose), all hooks are encapsulated. This means that you can decide where your hooks should run by using `register` as explained in the [plugins guide](./Plugins-Guide.md). If you pass a function, that function is bound to the right Fastify context and from there you have full access to the Fastify API.
 
@@ -470,7 +470,7 @@ Warn: if you declare the function with an [arrow function](https://developer.moz
 
 
 ## Route level hooks
-<a name="route-hooks"></a>
+<a id="route-hooks"></a>
 
 You can declare one or more custom lifecycle hooks ([onRequest](#onrequest), [onResponse](#onresponse), [preParsing](#preparsing), [preValidation](#prevalidation), [preHandler](#prehandler), [preSerialization](#preserialization), [onSend](#onsend), [onTimeout](#ontimeout), and [onError](#onerror)) hook(s) that will be **unique** for the route.
 If you do so, those hooks are always executed as the last hook in their category. 

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -25,15 +25,18 @@ By using hooks you can interact directly with the lifecycle of Fastify. There ar
   - [onRegister](#onregister)
 - [Scope](#scope)
 - [Route level hooks](#route-level-hooks)
+- [Diagnostics Channel Hooks](#diagnostics-channel-hooks)
 
 **Notice:** the `done` callback is not available when using `async`/`await` or returning a `Promise`. If you do invoke a `done` callback in this situation unexpected behavior may occur, e.g. duplicate invocation of handlers.
 
 ## Request/Reply Hooks
 
-[Request](Request.md) and [Reply](Reply.md) are the core Fastify objects.<br/>
-`done` is the function to continue with the [lifecycle](Lifecycle.md).
+[Request](./Request.md) and [Reply](./Reply.md) are the core Fastify objects.
 
-It is easy to understand where each hook is executed by looking at the [lifecycle page](Lifecycle.md).<br>
+`done` is the function to continue with the [lifecycle](./Lifecycle.md).
+
+It is easy to understand where each hook is executed by looking at the [lifecycle page](./Lifecycle.md).
+
 Hooks are affected by Fastify's encapsulation, and can thus be applied to selected routes. See the [Scopes](#scope) section for more information.
 
 There are eight different hooks that you can use in Request/Reply *(in order of execution)*:
@@ -150,9 +153,12 @@ fastify.addHook('onError', async (request, reply, error) => {
   // You should not use this hook to update the error
 })
 ```
-This hook is useful if you need to do some custom error logging or add some specific header in case of error.<br/>
-It is not intended for changing the error, and calling `reply.send` will throw an exception.<br/>
-This hook will be executed only after the `customErrorHandler` has been executed, and only if the `customErrorHandler` sends an error back to the user *(Note that the default `customErrorHandler` always sends the error back to the user)*.<br/>
+This hook is useful if you need to do some custom error logging or add some specific header in case of error.
+
+It is not intended for changing the error, and calling `reply.send` will throw an exception.
+
+This hook will be executed only after the `customErrorHandler` has been executed, and only if the `customErrorHandler` sends an error back to the user *(Note that the default `customErrorHandler` always sends the error back to the user)*.
+
 **Notice:** unlike the other hooks, pass an error to the `done` function is not supported.
 
 ### onSend
@@ -190,7 +196,6 @@ Note: If you change the payload, you may only change it to a `string`, a `Buffer
 
 ### onResponse
 ```js
-
 fastify.addHook('onResponse', (request, reply, done) => {
   // Some code
   done()
@@ -209,7 +214,6 @@ The `onResponse` hook is executed when a response has been sent, so you will not
 ### onTimeout
 
 ```js
-
 fastify.addHook('onTimeout', (request, reply, done) => {
   // Some code
   done()
@@ -241,7 +245,7 @@ fastify.addHook('preHandler', (request, reply, done) => {
   done(new Error('Some error'))
 })
 ```
-*The error will be handled by [`Reply`](Reply.md#errors).*
+*The error will be handled by [`Reply`](./Reply.md#errors).*
 
 Or if you're using `async/await` you can just throw an error:
 ```js
@@ -345,7 +349,8 @@ fastify.addHook('onReady', async function () {
 ### onClose
 <a name="on-close"></a>
 
-Triggered when `fastify.close()` is invoked to stop the server. It is useful when [plugins](Plugins.md) need a "shutdown" event, for example, to close an open connection to a database.<br>
+Triggered when `fastify.close()` is invoked to stop the server. It is useful when [plugins](./Plugins.md) need a "shutdown" event, for example, to close an open connection to a database.
+
 The first argument is the Fastify instance, the second one the `done` callback.
 ```js
 fastify.addHook('onClose', (instance, done) => {
@@ -389,8 +394,10 @@ fastify.addHook('onRoute', (routeOptions) => {
 ### onRegister
 <a name="on-register"></a>
 
-Triggered when a new plugin is registered and a new encapsulation context is created. The hook will be executed **before** the registered code.<br/>
-This hook can be useful if you are developing a plugin that needs to know when a plugin context is formed, and you want to operate in that specific context, thus this hook is encapsulated.<br/>
+Triggered when a new plugin is registered and a new encapsulation context is created. The hook will be executed **before** the registered code.
+
+This hook can be useful if you are developing a plugin that needs to know when a plugin context is formed, and you want to operate in that specific context, thus this hook is encapsulated.
+
 **Note:** This hook will not be called if a plugin is wrapped inside [`fastify-plugin`](https://github.com/fastify/fastify-plugin).
 ```js
 fastify.decorate('data', [])
@@ -424,7 +431,7 @@ fastify.addHook('onRegister', (instance, opts) => {
 ## Scope
 <a name="scope"></a>
 
-Except for [onClose](#onclose), all hooks are encapsulated. This means that you can decide where your hooks should run by using `register` as explained in the [plugins guide](Plugins-Guide.md). If you pass a function, that function is bound to the right Fastify context and from there you have full access to the Fastify API.
+Except for [onClose](#onclose), all hooks are encapsulated. This means that you can decide where your hooks should run by using `register` as explained in the [plugins guide](./Plugins-Guide.md). If you pass a function, that function is bound to the right Fastify context and from there you have full access to the Fastify API.
 
 ```js
 fastify.addHook('onRequest', function (request, reply, done) {
@@ -466,7 +473,8 @@ Warn: if you declare the function with an [arrow function](https://developer.moz
 <a name="route-hooks"></a>
 
 You can declare one or more custom lifecycle hooks ([onRequest](#onrequest), [onResponse](#onresponse), [preParsing](#preparsing), [preValidation](#prevalidation), [preHandler](#prehandler), [preSerialization](#preserialization), [onSend](#onsend), [onTimeout](#ontimeout), and [onError](#onerror)) hook(s) that will be **unique** for the route.
-If you do so, those hooks are always executed as the last hook in their category. <br/>
+If you do so, those hooks are always executed as the last hook in their category. 
+
 This can be useful if you need to implement authentication, where the [preParsing](#preparsing) or [preValidation](#prevalidation) hooks are exactly what you need.
 Multiple route-level hooks can also be specified as an array.
 

--- a/docs/LTS.md
+++ b/docs/LTS.md
@@ -1,7 +1,7 @@
 <h1 align="center">Fastify</h1>
 
 ## Long Term Support
-<a name="lts"></a>
+<a id="lts"></a>
 
 Fastify's Long Term Support (LTS) is provided according to the schedule laid
 out in this document:
@@ -41,7 +41,7 @@ A "month" is defined as 30 consecutive days.
 [semver]: https://semver.org/
 
 ### Schedule
-<a name="lts-schedule"></a>
+<a id="lts-schedule"></a>
 
 | Version | Release Date | End Of LTS Date | Node.js              |
 | :------ | :----------- | :-------------- | :------------------- |
@@ -50,7 +50,7 @@ A "month" is defined as 30 consecutive days.
 | 3.0.0   | 2020-07-07   | TBD             | 10, 12, 14, 16       |
 
 ### CI tested operating systems
-<a name="supported-os"></a>
+<a id="supported-os"></a>
 
 Fastify uses GitHub Actions for CI testing, please refer to
 [GitHub's documentation regarding workflow runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)

--- a/docs/Lifecycle.md
+++ b/docs/Lifecycle.md
@@ -1,7 +1,8 @@
 <h1 align="center">Fastify</h1>
 
 ## Lifecycle
-Following the schema of the internal lifecycle of Fastify.<br>
+Following the schema of the internal lifecycle of Fastify.
+
 On the right branch of every section there is the next phase of the lifecycle, on the left branch there is the corresponding error code that will be generated if the parent throws an error *(note that all the errors are automatically handled by Fastify)*.
 
 ```

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -82,7 +82,7 @@ const fastify = require('fastify')({
 })
 ```
 
-<a name="logging-request-id"></a>
+<a id="logging-request-id"></a>
 
 By default, Fastify adds an ID to every request for easier tracking. If the "request-id" header is present its value is used, otherwise a new incremental ID is generated. See Fastify Factory [`requestIdHeader`](./Reference/Server.md#factory-request-id-header) and Fastify Factory [`genReqId`](./Reference/Server.md#genreqid) for customization options.
 

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -86,7 +86,7 @@ const fastify = require('fastify')({
 
 By default, Fastify adds an ID to every request for easier tracking. If the "request-id" header is present its value is used, otherwise a new incremental ID is generated. See Fastify Factory [`requestIdHeader`](./Reference/Server.md#factory-request-id-header) and Fastify Factory [`genReqId`](./Reference/Server.md#genreqid) for customization options.
 
-The default logger is configured with a set of standard serializers that serialize objects with `req`, `res`, and `err` properties. The object received by `req` is the Fastify [`Request`](Request.md) object, while the object received by `res` is the Fastify [`Reply`](Reply.md) object.
+The default logger is configured with a set of standard serializers that serialize objects with `req`, `res`, and `err` properties. The object received by `req` is the Fastify [`Request`](./Request.md) object, while the object received by `res` is the Fastify [`Reply`](./Reply.md) object.
 This behaviour can be customized by specifying custom serializers.
 ```js
 const fastify = require('fastify')({
@@ -163,7 +163,7 @@ fastify.get('/', function (request, reply) {
 })
 ```
 
-*The logger instance for the current request is available in every part of the [lifecycle](Lifecycle.md).*
+*The logger instance for the current request is available in every part of the [lifecycle](./Lifecycle.md).*
 
 ## Log Redaction
 

--- a/docs/Middleware.md
+++ b/docs/Middleware.md
@@ -24,9 +24,9 @@ await fastify.register(require('middie'))
 fastify.use(require('cors')())
 ```
 
-Remember that middleware can be encapsulated; this means that you can decide where your middleware should run by using `register` as explained in the [plugins guide](Plugins-Guide.md).
+Remember that middleware can be encapsulated; this means that you can decide where your middleware should run by using `register` as explained in the [plugins guide](./Plugins-Guide.md).
 
-Fastify middleware do not expose the `send` method or other methods specific to the Fastify [Reply](Reply.md#reply) instance. This is because Fastify wraps the incoming `req` and `res` Node instances using the [Request](Request.md#request) and [Reply](Reply.md#reply) objects internally, but this is done after the middleware phase. If you need to create middleware, you have to use the Node `req` and `res` instances. Otherwise, you can use the `preHandler` hook that already has the [Request](Request.md#request) and [Reply](Reply.md#reply) Fastify instances. For more information, see [Hooks](Hooks.md#hooks).
+Fastify middleware do not expose the `send` method or other methods specific to the Fastify [Reply](./Reply.md#reply) instance. This is because Fastify wraps the incoming `req` and `res` Node instances using the [Request](./Request.md#request) and [Reply](./Reply.md#reply) objects internally, but this is done after the middleware phase. If you need to create middleware, you have to use the Node `req` and `res` instances. Otherwise, you can use the `preHandler` hook that already has the [Request](./Request.md#request) and [Reply](./Reply.md#reply) Fastify instances. For more information, see [Hooks](./Hooks.md#hooks).
 
 #### Restrict middleware execution to certain paths
 <a name="restrict-usage"></a>

--- a/docs/Middleware.md
+++ b/docs/Middleware.md
@@ -29,7 +29,7 @@ Remember that middleware can be encapsulated; this means that you can decide whe
 Fastify middleware do not expose the `send` method or other methods specific to the Fastify [Reply](./Reply.md#reply) instance. This is because Fastify wraps the incoming `req` and `res` Node instances using the [Request](./Request.md#request) and [Reply](./Reply.md#reply) objects internally, but this is done after the middleware phase. If you need to create middleware, you have to use the Node `req` and `res` instances. Otherwise, you can use the `preHandler` hook that already has the [Request](./Request.md#request) and [Reply](./Reply.md#reply) Fastify instances. For more information, see [Hooks](./Hooks.md#hooks).
 
 #### Restrict middleware execution to certain paths
-<a name="restrict-usage"></a>
+<a id="restrict-usage"></a>
 
 If you need to only run middleware under certain paths, just pass the path as the first parameter to `use` and you are done!
 

--- a/docs/Migration-Guide-V3.md
+++ b/docs/Migration-Guide-V3.md
@@ -34,8 +34,8 @@ fastify.use(require('cors')());
 
 ### Changed logging serialization ([#2017](https://github.com/fastify/fastify/pull/2017))
 
-The logging [Serializers](Logging.md) have been updated to now Fastify
-[`Request`](Request.md) and [`Reply`](Reply.md) objects instead of
+The logging [Serializers](./Logging.md) have been updated to now Fastify
+[`Request`](./Request.md) and [`Reply`](./Reply.md) objects instead of
 native ones.
 
 Any custom serializers must be updated if they rely upon `request` or `reply`
@@ -268,14 +268,14 @@ fastify.get('/', (request, reply) => {
 
 - Hooks now have consistent context regardless of how they are registered
 ([#2005](https://github.com/fastify/fastify/pull/2005))
-- Deprecated `request.req` and `reply.res` for [`request.raw`](Request.md) and
-[`reply.raw`](Reply.md) ([#2008](https://github.com/fastify/fastify/pull/2008))
+- Deprecated `request.req` and `reply.res` for [`request.raw`](./Request.md) and
+[`reply.raw`](./Reply.md) ([#2008](https://github.com/fastify/fastify/pull/2008))
 - Removed `modifyCoreObjects` option ([#2015](https://github.com/fastify/fastify/pull/2015))
 - Added [`connectionTimeout`](./Reference/Server.md#factory-connection-timeout)
 option ([#2086](https://github.com/fastify/fastify/pull/2086))
 - Added [`keepAliveTimeout`](./Reference/Server.md#factory-keep-alive-timeout)
 option ([#2086](https://github.com/fastify/fastify/pull/2086))
-- Added async-await support for [plugins](Plugins.md#async-await)
+- Added async-await support for [plugins](./Plugins.md#async-await)
 ([#2093](https://github.com/fastify/fastify/pull/2093))
 - Added the feature to throw object as error
 ([#2134](https://github.com/fastify/fastify/pull/2134))

--- a/docs/Plugins-Guide.md
+++ b/docs/Plugins-Guide.md
@@ -6,21 +6,23 @@ First of all, `DON'T PANIC`!
 Fastify was built from the beginning to be an extremely modular system. We built a powerful API that allows you to add methods and utilities to Fastify by creating a namespace. We built a system that creates an encapsulation model, which allows you to split your application into multiple microservices at any moment, without the need to refactor the entire application.
 
 **Table of contents**
-- [Register](#register)
-- [Decorators](#decorators)
-- [Hooks](#hooks)
-- [How to handle encapsulation and distribution](#distribution)
-- [ESM support](#esm-support)
-- [Handle errors](#handle-errors)
-- [Custom errors](#custom-errors)
-- [Emit warnings](#emit-warnings)
-- [Let's start!](#start)
+- [The hitchhiker's guide to plugins](#the-hitchhikers-guide-to-plugins)
+  - [Register](#register)
+  - [Decorators](#decorators)
+  - [Hooks](#hooks)
+  - [How to handle encapsulation and distribution](#how-to-handle-encapsulation-and-distribution)
+  - [ESM support](#esm-support)
+  - [Handle errors](#handle-errors)
+  - [Custom errors](#custom-errors)
+  - [Emit Warnings](#emit-warnings)
+  - [Let's start!](#lets-start)
 
 ## Register
 <a name="register"></a>
 
-As with JavaScript, where everything is an object, in Fastify everything is a plugin.<br>
-Your routes, your utilities, and so on are all plugins. To add a new plugin, whatever its functionality may be, in Fastify you have a nice and unique API: [`register`](Plugins.md).
+As with JavaScript, where everything is an object, in Fastify everything is a plugin.
+
+Your routes, your utilities, and so on are all plugins. To add a new plugin, whatever its functionality may be, in Fastify you have a nice and unique API: [`register`](./Plugins.md).
 ```js
 fastify.register(
   require('./my-plugin'),
@@ -29,12 +31,16 @@ fastify.register(
 ```
 `register` creates a new Fastify context, which means that if you perform any changes on the Fastify instance, those changes will not be reflected in the context's ancestors. In other words, encapsulation!
 
-*Why is encapsulation important?*<br>
-Well, let's say you are creating a new disruptive startup, what do you do? You create an API server with all your stuff, everything in the same place, a monolith!<br>
-Ok, you are growing very fast and you want to change your architecture and try microservices. Usually, this implies a huge amount of work, because of cross dependencies and a lack of separation of concerns in the codebase.<br>
+*Why is encapsulation important?*
+
+Well, let's say you are creating a new disruptive startup, what do you do? You create an API server with all your stuff, everything in the same place, a monolith!
+
+Ok, you are growing very fast and you want to change your architecture and try microservices. Usually, this implies a huge amount of work, because of cross dependencies and a lack of separation of concerns in the codebase.
+
 Fastify helps you in that regard. Thanks to the encapsulation model, it will completely avoid cross dependencies and will help you structure your code into cohesive blocks.
 
-*Let's return to how to correctly use `register`.*<br>
+*Let's return to how to correctly use `register`.*
+
 As you probably know, the required plugins must expose a single function with the following signature
 ```js
 module.exports = function (fastify, options, done) {}
@@ -73,11 +79,12 @@ console.log(util('that is ', 'awesome'))
 Now you will import your utility in every file you need it in. (And do not forget that you will probably also need it in your tests).
 
 Fastify offers you a more elegant and comfortable way to do this, *decorators*.
-Creating a decorator is extremely easy, just use the [`decorate`](Decorators.md) API:
+Creating a decorator is extremely easy, just use the [`decorate`](./Decorators.md) API:
 ```js
 fastify.decorate('util', (a, b) => a + b)
 ```
-Now you can access your utility just by calling `fastify.util` whenever you need it - even inside your test.<br>
+Now you can access your utility just by calling `fastify.util` whenever you need it - even inside your test.
+
 And here starts the magic; do you remember how just now we were talking about encapsulation? Well, using `register` and `decorate` in conjunction enable exactly that, let me show you an example to clarify this:
 ```js
 fastify.register((instance, opts, done) => {
@@ -93,7 +100,8 @@ fastify.register((instance, opts, done) => {
   done()
 })
 ```
-Inside the second register call `instance.util` will throw an error because `util` exists only inside the first register context.<br>
+Inside the second register call `instance.util` will throw an error because `util` exists only inside the first register context.
+
 Let's step back for a moment and dig deeper into this: every time you use the `register` API, a new context is created which avoids the negative situations mentioned above.
 
 Do note that encapsulation applies to the ancestors and siblings, but not the children.
@@ -120,7 +128,8 @@ fastify.register((instance, opts, done) => {
 
 `decorate` is not the only API that you can use to extend the server functionality, you can also use `decorateRequest` and `decorateReply`.
 
-*`decorateRequest` and `decorateReply`? Why do we need them if we already have `decorate`?*<br>
+*`decorateRequest` and `decorateReply`? Why do we need them if we already have `decorate`?*
+
 Good question, we added them to make Fastify more developer-friendly. Let's see an example:
 ```js
 fastify.decorate('html', payload => {
@@ -178,7 +187,7 @@ fastify.get('/happiness', (request, reply) => {
 })
 ```
 
-We have seen how to extend server functionality and how to handle the encapsulation system, but what if you need to add a function that must be executed every time when the server "[emits](Lifecycle.md)" an event?
+We have seen how to extend server functionality and how to handle the encapsulation system, but what if you need to add a function that must be executed every time when the server "[emits](./Lifecycle.md)" an event?
 
 ## Hooks
 <a name="hooks"></a>
@@ -199,7 +208,8 @@ fastify.get('/plugin2', (request, reply) => {
 ```
 I think we all agree that this is terrible. Repeated code, awful readability and it cannot scale.
 
-So what can you do to avoid this annoying issue? Yes, you are right, use a [hook](Hooks.md)!<br>
+So what can you do to avoid this annoying issue? Yes, you are right, use a [hook](./Hooks.md)!
+
 ```js
 fastify.decorate('util', (request, key, value) => { request[key] = value })
 
@@ -216,7 +226,8 @@ fastify.get('/plugin2', (request, reply) => {
   reply.send(request)
 })
 ```
-Now for every request, you will run your utility. You can register as many hooks as you need.<br>
+Now for every request, you will run your utility. You can register as many hooks as you need.
+
 Sometimes you want a hook that should be executed for just a subset of routes, how can you do that? Yep, encapsulation!
 
 ```js
@@ -241,7 +252,8 @@ fastify.get('/plugin2', (request, reply) => {
 ```
 Now your hook will run just for the first route!
 
-As you probably noticed by now, `request` and `reply` are not the standard Nodejs *request* and *response* objects, but Fastify's objects.<br>
+As you probably noticed by now, `request` and `reply` are not the standard Nodejs *request* and *response* objects, but Fastify's objects.
+
 
 ## How to handle encapsulation and distribution
 <a name="distribution"></a>
@@ -250,7 +262,8 @@ Perfect, now you know (almost) all of the tools that you can use to extend Fasti
 
 The preferred way to distribute a utility is to wrap all your code inside a `register`. Using this, your plugin can support asynchronous bootstrapping *(since `decorate` is a synchronous API)*, in the case of a database connection for example.
 
-*Wait, what? Didn't you tell me that `register` creates an encapsulation and that the stuff I create inside will not be available outside?*<br>
+*Wait, what? Didn't you tell me that `register` creates an encapsulation and that the stuff I create inside will not be available outside?*
+
 Yes, I said that. However, what I didn't tell you is that you can tell Fastify to avoid this behavior with the [`fastify-plugin`](https://github.com/fastify/fastify-plugin) module.
 ```js
 const fp = require('fastify-plugin')
@@ -267,7 +280,7 @@ module.exports = fp(dbPlugin)
 ```
 You can also tell `fastify-plugin` to check the installed version of Fastify, in case you need a specific API.
 
-As we mentioned earlier, Fastify starts loading its plugins __after__ `.listen()`, `.inject()` or `.ready()` are called and as such, __after__ they have been declared. This means that, even though the plugin may inject variables to the external Fastify instance via [`decorate`](Decorators.md), the decorated variables will not be accessible before calling `.listen()`, `.inject()` or `.ready()`.
+As we mentioned earlier, Fastify starts loading its plugins __after__ `.listen()`, `.inject()` or `.ready()` are called and as such, __after__ they have been declared. This means that, even though the plugin may inject variables to the external Fastify instance via [`decorate`](./Decorators.md), the decorated variables will not be accessible before calling `.listen()`, `.inject()` or `.ready()`.
 
 In case you rely on a variable injected by a preceding plugin and want to pass that in the `options` argument of `register`, you can do so by using a function instead of an object:
 ```js
@@ -326,7 +339,8 @@ fastify.listen(3000, (err, address) => {
 <a name="handle-errors"></a>
 
 It can happen that one of your plugins fails during startup. Maybe you expect it and you have a custom logic that will be triggered in that case. How can you implement this?
-The `after` API is what you need. `after` simply registers a callback that will be executed just after a register, and it can take up to three parameters.<br>
+The `after` API is what you need. `after` simply registers a callback that will be executed just after a register, and it can take up to three parameters.
+
 The callback changes based on the parameters you are giving:
 
 1. If no parameter is given to the callback and there is an error, that error will be passed to the next error handler.

--- a/docs/Plugins-Guide.md
+++ b/docs/Plugins-Guide.md
@@ -18,7 +18,7 @@ Fastify was built from the beginning to be an extremely modular system. We built
   - [Let's start!](#lets-start)
 
 ## Register
-<a name="register"></a>
+<a id="register"></a>
 
 As with JavaScript, where everything is an object, in Fastify everything is a plugin.
 
@@ -63,7 +63,7 @@ module.exports = function (fastify, options, done) {
 Well, now you know how to use the `register` API and how it works, but how do we add new functionality to Fastify and even better, share them with other developers?
 
 ## Decorators
-<a name="decorators"></a>
+<a id="decorators"></a>
 
 Okay, let's say that you wrote a utility that is so good that you decided to make it available along with all your code. How would you do it? Probably something like the following:
 ```js
@@ -190,7 +190,7 @@ fastify.get('/happiness', (request, reply) => {
 We have seen how to extend server functionality and how to handle the encapsulation system, but what if you need to add a function that must be executed every time when the server "[emits](./Lifecycle.md)" an event?
 
 ## Hooks
-<a name="hooks"></a>
+<a id="hooks"></a>
 
 You just built an amazing utility, but now you need to execute that for every request, this is what you will likely do:
 ```js
@@ -256,7 +256,7 @@ As you probably noticed by now, `request` and `reply` are not the standard Nodej
 
 
 ## How to handle encapsulation and distribution
-<a name="distribution"></a>
+<a id="distribution"></a>
 
 Perfect, now you know (almost) all of the tools that you can use to extend Fastify. Nevertheless, chances are that you came across one big issue: how is distribution handled?
 
@@ -303,7 +303,7 @@ fastify.register(require('your-plugin'), parent => {
 In the above example, the `parent` variable of the function passed in as the second argument of `register` is a copy of the **external Fastify instance** that the plugin was registered at. This means that we are able to access any variables that were injected by preceding plugins in the order of declaration.
 
 ## ESM support
-<a name="esm-support"></a>
+<a id="esm-support"></a>
 
 ESM is supported as well from [Node.js `v13.3.0`](https://nodejs.org/api/esm.html) and above! Just export your plugin as ESM module and you are good to go!
 
@@ -336,7 +336,7 @@ fastify.listen(3000, (err, address) => {
 ```
 
 ## Handle errors
-<a name="handle-errors"></a>
+<a id="handle-errors"></a>
 
 It can happen that one of your plugins fails during startup. Maybe you expect it and you have a custom logic that will be triggered in that case. How can you implement this?
 The `after` API is what you need. `after` simply registers a callback that will be executed just after a register, and it can take up to three parameters.
@@ -358,7 +358,7 @@ fastify
 ```
 
 ## Custom errors
-<a name="custom-errors"></a>
+<a id="custom-errors"></a>
 
 If your plugin needs to expose custom errors, you can easily generate consistent error objects across your codebase and plugins with the [`fastify-error`](https://github.com/fastify/fastify-error) module.
 
@@ -369,7 +369,7 @@ console.log(new CustomError())
 ```
 
 ## Emit Warnings
-<a name="emit-warnings"></a>
+<a id="emit-warnings"></a>
 
 If you want to deprecate an API, or you want to warn the user about a specific use case, you can use the [`fastify-warning`](https://github.com/fastify/fastify-warning) module.
 
@@ -380,7 +380,7 @@ warning.emit('FST_ERROR_CODE')
 ```
 
 ## Let's start!
-<a name="start"></a>
+<a id="start"></a>
 
 Awesome, now you know everything you need to know about Fastify and its plugin system to start building your first plugin, and please if you do, tell us! We will add it to the [*ecosystem*](https://github.com/fastify/fastify#ecosystem) section of our documentation!
 

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -2,7 +2,7 @@
 
 ## Plugins
 Fastify allows the user to extend its functionalities with plugins.
-A plugin can be a set of routes, a server [decorator](Decorators.md), or whatever. The API that you will need to use one or more plugins, is `register`.<br>
+A plugin can be a set of routes, a server [decorator](./Decorators.md), or whatever. The API that you will need to use one or more plugins, is `register`.
 
 By default, `register` creates a *new scope*, this means that if you make some changes to the Fastify instance (via `decorate`), this change will not be reflected by the current context ancestors, but only to its descendants. This feature allows us to achieve plugin *encapsulation* and *inheritance*, in this way we create a *direct acyclic graph* (DAG) and we will not have issues caused by cross dependencies.
 
@@ -16,9 +16,9 @@ fastify.register(plugin, [options])
 
 The optional `options` parameter for `fastify.register` supports a predefined set of options that Fastify itself will use, except when the plugin has been wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This options object will also be passed to the plugin upon invocation, regardless of whether or not the plugin has been wrapped. The currently supported list of Fastify specific options is:
 
-+ [`logLevel`](Routes.md#custom-log-level)
-+ [`logSerializers`](Routes.md#custom-log-serializer)
-+ [`prefix`](Plugins.md#route-prefixing-options)
++ [`logLevel`](./Routes.md#custom-log-level)
++ [`logSerializers`](./Routes.md#custom-log-serializer)
++ [`prefix`](./Plugins.md#route-prefixing-options)
 
 **Note: Those options will be ignored when used with fastify-plugin**
 
@@ -59,20 +59,22 @@ fastify.register(fp((fastify, opts, done) => {
 fastify.register(require('fastify-foo'), parent => parent.foo_bar)
 ```
 
-The Fastify instance passed on to the function is the latest state of the **external Fastify instance** the plugin was declared on, allowing access to variables injected via [`decorate`](Decorators.md) by preceding plugins according to the **order of registration**. This is useful in case a plugin depends on changes made to the Fastify instance by a preceding plugin i.e. utilizing an existing database connection to wrap around it.
+The Fastify instance passed on to the function is the latest state of the **external Fastify instance** the plugin was declared on, allowing access to variables injected via [`decorate`](./Decorators.md) by preceding plugins according to the **order of registration**. This is useful in case a plugin depends on changes made to the Fastify instance by a preceding plugin i.e. utilizing an existing database connection to wrap around it.
 
 Keep in mind that the Fastify instance passed on to the function is the same as the one that will be passed into the plugin, a copy of the external Fastify instance rather than a reference. Any usage of the instance will behave the same as it would if called within the plugins function i.e. if `decorate` is called, the decorated variables will be available within the plugins function unless it was wrapped with [`fastify-plugin`](https://github.com/fastify/fastify-plugin).
 
 #### Route Prefixing option
 <a name="route-prefixing-option"></a>
 
-If you pass an option with the key `prefix` with a `string` value, Fastify will use it to prefix all the routes inside the register, for more info check [here](Routes.md#route-prefixing).<br>
+If you pass an option with the key `prefix` with a `string` value, Fastify will use it to prefix all the routes inside the register, for more info check [here](./Routes.md#route-prefixing).
+
 Be aware that if you use [`fastify-plugin`](https://github.com/fastify/fastify-plugin) this option will not work.
 
 #### Error handling
 <a name="error-handling"></a>
 
-The error handling is done by [avvio](https://github.com/mcollina/avvio#error-handling).<br>
+The error handling is done by [avvio](https://github.com/mcollina/avvio#error-handling).
+
 As a general rule, it is highly recommended that you handle your errors in the next `after` or `ready` block, otherwise you will get them inside the `listen` callback.
 
 ```js
@@ -137,7 +139,8 @@ export default plugin
 ### Create a plugin
 <a name="create-plugin"></a>
 
-Creating a plugin is very easy, you just need to create a function that takes three parameters, the `fastify` instance, an `options` object, and the `done` callback.<br>
+Creating a plugin is very easy, you just need to create a function that takes three parameters, the `fastify` instance, an `options` object, and the `done` callback.
+
 Example:
 ```js
 module.exports = function (fastify, opts, done) {
@@ -160,14 +163,14 @@ module.exports = function (fastify, opts, done) {
   done()
 }
 ```
-Sometimes, you will need to know when the server is about to close, for example, because you must close a connection to a database. To know when this is going to happen, you can use the [`'onClose'`](Hooks.md#on-close) hook.
+Sometimes, you will need to know when the server is about to close, for example, because you must close a connection to a database. To know when this is going to happen, you can use the [`'onClose'`](./Hooks.md#on-close) hook.
 
 Do not forget that `register` will always create a new Fastify scope, if you do not need that, read the following section.
 
 ### Handle the scope
 <a name="handle-scope"></a>
 
-If you are using `register` only for extending the functionality of the server with  [`decorate`](Decorators.md), it is your responsibility to tell Fastify not to create a new scope. Otherwise, your changes will not be accessible by the user in the upper scope.
+If you are using `register` only for extending the functionality of the server with  [`decorate`](./Decorators.md), it is your responsibility to tell Fastify not to create a new scope. Otherwise, your changes will not be accessible by the user in the upper scope.
 
 You have two ways to tell Fastify to avoid the creation of a new context:
 - Use the [`fastify-plugin`](https://github.com/fastify/fastify-plugin) module

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -12,7 +12,7 @@ fastify.register(plugin, [options])
 ```
 
 ### Plugin Options
-<a name="plugin-options"></a>
+<a id="plugin-options"></a>
 
 The optional `options` parameter for `fastify.register` supports a predefined set of options that Fastify itself will use, except when the plugin has been wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This options object will also be passed to the plugin upon invocation, regardless of whether or not the plugin has been wrapped. The currently supported list of Fastify specific options is:
 
@@ -64,14 +64,14 @@ The Fastify instance passed on to the function is the latest state of the **exte
 Keep in mind that the Fastify instance passed on to the function is the same as the one that will be passed into the plugin, a copy of the external Fastify instance rather than a reference. Any usage of the instance will behave the same as it would if called within the plugins function i.e. if `decorate` is called, the decorated variables will be available within the plugins function unless it was wrapped with [`fastify-plugin`](https://github.com/fastify/fastify-plugin).
 
 #### Route Prefixing option
-<a name="route-prefixing-option"></a>
+<a id="route-prefixing-option"></a>
 
 If you pass an option with the key `prefix` with a `string` value, Fastify will use it to prefix all the routes inside the register, for more info check [here](./Routes.md#route-prefixing).
 
 Be aware that if you use [`fastify-plugin`](https://github.com/fastify/fastify-plugin) this option will not work.
 
 #### Error handling
-<a name="error-handling"></a>
+<a id="error-handling"></a>
 
 The error handling is done by [avvio](https://github.com/mcollina/avvio#error-handling).
 
@@ -96,7 +96,7 @@ fastify.listen(3000, (err, address) => {
 ```
 
 ### async/await
-<a name="async-await"></a>
+<a id="async-await"></a>
 
 *async/await* is supported by `after`, `ready` and `listen`, as well as
 `fastify` being a [Thenable](https://promisesaplus.com/).
@@ -112,7 +112,7 @@ await fastify.listen(3000)
 ```
 
 #### ESM support
-<a name="esm-support"></a>
+<a id="esm-support"></a>
 
 ESM is supported as well from [Node.js `v13.3.0`](https://nodejs.org/api/esm.html) and above!
 
@@ -137,7 +137,7 @@ export default plugin
 ```
 
 ### Create a plugin
-<a name="create-plugin"></a>
+<a id="create-plugin"></a>
 
 Creating a plugin is very easy, you just need to create a function that takes three parameters, the `fastify` instance, an `options` object, and the `done` callback.
 
@@ -168,7 +168,7 @@ Sometimes, you will need to know when the server is about to close, for example,
 Do not forget that `register` will always create a new Fastify scope, if you do not need that, read the following section.
 
 ### Handle the scope
-<a name="handle-scope"></a>
+<a id="handle-scope"></a>
 
 If you are using `register` only for extending the functionality of the server with  [`decorate`](./Decorators.md), it is your responsibility to tell Fastify not to create a new scope. Otherwise, your changes will not be accessible by the user in the upper scope.
 

--- a/docs/Recommendations.md
+++ b/docs/Recommendations.md
@@ -10,7 +10,7 @@ This document contains a set of recommendations when using Fastify.
 - [Kubernetes](#kubernetes)
 
 ## Use A Reverse Proxy
-<a name="reverseproxy"></a>
+<a id="reverseproxy"></a>
 
 Node.js is an early adopter of frameworks shipping with an easy-to-use web
 server within the standard library. Previously, with languages like PHP or
@@ -279,7 +279,7 @@ server {
 [nginx]: https://nginx.org/
 
 ## Kubernetes
-<a name="kubernetes"></a>
+<a id="kubernetes"></a>
 
 The `readinessProbe` uses [(by default](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)) the pod IP as the hostname. Fastify listens on `127.0.0.1` by default. The probe will not be able to reach the application in this case. In order to make it work, the application must listen on `0.0.0.0` or specify a custom hostname in the `readinessProbe.httpGet` spec, as per the following example:
 

--- a/docs/Recommendations.md
+++ b/docs/Recommendations.md
@@ -4,11 +4,13 @@
 
 This document contains a set of recommendations when using Fastify.
 
-* [Use A Reverse Proxy](#reverseproxy)
-* [Kubernetes](#kubernetes)
+- [Use A Reverse Proxy](#use-a-reverse-proxy)
+  - [HAProxy](#haproxy)
+  - [Nginx](#nginx)
+- [Kubernetes](#kubernetes)
 
 ## Use A Reverse Proxy
-<a id="reverseproxy"></a>
+<a name="reverseproxy"></a>
 
 Node.js is an early adopter of frameworks shipping with an easy-to-use web
 server within the standard library. Previously, with languages like PHP or
@@ -277,7 +279,7 @@ server {
 [nginx]: https://nginx.org/
 
 ## Kubernetes
-<a id="kubernetes"></a>
+<a name="kubernetes"></a>
 
 The `readinessProbe` uses [(by default](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)) the pod IP as the hostname. Fastify listens on `127.0.0.1` by default. The probe will not be able to reach the application in this case. In order to make it work, the application must listen on `0.0.0.0` or specify a custom hostname in the `readinessProbe.httpGet` spec, as per the following example:
 

--- a/docs/Reference/Encapsulation.md
+++ b/docs/Reference/Encapsulation.md
@@ -123,7 +123,7 @@ To see this, start the server and issue requests:
 [bearer]: https://github.com/fastify/fastify-bearer-auth
 
 ## Sharing Between Contexts
-<a name="shared-context"></a>
+<a id="shared-context"></a>
 
 Notice that each context in the prior example inherits _only_ from the parent
 contexts. Parent contexts cannot access any entities within their descendent

--- a/docs/Reference/Encapsulation.md
+++ b/docs/Reference/Encapsulation.md
@@ -4,12 +4,12 @@
 <a id="encapsulation"></a>
 
 A fundamental feature of Fastify is the "encapsulation context." The
-encapsulation context governs which [decorators](./Decorators.md), registered
-[hooks](./Hooks.md), and [plugins](./Plugins.md) are available to
-[routes](./Routes.md). A visual representation of the encapsulation context
+encapsulation context governs which [decorators](../Decorators.md), registered
+[hooks](../Hooks.md), and [plugins](../Plugins.md) are available to
+[routes](../Routes.md). A visual representation of the encapsulation context
 is shown in the following figure:
 
-![Figure 1](./resources/encapsulation_context.svg)
+![Figure 1](../resources/encapsulation_context.svg)
 
 In the above figure, there are several entities:
 
@@ -26,7 +26,7 @@ _child plugins_ registered within the containing _child context_, but the
 containing _child context_ **does not** have access to the _child plugins_
 registered within its _grandchild context_.
 
-Given that everything in Fastify is a [plugin](./Plugins.md), except for the
+Given that everything in Fastify is a [plugin](../Plugins.md), except for the
 _root context_, every "context" and "plugin" in this example is a plugin
 that can consist of decorators, hooks, plugins, and routes. Thus, to put
 this example into concrete terms, consider a basic scenario of a REST API
@@ -123,7 +123,7 @@ To see this, start the server and issue requests:
 [bearer]: https://github.com/fastify/fastify-bearer-auth
 
 ## Sharing Between Contexts
-<a id="shared-context"></a>
+<a name="shared-context"></a>
 
 Notice that each context in the prior example inherits _only_ from the parent
 contexts. Parent contexts cannot access any entities within their descendent

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1,7 +1,7 @@
 <h1 align="center">Fastify</h1>
 
 ## Factory
-<a name="factory"></a>
+<a id="factory"></a>
 
 The Fastify module exports a factory function that is used to create new
 <code><b>Fastify server</b></code> instances. This factory function accepts
@@ -82,14 +82,14 @@ document describes the properties available in that options object.
     - [initialConfig](#initialconfig)
 
 ### `http2`
-<a name="factory-http2"></a>
+<a id="factory-http2"></a>
 
 If `true` Node.js core's [HTTP/2](https://nodejs.org/dist/latest-v14.x/docs/api/http2.html) module is used for binding the socket.
 
 + Default: `false`
 
 ### `https`
-<a name="factory-https"></a>
+<a id="factory-https"></a>
 
 An object used to configure the server's listening socket for TLS. The options
 are the same as the Node.js core
@@ -101,7 +101,7 @@ This option also applies when the [`http2`](#factory-http2) option is set.
 + Default: `null`
 
 ### `connectionTimeout`
-<a name="factory-connection-timeout"></a>
+<a id="factory-connection-timeout"></a>
 
 Defines the server timeout in milliseconds. See documentation for
 [`server.timeout` property](https://nodejs.org/api/http.html#http_server_timeout)
@@ -111,7 +111,7 @@ specified, this option is ignored.
 + Default: `0` (no timeout)
 
 ### `keepAliveTimeout`
-<a name="factory-keep-alive-timeout"></a>
+<a id="factory-keep-alive-timeout"></a>
 
 Defines the server keep-alive timeout in milliseconds. See documentation for
 [`server.keepAliveTimeout` property](https://nodejs.org/api/http.html#http_server_keepalivetimeout)
@@ -121,7 +121,7 @@ is in use. Also, when `serverFactory` option is specified, this option is ignore
 + Default: `5000` (5 seconds)
 
 ### `maxRequestsPerSocket`
-<a name="factory-max-requests-per-socket"></a>
+<a id="factory-max-requests-per-socket"></a>
 
 Defines the maximum number of requests socket can handle before closing keep alive connection. See documentation for
 [`server.maxRequestsPerSocket` property](https://nodejs.org/dist/latest/docs/api/http.html#http_server_maxrequestspersocket)
@@ -132,7 +132,7 @@ is in use. Also, when `serverFactory` option is specified, this option is ignore
 + Default: `0` (no limit)
 
 ### `requestTimeout`
-<a name="factory-request-timeout"></a>
+<a id="factory-request-timeout"></a>
 
 Defines the maximum number of milliseconds for receiving the entire request from the client.
 [`server.requestTimeout` property](https://nodejs.org/dist/latest/docs/api/http.html#http_server_requesttimeout)
@@ -143,7 +143,7 @@ It must be set to a non-zero value (e.g. 120 seconds) to protect against potenti
 + Default: `0` (no limit)
 
 ### `ignoreTrailingSlash`
-<a name="factory-ignore-slash"></a>
+<a id="factory-ignore-slash"></a>
 
 Fastify uses [find-my-way](https://github.com/delvedor/find-my-way) to handle
 routing. This option may be set to `true` to ignore trailing slashes in routes.
@@ -169,7 +169,7 @@ fastify.get('/bar', function (req, reply) {
 ```
 
 ### `maxParamLength`
-<a name="factory-max-param-length"></a>
+<a id="factory-max-param-length"></a>
 
 You can set a custom length for parameters in parametric (standard, regex, and multi) routes by using `maxParamLength` option; the default value is 100 characters.
 
@@ -178,14 +178,14 @@ This can be useful especially if you have some regex based route, protecting you
 *If the maximum length limit is reached, the not found route will be invoked.*
 
 ### `bodyLimit`
-<a name="factory-body-limit"></a>
+<a id="factory-body-limit"></a>
 
 Defines the maximum payload, in bytes, the server is allowed to accept.
 
 + Default: `1048576` (1MiB)
 
 ### `onProtoPoisoning`
-<a name="factory-on-proto-poisoning"></a>
+<a id="factory-on-proto-poisoning"></a>
 
 Defines what action the framework must take when parsing a JSON object
 with `__proto__`. This functionality is provided by
@@ -198,7 +198,7 @@ Possible values are `'error'`, `'remove'` and `'ignore'`.
 + Default: `'error'`
 
 ### `onConstructorPoisoning`
-<a name="factory-on-constructor-poisoning"></a>
+<a id="factory-on-constructor-poisoning"></a>
 
 Defines what action the framework must take when parsing a JSON object
 with `constructor`. This functionality is provided by
@@ -211,7 +211,7 @@ Possible values are `'error'`, `'remove'` and `'ignore'`.
 + Default: `'error'`
 
 ### `logger`
-<a name="factory-logger"></a>
+<a id="factory-logger"></a>
 
 Fastify includes built-in logging via the [Pino](https://getpino.io/) logger.
 This property is used to configure the internal logger instance.
@@ -264,7 +264,7 @@ interface by having the following methods: `info`, `error`, `debug`, `fatal`, `w
   ```
 
 ### `disableRequestLogging`
-<a name="factory-disable-request-logging"></a>
+<a id="factory-disable-request-logging"></a>
 
 By default, when logging is enabled, Fastify will issue an `info` level log
 message when a request is received and when the response for that request has
@@ -290,7 +290,7 @@ fastify.addHook('onResponse', (req, reply, done) => {
 Please note that this setting will also disable an error log written by the default `onResponse` hook on reply callback errors.
 
 ### `serverFactory`
-<a name="custom-http-server"></a>
+<a id="custom-http-server"></a>
 
 You can pass a custom HTTP server to Fastify by using the `serverFactory` option.
 
@@ -318,7 +318,7 @@ Internally Fastify uses the API of Node core HTTP server, so if you are using a 
 
 
 ### `jsonShorthand`
-<a name="schema-json-shorthand"></a>
+<a id="schema-json-shorthand"></a>
 
 + Default: `true`
 
@@ -349,7 +349,7 @@ fastify.post('/', {
 **Note: Fastify does not currently throw on invalid schemas, so if you turn this off in an existing project, you need to be careful that none of your existing schemas become invalid as a result, since they will be treated as a catch-all.**
 
 ### `caseSensitive`
-<a name="factory-case-sensitive"></a>
+<a id="factory-case-sensitive"></a>
 
 By default, value equal to `true`, routes are registered as case sensitive. That is, `/foo` is not equivalent to `/Foo`. When set to `false`, routes are registered in a fashion such that `/foo` is equivalent to `/Foo` which is equivalent to `/FOO`.
 
@@ -368,21 +368,21 @@ Please note that setting this option to `false` goes against
 Also note, this setting will not affect query strings. If you want to change the way query strings are handled take a look at [`querystringParser`](#querystringparser).
 
 ### `requestIdHeader`
-<a name="factory-request-id-header"></a>
+<a id="factory-request-id-header"></a>
 
 The header name used to know the request-id. See [the request-id](../Logging.md#logging-request-id) section.
 
 + Default: `'request-id'`
 
 ### `requestIdLogLabel`
-<a name="factory-request-id-log-label"></a>
+<a id="factory-request-id-log-label"></a>
 
 Defines the label used for the request identifier when logging the request.
 
 + Default: `'reqId'`
 
 ### `genReqId`
-<a name="factory-gen-request-id"></a>
+<a id="factory-gen-request-id"></a>
 
 Function for generating the request-id. It will receive the incoming request as a parameter.
 
@@ -400,7 +400,7 @@ const fastify = require('fastify')({
 **Note: genReqId will _not_ be called if the header set in <code>[requestIdHeader](#requestidheader)</code> is available (defaults to 'request-id').**
 
 ### `trustProxy`
-<a name="factory-trust-proxy"></a>
+<a id="factory-trust-proxy"></a>
 
 By enabling the `trustProxy` option, Fastify will know that it is sitting behind a proxy and that the `X-Forwarded-*` header fields may be trusted, which otherwise may be easily spoofed.
 
@@ -436,7 +436,7 @@ fastify.get('/', (request, reply) => {
 **Note: if a request contains multiple <code>x-forwarded-host</code> or <code>x-forwarded-proto</code> headers, it is only the last one that is used to derive <code>request.hostname</code> and <code>request.protocol</code>**
 
 ### `pluginTimeout`
-<a name="plugin-timeout"></a>
+<a id="plugin-timeout"></a>
 
 The maximum amount of time in *milliseconds* in which a plugin can load.
 If not, [`ready`](#ready)
@@ -445,7 +445,7 @@ will complete with an `Error` with code `'ERR_AVVIO_PLUGIN_TIMEOUT'`.
 + Default: `10000`
 
 ### `querystringParser`
-<a name="factory-querystring-parser"></a>
+<a id="factory-querystring-parser"></a>
 
 The default query string parser that Fastify uses is the Node.js's core `querystring` module.
 
@@ -470,14 +470,14 @@ const fastify = require('fastify')({
 Note, if you only want the keys (and not the values) to be case insensitive we recommend using a custom parser to convert only the keys to lowercase.
 
 ### `exposeHeadRoutes`
-<a name="exposeHeadRoutes"></a>
+<a id="exposeHeadRoutes"></a>
 
 Automatically creates a sibling `HEAD` route for each `GET` route defined. If you want a custom `HEAD` handler without disabling this option, make sure to define it before the `GET` route.
 
 + Default: `false`
 
 ### `constraints`
-<a name="constraints"></a>
+<a id="constraints"></a>
 
 Fastify's built in route constraints are provided by `find-my-way`, which allow constraining routes by `version` or `host`. You are able to add new constraint strategies, or override the built in strategies by providing a `constraints` object with strategies for `find-my-way`. You can find more information on constraint strategies in the [find-my-way](https://github.com/delvedor/find-my-way) documentation.
 
@@ -505,7 +505,7 @@ const fastify = require('fastify')({
 ```
 
 ### `return503OnClosing`
-<a name="factory-return-503-on-closing"></a>
+<a id="factory-return-503-on-closing"></a>
 
 Returns 503 after calling `close` server method.
 If `false`, the server routes the incoming request as usual.
@@ -513,7 +513,7 @@ If `false`, the server routes the incoming request as usual.
 + Default: `true`
 
 ### `ajv`
-<a name="factory-ajv"></a>
+<a id="factory-ajv"></a>
 
 Configure the Ajv v6 instance used by Fastify without providing a custom one.
 
@@ -549,7 +549,7 @@ const fastify = require('fastify')({
 ```
 
 ### `serializerOpts`
-<a name="serializer-opts"></a>
+<a id="serializer-opts"></a>
 
 Customize the options of the default [`fast-json-stringify`](https://github.com/fastify/fast-json-stringify#options) instance that serialize the response's payload:
 
@@ -562,7 +562,7 @@ const fastify = require('fastify')({
 ```
 
 ### `http2SessionTimeout`
-<a name="http2-session-timeout"></a>
+<a id="http2-session-timeout"></a>
 
 Set a default
 [timeout](https://nodejs.org/api/http2.html#http2_http2session_settimeout_msecs_callback) to every incoming HTTP/2 session. The session will be closed on the timeout. Default: `5000` ms.
@@ -573,7 +573,7 @@ When the server is behind a load balancer or can scale automatically this value 
 increased to fit the use case. Node core defaults this to `0`. `
 
 ### `frameworkErrors`
-<a name="framework-errors"></a>
+<a id="framework-errors"></a>
 
 + Default: `null`
 
@@ -596,7 +596,7 @@ const fastify = require('fastify')({
 ```
 
 ### `clientErrorHandler`
-<a name="client-error-handler"></a>
+<a id="client-error-handler"></a>
 
 Set a [clientErrorHandler](https://nodejs.org/api/http.html#http_event_clienterror) that listens to `error` events emitted by client connections and responds with a `400`.
 
@@ -644,7 +644,7 @@ const fastify = require('fastify')({
 ```
 
 ### `rewriteUrl`
-<a name="rewrite-url"></a>
+<a id="rewrite-url"></a>
 
 Set a sync callback function that must return a string that allows rewriting URLs.
 
@@ -663,12 +663,12 @@ Note that `rewriteUrl` is called _before_ routing, it is not encapsulated and it
 ### Server Methods
 
 #### server
-<a name="server"></a>
+<a id="server"></a>
 
 `fastify.server`: The Node core [server](https://nodejs.org/api/http.html#http_class_http_server) object as returned by the [**`Fastify factory function`**](#factory).
 
 #### after
-<a name="after"></a>
+<a id="after"></a>
 
 Invoked when the current plugin and all the plugins
 that have been registered within it have finished loading.
@@ -712,7 +712,7 @@ console.log('Everything has been loaded')
 ```
 
 #### ready
-<a name="ready"></a>
+<a id="ready"></a>
 
 Function called when all the plugins have been loaded.
 It takes an error parameter if something went wrong.
@@ -732,7 +732,7 @@ fastify.ready().then(() => {
 ```
 
 #### listen
-<a name="listen"></a>
+<a id="listen"></a>
 
 Starts the server on the given port after all the plugins are loaded, internally waits for the `.ready()` event. The callback is the same as the Node core. By default, the server will listen on the address resolved by `localhost` when no specific address is provided (`127.0.0.1` or `::1` depending on the operating system). If listening on any available interface is desired, then specifying `0.0.0.0` for the address will listen on all IPv4 addresses. Using `::` for the address will listen on all IPv6 addresses and, depending on OS, may also listen on all IPv4 addresses. Be careful when deciding to listen on all interfaces; it comes with inherent [security risks](https://web.archive.org/web/20170831174611/https://snyk.io/blog/mongodb-hack-and-secure-defaults/).
 
@@ -838,7 +838,7 @@ fastify.listen({
 ```
 
 #### getDefaultRoute
-<a name="getDefaultRoute"></a>
+<a id="getDefaultRoute"></a>
 
 Method to get the `defaultRoute` for the server:
 
@@ -847,7 +847,7 @@ const defaultRoute = fastify.getDefaultRoute()
 ```
 
 #### setDefaultRoute
-<a name="setDefaultRoute"></a>
+<a id="setDefaultRoute"></a>
 
 Method to set the `defaultRoute` for the server:
 
@@ -860,7 +860,7 @@ fastify.setDefaultRoute(defaultRoute)
 ```
 
 #### routing
-<a name="routing"></a>
+<a id="routing"></a>
 
 Method to access the `lookup` method of the internal router and match the request to the appropriate handler:
 
@@ -869,12 +869,12 @@ fastify.routing(req, res)
 ```
 
 #### route
-<a name="route"></a>
+<a id="route"></a>
 
 Method to add routes to the server, it also has shorthand functions, check [here](../Routes.md).
 
 #### close
-<a name="close"></a>
+<a id="close"></a>
 
 `fastify.close(callback)`: call this function to close the server instance and run the [`'onClose'`](../Hooks.md#on-close) hook.
 
@@ -892,23 +892,23 @@ fastify.close().then(() => {
 ```
 
 #### decorate*
-<a name="decorate"></a>
+<a id="decorate"></a>
 
 Function useful if you need to decorate the fastify instance, Reply or Request, check [here](../Decorators.md).
 
 #### register
-<a name="register"></a>
+<a id="register"></a>
 
 Fastify allows the user to extend its functionality with plugins.
 A plugin can be a set of routes, a server decorator, or whatever, check [here](../Plugins.md).
 
 #### addHook
-<a name="addHook"></a>
+<a id="addHook"></a>
 
 Function to add a specific hook in the lifecycle of Fastify, check [here](../Hooks.md).
 
 #### prefix
-<a name="prefix"></a>
+<a id="prefix"></a>
 
 The full path that will be prefixed to a route.
 
@@ -937,7 +937,7 @@ fastify.register(function (instance, opts, done) {
 ```
 
 #### pluginName
-<a name="pluginName"></a>
+<a id="pluginName"></a>
 
 Name of the current plugin. There are three ways to define a name (in order).
 
@@ -950,39 +950,39 @@ Name of the current plugin. There are three ways to define a name (in order).
 Important: If you have to deal with nested plugins, the name differs with the usage of the [fastify-plugin](https://github.com/fastify/fastify-plugin) because no new scope is created and therefore we have no place to attach contextual data. In that case, the plugin name will represent the boot order of all involved plugins in the format of `plugin-A -> plugin-B`.
 
 #### log
-<a name="log"></a>
+<a id="log"></a>
 
 The logger instance, check [here](../Logging.md).
 
 #### version
-<a name="version"></a>
+<a id="version"></a>
 
 Fastify version of the instance. Used for plugin support. See [Plugins](../Plugins.md#handle-the-scope) for information on how the version is used by plugins.
 
 #### inject
-<a name="inject"></a>
+<a id="inject"></a>
 
 Fake HTTP injection (for testing purposes) [here](../Testing.md#inject).
 
 #### addSchema
-<a name="add-schema"></a>
+<a id="add-schema"></a>
 
 `fastify.addSchema(schemaObj)`, adds a JSON schema to the Fastify instance. This allows you to reuse it everywhere in your application just by using the standard `$ref` keyword.
 
 To learn more, read the [Validation and Serialization](../Validation-and-Serialization.md) documentation.
 
 #### getSchemas
-<a name="get-schemas"></a>
+<a id="get-schemas"></a>
 
 `fastify.getSchemas()`, returns a hash of all schemas added via `.addSchema`. The keys of the hash are the `$id`s of the JSON Schema provided.
 
 #### getSchema
-<a name="get-schema"></a>
+<a id="get-schema"></a>
 
 `fastify.getSchema(id)`, return the JSON schema added with `.addSchema` and the matching `id`. It returns `undefined` if it is not found.
 
 #### setReplySerializer
-<a name="set-reply-serializer"></a>
+<a id="set-reply-serializer"></a>
 
 Set the reply serializer for all the routes. This will be used as default if a [Reply.serializer(func)](../Reply.md#serializerfunc) has not been set. The handler is fully encapsulated, so different plugins can set different error handlers.
 Note: the function parameter is called only for status `2xx`. Check out the [`setErrorHandler`](#seterrorhandler) for errors.
@@ -995,40 +995,40 @@ fastify.setReplySerializer(function (payload, statusCode){
 ```
 
 #### setValidatorCompiler
-<a name="set-validator-compiler"></a>
+<a id="set-validator-compiler"></a>
 
 Set the schema validator compiler for all routes. See [#schema-validator](../Validation-and-Serialization.md#schema-validator).
 
 #### setSchemaErrorFormatter
-<a name="set-schema-error-formatter"></a>
+<a id="set-schema-error-formatter"></a>
 
 Set the schema error formatter for all routes. See [#error-handling](../Validation-and-Serialization.md#schemaerrorformatter).
 
 #### setSerializerCompiler
-<a name="set-serializer-resolver"></a>
+<a id="set-serializer-resolver"></a>
 
 Set the schema serializer compiler for all routes. See [#schema-serializer](../Validation-and-Serialization.md#schema-serializer).
 **Note:** [`setReplySerializer`](#set-reply-serializer) has priority if set!
 
 #### validatorCompiler
-<a name="validator-compiler"></a>
+<a id="validator-compiler"></a>
 
 This property can be used to get the schema validator. If not set, it will be `null` until the server starts, then it will be a function with the signature `function ({ schema, method, url, httpPart })` that returns the input `schema` compiled to a function for validating data.
 The input `schema` can access all the shared schemas added with [`.addSchema`](#add-schema) function.
 
 #### serializerCompiler
-<a name="serializer-compiler"></a>
+<a id="serializer-compiler"></a>
 
 This property can be used to get the schema serializer. If not set, it will be `null` until the server starts, then it will be a function with the signature `function ({ schema, method, url, httpPart })` that returns the input `schema` compiled to a function for validating data.
 The input `schema` can access all the shared schemas added with [`.addSchema`](#add-schema) function.
 
 #### schemaErrorFormatter
-<a name="schema-error-formatter"></a>
+<a id="schema-error-formatter"></a>
 
 This property can be used to set a function to format errors that happen while the `validationCompiler` fails to validate the schema. See [#error-handling](../Validation-and-Serialization.md#schemaerrorformatter).
 
 #### schemaController
-<a name="schema-controller"></a>
+<a id="schema-controller"></a>
 
 This property can be used to fully manage:
 - `bucket`: where the schemas of your application will be stored
@@ -1146,7 +1146,7 @@ const app = fastify({
 ```
 
 #### setNotFoundHandler
-<a name="set-not-found-handler"></a>
+<a id="set-not-found-handler"></a>
 
 `fastify.setNotFoundHandler(handler(request, reply))`: set the 404 handler. This call is encapsulated by prefix, so different plugins can set different not found handlers if a different [`prefix` option](../Plugins.md#route-prefixing-option) is passed to `fastify.register()`. The handler is treated as a regular route handler so requests will go through the full [Fastify lifecycle](../Lifecycle.md#lifecycle).
 
@@ -1180,7 +1180,7 @@ fastify.register(function (instance, options, done) {
 Fastify calls setNotFoundHandler to add a default 404 handler at startup before plugins are registered. If you would like to augment the behavior of the default 404 handler, for example with plugins, you can call setNotFoundHandler with no arguments `fastify.setNotFoundHandler()` within the context of these registered plugins.
 
 #### setErrorHandler
-<a name="set-error-handler"></a>
+<a id="set-error-handler"></a>
 
 `fastify.setErrorHandler(handler(error, request, reply))`: Set a function that will be called whenever an error happens. The handler is bound to the Fastify instance and is fully encapsulated, so different plugins can set different error handlers. *async-await* is supported as well.
 
@@ -1209,7 +1209,7 @@ if (statusCode >= 500) {
 ```
 
 #### printRoutes
-<a name="print-routes"></a>
+<a id="print-routes"></a>
 
 `fastify.printRoutes()`: Prints the representation of the internal radix tree used by the router, useful for debugging. Alternatively, `fastify.printRoutes({ commonPrefix: false })` can be used to print the flattened routes tree.
 
@@ -1266,7 +1266,7 @@ fastify.ready(() => {
 ```
 
 #### printPlugins
-<a name="print-plugins"></a>
+<a id="print-plugins"></a>
 
 `fastify.printPlugins()`: Prints the representation of the internal plugin tree used by the avvio, useful for debugging require order issues.
 
@@ -1289,7 +1289,7 @@ fastify.ready(() => {
 ```
 
 #### addContentTypeParser
-<a name="addContentTypeParser"></a>
+<a id="addContentTypeParser"></a>
 
 `fastify.addContentTypeParser(content-type, options, parser)` is used to pass custom parser for a given content type. Useful for adding parsers for custom content types, e.g. `text/json, application/vnd.oasis.opendocument.text`. `content-type` can be a string, string array or RegExp.
 
@@ -1300,13 +1300,13 @@ fastify.addContentTypeParser('text/json', { asString: true }, fastify.getDefault
 ```
 
 #### getDefaultJsonParser
-<a name="getDefaultJsonParser"></a>
+<a id="getDefaultJsonParser"></a>
 
 `fastify.getDefaultJsonParser(onProtoPoisoning, onConstructorPoisoning)` takes two arguments. First argument is ProtoType poisoning configuration and second argument is constructor poisoning configuration. See the [`secure-json-parse` documentation](https://github.com/fastify/secure-json-parse#api) for more information.
 
 
 #### defaultTextParser
-<a name="defaultTextParser"></a>
+<a id="defaultTextParser"></a>
 
 `fastify.defaultTextParser()` can be used to parse content as plain text.
 
@@ -1315,7 +1315,7 @@ fastify.addContentTypeParser('text/json', { asString: true }, fastify.defaultTex
 ```
 
 #### errorHandler
-<a name="errorHandler"></a>
+<a id="errorHandler"></a>
 
 `fastify.errorHandler` can be used to handle errors using fastify's default error handler.
 
@@ -1333,7 +1333,7 @@ fastify.get('/', {
 ```
 
 #### initialConfig
-<a name="initial-config"></a>
+<a id="initial-config"></a>
 
 `fastify.initialConfig`: Exposes a frozen read-only object registering the initial
 options passed down by the user to the Fastify instance.

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -8,39 +8,78 @@ The Fastify module exports a factory function that is used to create new
 an options object which is used to customize the resulting instance. This
 document describes the properties available in that options object.
 
-- [http2](./Server.md#http2)
-- [https](./Server.md#https)
-- [connectionTimeout](./Server.md#connectiontimeout)
-- [keepAliveTimeout](./Server.md#keepalivetimeout)
-- [maxRequestsPerSocket](./Server.md#maxRequestsPerSocket)
-- [requestTimeout](./Server.md#requestTimeout)
-- [ignoreTrailingSlash](./Server.md#ignoretrailingslash)
-- [maxParamLength](./Server.md#maxparamlength)
-- [onProtoPoisoning](./Server.md#onprotopoisoning)
-- [onConstructorPoisoning](./Server.md#onconstructorpoisoning)
-- [logger](./Server.md#logger)
-- [serverFactory](./Server.md#serverfactory)
-- [jsonShorthand](./Server.md#jsonshorthand)
-- [caseSensitive](./Server.md#casesensitive)
-- [requestIdHeader](./Server.md#requestidheader)
-- [requestIdLogLabel](./Server.md#requestidloglabel)
-- [genReqId](./Server.md#genreqid)
-- [trustProxy](./Server.md#trustProxy)
-- [pluginTimeout](./Server.md#plugintimeout)
-- [querystringParser](./Server.md#querystringparser)
-- [exposeHeadRoutes](./Server.md#exposeheadroutes)
-- [constraints](./Server.md#constraints)
-- [return503OnClosing](./Server.md#return503onclosing)
-- [ajv](./Server.md#ajv)
-- [serializerOpts](./Server.md#serializeropts)
-- [http2SessionTimeout](./Server.md#http2sessiontimeout)
-- [frameworkErrors](./Server.md#frameworkerrors)
-- [clientErrorHandler](./Server.md#clienterrorhandler)
-- [rewriteUrl](./Server.md#rewriteurl)
-- [Instance](./Server.md#instance)
-- [Server Methods](./Server.md#server-methods)
-- [initialConfig](./Server.md#initialConfig)
-
+- [Factory](#factory)
+  - [`http2`](#http2)
+  - [`https`](#https)
+  - [`connectionTimeout`](#connectiontimeout)
+  - [`keepAliveTimeout`](#keepalivetimeout)
+  - [`maxRequestsPerSocket`](#maxrequestspersocket)
+  - [`requestTimeout`](#requesttimeout)
+  - [`ignoreTrailingSlash`](#ignoretrailingslash)
+  - [`maxParamLength`](#maxparamlength)
+  - [`bodyLimit`](#bodylimit)
+  - [`onProtoPoisoning`](#onprotopoisoning)
+  - [`onConstructorPoisoning`](#onconstructorpoisoning)
+  - [`logger`](#logger)
+  - [`disableRequestLogging`](#disablerequestlogging)
+  - [`serverFactory`](#serverfactory)
+  - [`jsonShorthand`](#jsonshorthand)
+  - [`caseSensitive`](#casesensitive)
+  - [`requestIdHeader`](#requestidheader)
+  - [`requestIdLogLabel`](#requestidloglabel)
+  - [`genReqId`](#genreqid)
+  - [`trustProxy`](#trustproxy)
+  - [`pluginTimeout`](#plugintimeout)
+  - [`querystringParser`](#querystringparser)
+  - [`exposeHeadRoutes`](#exposeheadroutes)
+  - [`constraints`](#constraints)
+  - [`return503OnClosing`](#return503onclosing)
+  - [`ajv`](#ajv)
+  - [`serializerOpts`](#serializeropts)
+  - [`http2SessionTimeout`](#http2sessiontimeout)
+  - [`frameworkErrors`](#frameworkerrors)
+  - [`clientErrorHandler`](#clienterrorhandler)
+  - [`rewriteUrl`](#rewriteurl)
+- [Instance](#instance)
+  - [Server Methods](#server-methods)
+    - [server](#server)
+    - [after](#after)
+    - [ready](#ready)
+    - [listen](#listen)
+    - [getDefaultRoute](#getdefaultroute)
+    - [setDefaultRoute](#setdefaultroute)
+    - [routing](#routing)
+    - [route](#route)
+    - [close](#close)
+    - [decorate*](#decorate)
+    - [register](#register)
+    - [addHook](#addhook)
+    - [prefix](#prefix)
+    - [pluginName](#pluginname)
+    - [log](#log)
+    - [version](#version)
+    - [inject](#inject)
+    - [addSchema](#addschema)
+    - [getSchemas](#getschemas)
+    - [getSchema](#getschema)
+    - [setReplySerializer](#setreplyserializer)
+    - [setValidatorCompiler](#setvalidatorcompiler)
+    - [setSchemaErrorFormatter](#setschemaerrorformatter)
+    - [setSerializerCompiler](#setserializercompiler)
+    - [validatorCompiler](#validatorcompiler)
+    - [serializerCompiler](#serializercompiler)
+    - [schemaErrorFormatter](#schemaerrorformatter)
+    - [schemaController](#schemacontroller)
+      - [Ajv 8 as default schema validator](#ajv-8-as-default-schema-validator)
+    - [setNotFoundHandler](#setnotfoundhandler)
+    - [setErrorHandler](#seterrorhandler)
+    - [printRoutes](#printroutes)
+    - [printPlugins](#printplugins)
+    - [addContentTypeParser](#addcontenttypeparser)
+    - [getDefaultJsonParser](#getdefaultjsonparser)
+    - [defaultTextParser](#defaulttextparser)
+    - [errorHandler](#errorhandler)
+    - [initialConfig](#initialconfig)
 
 ### `http2`
 <a name="factory-http2"></a>
@@ -57,7 +96,7 @@ are the same as the Node.js core
 [`createServer` method](https://nodejs.org/dist/latest-v14.x/docs/api/https.html#https_https_createserver_options_requestlistener).
 When this property is `null`, the socket will not be configured for TLS.
 
-This option also applies when the [`http2`](./Server.md#factory-http2) option is set.
+This option also applies when the [`http2`](#factory-http2) option is set.
 
 + Default: `null`
 
@@ -132,8 +171,10 @@ fastify.get('/bar', function (req, reply) {
 ### `maxParamLength`
 <a name="factory-max-param-length"></a>
 
-You can set a custom length for parameters in parametric (standard, regex, and multi) routes by using `maxParamLength` option; the default value is 100 characters.<br>
-This can be useful especially if you have some regex based route, protecting you against [DoS attacks](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS).<br>
+You can set a custom length for parameters in parametric (standard, regex, and multi) routes by using `maxParamLength` option; the default value is 100 characters.
+
+This can be useful especially if you have some regex based route, protecting you against [DoS attacks](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS).
+
 *If the maximum length limit is reached, the not found route will be invoked.*
 
 ### `bodyLimit`
@@ -251,7 +292,8 @@ Please note that this setting will also disable an error log written by the defa
 ### `serverFactory`
 <a name="custom-http-server"></a>
 
-You can pass a custom HTTP server to Fastify by using the `serverFactory` option.<br/>
+You can pass a custom HTTP server to Fastify by using the `serverFactory` option.
+
 `serverFactory` is a function that takes a `handler` parameter, which takes the `request` and `response` objects as parameters, and an options object, which is the same you have passed to Fastify.
 
 ```js
@@ -272,7 +314,8 @@ fastify.get('/', (req, reply) => {
 fastify.listen(3000)
 ```
 
-Internally Fastify uses the API of Node core HTTP server, so if you are using a custom server you must be sure to have the same API exposed. If not, you can enhance the server instance inside the `serverFactory` function before the `return` statement.<br/>
+Internally Fastify uses the API of Node core HTTP server, so if you are using a custom server you must be sure to have the same API exposed. If not, you can enhance the server instance inside the `serverFactory` function before the `return` statement.
+
 
 ### `jsonShorthand`
 <a name="schema-json-shorthand"></a>
@@ -322,12 +365,12 @@ fastify.get('/user/:username', (request, reply) => {
 Please note that setting this option to `false` goes against
 [RFC3986](https://tools.ietf.org/html/rfc3986#section-6.2.2.1).
 
-Also note, this setting will not affect query strings. If you want to change the way query strings are handled take a look at [`querystringParser`](./Server.md#querystringparser).
+Also note, this setting will not affect query strings. If you want to change the way query strings are handled take a look at [`querystringParser`](#querystringparser).
 
 ### `requestIdHeader`
 <a name="factory-request-id-header"></a>
 
-The header name used to know the request-id. See [the request-id](Logging.md#logging-request-id) section.
+The header name used to know the request-id. See [the request-id](../Logging.md#logging-request-id) section.
 
 + Default: `'request-id'`
 
@@ -379,7 +422,7 @@ const fastify = Fastify({ trustProxy: true })
 
 For more examples, refer to the [`proxy-addr`](https://www.npmjs.com/package/proxy-addr) package.
 
-You may access the `ip`, `ips`, `hostname` and `protocol` values on the [`request`](Request.md) object.
+You may access the `ip`, `ips`, `hostname` and `protocol` values on the [`request`](../Request.md) object.
 
 ```js
 fastify.get('/', (request, reply) => {
@@ -396,7 +439,7 @@ fastify.get('/', (request, reply) => {
 <a name="plugin-timeout"></a>
 
 The maximum amount of time in *milliseconds* in which a plugin can load.
-If not, [`ready`](./Server.md#ready)
+If not, [`ready`](#ready)
 will complete with an `Error` with code `'ERR_AVVIO_PLUGIN_TIMEOUT'`.
 
 + Default: `10000`
@@ -404,7 +447,8 @@ will complete with an `Error` with code `'ERR_AVVIO_PLUGIN_TIMEOUT'`.
 ### `querystringParser`
 <a name="factory-querystring-parser"></a>
 
-The default query string parser that Fastify uses is the Node.js's core `querystring` module.<br/>
+The default query string parser that Fastify uses is the Node.js's core `querystring` module.
+
 You can change this default setting by passing the option `querystringParser` and use a custom one, such as [`qs`](https://www.npmjs.com/package/qs).
 
 ```js
@@ -621,7 +665,7 @@ Note that `rewriteUrl` is called _before_ routing, it is not encapsulated and it
 #### server
 <a name="server"></a>
 
-`fastify.server`: The Node core [server](https://nodejs.org/api/http.html#http_class_http_server) object as returned by the [**`Fastify factory function`**](./Server.md).
+`fastify.server`: The Node core [server](https://nodejs.org/api/http.html#http_class_http_server) object as returned by the [**`Fastify factory function`**](#factory).
 
 #### after
 <a name="after"></a>
@@ -827,14 +871,15 @@ fastify.routing(req, res)
 #### route
 <a name="route"></a>
 
-Method to add routes to the server, it also has shorthand functions, check [here](Routes.md).
+Method to add routes to the server, it also has shorthand functions, check [here](../Routes.md).
 
 #### close
 <a name="close"></a>
 
-`fastify.close(callback)`: call this function to close the server instance and run the [`'onClose'`](Hooks.md#on-close) hook.<br>
+`fastify.close(callback)`: call this function to close the server instance and run the [`'onClose'`](../Hooks.md#on-close) hook.
+
 Calling `close` will also cause the server to respond to every new incoming request with a `503` error and destroy that request.
-See [`return503OnClosing` flags](./Server.md#factory-return-503-on-closing) for changing this behavior.
+See [`return503OnClosing` flags](#factory-return-503-on-closing) for changing this behavior.
 
 If it is called without any arguments, it will return a Promise:
 
@@ -849,18 +894,18 @@ fastify.close().then(() => {
 #### decorate*
 <a name="decorate"></a>
 
-Function useful if you need to decorate the fastify instance, Reply or Request, check [here](Decorators.md).
+Function useful if you need to decorate the fastify instance, Reply or Request, check [here](../Decorators.md).
 
 #### register
 <a name="register"></a>
 
 Fastify allows the user to extend its functionality with plugins.
-A plugin can be a set of routes, a server decorator, or whatever, check [here](Plugins.md).
+A plugin can be a set of routes, a server decorator, or whatever, check [here](../Plugins.md).
 
 #### addHook
 <a name="addHook"></a>
 
-Function to add a specific hook in the lifecycle of Fastify, check [here](Hooks.md).
+Function to add a specific hook in the lifecycle of Fastify, check [here](../Hooks.md).
 
 #### prefix
 <a name="prefix"></a>
@@ -907,23 +952,24 @@ Important: If you have to deal with nested plugins, the name differs with the us
 #### log
 <a name="log"></a>
 
-The logger instance, check [here](Logging.md).
+The logger instance, check [here](../Logging.md).
 
 #### version
 <a name="version"></a>
 
-Fastify version of the instance. Used for plugin support. See [Plugins](Plugins.md#handle-the-scope) for information on how the version is used by plugins.
+Fastify version of the instance. Used for plugin support. See [Plugins](../Plugins.md#handle-the-scope) for information on how the version is used by plugins.
 
 #### inject
 <a name="inject"></a>
 
-Fake HTTP injection (for testing purposes) [here](Testing.md#inject).
+Fake HTTP injection (for testing purposes) [here](../Testing.md#inject).
 
 #### addSchema
 <a name="add-schema"></a>
 
-`fastify.addSchema(schemaObj)`, adds a JSON schema to the Fastify instance. This allows you to reuse it everywhere in your application just by using the standard `$ref` keyword.<br/>
-To learn more, read the [Validation and Serialization](Validation-and-Serialization.md) documentation.
+`fastify.addSchema(schemaObj)`, adds a JSON schema to the Fastify instance. This allows you to reuse it everywhere in your application just by using the standard `$ref` keyword.
+
+To learn more, read the [Validation and Serialization](../Validation-and-Serialization.md) documentation.
 
 #### getSchemas
 <a name="get-schemas"></a>
@@ -938,8 +984,8 @@ To learn more, read the [Validation and Serialization](Validation-and-Serializat
 #### setReplySerializer
 <a name="set-reply-serializer"></a>
 
-Set the reply serializer for all the routes. This will be used as default if a [Reply.serializer(func)](Reply.md#serializerfunc) has not been set. The handler is fully encapsulated, so different plugins can set different error handlers.
-Note: the function parameter is called only for status `2xx`. Check out the [`setErrorHandler`](./Server.md#seterrorhandler) for errors.
+Set the reply serializer for all the routes. This will be used as default if a [Reply.serializer(func)](../Reply.md#serializerfunc) has not been set. The handler is fully encapsulated, so different plugins can set different error handlers.
+Note: the function parameter is called only for status `2xx`. Check out the [`setErrorHandler`](#seterrorhandler) for errors.
 
 ```js
 fastify.setReplySerializer(function (payload, statusCode){
@@ -951,17 +997,17 @@ fastify.setReplySerializer(function (payload, statusCode){
 #### setValidatorCompiler
 <a name="set-validator-compiler"></a>
 
-Set the schema validator compiler for all routes. See [#schema-validator](Validation-and-Serialization.md#schema-validator).
+Set the schema validator compiler for all routes. See [#schema-validator](../Validation-and-Serialization.md#schema-validator).
 
 #### setSchemaErrorFormatter
 <a name="set-schema-error-formatter"></a>
 
-Set the schema error formatter for all routes. See [#error-handling](Validation-and-Serialization.md#schemaerrorformatter).
+Set the schema error formatter for all routes. See [#error-handling](../Validation-and-Serialization.md#schemaerrorformatter).
 
 #### setSerializerCompiler
 <a name="set-serializer-resolver"></a>
 
-Set the schema serializer compiler for all routes. See [#schema-serializer](Validation-and-Serialization.md#schema-serializer).
+Set the schema serializer compiler for all routes. See [#schema-serializer](../Validation-and-Serialization.md#schema-serializer).
 **Note:** [`setReplySerializer`](#set-reply-serializer) has priority if set!
 
 #### validatorCompiler
@@ -979,7 +1025,7 @@ The input `schema` can access all the shared schemas added with [`.addSchema`](#
 #### schemaErrorFormatter
 <a name="schema-error-formatter"></a>
 
-This property can be used to set a function to format errors that happen while the `validationCompiler` fails to validate the schema. See [#error-handling](Validation-and-Serialization.md#schemaerrorformatter).
+This property can be used to set a function to format errors that happen while the `validationCompiler` fails to validate the schema. See [#error-handling](../Validation-and-Serialization.md#schemaerrorformatter).
 
 #### schemaController
 <a name="schema-controller"></a>
@@ -1041,7 +1087,7 @@ const fastify = Fastify({
        */
       buildValidator: function factory (externalSchemas, ajvServerOption) {
         // This factory function must return a schema validator compiler.
-        // See [#schema-validator](Validation-and-Serialization.md#schema-validator) for details.
+        // See [#schema-validator](../Validation-and-Serialization.md#schema-validator) for details.
         const yourAjvInstance = new Ajv(ajvServerOption.customOptions)
         return function validatorCompiler ({ schema, method, url, httpPart }) {
           return yourAjvInstance.compile(schema)
@@ -1058,7 +1104,7 @@ const fastify = Fastify({
        */
       buildSerializer: function factory (externalSchemas, serializerOptsServerOption) {
         // This factory function must return a schema serializer compiler.
-        // See [#schema-serializer](Validation-and-Serialization.md#schema-serializer) for details.
+        // See [#schema-serializer](../Validation-and-Serialization.md#schema-serializer) for details.
         return function serializerCompiler ({ schema, method, url, httpStatus }) {
           return data => JSON.stringify(data)
         }
@@ -1102,11 +1148,11 @@ const app = fastify({
 #### setNotFoundHandler
 <a name="set-not-found-handler"></a>
 
-`fastify.setNotFoundHandler(handler(request, reply))`: set the 404 handler. This call is encapsulated by prefix, so different plugins can set different not found handlers if a different [`prefix` option](Plugins.md#route-prefixing-option) is passed to `fastify.register()`. The handler is treated as a regular route handler so requests will go through the full [Fastify lifecycle](Lifecycle.md#lifecycle).
+`fastify.setNotFoundHandler(handler(request, reply))`: set the 404 handler. This call is encapsulated by prefix, so different plugins can set different not found handlers if a different [`prefix` option](../Plugins.md#route-prefixing-option) is passed to `fastify.register()`. The handler is treated as a regular route handler so requests will go through the full [Fastify lifecycle](../Lifecycle.md#lifecycle).
 
 You can also register [`preValidation`](https://www.fastify.io/docs/latest/Hooks/#route-hooks) and [`preHandler`](https://www.fastify.io/docs/latest/Hooks/#route-hooks) hooks for the 404 handler.
 
-_Note: The `preValidation` hook registered using this method will run for a route that Fastify does not recognize and **not** when a route handler manually calls [`reply.callNotFound`](Reply.md#call-not-found)_. In which case, only preHandler will be run.
+_Note: The `preValidation` hook registered using this method will run for a route that Fastify does not recognize and **not** when a route handler manually calls [`reply.callNotFound`](../Reply.md#call-not-found)_. In which case, only preHandler will be run.
 
 ```js
 fastify.setNotFoundHandler({
@@ -1136,7 +1182,8 @@ Fastify calls setNotFoundHandler to add a default 404 handler at startup before 
 #### setErrorHandler
 <a name="set-error-handler"></a>
 
-`fastify.setErrorHandler(handler(error, request, reply))`: Set a function that will be called whenever an error happens. The handler is bound to the Fastify instance and is fully encapsulated, so different plugins can set different error handlers. *async-await* is supported as well.<br>
+`fastify.setErrorHandler(handler(error, request, reply))`: Set a function that will be called whenever an error happens. The handler is bound to the Fastify instance and is fully encapsulated, so different plugins can set different error handlers. *async-await* is supported as well.
+
 *Note: If the error `statusCode` is less than 400, Fastify will automatically set it at 500 before calling the error handler.*
 
 ```js
@@ -1164,7 +1211,8 @@ if (statusCode >= 500) {
 #### printRoutes
 <a name="print-routes"></a>
 
-`fastify.printRoutes()`: Prints the representation of the internal radix tree used by the router, useful for debugging. Alternatively, `fastify.printRoutes({ commonPrefix: false })` can be used to print the flattened routes tree.<br/>
+`fastify.printRoutes()`: Prints the representation of the internal radix tree used by the router, useful for debugging. Alternatively, `fastify.printRoutes({ commonPrefix: false })` can be used to print the flattened routes tree.
+
 *Remember to call it inside or after a `ready` call.*
 
 ```js
@@ -1220,7 +1268,8 @@ fastify.ready(() => {
 #### printPlugins
 <a name="print-plugins"></a>
 
-`fastify.printPlugins()`: Prints the representation of the internal plugin tree used by the avvio, useful for debugging require order issues.<br/>
+`fastify.printPlugins()`: Prints the representation of the internal plugin tree used by the avvio, useful for debugging require order issues.
+
 *Remember to call it inside or after a `ready` call.*
 
 ```js
@@ -1245,7 +1294,7 @@ fastify.ready(() => {
 `fastify.addContentTypeParser(content-type, options, parser)` is used to pass custom parser for a given content type. Useful for adding parsers for custom content types, e.g. `text/json, application/vnd.oasis.opendocument.text`. `content-type` can be a string, string array or RegExp.
 
 ```js
-// The two arguments passed to getDefaultJsonParser are for ProtoType poisoning and Constructor Poisoning configuration respectively. The possible values are 'ignore', 'remove', 'error'. ignore  skips all validations and it is similar to calling JSON.parse() directly. See the <a href="https://github.com/fastify/secure-json-parse#api">`secure-json-parse` documentation</a> for more information.
+// The two arguments passed to getDefaultJsonParser are for ProtoType poisoning and Constructor Poisoning configuration respectively. The possible values are 'ignore', 'remove', 'error'. ignore  skips all validations and it is similar to calling JSON.parse() directly. See the [`secure-json-parse` documentation](https://github.com/fastify/secure-json-parse#api) for more information.
 
 fastify.addContentTypeParser('text/json', { asString: true }, fastify.getDefaultJsonParser('ignore', 'ignore'))
 ```
@@ -1253,7 +1302,7 @@ fastify.addContentTypeParser('text/json', { asString: true }, fastify.getDefault
 #### getDefaultJsonParser
 <a name="getDefaultJsonParser"></a>
 
-`fastify.getDefaultJsonParser(onProtoPoisoning, onConstructorPoisoning)` takes two arguments. First argument is ProtoType poisoning configuration and second argument is constructor poisoning configuration. See the <a href="https://github.com/fastify/secure-json-parse#api">`secure-json-parse` documentation</a> for more information.
+`fastify.getDefaultJsonParser(onProtoPoisoning, onConstructorPoisoning)` takes two arguments. First argument is ProtoType poisoning configuration and second argument is constructor poisoning configuration. See the [`secure-json-parse` documentation](https://github.com/fastify/secure-json-parse#api) for more information.
 
 
 #### defaultTextParser

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -31,7 +31,7 @@
   - [.then(fulfilled, rejected)](#thenfulfilled-rejected)
 
 ### Introduction
-<a name="introduction"></a>
+<a id="introduction"></a>
 
 The second parameter of the handler function is `Reply`.
 Reply is a core Fastify object that exposes the following functions
@@ -79,12 +79,12 @@ fastify.get('/', {config: {foo: 'bar'}}, function (request, reply) {
 ```
 
 ### .code(statusCode)
-<a name="code"></a>
+<a id="code"></a>
 
 If not set via `reply.code`, the resulting `statusCode` will be `200`.
 
 ### .statusCode
-<a name="statusCode"></a>
+<a id="statusCode"></a>
 
 This property reads and sets the HTTP status code. It is an alias for `reply.code()` when used as a setter.
 ```js
@@ -94,7 +94,7 @@ if (reply.statusCode >= 299) {
 ```
 
 ### .server
-<a name="server"></a>
+<a id="server"></a>
 
 The Fastify server instance, scoped to the current [encapsulation context](./Reference/Encapsulation.md).
 
@@ -109,14 +109,14 @@ fastify.get('/', async function (req, rep) {
 ```
 
 ### .header(key, value)
-<a name="header"></a>
+<a id="header"></a>
 
 Sets a response header. If the value is omitted or undefined, it is coerced to `''`.
 
 For more information, see [`http.ServerResponse#setHeader`](https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_response_setheader_name_value).
 
 - ### set-cookie
-<a name="set-cookie"></a>
+<a id="set-cookie"></a>
 
     - When sending different values as a cookie with `set-cookie` as the key, every value will be sent as a cookie instead of replacing the previous value.
 
@@ -131,7 +131,7 @@ For more information, see [`http.ServerResponse#setHeader`](https://nodejs.org/d
 
 
 ### .headers(object)
-<a name="headers"></a>
+<a id="headers"></a>
 
 Sets all the keys of the object as response headers. [`.header`](#headerkey-value) will be called under the hood.
 ```js
@@ -142,7 +142,7 @@ reply.headers({
 ```
 
 ### .getHeader(key)
-<a name="getHeader"></a>
+<a id="getHeader"></a>
 
 Retrieves the value of a previously set header.
 ```js
@@ -151,7 +151,7 @@ reply.getHeader('x-foo') // 'foo'
 ```
 
 ### .getHeaders()
-<a name="getHeaders"></a>
+<a id="getHeaders"></a>
 
 Gets a shallow copy of all current response headers, including those set via the raw `http.ServerResponse`. Note that headers set via Fastify take precedence over those set via `http.ServerResponse`.
 
@@ -163,7 +163,7 @@ reply.getHeaders() // { 'x-foo': 'foo', 'x-bar': 'bar' }
 ```
 
 ### .removeHeader(key)
-<a name="getHeader"></a>
+<a id="getHeader"></a>
 
 Remove the value of a previously set header.
 ```js
@@ -173,12 +173,12 @@ reply.getHeader('x-foo') // undefined
 ```
 
 ### .hasHeader(key)
-<a name="hasHeader"></a>
+<a id="hasHeader"></a>
 
 Returns a boolean indicating if the specified header has been set.
 
 ### .redirect([code ,] dest)
-<a name="redirect"></a>
+<a id="redirect"></a>
 
 Redirects a request to the specified URL, the status code is optional, default to `302` (if status code is not already set by calling `code`).
 
@@ -203,7 +203,7 @@ reply.code(303).redirect(302, '/home')
 ```
 
 ### .callNotFound()
-<a name="call-not-found"></a>
+<a id="call-not-found"></a>
 
 Invokes the custom not found handler. Note that it will only call `preHandler` hook specified in [`setNotFoundHandler`](./Reference/Server.md#set-not-found-handler).
 
@@ -212,7 +212,7 @@ reply.callNotFound()
 ```
 
 ### .getResponseTime()
-<a name="getResponseTime"></a>
+<a id="getResponseTime"></a>
 
 Invokes the custom response time getter to calculate the amount of time passed since the request was started.
 
@@ -223,7 +223,7 @@ const milliseconds = reply.getResponseTime()
 ```
 
 ### .type(contentType)
-<a name="type"></a>
+<a id="type"></a>
 
 Sets the content type for the response.
 This is a shortcut for `reply.header('Content-Type', 'the/type')`.
@@ -233,7 +233,7 @@ reply.type('text/html')
 ```
 
 ### .serializer(func)
-<a name="serializer"></a>
+<a id="serializer"></a>
 
 `.send()` will by default JSON-serialize any value that is not one of: `Buffer`, `stream`, `string`, `undefined`, `Error`. If you need to replace the default serializer with a custom serializer for a particular request, you can do so with the `.serializer()` utility. Be aware that if you are using a custom serializer, you must set a custom `'Content-Type'` header.
 
@@ -254,7 +254,7 @@ reply
 See [`.send()`](#send) for more information on sending different types of values.
 
 ### .raw
-<a name="raw"></a>
+<a id="raw"></a>
 
 This is the [`http.ServerResponse`](https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_class_http_serverresponse) from Node core. Whilst you are using the Fastify `Reply` object, the use of `Reply.raw` functions is at your own risk as you are skipping all the Fastify
 logic of handling the HTTP response. e.g.:
@@ -272,7 +272,7 @@ app.get('/cookie-2', (req, reply) => {
 Another example of the misuse of `Reply.raw` is explained in [Reply](./Reply.md#getheaders).
 
 ### .sent
-<a name="sent"></a>
+<a id="sent"></a>
 
 As the name suggests, `.sent` is a property to indicate if
 a response has been sent via `reply.send()`.
@@ -298,7 +298,7 @@ app.get('/', (req, reply) => {
 If the handler rejects, the error will be logged.
 
 ### .hijack()
-<a name="hijack"></a>
+<a id="hijack"></a>
 
 Sometimes you might need to halt the execution of the normal request lifecycle and handle sending the response manually.
 
@@ -307,12 +307,12 @@ To achieve this, Fastify provides the `reply.hijack()` method that can be called
 NB (*): If `reply.raw` is used to send a response back to the user, `onResponse` hooks will still be executed
 
 ### .send(data)
-<a name="send"></a>
+<a id="send"></a>
 
 As the name suggests, `.send()` is the function that sends the payload to the end user.
 
 #### Objects
-<a name="send-object"></a>
+<a id="send-object"></a>
 
 As noted above, if you are sending JSON objects, `send` will serialize the object with [fast-json-stringify](https://www.npmjs.com/package/fast-json-stringify) if you set an output schema, otherwise, `JSON.stringify()` will be used.
 ```js
@@ -322,7 +322,7 @@ fastify.get('/json', options, function (request, reply) {
 ```
 
 #### Strings
-<a name="send-string"></a>
+<a id="send-string"></a>
 
 If you pass a string to `send` without a `Content-Type`, it will be sent as `text/plain; charset=utf-8`. If you set the `Content-Type` header and pass a string to `send`, it will be serialized with the custom serializer if one is set, otherwise, it will be sent unmodified (unless the `Content-Type` header is set to `application/json; charset=utf-8`, in which case it will be JSON-serialized like an object — see the section above).
 ```js
@@ -332,7 +332,7 @@ fastify.get('/json', options, function (request, reply) {
 ```
 
 #### Streams
-<a name="send-streams"></a>
+<a id="send-streams"></a>
 
 *send* can also handle streams out of the box. If you are sending a stream and you have not set a `'Content-Type'` header, *send* will set it at `'application/octet-stream'`.
 ```js
@@ -344,7 +344,7 @@ fastify.get('/streams', function (request, reply) {
 ```
 
 #### Buffers
-<a name="send-buffers"></a>
+<a id="send-buffers"></a>
 
 If you are sending a buffer and you have not set a `'Content-Type'` header, *send* will set it to `'application/octet-stream'`.
 ```js
@@ -357,7 +357,7 @@ fastify.get('/streams', function (request, reply) {
 ```
 
 #### Errors
-<a name="errors"></a>
+<a id="errors"></a>
 
 If you pass to *send* an object that is an instance of *Error*, Fastify will automatically create an error structured as the following:
 
@@ -443,7 +443,7 @@ fastify.setNotFoundHandler(function (request, reply) {
 ```
 
 #### Type of the final payload
-<a name="payload-type"></a>
+<a id="payload-type"></a>
 
 The type of the sent payload (after serialization and going through any [`onSend` hooks](./Hooks.md#the-onsend-hook)) must be one of the following types, otherwise, an error will be thrown:
 
@@ -454,7 +454,7 @@ The type of the sent payload (after serialization and going through any [`onSend
 - `null`
 
 #### Async-Await and Promises
-<a name="async-await-promise"></a>
+<a id="async-await-promise"></a>
 
 Fastify natively handles promises and supports async-await.
 
@@ -491,7 +491,7 @@ fastify.get('/botnet', async function (request, reply) {
 If you want to know more please review [Routes#async-await](./Routes.md#async-await).
 
 ### .then(fulfilled, rejected)
-<a name="then"></a>
+<a id="then"></a>
 
 As the name suggests, a `Reply` object can be awaited upon, i.e. `await reply` will wait until the reply is sent.
 The `await` syntax calls the `reply.then()`.

--- a/docs/Reply.md
+++ b/docs/Reply.md
@@ -4,23 +4,22 @@
 - [Reply](#reply)
   - [Introduction](#introduction)
   - [.code(statusCode)](#codestatuscode)
-  - [.statusCode](#statusCode)
+  - [.statusCode](#statuscode)
   - [.server](#server)
   - [.header(key, value)](#headerkey-value)
-      - [set-cookie](#set-cookie)
   - [.headers(object)](#headersobject)
   - [.getHeader(key)](#getheaderkey)
   - [.getHeaders()](#getheaders)
   - [.removeHeader(key)](#removeheaderkey)
   - [.hasHeader(key)](#hasheaderkey)
-  - [.redirect([code,] dest)](#redirectcode--dest)
+  - [.redirect([code ,] dest)](#redirectcode--dest)
   - [.callNotFound()](#callnotfound)
   - [.getResponseTime()](#getresponsetime)
   - [.type(contentType)](#typecontenttype)
-  - [.raw](#raw)
   - [.serializer(func)](#serializerfunc)
+  - [.raw](#raw)
   - [.sent](#sent)
-  - [.hijack](#hijack)
+  - [.hijack()](#hijack)
   - [.send(data)](#senddata)
     - [Objects](#objects)
     - [Strings](#strings)
@@ -29,7 +28,7 @@
     - [Errors](#errors)
     - [Type of the final payload](#type-of-the-final-payload)
     - [Async-Await and Promises](#async-await-and-promises)
-  - [.then](#then)
+  - [.then(fulfilled, rejected)](#thenfulfilled-rejected)
 
 ### Introduction
 <a name="introduction"></a>
@@ -59,7 +58,7 @@ and properties:
 - `.res` *(deprecated, use `.raw` instead)* - The [`http.ServerResponse`](https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_class_http_serverresponse) from Node core.
 - `.log` - The logger instance of the incoming request.
 - `.request` - The incoming request.
-- `.context` - Access the [Request's context](Request.md#Request) property.
+- `.context` - Access the [Request's context](./Request.md#Request) property.
 
 ```js
 fastify.get('/', options, function (request, reply) {
@@ -112,11 +111,9 @@ fastify.get('/', async function (req, rep) {
 ### .header(key, value)
 <a name="header"></a>
 
-Sets a response header. If the value is omitted or undefined, it is coerced
-to `''`.
 Sets a response header. If the value is omitted or undefined, it is coerced to `''`.
-For more information, see [`http.ServerResponse#setHeader`](https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_response_setheader_name_value).
 
+For more information, see [`http.ServerResponse#setHeader`](https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_response_setheader_name_value).
 
 - ### set-cookie
 <a name="set-cookie"></a>
@@ -219,7 +216,7 @@ reply.callNotFound()
 
 Invokes the custom response time getter to calculate the amount of time passed since the request was started.
 
-Note that unless this function is called in the [`onResponse` hook](Hooks.md#onresponse) it will always return `0`.
+Note that unless this function is called in the [`onResponse` hook](./Hooks.md#onresponse) it will always return `0`.
 
 ```js
 const milliseconds = reply.getResponseTime()
@@ -272,7 +269,7 @@ app.get('/cookie-2', (req, reply) => {
   reply.raw.end()
 })
 ```
-Another example of the misuse of `Reply.raw` is explained in [Reply](Reply.md#getheaders).
+Another example of the misuse of `Reply.raw` is explained in [Reply](./Reply.md#getheaders).
 
 ### .sent
 <a name="sent"></a>
@@ -373,7 +370,8 @@ If you pass to *send* an object that is an instance of *Error*, Fastify will aut
 }
 ```
 
-You can add custom properties to the Error object, such as `headers`, that will be used to enhance the HTTP response.<br>
+You can add custom properties to the Error object, such as `headers`, that will be used to enhance the HTTP response.
+
 *Note: If you are passing an error to `send` and the statusCode is less than 400, Fastify will automatically set it at 500.*
 
 Tip: you can simplify errors by using the [`http-errors`](https://npm.im/http-errors) module or [`fastify-sensible`](https://github.com/fastify/fastify-sensible) plugin to generate errors:
@@ -414,7 +412,8 @@ fastify.get('/', {
 })
 ```
 
-If you want to customize error handling, check out [`setErrorHandler`](./Reference/Server.md#seterrorhandler) API.<br>
+If you want to customize error handling, check out [`setErrorHandler`](./Reference/Server.md#seterrorhandler) API.
+
 *Note: you are responsible for logging when customizing the error handler*
 
 API:
@@ -446,7 +445,7 @@ fastify.setNotFoundHandler(function (request, reply) {
 #### Type of the final payload
 <a name="payload-type"></a>
 
-The type of the sent payload (after serialization and going through any [`onSend` hooks](Hooks.md#the-onsend-hook)) must be one of the following types, otherwise, an error will be thrown:
+The type of the sent payload (after serialization and going through any [`onSend` hooks](./Hooks.md#the-onsend-hook)) must be one of the following types, otherwise, an error will be thrown:
 
 - `string`
 - `Buffer`
@@ -457,7 +456,8 @@ The type of the sent payload (after serialization and going through any [`onSend
 #### Async-Await and Promises
 <a name="async-await-promise"></a>
 
-Fastify natively handles promises and supports async-await.<br>
+Fastify natively handles promises and supports async-await.
+
 *Note that in the following examples we are not using reply.send.*
 ```js
 const delay = promisify(setTimeout)
@@ -488,7 +488,7 @@ fastify.get('/botnet', async function (request, reply) {
 })
 ```
 
-If you want to know more please review [Routes#async-await](Routes.md#async-await).
+If you want to know more please review [Routes#async-await](./Routes.md#async-await).
 
 ### .then(fulfilled, rejected)
 <a name="then"></a>

--- a/docs/Request.md
+++ b/docs/Request.md
@@ -1,10 +1,11 @@
 <h1 align="center">Fastify</h1>
 
 ## Request
-The first parameter of the handler function is `Request`.<br>
+The first parameter of the handler function is `Request`.
+
 Request is a core Fastify object containing the following fields:
 - `query` - the parsed querystring, its format is specified by [`querystringParser`](./Reference/Server.md#querystringparser)
-- `body` - the request payload, see [Content Type Parser](ContentTypeParser.md) for details on what request payloads Fastify natively parses and how to support other content types
+- `body` - the request payload, see [Content-Type Parser](./ContentTypeParser.md) for details on what request payloads Fastify natively parses and how to support other content types
 - `params` - the params matching the URL
 - [`headers`](#headers) - the headers getter and setter
 - `raw` - the incoming HTTP request from Node core
@@ -24,7 +25,7 @@ Request is a core Fastify object containing the following fields:
 - `connection` - Deprecated, use `socket` instead. The underlying connection of the incoming request.
 - `socket` - the underlying connection of the incoming request
 - `context` - A Fastify internal object. You should not use it directly or modify it. It is useful to access one special key:
-  - `context.config` - The route [`config`](Routes.md#routes-config) object.
+  - `context.config` - The route [`config`](./Routes.md#routes-config) object.
 
 ### Headers
 

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -21,14 +21,14 @@ You have two ways to declare a route with Fastify, the shorthand method and the 
   - [Host Constraints](#host-constraints)
 
 ### Full declaration
-<a name="full-declaration"></a>
+<a id="full-declaration"></a>
 
 ```js
 fastify.route(options)
 ```
 
 ### Routes options
-<a name="options"></a>
+<a id="options"></a>
 
 * `method`: currently it supports `'DELETE'`, `'GET'`, `'HEAD'`, `'PATCH'`, `'POST'`, `'PUT'` and `'OPTIONS'`. It could also be an array of methods.
 * `url`: the path of the URL to match this route (alias: `path`).
@@ -105,7 +105,7 @@ fastify.route({
 ```
 
 ### Shorthand declaration
-<a name="shorthand-declaration"></a>
+<a id="shorthand-declaration"></a>
 
 The above route declaration is more *Hapi*-like, but if you prefer an *Express/Restify* approach, we support it as well:
 
@@ -167,7 +167,7 @@ fastify.get('/', opts)
 > Note: if the handler is specified in both the `options` and as the third parameter to the shortcut method then throws duplicate `handler` error.
 
 ### Url building
-<a name="url-building"></a>
+<a id="url-building"></a>
 
 Fastify supports both static and dynamic URLs.
 
@@ -210,7 +210,7 @@ fastify.post('/name::verb') // will be interpreted as /name:verb
 ```
 
 ### Async Await
-<a name="async-await"></a>
+<a id="async-await"></a>
 
 Are you an `async/await` user? We have you covered!
 ```js
@@ -260,7 +260,7 @@ fastify.get('/', options, async function (request, reply) {
 * You cannot return `undefined`. For more details read [promise-resolution](#promise-resolution).
 
 ### Promise resolution
-<a name="promise-resolution"></a>
+<a id="promise-resolution"></a>
 
 If your handler is an `async` function or returns a promise, you should be aware of a special behavior that is necessary to support the callback and promise control-flow. If the handler's promise is resolved with `undefined`, it will be ignored causing the request to hang and an *error* log to be emitted.
 
@@ -276,7 +276,7 @@ In this way, we can support both `callback-style` and `async-await`, with the mi
 **Notice**: Every async function returns a promise by itself.
 
 ### Route Prefixing
-<a name="route-prefixing"></a>
+<a id="route-prefixing"></a>
 
 Sometimes you need to maintain two or more different versions of the same API; a classic approach is to prefix all the routes with the API version number, `/v1/user` for example.
 Fastify offers you a fast and smart way to create different versions of the same API without changing all the route names by hand, *route prefixing*. Let's see how it works:
@@ -326,7 +326,7 @@ and `/something/`.
 See the `prefixTrailingSlash` route option above to change this behavior.
 
 ### Custom Log Level
-<a name="custom-log-level"></a>
+<a id="custom-log-level"></a>
 
 It could happen that you need different log levels in your routes; Fastify achieves this in a very straightforward way.
 
@@ -353,7 +353,7 @@ fastify.get('/', { logLevel: 'warn' }, (request, reply) => {
 *Remember that the custom log level is applied only to the routes, and not to the global Fastify Logger, accessible with `fastify.log`*
 
 ### Custom Log Serializer
-<a name="custom-log-serializer"></a>
+<a id="custom-log-serializer"></a>
 
 In some context, you may need to log a large object but it could be a waste of resources for some routes. In this case, you can define some [`serializer`](https://github.com/pinojs/pino/blob/master/docs/api.md#bindingsserializers-object) and attach them in the right context!
 
@@ -413,7 +413,7 @@ fastify.listen(3000)
 ```
 
 ### Config
-<a name="routes-config"></a>
+<a id="routes-config"></a>
 
 Registering a new handler, you can pass a configuration object to it and retrieve it in the handler.
 
@@ -432,7 +432,7 @@ fastify.listen(3000)
 ```
 
 ### Constraints
-<a name="constraints"></a>
+<a id="constraints"></a>
 
 Fastify supports constraining routes to match only certain requests based on some property of the request, like the `Host` header, or any other value via [`find-my-way`](https://github.com/delvedor/find-my-way) constraints. Constraints are specified in the `constraints` property of the route options. Fastify has two built-in constraints ready for use: the `version` constraint and the `host` constraint, and you can add your own custom constraint strategies to inspect other parts of a request to decide if a route should be executed for a request.
 

--- a/docs/Routes.md
+++ b/docs/Routes.md
@@ -5,18 +5,20 @@
 The routes methods will configure the endpoints of your application.
 You have two ways to declare a route with Fastify, the shorthand method and the full declaration.
 
-- [Full Declaration](#full-declaration)
-- [Route Options](#options)
-- [Shorthand Declaration](#shorthand-declaration)
-- [URL Parameters](#url-building)
-- [Use `async`/`await`](#async-await)
+- [Full declaration](#full-declaration)
+- [Routes options](#routes-options)
+- [Shorthand declaration](#shorthand-declaration)
+- [Url building](#url-building)
+- [Async Await](#async-await)
 - [Promise resolution](#promise-resolution)
 - [Route Prefixing](#route-prefixing)
-- Logs
-  - [Custom Log Level](#custom-log-level)
-  - [Custom Log Serializer](#custom-log-serializer)
-- [Route handler configuration](#routes-config)
-- [Route constraints](#constraints)
+  - [Handling of / route inside prefixed plugins](#handling-of--route-inside-prefixed-plugins)
+- [Custom Log Level](#custom-log-level)
+- [Custom Log Serializer](#custom-log-serializer)
+- [Config](#config)
+- [Constraints](#constraints)
+  - [Version Constraints](#version-constraints)
+  - [Host Constraints](#host-constraints)
 
 ### Full declaration
 <a name="full-declaration"></a>
@@ -32,7 +34,7 @@ fastify.route(options)
 * `url`: the path of the URL to match this route (alias: `path`).
 * `schema`: an object containing the schemas for the request and response.
 They need to be in
-  [JSON Schema](https://json-schema.org/) format, check [here](Validation-and-Serialization.md) for more info.
+  [JSON Schema](https://json-schema.org/) format, check [here](./Validation-and-Serialization.md) for more info.
 
   * `body`: validates the body of the request if it is a POST, PUT, or PATCH method.
   * `querystring` or `query`: validates the querystring. This can be a complete JSON
@@ -43,39 +45,39 @@ They need to be in
     schema allows us to have 10-20% more throughput.
 * `exposeHeadRoute`: creates a sibling `HEAD` route for any `GET` routes. Defaults to the value of [`exposeHeadRoutes`](./Reference/Server.md#exposeHeadRoutes) instance option. If you want a custom `HEAD` handler without disabling this option, make sure to define it before the `GET` route.
 * `attachValidation`: attach `validationError` to request, if there is a schema validation error, instead of sending the error to the error handler.
-* `onRequest(request, reply, done)`: a [function](Hooks.md#onrequest) as soon that a request is received, it could also be an array of functions.
-* `preParsing(request, reply, done)`: a [function](Hooks.md#preparsing) called before parsing the request, it could also be an array of functions.
-* `preValidation(request, reply, done)`: a [function](Hooks.md#prevalidation) called after the shared `preValidation` hooks, useful if you need to perform authentication at route level for example, it could also be an array of functions.
-* `preHandler(request, reply, done)`: a [function](Hooks.md#prehandler) called just before the request handler, it could also be an array of functions.
-* `preSerialization(request, reply, payload, done)`: a [function](Hooks.md#preserialization) called just before the serialization, it could also be an array of functions.
-* `onSend(request, reply, payload, done)`: a [function](Hooks.md#route-hooks) called right before a response is sent, it could also be an array of functions.
-* `onResponse(request, reply, done)`: a [function](Hooks.md#onresponse) called when a response has been sent, so you will not be able to send more data to the client. It could also be an array of functions.
-* `onTimeout(request, reply, done)`: a [function](Hooks.md#ontimeout) called when a request is timed out and the HTTP socket has been hanged up.
-* `onError(request, reply, error, done)`: a [function](Hooks.md#onerror) called when an Error is thrown or send to the client by the route handler.
+* `onRequest(request, reply, done)`: a [function](./Hooks.md#onrequest) as soon that a request is received, it could also be an array of functions.
+* `preParsing(request, reply, done)`: a [function](./Hooks.md#preparsing) called before parsing the request, it could also be an array of functions.
+* `preValidation(request, reply, done)`: a [function](./Hooks.md#prevalidation) called after the shared `preValidation` hooks, useful if you need to perform authentication at route level for example, it could also be an array of functions.
+* `preHandler(request, reply, done)`: a [function](./Hooks.md#prehandler) called just before the request handler, it could also be an array of functions.
+* `preSerialization(request, reply, payload, done)`: a [function](./Hooks.md#preserialization) called just before the serialization, it could also be an array of functions.
+* `onSend(request, reply, payload, done)`: a [function](./Hooks.md#route-hooks) called right before a response is sent, it could also be an array of functions.
+* `onResponse(request, reply, done)`: a [function](./Hooks.md#onresponse) called when a response has been sent, so you will not be able to send more data to the client. It could also be an array of functions.
+* `onTimeout(request, reply, done)`: a [function](./Hooks.md#ontimeout) called when a request is timed out and the HTTP socket has been hanged up.
+* `onError(request, reply, error, done)`: a [function](./Hooks.md#onerror) called when an Error is thrown or send to the client by the route handler.
 * `handler(request, reply)`: the function that will handle this request. The [Fastify server](./Reference/Server.md) will be bound to `this` when the handler is called. Note: using an arrow function will break the binding of `this`.
 * `errorHandler(error, request, reply)`: a custom error handler for the scope of the request. Overrides the default error global handler, and anything set by [`setErrorHandler`](./Reference/Server.md#setErrorHandler), for requests to the route. To access the default handler, you can access `instance.errorHandler`. Note that this will point to fastify's default `errorHandler` only if a plugin hasn't overridden it already.
-* `validatorCompiler({ schema, method, url, httpPart })`: function that builds schemas for request validations. See the [Validation and Serialization](Validation-and-Serialization.md#schema-validator) documentation.
-* `serializerCompiler({ { schema, method, url, httpStatus } })`: function that builds schemas for response serialization. See the [Validation and Serialization](Validation-and-Serialization.md#schema-serializer) documentation.
-* `schemaErrorFormatter(errors, dataVar)`: function that formats the errors from the validation compiler. See the [Validation and Serialization](Validation-and-Serialization.md#error-handling) documentation. Overrides the global schema error formatter handler, and anything set by `setSchemaErrorFormatter`, for requests to the route.
+* `validatorCompiler({ schema, method, url, httpPart })`: function that builds schemas for request validations. See the [Validation and Serialization](./Validation-and-Serialization.md#schema-validator) documentation.
+* `serializerCompiler({ { schema, method, url, httpStatus } })`: function that builds schemas for response serialization. See the [Validation and Serialization](./Validation-and-Serialization.md#schema-serializer) documentation.
+* `schemaErrorFormatter(errors, dataVar)`: function that formats the errors from the validation compiler. See the [Validation and Serialization](./Validation-and-Serialization.md#error-handling) documentation. Overrides the global schema error formatter handler, and anything set by `setSchemaErrorFormatter`, for requests to the route.
 * `bodyLimit`: prevents the default JSON body parser from parsing request bodies larger than this number of bytes. Must be an integer. You may also set this option globally when first creating the Fastify instance with `fastify(options)`. Defaults to `1048576` (1 MiB).
 * `logLevel`: set log level for this route. See below.
 * `logSerializers`: set serializers to log for this route.
 * `config`: object used to store custom configuration.
-* `version`: a [semver](https://semver.org/) compatible string that defined the version of the endpoint. [Example](Routes.md#version).
+* `version`: a [semver](https://semver.org/) compatible string that defined the version of the endpoint. [Example](./Routes.md#version).
 * `prefixTrailingSlash`: string used to determine how to handle passing `/` as a route with a prefix.
   * `both` (default): Will register both `/prefix` and `/prefix/`.
   * `slash`: Will register only `/prefix/`.
   * `no-slash`: Will register only `/prefix`.
 
-  `request` is defined in [Request](Request.md).
+  `request` is defined in [Request](./Request.md).
 
-  `reply` is defined in [Reply](Reply.md).
+  `reply` is defined in [Reply](./Reply.md).
 
 **Notice:** The documentation of `onRequest`, `preParsing`, `preValidation`,
 `preHandler`, `preSerialization`, `onSend`, and `onResponse` are described in
-more detail in [Hooks](Hooks.md). Additionally, to send a response before the
+more detail in [Hooks](./Hooks.md). Additionally, to send a response before the
 request is handled by the `handler` please refer to
-[Respond to a request from a hook](Hooks.md#respond-to-a-request-from-a-hook).
+[Respond to a request from a hook](./Hooks.md#respond-to-a-request-from-a-hook).
 
 Example:
 ```js
@@ -105,13 +107,20 @@ fastify.route({
 ### Shorthand declaration
 <a name="shorthand-declaration"></a>
 
-The above route declaration is more *Hapi*-like, but if you prefer an *Express/Restify* approach, we support it as well:<br>
-`fastify.get(path, [options], handler)`<br>
-`fastify.head(path, [options], handler)`<br>
-`fastify.post(path, [options], handler)`<br>
-`fastify.put(path, [options], handler)`<br>
-`fastify.delete(path, [options], handler)`<br>
-`fastify.options(path, [options], handler)`<br>
+The above route declaration is more *Hapi*-like, but if you prefer an *Express/Restify* approach, we support it as well:
+
+`fastify.get(path, [options], handler)`
+
+`fastify.head(path, [options], handler)`
+
+`fastify.post(path, [options], handler)`
+
+`fastify.put(path, [options], handler)`
+
+`fastify.delete(path, [options], handler)`
+
+`fastify.options(path, [options], handler)`
+
 `fastify.patch(path, [options], handler)`
 
 Example:
@@ -160,7 +169,8 @@ fastify.get('/', opts)
 ### Url building
 <a name="url-building"></a>
 
-Fastify supports both static and dynamic URLs.<br>
+Fastify supports both static and dynamic URLs.
+
 To register a **parametric** path, use the *colon* before the parameter name. For **wildcard**, use the *star*.
 *Remember that static routes are always checked before parametric and wildcard.*
 
@@ -318,7 +328,8 @@ See the `prefixTrailingSlash` route option above to change this behavior.
 ### Custom Log Level
 <a name="custom-log-level"></a>
 
-It could happen that you need different log levels in your routes; Fastify achieves this in a very straightforward way.<br/>
+It could happen that you need different log levels in your routes; Fastify achieves this in a very straightforward way.
+
 You just need to pass the option `logLevel` to the plugin option or the route option with the [value](https://github.com/pinojs/pino/blob/master/docs/api.md#level-string) that you need.
 
 Be aware that if you set the `logLevel` at plugin level, also the [`setNotFoundHandler`](./Reference/Server.md#setnotfoundhandler) and [`setErrorHandler`](./Reference/Server.md#seterrorhandler) will be affected.
@@ -427,8 +438,10 @@ Fastify supports constraining routes to match only certain requests based on som
 
 #### Version Constraints
 
-You can provide a `version` key in the `constraints` option to a route. Versioned routes allow you to declare multiple handlers for the same HTTP route path, which will then be matched according to each request's `Accept-Version` header. The `Accept-Version` header value should follow the [semver](http://semver.org/) specification, and routes should be declared with exact semver versions for matching.<br/>
-Fastify will require a request `Accept-Version` header to be set if the route has a version set, and will prefer a versioned route to a non-versioned route for the same path. Advanced version ranges and pre-releases currently are not supported.<br/>
+You can provide a `version` key in the `constraints` option to a route. Versioned routes allow you to declare multiple handlers for the same HTTP route path, which will then be matched according to each request's `Accept-Version` header. The `Accept-Version` header value should follow the [semver](http://semver.org/) specification, and routes should be declared with exact semver versions for matching.
+
+Fastify will require a request `Accept-Version` header to be set if the route has a version set, and will prefer a versioned route to a non-versioned route for the same path. Advanced version ranges and pre-releases currently are not supported.
+
 *Be aware that using this feature will cause a degradation of the overall performances of the router.*
 
 ```js
@@ -470,7 +483,8 @@ fastify.inject({
 > })
 > ```
 
-If you declare multiple versions with the same major or minor, Fastify will always choose the highest compatible with the `Accept-Version` header value.<br/>
+If you declare multiple versions with the same major or minor, Fastify will always choose the highest compatible with the `Accept-Version` header value.
+
 If the request will not have the `Accept-Version` header, a 404 error will be returned.
 
 It is possible to define a custom version matching logic. This can be done through the [`constraints`](./Reference/Server.md#constraints) configuration when creating a Fastify server instance.

--- a/docs/Serverless.md
+++ b/docs/Serverless.md
@@ -112,7 +112,7 @@ const fastify = require("fastify")({
 
 ### Add Custom `contentTypeParser` to Fastify instance
 
-As explained [in issue #946](https://github.com/fastify/fastify/issues/946#issuecomment-766319521), since the Google Cloud Functions platform parses the body of the request before it arrives into Fastify instance, troubling the body request in case of `POST` and `PATCH` methods, you need to add a custom [`ContentTypeParser`](https://www.fastify.io/docs/latest/ContentTypeParser/) to mitigate this behavior.
+As explained [in issue #946](https://github.com/fastify/fastify/issues/946#issuecomment-766319521), since the Google Cloud Functions platform parses the body of the request before it arrives into Fastify instance, troubling the body request in case of `POST` and `PATCH` methods, you need to add a custom [`Content-Type Parser`](./ContentTypeParser.md) to mitigate this behavior.
 
 ```js
 fastify.addContentTypeParser('application/json', {}, (req, body, done) => {
@@ -188,7 +188,7 @@ npm i --save-dev @google-cloud/functions-framework
 ```
 
 Than you can run your function locally with Functions Framework:
-``` bash
+```bash
 npx @google-cloud/functions-framework --target=fastifyFunction
 ```
 

--- a/docs/Style-Guide.md
+++ b/docs/Style-Guide.md
@@ -8,7 +8,7 @@ Welcome to *Fastify Style Guide*. This guide is here to provide you with a conve
 
 This guide is for anyone who loves to build with Fastify or wants to contribute to our documentation. You do not need to be an expert in writing technical documentation. This guide is here to help you.
 
-Visit the [contribute](https://www.fastify.io/contribute) page on our website or read the [CONTRIBUTING.md](/CONTRIBUTING.md) file on GitHub to join our Open Source folks.
+Visit the [contribute](https://www.fastify.io/contribute) page on our website or read the [CONTRIBUTING.md](https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md) file on GitHub to join our Open Source folks.
 
 ## Before you write
 
@@ -64,7 +64,7 @@ There are a few things you need to use and avoid when writing your documentation
 
 ### When to use the second person "you" as the pronoun
 
-When writing articles or guides, your content should communicate directly to readers in the second person ("you") addressed form. It is easier to give them direct instruction on what to do on a particular topic. To see an example, visit the [Plugins-guide.md](/docs/Plugins-Guide.md) page on Github. 
+When writing articles or guides, your content should communicate directly to readers in the second person ("you") addressed form. It is easier to give them direct instruction on what to do on a particular topic. To see an example, visit the [Plugins-guide.md](./Plugins-Guide.md) page on Github. 
 
 **Example**
 
@@ -84,7 +84,7 @@ Less like this: You can use the following recommendation as an example.
 
 More like this: As an example, the following recommendations should be referenced.
 
-To view a live example, refer to the [Decorators.md](/docs/Decorators.md) reference document. 
+To view a live example, refer to the [Decorators.md](./Decorators.md) reference document. 
 
 
 ### Avoid using contractions
@@ -150,9 +150,12 @@ Active:  npm installs packages and node dependencies.
 
 When creating a new guide, API, or reference in the `/docs/` directory, use short titles that best describe the topic of your documentation. Name your files in kebab-cases and avoid Raw or camelCase. To learn more about kebab-case you can visit this medium article on [Case Styles](https://medium.com/better-programming/string-case-styles-camel-pascal-snake-and-kebab-case-981407998841).
 
-**Examples**: <br>
->`hook-and-plugins.md`, <br> 
- `adding-test-plugins.md`, <br>
+**Examples**: 
+
+>`hook-and-plugins.md`, 
+ 
+ `adding-test-plugins.md`, 
+
  `removing-requests.md`.
 
 ### Hyperlinks

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -4,7 +4,7 @@
 
 The Fastify framework is written in vanilla JavaScript, and as such type definitions are not as easy to maintain; however, since version 2 and beyond, maintainers and contributors have put in a great effort to improve the types.
 
-The type system was changed in Fastify version 3. The new type system introduces generic constraining and defaulting, plus a new way to define schema types such as a request body, querystring, and more! As the team works on improving framework and type definition synergy, sometimes parts of the API will not be typed or may be typed incorrectly. We encourage you to **contribute** to help us fill in the gaps. Just make sure to read our [`CONTRIBUTING.md`](https://github.com/fastify/fastify/blob/HEAD/CONTRIBUTING.md) file before getting started to make sure things go smoothly!
+The type system was changed in Fastify version 3. The new type system introduces generic constraining and defaulting, plus a new way to define schema types such as a request body, querystring, and more! As the team works on improving framework and type definition synergy, sometimes parts of the API will not be typed or may be typed incorrectly. We encourage you to **contribute** to help us fill in the gaps. Just make sure to read our [`CONTRIBUTING.md`](https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md) file before getting started to make sure things go smoothly!
 
 > The documentation in this section covers Fastify version 3.x typings
 
@@ -130,7 +130,7 @@ The type system heavily relies on generic properties to provide the most accurat
 
 ### JSON Schema
 
-To validate your requests and responses you can use JSON Schema files. If you didn't know already, defining schemas for your Fastify routes can increase their throughput! Check out the [Validation and Serialization](Validation-and-Serialization.md) documentation for more info.
+To validate your requests and responses you can use JSON Schema files. If you didn't know already, defining schemas for your Fastify routes can increase their throughput! Check out the [Validation and Serialization](./Validation-and-Serialization.md) documentation for more info.
 
 Also it has the advantage to use the defined type within your handlers (including pre-validation, etc.).
 
@@ -376,7 +376,7 @@ fastify.post<{ Body: FromSchema<typeof todo> }>(
 
 ### Plugins
 
-One of Fastify's most distinguishable features is its extensive plugin ecosystem. Plugin types are fully supported, and take advantage of the [declaration merging]() pattern. This example is broken up into three parts: Creating a TypeScript Fastify Plugin, Creating Type Definitions for a Fastify Plugin, and Using a Fastify Plugin in a TypeScript Project.
+One of Fastify's most distinguishable features is its extensive plugin ecosystem. Plugin types are fully supported, and take advantage of the [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) pattern. This example is broken up into three parts: Creating a TypeScript Fastify Plugin, Creating Type Definitions for a Fastify Plugin, and Using a Fastify Plugin in a TypeScript Project.
 
 #### Creating a TypeScript Fastify Plugin
 
@@ -660,7 +660,7 @@ Constraints: `string | Buffer`
 #### Fastify
 
 ##### fastify<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [Logger][LoggerGeneric]>(opts?: [FastifyServerOptions][FastifyServerOptions]): [FastifyInstance][FastifyInstance]
-[src](./../fastify.d.ts#L19)
+[src](https://github.com/fastify/fastify/blob/main/fastify.d.ts#L19)
 
 The main Fastify API method. By default creates an HTTP server. Utilizing discriminant unions and overload methods, the type system will automatically infer which type of server (http, https, or http2) is being created purely based on the options based to the method (see the examples below for more information). It also supports an extensive generic type system to allow the user to extend the underlying Node.js Server, Request, and Reply objects. Additionally, the `Logger` generic exists for custom log types. See the examples and generic breakdown below for more information.
 
@@ -718,7 +718,7 @@ const secureServer = fastify({
 })
 ```
 
-For more details on using HTTP2 check out the Fastify [HTTP2](HTTP2.md) documentation page.
+For more details on using HTTP2 check out the Fastify [HTTP2](./HTTP2.md) documentation page.
 
 ###### Example 4: Extended HTTP server
 
@@ -741,7 +741,7 @@ server.get('/', async (request, reply) => {
 
 ###### Example 5: Specifying logger types
 
-Fastify uses [Pino](https://getpino.io/#/) logging library under the hood. Some of it's properties can be configured via `logger` field when constructing Fastify's instance. If properties you need aren't exposed, it's also possible to pass a preconfigured external instance of Pino (or any other compatible logger) to Fastify via the same field. This allows creating custom serializers as well, see the [Logging](Logging.md) documentation for more info.
+Fastify uses [Pino](https://getpino.io/#/) logging library under the hood. Some of it's properties can be configured via `logger` field when constructing Fastify's instance. If properties you need aren't exposed, it's also possible to pass a preconfigured external instance of Pino (or any other compatible logger) to Fastify via the same field. This allows creating custom serializers as well, see the [Logging](./Logging.md) documentation for more info.
 
 To use an external instance of Pino, add `@types/pino` to devDependencies and pass the instance to `logger` field:
 
@@ -766,19 +766,19 @@ server.get('/', async (request, reply) => {
 ---
 
 ##### fastify.HTTPMethods
-[src](./../types/utils.d.ts#L8)
+[src](https://github.com/fastify/fastify/blob/main/types/utils.d.ts#L8)
 
 Union type of: `'DELETE' | 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'OPTIONS'`
 
 ##### fastify.RawServerBase
-[src](./../types/utils.d.ts#L13)
+[src](https://github.com/fastify/fastify/blob/main/types/utils.d.ts#L13)
 
 Dependant on `@types/node` modules `http`, `https`, `http2`
 
 Union type of: `http.Server | https.Server | http2.Http2Server | http2.Http2SecureServer`
 
 ##### fastify.RawServerDefault
-[src](./../types/utils.d.ts#L18)
+[src](https://github.com/fastify/fastify/blob/main/types/utils.d.ts#L18)
 
 Dependant on `@types/node` modules `http`
 
@@ -788,7 +788,7 @@ Type alias for `http.Server`
 
 ##### fastify.FastifyServerOptions<[RawServer][RawServerGeneric], [Logger][LoggerGeneric]>
 
-[src](../fastify.d.ts#L29)
+[src](https://github.com/fastify/fastify/blob/main/fastify.d.ts#L29)
 
 An interface of properties used in the instantiation of the Fastify server. Is used in the main [`fastify()`][Fastify] method. The `RawServer` and `Logger` generic parameters are passed down through that method.
 
@@ -796,7 +796,7 @@ See the main [fastify][Fastify] method type definition section for examples on i
 
 ##### fastify.FastifyInstance<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RequestGeneric][FastifyRequestGenericInterface], [Logger][LoggerGeneric]>
 
-[src](../types/instance.d.ts#L16)
+[src](https://github.com/fastify/fastify/blob/main/types/instance.d.ts#L16)
 
 Interface that represents the Fastify server object. This is the returned server instance from the [`fastify()`][Fastify] method. This type is an interface so it can be extended via [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) if your code makes use of the `decorate` method.
 
@@ -809,7 +809,7 @@ Check out the main [Learn by Example](#learn-by-example) section for detailed gu
 #### Request
 
 ##### fastify.FastifyRequest<[RequestGeneric][FastifyRequestGenericInterface], [RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric]>
-[src](./../types/request.d.ts#L15)
+[src](https://github.com/fastify/fastify/blob/main/types/request.d.ts#L15)
 
 This interface contains properties of Fastify request object. The properties added here disregard what kind of request object (http vs http2) and disregard what route level it is serving; thus calling `request.body` inside a GET request will not throw an error (but good luck sending a GET request with a body 😉).
 
@@ -848,7 +848,7 @@ server.get('/typedRequest', async (request: CustomRequest, reply: FastifyReply) 
 ```
 
 ##### fastify.RequestGenericInterface
-[src](./../types/request.d.ts#L4)
+[src](https://github.com/fastify/fastify/blob/main/types/request.d.ts#L4)
 
 Fastify request objects have four dynamic properties: `body`, `params`, `query`, and `headers`. Their respective types are assignable through this interface. It is a named property interface enabling the developer to ignore the properties they do not want to specify. All omitted properties are defaulted to `unknown`. The corresponding property names are: `Body`, `Querystring`, `Params`, `Headers`.
 
@@ -872,7 +872,7 @@ server.get<requestGeneric>('/', async (request, reply) => {
 If you want to see a detailed example of using this interface check out the Learn by Example section: [JSON Schema](#jsonschema).
 
 ##### fastify.RawRequestDefaultExpression\<[RawServer][RawServerGeneric]\>
-[src](./../types/utils.d.ts#L23)
+[src](https://github.com/fastify/fastify/blob/main/types/utils.d.ts#L23)
 
 Dependant on `@types/node` modules `http`, `https`, `http2`
 
@@ -894,7 +894,7 @@ RawRequestDefaultExpression<http2.Http2Server> // -> http2.Http2ServerRequest
 #### Reply
 
 ##### fastify.FastifyReply<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>
-[src](./../types/reply.d.ts#L32)
+[src](https://github.com/fastify/fastify/blob/main/types/reply.d.ts#L32)
 
 This interface contains the custom properties that Fastify adds to the standard Node.js reply object. The properties added here disregard what kind of reply object (http vs http2).
 
@@ -924,7 +924,7 @@ declare module 'fastify' {
 ```
 
 ##### fastify.RawReplyDefaultExpression<[RawServer][RawServerGeneric]>
-[src](./../types/utils.d.ts#L27)
+[src](https://github.com/fastify/fastify/blob/main/types/utils.d.ts#L27)
 
 Dependant on `@types/node` modules `http`, `https`, `http2`
 
@@ -950,24 +950,24 @@ Fastify allows the user to extend its functionalities with plugins. A plugin can
 When creating plugins for Fastify, it is recommended to use the `fastify-plugin` module. Additionally, there is a guide to creating plugins with TypeScript and Fastify available in the Learn by Example, [Plugins](#plugins) section.
 
 ##### fastify.FastifyPluginCallback<[Options][FastifyPluginOptions]>
-[src](../types/plugin.d.ts#L9)
+[src](https://github.com/fastify/fastify/blob/main/types/plugin.d.ts#L9)
 
 Interface method definition used within the [`fastify.register()`][FastifyRegister] method.
 
 ##### fastify.FastifyPluginAsync<[Options][FastifyPluginOptions]>
-[src](../types/plugin.d.ts#L20)
+[src](https://github.com/fastify/fastify/blob/main/types/plugin.d.ts#L20)
 
 Interface method definition used within the [`fastify.register()`][FastifyRegister] method.
 
 ##### fastify.FastifyPlugin<[Options][FastifyPluginOptions]>
-[src](../types/plugin.d.ts#L29)
+[src](https://github.com/fastify/fastify/blob/main/types/plugin.d.ts#L29)
 
 Interface method definition used within the [`fastify.register()`][FastifyRegister] method.
 Document deprecated in favor of `FastifyPluginCallback` and `FastifyPluginAsync` since general
 `FastifyPlugin` doesn't properly infer types for async functions.
 
 ##### fastify.FastifyPluginOptions
-[src](../types/plugin.d.ts#L31)
+[src](https://github.com/fastify/fastify/blob/main/types/plugin.d.ts#L31)
 
 A loosely typed object used to constrain the `options` parameter of [`fastify.register()`][FastifyRegister] to an object. When creating a plugin, define its options as an extension of this interface (`interface MyPluginOptions extends FastifyPluginOptions`) so they can be passed to the register method.
 
@@ -976,11 +976,11 @@ A loosely typed object used to constrain the `options` parameter of [`fastify.re
 #### Register
 
 ##### fastify.FastifyRegister(plugin: [FastifyPluginCallback][FastifyPluginCallback], opts: [FastifyRegisterOptions][FastifyRegisterOptions])
-[src](../types/register.d.ts#L9)
+[src](https://github.com/fastify/fastify/blob/main/types/register.d.ts#L9)
 ##### fastify.FastifyRegister(plugin: [FastifyPluginAsync][FastifyPluginAsync], opts: [FastifyRegisterOptions][FastifyRegisterOptions])
-[src](../types/register.d.ts#L9)
+[src](https://github.com/fastify/fastify/blob/main/types/register.d.ts#L9)
 ##### fastify.FastifyRegister(plugin: [FastifyPlugin][FastifyPlugin], opts: [FastifyRegisterOptions][FastifyRegisterOptions])
-[src](../types/register.d.ts#L9)
+[src](https://github.com/fastify/fastify/blob/main/types/register.d.ts#L9)
 
 This type interface specifies the type for the [`fastify.register()`](./Reference/Server.md#register) method. The type interface returns a function signature with an underlying generic `Options` which is defaulted to [FastifyPluginOptions][FastifyPluginOptions]. It infers this generic from the FastifyPlugin parameter when calling this function so there is no need to specify the underlying generic. The options parameter is the intersection of the plugin's options and two additional optional properties: `prefix: string` and `logLevel`: [LogLevel][LogLevel].
 
@@ -1000,8 +1000,8 @@ fastify().register(plugin, { option1: '', option2: true }) // OK - options objec
 
 See the Learn By Example, [Plugins](#plugins) section for more detailed examples of creating TypeScript plugins in Fastify.
 
-##### fastify.FastifyRegisterOptions<Options>
-[src](../types/register.d.ts#L16)
+##### fastify.FastifyRegisterOptions
+[src](https://github.com/fastify/fastify/blob/main/types/register.d.ts#L16)
 
 This type is the intersection of the `Options` generic and a non-exported interface `RegisterOptions` that specifies two optional properties: `prefix: string` and `logLevel`: [LogLevel][LogLevel]. This type can also be specified as a function that returns the previously described intersection.
 
@@ -1013,19 +1013,19 @@ Check out the [Specifying Logger Types](#example-5-specifying-logger-types) exam
 
 ##### fastify.FastifyLoggerOptions<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric]>
 
-[src](../types/logger.d.ts#L17)
+[src](https://github.com/fastify/fastify/blob/main/types/logger.d.ts#L17)
 
-An interface definition for the internal Fastify logger. It is emulative of the [Pino.js](https://getpino.io/#/) logger. When enabled through server options, use it following the general [logger](Logging.md) documentation.
+An interface definition for the internal Fastify logger. It is emulative of the [Pino.js](https://getpino.io/#/) logger. When enabled through server options, use it following the general [logger](./Logging.md) documentation.
 
 ##### fastify.FastifyLogFn
 
-[src](../types/logger.d.ts#L7)
+[src](https://github.com/fastify/fastify/blob/main/types/logger.d.ts#L7)
 
 An overload function interface that implements the two ways Fastify calls log methods. This interface is passed to all associated log level properties on the FastifyLoggerOptions object.
 
 ##### fastify.LogLevel
 
-[src](../types/logger.d.ts#L12)
+[src](https://github.com/fastify/fastify/blob/main/types/logger.d.ts#L12)
 
 Union type of: `'info' | 'error' | 'debug' | 'fatal' | 'warn' | 'trace'`
 
@@ -1037,7 +1037,7 @@ The context type definition is similar to the other highly dynamic pieces of the
 
 ##### fastify.FastifyContext
 
-[src](../types/context.d.ts#L6)
+[src](https://github.com/fastify/fastify/blob/main/types/context.d.ts#L6)
 
 An interface with a single required property `config` that is set by default to `unknown`. Can be specified either using a generic or an overload.
 
@@ -1051,13 +1051,13 @@ One of the core principles in Fastify is its routing capabilities. Most of the t
 
 ##### fastify.RouteHandlerMethod<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>
 
-[src](../types/route.d.ts#L105)
+[src](https://github.com/fastify/fastify/blob/main/types/route.d.ts#L105)
 
 A type declaration for the route handler methods. Has two arguments, `request` and `reply` which are typed by `FastifyRequest` and `FastifyReply` respectfully. The generics parameters are passed through to these arguments. The method returns either `void` or `Promise<any>` for synchronous and asynchronous handlers respectfully.
 
 ##### fastify.RouteOptions<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>
 
-[src](../types/route.d.ts#L78)
+[src](https://github.com/fastify/fastify/blob/main/types/route.d.ts#L78)
 
 An interface than extends RouteShorthandOptions and adds the follow three required properties:
 1. `method` which corresponds to a singular [HTTPMethod][HTTPMethods] or a list of [HTTPMethods][HTTPMethods]
@@ -1066,19 +1066,19 @@ An interface than extends RouteShorthandOptions and adds the follow three requir
 
 ##### fastify.RouteShorthandMethod<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric]>
 
-[src](../types/route.d.ts#12)
+[src](https://github.com/fastify/fastify/blob/main/types/route.d.ts#12)
 
 An overloaded function interface for three kinds of shorthand route methods to be used in conjunction with the `.get/.post/.etc` methods.
 
 ##### fastify.RouteShorthandOptions<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>
 
-[src](../types/route.d.ts#55)
+[src](https://github.com/fastify/fastify/blob/main/types/route.d.ts#55)
 
 An interface that covers all of the base options for a route. Each property on this interface is optional, and it serves as the base for the RouteOptions and RouteShorthandOptionsWithHandler interfaces.
 
 ##### fastify.RouteShorthandOptionsWithHandler<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>
 
-[src](../types/route.d.ts#93)
+[src](https://github.com/fastify/fastify/blob/main/types/route.d.ts#93)
 
 This interface adds a single, required property to the RouteShorthandOptions interface `handler` which is of type RouteHandlerMethod
 
@@ -1092,25 +1092,25 @@ A generic type that is either a `string` or `Buffer`
 
 ##### fastify.FastifyBodyParser<[RawBody][RawBodyGeneric], [RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric]>
 
-[src](../types/content-type-parser.d.ts#L7)
+[src](https://github.com/fastify/fastify/blob/main/types/content-type-parser.d.ts#L7)
 
 A function type definition for specifying a body parser method. Use the `RawBody` generic to specify the type of the body being parsed.
 
 ##### fastify.FastifyContentTypeParser<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric]>
 
-[src](../types/content-type-parser.d.ts#L17)
+[src](https://github.com/fastify/fastify/blob/main/types/content-type-parser.d.ts#L17)
 
 A function type definition for specifying a body parser method. Content is typed via the `RawRequest` generic.
 
 ##### fastify.AddContentTypeParser<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric]>
 
-[src](../types/content-type-parser.d.ts#L46)
+[src](https://github.com/fastify/fastify/blob/main/types/content-type-parser.d.ts#L46)
 
 An overloaded interface function definition for the `addContentTypeParser` method. If `parseAs` is passed to the `opts` parameter, the definition uses [FastifyBodyParser][] for the `parser` parameter; otherwise, it uses [FastifyContentTypeParser][].
 
 ##### fastify.hasContentTypeParser
 
-[src](../types/content-type-parser.d.ts#L63)
+[src](https://github.com/fastify/fastify/blob/main/types/content-type-parser.d.ts#L63)
 
 A method for checking the existence of a type parser of a certain content type
 
@@ -1120,7 +1120,7 @@ A method for checking the existence of a type parser of a certain content type
 
 ##### fastify.FastifyError
 
-[src](../types/error.d.ts#L17)
+[src](https://github.com/fastify/fastify/blob/main/types/error.d.ts#L17)
 
 FastifyError is a custom error object that includes status code and validation results.
 
@@ -1128,7 +1128,7 @@ It extends the Node.js `Error` type, and adds two additional, optional propertie
 
 ##### fastify.ValidationResult
 
-[src](../types/error.d.ts#L4)
+[src](https://github.com/fastify/fastify/blob/main/types/error.d.ts#L4)
 
 The route validation internally relies upon Ajv, which is a high-performance JSON schema validator.
 
@@ -1140,7 +1140,7 @@ This interface is passed to instance of FastifyError.
 
 ##### fastify.onRequestHookHandler<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>(request: [FastifyRequest][FastifyRequest], reply: [FastifyReply][FastifyReply], done: (err?: [FastifyError][FastifyError]) => void): Promise\<unknown\> | void
 
-[src](../types/hooks.d.ts#L17)
+[src](https://github.com/fastify/fastify/blob/main/types/hooks.d.ts#L17)
 
 `onRequest` is the first hook to be executed in the request lifecycle. There was no previous hook, the next hook will be `preParsing`.
 
@@ -1148,7 +1148,7 @@ Notice: in the `onRequest` hook, request.body will always be null, because the b
 
 ##### fastify.preParsingHookHandler<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>(request: [FastifyRequest][FastifyRequest], reply: [FastifyReply][FastifyReply], done: (err?: [FastifyError][FastifyError]) => void): Promise\<unknown\> | void
 
-[src](../types/hooks.d.ts#L35)
+[src](https://github.com/fastify/fastify/blob/main/types/hooks.d.ts#L35)
 
 preParsing` is the second hook to be executed in the request lifecycle. The previous hook was `onRequest`, the next hook will be `preValidation`.
 
@@ -1158,19 +1158,19 @@ Notice: you should also add `receivedEncodedLength` property to the returned str
 
 ##### fastify.preValidationHookHandler<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>(request: [FastifyRequest][FastifyRequest], reply: [FastifyReply][FastifyReply], done: (err?: [FastifyError][FastifyError]) => void): Promise\<unknown\> | void
 
-[src](../types/hooks.d.ts#L53)
+[src](https://github.com/fastify/fastify/blob/main/types/hooks.d.ts#L53)
 
 `preValidation` is the third hook to be executed in the request lifecycle. The previous hook was `preParsing`, the next hook will be `preHandler`.
 
 ##### fastify.preHandlerHookHandler<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>(request: [FastifyRequest][FastifyRequest], reply: [FastifyReply][FastifyReply], done: (err?: [FastifyError][FastifyError]) => void): Promise\<unknown\> | void
 
-[src](../types/hooks.d.ts#L70)
+[src](https://github.com/fastify/fastify/blob/main/types/hooks.d.ts#L70)
 
 `preHandler` is the fourth hook to be executed in the request lifecycle. The previous hook was `preValidation`, the next hook will be `preSerialization`.
 
 ##### fastify.preSerializationHookHandler<PreSerializationPayload, [RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>(request: [FastifyRequest][FastifyRequest], reply: [FastifyReply][FastifyReply], payload: PreSerializationPayload, done: (err: [FastifyError][FastifyError] | null, res?: unknown) => void): Promise\<unknown\> | void
 
-[src](../types/hooks.d.ts#L94)
+[src](https://github.com/fastify/fastify/blob/main/types/hooks.d.ts#L94)
 
 `preSerialization` is the fifth hook to be executed in the request lifecycle. The previous hook was `preHandler`, the next hook will be `onSend`.
 
@@ -1178,7 +1178,7 @@ Note: the hook is NOT called if the payload is a string, a Buffer, a stream or n
 
 ##### fastify.onSendHookHandler<OnSendPayload, [RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>(request: [FastifyRequest][FastifyRequest], reply: [FastifyReply][FastifyReply], payload: OnSendPayload, done: (err: [FastifyError][FastifyError] | null, res?: unknown) => void): Promise\<unknown\> | void
 
-[src](../types/hooks.d.ts#L114)
+[src](https://github.com/fastify/fastify/blob/main/types/hooks.d.ts#L114)
 
 You can change the payload with the `onSend` hook. It is the sixth hook to be executed in the request lifecycle. The previous hook was `preSerialization`, the next hook will be `onResponse`.
 
@@ -1186,7 +1186,7 @@ Note: If you change the payload, you may only change it to a string, a Buffer, a
 
 ##### fastify.onResponseHookHandler<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>(request: [FastifyRequest][FastifyRequest], reply: [FastifyReply][FastifyReply], done: (err?: [FastifyError][FastifyError]) => void): Promise\<unknown\> | void
 
-[src](../types/hooks.d.ts#L134)
+[src](https://github.com/fastify/fastify/blob/main/types/hooks.d.ts#L134)
 
 `onResponse` is the seventh and last hook in the request hook lifecycle. The previous hook was `onSend`, there is no next hook.
 
@@ -1194,7 +1194,7 @@ The onResponse hook is executed when a response has been sent, so you will not b
 
 ##### fastify.onErrorHookHandler<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>(request: [FastifyRequest][FastifyRequest], reply: [FastifyReply][FastifyReply], error: [FastifyError][FastifyError], done: () => void): Promise\<unknown\> | void
 
-[src](../types/hooks.d.ts#L154)
+[src](https://github.com/fastify/fastify/blob/main/types/hooks.d.ts#L154)
 
 This hook is useful if you need to do some custom error logging or add some specific header in case of error.
 
@@ -1206,13 +1206,13 @@ Notice: unlike the other hooks, pass an error to the done function is not suppor
 
 ##### fastify.onRouteHookHandler<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>(opts: [RouteOptions][RouteOptions] & { path: string; prefix: string }): Promise\<unknown\> | void
 
-[src](../types/hooks.d.ts#L174)
+[src](https://github.com/fastify/fastify/blob/main/types/hooks.d.ts#L174)
 
 Triggered when a new route is registered. Listeners are passed a routeOptions object as the sole parameter. The interface is synchronous, and, as such, the listener does not get passed a callback
 
 ##### fastify.onRegisterHookHandler<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [Logger][LoggerGeneric]>(instance: [FastifyInstance][FastifyInstance], done: (err?: [FastifyError][FastifyError]) => void): Promise\<unknown\> | void
 
-[src](../types/hooks.d.ts#L191)
+[src](https://github.com/fastify/fastify/blob/main/types/hooks.d.ts#L191)
 
 Triggered when a new plugin is registered and a new encapsulation context is created. The hook will be executed before the registered code.
 
@@ -1222,7 +1222,7 @@ Note: This hook will not be called if a plugin is wrapped inside fastify-plugin.
 
 ##### fastify.onCloseHookHandler<[RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [Logger][LoggerGeneric]>(instance: [FastifyInstance][FastifyInstance], done: (err?: [FastifyError][FastifyError]) => void): Promise\<unknown\> | void
 
-[src](../types/hooks.d.ts#L206)
+[src](https://github.com/fastify/fastify/blob/main/types/hooks.d.ts#L206)
 
 Triggered when fastify.close() is invoked to stop the server. It is useful when plugins need a "shutdown" event, for example to close an open connection to a database.
 

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -573,7 +573,7 @@ fastify.get('/user', {
 })
 ```
 
-*If you need a custom serializer in a very specific part of your code, you can set one with [`reply.serializer(...)`](Reply.md#serializerfunc).*
+*If you need a custom serializer in a very specific part of your code, you can set one with [`reply.serializer(...)`](./Reply.md#serializerfunc).*
 
 ### Error Handling
 When schema validation fails for a request, Fastify will automatically return a  status 400 response including the result from the validator in the payload. As an example, if you have the following schema for your route

--- a/docs/Validation-and-Serialization.md
+++ b/docs/Validation-and-Serialization.md
@@ -24,7 +24,7 @@ The validation and the serialization tasks are processed by two different, and c
 These two separate entities share only the JSON schemas added to Fastify's instance through `.addSchema(schema)`.
 
 #### Adding a shared schema
-<a name="shared-schema"></a>
+<a id="shared-schema"></a>
 
 Thanks to the `addSchema` API, you can add multiple schemas to the Fastify instance and then reuse them in multiple parts of your application.
 As usual, this API is encapsulated.
@@ -82,7 +82,7 @@ fastify.post('/', {
 ```
 
 #### Retrieving the shared schemas
-<a name="get-shared-schema"></a>
+<a id="get-shared-schema"></a>
 
 If the validator and the serializer are customized, the `.addSchema` method will not be useful since the actors are no longer
 controlled by Fastify.
@@ -303,7 +303,7 @@ server.setValidatorCompiler(req => {
 For further information see [here](https://ajv.js.org/coercion.html)
 
 #### Ajv Plugins
-<a name="ajv-plugins"></a>
+<a id="ajv-plugins"></a>
 
 You can provide a list of plugins you want to use with the default `ajv` instance.
 Note that the plugin must be **compatible with Ajv v6**.
@@ -367,7 +367,7 @@ fastify.post('/foo', {
 ```
 
 #### Validator Compiler
-<a name="schema-validator"></a>
+<a id="schema-validator"></a>
 
 The `validatorCompiler` is a function that returns a function that validates the body, URL  parameters, headers, and query string.
 The default `validatorCompiler` returns a function that implements the [ajv](https://ajv.js.org/) validation interface.
@@ -407,7 +407,7 @@ fastify.setValidatorCompiler(({ schema, method, url, httpPart }) => {
 _**Note:** If you use a custom instance of any validator (even Ajv), you have to add schemas to the validator instead of Fastify, since Fastify's default validator is no longer used, and Fastify's `addSchema` method has no idea what validator you are using._
 
 ##### Using other validation libraries
-<a name="using-other-validation-libraries"></a>
+<a id="using-other-validation-libraries"></a>
 
 The `setValidatorCompiler` function makes it easy to substitute `ajv` with almost any Javascript validation library ([joi](https://github.com/hapijs/joi/), [yup](https://github.com/jquense/yup/), ...) or a custom one:
 
@@ -505,7 +505,7 @@ const errorHandler = (error, request, reply) => {
 ```
 
 ### Serialization
-<a name="serialization"></a>
+<a id="serialization"></a>
 
 Usually, you will send your data to the clients as JSON, and Fastify has a powerful tool to help you, [fast-json-stringify](https://www.npmjs.com/package/fast-json-stringify), which is used if you have provided an output schema in the route options.
 We encourage you to use an output schema, as it can drastically increase throughput and help prevent accidental disclosure of sensitive information.
@@ -549,7 +549,7 @@ fastify.post('/the/url', { schema }, handler)
 ```
 
 #### Serializer Compiler
-<a name="schema-serializer"></a>
+<a id="schema-serializer"></a>
 
 The `serializerCompiler` is a function that returns a function that must return a string from an input object. When you define a response JSON Schema, you can change the default serialization method by providing a function to serialize every route where you do.
 
@@ -839,7 +839,7 @@ const refToSharedSchemaDefinitions = {
 ```
 
 ### Resources
-<a name="resources"></a>
+<a id="resources"></a>
 
 - [JSON Schema](https://json-schema.org/)
 - [Understanding JSON Schema](https://spacetelescope.github.io/understanding-json-schema/)

--- a/docs/Write-Plugin.md
+++ b/docs/Write-Plugin.md
@@ -1,20 +1,22 @@
 <h1 align="center">Fastify</h1>
 
 # How to write a good plugin
-First, thank you for deciding to write a plugin for Fastify. Fastify is a minimal framework and plugins are its strength, so thank you.<br>
+First, thank you for deciding to write a plugin for Fastify. Fastify is a minimal framework and plugins are its strength, so thank you.
+
 The core principles of Fastify are performance, low overhead, and providing a good experience to our users. When writing a plugin, it is important to keep these principles in mind. Therefore, in this document, we will analyze what characterizes a quality plugin.
 
 *Need some inspiration? You can use the label ["plugin suggestion"](https://github.com/fastify/fastify/issues?q=is%3Aissue+is%3Aopen+label%3A%22plugin+suggestion%22) in our issue tracker!*
 
 ## Code
-Fastify uses different techniques to optimize its code, many of them are documented in our Guides. We highly recommend you read [the hitchhiker's guide to plugins](Plugins-Guide.md) to discover all the APIs you can use to build your plugin and learn how to use them.
+Fastify uses different techniques to optimize its code, many of them are documented in our Guides. We highly recommend you read [the hitchhiker's guide to plugins](./Plugins-Guide.md) to discover all the APIs you can use to build your plugin and learn how to use them.
 
 Do you have a question or need some advice? We are more than happy to help you! Just open an issue in our [help repository](https://github.com/fastify/help).
 
-Once you submit a plugin to our [ecosystem list](Ecosystem.md), we will review your code and help you improve it if necessary.
+Once you submit a plugin to our [ecosystem list](./Ecosystem.md), we will review your code and help you improve it if necessary.
 
 ## Documentation
-Documentation is extremely important. If your plugin is not well documented we will not accept it to the ecosystem list. Lack of quality documentation makes it more difficult for people to use your plugin, and will likely result in it going unused.<br>
+Documentation is extremely important. If your plugin is not well documented we will not accept it to the ecosystem list. Lack of quality documentation makes it more difficult for people to use your plugin, and will likely result in it going unused.
+
 If you want to see some good examples on how to document a plugin take a look at:
 - [`fastify-caching`](https://github.com/fastify/fastify-caching)
 - [`fastify-compress`](https://github.com/fastify/fastify-compress)
@@ -23,14 +25,16 @@ If you want to see some good examples on how to document a plugin take a look at
 - [`under-pressure`](https://github.com/fastify/under-pressure)
 
 ## License
-You can license your plugin as you prefer, we do not enforce any kind of license.<br>
+You can license your plugin as you prefer, we do not enforce any kind of license.
+
 We prefer the [MIT license](https://choosealicense.com/licenses/mit/) because we think it allows more people to use the code freely. For a list of alternative licenses see the [OSI list](https://opensource.org/licenses) or GitHub's [choosealicense.com](https://choosealicense.com/).
 
 ## Examples
 Always put an example file in your repository. Examples are very helpful for users and give a very fast way to test your plugin. Your users will be grateful.
 
 ## Test
-It is extremely important that a plugin is thoroughly tested to verify that is working properly.<br>
+It is extremely important that a plugin is thoroughly tested to verify that is working properly.
+
 A plugin without tests will not be accepted to the ecosystem list. A lack of tests does not inspire trust nor guarantee that the code will continue to work among different versions of its dependencies.
 
 We do not enforce any testing library. We use [`tap`](https://www.node-tap.org/) since it offers out-of-the-box parallel testing and code coverage, but it is up to you to choose your library of preference.
@@ -41,7 +45,8 @@ It is not mandatory, but we highly recommend you use a code linter in your plugi
 We use [`standard`](https://standardjs.com/) since it works without the need to configure it and is very easy to integrate into a test suite.
 
 ## Continuous Integration
-It is not mandatory, but if you release your code as open source, it helps to use Continuous Integration to ensure contributions do not break your plugin and to show that the plugin works as intended. Both [CircleCI](https://circleci.com/) and [GitHub Actions](https://github.com/features/actions) are free for open source projects and easy to set up.<br>
+It is not mandatory, but if you release your code as open source, it helps to use Continuous Integration to ensure contributions do not break your plugin and to show that the plugin works as intended. Both [CircleCI](https://circleci.com/) and [GitHub Actions](https://github.com/features/actions) are free for open source projects and easy to set up.
+
 In addition, you can enable services like [Dependabot](https://dependabot.com/) or [Snyk](https://snyk.io/), which will help you keep your dependencies up to date and discover if a new release of Fastify has some issues with your plugin.
 
 ## Let's start!

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,16 +2,13 @@
 
 The documentation for Fastify is split into two categories:
 
-+ [Reference documentation][Reference]
-+ [Guides][Guides]
+- [Reference documentation](./Reference/index.md)
+- [Guides](./Guides/index.md)
 
 The reference documenation utilizes a very formal style in an effort to document
 Fastify's API and implementation details thoroughly for the developer who
 needs such. The guides category utilizes an informal, educational, style as
 a means to introduce newcomers to core, and advanced, Fastify concepts.
-
-[Reference]: ./Reference/index.md
-[Guides]: ./Guides/index.md
 
 ## Where To Start
 
@@ -22,8 +19,6 @@ Developers experienced with Fastify should consult the
 [reference documentation][Reference] directly to find the topic they are
 seeking more information about.
 
-[gs]: ./Guides/Getting-Started.md
-
 ## Additional Documentation
 
-+ Fastify's [Long Term Support (LTS)][./LTS.md] policy
+- Fastify's [Long Term Support (LTS)](./LTS.md) policy


### PR DESCRIPTION
This is a preparation commit before I start moving files into the Guide/Reference folders. I've manually removed any of the Docusaurus-specific changes for now so that the docs can still build against the current compiler (Metalsmith).

#### Changes
- All .md files are now connected via relative links (e.g. Request.md -> ./Request.md)
- Added absolute paths to previously broken links (e.g. ../examples/parser.js -> https://github.com/fastify/fastify/blob/main/examples/parser.js)
- Changed `<a>` tag property from `name` to `id` for consistency
- Updated tables of contents automatically with [Markdown All in One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one)
- Replaced `<br>` and `<br/>` with newline (this is closer to the Markdown specification)

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
