### PR TITLE
Tests for http2 host constraint server

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "fast-json-stringify": "^2.5.2",
     "fastify-error": "^0.3.0",
     "fastify-warning": "^0.2.0",
-    "find-my-way": "^4.1.0",
+    "find-my-way": "^5.1.0",
     "flatstr": "^1.0.12",
     "light-my-request": "^4.2.0",
     "pino": "^6.13.0",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "fast-json-stringify": "^2.5.2",
     "fastify-error": "^0.3.0",
     "fastify-warning": "^0.2.0",
-    "find-my-way": "^5.1.0",
+    "find-my-way": "^4.5.0",
     "flatstr": "^1.0.12",
     "light-my-request": "^4.2.0",
     "pino": "^6.13.0",

--- a/test/http2/constraint.test.js
+++ b/test/http2/constraint.test.js
@@ -1,0 +1,91 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('../..')
+const h2url = require('h2url')
+
+const alpha = { res: 'alpha' }
+const beta = { res: 'beta' }
+
+const { buildCertificate } = require('../build-certificate')
+t.before(buildCertificate)
+
+test('A route supports host constraints under http2 protocol and secure connection', (t) => {
+  t.plan(5)
+
+  let fastify
+  try {
+    fastify = Fastify({
+      http2: true,
+      https: {
+        key: global.context.key,
+        cert: global.context.cert
+      }
+    })
+    t.pass('Key/cert successfully loaded')
+  } catch (e) {
+    t.fail('Key/cert loading failed', e)
+  }
+
+  const constrain = 'fastify.io'
+
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    handler: function (_, reply) {
+      reply.code(200).send(alpha)
+    }
+  })
+  fastify.route({
+    method: 'GET',
+    url: '/beta',
+    constraints: { host: constrain },
+    handler: function (_, reply) {
+      reply.code(200).send(beta)
+    }
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
+
+    t.test('https get request - no constrain', async (t) => {
+      t.plan(3)
+
+      const url = `https://localhost:${fastify.server.address().port}`
+      const res = await h2url.concat({ url })
+
+      t.equal(res.headers[':status'], 200)
+      t.equal(res.headers['content-length'], '' + JSON.stringify(alpha).length)
+      t.same(JSON.parse(res.body), alpha)
+    })
+
+    t.test('https get request - constrain', async (t) => {
+      t.plan(3)
+
+      const url = `https://localhost:${fastify.server.address().port}/beta`
+      const res = await h2url.concat({
+        url,
+        headers: {
+          ':authority': constrain
+        }
+      })
+
+      t.equal(res.headers[':status'], 200)
+      t.equal(res.headers['content-length'], '' + JSON.stringify(beta).length)
+      t.same(JSON.parse(res.body), beta)
+    })
+
+    t.test('https get request - constrain - not found', async (t) => {
+      t.plan(1)
+
+      const url = `https://localhost:${fastify.server.address().port}/beta`
+      const res = await h2url.concat({
+        url
+      })
+
+      t.equal(res.headers[':status'], 404)
+    })
+  })
+})


### PR DESCRIPTION
Add tests for secure http2 server routes with **host constraints**. This is part of the fix to the `find-my-way` package as discussed in #3408

Depends on delvedor/find-my-way#214

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
