### PR TITLE
Type Provider Reply Types

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
   "devDependencies": {
     "@fastify/ajv-compiler-6": "npm:@fastify/ajv-compiler@^1.0.0",
     "@fastify/pre-commit": "^2.0.2",
-    "@sinclair/typebox": "^0.20.5",
+    "@sinclair/typebox": "^0.23.1",
     "@sinonjs/fake-timers": "^7.1.2",
     "@types/node": "^16.7.10",
     "@typescript-eslint/eslint-plugin": "^4.30.0",

--- a/test/types/type-provider.test-d.ts
+++ b/test/types/type-provider.test-d.ts
@@ -1,5 +1,5 @@
 import fastify, { FastifyTypeProvider } from '../../fastify'
-import { expectAssignable, expectType, printType } from 'tsd'
+import { expectAssignable, expectType } from 'tsd'
 import { IncomingHttpHeaders } from 'http'
 import { Type, TSchema, Static } from '@sinclair/typebox'
 import { FromSchema, JSONSchema } from 'json-schema-to-ts'
@@ -192,5 +192,142 @@ expectAssignable(server.withTypeProvider<TypeBoxProvider>().get(
     expectType<number>(req.body.x)
     expectType<string>(req.body.y)
     expectType<boolean>(req.body.z)
+  }
+))
+
+// -------------------------------------------------------------------
+// TypeBox Response Type
+// -------------------------------------------------------------------
+
+expectAssignable(server.withTypeProvider<TypeBoxProvider>().get(
+  '/',
+  {
+    schema: {
+      response: {
+        200: Type.String(),
+        400: Type.Number(),
+        500: Type.Object({
+          error: Type.String()
+        })
+      }
+    }
+  },
+  async (_, res) => {
+    res.send('hello')
+    res.send(42)
+    res.send({ error: 'error' })
+  }
+))
+// -------------------------------------------------------------------
+// TypeBox Response Type: Return
+// -------------------------------------------------------------------
+
+expectAssignable(server.withTypeProvider<TypeBoxProvider>().get(
+  '/',
+  {
+    schema: {
+      response: {
+        200: Type.String(),
+        400: Type.Number(),
+        500: Type.Object({
+          error: Type.String()
+        })
+      }
+    }
+  },
+  async (_, res) => {
+    const option = 1 as 1 | 2 | 3
+    switch (option) {
+      case 1: return 'hello'
+      case 2: return 42
+      case 3: return { error: 'error' }
+    }
+  }
+))
+
+// -------------------------------------------------------------------
+// JsonSchemaToTs Response Type
+// -------------------------------------------------------------------
+
+expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
+  '/',
+  {
+    schema: {
+      response: {
+        200: { type: 'string' },
+        400: { type: 'number' },
+        500: { type: 'object', properties: { error: { type: 'string' } } }
+      } as const
+    }
+  },
+  async (_, res) => {
+    res.send('hello')
+    res.send(42)
+    res.send({ error: 'error' })
+  }
+))
+
+// -------------------------------------------------------------------
+// JsonSchemaToTs Response Type: Return
+// -------------------------------------------------------------------
+
+expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
+  '/',
+  {
+    schema: {
+      response: {
+        200: { type: 'string' },
+        400: { type: 'number' },
+        500: { type: 'object', properties: { error: { type: 'string' } } }
+      } as const
+    }
+  },
+  async (_, res) => {
+    const option = 1 as 1 | 2 | 3
+    switch (option) {
+      case 1: return 'hello'
+      case 2: return 42
+      case 3: return { error: 'error' }
+    }
+  }
+))
+
+// -------------------------------------------------------------------
+// Response Type Override
+// -------------------------------------------------------------------
+
+expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get<{Reply: number}>(
+  '/',
+  {
+    schema: {
+      response: {
+        200: { type: 'string' },
+        400: { type: 'number' },
+        500: { type: 'object', properties: { error: { type: 'string' } } }
+      } as const
+    }
+  },
+  async (_, res) => {
+    res.send(42)
+  }
+))
+
+// -------------------------------------------------------------------
+// Response Type Override: Return
+// -------------------------------------------------------------------
+
+expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get<{Reply: number}>(
+  '/',
+  {
+    schema: {
+      response: {
+        200: { type: 'string' },
+        400: { type: 'number' },
+        500: { type: 'object', properties: { error: { type: 'string' } } }
+      } as const
+    }
+  },
+  async (_, res) => {
+    return 42
   }
 ))

