### PR TITLE
build: drop node 12 support

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,15 +9,13 @@ jobs:
     if: ${{ github.event.label.name == 'benchmark' }}
     runs-on: ubuntu-latest
     outputs:
-      PR-BENCH-12: ${{ steps.benchmark-pr.outputs.BENCH_RESULT12 }}
       PR-BENCH-14: ${{ steps.benchmark-pr.outputs.BENCH_RESULT14 }}
       PR-BENCH-16: ${{ steps.benchmark-pr.outputs.BENCH_RESULT16 }}
-      MAIN-BENCH-12: ${{ steps.benchmark-main.outputs.BENCH_RESULT12 }}
       MAIN-BENCH-14: ${{ steps.benchmark-main.outputs.BENCH_RESULT14 }}
       MAIN-BENCH-16: ${{ steps.benchmark-main.outputs.BENCH_RESULT16 }}
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [14, 16]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -64,12 +62,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: |
-            **Node**: 12
-            **PR**: ${{ needs.benchmark.outputs.PR-BENCH-12 }}
-            **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-12 }}
-            
-            ---
-            
             **Node**: 14
             **PR**: ${{ needs.benchmark.outputs.PR-BENCH-14 }}
             **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-14 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12, 14, 16, 17]
+        node-version: [14, 16, 17]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         # Maintenance and active LTS
-        node-version: [12, 14]
+        node-version: [14, 16]
         os: [ubuntu-18.04]
 
     steps:
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         # Maintenance and active LTS
-        node-version: [12, 14]
+        node-version: [14, 16]
         os: [ubuntu-18.04]
 
     steps:

--- a/docs/LTS.md
+++ b/docs/LTS.md
@@ -50,6 +50,7 @@ A "month" is defined as 30 consecutive days.
 | 1.0.0   | 2018-03-06   | 2019-09-01      | 6, 8, 9, 10, 11      |
 | 2.0.0   | 2019-02-25   | 2021-01-31      | 6, 8, 10, 12, 14     |
 | 3.0.0   | 2020-07-07   | TBD             | 10, 12, 14, 16       |
+| 4.0.0   | TBD          | TBD             | 14, 16               |
 
 <a name="supported-os"></a>
 
@@ -62,9 +63,9 @@ the YAML workflow labels below:
 
 | OS      | YAML Workflow Label    | Package Manager           | Node.js      |
 |---------|------------------------|---------------------------|--------------|
-| Linux   | `ubuntu-latest`        | npm                       | 10,12,14,16  |
-| Linux   | `ubuntu-18.04`         | yarn,pnpm                 | 10,12        |
-| Windows | `windows-latest`       | npm                       | 10,12,14,16  |
-| MacOS   | `macos-latest`         | npm                       | 10,12,14,16  |
+| Linux   | `ubuntu-latest`        | npm                       | 14,16        |
+| Linux   | `ubuntu-18.04`         | yarn,pnpm                 | 14,16        |
+| Windows | `windows-latest`       | npm                       | 14,16        |
+| MacOS   | `macos-latest`         | npm                       | 14,16        |
 
 Using [yarn](https://yarnpkg.com/) might require passing the `--ignore-engines` flag.

--- a/test/esm/index.test.js
+++ b/test/esm/index.test.js
@@ -3,20 +3,6 @@
 const t = require('tap')
 const semver = require('semver')
 
-if (semver.lt(process.versions.node, '13.3.0')) {
-  t.skip('Skip esm because Node version <= 13.3.0')
-} else {
-  // Node v8 throw a `SyntaxError: Unexpected token import`
-  // even if this branch is never touch in the code,
-  // by using `eval` we can avoid this issue.
-  // eslint-disable-next-line
-  new Function('module', 'return import(module)')('./esm.mjs').catch((err) => {
-    process.nextTick(() => {
-      throw err
-    })
-  })
-}
-
 if (semver.lt(process.versions.node, '14.13.0')) {
   t.skip('Skip named exports because Node version < 14.13.0')
 } else {

--- a/test/http2/closing.test.js
+++ b/test/http2/closing.test.js
@@ -3,7 +3,6 @@
 const t = require('tap')
 const Fastify = require('../..')
 const http2 = require('http2')
-const semver = require('semver')
 const { promisify } = require('util')
 const connect = promisify(http2.connect)
 const { once } = require('events')
@@ -37,8 +36,7 @@ t.test('http/2 request while fastify closing', t => {
     t.error(err)
     fastify.server.unref()
 
-    // Skipped because there is likely a bug on Node 8.
-    t.test('return 200', { skip: semver.lt(process.versions.node, '10.15.0') }, t => {
+    t.test('return 200', t => {
       const url = getUrl(fastify)
       const session = http2.connect(url, function () {
         this.request({
@@ -85,8 +83,7 @@ t.test('http/2 request while fastify closing - return503OnClosing: false', t => 
     t.error(err)
     fastify.server.unref()
 
-    // Skipped because there is likely a bug on Node 8.
-    t.test('return 200', { skip: semver.lt(process.versions.node, '10.15.0') }, t => {
+    t.test('return 200', t => {
       const url = getUrl(fastify)
       const session = http2.connect(url, function () {
         this.request({
@@ -115,8 +112,7 @@ t.test('http/2 request while fastify closing - return503OnClosing: false', t => 
   })
 })
 
-// Skipped because there is likely a bug on Node 8.
-t.test('http/2 closes successfully with async await', { skip: semver.lt(process.versions.node, '10.15.0') }, async t => {
+t.test('http/2 closes successfully with async await', async t => {
   const fastify = Fastify({
     http2SessionTimeout: 100,
     http2: true
@@ -131,8 +127,7 @@ t.test('http/2 closes successfully with async await', { skip: semver.lt(process.
   await fastify.close()
 })
 
-// Skipped because there is likely a bug on Node 8.
-t.test('https/2 closes successfully with async await', { skip: semver.lt(process.versions.node, '10.15.0') }, async t => {
+t.test('https/2 closes successfully with async await', async t => {
   const fastify = Fastify({
     http2SessionTimeout: 100,
     http2: true,
@@ -151,8 +146,7 @@ t.test('https/2 closes successfully with async await', { skip: semver.lt(process
   await fastify.close()
 })
 
-// Skipped because there is likely a bug on Node 8.
-t.test('http/2 server side session emits a timeout event', { skip: semver.lt(process.versions.node, '10.15.0') }, async t => {
+t.test('http/2 server side session emits a timeout event', async t => {
   let _resolve
   const p = new Promise((resolve) => { _resolve = resolve })
 


### PR DESCRIPTION
Solves one of the issues in https://github.com/fastify/fastify/issues/3482 to prepare for v4 release

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
