### PR TITLE
docs(ecosystem): adds @immobiliarelabs/fastify-metrics

### DIFF
--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -60,6 +60,7 @@ Plugins maintained by the Fastify team are listed under [Core](#core) while plug
 - [`@dnlup/fastify-doc`](https://github.com/dnlup/fastify-doc) A plugin for sampling process metrics.
 - [`@dnlup/fastify-traps`](https://github.com/dnlup/fastify-traps) A plugin to close the server gracefully on `SIGINT` and `SIGTERM` signals.
 - [`@gquittet/graceful-server`](https://github.com/gquittet/graceful-server) Tiny (~5k), Fast, KISS, and dependency-free Node.JS library to make your Fastify API graceful.
+- [`@immobiliarelabs/fastify-metrics`](https://github.com/immobiliare/fastify-metrics) Minimalistic and opinionated plugin that collects usage/process metrics and dispatches to [statsd](https://github.com/statsd/statsd).
 - [`@mgcrea/fastify-graceful-exit`](https://github.com/mgcrea/fastify-graceful-exit) A plugin to close the server gracefully
 - [`@mgcrea/fastify-request-logger`](https://github.com/mgcrea/fastify-request-logger) A plugin to enable compact request logging for Fastify
 - [`@mgcrea/fastify-session-redis-store`](https://github.com/mgcrea/fastify-session-redis-store) Redis store for @mgcrea/fastify-session using ioredis


### PR DESCRIPTION
Hey 👋  

We recently released [this plugin](https://github.com/immobiliare/fastify-metrics) which we use internally to collect usage/process metrics and send them to [statsd daemon](https://github.com/statsd/statsd)! We thought it could be useful for the community and wanted to share it, do you think it can be added to the ecosystem?

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
