### PR TITLE
fix: use hasKey to check request dependencies

### DIFF
--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -40,7 +40,7 @@ function decorateConstructor (konstructor, name, fn, dependencies) {
     throw new FST_ERR_DEC_ALREADY_PRESENT(name)
   }
 
-  checkDependencies(instance, name, dependencies)
+  checkDependencies(konstructor, name, dependencies)
 
   if (fn && (typeof fn.getter === 'function' || typeof fn.setter === 'function')) {
     Object.defineProperty(instance, name, {
@@ -68,14 +68,17 @@ function decorateFastify (name, fn, dependencies) {
 
 function checkExistence (instance, name) {
   if (name) {
-    return name in instance
+    return name in instance || hasKey(instance, name)
   }
 
   return instance in this
 }
 
 function hasKey (fn, name) {
-  return fn.props.find(({ key }) => key === name)
+  if (fn.props) {
+    return fn.props.find(({ key }) => key === name)
+  }
+  return false
 }
 
 function checkRequestExistence (name) {

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -1024,3 +1024,27 @@ test('decorateRequest/decorateReply is not set to a value', t => {
     })
   })
 })
+
+test('decorateRequest with dependencies', (t) => {
+  t.plan(2)
+  const app = Fastify()
+
+  const decorator1 = {
+    config: {},
+    app: {}
+  }
+  const decorator2 = {
+    stuff: {}
+  }
+
+  app.decorate('decorator1', decorator1)
+  app.decorateRequest('decorator1', decorator1)
+
+  if (
+    app.hasDecorator('decorator1') &&
+    app.hasRequestDecorator('decorator1')
+  ) {
+    t.doesNotThrow(() => app.decorateRequest('decorator2', decorator2, ['decorator1']))
+    t.ok(app.hasRequestDecorator('decorator2'))
+  }
+})


### PR DESCRIPTION
Address: https://github.com/fastify/fastify/issues/3517

That issue was added by: #3317 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
