### PR TITLE
Guides toc

### DIFF
--- a/docs/Guides/Benchmarking.md
+++ b/docs/Guides/Benchmarking.md
@@ -1,13 +1,22 @@
 <h1 align="center">Fastify</h1>
 
 ## Benchmarking
-Benchmarking is important if you want to measure how a change can affect the performance of your application. We provide a simple way to benchmark your application from the point of view of a user and contributor. The setup allows you to automate benchmarks in different branches and on different Node.js versions.
+Benchmarking is important if you want to measure how a change can affect the
+performance of your application. We provide a simple way to benchmark your
+application from the point of view of a user and contributor. The setup allows
+you to automate benchmarks in different branches and on different Node.js
+versions.
 
 The modules we will use:
-- [Autocannon](https://github.com/mcollina/autocannon): A HTTP/1.1 benchmarking tool written in node.
-- [Branch-comparer](https://github.com/StarpTech/branch-comparer): Checkout multiple git branches, execute scripts and log the results.
-- [Concurrently](https://github.com/kimmobrunfeldt/concurrently): Run commands concurrently.
-- [Npx](https://github.com/npm/npx): NPM package runner used to run scripts against different Node.js Versions and to execute local binaries. Shipped with npm@5.2.0.
+- [Autocannon](https://github.com/mcollina/autocannon): A HTTP/1.1 benchmarking
+  tool written in node.
+- [Branch-comparer](https://github.com/StarpTech/branch-comparer): Checkout
+  multiple git branches, execute scripts and log the results.
+- [Concurrently](https://github.com/kimmobrunfeldt/concurrently): Run commands
+  concurrently.
+- [Npx](https://github.com/npm/npx): NPM package runner used to run scripts
+  against different Node.js Versions and to execute local binaries. Shipped with
+  npm@5.2.0.
 
 ## Simple
 

--- a/docs/Guides/Contributing.md
+++ b/docs/Guides/Contributing.md
@@ -1,20 +1,22 @@
 # Contributing To Fastify
 <a id="contributing"></a>
 
-Thank you for taking an interest in contributing to Fastify. We are excited
-to receive your support and knowledge. This guide is our attempt to help you
-help us.
+Thank you for taking an interest in contributing to Fastify. We are excited to
+receive your support and knowledge. This guide is our attempt to help you help
+us.
 
 > ## Note
-> This is an informal guide. Please review the formal
-> [CONTRIBUTING document](https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md) for full details and our
-> [Developer Certificate of Origin](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin).
+> This is an informal guide. Please review the formal [CONTRIBUTING
+> document](https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md) for
+> full details and our [Developer Certificate of
+> Origin](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin).
 
 ## Table Of Contents
 <a id="contributing-toc"></a>
 
 - [Table Of Contents](#table-of-contents)
-- [Types Of Contributions We're Looking For](#types-of-contributions-were-looking-for)
+- [Types Of Contributions We're Looking
+  For](#types-of-contributions-were-looking-for)
 - [Ground Rules & Expectations](#ground-rules--expectations)
 - [How To Contribute](#how-to-contribute)
 - [Setting Up Your Environment](#setting-up-your-environment)
@@ -26,34 +28,39 @@ help us.
 In short, we welcome any type of contribution you are willing to provide. No
 contribution is too small. We gladly accept contributions such as:
 
-* Documentation improvements: from small typo corrections to major document reworks
-* Helping others by answering questions in pull requests and [discussions](https://github.com/fastify/fastify/discussions)
-* Fixing [known bugs](https://github.com/fastify/fastify/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
-* Reporting previously unknown bugs by opening an issue with a minimal reproduction
+* Documentation improvements: from small typo corrections to major document
+  reworks
+* Helping others by answering questions in pull requests and
+  [discussions](https://github.com/fastify/fastify/discussions)
+* Fixing [known
+  bugs](https://github.com/fastify/fastify/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
+* Reporting previously unknown bugs by opening an issue with a minimal
+  reproduction
 
 ## Ground Rules & Expectations
 <a id="contributing-rules"></a>
 
-Before we get started, here are a few things we expect from you (and that
-you should expect from others):
+Before we get started, here are a few things we expect from you (and that you
+should expect from others):
 
 * Be respectful and thoughtful in your conversations around this project. This
   project is maintained by a diverse set of people from all across the globe.
   Each person has their own views and opinions about the project. Try to listen
   to each other and reach an agreement or compromise.
-* We have a [Code of Conduct](https://github.com/fastify/fastify/blob/main/CODE_OF_CONDUCT.md). You must adhere to it to
-  participate in this project.
+* We have a [Code of
+  Conduct](https://github.com/fastify/fastify/blob/main/CODE_OF_CONDUCT.md). You
+  must adhere to it to participate in this project.
 * If you open a pull request, please ensure that your contribution passes all
-  tests. If there are test failures, you will need to address them before we
-  can merge your contribution.
+  tests. If there are test failures, you will need to address them before we can
+  merge your contribution.
 
 ## How To Contribute
 <a id="contributing-how-to"></a>
 
 If you'd like to contribute, start by searching through the
-[issues](https://github.com/fastify/fastify/issues) and
-[pull requests](https://github.com/fastify/fastify/pulls) to see whether
-someone else has raised a similar idea or question.
+[issues](https://github.com/fastify/fastify/issues) and [pull
+requests](https://github.com/fastify/fastify/pulls) to see whether someone else
+has raised a similar idea or question.
 
 If you don't see your idea listed, and you think it fits into the goals of this
 guide, do one of the following:
@@ -78,15 +85,15 @@ conforms to the styles this project uses. Notably, this project uses
 ### Using Visual Studio Code
 <a id="contributing-vscode"></a>
 
-What follows is how to use [Visual Studio Code (VSCode) portable](https://code.visualstudio.com/docs/editor/portable)
-to create a Fastify specific environment. This guide is written as if you are
-setting up the environment on macOS, but the principles are the same across
-all platforms. See the previously linked VSCode portable guide for help with
-other platforms.
+What follows is how to use [Visual Studio Code (VSCode)
+portable](https://code.visualstudio.com/docs/editor/portable) to create a
+Fastify specific environment. This guide is written as if you are setting up the
+environment on macOS, but the principles are the same across all platforms. See
+the previously linked VSCode portable guide for help with other platforms.
 
 First, [download VSCode](https://code.visualstudio.com/download) and unpackage
-it to `/Applications/VSCodeFastify/`. Upon doing so, the following should
-output "found" when run in a terminal:
+it to `/Applications/VSCodeFastify/`. Upon doing so, the following should output
+"found" when run in a terminal:
 
 ```sh
 [ -d /Applications/VSCodeFastify/Visual\ Studio\ Code.app ] && echo "found"
@@ -105,14 +112,15 @@ Next, create the required data directories for VSCode:
 mkdir -p /Applications/VSCodeFastify/code-portable-data/{user-data,extensions}
 ```
 
-Before continuing, we need to add the `code` command to your terminal's
-`PATH`. To do so, we will [manually add VSCode to the `PATH`](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line). As outlined in that document, the
-instructions vary depending on your default shell, so you should follow the
-instructions in that guide as relates to your preferred shell. However, we will
-tweak them slightly by defining an alias instead of a direct reference to the
-`code` tool. This is so we do not conflict with any other installation of
-VSCode you may have, and to keep this guide specific to Fastify. So, ultimately,
-we want the following:
+Before continuing, we need to add the `code` command to your terminal's `PATH`.
+To do so, we will [manually add VSCode to the
+`PATH`](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line).
+As outlined in that document, the instructions vary depending on your default
+shell, so you should follow the instructions in that guide as relates to your
+preferred shell. However, we will tweak them slightly by defining an alias
+instead of a direct reference to the `code` tool. This is so we do not conflict
+with any other installation of VSCode you may have, and to keep this guide
+specific to Fastify. So, ultimately, we want the following:
 
 ```sh
 alias code-fastify="/Applications/VSCodeFastify/Visual\ Studio\ Code.app/Contents/Resources/app/bin/code"
@@ -127,9 +135,9 @@ The result should be that `code-fastify --version` results in something like:
 x64
 ```
 
-Now that VSCode is installed, and we can work with it via the command line,
-we need to install an extension that will aid in keeping any JavaScript you
-write for the project formatted according to the project's style:
+Now that VSCode is installed, and we can work with it via the command line, we
+need to install an extension that will aid in keeping any JavaScript you write
+for the project formatted according to the project's style:
 
 ```sh
 code-fastify --install-extension dbaeumer.vscode-eslint
@@ -149,15 +157,14 @@ can open VSCode:
 code-fastify .
 ```
 
-A new VSCode window should open and you should see the Fastify project files
-in the left sidebar. But wait! We are not quite done yet. There are a few more
+A new VSCode window should open and you should see the Fastify project files in
+the left sidebar. But wait! We are not quite done yet. There are a few more
 baseline settings that should be set before VSCode is ready.
 
-Press `cmd+shift+p` to bring up the VSCode command input prompt. Type
-`open settings (json)` and then choose the same item from the filtered menu.
-This will open a document that is the settings for the editor. Paste
-the following JSON into this document, overwriting any text already present,
-and save it:
+Press `cmd+shift+p` to bring up the VSCode command input prompt. Type `open
+settings (json)` and then choose the same item from the filtered menu. This will
+open a document that is the settings for the editor. Paste the following JSON
+into this document, overwriting any text already present, and save it:
 
 ```json
 {
@@ -177,9 +184,9 @@ and save it:
 Next, from the menu bar, select "Terminal > New Terminal" to open a new terminal
 in the editor. Run `npm install` to install the Fastify dependencies. Finally,
 we need to tell the eslint plugin to use the Fastify local install of eslint.
-Press `cmd+shift+p` to bring up the VSCode command input, type
-`eslint: manage library execution` and select it from the filtered menu. On
-the prompt, click the "Allow" button.
+Press `cmd+shift+p` to bring up the VSCode command input, type `eslint: manage
+library execution` and select it from the filtered menu. On the prompt, click
+the "Allow" button.
 
 At this point, you are all setup with a custom VSCode instance that can be used
 to work on Fastify contributions. As you edit and save JavaScript files, the

--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -2,214 +2,507 @@
 
 ## Ecosystem
 
-Plugins maintained by the Fastify team are listed under [Core](#core) while plugins maintained by the community are listed in the [Community](#community) section.
+Plugins maintained by the Fastify team are listed under [Core](#core) while
+plugins maintained by the community are listed in the [Community](#community)
+section.
 
 #### [Core](#core)
 
-- [`fastify-accepts`](https://github.com/fastify/fastify-accepts) to have [accepts](https://www.npmjs.com/package/accepts) in your request object.
-- [`fastify-accepts-serializer`](https://github.com/fastify/fastify-accepts-serializer) to serialize to output according to `Accept` header.
-- [`fastify-auth`](https://github.com/fastify/fastify-auth) Run multiple auth functions in Fastify.
-- [`fastify-autoload`](https://github.com/fastify/fastify-autoload) Require all plugins in a directory.
-- [`fastify-awilix`](https://github.com/fastify/fastify-awilix) Dependency injection support for Fastify, based on [awilix](https://github.com/jeffijoe/awilix).
-- [`fastify-bankai`](https://github.com/fastify/fastify-bankai) [Bankai](https://github.com/yoshuawuyts/bankai) assets compiler for Fastify.
-- [`fastify-basic-auth`](https://github.com/fastify/fastify-basic-auth) Basic auth plugin for Fastify.
-- [`fastify-bearer-auth`](https://github.com/fastify/fastify-bearer-auth) Bearer auth plugin for Fastify.
-- [`fastify-caching`](https://github.com/fastify/fastify-caching) General server-side cache and ETag support.
-- [`fastify-circuit-breaker`](https://github.com/fastify/fastify-circuit-breaker) A low overhead circuit breaker for your routes.
-- [`fastify-compress`](https://github.com/fastify/fastify-compress) Fastify compression utils.
-- [`fastify-cookie`](https://github.com/fastify/fastify-cookie) Parse and set cookie headers.
-- [`fastify-cors`](https://github.com/fastify/fastify-cors) Enables the use of CORS in a Fastify application.
-- [`fastify-csrf`](https://github.com/fastify/fastify-csrf) A plugin for adding [CSRF](https://en.wikipedia.org/wiki/Cross-site_request_forgery) protection to Fastify.
-- [`fastify-diagnostics-channel`](https://github.com/fastify/fastify-diagnostics-channel) Plugin to deal with `diagnostics_channel` on Fastify
-- [`fastify-elasticsearch`](https://github.com/fastify/fastify-elasticsearch) Plugin to share the same ES client.
-- [`fastify-env`](https://github.com/fastify/fastify-env) Load and check configuration.
-- [`fastify-etag`](https://github.com/fastify/fastify-etag) Automatically generate ETags for HTTP responses.
-- [`fastify-flash`](https://github.com/fastify/fastify-flash) Set and get flash messages using the session.
-- [`fastify-formbody`](https://github.com/fastify/fastify-formbody) Plugin to parse x-www-form-urlencoded bodies.
-- [`fastify-funky`](https://github.com/fastify/fastify-funky) Makes functional programming in Fastify more convenient. Adds support for Fastify routes returning functional structures, such as Either, Task or plain parameterless function.
-- [`fastify-helmet`](https://github.com/fastify/fastify-helmet) Important security headers for Fastify.
-- [`fastify-http-proxy`](https://github.com/fastify/fastify-http-proxy) Proxy your HTTP requests to another server, with hooks.
-- [`fastify-jwt`](https://github.com/fastify/fastify-jwt) JWT utils for Fastify, internally uses [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken).
-- [`fastify-leveldb`](https://github.com/fastify/fastify-leveldb) Plugin to share a common LevelDB connection across Fastify.
-- [`fastify-mongodb`](https://github.com/fastify/fastify-mongodb) Fastify MongoDB connection plugin, with which you can share the same MongoDB connection pool across every part of your server.
-- [`fastify-multipart`](https://github.com/fastify/fastify-multipart) Multipart support for Fastify.
-- [`fastify-oauth2`](https://github.com/fastify/fastify-oauth2) Wrap around [`simple-oauth2`](https://github.com/lelylan/simple-oauth2).
-- [`fastify-postgres`](https://github.com/fastify/fastify-postgres) Fastify PostgreSQL connection plugin, with this you can share the same PostgreSQL connection pool in every part of your server.
-- [`fastify-rate-limit`](https://github.com/fastify/fastify-rate-limit) A low overhead rate limiter for your routes.
-- [`fastify-request-context`](https://github.com/fastify/fastify-request-context) Request-scoped storage, based on [AsyncLocalStorage](https://nodejs.org/api/async_hooks.html#async_hooks_class_asynclocalstorage) (with fallback to [cls-hooked](https://github.com/Jeff-Lewis/cls-hooked)), providing functionality similar to thread-local storages.
-- [`fastify-response-validation`](https://github.com/fastify/fastify-response-validation) A simple plugin that enables response validation for Fastify.
-- [`fastify-nextjs`](https://github.com/fastify/fastify-nextjs) React server-side rendering support for Fastify with [Next](https://github.com/zeit/next.js/).
-- [`fastify-redis`](https://github.com/fastify/fastify-redis) Fastify Redis connection plugin, with which you can share the same Redis connection across every part of your server.
-- [`fastify-reply-from`](https://github.com/fastify/fastify-reply-from) Plugin to forward the current HTTP request to another server.
-- [`fastify-routes`](https://github.com/fastify/fastify-routes) Plugin that provides a `Map` of routes.
-- [`fastify-schedule`](https://github.com/fastify/fastify-schedule) Plugin for scheduling periodic jobs, based on [toad-scheduler](https://github.com/kibertoad/toad-scheduler).
-- [`fastify-sensible`](https://github.com/fastify/fastify-sensible) Defaults for Fastify that everyone can agree on. It adds some useful decorators such as HTTP errors and assertions, but also more request and reply methods.
-- [`@fastify/session`](https://github.com/fastify/session) a session plugin for Fastify.
-- [`fastify-static`](https://github.com/fastify/fastify-static) Plugin for serving static files as fast as possible.
-- [`fastify-swagger`](https://github.com/fastify/fastify-swagger) Plugin for serving Swagger/OpenAPI documentation for Fastify, supporting dynamic generation.
-- [`fastify-websocket`](https://github.com/fastify/fastify-websocket) WebSocket support for Fastify. Built upon [ws](https://github.com/websockets/ws).
-- [`fastify-url-data`](https://github.com/fastify/fastify-url-data) Decorate the `Request` object with a method to access raw URL components.
+- [`fastify-accepts`](https://github.com/fastify/fastify-accepts) to have
+  [accepts](https://www.npmjs.com/package/accepts) in your request object.
+- [`fastify-accepts-serializer`](https://github.com/fastify/fastify-accepts-serializer)
+  to serialize to output according to `Accept` header.
+- [`fastify-auth`](https://github.com/fastify/fastify-auth) Run multiple auth
+  functions in Fastify.
+- [`fastify-autoload`](https://github.com/fastify/fastify-autoload) Require all
+  plugins in a directory.
+- [`fastify-awilix`](https://github.com/fastify/fastify-awilix) Dependency
+  injection support for Fastify, based on
+  [awilix](https://github.com/jeffijoe/awilix).
+- [`fastify-bankai`](https://github.com/fastify/fastify-bankai)
+  [Bankai](https://github.com/yoshuawuyts/bankai) assets compiler for Fastify.
+- [`fastify-basic-auth`](https://github.com/fastify/fastify-basic-auth) Basic
+  auth plugin for Fastify.
+- [`fastify-bearer-auth`](https://github.com/fastify/fastify-bearer-auth) Bearer
+  auth plugin for Fastify.
+- [`fastify-caching`](https://github.com/fastify/fastify-caching) General
+  server-side cache and ETag support.
+- [`fastify-circuit-breaker`](https://github.com/fastify/fastify-circuit-breaker)
+  A low overhead circuit breaker for your routes.
+- [`fastify-compress`](https://github.com/fastify/fastify-compress) Fastify
+  compression utils.
+- [`fastify-cookie`](https://github.com/fastify/fastify-cookie) Parse and set
+  cookie headers.
+- [`fastify-cors`](https://github.com/fastify/fastify-cors) Enables the use of
+  CORS in a Fastify application.
+- [`fastify-csrf`](https://github.com/fastify/fastify-csrf) A plugin for adding
+  [CSRF](https://en.wikipedia.org/wiki/Cross-site_request_forgery) protection to
+  Fastify.
+- [`fastify-diagnostics-channel`](https://github.com/fastify/fastify-diagnostics-channel)
+  Plugin to deal with `diagnostics_channel` on Fastify
+- [`fastify-elasticsearch`](https://github.com/fastify/fastify-elasticsearch)
+  Plugin to share the same ES client.
+- [`fastify-env`](https://github.com/fastify/fastify-env) Load and check
+  configuration.
+- [`fastify-etag`](https://github.com/fastify/fastify-etag) Automatically
+  generate ETags for HTTP responses.
+- [`fastify-flash`](https://github.com/fastify/fastify-flash) Set and get flash
+  messages using the session.
+- [`fastify-formbody`](https://github.com/fastify/fastify-formbody) Plugin to
+  parse x-www-form-urlencoded bodies.
+- [`fastify-funky`](https://github.com/fastify/fastify-funky) Makes functional
+  programming in Fastify more convenient. Adds support for Fastify routes
+  returning functional structures, such as Either, Task or plain parameterless
+  function.
+- [`fastify-helmet`](https://github.com/fastify/fastify-helmet) Important
+  security headers for Fastify.
+- [`fastify-http-proxy`](https://github.com/fastify/fastify-http-proxy) Proxy
+  your HTTP requests to another server, with hooks.
+- [`fastify-jwt`](https://github.com/fastify/fastify-jwt) JWT utils for Fastify,
+  internally uses [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken).
+- [`fastify-leveldb`](https://github.com/fastify/fastify-leveldb) Plugin to
+  share a common LevelDB connection across Fastify.
+- [`fastify-mongodb`](https://github.com/fastify/fastify-mongodb) Fastify
+  MongoDB connection plugin, with which you can share the same MongoDB
+  connection pool across every part of your server.
+- [`fastify-multipart`](https://github.com/fastify/fastify-multipart) Multipart
+  support for Fastify.
+- [`fastify-oauth2`](https://github.com/fastify/fastify-oauth2) Wrap around
+  [`simple-oauth2`](https://github.com/lelylan/simple-oauth2).
+- [`fastify-postgres`](https://github.com/fastify/fastify-postgres) Fastify
+  PostgreSQL connection plugin, with this you can share the same PostgreSQL
+  connection pool in every part of your server.
+- [`fastify-rate-limit`](https://github.com/fastify/fastify-rate-limit) A low
+  overhead rate limiter for your routes.
+- [`fastify-request-context`](https://github.com/fastify/fastify-request-context)
+  Request-scoped storage, based on
+  [AsyncLocalStorage](https://nodejs.org/api/async_hooks.html#async_hooks_class_asynclocalstorage)
+  (with fallback to [cls-hooked](https://github.com/Jeff-Lewis/cls-hooked)),
+  providing functionality similar to thread-local storages.
+- [`fastify-response-validation`](https://github.com/fastify/fastify-response-validation)
+  A simple plugin that enables response validation for Fastify.
+- [`fastify-nextjs`](https://github.com/fastify/fastify-nextjs) React
+  server-side rendering support for Fastify with
+  [Next](https://github.com/zeit/next.js/).
+- [`fastify-redis`](https://github.com/fastify/fastify-redis) Fastify Redis
+  connection plugin, with which you can share the same Redis connection across
+  every part of your server.
+- [`fastify-reply-from`](https://github.com/fastify/fastify-reply-from) Plugin
+  to forward the current HTTP request to another server.
+- [`fastify-routes`](https://github.com/fastify/fastify-routes) Plugin that
+  provides a `Map` of routes.
+- [`fastify-schedule`](https://github.com/fastify/fastify-schedule) Plugin for
+  scheduling periodic jobs, based on
+  [toad-scheduler](https://github.com/kibertoad/toad-scheduler).
+- [`fastify-sensible`](https://github.com/fastify/fastify-sensible) Defaults for
+  Fastify that everyone can agree on. It adds some useful decorators such as
+  HTTP errors and assertions, but also more request and reply methods.
+- [`@fastify/session`](https://github.com/fastify/session) a session plugin for
+  Fastify.
+- [`fastify-static`](https://github.com/fastify/fastify-static) Plugin for
+  serving static files as fast as possible.
+- [`fastify-swagger`](https://github.com/fastify/fastify-swagger) Plugin for
+  serving Swagger/OpenAPI documentation for Fastify, supporting dynamic
+  generation.
+- [`fastify-websocket`](https://github.com/fastify/fastify-websocket) WebSocket
+  support for Fastify. Built upon [ws](https://github.com/websockets/ws).
+- [`fastify-url-data`](https://github.com/fastify/fastify-url-data) Decorate the
+  `Request` object with a method to access raw URL components.
 - [`middie`](https://github.com/fastify/middie) Middleware engine for Fastify.
-- [`point-of-view`](https://github.com/fastify/point-of-view) Templates rendering (_ejs, pug, handlebars, marko_) plugin support for Fastify.
-- [`under-pressure`](https://github.com/fastify/under-pressure) Measure process load with automatic handling of _"Service Unavailable"_ plugin for Fastify.
+- [`point-of-view`](https://github.com/fastify/point-of-view) Templates
+  rendering (_ejs, pug, handlebars, marko_) plugin support for Fastify.
+- [`under-pressure`](https://github.com/fastify/under-pressure) Measure process
+  load with automatic handling of _"Service Unavailable"_ plugin for Fastify.
 
 #### [Community](#community)
 
-- [`@applicazza/fastify-nextjs`](https://github.com/applicazza/fastify-nextjs) Alternate Fastify and Next.js integration.
-- [`@coobaha/typed-fastify`](https://github.com/Coobaha/typed-fastify) Strongly typed routes with a runtime validation using JSON schema generated from types.
-- [`@dnlup/fastify-doc`](https://github.com/dnlup/fastify-doc) A plugin for sampling process metrics.
-- [`@dnlup/fastify-traps`](https://github.com/dnlup/fastify-traps) A plugin to close the server gracefully on `SIGINT` and `SIGTERM` signals.
-- [`@gquittet/graceful-server`](https://github.com/gquittet/graceful-server) Tiny (~5k), Fast, KISS, and dependency-free Node.JS library to make your Fastify API graceful.
-- [`@immobiliarelabs/fastify-metrics`](https://github.com/immobiliare/fastify-metrics) Minimalistic and opinionated plugin that collects usage/process metrics and dispatches to [statsd](https://github.com/statsd/statsd).
-- [`@mgcrea/fastify-graceful-exit`](https://github.com/mgcrea/fastify-graceful-exit) A plugin to close the server gracefully
-- [`@mgcrea/fastify-request-logger`](https://github.com/mgcrea/fastify-request-logger) A plugin to enable compact request logging for Fastify
-- [`@mgcrea/fastify-session-redis-store`](https://github.com/mgcrea/fastify-session-redis-store) Redis store for @mgcrea/fastify-session using ioredis
-- [`@mgcrea/fastify-session-sodium-crypto`](https://github.com/mgcrea/fastify-session-sodium-crypto) Fast sodium-based crypto for @mgcrea/fastify-session
-- [`@mgcrea/fastify-session`](https://github.com/mgcrea/fastify-session) Session plugin for Fastify that supports both stateless and stateful sessions
-- [`@mgcrea/pino-pretty-compact`](https://github.com/mgcrea/pino-pretty-compact) A custom compact pino-base prettifier
-- [`@trubavuong/fastify-seaweedfs`](https://github.com/trubavuong/fastify-seaweedfs) SeaweedFS for Fastify
-- [`apollo-server-fastify`](https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-fastify) Run an [Apollo Server](https://github.com/apollographql/apollo-server) to serve GraphQL with Fastify.
-- [`arecibo`](https://github.com/nucleode/arecibo) Fastify ping responder for Kubernetes Liveness and Readiness Probes.
-- [`cls-rtracer`](https://github.com/puzpuzpuz/cls-rtracer) Fastify middleware for CLS-based request ID generation. An out-of-the-box solution for adding request IDs into your logs.
-- [`fastify-405`](https://github.com/Eomm/fastify-405) Fastify plugin that adds 405 HTTP status to your routes
-- [`fastify-allow`](https://github.com/mattbishop/fastify-allow) Fastify plugin that automatically adds an Allow header to responses with routes. Also sends 405 responses for routes that have a handler but not for the request's method.
-- [`fastify-amqp`](https://github.com/RafaelGSS/fastify-amqp) Fastify AMQP connection plugin, to use with RabbitMQ or another connector. Just a wrapper to [`amqplib`](https://github.com/squaremo/amqp.node).
-- [`fastify-angular-universal`](https://github.com/exequiel09/fastify-angular-universal) Angular server-side rendering support using [`@angular/platform-server`](https://github.com/angular/angular/tree/master/packages/platform-server) for Fastify
-- [`fastify-api-key`](https://github.com/arkerone/fastify-api-key) Fastify plugin to authenticate HTTP requests based on api key and signature
-- [`fastify-appwrite`](https://github.com/Dev-Manny/fastify-appwrite) Fastify Plugin for interacting with Appwrite server.
-- [`fastify-auth0-verify`](https://github.com/nearform/fastify-auth0-verify): Auth0 verification plugin for Fastify, internally uses [fastify-jwt](https://npm.im/fastify-jwt) and [jsonwebtoken](https://npm.im/jsonwebtoken).
-- [`fastify-autocrud`](https://github.com/paranoiasystem/fastify-autocrud) Plugin to auto-generate CRUD routes as fast as possible.
-- [`fastify-autoroutes`](https://github.com/GiovanniCardamone/fastify-autoroutes) Plugin to scan and load routes based on filesystem path from a custom directory.
-- [`fastify-axios`](https://github.com/davidedantonio/fastify-axios) Plugin to send HTTP requests via [axios](https://github.com/axios/axios).
-- [`fastify-babel`](https://github.com/cfware/fastify-babel) Fastify plugin for development servers that require Babel transformations of JavaScript sources.
-- [`fastify-bcrypt`](https://github.com/heply/fastify-bcrypt) A Bcrypt hash generator & checker.
-- [`fastify-blipp`](https://github.com/PavelPolyakov/fastify-blipp) Prints your routes to the console, so you definitely know which endpoints are available.
-- [`fastify-bookshelf`](https://github.com/butlerx/fastify-bookshelfjs) Fastify plugin to add [bookshelf.js](https://bookshelfjs.org/) ORM support.
-- [`fastify-boom`](https://github.com/jeromemacias/fastify-boom) Fastify plugin to add [boom](https://github.com/hapijs/boom) support.
-- [`fastify-bree`](https://github.com/climba03003/fastify-bree) Fastify plugin to add [bree](https://github.com/breejs/bree) support.
-- [`fastify-casbin`](https://github.com/nearform/fastify-casbin) Casbin support for Fastify.
-- [`fastify-casbin-rest`](https://github.com/nearform/fastify-casbin-rest) Casbin support for Fastify based on a RESTful model.
-- [`fastify-casl`](https://github.com/Inlecom/fastify-casl) Fastify [CASL](https://github.com/stalniy/casl) plugin that supports ACL-like protection of endpoints via either a preSerialization & preHandler hook, sanitizing the inputs and outputs of your application based on user rights.
-- [`fastify-cloudevents`](https://github.com/smartiniOnGitHub/fastify-cloudevents) Fastify plugin to generate and forward Fastify events in the Cloudevents format.
-- [`fastify-cockroachdb`](https://github.com/alex-ppg/fastify-cockroachdb) Fastify plugin to connect to a CockroachDB PostgreSQL instance via the Sequelize ORM.
-- [`fastify-couchdb`](https://github.com/nigelhanlon/fastify-couchdb) Fastify plugin to add CouchDB support via [nano](https://github.com/apache/nano).
-- [`fastify-crud-generator`](https://github.com/heply/fastify-crud-generator) A plugin to rapidly generate CRUD routes for any entity.
-- [`fastify-custom-healthcheck`](https://github.com/gkampitakis/fastify-custom-healthcheck) Fastify plugin to add health route in your server that asserts custom functions.
-- [`fastify-decorators`](https://github.com/L2jLiga/fastify-decorators) Fastify plugin that provides the set of TypeScript decorators.
-- [`fastify-disablecache`](https://github.com/Fdawgs/fastify-disablecache) Fastify plugin to disable client-side caching, inspired by [nocache](https://github.com/helmetjs/nocache).
-- [`fastify-dynamodb`](https://github.com/matrus2/fastify-dynamodb) AWS DynamoDB plugin for Fastify. It exposes [AWS.DynamoDB.DocumentClient()](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html) object.
-- [`fastify-dynareg`](https://github.com/greguz/fastify-dynareg) Dynamic plugin register for Fastify.
-- [`fastify-early-hints`](https://github.com/zekth/fastify-early-hints) Plugin to add HTTP 103 feature based on [RFC 8297](https://httpwg.org/specs/rfc8297.html)
-- [`fastify-envalid`](https://github.com/alemagio/fastify-envalid) Fastify plugin to integrate [envalid](https://github.com/af/envalid) in your Fastify project.
-- [`fastify-error-page`](https://github.com/hemerajs/fastify-error-page) Fastify plugin to print errors in structured HTML to the browser.
-- [`fastify-esso`](https://github.com/patrickpissurno/fastify-esso) The easiest authentication plugin for Fastify, with built-in support for Single sign-on (and great documentation).
-- [`fastify-explorer`](https://github.com/Eomm/fastify-explorer) Get control of your decorators across all the encapsulated contexts.
-- [`fastify-favicon`](https://github.com/smartiniOnGitHub/fastify-favicon) Fastify plugin to serve default favicon.
-- [`fastify-feature-flags`](https://gitlab.com/m03geek/fastify-feature-flags) Fastify feature flags plugin with multiple providers support (e.g. env, [config](https://lorenwest.github.io/node-config/), [unleash](https://unleash.github.io/)).
-- [`fastify-file-upload`](https://github.com/huangang/fastify-file-upload) Fastify plugin for uploading files.
-- [`fastify-firebase`](https://github.com/now-ims/fastify-firebase) Fastify plugin for [Firebase Admin SDK](https://firebase.google.com/docs/admin/setup) to Fastify so you can easily use Firebase Auth, Firestore, Cloud Storage, Cloud Messaging, and more.
-- [`fastify-firebase-auth`](https://github.com/oxsav/fastify-firebase-auth) Firebase Authentication for Fastify supporting all of the methods relating to the authentication API.
-- [`fastify-formidable`](https://github.com/climba03003/fastify-formidable) Handy plugin to provide multipart support and fastify-swagger integration.
-- [`fastify-gcloud-trace`](https://github.com/mkinoshi/fastify-gcloud-trace) [Google Cloud Trace API](https://cloud.google.com/trace/docs/reference) Connector for Fastify.
-- [`fastify-get-head`](https://github.com/MetCoder95/fastify-get-head) Small plugin to set a new HEAD route handler for each GET route previously registered in Fastify.
-- [`fastify-good-sessions`](https://github.com/Phara0h/fastify-good-sessions) A good Fastify sessions plugin focused on speed.
-- [`fastify-google-cloud-storage`](https://github.com/carlozamagni/fastify-google-cloud-storage) Fastify plugin that exposes a GCP Cloud Storage client instance.
-- [`fastify-grant`](https://github.com/simov/fastify-grant) Authentication/Authorization plugin for Fastify that supports 200+ OAuth Providers.
-- [`fastify-guard`](https://github.com/hsynlms/fastify-guard) A Fastify plugin that protects endpoints by checking authenticated user roles and/or scopes.
-- [`fastify-graceful-shutdown`](https://github.com/hemerajs/fastify-graceful-shutdown) Shutdown Fastify gracefully and asynchronously.
-- [`fastify-hasura`](https://github.com/ManUtopiK/fastify-hasura) A Fastify plugin to have fun with [Hasura](https://github.com/hasura/graphql-engine).
-- [`fastify-healthcheck`](https://github.com/smartiniOnGitHub/fastify-healthcheck) Fastify plugin to serve a health check route and a probe script.
-- [`fastify-hemera`](https://github.com/hemerajs/fastify-hemera) Fastify Hemera plugin, for writing reliable & fault-tolerant microservices with [nats.io](https://nats.io/).
-- [`fastify-http-context`](https://github.com/thorough-developer/fastify-http-context) Fastify plugin for "simulating" a thread of execution to allow for true HTTP context to take place per API call within the Fastify lifecycle of calls.
-- [`fastify-http2https`](https://github.com/lolo32/fastify-http2https) Redirect HTTP requests to HTTPS, both using the same port number, or different response on HTTP and HTTPS.
-- [`fastify-http-client`](https://github.com/kenuyx/fastify-http-client) Plugin to send HTTP(s) requests. Built upon [urllib](https://github.com/node-modules/urllib).
-- [`fastify-http-errors-enhanced`](https://github.com/ShogunPanda/fastify-http-errors-enhanced) An error handling plugin for Fastify that uses enhanced HTTP errors.
-- [`fastify-https-redirect`](https://github.com/tomsvogel/fastify-https-redirect) Fastify plugin for auto-redirect from HTTP to HTTPS.
-- [`fastify-influxdb`](https://github.com/alex-ppg/fastify-influxdb) Fastify InfluxDB plugin connecting to an InfluxDB instance via the Influx default package.
-- [`fastify-jwt-authz`](https://github.com/Ethan-Arrowood/fastify-jwt-authz) JWT user scope verifier.
-- [`fastify-jwt-webapp`](https://github.com/charlesread/fastify-jwt-webapp) JWT authentication for Fastify-based web apps.
-- [`fastify-knexjs`](https://github.com/chapuletta/fastify-knexjs) Fastify plugin for support KnexJS Query Builder.
-- [`fastify-knexjs-mock`](https://github.com/chapuletta/fastify-knexjs-mock) Fastify Mock KnexJS for testing support.
-- [`fastify-kubernetes`](https://github.com/greguz/fastify-kubernetes) Fastify Kubernetes client plugin.
-- [`fastify-language-parser`](https://github.com/lependu/fastify-language-parser) Fastify plugin to parse request language.
-- [`fastify-loader`](https://github.com/TheNoim/fastify-loader) Load routes from a directory and inject the Fastify instance in each file.
-- [`fastify-lured`](https://github.com/lependu/fastify-lured) Plugin to load lua scripts with [fastify-redis](https://github.com/fastify/fastify-redis) and [lured](https://github.com/enobufs/lured).
-- [`fastify-mailer`](https://github.com/coopflow/fastify-mailer) Plugin to initialize and encapsulate [Nodemailer](https://nodemailer.com)'s transporters instances in Fastify.
-- [`fastify-markdown`](https://github.com/freezestudio/fastify-markdown) Plugin to markdown support.
-- [`fastify-method-override`](https://github.com/corsicanec82/fastify-method-override) Plugin for Fastify, which allows the use of HTTP verbs, such as DELETE, PATCH, HEAD, PUT, OPTIONS in case the client doesn't support them.
-- [`fastify-metrics`](https://gitlab.com/m03geek/fastify-metrics) Plugin for exporting [Prometheus](https://prometheus.io) metrics.
-- [`fastify-minify`](https://github.com/Jelenkee/fastify-minify) Plugin for minification and transformation of responses.
-- [`fastify-mongo-memory`](https://github.com/chapuletta/fastify-mongo-memory) Fastify MongoDB in Memory Plugin for testing support.
-- [`fastify-mongoose-api`](https://github.com/jeka-kiselyov/fastify-mongoose-api) Fastify plugin to create REST API methods based on Mongoose MongoDB models.
-- [`fastify-mongoose-driver`](https://github.com/alex-ppg/fastify-mongoose) Fastify Mongoose plugin that connects to a MongoDB via the Mongoose plugin with support for Models.
-- [`fastify-msgpack`](https://github.com/kenriortega/fastify-msgpack) Fastify and MessagePack, together at last. Uses @msgpack/msgpack by default. 
-- [`fastify-multer`](https://github.com/fox1t/fastify-multer) Multer is a plugin for handling multipart/form-data, which is primarily used for uploading files.
-- [`fastify-nats`](https://github.com/mahmed8003/fastify-nats) Plugin to share [NATS](https://nats.io) client across Fastify.
-- [`fastify-no-additional-properties`](https://github.com/greguz/fastify-no-additional-properties) Add `additionalProperties: false` by default to your JSON Schemas.
-- [`fastify-no-icon`](https://github.com/jsumners/fastify-no-icon) Plugin to eliminate thrown errors for `/favicon.ico` requests.
-- [`fastify-nodemailer`](https://github.com/lependu/fastify-nodemailer) Plugin to share [nodemailer](https://nodemailer.com) transporter across Fastify.
-- [`fastify-normalize-request-reply`](https://github.com/ericrglass/fastify-normalize-request-reply) Plugin to normalize the request and reply to the Express version 4.x request and response, which allows use of middleware, like swagger-stats, that was originally written for Express.
-- [`fastify-now`](https://github.com/yonathan06/fastify-now) Structure your endpoints in a folder and load them dynamically with Fastify.
-- [`fastify-nuxtjs`](https://github.com/gomah/fastify-nuxtjs) Vue server-side rendering support for Fastify with Nuxt.js Framework.
-- [`fastify-oas`](https://gitlab.com/m03geek/fastify-oas) Generates OpenAPI 3.0+ documentation from routes schemas for Fastify.
-- [`fastify-objectionjs`](https://github.com/jarcodallo/fastify-objectionjs) Plugin for the Fastify framework that provides integration with objectionjs ORM.
-- [`fastify-objectionjs-classes`](https://github.com/kamikazechaser/fastify-objectionjs-classes) Plugin to cherry-pick classes from objectionjs ORM.
-- [`fastify-openapi-docs`](https://github.com/ShogunPanda/fastify-openapi-docs) A Fastify plugin that generates OpenAPI spec automatically.
-- [`fastify-openapi-glue`](https://github.com/seriousme/fastify-openapi-glue) Glue for OpenAPI specifications in Fastify, autogenerates routes based on an OpenAPI Specification.
-- [`fastify-opentelemetry`](https://github.com/autotelic/fastify-opentelemetry) A Fastify plugin that uses the [OpenTelemetry API](https://github.com/open-telemetry/opentelemetry-js-api) to provide request tracing.
-- [`fastify-oracle`](https://github.com/cemremengu/fastify-oracle) Attaches an [`oracledb`](https://github.com/oracle/node-oracledb) connection pool to a Fastify server instance.
-- [`fastify-orientdb`](https://github.com/mahmed8003/fastify-orientdb) Fastify OrientDB connection plugin, with which you can share the OrientDB connection across every part of your server.
-- [`fastify-piscina`](https://github.com/piscinajs/fastify-piscina) A worker thread pool plugin using [Piscina](https://github.com/piscinajs/piscina).
-- [`fastify-peekaboo`](https://github.com/simone-sanfratello/fastify-peekaboo) Fastify plugin for memoize responses by expressive settings.
-- [`fastify-polyglot`](https://github.com/heply/fastify-polyglot) A plugin to handle i18n using [node-polyglot](https://www.npmjs.com/package/node-polyglot).
-- [`fastify-postgraphile`](https://github.com/alemagio/fastify-postgraphile) Plugin to integrate [PostGraphile](https://www.graphile.org/postgraphile/) in a Fastify project.
-- [`fastify-prettier`](https://github.com/hsynlms/fastify-prettier) A Fastify plugin that uses [prettier](https://github.com/prettier/prettier) under the hood to beautify outgoing responses and/or other things in the Fastify server.
-- [`fastify-print-routes`](https://github.com/ShogunPanda/fastify-print-routes) A Fastify plugin that prints all available routes.
-- [`fastify-protobufjs`](https://github.com/kenriortega/fastify-protobufjs) Fastify and protobufjs, together at last. Uses protobufjs by default. 
-- [`fastify-qrcode`](https://github.com/chonla/fastify-qrcode) This plugin utilizes [qrcode](https://github.com/soldair/node-qrcode) to generate QR Code.
-- [`fastify-qs`](https://github.com/webdevium/fastify-qs) A plugin for Fastify that adds support for parsing URL query parameters with [qs](https://github.com/ljharb/qs).
-- [`fastify-raw-body`](https://github.com/Eomm/fastify-raw-body) Add the `request.rawBody` field.
-- [`fastify-rbac`](https://gitlab.com/m03geek/fastify-rbac) Fastify role-based access control plugin.
-- [`fastify-recaptcha`](https://github.com/qwertyforce/fastify-recaptcha) Fastify plugin for recaptcha verification.
-- [`fastify-redis-channels`](https://github.com/hearit-io/fastify-redis-channels) A plugin for fast, reliable, and scalable channels implementation based on Redis streams.
-- [`fastify-register-routes`](https://github.com/israeleriston/fastify-register-routes) Plugin to automatically load routes from a specified path and optionally limit loaded file names by a regular expression.
-- [`fastify-response-time`](https://github.com/lolo32/fastify-response-time) Add `X-Response-Time` header at each request for Fastify, in milliseconds.
-- [`fastify-response-caching`](https://github.com/codeaholicguy/fastify-response-caching) A Fastify plugin for caching the response.
-- [`fastify-resty`](https://github.com/FastifyResty/fastify-resty) Fastify-based web framework with REST API routes auto-generation for TypeORM entities using DI and decorators.
-- [`fastify-reverse-routes`](https://github.com/dimonnwc3/fastify-reverse-routes) Fastify reverse routes plugin, allows to defined named routes and build path using name and parameters.
-- [`fastify-rob-config`](https://github.com/jeromemacias/fastify-rob-config) Fastify Rob-Config integration.
-- [`fastify-route-group`](https://github.com/TakNePoidet/fastify-route-group) Convenient grouping and inheritance of routes
-- [`fastify-schema-constraint`](https://github.com/Eomm/fastify-schema-constraint) Choose the JSON schema to use based on request parameters.
-- [`fastify-schema-to-typescript`](https://github.com/thomasthiebaud/fastify-schema-to-typescript) Generate typescript types based on your JSON/YAML validation schemas so they are always in sync.
-- [`fastify-secure-session`](https://github.com/mcollina/fastify-secure-session) Create a secure stateless cookie session for Fastify.
-- [`fastify-sentry`](https://github.com/alex-ppg/fastify-sentry) Fastify plugin to add the Sentry SDK error handler to requests.
-- [`fastify-sequelize`](https://github.com/lyquocnam/fastify-sequelize) Fastify plugin work with Sequelize (adapter for NodeJS -> Sqlite, Mysql, Mssql, Postgres).
-- [`fastify-server-session`](https://github.com/jsumners/fastify-server-session) A session plugin with support for arbitrary backing caches via `fastify-caching`.
-- [`fastify-slonik`](https://github.com/Unbuttun/fastify-slonik) Fastify Slonik plugin, with this you can use slonik in every part of your server.
-- [`fastify-soap-client`](https://github.com/fastify/fastify-soap-client) a SOAP client plugin for Fastify.
-- [`fastify-socket.io`](https://github.com/alemagio/fastify-socket.io) a Socket.io plugin for Fastify.
-- [`fastify-sse`](https://github.com/lolo32/fastify-sse) to provide Server-Sent Events with `reply.sse( … )` to Fastify.
-- [`fastify-sse-v2`](https://github.com/nodefactoryio/fastify-sse-v2) to provide Server-Sent Events using Async Iterators (supports newer versions of Fastify).
-- [`fastify-stripe`](https://github.com/coopflow/fastify-stripe) Plugin to initialize and encapsulate [Stripe Node.js](https://github.com/stripe/stripe-node) instances in Fastify.
-- [`fastify-supabase`](https://github.com/coopflow/fastify-supabase) Plugin to initialize and encapsulate [Supabase](https://github.com/supabase/supabase-js) instances in Fastify.
-- [`fastify-tls-keygen`](https://gitlab.com/sebdeckers/fastify-tls-keygen) Automatically generate a browser-compatible, trusted, self-signed, localhost-only, TLS certificate.
-- [`fastify-tokenize`](https://github.com/Bowser65/fastify-tokenize) [Tokenize](https://github.com/Bowser65/Tokenize) plugin for Fastify that removes the pain of managing authentication tokens, with built-in integration for `fastify-auth`.
-- [`fastify-totp`](https://github.com/heply/fastify-totp) A plugin to handle TOTP (e.g. for 2FA).
-- [`fastify-twitch-ebs-tools`](https://github.com/lukemnet/fastify-twitch-ebs-tools) Useful functions for Twitch Extension Backend Services (EBS).
-- [`fastify-typeorm-plugin`](https://github.com/inthepocket/fastify-typeorm-plugin) Fastify plugin to work with TypeORM.
-- [`fastify-vhost`](https://github.com/patrickpissurno/fastify-vhost) Proxy subdomain HTTP requests to another server (useful if you want to point multiple subdomains to the same IP address, while running different servers on the same machine).
-- [`fastify-vite`](https://github.com/galvez/fastify-vite) [Vite](https://vitejs.dev/) plugin for Fastify with SSR data support.
-- [`fastify-vue-plugin`](https://github.com/TheNoim/fastify-vue) [Nuxt.js](https://nuxtjs.org) plugin for Fastify. Control the routes nuxt should use.
-- [`fastify-wamp-router`](https://github.com/lependu/fastify-wamp-router) Web Application Messaging Protocol router for Fastify.
-- [`fast-water`](https://github.com/tswayne/fast-water) A Fastify plugin for waterline. Decorates Fastify with waterline models.
-- [`fastify-webpack-hmr`](https://github.com/lependu/fastify-webpack-hmr) Webpack hot module reloading plugin for Fastify.
-- [`fastify-ws`](https://github.com/gj/fastify-ws) WebSocket integration for Fastify — with support for WebSocket lifecycle hooks instead of a single handler function. Built upon [ws](https://github.com/websockets/ws) and [uws](https://github.com/uNetworking/uWebSockets).
-- [`fastify-xml-body-parser`](https://github.com/NaturalIntelligence/fastify-xml-body-parser) Parse XML payload / request body into JS / JSON object.
-- [`fastify-xray`](https://github.com/jeromemacias/fastify-xray) Fastify plugin for AWS XRay recording.
-- [`i18next-http-middleware`](https://github.com/i18next/i18next-http-middleware#fastify-usage) An [i18next](https://www.i18next.com) based i18n (internationalization) middleware to be used with Node.js web frameworks like Express or Fastify and also for Deno.
-- [`k-fastify-gateway`](https://github.com/jkyberneees/fastify-gateway) API Gateway plugin for Fastify, a low footprint implementation that uses the `fastify-reply-from` HTTP proxy library.
-- [`mercurius`](https://mercurius.dev/) A fully-featured and performant GraphQL server implementation for Fastify.
-- [`nstats`](https://github.com/Phara0h/nstats) A fast and compact way to get all your network and process stats for your node application. Websocket, HTTP/S, and prometheus compatible!
-- [`oas-fastify`](https://github.com/ahmadnassri/node-oas-fastify) OAS 3.x to Fastify routes automation. Automatically generates route handlers with fastify configuration and validation.
-- [`openapi-validator-middleware`](https://github.com/PayU/openapi-validator-middleware#fastify) Swagger and OpenAPI 3.0 spec-based request validation middleware that supports Fastify.
-- [`sequelize-fastify`](https://github.com/hsynlms/sequelize-fastify) A simple and lightweight Sequelize plugin for Fastify.
+- [`@applicazza/fastify-nextjs`](https://github.com/applicazza/fastify-nextjs)
+  Alternate Fastify and Next.js integration.
+- [`@coobaha/typed-fastify`](https://github.com/Coobaha/typed-fastify) Strongly
+  typed routes with a runtime validation using JSON schema generated from types.
+- [`@dnlup/fastify-doc`](https://github.com/dnlup/fastify-doc) A plugin for
+  sampling process metrics.
+- [`@dnlup/fastify-traps`](https://github.com/dnlup/fastify-traps) A plugin to
+  close the server gracefully on `SIGINT` and `SIGTERM` signals.
+- [`@gquittet/graceful-server`](https://github.com/gquittet/graceful-server)
+  Tiny (~5k), Fast, KISS, and dependency-free Node.JS library to make your
+  Fastify API graceful.
+- [`@immobiliarelabs/fastify-metrics`](https://github.com/immobiliare/fastify-metrics)
+  Minimalistic and opinionated plugin that collects usage/process metrics and
+  dispatches to [statsd](https://github.com/statsd/statsd).
+- [`@mgcrea/fastify-graceful-exit`](https://github.com/mgcrea/fastify-graceful-exit)
+  A plugin to close the server gracefully
+- [`@mgcrea/fastify-request-logger`](https://github.com/mgcrea/fastify-request-logger)
+  A plugin to enable compact request logging for Fastify
+- [`@mgcrea/fastify-session-redis-store`](https://github.com/mgcrea/fastify-session-redis-store)
+  Redis store for @mgcrea/fastify-session using ioredis
+- [`@mgcrea/fastify-session-sodium-crypto`](https://github.com/mgcrea/fastify-session-sodium-crypto)
+  Fast sodium-based crypto for @mgcrea/fastify-session
+- [`@mgcrea/fastify-session`](https://github.com/mgcrea/fastify-session) Session
+  plugin for Fastify that supports both stateless and stateful sessions
+- [`@mgcrea/pino-pretty-compact`](https://github.com/mgcrea/pino-pretty-compact)
+  A custom compact pino-base prettifier
+- [`@trubavuong/fastify-seaweedfs`](https://github.com/trubavuong/fastify-seaweedfs)
+  SeaweedFS for Fastify
+- [`apollo-server-fastify`](https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-fastify)
+  Run an [Apollo Server](https://github.com/apollographql/apollo-server) to
+  serve GraphQL with Fastify.
+- [`arecibo`](https://github.com/nucleode/arecibo) Fastify ping responder for
+  Kubernetes Liveness and Readiness Probes.
+- [`cls-rtracer`](https://github.com/puzpuzpuz/cls-rtracer) Fastify middleware
+  for CLS-based request ID generation. An out-of-the-box solution for adding
+  request IDs into your logs.
+- [`fastify-405`](https://github.com/Eomm/fastify-405) Fastify plugin that adds
+  405 HTTP status to your routes
+- [`fastify-allow`](https://github.com/mattbishop/fastify-allow) Fastify plugin
+  that automatically adds an Allow header to responses with routes. Also sends
+  405 responses for routes that have a handler but not for the request's method.
+- [`fastify-amqp`](https://github.com/RafaelGSS/fastify-amqp) Fastify AMQP
+  connection plugin, to use with RabbitMQ or another connector. Just a wrapper
+  to [`amqplib`](https://github.com/squaremo/amqp.node).
+- [`fastify-angular-universal`](https://github.com/exequiel09/fastify-angular-universal)
+  Angular server-side rendering support using
+  [`@angular/platform-server`](https://github.com/angular/angular/tree/master/packages/platform-server)
+  for Fastify
+- [`fastify-api-key`](https://github.com/arkerone/fastify-api-key) Fastify
+  plugin to authenticate HTTP requests based on api key and signature
+- [`fastify-appwrite`](https://github.com/Dev-Manny/fastify-appwrite) Fastify
+  Plugin for interacting with Appwrite server.
+- [`fastify-auth0-verify`](https://github.com/nearform/fastify-auth0-verify):
+  Auth0 verification plugin for Fastify, internally uses
+  [fastify-jwt](https://npm.im/fastify-jwt) and
+  [jsonwebtoken](https://npm.im/jsonwebtoken).
+- [`fastify-autocrud`](https://github.com/paranoiasystem/fastify-autocrud)
+  Plugin to auto-generate CRUD routes as fast as possible.
+- [`fastify-autoroutes`](https://github.com/GiovanniCardamone/fastify-autoroutes)
+  Plugin to scan and load routes based on filesystem path from a custom
+  directory.
+- [`fastify-axios`](https://github.com/davidedantonio/fastify-axios) Plugin to
+  send HTTP requests via [axios](https://github.com/axios/axios).
+- [`fastify-babel`](https://github.com/cfware/fastify-babel) Fastify plugin for
+  development servers that require Babel transformations of JavaScript sources.
+- [`fastify-bcrypt`](https://github.com/heply/fastify-bcrypt) A Bcrypt hash
+  generator & checker.
+- [`fastify-blipp`](https://github.com/PavelPolyakov/fastify-blipp) Prints your
+  routes to the console, so you definitely know which endpoints are available.
+- [`fastify-bookshelf`](https://github.com/butlerx/fastify-bookshelfjs) Fastify
+  plugin to add [bookshelf.js](https://bookshelfjs.org/) ORM support.
+- [`fastify-boom`](https://github.com/jeromemacias/fastify-boom) Fastify plugin
+  to add [boom](https://github.com/hapijs/boom) support.
+- [`fastify-bree`](https://github.com/climba03003/fastify-bree) Fastify plugin
+  to add [bree](https://github.com/breejs/bree) support.
+- [`fastify-casbin`](https://github.com/nearform/fastify-casbin) Casbin support
+  for Fastify.
+- [`fastify-casbin-rest`](https://github.com/nearform/fastify-casbin-rest)
+  Casbin support for Fastify based on a RESTful model.
+- [`fastify-casl`](https://github.com/Inlecom/fastify-casl) Fastify
+  [CASL](https://github.com/stalniy/casl) plugin that supports ACL-like
+  protection of endpoints via either a preSerialization & preHandler hook,
+  sanitizing the inputs and outputs of your application based on user rights.
+- [`fastify-cloudevents`](https://github.com/smartiniOnGitHub/fastify-cloudevents)
+  Fastify plugin to generate and forward Fastify events in the Cloudevents
+  format.
+- [`fastify-cockroachdb`](https://github.com/alex-ppg/fastify-cockroachdb)
+  Fastify plugin to connect to a CockroachDB PostgreSQL instance via the
+  Sequelize ORM.
+- [`fastify-couchdb`](https://github.com/nigelhanlon/fastify-couchdb) Fastify
+  plugin to add CouchDB support via [nano](https://github.com/apache/nano).
+- [`fastify-crud-generator`](https://github.com/heply/fastify-crud-generator) A
+  plugin to rapidly generate CRUD routes for any entity.
+- [`fastify-custom-healthcheck`](https://github.com/gkampitakis/fastify-custom-healthcheck)
+  Fastify plugin to add health route in your server that asserts custom
+  functions.
+- [`fastify-decorators`](https://github.com/L2jLiga/fastify-decorators) Fastify
+  plugin that provides the set of TypeScript decorators.
+- [`fastify-disablecache`](https://github.com/Fdawgs/fastify-disablecache)
+  Fastify plugin to disable client-side caching, inspired by
+  [nocache](https://github.com/helmetjs/nocache).
+- [`fastify-dynamodb`](https://github.com/matrus2/fastify-dynamodb) AWS DynamoDB
+  plugin for Fastify. It exposes
+  [AWS.DynamoDB.DocumentClient()](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html)
+  object.
+- [`fastify-dynareg`](https://github.com/greguz/fastify-dynareg) Dynamic plugin
+  register for Fastify.
+- [`fastify-early-hints`](https://github.com/zekth/fastify-early-hints) Plugin
+  to add HTTP 103 feature based on [RFC
+  8297](https://httpwg.org/specs/rfc8297.html)
+- [`fastify-envalid`](https://github.com/alemagio/fastify-envalid) Fastify
+  plugin to integrate [envalid](https://github.com/af/envalid) in your Fastify
+  project.
+- [`fastify-error-page`](https://github.com/hemerajs/fastify-error-page) Fastify
+  plugin to print errors in structured HTML to the browser.
+- [`fastify-esso`](https://github.com/patrickpissurno/fastify-esso) The easiest
+  authentication plugin for Fastify, with built-in support for Single sign-on
+  (and great documentation).
+- [`fastify-explorer`](https://github.com/Eomm/fastify-explorer) Get control of
+  your decorators across all the encapsulated contexts.
+- [`fastify-favicon`](https://github.com/smartiniOnGitHub/fastify-favicon)
+  Fastify plugin to serve default favicon.
+- [`fastify-feature-flags`](https://gitlab.com/m03geek/fastify-feature-flags)
+  Fastify feature flags plugin with multiple providers support (e.g. env,
+  [config](https://lorenwest.github.io/node-config/),
+  [unleash](https://unleash.github.io/)).
+- [`fastify-file-upload`](https://github.com/huangang/fastify-file-upload)
+  Fastify plugin for uploading files.
+- [`fastify-firebase`](https://github.com/now-ims/fastify-firebase) Fastify
+  plugin for [Firebase Admin SDK](https://firebase.google.com/docs/admin/setup)
+  to Fastify so you can easily use Firebase Auth, Firestore, Cloud Storage,
+  Cloud Messaging, and more.
+- [`fastify-firebase-auth`](https://github.com/oxsav/fastify-firebase-auth)
+  Firebase Authentication for Fastify supporting all of the methods relating to
+  the authentication API.
+- [`fastify-formidable`](https://github.com/climba03003/fastify-formidable)
+  Handy plugin to provide multipart support and fastify-swagger integration.
+- [`fastify-gcloud-trace`](https://github.com/mkinoshi/fastify-gcloud-trace)
+  [Google Cloud Trace API](https://cloud.google.com/trace/docs/reference)
+  Connector for Fastify.
+- [`fastify-get-head`](https://github.com/MetCoder95/fastify-get-head) Small
+  plugin to set a new HEAD route handler for each GET route previously
+  registered in Fastify.
+- [`fastify-good-sessions`](https://github.com/Phara0h/fastify-good-sessions) A
+  good Fastify sessions plugin focused on speed.
+- [`fastify-google-cloud-storage`](https://github.com/carlozamagni/fastify-google-cloud-storage)
+  Fastify plugin that exposes a GCP Cloud Storage client instance.
+- [`fastify-grant`](https://github.com/simov/fastify-grant)
+  Authentication/Authorization plugin for Fastify that supports 200+ OAuth
+  Providers.
+- [`fastify-guard`](https://github.com/hsynlms/fastify-guard) A Fastify plugin
+  that protects endpoints by checking authenticated user roles and/or scopes.
+- [`fastify-graceful-shutdown`](https://github.com/hemerajs/fastify-graceful-shutdown)
+  Shutdown Fastify gracefully and asynchronously.
+- [`fastify-hasura`](https://github.com/ManUtopiK/fastify-hasura) A Fastify
+  plugin to have fun with [Hasura](https://github.com/hasura/graphql-engine).
+- [`fastify-healthcheck`](https://github.com/smartiniOnGitHub/fastify-healthcheck)
+  Fastify plugin to serve a health check route and a probe script.
+- [`fastify-hemera`](https://github.com/hemerajs/fastify-hemera) Fastify Hemera
+  plugin, for writing reliable & fault-tolerant microservices with
+  [nats.io](https://nats.io/).
+- [`fastify-http-context`](https://github.com/thorough-developer/fastify-http-context)
+  Fastify plugin for "simulating" a thread of execution to allow for true HTTP
+  context to take place per API call within the Fastify lifecycle of calls.
+- [`fastify-http2https`](https://github.com/lolo32/fastify-http2https) Redirect
+  HTTP requests to HTTPS, both using the same port number, or different response
+  on HTTP and HTTPS.
+- [`fastify-http-client`](https://github.com/kenuyx/fastify-http-client) Plugin
+  to send HTTP(s) requests. Built upon
+  [urllib](https://github.com/node-modules/urllib).
+- [`fastify-http-errors-enhanced`](https://github.com/ShogunPanda/fastify-http-errors-enhanced)
+  An error handling plugin for Fastify that uses enhanced HTTP errors.
+- [`fastify-https-redirect`](https://github.com/tomsvogel/fastify-https-redirect)
+  Fastify plugin for auto-redirect from HTTP to HTTPS.
+- [`fastify-influxdb`](https://github.com/alex-ppg/fastify-influxdb) Fastify
+  InfluxDB plugin connecting to an InfluxDB instance via the Influx default
+  package.
+- [`fastify-jwt-authz`](https://github.com/Ethan-Arrowood/fastify-jwt-authz) JWT
+  user scope verifier.
+- [`fastify-jwt-webapp`](https://github.com/charlesread/fastify-jwt-webapp) JWT
+  authentication for Fastify-based web apps.
+- [`fastify-knexjs`](https://github.com/chapuletta/fastify-knexjs) Fastify
+  plugin for support KnexJS Query Builder.
+- [`fastify-knexjs-mock`](https://github.com/chapuletta/fastify-knexjs-mock)
+  Fastify Mock KnexJS for testing support.
+- [`fastify-kubernetes`](https://github.com/greguz/fastify-kubernetes) Fastify
+  Kubernetes client plugin.
+- [`fastify-language-parser`](https://github.com/lependu/fastify-language-parser)
+  Fastify plugin to parse request language.
+- [`fastify-loader`](https://github.com/TheNoim/fastify-loader) Load routes from
+  a directory and inject the Fastify instance in each file.
+- [`fastify-lured`](https://github.com/lependu/fastify-lured) Plugin to load lua
+  scripts with [fastify-redis](https://github.com/fastify/fastify-redis) and
+  [lured](https://github.com/enobufs/lured).
+- [`fastify-mailer`](https://github.com/coopflow/fastify-mailer) Plugin to
+  initialize and encapsulate [Nodemailer](https://nodemailer.com)'s transporters
+  instances in Fastify.
+- [`fastify-markdown`](https://github.com/freezestudio/fastify-markdown) Plugin
+  to markdown support.
+- [`fastify-method-override`](https://github.com/corsicanec82/fastify-method-override)
+  Plugin for Fastify, which allows the use of HTTP verbs, such as DELETE, PATCH,
+  HEAD, PUT, OPTIONS in case the client doesn't support them.
+- [`fastify-metrics`](https://gitlab.com/m03geek/fastify-metrics) Plugin for
+  exporting [Prometheus](https://prometheus.io) metrics.
+- [`fastify-minify`](https://github.com/Jelenkee/fastify-minify) Plugin for
+  minification and transformation of responses.
+- [`fastify-mongo-memory`](https://github.com/chapuletta/fastify-mongo-memory)
+  Fastify MongoDB in Memory Plugin for testing support.
+- [`fastify-mongoose-api`](https://github.com/jeka-kiselyov/fastify-mongoose-api)
+  Fastify plugin to create REST API methods based on Mongoose MongoDB models.
+- [`fastify-mongoose-driver`](https://github.com/alex-ppg/fastify-mongoose)
+  Fastify Mongoose plugin that connects to a MongoDB via the Mongoose plugin
+  with support for Models.
+- [`fastify-msgpack`](https://github.com/kenriortega/fastify-msgpack) Fastify
+  and MessagePack, together at last. Uses @msgpack/msgpack by default.
+- [`fastify-multer`](https://github.com/fox1t/fastify-multer) Multer is a plugin
+  for handling multipart/form-data, which is primarily used for uploading files.
+- [`fastify-nats`](https://github.com/mahmed8003/fastify-nats) Plugin to share
+  [NATS](https://nats.io) client across Fastify.
+- [`fastify-no-additional-properties`](https://github.com/greguz/fastify-no-additional-properties)
+  Add `additionalProperties: false` by default to your JSON Schemas.
+- [`fastify-no-icon`](https://github.com/jsumners/fastify-no-icon) Plugin to
+  eliminate thrown errors for `/favicon.ico` requests.
+- [`fastify-nodemailer`](https://github.com/lependu/fastify-nodemailer) Plugin
+  to share [nodemailer](https://nodemailer.com) transporter across Fastify.
+- [`fastify-normalize-request-reply`](https://github.com/ericrglass/fastify-normalize-request-reply)
+  Plugin to normalize the request and reply to the Express version 4.x request
+  and response, which allows use of middleware, like swagger-stats, that was
+  originally written for Express.
+- [`fastify-now`](https://github.com/yonathan06/fastify-now) Structure your
+  endpoints in a folder and load them dynamically with Fastify.
+- [`fastify-nuxtjs`](https://github.com/gomah/fastify-nuxtjs) Vue server-side
+  rendering support for Fastify with Nuxt.js Framework.
+- [`fastify-oas`](https://gitlab.com/m03geek/fastify-oas) Generates OpenAPI 3.0+
+  documentation from routes schemas for Fastify.
+- [`fastify-objectionjs`](https://github.com/jarcodallo/fastify-objectionjs)
+  Plugin for the Fastify framework that provides integration with objectionjs
+  ORM.
+- [`fastify-objectionjs-classes`](https://github.com/kamikazechaser/fastify-objectionjs-classes)
+  Plugin to cherry-pick classes from objectionjs ORM.
+- [`fastify-openapi-docs`](https://github.com/ShogunPanda/fastify-openapi-docs)
+  A Fastify plugin that generates OpenAPI spec automatically.
+- [`fastify-openapi-glue`](https://github.com/seriousme/fastify-openapi-glue)
+  Glue for OpenAPI specifications in Fastify, autogenerates routes based on an
+  OpenAPI Specification.
+- [`fastify-opentelemetry`](https://github.com/autotelic/fastify-opentelemetry)
+  A Fastify plugin that uses the [OpenTelemetry
+  API](https://github.com/open-telemetry/opentelemetry-js-api) to provide
+  request tracing.
+- [`fastify-oracle`](https://github.com/cemremengu/fastify-oracle) Attaches an
+  [`oracledb`](https://github.com/oracle/node-oracledb) connection pool to a
+  Fastify server instance.
+- [`fastify-orientdb`](https://github.com/mahmed8003/fastify-orientdb) Fastify
+  OrientDB connection plugin, with which you can share the OrientDB connection
+  across every part of your server.
+- [`fastify-piscina`](https://github.com/piscinajs/fastify-piscina) A worker
+  thread pool plugin using [Piscina](https://github.com/piscinajs/piscina).
+- [`fastify-peekaboo`](https://github.com/simone-sanfratello/fastify-peekaboo)
+  Fastify plugin for memoize responses by expressive settings.
+- [`fastify-polyglot`](https://github.com/heply/fastify-polyglot) A plugin to
+  handle i18n using
+  [node-polyglot](https://www.npmjs.com/package/node-polyglot).
+- [`fastify-postgraphile`](https://github.com/alemagio/fastify-postgraphile)
+  Plugin to integrate [PostGraphile](https://www.graphile.org/postgraphile/) in
+  a Fastify project.
+- [`fastify-prettier`](https://github.com/hsynlms/fastify-prettier) A Fastify
+  plugin that uses [prettier](https://github.com/prettier/prettier) under the
+  hood to beautify outgoing responses and/or other things in the Fastify server.
+- [`fastify-print-routes`](https://github.com/ShogunPanda/fastify-print-routes)
+  A Fastify plugin that prints all available routes.
+- [`fastify-protobufjs`](https://github.com/kenriortega/fastify-protobufjs)
+  Fastify and protobufjs, together at last. Uses protobufjs by default.
+- [`fastify-qrcode`](https://github.com/chonla/fastify-qrcode) This plugin
+  utilizes [qrcode](https://github.com/soldair/node-qrcode) to generate QR Code.
+- [`fastify-qs`](https://github.com/webdevium/fastify-qs) A plugin for Fastify
+  that adds support for parsing URL query parameters with
+  [qs](https://github.com/ljharb/qs).
+- [`fastify-raw-body`](https://github.com/Eomm/fastify-raw-body) Add the
+  `request.rawBody` field.
+- [`fastify-rbac`](https://gitlab.com/m03geek/fastify-rbac) Fastify role-based
+  access control plugin.
+- [`fastify-recaptcha`](https://github.com/qwertyforce/fastify-recaptcha)
+  Fastify plugin for recaptcha verification.
+- [`fastify-redis-channels`](https://github.com/hearit-io/fastify-redis-channels)
+  A plugin for fast, reliable, and scalable channels implementation based on
+  Redis streams.
+- [`fastify-register-routes`](https://github.com/israeleriston/fastify-register-routes)
+  Plugin to automatically load routes from a specified path and optionally limit
+  loaded file names by a regular expression.
+- [`fastify-response-time`](https://github.com/lolo32/fastify-response-time) Add
+  `X-Response-Time` header at each request for Fastify, in milliseconds.
+- [`fastify-response-caching`](https://github.com/codeaholicguy/fastify-response-caching)
+  A Fastify plugin for caching the response.
+- [`fastify-resty`](https://github.com/FastifyResty/fastify-resty) Fastify-based
+  web framework with REST API routes auto-generation for TypeORM entities using
+  DI and decorators.
+- [`fastify-reverse-routes`](https://github.com/dimonnwc3/fastify-reverse-routes)
+  Fastify reverse routes plugin, allows to defined named routes and build path
+  using name and parameters.
+- [`fastify-rob-config`](https://github.com/jeromemacias/fastify-rob-config)
+  Fastify Rob-Config integration.
+- [`fastify-route-group`](https://github.com/TakNePoidet/fastify-route-group)
+  Convenient grouping and inheritance of routes
+- [`fastify-schema-constraint`](https://github.com/Eomm/fastify-schema-constraint)
+  Choose the JSON schema to use based on request parameters.
+- [`fastify-schema-to-typescript`](https://github.com/thomasthiebaud/fastify-schema-to-typescript)
+  Generate typescript types based on your JSON/YAML validation schemas so they
+  are always in sync.
+- [`fastify-secure-session`](https://github.com/mcollina/fastify-secure-session)
+  Create a secure stateless cookie session for Fastify.
+- [`fastify-sentry`](https://github.com/alex-ppg/fastify-sentry) Fastify plugin
+  to add the Sentry SDK error handler to requests.
+- [`fastify-sequelize`](https://github.com/lyquocnam/fastify-sequelize) Fastify
+  plugin work with Sequelize (adapter for NodeJS -> Sqlite, Mysql, Mssql,
+  Postgres).
+- [`fastify-server-session`](https://github.com/jsumners/fastify-server-session)
+  A session plugin with support for arbitrary backing caches via
+  `fastify-caching`.
+- [`fastify-slonik`](https://github.com/Unbuttun/fastify-slonik) Fastify Slonik
+  plugin, with this you can use slonik in every part of your server.
+- [`fastify-soap-client`](https://github.com/fastify/fastify-soap-client) a SOAP
+  client plugin for Fastify.
+- [`fastify-socket.io`](https://github.com/alemagio/fastify-socket.io) a
+  Socket.io plugin for Fastify.
+- [`fastify-sse`](https://github.com/lolo32/fastify-sse) to provide Server-Sent
+  Events with `reply.sse( … )` to Fastify.
+- [`fastify-sse-v2`](https://github.com/nodefactoryio/fastify-sse-v2) to provide
+  Server-Sent Events using Async Iterators (supports newer versions of Fastify).
+- [`fastify-stripe`](https://github.com/coopflow/fastify-stripe) Plugin to
+  initialize and encapsulate [Stripe
+  Node.js](https://github.com/stripe/stripe-node) instances in Fastify.
+- [`fastify-supabase`](https://github.com/coopflow/fastify-supabase) Plugin to
+  initialize and encapsulate [Supabase](https://github.com/supabase/supabase-js)
+  instances in Fastify.
+- [`fastify-tls-keygen`](https://gitlab.com/sebdeckers/fastify-tls-keygen)
+  Automatically generate a browser-compatible, trusted, self-signed,
+  localhost-only, TLS certificate.
+- [`fastify-tokenize`](https://github.com/Bowser65/fastify-tokenize)
+  [Tokenize](https://github.com/Bowser65/Tokenize) plugin for Fastify that
+  removes the pain of managing authentication tokens, with built-in integration
+  for `fastify-auth`.
+- [`fastify-totp`](https://github.com/heply/fastify-totp) A plugin to handle
+  TOTP (e.g. for 2FA).
+- [`fastify-twitch-ebs-tools`](https://github.com/lukemnet/fastify-twitch-ebs-tools)
+  Useful functions for Twitch Extension Backend Services (EBS).
+- [`fastify-typeorm-plugin`](https://github.com/inthepocket/fastify-typeorm-plugin)
+  Fastify plugin to work with TypeORM.
+- [`fastify-vhost`](https://github.com/patrickpissurno/fastify-vhost) Proxy
+  subdomain HTTP requests to another server (useful if you want to point
+  multiple subdomains to the same IP address, while running different servers on
+  the same machine).
+- [`fastify-vite`](https://github.com/galvez/fastify-vite)
+  [Vite](https://vitejs.dev/) plugin for Fastify with SSR data support.
+- [`fastify-vue-plugin`](https://github.com/TheNoim/fastify-vue)
+  [Nuxt.js](https://nuxtjs.org) plugin for Fastify. Control the routes nuxt
+  should use.
+- [`fastify-wamp-router`](https://github.com/lependu/fastify-wamp-router) Web
+  Application Messaging Protocol router for Fastify.
+- [`fast-water`](https://github.com/tswayne/fast-water) A Fastify plugin for
+  waterline. Decorates Fastify with waterline models.
+- [`fastify-webpack-hmr`](https://github.com/lependu/fastify-webpack-hmr)
+  Webpack hot module reloading plugin for Fastify.
+- [`fastify-ws`](https://github.com/gj/fastify-ws) WebSocket integration for
+  Fastify — with support for WebSocket lifecycle hooks instead of a single
+  handler function. Built upon [ws](https://github.com/websockets/ws) and
+  [uws](https://github.com/uNetworking/uWebSockets).
+- [`fastify-xml-body-parser`](https://github.com/NaturalIntelligence/fastify-xml-body-parser)
+  Parse XML payload / request body into JS / JSON object.
+- [`fastify-xray`](https://github.com/jeromemacias/fastify-xray) Fastify plugin
+  for AWS XRay recording.
+- [`i18next-http-middleware`](https://github.com/i18next/i18next-http-middleware#fastify-usage)
+  An [i18next](https://www.i18next.com) based i18n (internationalization)
+  middleware to be used with Node.js web frameworks like Express or Fastify and
+  also for Deno.
+- [`k-fastify-gateway`](https://github.com/jkyberneees/fastify-gateway) API
+  Gateway plugin for Fastify, a low footprint implementation that uses the
+  `fastify-reply-from` HTTP proxy library.
+- [`mercurius`](https://mercurius.dev/) A fully-featured and performant GraphQL
+  server implementation for Fastify.
+- [`nstats`](https://github.com/Phara0h/nstats) A fast and compact way to get
+  all your network and process stats for your node application. Websocket,
+  HTTP/S, and prometheus compatible!
+- [`oas-fastify`](https://github.com/ahmadnassri/node-oas-fastify) OAS 3.x to
+  Fastify routes automation. Automatically generates route handlers with fastify
+  configuration and validation.
+- [`openapi-validator-middleware`](https://github.com/PayU/openapi-validator-middleware#fastify)
+  Swagger and OpenAPI 3.0 spec-based request validation middleware that supports
+  Fastify.
+- [`sequelize-fastify`](https://github.com/hsynlms/sequelize-fastify) A simple
+  and lightweight Sequelize plugin for Fastify.

--- a/docs/Guides/Fluent-Schema.md
+++ b/docs/Guides/Fluent-Schema.md
@@ -2,10 +2,10 @@
 
 ## Fluent Schema
 
-The [Validation and Serialization](/docs/Reference/Validation-and-Serialization.md)
-documentation outlines all parameters accepted by Fastify to set up JSON Schema
-Validation to validate the input, and JSON Schema Serialization to optimize the
-output.
+The [Validation and
+Serialization](/docs/Reference/Validation-and-Serialization.md) documentation
+outlines all parameters accepted by Fastify to set up JSON Schema Validation to
+validate the input, and JSON Schema Serialization to optimize the output.
 
 [`fluent-json-schema`](https://github.com/fastify/fluent-json-schema) can be
 used to simplify this task while allowing the reuse of constants.

--- a/docs/Guides/Getting-Started.md
+++ b/docs/Guides/Getting-Started.md
@@ -4,7 +4,9 @@
 
 Hello! Thank you for checking out Fastify!
 
-This document aims to be a gentle introduction to the framework and its features. It is an elementary preface with examples and links to other parts of the documentation.
+This document aims to be a gentle introduction to the framework and its
+features. It is an elementary preface with examples and links to other parts of
+the documentation.
 
 Let's start!
 
@@ -54,7 +56,9 @@ fastify.listen(3000, function (err, address) {
 
 Do you prefer to use `async/await`? Fastify supports it out-of-the-box.
 
-*(We also suggest using [make-promises-safe](https://github.com/mcollina/make-promises-safe) to avoid file descriptor and memory leaks.)*
+*(We also suggest using
+[make-promises-safe](https://github.com/mcollina/make-promises-safe) to avoid
+file descriptor and memory leaks.)*
 ```js
 // ESM
 import Fastify from 'fastify'
@@ -83,12 +87,19 @@ start()
 
 Awesome, that was easy.
 
-Unfortunately, writing a complex application requires significantly more code than this example. A classic problem when you are building a new application is how to handle multiple files, asynchronous bootstrapping, and the architecture of your code.
+Unfortunately, writing a complex application requires significantly more code
+than this example. A classic problem when you are building a new application is
+how to handle multiple files, asynchronous bootstrapping, and the architecture
+of your code.
 
-Fastify offers an easy platform that helps to solve all of the problems outlined above, and more!
+Fastify offers an easy platform that helps to solve all of the problems outlined
+above, and more!
 
 > ## Note
-> The above examples, and subsequent examples in this document, default to listening *only* on the localhost `127.0.0.1` interface. To listen on all available IPv4 interfaces the example should be modified to listen on `0.0.0.0` like so:
+> The above examples, and subsequent examples in this document, default to
+> listening *only* on the localhost `127.0.0.1` interface. To listen on all
+> available IPv4 interfaces the example should be modified to listen on
+> `0.0.0.0` like so:
 >
 > ```js
 > fastify.listen(3000, '0.0.0.0', function (err, address) {
@@ -100,18 +111,24 @@ Fastify offers an easy platform that helps to solve all of the problems outlined
 > })
 > ```
 >
-> Similarly, specify `::1` to accept only local connections via IPv6. Or specify `::` to accept connections on all IPv6 addresses, and, if the operating system supports it, also on all IPv4 addresses.
+> Similarly, specify `::1` to accept only local connections via IPv6. Or specify
+> `::` to accept connections on all IPv6 addresses, and, if the operating system
+> supports it, also on all IPv4 addresses.
 >
-> When deploying to a Docker (or another type of) container using `0.0.0.0` or `::` would be the easiest method for exposing the application.
+> When deploying to a Docker (or another type of) container using `0.0.0.0` or
+> `::` would be the easiest method for exposing the application.
 
 ### Your first plugin
 <a id="first-plugin"></a>
 
-As with JavaScript, where everything is an object, with Fastify everything is a plugin.
+As with JavaScript, where everything is an object, with Fastify everything is a
+plugin.
 
 Before digging into it, let's see how it works!
 
-Let's declare our basic server, but instead of declaring the route inside the entry point, we'll declare it in an external file (check out the [route declaration](../Reference/Routes.md) docs).
+Let's declare our basic server, but instead of declaring the route inside the
+entry point, we'll declare it in an external file (check out the [route
+declaration](../Reference/Routes.md) docs).
 ```js
 // ESM
 import Fastify from 'fastify'
@@ -159,13 +176,19 @@ async function routes (fastify, options) {
 
 module.exports = routes
 ```
-In this example, we used the `register` API, which is the core of the Fastify framework. It is the only way to add routes, plugins, et cetera.
+In this example, we used the `register` API, which is the core of the Fastify
+framework. It is the only way to add routes, plugins, et cetera.
 
-At the beginning of this guide, we noted that Fastify provides a foundation that assists with asynchronous bootstrapping of your application. Why is this important?
+At the beginning of this guide, we noted that Fastify provides a foundation that
+assists with asynchronous bootstrapping of your application. Why is this
+important?
 
-Consider the scenario where a database connection is needed to handle data storage. The database connection needs to be available before the server is accepting connections. How do we address this problem?
+Consider the scenario where a database connection is needed to handle data
+storage. The database connection needs to be available before the server is
+accepting connections. How do we address this problem?
 
-A typical solution is to use a complex callback, or promises - a system that will mix the framework API with other libraries and the application code.
+A typical solution is to use a complex callback, or promises - a system that
+will mix the framework API with other libraries and the application code.
 
 Fastify handles this internally, with minimum effort!
 
@@ -304,20 +327,34 @@ Wow, that was fast!
 
 Let's recap what we have done here since we've introduced some new concepts.
 
-As you can see, we used `register` for both the database connector and the registration of the routes.
+As you can see, we used `register` for both the database connector and the
+registration of the routes.
 
-This is one of the best features of Fastify, it will load your plugins in the same order you declare them, and it will load the next plugin only once the current one has been loaded. In this way, we can register the database connector in the first plugin and use it in the second *(read [here](../Reference/Plugins.md#handle-the-scope) to understand how to handle the scope of a plugin)*.
+This is one of the best features of Fastify, it will load your plugins in the
+same order you declare them, and it will load the next plugin only once the
+current one has been loaded. In this way, we can register the database connector
+in the first plugin and use it in the second *(read
+[here](../Reference/Plugins.md#handle-the-scope) to understand how to handle the
+scope of a plugin)*.
 
-Plugin loading starts when you call `fastify.listen()`, `fastify.inject()` or `fastify.ready()`
+Plugin loading starts when you call `fastify.listen()`, `fastify.inject()` or
+`fastify.ready()`
 
-The MongoDB plugin uses the `decorate` API to add custom objects to the Fastify instance, making them available for use everywhere. Use of this API is encouraged to facilitate easy code reuse and to decrease code or logic duplication.
+The MongoDB plugin uses the `decorate` API to add custom objects to the Fastify
+instance, making them available for use everywhere. Use of this API is
+encouraged to facilitate easy code reuse and to decrease code or logic
+duplication.
 
-To dig deeper into how Fastify plugins work, how to develop new plugins, and for details on how to use the whole Fastify API to deal with the complexity of asynchronously bootstrapping an application, read [the hitchhiker's guide to plugins](./Plugins-Guide.md).
+To dig deeper into how Fastify plugins work, how to develop new plugins, and for
+details on how to use the whole Fastify API to deal with the complexity of
+asynchronously bootstrapping an application, read [the hitchhiker's guide to
+plugins](./Plugins-Guide.md).
 
 ### Loading order of your plugins
 <a id="plugin-loading-order"></a>
 
-To guarantee consistent and predictable behavior of your application, we highly recommend to always load your code as shown below:
+To guarantee consistent and predictable behavior of your application, we highly
+recommend to always load your code as shown below:
 ```
 └── plugins (from the Fastify ecosystem)
 └── your plugins (your custom plugins)
@@ -325,9 +362,13 @@ To guarantee consistent and predictable behavior of your application, we highly 
 └── hooks
 └── your services
 ```
-In this way, you will always have access to all of the properties declared in the current scope.
+In this way, you will always have access to all of the properties declared in
+the current scope.
 
-As discussed previously, Fastify offers a solid encapsulation model, to help you build your application as single and independent services. If you want to register a plugin only for a subset of routes, you just have to replicate the above structure.
+As discussed previously, Fastify offers a solid encapsulation model, to help you
+build your application as single and independent services. If you want to
+register a plugin only for a subset of routes, you just have to replicate the
+above structure.
 ```
 └── plugins (from the Fastify ecosystem)
 └── your plugins (your custom plugins)
@@ -355,7 +396,8 @@ As discussed previously, Fastify offers a solid encapsulation model, to help you
 
 Data validation is extremely important and a core concept of the framework.
 
-To validate incoming requests, Fastify uses [JSON Schema](https://json-schema.org/).
+To validate incoming requests, Fastify uses [JSON
+Schema](https://json-schema.org/).
 
 (JTD schemas are loosely supported, but `jsonShorthand` must be disabled first)
 
@@ -377,16 +419,21 @@ fastify.post('/', opts, async (request, reply) => {
   return { hello: 'world' }
 })
 ```
-This example shows how to pass an options object to the route, which accepts a `schema` key that contains all of the schemas for route, `body`, `querystring`, `params`, and `headers`.
+This example shows how to pass an options object to the route, which accepts a
+`schema` key that contains all of the schemas for route, `body`, `querystring`,
+`params`, and `headers`.
 
-Read [Validation and Serialization](../Reference/Validation-and-Serialization.md) to learn more.
+Read [Validation and
+Serialization](../Reference/Validation-and-Serialization.md) to learn more.
 
 ### Serialize your data
 <a id="serialize-data"></a>
 
-Fastify has first class support for JSON. It is extremely optimized to parse JSON bodies and to serialize JSON output.
+Fastify has first class support for JSON. It is extremely optimized to parse
+JSON bodies and to serialize JSON output.
 
-To speed up JSON serialization (yes, it is slow!) use the `response` key of the schema option as shown in the following example:
+To speed up JSON serialization (yes, it is slow!) use the `response` key of the
+schema option as shown in the following example:
 ```js
 const opts = {
   schema: {
@@ -405,13 +452,18 @@ fastify.get('/', opts, async (request, reply) => {
   return { hello: 'world' }
 })
 ```
-By specifying a schema as shown, you can speed up serialization by a factor of 2-3. This also helps to protect against leakage of potentially sensitive data, since Fastify will serialize only the data present in the response schema.
-Read [Validation and Serialization](../Reference/Validation-and-Serialization.md) to learn more.
+By specifying a schema as shown, you can speed up serialization by a factor of
+2-3. This also helps to protect against leakage of potentially sensitive data,
+since Fastify will serialize only the data present in the response schema. Read
+[Validation and Serialization](../Reference/Validation-and-Serialization.md) to
+learn more.
 
 ### Parsing request payloads
 <a id="request-payload"></a>
 
-Fastify parses `'application/json'` and `'text/plain'` request payloads natively, with the result accessible from the [Fastify request](../Reference/Request.md) object at `request.body`.
+Fastify parses `'application/json'` and `'text/plain'` request payloads
+natively, with the result accessible from the [Fastify
+request](../Reference/Request.md) object at `request.body`.
 
 The following example returns the parsed body of a request back to the client:
 
@@ -422,26 +474,33 @@ fastify.post('/', opts, async (request, reply) => {
 })
 ```
 
-Read [Content-Type Parser](../Reference/ContentTypeParser.md) to learn more about Fastify's default parsing functionality and how to support other content types.
+Read [Content-Type Parser](../Reference/ContentTypeParser.md) to learn more
+about Fastify's default parsing functionality and how to support other content
+types.
 
 ### Extend your server
 <a id="extend-server"></a>
 
-Fastify is built to be extremely extensible and minimal, we believe that a bare-bones framework is all that is necessary to make great applications possible.
+Fastify is built to be extremely extensible and minimal, we believe that a
+bare-bones framework is all that is necessary to make great applications
+possible.
 
-In other words, Fastify is not a "batteries included" framework, and relies on an amazing [ecosystem](./Ecosystem.md)!
+In other words, Fastify is not a "batteries included" framework, and relies on
+an amazing [ecosystem](./Ecosystem.md)!
 
 ### Test your server
 <a id="test-server"></a>
 
-Fastify does not offer a testing framework, but we do recommend a way to write your tests that uses the features and architecture of Fastify.
+Fastify does not offer a testing framework, but we do recommend a way to write
+your tests that uses the features and architecture of Fastify.
 
 Read the [testing](./Testing.md) documentation to learn more!
 
 ### Run your server from CLI
 <a id="cli"></a>
 
-Fastify also has CLI integration thanks to [fastify-cli](https://github.com/fastify/fastify-cli).
+Fastify also has CLI integration thanks to
+[fastify-cli](https://github.com/fastify/fastify-cli).
 
 First, install `fastify-cli`:
 
@@ -481,9 +540,17 @@ npm start
 <a id="slides"></a>
 
 - Slides
-  - [Take your HTTP server to ludicrous speed](https://mcollina.github.io/take-your-http-server-to-ludicrous-speed) by [@mcollina](https://github.com/mcollina)
-  - [What if I told you that HTTP can be fast](https://delvedor.github.io/What-if-I-told-you-that-HTTP-can-be-fast) by [@delvedor](https://github.com/delvedor)
+  - [Take your HTTP server to ludicrous
+    speed](https://mcollina.github.io/take-your-http-server-to-ludicrous-speed)
+    by [@mcollina](https://github.com/mcollina)
+  - [What if I told you that HTTP can be
+    fast](https://delvedor.github.io/What-if-I-told-you-that-HTTP-can-be-fast)
+    by [@delvedor](https://github.com/delvedor)
 
 - Videos
-  - [Take your HTTP server to ludicrous speed](https://www.youtube.com/watch?v=5z46jJZNe8k) by [@mcollina](https://github.com/mcollina)
-  - [What if I told you that HTTP can be fast](https://www.webexpo.net/prague2017/talk/what-if-i-told-you-that-http-can-be-fast/) by [@delvedor](https://github.com/delvedor)
+  - [Take your HTTP server to ludicrous
+    speed](https://www.youtube.com/watch?v=5z46jJZNe8k) by
+    [@mcollina](https://github.com/mcollina)
+  - [What if I told you that HTTP can be
+    fast](https://www.webexpo.net/prague2017/talk/what-if-i-told-you-that-http-can-be-fast/)
+    by [@delvedor](https://github.com/delvedor)

--- a/docs/Guides/Index.md
+++ b/docs/Guides/Index.md
@@ -1,6 +1,32 @@
-# Guides
+<h1 align="center">Fastify</h1>
 
-## General
-<a id="guides-general"></a>
+## Guides Table Of Contents
+<a id="guides-toc"></a>
 
-* [Contributing To Fastify](./Contributing.md)
+This table of contents is in alphabetical order.
+
++ [Benchmarking](./Benchmarking.md): This guide introduces how to benchmark
+  applications based upon Fastify.
++ [Contributing](./Contributing.md): Details how to participate in the
+  development of Fastify, and shows how to setup an environment compatible with
+  the project's code style.
++ [Ecosystem](./Ecosystem.md): Lists all core plugins and many known community
+  plugins.
++ [Fluent Schema](./Fluent-Schema.md): Shows how writing JSON Schema can be
+  written with a fluent API and used in Fastify.
++ [Getting Started](./Getting-Started.md): Introduction tutorial for Fastify.
+  This is where beginners should start.
++ [Migration Guide (v3)](./Migration-Guide-V3.md): Details how to migrate to
+  Fastify v3 from earlier versions.
++ [Plugins Guide](./Plugins-Guide.md): An informal introduction to writing
+  Fastify plugins.
++ [Recommendations](./Recommendations.md): Recommendations for how to deploy
+  Fastify into production environments.
++ [Serverless](./Serverless.md): Details on how to deploy Fastify applications
+  in various Function as a Service (FaaS) environments.
++ [Style Guide](./Style-Guide.md): Explains the writing style we use for the
+  Fastify documentation for those who want to contribute documentation.
++ [Testing](./Testing.md): Explains how to write unit tests for Fastify
+  applications.
++ [Write Plugin](./Write-Plugin.md): A set of guidelines for what the Fastify
+  team considers good practices for writing a Fastify plugin.

--- a/docs/Guides/Migration-Guide-V3.md
+++ b/docs/Guides/Migration-Guide-V3.md
@@ -34,9 +34,9 @@ fastify.use(require('cors')());
 
 ### Changed logging serialization ([#2017](https://github.com/fastify/fastify/pull/2017))
 
-The logging [Serializers](../Reference/Logging.md) have been updated to now Fastify
-[`Request`](../Reference/Request.md) and [`Reply`](../Reference/Reply.md) objects instead of
-native ones.
+The logging [Serializers](../Reference/Logging.md) have been updated to now
+Fastify [`Request`](../Reference/Request.md) and
+[`Reply`](../Reference/Reply.md) objects instead of native ones.
 
 Any custom serializers must be updated if they rely upon `request` or `reply`
 properties that are present on the native objects but not the Fastify objects.
@@ -79,8 +79,9 @@ const fastify = require('fastify')({
 
 The non-standard `replace-way` shared schema support has been removed. This
 feature has been replaced with JSON Schema specification compliant `$ref` based
-substitution. To help understand this change read
-[Validation and Serialization in Fastify v3](https://dev.to/eomm/validation-and-serialization-in-fastify-v3-2e8l).
+substitution. To help understand this change read [Validation and Serialization
+in Fastify
+v3](https://dev.to/eomm/validation-and-serialization-in-fastify-v3-2e8l).
 
 **v2:**
 
@@ -104,10 +105,10 @@ fastify.route({ method, url, schema, handler });
 
 ### Changed schema validation options ([#2023](https://github.com/fastify/fastify/pull/2023))
 
-The `setSchemaCompiler` and `setSchemaResolver` options have been replaced
-with the `setValidatorCompiler` to enable future tooling improvements.
-To help understand this change read
-[Validation and Serialization in Fastify v3](https://dev.to/eomm/validation-and-serialization-in-fastify-v3-2e8l).
+The `setSchemaCompiler` and `setSchemaResolver` options have been replaced with
+the `setValidatorCompiler` to enable future tooling improvements. To help
+understand this change read [Validation and Serialization in Fastify
+v3](https://dev.to/eomm/validation-and-serialization-in-fastify-v3-2e8l).
 
 **v2:**
 
@@ -136,22 +137,23 @@ fastify.setValidatorCompiler(({ schema, method, url, httpPart }) =>
 
 ### Changed preParsing hook behavior ([#2286](https://github.com/fastify/fastify/pull/2286))
 
-From Fastify v3, the behavior of the `preParsing` hook will change slightly
-in order to support request payload manipulation.
+From Fastify v3, the behavior of the `preParsing` hook will change slightly in
+order to support request payload manipulation.
 
 The hook now takes an additional argument, `payload`, and therefore the new hook
-signature is `fn(request, reply, payload, done)` or
-`async fn(request, reply, payload)`.
+signature is `fn(request, reply, payload, done)` or `async fn(request, reply,
+payload)`.
 
 The hook can optionally return a new stream via `done(null, stream)` or
 returning the stream in case of async functions.
 
-If the hook returns a new stream, it will be used instead of the original one in subsequent hooks. A sample use case for this is handling compressed requests.
+If the hook returns a new stream, it will be used instead of the original one in
+subsequent hooks. A sample use case for this is handling compressed requests.
 
 The new stream should add the `receivedEncodedLength` property to the stream
 that should reflect the actual data size received from the client. For instance,
-in a compressed request it should be the size of the compressed payload.
-This property can (and should) be dynamically updated during `data` events.
+in a compressed request it should be the size of the compressed payload. This
+property can (and should) be dynamically updated during `data` events.
 
 The old syntax of Fastify v2 without payload is supported but it is deprecated.
 
@@ -161,23 +163,24 @@ From Fastify v3, the behavior of `onRoute` and `onRegister` hooks will change
 slightly in order to support hook encapsulation.
 
 - `onRoute` - The hook will be called asynchronously. The hook is now inherited
-when registering a new plugin within the same encapsulation scope. Thus, this
-hook should be registered _before_ registering any plugins.
+  when registering a new plugin within the same encapsulation scope. Thus, this
+  hook should be registered _before_ registering any plugins.
 - `onRegister` - Same as the onRoute hook. The only difference is that now the
-very first call will no longer be the framework itself, but the first registered
-plugin.
+  very first call will no longer be the framework itself, but the first
+  registered plugin.
 
 ### Changed Content Type Parser syntax ([#2286](https://github.com/fastify/fastify/pull/2286))
 
 In Fastify v3 the content type parsers now have a single signature for parsers.
 
-The new signatures are `fn(request, payload, done)` or `async fn(request, payload)`.
-Note that `request` is now a Fastify request, not an `IncomingMessage`.
-The payload is by default a stream. If the `parseAs` option is used in
-`addContentTypeParser`, then `payload` reflects the option value (string or buffer).
+The new signatures are `fn(request, payload, done)` or `async fn(request,
+payload)`. Note that `request` is now a Fastify request, not an
+`IncomingMessage`. The payload is by default a stream. If the `parseAs` option
+is used in `addContentTypeParser`, then `payload` reflects the option value
+(string or buffer).
 
-The old signatures `fn(req, [done])` or `fn(req, payload, [done])`
-(where `req` is `IncomingMessage`) are still supported but are deprecated.
+The old signatures `fn(req, [done])` or `fn(req, payload, [done])` (where `req`
+is `IncomingMessage`) are still supported but are deprecated.
 
 ### Changed TypeScript support
 
@@ -267,15 +270,18 @@ fastify.get('/', (request, reply) => {
 ## Further additions and improvements
 
 - Hooks now have consistent context regardless of how they are registered
-([#2005](https://github.com/fastify/fastify/pull/2005))
-- Deprecated `request.req` and `reply.res` for [`request.raw`](../Reference/Request.md) and
-[`reply.raw`](../Reference/Reply.md) ([#2008](https://github.com/fastify/fastify/pull/2008))
-- Removed `modifyCoreObjects` option ([#2015](https://github.com/fastify/fastify/pull/2015))
+  ([#2005](https://github.com/fastify/fastify/pull/2005))
+- Deprecated `request.req` and `reply.res` for
+  [`request.raw`](../Reference/Request.md) and
+  [`reply.raw`](../Reference/Reply.md)
+  ([#2008](https://github.com/fastify/fastify/pull/2008))
+- Removed `modifyCoreObjects` option
+  ([#2015](https://github.com/fastify/fastify/pull/2015))
 - Added [`connectionTimeout`](../Reference/Server.md#factory-connection-timeout)
-option ([#2086](https://github.com/fastify/fastify/pull/2086))
+  option ([#2086](https://github.com/fastify/fastify/pull/2086))
 - Added [`keepAliveTimeout`](../Reference/Server.md#factory-keep-alive-timeout)
-option ([#2086](https://github.com/fastify/fastify/pull/2086))
+  option ([#2086](https://github.com/fastify/fastify/pull/2086))
 - Added async-await support for [plugins](../Reference/Plugins.md#async-await)
-([#2093](https://github.com/fastify/fastify/pull/2093))
+  ([#2093](https://github.com/fastify/fastify/pull/2093))
 - Added the feature to throw object as error
-([#2134](https://github.com/fastify/fastify/pull/2134))
+  ([#2134](https://github.com/fastify/fastify/pull/2134))

--- a/docs/Guides/Plugins-Guide.md
+++ b/docs/Guides/Plugins-Guide.md
@@ -3,14 +3,19 @@
 # The hitchhiker's guide to plugins
 First of all, `DON'T PANIC`!
 
-Fastify was built from the beginning to be an extremely modular system. We built a powerful API that allows you to add methods and utilities to Fastify by creating a namespace. We built a system that creates an encapsulation model, which allows you to split your application into multiple microservices at any moment, without the need to refactor the entire application.
+Fastify was built from the beginning to be an extremely modular system. We built
+a powerful API that allows you to add methods and utilities to Fastify by
+creating a namespace. We built a system that creates an encapsulation model,
+which allows you to split your application into multiple microservices at any
+moment, without the need to refactor the entire application.
 
 **Table of contents**
 - [The hitchhiker's guide to plugins](#the-hitchhikers-guide-to-plugins)
   - [Register](#register)
   - [Decorators](#decorators)
   - [Hooks](#hooks)
-  - [How to handle encapsulation and distribution](#how-to-handle-encapsulation-and-distribution)
+  - [How to handle encapsulation and
+    distribution](#how-to-handle-encapsulation-and-distribution)
   - [ESM support](#esm-support)
   - [Handle errors](#handle-errors)
   - [Custom errors](#custom-errors)
@@ -20,36 +25,55 @@ Fastify was built from the beginning to be an extremely modular system. We built
 ## Register
 <a id="register"></a>
 
-As with JavaScript, where everything is an object, in Fastify everything is a plugin.
+As with JavaScript, where everything is an object, in Fastify everything is a
+plugin.
 
-Your routes, your utilities, and so on are all plugins. To add a new plugin, whatever its functionality may be, in Fastify you have a nice and unique API: [`register`](../Reference/Plugins.md).
+Your routes, your utilities, and so on are all plugins. To add a new plugin,
+whatever its functionality may be, in Fastify you have a nice and unique API:
+[`register`](../Reference/Plugins.md).
 ```js
 fastify.register(
   require('./my-plugin'),
   { options }
 )
 ```
-`register` creates a new Fastify context, which means that if you perform any changes on the Fastify instance, those changes will not be reflected in the context's ancestors. In other words, encapsulation!
+`register` creates a new Fastify context, which means that if you perform any
+changes on the Fastify instance, those changes will not be reflected in the
+context's ancestors. In other words, encapsulation!
 
 *Why is encapsulation important?*
 
-Well, let's say you are creating a new disruptive startup, what do you do? You create an API server with all your stuff, everything in the same place, a monolith!
+Well, let's say you are creating a new disruptive startup, what do you do? You
+create an API server with all your stuff, everything in the same place, a
+monolith!
 
-Ok, you are growing very fast and you want to change your architecture and try microservices. Usually, this implies a huge amount of work, because of cross dependencies and a lack of separation of concerns in the codebase.
+Ok, you are growing very fast and you want to change your architecture and try
+microservices. Usually, this implies a huge amount of work, because of cross
+dependencies and a lack of separation of concerns in the codebase.
 
-Fastify helps you in that regard. Thanks to the encapsulation model, it will completely avoid cross dependencies and will help you structure your code into cohesive blocks.
+Fastify helps you in that regard. Thanks to the encapsulation model, it will
+completely avoid cross dependencies and will help you structure your code into
+cohesive blocks.
 
 *Let's return to how to correctly use `register`.*
 
-As you probably know, the required plugins must expose a single function with the following signature
+As you probably know, the required plugins must expose a single function with
+the following signature
 ```js
 module.exports = function (fastify, options, done) {}
 ```
-Where `fastify` is the encapsulated Fastify instance, `options` is the options object, and `done` is the function you **must** call when your plugin is ready.
+Where `fastify` is the encapsulated Fastify instance, `options` is the options
+object, and `done` is the function you **must** call when your plugin is ready.
 
-Fastify's plugin model is fully reentrant and graph-based, it handles asynchronous code without any problems and it enforces both the load and close order of plugins. *How?* Glad you asked, check out [`avvio`](https://github.com/mcollina/avvio)! Fastify starts loading the plugin __after__ `.listen()`, `.inject()` or `.ready()` are called.
+Fastify's plugin model is fully reentrant and graph-based, it handles
+asynchronous code without any problems and it enforces both the load and close
+order of plugins. *How?* Glad you asked, check out
+[`avvio`](https://github.com/mcollina/avvio)! Fastify starts loading the plugin
+__after__ `.listen()`, `.inject()` or `.ready()` are called.
 
-Inside a plugin you can do whatever you want, register routes, utilities (we will see this in a moment) and do nested registers, just remember to call `done` when everything is set up!
+Inside a plugin you can do whatever you want, register routes, utilities (we
+will see this in a moment) and do nested registers, just remember to call `done`
+when everything is set up!
 ```js
 module.exports = function (fastify, options, done) {
   fastify.get('/plugin', (request, reply) => {
@@ -60,12 +84,16 @@ module.exports = function (fastify, options, done) {
 }
 ```
 
-Well, now you know how to use the `register` API and how it works, but how do we add new functionality to Fastify and even better, share them with other developers?
+Well, now you know how to use the `register` API and how it works, but how do we
+add new functionality to Fastify and even better, share them with other
+developers?
 
 ## Decorators
 <a id="decorators"></a>
 
-Okay, let's say that you wrote a utility that is so good that you decided to make it available along with all your code. How would you do it? Probably something like the following:
+Okay, let's say that you wrote a utility that is so good that you decided to
+make it available along with all your code. How would you do it? Probably
+something like the following:
 ```js
 // your-awesome-utility.js
 module.exports = function (a, b) {
@@ -76,16 +104,21 @@ module.exports = function (a, b) {
 const util = require('./your-awesome-utility')
 console.log(util('that is ', 'awesome'))
 ```
-Now you will import your utility in every file you need it in. (And do not forget that you will probably also need it in your tests).
+Now you will import your utility in every file you need it in. (And do not
+forget that you will probably also need it in your tests).
 
 Fastify offers you a more elegant and comfortable way to do this, *decorators*.
-Creating a decorator is extremely easy, just use the [`decorate`](../Reference/Decorators.md) API:
+Creating a decorator is extremely easy, just use the
+[`decorate`](../Reference/Decorators.md) API:
 ```js
 fastify.decorate('util', (a, b) => a + b)
 ```
-Now you can access your utility just by calling `fastify.util` whenever you need it - even inside your test.
+Now you can access your utility just by calling `fastify.util` whenever you need
+it - even inside your test.
 
-And here starts the magic; do you remember how just now we were talking about encapsulation? Well, using `register` and `decorate` in conjunction enable exactly that, let me show you an example to clarify this:
+And here starts the magic; do you remember how just now we were talking about
+encapsulation? Well, using `register` and `decorate` in conjunction enable
+exactly that, let me show you an example to clarify this:
 ```js
 fastify.register((instance, opts, done) => {
   instance.decorate('util', (a, b) => a + b)
@@ -100,11 +133,15 @@ fastify.register((instance, opts, done) => {
   done()
 })
 ```
-Inside the second register call `instance.util` will throw an error because `util` exists only inside the first register context.
+Inside the second register call `instance.util` will throw an error because
+`util` exists only inside the first register context.
 
-Let's step back for a moment and dig deeper into this: every time you use the `register` API, a new context is created which avoids the negative situations mentioned above.
+Let's step back for a moment and dig deeper into this: every time you use the
+`register` API, a new context is created which avoids the negative situations
+mentioned above.
 
-Do note that encapsulation applies to the ancestors and siblings, but not the children.
+Do note that encapsulation applies to the ancestors and siblings, but not the
+children.
 ```js
 fastify.register((instance, opts, done) => {
   instance.decorate('util', (a, b) => a + b)
@@ -124,13 +161,19 @@ fastify.register((instance, opts, done) => {
   done()
 })
 ```
-*Take home message: if you need a utility that is available in every part of your application, take care that it is declared in the root scope of your application. If that is not an option,  you can use the `fastify-plugin` utility as described [here](#distribution).*
+*Take home message: if you need a utility that is available in every part of
+your application, take care that it is declared in the root scope of your
+application. If that is not an option,  you can use the `fastify-plugin` utility
+as described [here](#distribution).*
 
-`decorate` is not the only API that you can use to extend the server functionality, you can also use `decorateRequest` and `decorateReply`.
+`decorate` is not the only API that you can use to extend the server
+functionality, you can also use `decorateRequest` and `decorateReply`.
 
-*`decorateRequest` and `decorateReply`? Why do we need them if we already have `decorate`?*
+*`decorateRequest` and `decorateReply`? Why do we need them if we already have
+`decorate`?*
 
-Good question, we added them to make Fastify more developer-friendly. Let's see an example:
+Good question, we added them to make Fastify more developer-friendly. Let's see
+an example:
 ```js
 fastify.decorate('html', payload => {
   return generateHtml(payload)
@@ -187,12 +230,16 @@ fastify.get('/happiness', (request, reply) => {
 })
 ```
 
-We have seen how to extend server functionality and how to handle the encapsulation system, but what if you need to add a function that must be executed every time when the server "[emits](../Reference/Lifecycle.md)" an event?
+We have seen how to extend server functionality and how to handle the
+encapsulation system, but what if you need to add a function that must be
+executed every time when the server "[emits](../Reference/Lifecycle.md)" an
+event?
 
 ## Hooks
 <a id="hooks"></a>
 
-You just built an amazing utility, but now you need to execute that for every request, this is what you will likely do:
+You just built an amazing utility, but now you need to execute that for every
+request, this is what you will likely do:
 ```js
 fastify.decorate('util', (request, key, value) => { request[key] = value })
 
@@ -206,9 +253,11 @@ fastify.get('/plugin2', (request, reply) => {
   reply.send(request)
 })
 ```
-I think we all agree that this is terrible. Repeated code, awful readability and it cannot scale.
+I think we all agree that this is terrible. Repeated code, awful readability and
+it cannot scale.
 
-So what can you do to avoid this annoying issue? Yes, you are right, use a [hook](../Reference/Hooks.md)!
+So what can you do to avoid this annoying issue? Yes, you are right, use a
+[hook](../Reference/Hooks.md)!
 
 ```js
 fastify.decorate('util', (request, key, value) => { request[key] = value })
@@ -226,9 +275,11 @@ fastify.get('/plugin2', (request, reply) => {
   reply.send(request)
 })
 ```
-Now for every request, you will run your utility. You can register as many hooks as you need.
+Now for every request, you will run your utility. You can register as many hooks
+as you need.
 
-Sometimes you want a hook that should be executed for just a subset of routes, how can you do that? Yep, encapsulation!
+Sometimes you want a hook that should be executed for just a subset of routes,
+how can you do that? Yep, encapsulation!
 
 ```js
 fastify.register((instance, opts, done) => {
@@ -252,19 +303,28 @@ fastify.get('/plugin2', (request, reply) => {
 ```
 Now your hook will run just for the first route!
 
-As you probably noticed by now, `request` and `reply` are not the standard Nodejs *request* and *response* objects, but Fastify's objects.
+As you probably noticed by now, `request` and `reply` are not the standard
+Nodejs *request* and *response* objects, but Fastify's objects.
 
 
 ## How to handle encapsulation and distribution
 <a id="distribution"></a>
 
-Perfect, now you know (almost) all of the tools that you can use to extend Fastify. Nevertheless, chances are that you came across one big issue: how is distribution handled?
+Perfect, now you know (almost) all of the tools that you can use to extend
+Fastify. Nevertheless, chances are that you came across one big issue: how is
+distribution handled?
 
-The preferred way to distribute a utility is to wrap all your code inside a `register`. Using this, your plugin can support asynchronous bootstrapping *(since `decorate` is a synchronous API)*, in the case of a database connection for example.
+The preferred way to distribute a utility is to wrap all your code inside a
+`register`. Using this, your plugin can support asynchronous bootstrapping
+*(since `decorate` is a synchronous API)*, in the case of a database connection
+for example.
 
-*Wait, what? Didn't you tell me that `register` creates an encapsulation and that the stuff I create inside will not be available outside?*
+*Wait, what? Didn't you tell me that `register` creates an encapsulation and
+that the stuff I create inside will not be available outside?*
 
-Yes, I said that. However, what I didn't tell you is that you can tell Fastify to avoid this behavior with the [`fastify-plugin`](https://github.com/fastify/fastify-plugin) module.
+Yes, I said that. However, what I didn't tell you is that you can tell Fastify
+to avoid this behavior with the
+[`fastify-plugin`](https://github.com/fastify/fastify-plugin) module.
 ```js
 const fp = require('fastify-plugin')
 const dbClient = require('db-client')
@@ -278,11 +338,19 @@ function dbPlugin (fastify, opts, done) {
 
 module.exports = fp(dbPlugin)
 ```
-You can also tell `fastify-plugin` to check the installed version of Fastify, in case you need a specific API.
+You can also tell `fastify-plugin` to check the installed version of Fastify, in
+case you need a specific API.
 
-As we mentioned earlier, Fastify starts loading its plugins __after__ `.listen()`, `.inject()` or `.ready()` are called and as such, __after__ they have been declared. This means that, even though the plugin may inject variables to the external Fastify instance via [`decorate`](../Reference/Decorators.md), the decorated variables will not be accessible before calling `.listen()`, `.inject()` or `.ready()`.
+As we mentioned earlier, Fastify starts loading its plugins __after__
+`.listen()`, `.inject()` or `.ready()` are called and as such, __after__ they
+have been declared. This means that, even though the plugin may inject variables
+to the external Fastify instance via [`decorate`](../Reference/Decorators.md),
+the decorated variables will not be accessible before calling `.listen()`,
+`.inject()` or `.ready()`.
 
-In case you rely on a variable injected by a preceding plugin and want to pass that in the `options` argument of `register`, you can do so by using a function instead of an object:
+In case you rely on a variable injected by a preceding plugin and want to pass
+that in the `options` argument of `register`, you can do so by using a function
+instead of an object:
 ```js
 const fastify = require('fastify')()
 const fp = require('fastify-plugin')
@@ -300,12 +368,17 @@ fastify.register(require('your-plugin'), parent => {
   return { connection: parent.db, otherOption: 'foo-bar' }
 })
 ```
-In the above example, the `parent` variable of the function passed in as the second argument of `register` is a copy of the **external Fastify instance** that the plugin was registered at. This means that we are able to access any variables that were injected by preceding plugins in the order of declaration.
+In the above example, the `parent` variable of the function passed in as the
+second argument of `register` is a copy of the **external Fastify instance**
+that the plugin was registered at. This means that we are able to access any
+variables that were injected by preceding plugins in the order of declaration.
 
 ## ESM support
 <a id="esm-support"></a>
 
-ESM is supported as well from [Node.js `v13.3.0`](https://nodejs.org/api/esm.html) and above! Just export your plugin as ESM module and you are good to go!
+ESM is supported as well from [Node.js
+`v13.3.0`](https://nodejs.org/api/esm.html) and above! Just export your plugin
+as ESM module and you are good to go!
 
 ```js
 // plugin.mjs
@@ -317,7 +390,8 @@ async function plugin (fastify, opts) {
 
 export default plugin
 ```
-__Note__: Fastify does not support named imports within an ESM context. Instead, the `default` export is available.
+__Note__: Fastify does not support named imports within an ESM context. Instead,
+the `default` export is available.
 
 ```js
 // server.mjs
@@ -338,15 +412,24 @@ fastify.listen(3000, (err, address) => {
 ## Handle errors
 <a id="handle-errors"></a>
 
-It can happen that one of your plugins fails during startup. Maybe you expect it and you have a custom logic that will be triggered in that case. How can you implement this?
-The `after` API is what you need. `after` simply registers a callback that will be executed just after a register, and it can take up to three parameters.
+It can happen that one of your plugins fails during startup. Maybe you expect it
+and you have a custom logic that will be triggered in that case. How can you
+implement this? The `after` API is what you need. `after` simply registers a
+callback that will be executed just after a register, and it can take up to
+three parameters.
 
 The callback changes based on the parameters you are giving:
 
-1. If no parameter is given to the callback and there is an error, that error will be passed to the next error handler.
-1. If one parameter is given to the callback, that parameter will be the error object.
-1. If two parameters are given to the callback, the first will be the error object; the second will be the done callback.
-1. If three parameters are given to the callback, the first will be the error object, the second will be the top-level context unless you have specified both server and override, in that case, the context will be what the override returns, and the third the done callback.
+1. If no parameter is given to the callback and there is an error, that error
+   will be passed to the next error handler.
+1. If one parameter is given to the callback, that parameter will be the error
+   object.
+1. If two parameters are given to the callback, the first will be the error
+   object; the second will be the done callback.
+1. If three parameters are given to the callback, the first will be the error
+   object, the second will be the top-level context unless you have specified
+   both server and override, in that case, the context will be what the override
+   returns, and the third the done callback.
 
 Let's see how to use it:
 ```js
@@ -360,7 +443,9 @@ fastify
 ## Custom errors
 <a id="custom-errors"></a>
 
-If your plugin needs to expose custom errors, you can easily generate consistent error objects across your codebase and plugins with the [`fastify-error`](https://github.com/fastify/fastify-error) module.
+If your plugin needs to expose custom errors, you can easily generate consistent
+error objects across your codebase and plugins with the
+[`fastify-error`](https://github.com/fastify/fastify-error) module.
 
 ```js
 const createError = require('fastify-error')
@@ -371,7 +456,9 @@ console.log(new CustomError())
 ## Emit Warnings
 <a id="emit-warnings"></a>
 
-If you want to deprecate an API, or you want to warn the user about a specific use case, you can use the [`fastify-warning`](https://github.com/fastify/fastify-warning) module.
+If you want to deprecate an API, or you want to warn the user about a specific
+use case, you can use the
+[`fastify-warning`](https://github.com/fastify/fastify-warning) module.
 
 ```js
 const warning = require('fastify-warning')()
@@ -382,16 +469,21 @@ warning.emit('FST_ERROR_CODE')
 ## Let's start!
 <a id="start"></a>
 
-Awesome, now you know everything you need to know about Fastify and its plugin system to start building your first plugin, and please if you do, tell us! We will add it to the [*ecosystem*](https://github.com/fastify/fastify#ecosystem) section of our documentation!
+Awesome, now you know everything you need to know about Fastify and its plugin
+system to start building your first plugin, and please if you do, tell us! We
+will add it to the [*ecosystem*](https://github.com/fastify/fastify#ecosystem)
+section of our documentation!
 
 If you want to see some real-world examples, check out:
-- [`point-of-view`](https://github.com/fastify/point-of-view)
-Templates rendering (*ejs, pug, handlebars, marko*) plugin support for Fastify.
-- [`fastify-mongodb`](https://github.com/fastify/fastify-mongodb)
-Fastify MongoDB connection plugin, with this you can share the same MongoDB connection pool in every part of your server.
-- [`fastify-multipart`](https://github.com/fastify/fastify-multipart)
-Multipart support for Fastify
-- [`fastify-helmet`](https://github.com/fastify/fastify-helmet) Important security headers for Fastify
+- [`point-of-view`](https://github.com/fastify/point-of-view) Templates
+  rendering (*ejs, pug, handlebars, marko*) plugin support for Fastify.
+- [`fastify-mongodb`](https://github.com/fastify/fastify-mongodb) Fastify
+  MongoDB connection plugin, with this you can share the same MongoDB connection
+  pool in every part of your server.
+- [`fastify-multipart`](https://github.com/fastify/fastify-multipart) Multipart
+  support for Fastify
+- [`fastify-helmet`](https://github.com/fastify/fastify-helmet) Important
+  security headers for Fastify
 
 
 *Do you feel like something is missing here? Let us know! :)*

--- a/docs/Guides/Recommendations.md
+++ b/docs/Guides/Recommendations.md
@@ -16,11 +16,11 @@ Node.js is an early adopter of frameworks shipping with an easy-to-use web
 server within the standard library. Previously, with languages like PHP or
 Python, one would need either a web server with specific support for the
 language or the ability to set up some sort of [CGI gateway][cgi] that works
-with the language. With Node.js, one can write an application that
-_directly_ handles HTTP requests. As a result, the temptation is to write
-applications that handle requests for multiple domains, listen on multiple
-ports (i.e. HTTP _and_ HTTPS), and then expose these applications directly
-to the Internet to handle requests.
+with the language. With Node.js, one can write an application that _directly_
+handles HTTP requests. As a result, the temptation is to write applications that
+handle requests for multiple domains, listen on multiple ports (i.e. HTTP _and_
+HTTPS), and then expose these applications directly to the Internet to handle
+requests.
 
 The Fastify team **strongly** considers this to be an anti-pattern and extremely
 bad practice:
@@ -180,7 +180,7 @@ upstream fastify_app {
 }
 
 # This server block asks NGINX to respond with a redirect when
-# an incoming request from port 80 (typically plain HTTP), to 
+# an incoming request from port 80 (typically plain HTTP), to
 # the same request URL but with HTTPS as protocol.
 # This block is optional, and usually used if you are handling
 # SSL termination in NGINX, like in the example here.
@@ -190,7 +190,7 @@ server {
   # which in this case is any address and port 80
   listen 80 default_server;
   listen [::]:80 default_server;
-  
+
   # With a server_name directive you can also ask NGINX to
   # use this server block only with matching server name(s)
   # listen 80;
@@ -281,7 +281,12 @@ server {
 ## Kubernetes
 <a id="kubernetes"></a>
 
-The `readinessProbe` uses [(by default](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)) the pod IP as the hostname. Fastify listens on `127.0.0.1` by default. The probe will not be able to reach the application in this case. In order to make it work, the application must listen on `0.0.0.0` or specify a custom hostname in the `readinessProbe.httpGet` spec, as per the following example:
+The `readinessProbe` uses [(by
+default](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes))
+the pod IP as the hostname. Fastify listens on `127.0.0.1` by default. The probe
+will not be able to reach the application in this case. In order to make it
+work, the application must listen on `0.0.0.0` or specify a custom hostname in
+the `readinessProbe.httpGet` spec, as per the following example:
 
 ```yaml
 readinessProbe:

--- a/docs/Guides/Serverless.md
+++ b/docs/Guides/Serverless.md
@@ -1,23 +1,26 @@
 <h1 align="center">Serverless</h1>
 
-Run serverless applications and REST APIs using your existing Fastify application.
-By default, Fastify will not work on your serverless platform of choice, you will need
-to make some small changes to fix this. This document contains a small guide for
-the most popular serverless providers and how to use Fastify with them.
+Run serverless applications and REST APIs using your existing Fastify
+application. By default, Fastify will not work on your serverless platform of
+choice, you will need to make some small changes to fix this. This document
+contains a small guide for the most popular serverless providers and how to use
+Fastify with them.
 
 #### Should you use Fastify in a serverless platform?
 
 That is up to you! Keep in mind that functions as a service should always use
-small and focused functions, but you can also run an entire web application with them.
-It is important to remember that the bigger the application the slower the initial boot will be.
-The best way to run Fastify applications in serverless environments
-is to use platforms like Google Cloud Run, AWS Fargate, and Azure Container Instances,
-where the server can handle multiple requests at the same time and make full use of Fastify's features.
+small and focused functions, but you can also run an entire web application with
+them. It is important to remember that the bigger the application the slower the
+initial boot will be. The best way to run Fastify applications in serverless
+environments is to use platforms like Google Cloud Run, AWS Fargate, and Azure
+Container Instances, where the server can handle multiple requests at the same
+time and make full use of Fastify's features.
 
-One of the best features of using Fastify in serverless applications is the ease of development.
-In your local environment, you will always run the Fastify application directly without the need
-for any additional tools, while the same code will be executed in your serverless platform of
-choice with an additional snippet of code.
+One of the best features of using Fastify in serverless applications is the ease
+of development. In your local environment, you will always run the Fastify
+application directly without the need for any additional tools, while the same
+code will be executed in your serverless platform of choice with an additional
+snippet of code.
 
 ### Contents
 
@@ -29,10 +32,12 @@ choice with an additional snippet of code.
 
 ## AWS Lambda
 
-The sample provided allows you to easily build serverless web applications/services
-and RESTful APIs using Fastify on top of AWS Lambda and Amazon API Gateway.
+The sample provided allows you to easily build serverless web
+applications/services and RESTful APIs using Fastify on top of AWS Lambda and
+Amazon API Gateway.
 
-*Note: Using [aws-lambda-fastify](https://github.com/fastify/aws-lambda-fastify) is just one possible way.*
+*Note: Using [aws-lambda-fastify](https://github.com/fastify/aws-lambda-fastify)
+is just one possible way.*
 
 ### app.js
 
@@ -57,13 +62,14 @@ if (require.main === module) {
 }
 ```
 
-When executed in your lambda function we do not need to listen to a specific port,
-so we just export the wrapper function `init` in this case.
-The [`lambda.js`](https://www.fastify.io/docs/latest/Serverless/#lambda-js) file will use this export.
+When executed in your lambda function we do not need to listen to a specific
+port, so we just export the wrapper function `init` in this case. The
+[`lambda.js`](https://www.fastify.io/docs/latest/Serverless/#lambda-js) file
+will use this export.
 
-When you execute your Fastify application like always,
-i.e. `node app.js` *(the detection for this could be `require.main === module`)*,
-you can normally listen to your port, so you can still run your Fastify function locally.
+When you execute your Fastify application like always, i.e. `node app.js` *(the
+detection for this could be `require.main === module`)*, you can normally listen
+to your port, so you can still run your Fastify function locally.
 
 ### lambda.js
 
@@ -84,22 +90,30 @@ exports.handler = proxy;
 // exports.handler = async (event, context) => proxy(event, context);
 ```
 
-We just require [aws-lambda-fastify](https://github.com/fastify/aws-lambda-fastify)
-(make sure you install the dependency `npm i --save aws-lambda-fastify`) and our
-[`app.js`](https://www.fastify.io/docs/latest/Serverless/#app-js) file and call the
-exported `awsLambdaFastify` function with the `app` as the only parameter.
-The resulting `proxy` function has the correct signature to be used as a lambda `handler` function.
-This way all the incoming events (API Gateway requests) are passed to the `proxy` function of [aws-lambda-fastify](https://github.com/fastify/aws-lambda-fastify).
+We just require
+[aws-lambda-fastify](https://github.com/fastify/aws-lambda-fastify) (make sure
+you install the dependency `npm i --save aws-lambda-fastify`) and our
+[`app.js`](https://www.fastify.io/docs/latest/Serverless/#app-js) file and call
+the exported `awsLambdaFastify` function with the `app` as the only parameter.
+The resulting `proxy` function has the correct signature to be used as a lambda
+`handler` function. This way all the incoming events (API Gateway requests) are
+passed to the `proxy` function of
+[aws-lambda-fastify](https://github.com/fastify/aws-lambda-fastify).
 
 ### Example
 
-An example deployable with [claudia.js](https://claudiajs.com/tutorials/serverless-express.html) can be found [here](https://github.com/claudiajs/example-projects/tree/master/fastify-app-lambda).
+An example deployable with
+[claudia.js](https://claudiajs.com/tutorials/serverless-express.html) can be
+found
+[here](https://github.com/claudiajs/example-projects/tree/master/fastify-app-lambda).
 
 
 ### Considerations
 
-- API Gateway does not support streams yet, so you are not able to handle [streams](https://www.fastify.io/docs/latest/Reply/#streams).
-- API Gateway has a timeout of 29 seconds, so it is important to provide a reply during this time.
+- API Gateway does not support streams yet, so you are not able to handle
+  [streams](https://www.fastify.io/docs/latest/Reply/#streams).
+- API Gateway has a timeout of 29 seconds, so it is important to provide a reply
+  during this time.
 
 ## Google Cloud Functions
 
@@ -112,7 +126,12 @@ const fastify = require("fastify")({
 
 ### Add Custom `contentTypeParser` to Fastify instance
 
-As explained [in issue #946](https://github.com/fastify/fastify/issues/946#issuecomment-766319521), since the Google Cloud Functions platform parses the body of the request before it arrives into Fastify instance, troubling the body request in case of `POST` and `PATCH` methods, you need to add a custom [`Content-Type Parser`](../Reference/ContentTypeParser.md) to mitigate this behavior.
+As explained [in issue
+#946](https://github.com/fastify/fastify/issues/946#issuecomment-766319521),
+since the Google Cloud Functions platform parses the body of the request before
+it arrives into Fastify instance, troubling the body request in case of `POST`
+and `PATCH` methods, you need to add a custom [`Content-Type
+Parser`](../Reference/ContentTypeParser.md) to mitigate this behavior.
 
 ```js
 fastify.addContentTypeParser('application/json', {}, (req, body, done) => {
@@ -129,7 +148,7 @@ fastify.get('/', async (request, reply) => {
 })
 ```
 
-Or a more complete `POST` endpoint with schema validation: 
+Or a more complete `POST` endpoint with schema validation:
 ```js
 fastify.route({
   method: 'POST',
@@ -144,7 +163,7 @@ fastify.route({
     },
     response: {
       200: {
-        type: 'object', 
+        type: 'object',
         properties: {
           message: {type: 'string'}
         }
@@ -162,7 +181,8 @@ fastify.route({
 
 ### Implement and export the function
 
-Final step, implement the function to handle the request and pass it to Fastify by emitting `request` event to `fastify.server`:
+Final step, implement the function to handle the request and pass it to Fastify
+by emitting `request` event to `fastify.server`:
 
 ```js
 const fastifyFunction = async (request, reply) => {
@@ -175,7 +195,8 @@ export.fastifyFunction = fastifyFunction;
 
 ### Local test
 
-Install [Google Functions Framework for Node.js](https://github.com/GoogleCloudPlatform/functions-framework-nodejs).
+Install [Google Functions Framework for
+Node.js](https://github.com/GoogleCloudPlatform/functions-framework-nodejs).
 
 You can install it globally:
 ```bash
@@ -221,17 +242,25 @@ curl -X POST https://$GOOGLE_REGION-$GOOGLE_PROJECT.cloudfunctions.net/me -H "Co
 ```
 
 ### References
-- [Google Cloud Functions - Node.js Quickstart ](https://cloud.google.com/functions/docs/quickstart-nodejs)
+- [Google Cloud Functions - Node.js Quickstart
+  ](https://cloud.google.com/functions/docs/quickstart-nodejs)
 
 ## Google Cloud Run
 
-Unlike AWS Lambda or Google Cloud Functions, Google Cloud Run is a serverless **container** environment. Its primary purpose is to provide an infrastructure-abstracted environment to run arbitrary containers. As a result, Fastify can be deployed to Google Cloud Run with little-to-no code changes from the way you would write your Fastify app normally.
+Unlike AWS Lambda or Google Cloud Functions, Google Cloud Run is a serverless
+**container** environment. Its primary purpose is to provide an
+infrastructure-abstracted environment to run arbitrary containers. As a result,
+Fastify can be deployed to Google Cloud Run with little-to-no code changes from
+the way you would write your Fastify app normally.
 
-*Follow the steps below to deploy to Google Cloud Run if you are already familiar with gcloud or just follow their [quickstart](https://cloud.google.com/run/docs/quickstarts/build-and-deploy)*.
+*Follow the steps below to deploy to Google Cloud Run if you are already
+familiar with gcloud or just follow their
+[quickstart](https://cloud.google.com/run/docs/quickstarts/build-and-deploy)*.
 
 ### Adjust Fastify server
 
-In order for Fastify to properly listen for requests within the container, be sure to set the correct port and address:
+In order for Fastify to properly listen for requests within the container, be
+sure to set the correct port and address:
 
 ```js
 function build() {
@@ -269,7 +298,9 @@ if (require.main === module) {
 
 ### Add a Dockerfile
 
-You can add any valid `Dockerfile` that packages and runs a Node app. A basic `Dockerfile` can be found in the official [gcloud docs](https://github.com/knative/docs/blob/2d654d1fd6311750cc57187a86253c52f273d924/docs/serving/samples/hello-world/helloworld-nodejs/Dockerfile).
+You can add any valid `Dockerfile` that packages and runs a Node app. A basic
+`Dockerfile` can be found in the official [gcloud
+docs](https://github.com/knative/docs/blob/2d654d1fd6311750cc57187a86253c52f273d924/docs/serving/samples/hello-world/helloworld-nodejs/Dockerfile).
 
 ```Dockerfile
 # Use the official Node.js 10 image.
@@ -296,7 +327,8 @@ CMD [ "npm", "start" ]
 
 ### Add a .dockerignore
 
-To keep build artifacts out of your container (which keeps it small and improves build times) add a `.dockerignore` file like the one below:
+To keep build artifacts out of your container (which keeps it small and improves
+build times) add a `.dockerignore` file like the one below:
 
 ```.dockerignore
 Dockerfile
@@ -307,7 +339,9 @@ npm-debug.log
 
 ### Submit build
 
-Next, submit your app to be built into a Docker image by running the following command (replacing `PROJECT-ID` and `APP-NAME` with your GCP project id and an app name):
+Next, submit your app to be built into a Docker image by running the following
+command (replacing `PROJECT-ID` and `APP-NAME` with your GCP project id and an
+app name):
 
 ```bash
 gcloud builds submit --tag gcr.io/PROJECT-ID/APP-NAME
@@ -328,7 +362,8 @@ Your app will be accessible from the URL GCP provides.
 
 First, please perform all preparation steps related to **AWS Lambda**.
 
-Create a folder called `functions`,  then create `server.js` (and your endpoint path will be `server.js`) inside the `functions` folder.
+Create a folder called `functions`,  then create `server.js` (and your endpoint
+path will be `server.js`) inside the `functions` folder.
 
 ### functions/server.js
 
@@ -407,9 +442,9 @@ Then it should work fine
 
 ## Vercel
 
-[Vercel](https://vercel.com) provides zero-configuration deployment for
-Node.js applications. In order to use it now, it is as simple as
-configuring your `vercel.json` file like the following:
+[Vercel](https://vercel.com) provides zero-configuration deployment for Node.js
+applications. In order to use it now, it is as simple as configuring your
+`vercel.json` file like the following:
 
 ```json
 {

--- a/docs/Guides/Style-Guide.md
+++ b/docs/Guides/Style-Guide.md
@@ -2,13 +2,21 @@
 
 ## Welcome
 
-Welcome to *Fastify Style Guide*. This guide is here to provide you with a conventional writing style for users writing developer documentation on our Open Source framework. Each topic is precise and well explained to help you write documentation users can easily understand and implement.
+Welcome to *Fastify Style Guide*. This guide is here to provide you with a
+conventional writing style for users writing developer documentation on our Open
+Source framework. Each topic is precise and well explained to help you write
+documentation users can easily understand and implement.
 
 ## Who is this guide for?
 
-This guide is for anyone who loves to build with Fastify or wants to contribute to our documentation. You do not need to be an expert in writing technical documentation. This guide is here to help you.
+This guide is for anyone who loves to build with Fastify or wants to contribute
+to our documentation. You do not need to be an expert in writing technical
+documentation. This guide is here to help you.
 
-Visit the [contribute](https://www.fastify.io/contribute) page on our website or read the [CONTRIBUTING.md](https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md) file on GitHub to join our Open Source folks.
+Visit the [contribute](https://www.fastify.io/contribute) page on our website or
+read the
+[CONTRIBUTING.md](https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md)
+file on GitHub to join our Open Source folks.
 
 ## Before you write
 
@@ -20,26 +28,44 @@ You need to know the following:
 * GitHub
 * Markdown
 * HTTP
-* NPM 
+* NPM
 
 ### Consider your Audience
 
-Before you start writing, think about your audience. In this case, your audience should already know HTTP, JavaScript, NPM, and Node.js. It is necessary to keep your readers in mind because they are the ones consuming your content. You want to give as much useful information as possible. Consider the vital things they need to know and how they can understand them. Use words and references that readers can relate to easily. Ask for feedback from the community, it can help you write better documentation that focuses on the user and what you want to achieve.
+Before you start writing, think about your audience. In this case, your audience
+should already know HTTP, JavaScript, NPM, and Node.js. It is necessary to keep
+your readers in mind because they are the ones consuming your content. You want
+to give as much useful information as possible. Consider the vital things they
+need to know and how they can understand them. Use words and references that
+readers can relate to easily. Ask for feedback from the community, it can help
+you write better documentation that focuses on the user and what you want to
+achieve.
 
 ### Get straight to the point
 
-Give your readers a clear and precise action to take. Start with what is most important. This way, you can help them find what they need faster. Mostly, readers tend to read the first content on a page, and many will not scroll further.
+Give your readers a clear and precise action to take. Start with what is most
+important. This way, you can help them find what they need faster. Mostly,
+readers tend to read the first content on a page, and many will not scroll
+further.
 
 **Example**
 
-Less like this: Colons are very important to register a parametric path. It lets the framework know there is a new parameter created. You can place the colon before the parameter name so the parametric path can be created.
+Less like this: Colons are very important to register a parametric path. It lets
+the framework know there is a new parameter created. You can place the colon
+before the parameter name so the parametric path can be created.
 
-More Like this: To register a parametric path, put a colon before the parameter name. Using a colon lets the framework know it is a parametric path and not a static path.
+More Like this: To register a parametric path, put a colon before the parameter
+name. Using a colon lets the framework know it is a parametric path and not a
+static path.
 
-### Avoid adding video or image content 
+### Avoid adding video or image content
 
 
-Do not add videos or screenshots in the documentation. It is easier to keep under version control. Videos and images will eventually end up becoming outdated as new updates keep developing. Instead, make a referral link or a YouTube video. You can add links by using `[Title](www.websitename.com)` in the markdown.
+Do not add videos or screenshots in the documentation. It is easier to keep
+under version control. Videos and images will eventually end up becoming
+outdated as new updates keep developing. Instead, make a referral link or a
+YouTube video. You can add links by using `[Title](www.websitename.com)` in the
+markdown.
 
 **Example**
 
@@ -48,23 +74,31 @@ To learn more about hooks, see [Fastify hooks](https://www.fastify.io/docs/lates
 ```
 
 Result:
->To learn more about hooks, see [Fastify hooks](https://www.fastify.io/docs/latest/Hooks/).
+>To learn more about hooks, see [Fastify
+>hooks](https://www.fastify.io/docs/latest/Hooks/).
 
 
 
 ### Avoid plagiarism
 
-Make sure you avoid copying other people's work. Keep it as original as possible. You can learn from what they have done and reference where it is from if you used a particular quote from their work.
+Make sure you avoid copying other people's work. Keep it as original as
+possible. You can learn from what they have done and reference where it is from
+if you used a particular quote from their work.
 
 
 ## Word Choice
 
-There are a few things you need to use and avoid when writing your documentation to improve readability for readers and make documentation neat, direct, and clean.
+There are a few things you need to use and avoid when writing your documentation
+to improve readability for readers and make documentation neat, direct, and
+clean.
 
 
 ### When to use the second person "you" as the pronoun
 
-When writing articles or guides, your content should communicate directly to readers in the second person ("you") addressed form. It is easier to give them direct instruction on what to do on a particular topic. To see an example, visit the [Plugins Guide](./Plugins-Guide.md). 
+When writing articles or guides, your content should communicate directly to
+readers in the second person ("you") addressed form. It is easier to give them
+direct instruction on what to do on a particular topic. To see an example, visit
+the [Plugins Guide](./Plugins-Guide.md).
 
 **Example**
 
@@ -72,70 +106,89 @@ Less like this: we can use the following plugins.
 
 More like this: You can use the following plugins.
 
-> According to [Wikipedia](#), ***You*** is usually a second person pronoun. Also, used to refer to an indeterminate person, as a more common alternative to a very formal indefinite pronoun.
+> According to [Wikipedia](#), ***You*** is usually a second person pronoun.
+> Also, used to refer to an indeterminate person, as a more common alternative
+> to a very formal indefinite pronoun.
 
 ## When to avoid the second person "you" as the pronoun
 
-One of the main rules of formal writing such as reference documentation, or API documentation, is to avoid the second person ("you") or directly addressing the reader.
+One of the main rules of formal writing such as reference documentation, or API
+documentation, is to avoid the second person ("you") or directly addressing the
+reader.
 
 **Example**
 
 Less like this: You can use the following recommendation as an example.
 
-More like this: As an example, the following recommendations should be referenced.
+More like this: As an example, the following recommendations should be
+referenced.
 
-To view a live example, refer to the [Decorators](../Reference/Decorators.md) reference document.
+To view a live example, refer to the [Decorators](../Reference/Decorators.md)
+reference document.
 
 
 ### Avoid using contractions
 
-Contractions are the shortened version of written and spoken forms of a word, i.e. using "don't" instead of "do not".
-Avoid contractions to provide a more formal tone.
+Contractions are the shortened version of written and spoken forms of a word,
+i.e. using "don't" instead of "do not". Avoid contractions to provide a more
+formal tone.
 
 ### Avoid using condescending terms
 
 Condescending terms are words that include:
 
-* Just 
+* Just
 * Easy
 * Simply
 * Basically
 * Obviously
 
-The reader may not find it easy to use Fastify's framework and plugins; avoid words that make it sound simple, easy, offensive, or insensitive. Not everyone who reads the documentation has the same level of understanding.
+The reader may not find it easy to use Fastify's framework and plugins; avoid
+words that make it sound simple, easy, offensive, or insensitive. Not everyone
+who reads the documentation has the same level of understanding.
 
 
 ### Starting with a verb
 
-Mostly start your description with a verb, which makes it simple and precise for the reader to follow. Prefer using present tense because it is easier to read and understand than the past or future tense.
+Mostly start your description with a verb, which makes it simple and precise for
+the reader to follow. Prefer using present tense because it is easier to read
+and understand than the past or future tense.
 
 **Example**
 
- Less like this: There is a need for Node.js to be installed before you can be able to use Fastify.
+ Less like this: There is a need for Node.js to be installed before you can be
+ able to use Fastify.
 
  More like this: Install Node.js to make use of Fastify.
 
-### Grammatical moods 
+### Grammatical moods
 
-Grammatical moods are a great way to express your writing. Avoid sounding too bossy while making a direct statement. Know when to switch between indicative, imperative, and subjunctive moods.
+Grammatical moods are a great way to express your writing. Avoid sounding too
+bossy while making a direct statement. Know when to switch between indicative,
+imperative, and subjunctive moods.
 
 
-**Indicative** - Use when making a factual statement or question. 
+**Indicative** - Use when making a factual statement or question.
 
-Example: Since there is no testing framework available, "Fastify recommends ways to write tests".
+Example: Since there is no testing framework available, "Fastify recommends ways
+to write tests".
 
-**Imperative** - Use when giving instructions, actions, commands, or when you write your headings.
+**Imperative** - Use when giving instructions, actions, commands, or when you
+write your headings.
 
 Example: Install dependencies before starting development.
 
 
-**Subjunctive** -  Use when making suggestions, hypotheses, or non-factual statements.
+**Subjunctive** -  Use when making suggestions, hypotheses, or non-factual
+statements.
 
-Example: Reading the documentation on our website is recommended to get comprehensive knowledge of the framework.
+Example: Reading the documentation on our website is recommended to get
+comprehensive knowledge of the framework.
 
 ### Use **active** voice instead of **passive**
 
-Using active voice is a more compact and direct way of conveying your documentation.
+Using active voice is a more compact and direct way of conveying your
+documentation.
 
 **Example**
 
@@ -148,20 +201,24 @@ Active:  npm installs packages and node dependencies.
 
 ### Documentation titles
 
-When creating a new guide, API, or reference in the `/docs/` directory, use short titles that best describe the topic of your documentation. Name your files in kebab-cases and avoid Raw or camelCase. To learn more about kebab-case you can visit this medium article on [Case Styles](https://medium.com/better-programming/string-case-styles-camel-pascal-snake-and-kebab-case-981407998841).
+When creating a new guide, API, or reference in the `/docs/` directory, use
+short titles that best describe the topic of your documentation. Name your files
+in kebab-cases and avoid Raw or camelCase. To learn more about kebab-case you
+can visit this medium article on [Case
+Styles](https://medium.com/better-programming/string-case-styles-camel-pascal-snake-and-kebab-case-981407998841).
 
-**Examples**: 
+**Examples**:
 
->`hook-and-plugins.md`, 
- 
- `adding-test-plugins.md`, 
+>`hook-and-plugins.md`,
+
+ `adding-test-plugins.md`,
 
  `removing-requests.md`.
 
 ### Hyperlinks
 
-Hyperlinks should have a clear title of what it references.
-Here is how your hyperlink should look: 
+Hyperlinks should have a clear title of what it references. Here is how your
+hyperlink should look:
 
 ```MD
 <!-- More like this -->
@@ -171,7 +228,7 @@ Here is how your hyperlink should look:
 
 <!--Less like this -->
 
-// incomplete description 
+// incomplete description
 [Fastify] (https://www.fastify.io/docs/latest/Plugins/)
 
 // Adding title in link brackets
@@ -185,4 +242,5 @@ Here is how your hyperlink should look:
 
 ```
 
-Include in your documentation as many essential references as possible, but avoid having numerous links when writing for beginners to avoid distractions.
+Include in your documentation as many essential references as possible, but
+avoid having numerous links when writing for beginners to avoid distractions.

--- a/docs/Guides/Testing.md
+++ b/docs/Guides/Testing.md
@@ -2,9 +2,13 @@
 
 ## Testing
 
-Testing is one of the most important parts of developing an application. Fastify is very flexible when it comes to testing and is compatible with most testing frameworks (such as [Tap](https://www.npmjs.com/package/tap), which is used in the examples below).
+Testing is one of the most important parts of developing an application. Fastify
+is very flexible when it comes to testing and is compatible with most testing
+frameworks (such as [Tap](https://www.npmjs.com/package/tap), which is used in
+the examples below).
 
-Let's `cd` into a fresh directory called 'testing-example' and type `npm init -y` in our terminal.
+Let's `cd` into a fresh directory called 'testing-example' and type `npm init
+-y` in our terminal.
 
 Run `npm install fastify && npm install tap pino-pretty --save-dev`
 
@@ -53,9 +57,11 @@ server.listen(3000, (err, address) => {
 
 ### Benefits of using fastify.inject()
 
-Fastify comes with built-in support for fake HTTP injection thanks to [`light-my-request`](https://github.com/fastify/light-my-request).
+Fastify comes with built-in support for fake HTTP injection thanks to
+[`light-my-request`](https://github.com/fastify/light-my-request).
 
-Before introducing any tests, we will use the `.inject` method to make a fake request to our route:
+Before introducing any tests, we will use the `.inject` method to make a fake
+request to our route:
 
 **app.test.js**:
 
@@ -78,9 +84,12 @@ const test = async () => {
 test()
 ```
 
-First, our code will run inside an asynchronous function, giving us access to async/await.
+First, our code will run inside an asynchronous function, giving us access to
+async/await.
 
-`.inject` ensures all registered plugins have booted up and our application is ready to test. Finally, we pass the request method we want to use and a route. Using await we can store the response without a callback.
+`.inject` ensures all registered plugins have booted up and our application is
+ready to test. Finally, we pass the request method we want to use and a route.
+Using await we can store the response without a callback.
 
 
 
@@ -225,13 +234,15 @@ tap.test('GET `/` route', t => {
 ```
 
 ### Testing with a running server
-Fastify can also be tested after starting the server with `fastify.listen()` or after initializing routes and plugins with `fastify.ready()`.
+Fastify can also be tested after starting the server with `fastify.listen()` or
+after initializing routes and plugins with `fastify.ready()`.
 
 #### Example:
 
 Uses **app.js** from the previous example.
 
-**test-listen.js** (testing with [`Request`](https://www.npmjs.com/package/request))
+**test-listen.js** (testing with
+[`Request`](https://www.npmjs.com/package/request))
 ```js
 const tap = require('tap')
 const request = require('request')
@@ -260,7 +271,8 @@ tap.test('GET `/` route', t => {
 })
 ```
 
-**test-ready.js** (testing with [`SuperTest`](https://www.npmjs.com/package/supertest))
+**test-ready.js** (testing with
+[`SuperTest`](https://www.npmjs.com/package/supertest))
 ```js
 const tap = require('tap')
 const supertest = require('supertest')
@@ -293,6 +305,8 @@ test('should ...', {only: true}, t => ...)
 - `-O` specifies to run tests with the `only` option enabled
 - `-T` specifies not to timeout (while you're debugging)
 - `--node-arg=--inspect-brk` will launch the node debugger
-3. In VS Code, create and launch a `Node.js: Attach` debug configuration. No modification should be necessary.
+3. In VS Code, create and launch a `Node.js: Attach` debug configuration. No
+   modification should be necessary.
 
-Now you should be able to step through your test file (and the rest of `Fastify`) in your code editor.
+Now you should be able to step through your test file (and the rest of
+`Fastify`) in your code editor.

--- a/docs/Guides/Write-Plugin.md
+++ b/docs/Guides/Write-Plugin.md
@@ -1,23 +1,38 @@
 <h1 align="center">Fastify</h1>
 
 # How to write a good plugin
-First, thank you for deciding to write a plugin for Fastify. Fastify is a minimal framework and plugins are its strength, so thank you.
+First, thank you for deciding to write a plugin for Fastify. Fastify is a
+minimal framework and plugins are its strength, so thank you.
 
-The core principles of Fastify are performance, low overhead, and providing a good experience to our users. When writing a plugin, it is important to keep these principles in mind. Therefore, in this document, we will analyze what characterizes a quality plugin.
+The core principles of Fastify are performance, low overhead, and providing a
+good experience to our users. When writing a plugin, it is important to keep
+these principles in mind. Therefore, in this document, we will analyze what
+characterizes a quality plugin.
 
-*Need some inspiration? You can use the label ["plugin suggestion"](https://github.com/fastify/fastify/issues?q=is%3Aissue+is%3Aopen+label%3A%22plugin+suggestion%22) in our issue tracker!*
+*Need some inspiration? You can use the label ["plugin
+suggestion"](https://github.com/fastify/fastify/issues?q=is%3Aissue+is%3Aopen+label%3A%22plugin+suggestion%22)
+in our issue tracker!*
 
 ## Code
-Fastify uses different techniques to optimize its code, many of them are documented in our Guides. We highly recommend you read [the hitchhiker's guide to plugins](./Plugins-Guide.md) to discover all the APIs you can use to build your plugin and learn how to use them.
+Fastify uses different techniques to optimize its code, many of them are
+documented in our Guides. We highly recommend you read [the hitchhiker's guide
+to plugins](./Plugins-Guide.md) to discover all the APIs you can use to build
+your plugin and learn how to use them.
 
-Do you have a question or need some advice? We are more than happy to help you! Just open an issue in our [help repository](https://github.com/fastify/help).
+Do you have a question or need some advice? We are more than happy to help you!
+Just open an issue in our [help repository](https://github.com/fastify/help).
 
-Once you submit a plugin to our [ecosystem list](./Ecosystem.md), we will review your code and help you improve it if necessary.
+Once you submit a plugin to our [ecosystem list](./Ecosystem.md), we will review
+your code and help you improve it if necessary.
 
 ## Documentation
-Documentation is extremely important. If your plugin is not well documented we will not accept it to the ecosystem list. Lack of quality documentation makes it more difficult for people to use your plugin, and will likely result in it going unused.
+Documentation is extremely important. If your plugin is not well documented we
+will not accept it to the ecosystem list. Lack of quality documentation makes it
+more difficult for people to use your plugin, and will likely result in it going
+unused.
 
-If you want to see some good examples on how to document a plugin take a look at:
+If you want to see some good examples on how to document a plugin take a look
+at:
 - [`fastify-caching`](https://github.com/fastify/fastify-caching)
 - [`fastify-compress`](https://github.com/fastify/fastify-compress)
 - [`fastify-cookie`](https://github.com/fastify/fastify-cookie)
@@ -25,39 +40,63 @@ If you want to see some good examples on how to document a plugin take a look at
 - [`under-pressure`](https://github.com/fastify/under-pressure)
 
 ## License
-You can license your plugin as you prefer, we do not enforce any kind of license.
+You can license your plugin as you prefer, we do not enforce any kind of
+license.
 
-We prefer the [MIT license](https://choosealicense.com/licenses/mit/) because we think it allows more people to use the code freely. For a list of alternative licenses see the [OSI list](https://opensource.org/licenses) or GitHub's [choosealicense.com](https://choosealicense.com/).
+We prefer the [MIT license](https://choosealicense.com/licenses/mit/) because we
+think it allows more people to use the code freely. For a list of alternative
+licenses see the [OSI list](https://opensource.org/licenses) or GitHub's
+[choosealicense.com](https://choosealicense.com/).
 
 ## Examples
-Always put an example file in your repository. Examples are very helpful for users and give a very fast way to test your plugin. Your users will be grateful.
+Always put an example file in your repository. Examples are very helpful for
+users and give a very fast way to test your plugin. Your users will be grateful.
 
 ## Test
-It is extremely important that a plugin is thoroughly tested to verify that is working properly.
+It is extremely important that a plugin is thoroughly tested to verify that is
+working properly.
 
-A plugin without tests will not be accepted to the ecosystem list. A lack of tests does not inspire trust nor guarantee that the code will continue to work among different versions of its dependencies.
+A plugin without tests will not be accepted to the ecosystem list. A lack of
+tests does not inspire trust nor guarantee that the code will continue to work
+among different versions of its dependencies.
 
-We do not enforce any testing library. We use [`tap`](https://www.node-tap.org/) since it offers out-of-the-box parallel testing and code coverage, but it is up to you to choose your library of preference.
+We do not enforce any testing library. We use [`tap`](https://www.node-tap.org/)
+since it offers out-of-the-box parallel testing and code coverage, but it is up
+to you to choose your library of preference.
 
 ## Code Linter
-It is not mandatory, but we highly recommend you use a code linter in your plugin. It will ensure a consistent code style and help you to avoid many errors.
+It is not mandatory, but we highly recommend you use a code linter in your
+plugin. It will ensure a consistent code style and help you to avoid many
+errors.
 
-We use [`standard`](https://standardjs.com/) since it works without the need to configure it and is very easy to integrate into a test suite.
+We use [`standard`](https://standardjs.com/) since it works without the need to
+configure it and is very easy to integrate into a test suite.
 
 ## Continuous Integration
-It is not mandatory, but if you release your code as open source, it helps to use Continuous Integration to ensure contributions do not break your plugin and to show that the plugin works as intended. Both [CircleCI](https://circleci.com/) and [GitHub Actions](https://github.com/features/actions) are free for open source projects and easy to set up.
+It is not mandatory, but if you release your code as open source, it helps to
+use Continuous Integration to ensure contributions do not break your plugin and
+to show that the plugin works as intended. Both
+[CircleCI](https://circleci.com/) and [GitHub
+Actions](https://github.com/features/actions) are free for open source projects
+and easy to set up.
 
-In addition, you can enable services like [Dependabot](https://dependabot.com/) or [Snyk](https://snyk.io/), which will help you keep your dependencies up to date and discover if a new release of Fastify has some issues with your plugin.
+In addition, you can enable services like [Dependabot](https://dependabot.com/)
+or [Snyk](https://snyk.io/), which will help you keep your dependencies up to
+date and discover if a new release of Fastify has some issues with your plugin.
 
 ## Let's start!
-Awesome, now you know everything you need to know about how to write a good plugin for Fastify!
-After you have built one (or more!) let us know! We will add it to the [ecosystem](https://github.com/fastify/fastify#ecosystem) section of our documentation!
+Awesome, now you know everything you need to know about how to write a good
+plugin for Fastify! After you have built one (or more!) let us know! We will add
+it to the [ecosystem](https://github.com/fastify/fastify#ecosystem) section of
+our documentation!
 
 If you want to see some real world examples, check out:
-- [`point-of-view`](https://github.com/fastify/point-of-view)
-Templates rendering (*ejs, pug, handlebars, marko*) plugin support for Fastify.
-- [`fastify-mongodb`](https://github.com/fastify/fastify-mongodb)
-Fastify MongoDB connection plugin, with this you can share the same MongoDB connection pool in every part of your server.
-- [`fastify-multipart`](https://github.com/fastify/fastify-multipart)
-Multipart support for Fastify.
-- [`fastify-helmet`](https://github.com/fastify/fastify-helmet) Important security headers for Fastify.
+- [`point-of-view`](https://github.com/fastify/point-of-view) Templates
+  rendering (*ejs, pug, handlebars, marko*) plugin support for Fastify.
+- [`fastify-mongodb`](https://github.com/fastify/fastify-mongodb) Fastify
+  MongoDB connection plugin, with this you can share the same MongoDB connection
+  pool in every part of your server.
+- [`fastify-multipart`](https://github.com/fastify/fastify-multipart) Multipart
+  support for Fastify.
+- [`fastify-helmet`](https://github.com/fastify/fastify-helmet) Important
+  security headers for Fastify.

--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -1489,26 +1489,30 @@ database.
 
 <!-- Links -->
 
-[Fastify]:
-#fastifyrawserver-rawrequest-rawreply-loggeropts-fastifyserveroptions-fastifyinstance
-[RawServerGeneric]: #rawserver [RawRequestGeneric]: #rawrequest
-[RawReplyGeneric]: #rawreply [LoggerGeneric]: #logger [RawBodyGeneric]: #rawbody
-[HTTPMethods]: #fastifyhttpmethods [RawServerBase]: #fastifyrawserverbase
-[RawServerDefault]: #fastifyrawserverdefault [FastifyRequest]:
-#fastifyfastifyrequestrawserver-rawrequest-requestgeneric
+[Fastify]: #fastifyrawserver-rawrequest-rawreply-loggeropts-fastifyserveroptions-fastifyinstance
+[RawServerGeneric]: #rawserver
+[RawRequestGeneric]: #rawrequest
+[RawReplyGeneric]: #rawreply
+[LoggerGeneric]: #logger
+[RawBodyGeneric]: #rawbody
+[HTTPMethods]: #fastifyhttpmethods
+[RawServerBase]: #fastifyrawserverbase
+[RawServerDefault]: #fastifyrawserverdefault
+[FastifyRequest]: #fastifyfastifyrequestrawserver-rawrequest-requestgeneric
 [FastifyRequestGenericInterface]: #fastifyrequestgenericinterface
 [RawRequestDefaultExpression]: #fastifyrawrequestdefaultexpressionrawserver
 [FastifyReply]: #fastifyfastifyreplyrawserver-rawreply-contextconfig
 [RawReplyDefaultExpression]: #fastifyrawreplydefaultexpression
 [FastifyServerOptions]: #fastifyfastifyserveroptions-rawserver-logger
-[FastifyInstance]: #fastifyfastifyinstance [FastifyLoggerOptions]:
-#fastifyfastifyloggeroptions [ContextConfigGeneric]: #ContextConfigGeneric
-[FastifyPlugin]:
-##fastifyfastifypluginoptions-rawserver-rawrequest-requestgeneric
+[FastifyInstance]: #fastifyfastifyinstance
+[FastifyLoggerOptions]: #fastifyfastifyloggeroptions
+[ContextConfigGeneric]: #ContextConfigGeneric
+[FastifyPlugin]: #fastifyfastifypluginoptions-rawserver-rawrequest-requestgeneric
 [FastifyPluginCallback]: #fastifyfastifyplugincallbackoptions
-[FastifyPluginAsync]: #fastifyfastifypluginasyncoptions [FastifyPluginOptions]:
-#fastifyfastifypluginoptions [FastifyRegister]:
-#fastifyfastifyregisterrawserver-rawrequest-requestgenericplugin-fastifyplugin-opts-fastifyregisteroptions
-[FastifyRegisterOptions]: #fastifyfastifytregisteroptions [LogLevel]:
-#fastifyloglevel [FastifyError]: #fastifyfastifyerror [RouteOptions]:
-#fastifyrouteoptionsrawserver-rawrequest-rawreply-requestgeneric-contextconfig
+[FastifyPluginAsync]: #fastifyfastifypluginasyncoptions
+[FastifyPluginOptions]: #fastifyfastifypluginoptions
+[FastifyRegister]: #fastifyfastifyregisterrawserver-rawrequest-requestgenericplugin-fastifyplugin-opts-fastifyregisteroptions
+[FastifyRegisterOptions]: #fastifyfastifytregisteroptions
+[LogLevel]: #fastifyloglevel
+[FastifyError]: #fastifyfastifyerror
+[RouteOptions]: #fastifyrouteoptionsrawserver-rawrequest-rawreply-requestgeneric-contextconfig

--- a/docs/Reference/index.md
+++ b/docs/Reference/index.md
@@ -8,25 +8,25 @@ list is a subset of the full TOC that detail core Fastify APIs and concepts in
 order of most likely importance to the reader:
 
 + [Server](./Server.md): Documents the core Fastify API. Includes documentation
-for the factory function and the object returned by the factory function.
+  for the factory function and the object returned by the factory function.
 + [Lifecycle](./Lifecycle.md): Explains the Fastify request lifecycle and
-illustrates where [Hooks](./Hooks.md) are available for integrating with it.
+  illustrates where [Hooks](./Hooks.md) are available for integrating with it.
 + [Routes](./Routes.md): Details how to register routes with Fastify and how
-Fastify builds and evaluates the routing trie.
-+ [Request](./Request.md): Details Fastify's request object that is passed
-into each request handler.
+  Fastify builds and evaluates the routing trie.
++ [Request](./Request.md): Details Fastify's request object that is passed into
+  each request handler.
 + [Reply](./Reply.md): Details Fastify's response object available to each
-request handler.
+  request handler.
 + [Validation and Serialization](./Validation-and-Serialization.md): Details
-Fastify's support for validating incoming data and how Fastify serializes
-data for responses.
+  Fastify's support for validating incoming data and how Fastify serializes data
+  for responses.
 + [Plugins](./Plugins.md): Explains Fastify's plugin architecture and API.
 + [Encapsulation](./Encapsulation.md): Explains a core concept upon which all
-Fastify plugins are built.
+  Fastify plugins are built.
 + [Decorators](./Decorators.md): Explains the server, request, and response
-decorator APIs.
+  decorator APIs.
 + [Hooks](./Hooks.md): Details the API by which Fastify plugins can inject
-themselves into Fastify's handling of the request lifecycle.
+  themselves into Fastify's handling of the request lifecycle.
 
 
 ## Reference Documentation Table Of Contents
@@ -35,37 +35,37 @@ themselves into Fastify's handling of the request lifecycle.
 This table of contents is in alphabetical order.
 
 + [Content Type Parser](./ContentTypeParser.md): Documents Fastify's default
-content type parser and how to add support for new content types.
+  content type parser and how to add support for new content types.
 + [Decorators](./Decorators.md): Explains the server, request, and response
-decorator APIs.
+  decorator APIs.
 + [Encapsulation](./Encapsulation.md): Explains a core concept upon which all
-Fastify plugins are built.
+  Fastify plugins are built.
 + [Errors](./Errors.md): Details how Fastify handles errors and lists the
-standard set of errors Fastify generates.
+  standard set of errors Fastify generates.
 + [Hooks](./Hooks.md): Details the API by which Fastify plugins can inject
-themselves into Fastify's handling of the request lifecycle.
+  themselves into Fastify's handling of the request lifecycle.
 + [HTTP2](/./HTTP2.md): Details Fastify's HTTP2 support.
 + [Lifecycle](./Lifecycle.md): Explains the Fastify request lifecycle and
-illustrates where [Hooks](./Hooks.md) are available for integrating with it.
+  illustrates where [Hooks](./Hooks.md) are available for integrating with it.
 + [Logging](./Logging.md): Details Fastify's included logging and how to
-customize it.
+  customize it.
 + [Long Term Support](./LTS.md): Explains Fastify's long term support (LTS)
-guarantee and the exceptions possible to the [semver](https://semver.org)
-contract.
-+ [Middleware](./Middleware.md): Details Fastify's support for Express.js
-style middleware.
+  guarantee and the exceptions possible to the [semver](https://semver.org)
+  contract.
++ [Middleware](./Middleware.md): Details Fastify's support for Express.js style
+  middleware.
 + [Plugins](./Plugins.md): Explains Fastify's plugin architecture and API.
 + [Reply](./Reply.md): Details Fastify's response object available to each
-request handler.
-+ [Request](./Request.md): Details Fastify's request object that is passed
-into each request handler.
+  request handler.
++ [Request](./Request.md): Details Fastify's request object that is passed into
+  each request handler.
 + [Routes](./Routes.md): Details how to register routes with Fastify and how
-Fastify builds and evaluates the routing trie.
+  Fastify builds and evaluates the routing trie.
 + [Server](./Server.md): Documents the core Fastify API. Includes documentation
-for the factory function and the object returned by the factory function.
+  for the factory function and the object returned by the factory function.
 + [TypeScript](./TypeScript.md): Documents Fastify's TypeScript support and
-provides recommendations for writing applications in TypeScript that utilize
-Fastify.
+  provides recommendations for writing applications in TypeScript that utilize
+  Fastify.
 + [Validation and Serialization](./Validation-and-Serialization.md): Details
-Fastify's support for validating incoming data and how Fastify serializes
-data for responses.
+  Fastify's support for validating incoming data and how Fastify serializes data
+  for responses.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,17 +6,18 @@ The documentation for Fastify is split into two categories:
 - [Guides](./Guides/index.md)
 
 The reference documenation utilizes a very formal style in an effort to document
-Fastify's API and implementation details thoroughly for the developer who
-needs such. The guides category utilizes an informal, educational, style as
-a means to introduce newcomers to core, and advanced, Fastify concepts.
+Fastify's API and implementation details thoroughly for the developer who needs
+such. The guides category utilizes an informal, educational, style as a means to
+introduce newcomers to core, and advanced, Fastify concepts.
 
 ## Where To Start
 
-Complete newcomers to Fastify should first read our [Getting Started](./Guides/Getting-Started.md) guide.
+Complete newcomers to Fastify should first read our [Getting
+Started](./Guides/Getting-Started.md) guide.
 
-Developers experienced with Fastify should consult the
-[reference documentation](./Reference/index.md) directly to find the topic they are
-seeking more information about.
+Developers experienced with Fastify should consult the [reference
+documentation](./Reference/index.md) directly to find the topic they are seeking
+more information about.
 
 ## Additional Documentation
 


### PR DESCRIPTION
As with #3525 this PR implements the table of contents for the `docs/Guides`. It also applies hard line wrapping to each of the guides, and fixes some bad line wrapping in the `TypeScript.md` document (introduced by https://github.com/stkb/Rewrap/issues/93).

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
