### PR TITLE
Fix docs broken links

### DIFF
--- a/docs/Guides/Fluent-Schema.md
+++ b/docs/Guides/Fluent-Schema.md
@@ -59,7 +59,7 @@ With `fluent-json-schema` you can manipulate your schemas more easily and
 programmatically and then reuse them thanks to the `addSchema()` method. You can
 refer to the schema in two different manners that are detailed in the
 [Validation and
-Serialization](./Validation-and-Serialization.md#adding-a-shared-schema)
+Serialization](../Referemce/Validation-and-Serialization.md#adding-a-shared-schema)
 documentation.
 
 Here are some usage examples:

--- a/docs/Guides/Fluent-Schema.md
+++ b/docs/Guides/Fluent-Schema.md
@@ -3,7 +3,7 @@
 ## Fluent Schema
 
 The [Validation and
-Serialization](/docs/Reference/Validation-and-Serialization.md) documentation
+Serialization](../Reference/Validation-and-Serialization.md) documentation
 outlines all parameters accepted by Fastify to set up JSON Schema Validation to
 validate the input, and JSON Schema Serialization to optimize the output.
 

--- a/docs/Guides/Fluent-Schema.md
+++ b/docs/Guides/Fluent-Schema.md
@@ -59,7 +59,7 @@ With `fluent-json-schema` you can manipulate your schemas more easily and
 programmatically and then reuse them thanks to the `addSchema()` method. You can
 refer to the schema in two different manners that are detailed in the
 [Validation and
-Serialization](../Referemce/Validation-and-Serialization.md#adding-a-shared-schema)
+Serialization](../Reference/Validation-and-Serialization.md#adding-a-shared-schema)
 documentation.
 
 Here are some usage examples:

--- a/docs/Guides/Serverless.md
+++ b/docs/Guides/Serverless.md
@@ -64,7 +64,7 @@ if (require.main === module) {
 
 When executed in your lambda function we do not need to listen to a specific
 port, so we just export the wrapper function `init` in this case. The
-[`lambda.js`](https://www.fastify.io/docs/latest/Serverless/#lambda-js) file
+[`lambda.js`](#lambda-js) file
 will use this export.
 
 When you execute your Fastify application like always, i.e. `node app.js` *(the
@@ -93,7 +93,7 @@ exports.handler = proxy;
 We just require
 [aws-lambda-fastify](https://github.com/fastify/aws-lambda-fastify) (make sure
 you install the dependency `npm i --save aws-lambda-fastify`) and our
-[`app.js`](https://www.fastify.io/docs/latest/Serverless/#app-js) file and call
+[`app.js`](#app-js) file and call
 the exported `awsLambdaFastify` function with the `app` as the only parameter.
 The resulting `proxy` function has the correct signature to be used as a lambda
 `handler` function. This way all the incoming events (API Gateway requests) are
@@ -111,7 +111,7 @@ found
 ### Considerations
 
 - API Gateway does not support streams yet, so you are not able to handle
-  [streams](https://www.fastify.io/docs/latest/Reply/#streams).
+  [streams](../Reference/Reply.md#streams).
 - API Gateway has a timeout of 29 seconds, so it is important to provide a reply
   during this time.
 

--- a/docs/Guides/Serverless.md
+++ b/docs/Guides/Serverless.md
@@ -64,7 +64,7 @@ if (require.main === module) {
 
 When executed in your lambda function we do not need to listen to a specific
 port, so we just export the wrapper function `init` in this case. The
-[`lambda.js`](#lambda-js) file
+[`lambda.js`](#lambdajs) file
 will use this export.
 
 When you execute your Fastify application like always, i.e. `node app.js` *(the
@@ -93,7 +93,7 @@ exports.handler = proxy;
 We just require
 [aws-lambda-fastify](https://github.com/fastify/aws-lambda-fastify) (make sure
 you install the dependency `npm i --save aws-lambda-fastify`) and our
-[`app.js`](#app-js) file and call
+[`app.js`](#appjs) file and call
 the exported `awsLambdaFastify` function with the `app` as the only parameter.
 The resulting `proxy` function has the correct signature to be used as a lambda
 `handler` function. This way all the incoming events (API Gateway requests) are

--- a/docs/Guides/Style-Guide.md
+++ b/docs/Guides/Style-Guide.md
@@ -70,7 +70,7 @@ markdown.
 **Example**
 
 ```
-To learn more about hooks, see [Fastify hooks](https://www.fastify.io/docs/latest/Hooks).
+To learn more about hooks, see [Fastify hooks](../Reference/Hooks.md).
 ```
 
 Result:

--- a/docs/Guides/Style-Guide.md
+++ b/docs/Guides/Style-Guide.md
@@ -70,12 +70,12 @@ markdown.
 **Example**
 
 ```
-To learn more about hooks, see [Fastify hooks](../Reference/Hooks.md).
+To learn more about hooks, see [Fastify hooks](https://www.fastify.io/docs/latest/Reference/Hooks/).
 ```
 
 Result:
 >To learn more about hooks, see [Fastify
->hooks](https://www.fastify.io/docs/latest/Hooks/).
+>hooks](https://www.fastify.io/docs/latest/Reference/Hooks/).
 
 
 

--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -112,7 +112,7 @@ existing content type parsers. In the example below we achieve exactly the same
 as in the example above except that we do not need to specify each content type
 to delete. Just like `removeContentTypeParser`, this API supports encapsulation.
 The API is especially useful if you want to register a [catch-all content type
-parser](#Catch-All) that should be executed for every content type and the
+parser](#catch-all) that should be executed for every content type and the
 built-in parsers should be ignored as well.
 
 ```js

--- a/docs/Reference/Decorators.md
+++ b/docs/Reference/Decorators.md
@@ -72,7 +72,7 @@ topic.
 #### `decorate(name, value, [dependencies])`
 <a id="decorate"></a>
 
-This method is used to customize the Fastify [server](./Reference/Server.md)
+This method is used to customize the Fastify [server](./Server.md)
 instance.
 
 For example, to attach a new method to the server instance:
@@ -100,8 +100,8 @@ fastify.utility()
 console.log(fastify.conf.db)
 ```
 
-The decorated [Fastify server](./Reference/Server.md) is bound to `this` in
-route [route](Routes.md) handlers:
+The decorated [Fastify server](./Server.md) is bound to `this` in
+route [route](./Routes.md) handlers:
 
 ```js
 fastify.decorate('db', new DbConnection())

--- a/docs/Reference/Errors.md
+++ b/docs/Reference/Errors.md
@@ -96,7 +96,7 @@ The parser for this content type was already registered.
 The request body is larger than the provided limit.
 
 This setting can be defined in the Fastify server instance:
-[`bodyLimit`](./Server.md#bodyLimit)
+[`bodyLimit`](./Server.md#bodylimit)
 
 #### FST_ERR_CTP_EMPTY_TYPE
 <a id="FST_ERR_CTP_EMPTY_TYPE"></a>

--- a/docs/Reference/Index.md
+++ b/docs/Reference/Index.md
@@ -44,7 +44,7 @@ This table of contents is in alphabetical order.
   standard set of errors Fastify generates.
 + [Hooks](./Hooks.md): Details the API by which Fastify plugins can inject
   themselves into Fastify's handling of the request lifecycle.
-+ [HTTP2](/./HTTP2.md): Details Fastify's HTTP2 support.
++ [HTTP2](./HTTP2.md): Details Fastify's HTTP2 support.
 + [Lifecycle](./Lifecycle.md): Explains the Fastify request lifecycle and
   illustrates where [Hooks](./Hooks.md) are available for integrating with it.
 + [Logging](./Logging.md): Details Fastify's included logging and how to

--- a/docs/Reference/Plugins.md
+++ b/docs/Reference/Plugins.md
@@ -12,7 +12,7 @@ feature allows us to achieve plugin *encapsulation* and *inheritance*, in this
 way we create a *direct acyclic graph* (DAG) and we will not have issues caused
 by cross dependencies.
 
-You already see in the [getting started](../Guides/Getting-Started.md#register)
+You already see in the [getting started](../Guides/Getting-Started.md#your-first-plugin)
 section how using this API is pretty straightforward.
 ```
 fastify.register(plugin, [options])
@@ -30,7 +30,7 @@ Fastify specific options is:
 
 + [`logLevel`](./Routes.md#custom-log-level)
 + [`logSerializers`](./Routes.md#custom-log-serializer)
-+ [`prefix`](#route-prefixing-options)
++ [`prefix`](#route-prefixing-option)
 
 **Note: Those options will be ignored when used with fastify-plugin**
 

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -67,7 +67,7 @@ object that exposes the following functions and properties:
   from Node core.
 - `.log` - The logger instance of the incoming request.
 - `.request` - The incoming request.
-- `.context` - Access the [Request's context](./Request.md#Request) property.
+- `.context` - Access the [Request's context](./Request.md) property.
 
 ```js
 fastify.get('/', options, function (request, reply) {
@@ -510,7 +510,7 @@ fastify.setNotFoundHandler(function (request, reply) {
 <a id="payload-type"></a>
 
 The type of the sent payload (after serialization and going through any
-[`onSend` hooks](./Hooks.md#the-onsend-hook)) must be one of the following
+[`onSend` hooks](./Hooks.md#onsend)) must be one of the following
 types, otherwise, an error will be thrown:
 
 - `string`

--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -82,7 +82,7 @@ fastify.route(options)
   called. Note: using an arrow function will break the binding of `this`.
 * `errorHandler(error, request, reply)`: a custom error handler for the scope of
   the request. Overrides the default error global handler, and anything set by
-  [`setErrorHandler`](./Server.md#setErrorHandler), for requests to the route.
+  [`setErrorHandler`](./Server.md#seterrorhandler), for requests to the route.
   To access the default handler, you can access `instance.errorHandler`. Note
   that this will point to fastify's default `errorHandler` only if a plugin
   hasn't overridden it already.
@@ -107,7 +107,7 @@ fastify.route(options)
 * `logSerializers`: set serializers to log for this route.
 * `config`: object used to store custom configuration.
 * `version`: a [semver](https://semver.org/) compatible string that defined the
-  version of the endpoint. [Example](#version).
+  version of the endpoint. [Example](#version-constraints).
 * `prefixTrailingSlash`: string used to determine how to handle passing `/` as a
   route with a prefix.
   * `both` (default): Will register both `/prefix` and `/prefix/`.
@@ -437,7 +437,7 @@ the global Fastify Logger, accessible with `fastify.log`*
 
 In some context, you may need to log a large object but it could be a waste of
 resources for some routes. In this case, you can define some
-[`serializer`](https://github.com/pinojs/pino/blob/master/docs/api.md#bindingsserializers-object)
+[`serializer`](https://github.com/pinojs/pino/blob/master/docs/api.md#serializers-object)
 and attach them in the right context!
 
 ```js

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1075,7 +1075,7 @@ used by plugins.
 #### inject
 <a id="inject"></a>
 
-Fake HTTP injection (for testing purposes) [here](../Guides/Testing.md#inject).
+Fake HTTP injection (for testing purposes) [here](../Guides/Testing.md#benefits-of-using-fastifyinject).
 
 #### addSchema
 <a id="add-schema"></a>
@@ -1291,8 +1291,8 @@ handler so requests will go through the full [Fastify
 lifecycle](./Lifecycle.md#lifecycle).
 
 You can also register
-[`preValidation`](https://www.fastify.io/docs/latest/Hooks/#route-hooks) and
-[`preHandler`](https://www.fastify.io/docs/latest/Hooks/#route-hooks) hooks for
+[`preValidation`](./Hooks.md#route-hooks) and
+[`preHandler`](./Hooks.md#route-hooks) hooks for
 the 404 handler.
 
 _Note: The `preValidation` hook registered using this method will run for a
@@ -1402,7 +1402,7 @@ fastify.ready(() => {
 the `route.store` object for each displayed route. This can be an `array` of
 keys (e.g. `['onRequest', Symbol('key')]`), or `true` to display all properties.
 A shorthand option, `fastify.printRoutes({ includeHooks: true })` will include
-all [hooks](https://www.fastify.io/docs/latest/Hooks/).
+all [hooks](./Hooks.md).
 
 ```js
   console.log(fastify.printRoutes({ includeHooks: true, includeMeta: ['metaProperty'] }))

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -713,7 +713,7 @@ fastify.setSchemaErrorFormatter(function (errors, dataVar) {
 ```
 
 You can also use
-[setErrorHandler](./Server#seterrorhandler) to
+[setErrorHandler](./Server.md#seterrorhandler) to
 define a custom response for validation errors such as
 
 ```js

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -713,7 +713,7 @@ fastify.setSchemaErrorFormatter(function (errors, dataVar) {
 ```
 
 You can also use
-[setErrorHandler](./Server/#seterrorhandler) to
+[setErrorHandler](./Server#seterrorhandler) to
 define a custom response for validation errors such as
 
 ```js

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -713,7 +713,7 @@ fastify.setSchemaErrorFormatter(function (errors, dataVar) {
 ```
 
 You can also use
-[setErrorHandler](https://www.fastify.io/docs/latest/Server/#seterrorhandler) to
+[setErrorHandler](./Server/#seterrorhandler) to
 define a custom response for validation errors such as
 
 ```js


### PR DESCRIPTION
Due to some reports about broken links, I'm opening this PR to fix all missing or old links.

### Broken Links list:

- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Guides/Fluent-Schema.md?plain=1#L62) wrong link
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Guides/Serverless.md?plain=1#L67) wrong link
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Guides/Serverless.md?plain=1#L96) wrong link
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Guides/Serverless.md?plain=1#L114) wrong link
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Guides/Style-Guide.md?plain=1#L73) wrong link
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Reference/Decorators.md?plain=1#L75) wrong link
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Reference/Decorators.md?plain=1#L103) wrong link
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Reference/Decorators.md?plain=1#L104) wrong link
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Reference/Errors.md?plain=1#L99) #bodyLimit should be #bodylimit
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Reference/Plugins.md?plain=1#L15) wrong #tag
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Reference/Plugins.md?plain=1#L33) should be #route-prefixing-option
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Reference/Reply.md?plain=1#L70) There is not a #Request tag (remove)
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Reference/Reply.md?plain=1#L513) # should be #onsend
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Reference/Routes.md?plain=1#L85) # should be #seterrorhandler
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Reference/Routes.md?plain=1#L110) #version does not exist
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Reference/Routes.md?plain=1#L440) # should be #serializers-object
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Reference/Server.md?plain=1#L1078) # no longer exists
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Reference/Server.md?plain=1#L1294) make relative (wrong absolute path)
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Reference/Server.md?plain=1#L1295) make relative (wrong absolute path)
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Reference/Server.md?plain=1#L1405) make relative (wrong absolute path)
- [x] [docs](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Reference/Validation-and-Serialization.md?plain=1#L716) make relative (wrong absolute path)

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