--- a/test/types/type-provider.test-d.ts
+++ b/test/types/type-provider.test-d.ts
@@ -1,5 +1,5 @@
 import fastify, { FastifyTypeProvider } from '../../fastify'
-import { expectAssignable, expectType } from 'tsd'
+import { expectAssignable, expectError, expectType } from 'tsd'
 import { IncomingHttpHeaders } from 'http'
 import { Type, TSchema, Static } from '@sinclair/typebox'
 import { FromSchema, JSONSchema } from 'json-schema-to-ts'
@@ -196,7 +196,7 @@ expectAssignable(server.withTypeProvider<TypeBoxProvider>().get(
 ))
 
 // -------------------------------------------------------------------
-// TypeBox Response Type
+// TypeBox Reply Type
 // -------------------------------------------------------------------
 
 expectAssignable(server.withTypeProvider<TypeBoxProvider>().get(
@@ -218,8 +218,31 @@ expectAssignable(server.withTypeProvider<TypeBoxProvider>().get(
     res.send({ error: 'error' })
   }
 ))
+
 // -------------------------------------------------------------------
-// TypeBox Response Type: Return
+// TypeBox Reply Type: Non Assignable
+// -------------------------------------------------------------------
+
+expectError(server.withTypeProvider<TypeBoxProvider>().get(
+  '/',
+  {
+    schema: {
+      response: {
+        200: Type.String(),
+        400: Type.Number(),
+        500: Type.Object({
+          error: Type.String()
+        })
+      }
+    }
+  },
+  async (_, res) => {
+    res.send(false)
+  }
+))
+
+// -------------------------------------------------------------------
+// TypeBox Reply Return Type
 // -------------------------------------------------------------------
 
 expectAssignable(server.withTypeProvider<TypeBoxProvider>().get(
@@ -246,7 +269,29 @@ expectAssignable(server.withTypeProvider<TypeBoxProvider>().get(
 ))
 
 // -------------------------------------------------------------------
-// JsonSchemaToTs Response Type
+// TypeBox Reply Return Type: Non Assignable
+// -------------------------------------------------------------------
+
+expectError(server.withTypeProvider<TypeBoxProvider>().get(
+  '/',
+  {
+    schema: {
+      response: {
+        200: Type.String(),
+        400: Type.Number(),
+        500: Type.Object({
+          error: Type.String()
+        })
+      }
+    }
+  },
+  async (_, res) => {
+    return false
+  }
+))
+
+// -------------------------------------------------------------------
+// JsonSchemaToTs Reply Type
 // -------------------------------------------------------------------
 
 expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
@@ -268,7 +313,27 @@ expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
 ))
 
 // -------------------------------------------------------------------
-// JsonSchemaToTs Response Type: Return
+// JsonSchemaToTs Reply Type: Non Assignable
+// -------------------------------------------------------------------
+
+expectError(server.withTypeProvider<JsonSchemaToTsProvider>().get(
+  '/',
+  {
+    schema: {
+      response: {
+        200: { type: 'string' },
+        400: { type: 'number' },
+        500: { type: 'object', properties: { error: { type: 'string' } } }
+      } as const
+    }
+  },
+  async (_, res) => {
+    res.send(false)
+  }
+))
+
+// -------------------------------------------------------------------
+// JsonSchemaToTs Reply Type Return
 // -------------------------------------------------------------------
 
 expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
@@ -291,9 +356,28 @@ expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
     }
   }
 ))
+// -------------------------------------------------------------------
+// JsonSchemaToTs Reply Type Return: Non Assignable
+// -------------------------------------------------------------------
+
+expectError(server.withTypeProvider<JsonSchemaToTsProvider>().get(
+  '/',
+  {
+    schema: {
+      response: {
+        200: { type: 'string' },
+        400: { type: 'number' },
+        500: { type: 'object', properties: { error: { type: 'string' } } }
+      } as const
+    }
+  },
+  async (_, res) => {
+    return false
+  }
+))
 
 // -------------------------------------------------------------------
-// Response Type Override
+// Reply Type Override
 // -------------------------------------------------------------------
 
 expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get<{Reply: boolean}>(
@@ -313,7 +397,7 @@ expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get<{Reply: b
 ))
 
 // -------------------------------------------------------------------
