### PR TITLE
Pass constraint values to the router when checking for a preexisting HEAD route

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -248,7 +248,7 @@ function buildRouting (options) {
         opts.schemaErrorFormatter || this[kSchemaErrorFormatter]
       )
 
-      const headRouteExists = router.find('HEAD', url) != null
+      const headRouteExists = router.find('HEAD', url, constraints) != null
 
       try {
         router.on(opts.method, opts.url, { constraints }, routeHandler, context)


### PR DESCRIPTION
047429eb832d7a631531a559231cfeacc1d682e7 introduced a handy new call to the router when new routes are defined to check if a HEAD route exists already before automatically registering one. This new call to the router didn't pass the newer third argument that .find expects for the derived constraint values. Most routes aren't constrained and thus never checked the derived constraints, so the undefined value was fine most of the time. But, for those using constraints, an error like this would be thrown when checking for the head route:

```
TypeError: Cannot read property 'host' of undefined
    at Node.eval [as _getHandlerMatchingConstraints] (eval at Node._compileGetHandlerMatchingConstraints (/Users/airhorns/Code/fastify/node_modules/find-my-way/node.js:320:41), <anonymous>:9:32)
    at Node.compileThenGetHandlerMatchingConstraints [as _getHandlerMatchingConstraints] (/Users/airhorns/Code/fastify/node_modules/find-my-way/node.js:204:15)
    at Node.getMatchingHandler (/Users/airhorns/Code/fastify/node_modules/find-my-way/node.js:211:17)
    at Node.findMatchingChild (/Users/airhorns/Code/fastify/node_modules/find-my-way/node.js:147:67)
    at Router.find (/Users/airhorns/Code/fastify/node_modules/find-my-way/index.js:414:28)
    at Object.afterRouteAdded (/Users/airhorns/Code/fastify/lib/route.js:251:38)
    at /Users/airhorns/Code/fastify/lib/route.js:181:25
    at Object._encapsulateThreeParam (/Users/airhorns/Code/fastify/node_modules/avvio/boot.js:551:7)
    at Boot.timeoutCall (/Users/airhorns/Code/fastify/node_modules/avvio/boot.js:447:5)
    at Boot.callWithCbOrNextTick (/Users/airhorns/Code/fastify/node_modules/avvio/boot.js:428:19)
```

That's the router expecting that third argument to .find (`derivedConstraints`) to exist. In find-my-way we were careful to not default this argument to cause any extra allocations -- had we done so we would have avoided this error but we preferred performance :+1:

This changes us to pass that third argument and expands the constrained route test suite to make sure this case was encountered.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
