### PR TITLE
Add missing types & docs for async onClose hook

### DIFF
--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -397,7 +397,8 @@ Triggered when `fastify.close()` is invoked to stop the server. It is useful
 when [plugins](./Plugins.md) need a "shutdown" event, for example, to close an
 open connection to a database.
 
-The first argument is the Fastify instance, the second one the `done` callback.
+The hook function takes the Fastify instance as a first argument, 
+and a `done` callback for synchronous hook functions.
 ```js
 // callback style
 fastify.addHook('onClose', (instance, done) => {

--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -399,9 +399,16 @@ open connection to a database.
 
 The first argument is the Fastify instance, the second one the `done` callback.
 ```js
+// callback style
 fastify.addHook('onClose', (instance, done) => {
   // Some code
   done()
+})
+
+// or async/await style
+fastify.addHook('onClose', async (instance) => {
+  // Some async code
+  await closeDatabaseConnections()
 })
 ```
 

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -395,5 +395,16 @@ export interface onCloseHookHandler<
   (
     instance: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     done: HookHandlerDoneFunction
-  ): Promise<unknown> | void;
+  ): void;
+}
+
+export interface onCloseAsyncHookHandler<
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
+  Logger = FastifyLoggerInstance
+> {
+  (
+    instance: FastifyInstance<RawServer, RawRequest, RawReply, Logger>
+  ): Promise<unknown>;
 }

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -4,7 +4,7 @@ import { FastifySchema, FastifySchemaCompiler, FastifySchemaValidationError, Fas
 import { RawServerBase, RawRequestDefaultExpression, RawServerDefault, RawReplyDefaultExpression, ContextConfigDefault } from './utils'
 import { FastifyLoggerInstance } from './logger'
 import { FastifyRegister } from './register'
-import { onRequestHookHandler, preParsingHookHandler, onSendHookHandler, preValidationHookHandler, preHandlerHookHandler, preSerializationHookHandler, onResponseHookHandler, onErrorHookHandler, onRouteHookHandler, onRegisterHookHandler, onCloseHookHandler, onReadyHookHandler, onTimeoutHookHandler, preParsingAsyncHookHandler, preValidationAsyncHookHandler, preHandlerAsyncHookHandler, preSerializationAsyncHookHandler, onSendAsyncHookHandler, onResponseAsyncHookHandler, onTimeoutAsyncHookHandler, onErrorAsyncHookHandler, onReadyAsyncHookHandler, onRequestAsyncHookHandler } from './hooks'
+import { onRequestHookHandler, preParsingHookHandler, onSendHookHandler, preValidationHookHandler, preHandlerHookHandler, preSerializationHookHandler, onResponseHookHandler, onErrorHookHandler, onRouteHookHandler, onRegisterHookHandler, onCloseHookHandler, onCloseAsyncHookHandler, onReadyHookHandler, onTimeoutHookHandler, preParsingAsyncHookHandler, preValidationAsyncHookHandler, preHandlerAsyncHookHandler, preSerializationAsyncHookHandler, onSendAsyncHookHandler, onResponseAsyncHookHandler, onTimeoutAsyncHookHandler, onErrorAsyncHookHandler, onReadyAsyncHookHandler, onRequestAsyncHookHandler } from './hooks'
 import { FastifyRequest } from './request'
 import { FastifyReply } from './reply'
 import { FastifyError } from 'fastify-error'
@@ -331,6 +331,11 @@ export interface FastifyInstance<
   addHook(
     name: 'onClose',
     hook: onCloseHookHandler<RawServer, RawRequest, RawReply, Logger>
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+
+  addHook(
+    name: 'onClose',
+    hook: onCloseAsyncHookHandler<RawServer, RawRequest, RawReply, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**


### PR DESCRIPTION
Tests and implementation were already included for async onClose hooks, but documentation and TypeScript types were missing.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