-// Response Type Override: Return
+// Reply Type Return Override
 // -------------------------------------------------------------------
 
 expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get<{Reply: boolean}>(

--- a/test/types/type-provider.test-d.ts
+++ b/test/types/type-provider.test-d.ts
@@ -305,7 +305,7 @@ expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
       } as const
     }
   },
-  async (_, res) => {
+  (_, res) => {
     res.send('hello')
     res.send(42)
     res.send({ error: 'error' })

--- a/test/types/type-provider.test-d.ts
+++ b/test/types/type-provider.test-d.ts
@@ -296,7 +296,7 @@ expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
 // Response Type Override
 // -------------------------------------------------------------------
 
-expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get<{Reply: number}>(
+expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get<{Reply: boolean}>(
   '/',
   {
     schema: {
@@ -308,7 +308,7 @@ expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get<{Reply: n
     }
   },
   async (_, res) => {
-    res.send(42)
+    res.send(true)
   }
 ))
 
@@ -316,7 +316,7 @@ expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get<{Reply: n
 // Response Type Override: Return
 // -------------------------------------------------------------------
 
-expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get<{Reply: number}>(
+expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get<{Reply: boolean}>(
   '/',
   {
     schema: {
@@ -328,6 +328,6 @@ expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get<{Reply: n
     }
   },
   async (_, res) => {
-    return 42
+    return true
   }
 ))

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -23,7 +23,7 @@ export interface FastifyReply<
   ContextConfig = ContextConfigDefault,
   SchemaCompiler extends FastifySchema = FastifySchema,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
-  Context extends FastifyReplyType = ResolveFastifyReplyType<TypeProvider, SchemaCompiler, RouteGeneric>
+  ReplyType extends FastifyReplyType = ResolveFastifyReplyType<TypeProvider, SchemaCompiler, RouteGeneric>
 > {
   raw: RawReply;
   context: FastifyContext<ContextConfig>;
@@ -34,7 +34,7 @@ export interface FastifyReply<
   status(statusCode: number): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
   statusCode: number;
   sent: boolean;
-  send(payload?: Context): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
+  send(payload?: ReplyType): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
   header(key: string, value: any): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
   headers(values: {[key: string]: any}): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
   getHeader(key: string): string | undefined;

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -1,10 +1,10 @@
 import { RawReplyDefaultExpression, RawServerBase, RawServerDefault, ContextConfigDefault, RawRequestDefaultExpression, ReplyDefault } from './utils'
+import { FastifyReplyType, ResolveFastifyReplyType, FastifyTypeProvider, FastifyTypeProviderDefault } from './type-provider'
 import { FastifyContext } from './context'
 import { FastifyLoggerInstance } from './logger'
 import { FastifyRequest } from './request'
 import { RouteGenericInterface } from './route'
 import { FastifyInstance } from './instance'
-import { FastifyTypeProvider, FastifyTypeProviderDefault } from './type-provider'
 import { FastifySchema } from './schema'
 
 export interface ReplyGenericInterface {
@@ -23,6 +23,7 @@ export interface FastifyReply<
   ContextConfig = ContextConfigDefault,
   SchemaCompiler extends FastifySchema = FastifySchema,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+  Context extends FastifyReplyType = ResolveFastifyReplyType<TypeProvider, SchemaCompiler, RouteGeneric>
 > {
   raw: RawReply;
   context: FastifyContext<ContextConfig>;
@@ -33,7 +34,7 @@ export interface FastifyReply<
   status(statusCode: number): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
   statusCode: number;
   sent: boolean;
-  send(payload?: RouteGeneric['Reply']): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
+  send(payload?: Context): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
   header(key: string, value: any): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
   headers(values: {[key: string]: any}): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
   getHeader(key: string): string | undefined;

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -2,7 +2,7 @@ import { FastifyLoggerInstance } from './logger'
 import { ContextConfigDefault, RawServerBase, RawServerDefault, RawRequestDefaultExpression, RequestBodyDefault, RequestQuerystringDefault, RequestParamsDefault, RequestHeadersDefault } from './utils'
 import { RouteGenericInterface } from './route'
 import { FastifyInstance } from './instance'
-import { FastifyTypeProvider, FastifyTypeProviderDefault, CallTypeProvider } from './type-provider'
+import { FastifyTypeProvider, FastifyTypeProviderDefault, FastifyRequestType, ResolveFastifyRequestType } from './type-provider'
 import { FastifySchema } from './schema'
 import { FastifyContext } from './context'
 
@@ -12,34 +12,6 @@ export interface RequestGenericInterface {
   Params?: RequestParamsDefault;
   Headers?: RequestHeadersDefault;
 }
-
-/** Request context target type. Undefined always resolve to unknown */
-export interface FastifyRequestContext<Params = unknown, Querystring = unknown, Headers = unknown, Body = unknown> {
-  params: Params,
-  query: Querystring,
-  headers: Headers,
-  body: Body
-}
-
-type UndefinedToUnknown<T> = T extends undefined ? unknown : T
-
-/**
- * This type handles request context resolution either via generic arguments
- * or type provider. If the user specifies both generic arguments as well as
- * a type provider, this type will override the type provider and use the
- * generic arguments. This enables users to override undesirable inference
- * behaviours in the type provider.
- */
-export type ResolveFastifyRequestContext<
-  TypeProvider extends FastifyTypeProvider,
-  SchemaCompiler extends FastifySchema,
-  RouteGeneric extends RouteGenericInterface
-> = FastifyRequestContext<
-UndefinedToUnknown<keyof RouteGeneric['Params'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['params']>: RouteGeneric['Params']>,
-UndefinedToUnknown<keyof RouteGeneric['Querystring'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['querystring']> : RouteGeneric['Querystring']>,
-UndefinedToUnknown<keyof RouteGeneric['Headers'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['headers']> : RouteGeneric['Headers']>,
-UndefinedToUnknown<keyof RouteGeneric['Body'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['body']> : RouteGeneric['Body']>
->
 
 /**
  * FastifyRequest is an instance of the standard http or http2 request objects.
@@ -52,7 +24,7 @@ export interface FastifyRequest<
   SchemaCompiler extends FastifySchema = FastifySchema,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
   ContextConfig = ContextConfigDefault,
-  Context extends FastifyRequestContext = ResolveFastifyRequestContext<TypeProvider, SchemaCompiler, RouteGeneric>
+  Context extends FastifyRequestType = ResolveFastifyRequestType<TypeProvider, SchemaCompiler, RouteGeneric>
 > {
   id: any;
   params: Context['params'];

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -24,16 +24,16 @@ export interface FastifyRequest<
   SchemaCompiler extends FastifySchema = FastifySchema,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
   ContextConfig = ContextConfigDefault,
-  Context extends FastifyRequestType = ResolveFastifyRequestType<TypeProvider, SchemaCompiler, RouteGeneric>
+  RequestType extends FastifyRequestType = ResolveFastifyRequestType<TypeProvider, SchemaCompiler, RouteGeneric>
 > {
   id: any;
-  params: Context['params'];
+  params: RequestType['params'];
   raw: RawRequest;
-  query: Context['query'];
-  headers: RawRequest['headers'] & Context['headers']; // this enables the developer to extend the existing http(s|2) headers list
+  query: RequestType['query'];
+  headers: RawRequest['headers'] & RequestType['headers']; // this enables the developer to extend the existing http(s|2) headers list
   log: FastifyLoggerInstance;
   server: FastifyInstance;
-  body: Context['body'];
+  body: RequestType['body'];
   context: FastifyContext<ContextConfig>;
 
   /** in order for this to be used the user should ensure they have set the attachValidation option. */

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -62,11 +62,12 @@ export type RouteHandlerMethod<
   ContextConfig = ContextConfigDefault,
   SchemaCompiler extends FastifySchema = FastifySchema,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+  ReturnType = ResolveFastifyReplyReturnType<TypeProvider, SchemaCompiler, RouteGeneric>
 > = (
   this: FastifyInstance<RawServer, RawRequest, RawReply, FastifyLoggerInstance, TypeProvider>,
   request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
   reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>
-) => ResolveFastifyReplyReturnType<TypeProvider, SchemaCompiler, RouteGeneric>
+) => ReturnType
 
 /**
  * Shorthand options including the handler function property

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -6,7 +6,7 @@ import { HTTPMethods, RawServerBase, RawServerDefault, RawRequestDefaultExpressi
 import { preValidationHookHandler, preHandlerHookHandler, preSerializationHookHandler, onRequestHookHandler, preParsingHookHandler, onResponseHookHandler, onSendHookHandler, onErrorHookHandler, onTimeoutHookHandler } from './hooks'
 import { FastifyError } from 'fastify-error'
 import { FastifyContext } from './context'
-import { FastifyTypeProvider, FastifyTypeProviderDefault } from './type-provider'
+import { FastifyTypeProvider, FastifyTypeProviderDefault, ResolveFastifyReplyReturnType } from './type-provider'
 import { FastifyLoggerInstance, LogLevel } from './logger'
 
 export interface RouteGenericInterface extends RequestGenericInterface, ReplyGenericInterface {}
@@ -66,7 +66,7 @@ export type RouteHandlerMethod<
   this: FastifyInstance<RawServer, RawRequest, RawReply, FastifyLoggerInstance, TypeProvider>,
   request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
   reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>
-) => void | Promise<RouteGeneric['Reply'] | void>
+) => ResolveFastifyReplyReturnType<TypeProvider, SchemaCompiler, RouteGeneric>
 
 /**
  * Shorthand options including the handler function property

--- a/types/type-provider.d.ts
+++ b/types/type-provider.d.ts
@@ -21,9 +21,20 @@ export type CallTypeProvider<F extends FastifyTypeProvider, I> = (F & { input: I
 // FastifyRequestType
 // -----------------------------------------------------------------------------------------------
 
+// Used to map undefined SchemaCompiler properties to unknown
 type UndefinedToUnknown<T> = T extends undefined ? unknown : T
 
-// Fastify request container type
+// Resolves Request types either from generic argument or Type Provider.
+type ResolveRequestParams<TypeProvider extends FastifyTypeProvider, SchemaCompiler extends FastifySchema, RouteGeneric extends RouteGenericInterface> =
+  UndefinedToUnknown<keyof RouteGeneric['Params'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['params']> : RouteGeneric['Params']>
+type ResolveRequestQuerystring<TypeProvider extends FastifyTypeProvider, SchemaCompiler extends FastifySchema, RouteGeneric extends RouteGenericInterface> =
+  UndefinedToUnknown<keyof RouteGeneric['Querystring'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['querystring']> : RouteGeneric['Querystring']>
+type ResolveRequestHeaders<TypeProvider extends FastifyTypeProvider, SchemaCompiler extends FastifySchema, RouteGeneric extends RouteGenericInterface> =
+  UndefinedToUnknown<keyof RouteGeneric['Headers'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['headers']> : RouteGeneric['Headers']>
+type ResolveRequestBody<TypeProvider extends FastifyTypeProvider, SchemaCompiler extends FastifySchema, RouteGeneric extends RouteGenericInterface> =
+  UndefinedToUnknown<keyof RouteGeneric['Body'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['body']> : RouteGeneric['Body']>
+
+// The target request type. This type in inferenced on fastify 'requests' via generic argument assignment
 export interface FastifyRequestType<Params = unknown, Querystring = unknown, Headers = unknown, Body = unknown> {
   params: Params,
   query: Querystring,
@@ -31,51 +42,48 @@ export interface FastifyRequestType<Params = unknown, Querystring = unknown, Hea
   body: Body
 }
 
-// Resolves the request context. Generic arguments specificed by the caller will always override the type provider.
-export type ResolveFastifyRequestType<
-  TypeProvider extends FastifyTypeProvider,
-  SchemaCompiler extends FastifySchema,
-  RouteGeneric extends RouteGenericInterface
-> = FastifyRequestType<
-UndefinedToUnknown<keyof RouteGeneric['Params'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['params']> : RouteGeneric['Params']>,
-UndefinedToUnknown<keyof RouteGeneric['Querystring'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['querystring']> : RouteGeneric['Querystring']>,
-UndefinedToUnknown<keyof RouteGeneric['Headers'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['headers']> : RouteGeneric['Headers']>,
-UndefinedToUnknown<keyof RouteGeneric['Body'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['body']> : RouteGeneric['Body']>
+export type ResolveFastifyRequestType<TypeProvider extends FastifyTypeProvider, SchemaCompiler extends FastifySchema, RouteGeneric extends RouteGenericInterface> = FastifyRequestType<
+ResolveRequestParams<TypeProvider, SchemaCompiler, RouteGeneric>,
+ResolveRequestQuerystring<TypeProvider, SchemaCompiler, RouteGeneric>,
+ResolveRequestHeaders<TypeProvider, SchemaCompiler, RouteGeneric>,
+ResolveRequestBody<TypeProvider, SchemaCompiler, RouteGeneric>
 >
 
 // -----------------------------------------------------------------------------------------------
 // FastifyReplyType
 // -----------------------------------------------------------------------------------------------
 
-// Returns true if the user has supplied a generic argument
+// Tests if the user has specified a generic argument for Reply
 type UseReplyFromRouteGeneric<RouteGeneric extends RouteGenericInterface> = keyof RouteGeneric['Reply'] extends never ? false : true
 
-// Returns true if the user has supplied a response schema
+// Tests if the user has specified a response schema.
 type UseReplyFromSchemaCompiler<SchemaCompiler extends FastifySchema> = keyof SchemaCompiler['response'] extends never ? false : true
 
-// Resolves a reply context from the users generic arguments
+// Resolves the Reply type from the generic argument
 type ResolveReplyFromRouteGeneric<RouteGeneric extends RouteGenericInterface> = RouteGeneric['Reply']
 
-// Resolves the reply context from the schema compiler by taking a union all all specified status codes.
+// Resolves the Reply type by taking a union of response status codes
 type ResolveReplyFromSchemaCompiler<TypeProvider extends FastifyTypeProvider, SchemaCompiler extends FastifySchema> = {
   [K in keyof SchemaCompiler['response']]: CallTypeProvider<TypeProvider, SchemaCompiler['response'][K]>
 } extends infer Result ? Result[keyof Result] : unknown
 
-// Container type for the reply context
+// The target reply type. This type in inferenced on fastify 'replies' via generic argument assignment
 export type FastifyReplyType<Reply = unknown> = Reply
 
-// Resolves the reply context. Generic arguments specificed by the caller will always override the type provider.
-export type ResolveFastifyReplyType<
-  TypeProvider extends FastifyTypeProvider,
-  SchemaCompiler extends FastifySchema,
-  RouteGeneric extends RouteGenericInterface,
-> = FastifyReplyType<
+// Resolves the Reply type either via generic argument or from response schema. This type uses a different
+// resolution strategy to Requests where the Reply will infer a union of each status code type specified
+// by the user. The Reply can be explicitly overriden by users providing a generic Reply type on the route.
+export type ResolveFastifyReplyType<TypeProvider extends FastifyTypeProvider, SchemaCompiler extends FastifySchema, RouteGeneric extends RouteGenericInterface> = FastifyReplyType<
 UseReplyFromRouteGeneric<RouteGeneric> extends true ? ResolveReplyFromRouteGeneric<RouteGeneric> :
   UseReplyFromSchemaCompiler<SchemaCompiler> extends true ? ResolveReplyFromSchemaCompiler<TypeProvider, SchemaCompiler> :
     unknown
 >
 
-// Resolves the return type for fastify routes. This type is inferred from the ResolveFastifyReplyType type
+// -----------------------------------------------------------------------------------------------
+// FastifyReplyReturnType
+// -----------------------------------------------------------------------------------------------
+
+// The target reply return type. This type in inferenced on fastify 'routes' via generic argument assignment
 export type ResolveFastifyReplyReturnType<
   TypeProvider extends FastifyTypeProvider,
   SchemaCompiler extends FastifySchema,

--- a/types/type-provider.d.ts
+++ b/types/type-provider.d.ts
@@ -34,7 +34,7 @@ type ResolveRequestHeaders<TypeProvider extends FastifyTypeProvider, SchemaCompi
 type ResolveRequestBody<TypeProvider extends FastifyTypeProvider, SchemaCompiler extends FastifySchema, RouteGeneric extends RouteGenericInterface> =
   UndefinedToUnknown<keyof RouteGeneric['Body'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['body']> : RouteGeneric['Body']>
 
-// The target request type. This type in inferenced on fastify 'requests' via generic argument assignment
+// The target request type. This type is inferenced on fastify 'requests' via generic argument assignment
 export interface FastifyRequestType<Params = unknown, Querystring = unknown, Headers = unknown, Body = unknown> {
   params: Params,
   query: Querystring,
@@ -67,7 +67,7 @@ type ResolveReplyFromSchemaCompiler<TypeProvider extends FastifyTypeProvider, Sc
   [K in keyof SchemaCompiler['response']]: CallTypeProvider<TypeProvider, SchemaCompiler['response'][K]>
 } extends infer Result ? Result[keyof Result] : unknown
 
-// The target reply type. This type in inferenced on fastify 'replies' via generic argument assignment
+// The target reply type. This type is inferenced on fastify 'replies' via generic argument assignment
 export type FastifyReplyType<Reply = unknown> = Reply
 
 // Resolves the Reply type either via generic argument or from response schema. This type uses a different
@@ -83,7 +83,7 @@ UseReplyFromRouteGeneric<RouteGeneric> extends true ? ResolveReplyFromRouteGener
 // FastifyReplyReturnType
 // -----------------------------------------------------------------------------------------------
 
-// The target reply return type. This type in inferenced on fastify 'routes' via generic argument assignment
+// The target reply return type. This type is inferenced on fastify 'routes' via generic argument assignment
 export type ResolveFastifyReplyReturnType<
   TypeProvider extends FastifyTypeProvider,
   SchemaCompiler extends FastifySchema,

--- a/types/type-provider.d.ts
+++ b/types/type-provider.d.ts
@@ -1,3 +1,11 @@
+
+import { RouteGenericInterface } from './route'
+import { FastifySchema } from './schema'
+
+// -----------------------------------------------------------------------------------------------
+// TypeProvider
+// -----------------------------------------------------------------------------------------------
+
 export interface FastifyTypeProvider {
   readonly input: unknown,
   readonly output: unknown,
@@ -8,3 +16,76 @@ export interface FastifyTypeProviderDefault extends FastifyTypeProvider {
 }
 
 export type CallTypeProvider<F extends FastifyTypeProvider, I> = (F & { input: I })['output']
+
+// -----------------------------------------------------------------------------------------------
+// FastifyRequestType
+// -----------------------------------------------------------------------------------------------
+
+type UndefinedToUnknown<T> = T extends undefined ? unknown : T
+
+// Fastify request container type
+export interface FastifyRequestType<Params = unknown, Querystring = unknown, Headers = unknown, Body = unknown> {
+  params: Params,
+  query: Querystring,
+  headers: Headers,
+  body: Body
+}
+
+// Resolves the request context. Generic arguments specificed by the caller will always override the type provider.
+export type ResolveFastifyRequestType<
+  TypeProvider extends FastifyTypeProvider,
+  SchemaCompiler extends FastifySchema,
+  RouteGeneric extends RouteGenericInterface
+> = FastifyRequestType<
+UndefinedToUnknown<keyof RouteGeneric['Params'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['params']> : RouteGeneric['Params']>,
+UndefinedToUnknown<keyof RouteGeneric['Querystring'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['querystring']> : RouteGeneric['Querystring']>,
+UndefinedToUnknown<keyof RouteGeneric['Headers'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['headers']> : RouteGeneric['Headers']>,
+UndefinedToUnknown<keyof RouteGeneric['Body'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['body']> : RouteGeneric['Body']>
+>
+
+// -----------------------------------------------------------------------------------------------
+// FastifyReplyType
+// -----------------------------------------------------------------------------------------------
+
+// Returns true if the user has supplied a generic argument
+type UseReplyFromRouteGeneric<RouteGeneric extends RouteGenericInterface> = keyof RouteGeneric['Reply'] extends never ? false : true
+
+// Returns true if the user has supplied a response schema
+type UseReplyFromSchemaCompiler<SchemaCompiler extends FastifySchema> = keyof SchemaCompiler['response'] extends never ? false : true
+
+// Resolves a reply context from the users generic arguments
+type ResolveReplyFromRouteGeneric<RouteGeneric extends RouteGenericInterface> = RouteGeneric['Reply']
+
+// Resolves the reply context from the schema compiler by taking a union all all specified status codes.
+type ResolveReplyFromSchemaCompiler<TypeProvider extends FastifyTypeProvider, SchemaCompiler extends FastifySchema> = {
+  [K in keyof SchemaCompiler['response']]: CallTypeProvider<TypeProvider, SchemaCompiler['response'][K]>
+} extends infer Result ? Result[keyof Result] : unknown
+
+// Container type for the reply context
+export type FastifyReplyType<Reply = unknown> = Reply
+
+// Resolves the reply context. Generic arguments specificed by the caller will always override the type provider.
+export type ResolveFastifyReplyType<
+  TypeProvider extends FastifyTypeProvider,
+  SchemaCompiler extends FastifySchema,
+  RouteGeneric extends RouteGenericInterface,
+> = FastifyReplyType<
+UseReplyFromRouteGeneric<RouteGeneric> extends true ? ResolveReplyFromRouteGeneric<RouteGeneric> :
+  UseReplyFromSchemaCompiler<SchemaCompiler> extends true ? ResolveReplyFromSchemaCompiler<TypeProvider, SchemaCompiler> :
+    unknown
+>
+
+// Resolves the return type for fastify routes. This type is inferred from the ResolveFastifyReplyType type
+export type ResolveFastifyReplyReturnType<
+  TypeProvider extends FastifyTypeProvider,
+  SchemaCompiler extends FastifySchema,
+  RouteGeneric extends RouteGenericInterface,
+> = ResolveFastifyReplyType<
+TypeProvider,
+SchemaCompiler,
+RouteGeneric
+> extends infer Return ?
+  (void | Promise<Return | void>)
+// review: support both async and sync return types
+// (Promise<Return> | Return | Promise<void> | void)
+  : unknown


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

### Reply Types

This PR implements `Reply` type inference using the Type Provider mechanism submitted on PR https://github.com/fastify/fastify/pull/3398.

### Current
The current implementation involves specifying a union type for each expected status code
```typescript
server.get<{
   Reply: string | number | boolean // varying reply type
}>('/', {
  schema: {
     response: { 
       200: { type: 'string' },
       400: { type: 'number' },
       500: { type: 'boolean' },
     }
  } as const
}, (_, res) => {
    res.send('hello')
    res.send(42)
    res.send(false)
})
```
### Proposed
The proposed implementation infers this union directly from the response schemas.
```typescript
server.withTypeProvider<JsonSchemaToTsProvider>().get('/', {
  schema: {
     response: {  // infer as string | number | boolean
       200: { type: 'string' },
       400: { type: 'number' },
       500: { type: 'boolean' },
     }
  } as const
}, (_, res) => {
    res.send('hello')
    res.send(42)
    res.send(false)
})
```
Additionally, this implementation supports inference on route return values.
```typescript
server.withTypeProvider<JsonSchemaToTsProvider>().get('/', {
  schema: {
     response: {  // infer as string | number | boolean
       200: { type: 'string' },
       400: { type: 'number' },
       500: { type: 'boolean' },
     }
  } as const
}, (_, res) => {
    const option = 1 as 1 | 2 | 3
    switch(option) {
      case 1: return 'hello'
      case 2: return 42
      case 3: return false
    }
})
```

### Future Work

There may be potential to narrow reply types derived from user specified status codes, however this PR only implements inference to produce the varying union type. Such narrowing would allow TypeScript to catch status code / schema mismatch errors such as the following. 

```typescript
server.withTypeProvider<JsonSchemaToTsProvider>().get('/', {
  schema: {
     response: {
       200: { type: 'string' },
       400: { type: 'number' }
     }
  } as const
}, (_, res) => {
    res.status(400).send('hello') // error: not a number
})
```
A reference implementation of status code narrowing has been partially implemented [here](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAMQIYGcbAGYE8A0cDecAKlmAKZwC+cGUEIcA5BqutgLQylkBGEAHowCwAKFEBjCADs0NVpixwAvInnYAFAEpRolmgUA6SGnWMA9AFcUZKCjMAuKzYCSAE0Z5CouD7gpxABZkIEj2BN6+kXyuWGEk5AYA8jwAVmTiMOr4EZG5cPxx3AYAchYgPDZaODl5vrHERaXlldoitVSa1W21UGQokDJkYdnd7T4ATAAMk4UJyWkZWTVjvr0oFgA2MLNkJWUVUFrLtZSt7ZQ1FyKUeOq9AI4WfTB4vWAbWJrKAHzho3A1MxmODsUFg8EQyFQ6HsQHAgBKZEezxQcJBMIxmMhOn+QLgXHIcAACkgoEgQChlAQ4E4oG4wmgoMApABzKg4yKSGTwQi0txUKkPJ5oIyk8mosS44EEigAIQgMSphAKcCk+xseHqauaUHZks50lkys1ApUQueBmiihWPg5vjxWMdWLRiPewD6aKdXuhdp8eJlcER-UNFBUhCmM2pa0221V6t11CuNTeHwM1ikriycGjWzCAEZph0bbk8TY6FAwlIIH4YEgYFY4JJXBR+ulMO7XL7s2R3lg07X6yh1AAWaaaNNkDNZnOx4fjIuRUtQcthUeTGt1htNihV+DNjDMsid-WrHuptCbocR8fpzOEGdhRhzxgLuBLlfd9ZbfHcODASm7nGOpdimfYXoO6jXhOU73n0MZhPwcAANRwNapx+sCEAANZhAAhKIpxAA), but deferred for this PR as there are some challenges resolving status code types for routes that `return` values rather than using `reply.send(...)`.

Submitting for community review

