### PR TITLE
feat: listen to multiple hosts by default

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -357,7 +357,6 @@ function fastify (options) {
     fastify.onClose((instance, done) => {
       fastify[kState].closing = true
       router.closeRoutes()
-      // TODO: binding server should also be closed
       if (fastify[kState].listening) {
         // No new TCP connections are accepted
         instance.server.close(done)

--- a/fastify.js
+++ b/fastify.js
@@ -25,7 +25,8 @@ const {
   kOptions,
   kPluginNameChain,
   kSchemaErrorFormatter,
-  kErrorHandler
+  kErrorHandler,
+  kBindingServer
 } = require('./lib/symbols.js')
 
 const { createServer } = require('./lib/server')
@@ -186,7 +187,8 @@ function fastify (options) {
     [kState]: {
       listening: false,
       closing: false,
-      started: false
+      started: false,
+      bindingListening: false
     },
     [kOptions]: options,
     [kChildren]: [],
@@ -210,6 +212,7 @@ function fastify (options) {
     [pluginUtils.registeredPlugins]: [],
     [kPluginNameChain]: [],
     [kAvvioBoot]: null,
+    [kBindingServer]: null,
     // routing method
     routing: httpHandler,
     getDefaultRoute: router.getDefaultRoute.bind(router),
@@ -358,6 +361,8 @@ function fastify (options) {
       if (fastify[kState].listening) {
         // No new TCP connections are accepted
         instance.server.close(done)
+      } if (fastify[kState].bindingListening) {
+        instance[kBindingServer].close(done)
       } else {
         done(null)
       }

--- a/fastify.js
+++ b/fastify.js
@@ -354,6 +354,7 @@ function fastify (options) {
     fastify.onClose((instance, done) => {
       fastify[kState].closing = true
       router.closeRoutes()
+      // TODO: binding server should also be closed
       if (fastify[kState].listening) {
         // No new TCP connections are accepted
         instance.server.close(done)

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -184,6 +184,18 @@ const codes = {
   ),
 
   /**
+   * Create Server
+   */
+  FST_ERR_CREATE_SERVER_MISSING_OPTIONS: createError(
+    'FST_ERR_CREATE_SERVER_MISSING_OPTIONS',
+    "Missing options for createServer: '%s'"
+  ),
+  FST_ERR_CREATE_SERVER_MISSING_HTTP_HANDLER: createError(
+    'FST_ERR_CREATE_SERVER_MISSING_HTTP_HANDLER',
+    "Missing http handler for createServer: '%s'"
+  ),
+
+  /**
    * router
    */
   FST_ERR_DUPLICATED_ROUTE: createError(

--- a/lib/server.js
+++ b/lib/server.js
@@ -68,7 +68,7 @@ function createServer (options, httpHandler) {
 
     if (secondHost != null) {
       this[kBindingServer] = secondHost
-      return Promise.any([
+      return Promise.all([
         // Main host
         bindedListen(server, listenOptions),
         // Binding host

--- a/lib/server.js
+++ b/lib/server.js
@@ -68,8 +68,6 @@ function createServer (options, httpHandler) {
 
     if (secondHost != null) {
       this[kBindingServer] = secondHost
-      // NOTE: If following this, we can completely ignore the error
-      // of ::1 not supported, but not sure if it is a good idea
       return Promise.any([
         // Main host
         bindedListen(server, listenOptions),

--- a/lib/server.js
+++ b/lib/server.js
@@ -86,8 +86,10 @@ function createServer (options, httpHandler) {
     const wrap = err => {
       httpServer.removeListener('error', wrap)
       if (!err) {
+        const isServerReady = this[kState].bindingListening && this[kState].listening
         const address = logServerAddress()
-        cb(null, address)
+
+        if (isServerReady && !isBindingServer) cb(null, address)
       } else {
         this[kState].listening = isBindingServer ? this[kState].listening : false
         this[kState].bindingListening = isBindingServer ? false : this[kState].bindingListening

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,8 +1,6 @@
 'use strict'
 
 const assert = require('assert')
-const http = require('http')
-const https = require('https')
 
 const { kState, kOptions } = require('./symbols')
 const { FST_ERR_HTTP2_INVALID_VERSION, FST_ERR_REOPENED_CLOSE_SERVER, FST_ERR_REOPENED_SERVER } = require('./errors')
@@ -15,19 +13,11 @@ function createServer (options, httpHandler) {
   if (options.serverFactory) {
     server = options.serverFactory(httpHandler, options)
   } else if (options.http2) {
-    if (options.https) {
-      server = http2().createSecureServer(options.https, httpHandler)
-    } else {
-      server = http2().createServer(httpHandler)
-    }
+    server = http2(httpHandler, options.https)
     server.on('session', sessionTimeout(options.http2SessionTimeout))
   } else {
     // this is http1
-    if (options.https) {
-      server = https.createServer(options.https, httpHandler)
-    } else {
-      server = http.createServer(httpHandler)
-    }
+    server = http(httpHandler, options.https)
     server.keepAliveTimeout = options.keepAliveTimeout
     server.requestTimeout = options.requestTimeout
     // we treat zero as null
@@ -56,6 +46,11 @@ function createServer (options, httpHandler) {
 
       const firstArg = args[0]
       const argsLength = args.length
+      // This will listen to what localhost is.
+      // It can be 127.0.0.1 or ::1, depending on the operating system.
+      // Fixes https://github.com/fastify/fastify/issues/1022.
+      // IPv4 by default
+      const host = argsLength >= 2 && args[1] ? args[1] : '127.0.0.1'
       const lastArg = args[argsLength - 1]
       /* Deal with listen (options) || (handle[, backlog]) */
       if (typeof firstArg === 'object' && firstArg !== null) {
@@ -68,10 +63,7 @@ function createServer (options, httpHandler) {
       } else {
         /* Deal with listen ([port[, host[, backlog]]]) */
         options.port = argsLength >= 1 && firstArg ? firstArg : 0
-        // This will listen to what localhost is.
-        // It can be 127.0.0.1 or ::1, depending on the operating system.
-        // Fixes https://github.com/fastify/fastify/issues/1022.
-        options.host = argsLength >= 2 && args[1] ? args[1] : 'localhost'
+        options.host = host
         options.backlog = argsLength >= 3 ? args[2] : undefined
       }
 
@@ -160,9 +152,21 @@ function createServer (options, httpHandler) {
   }
 }
 
-function http2 () {
+function http (httpHandler, httpsOpts) {
+  if (httpsOpts) {
+    return require('https').createServer(httpsOpts, httpHandler)
+  } else {
+    return require('http').createServer(httpHandler)
+  }
+}
+
+function http2 (httpHandler, httpsOpts) {
   try {
-    return require('http2')
+    if (httpsOpts) {
+      return require('http2').createSecureServer(httpsOpts, httpHandler)
+    } else {
+      return require('http2').createServer(httpHandler)
+    }
   } catch (err) {
     throw new FST_ERR_HTTP2_INVALID_VERSION()
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -20,7 +20,7 @@ function createServer (options, httpHandler) {
   // `this` is the Fastify object
   function listen () {
     const normalizeListenArgs = (args) => {
-      const defaultHost = '127.0.0.1'
+      const defaultHost = 'localhost'
       if (args.length === 0) {
         return { port: 0, host: defaultHost }
       }

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { kState, kOptions } = require('./symbols')
+const { kState, kOptions, kBindingServer } = require('./symbols')
 const { FST_ERR_CREATE_SERVER_MISSING_OPTIONS, FST_ERR_CREATE_SERVER_MISSING_HTTP_HANDLER } = require('./errors')
 const { FST_ERR_HTTP2_INVALID_VERSION, FST_ERR_REOPENED_CLOSE_SERVER, FST_ERR_REOPENED_SERVER } = require('./errors')
 
@@ -62,15 +62,22 @@ function createServer (options, httpHandler) {
     // TODO: Remove once finished
     process._rawDebug('Binding second host:', listenOptions.host === '127.0.0.1' || listenOptions.host === '::1')
     if (listenOptions.host === '127.0.0.1' || listenOptions.host === '::1') {
-      clonedOptions = Object.assign({}, listenOptions, { host: '::1' })
+      const bindingHost = listenOptions.host === '127.0.0.1' ? '::1' : '127.0.0.1'
+      clonedOptions = Object.assign({}, listenOptions, { host: bindingHost })
       secondHost = getServerInstance(httpHandler, options)
     }
 
     // Main host
     bindedListen(server, listenOptions)
 
-    // Secundary host
+    // Secondary host
     if (secondHost != null) {
+      this[kBindingServer] = secondHost
+      // TODO: Remove once finished
+
+      secondHost.on('close', () => {
+        process._rawDebug('Secondary host closed', this[kState])
+      })
       bindedListen(secondHost, clonedOptions, true)
     }
   }
@@ -119,7 +126,6 @@ function createServer (options, httpHandler) {
             resolve(logServerAddress())
           })
           // we set it afterwards because listen can throw
-          // TODO: use kState instead
           this[kState].listening = isBinding ? this[kState].listening : true
           this[kState].bindingListening = isBinding ? true : this[kState].bindingListening
         })
@@ -133,6 +139,8 @@ function createServer (options, httpHandler) {
 
     const logServerAddress = () => {
       let address = httpServer.address()
+      // TODO: remove once finished
+      process._rawDebug('Address object', address)
       const isUnixSocket = typeof address === 'string'
       /* istanbul ignore next */
       if (!isUnixSocket) {
@@ -144,6 +152,8 @@ function createServer (options, httpHandler) {
       }
       /* istanbul ignore next */
       address = (isUnixSocket ? '' : ('http' + (this[kOptions].https ? 's' : '') + '://')) + address
+      // TODO: Remove when finished
+      process._rawDebug('Server listening', address)
       this.log.info('Server listening at ' + address)
       return address
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,44 +1,27 @@
 'use strict'
 
-const assert = require('assert')
-
-const { kState, kOptions } = require('./symbols')
+const { kState, kOptions, kBindingServerListening } = require('./symbols')
+const { FST_ERR_CREATE_SERVER_MISSING_OPTIONS, FST_ERR_CREATE_SERVER_MISSING_HTTP_HANDLER } = require('./errors')
 const { FST_ERR_HTTP2_INVALID_VERSION, FST_ERR_REOPENED_CLOSE_SERVER, FST_ERR_REOPENED_SERVER } = require('./errors')
 
 function createServer (options, httpHandler) {
-  assert(options, 'Missing options')
-  assert(httpHandler, 'Missing http handler')
-
-  let server = null
-  if (options.serverFactory) {
-    server = options.serverFactory(httpHandler, options)
-  } else if (options.http2) {
-    server = http2(httpHandler, options.https)
-    server.on('session', sessionTimeout(options.http2SessionTimeout))
-  } else {
-    // this is http1
-    server = http(httpHandler, options.https)
-    server.keepAliveTimeout = options.keepAliveTimeout
-    server.requestTimeout = options.requestTimeout
-    // we treat zero as null
-    // and null is the default setting from nodejs
-    // so we do not pass the option to server
-    if (options.maxRequestsPerSocket > 0) {
-      server.maxRequestsPerSocket = options.maxRequestsPerSocket
-    }
+  if (options == null) {
+    throw new FST_ERR_CREATE_SERVER_MISSING_OPTIONS(typeof options)
   }
 
-  if (!options.serverFactory) {
-    server.setTimeout(options.connectionTimeout)
+  if (httpHandler == null) {
+    throw new FST_ERR_CREATE_SERVER_MISSING_HTTP_HANDLER(typeof httpHandler)
   }
+
+  const server = getServerInstance(httpHandler, options)
 
   return { server, listen }
 
-  // `this` is the Fastify object
   function listen () {
     const normalizeListenArgs = (args) => {
+      const defaultHost = '127.0.0.1'
       if (args.length === 0) {
-        return { port: 0, host: 'localhost' }
+        return { port: 0, host: defaultHost }
       }
 
       const cb = typeof args[args.length - 1] === 'function' ? args.pop() : undefined
@@ -50,7 +33,7 @@ function createServer (options, httpHandler) {
       // It can be 127.0.0.1 or ::1, depending on the operating system.
       // Fixes https://github.com/fastify/fastify/issues/1022.
       // IPv4 by default
-      const host = argsLength >= 2 && args[1] ? args[1] : '127.0.0.1'
+      const host = argsLength >= 2 && args[1] ? args[1] : defaultHost
       const lastArg = args[argsLength - 1]
       /* Deal with listen (options) || (handle[, backlog]) */
       if (typeof firstArg === 'object' && firstArg !== null) {
@@ -70,11 +53,29 @@ function createServer (options, httpHandler) {
       return options
     }
 
+    const bindedListen = _listen.bind(this)
     const listenOptions = normalizeListenArgs(Array.from(arguments))
+
+    let secondHost
+    let clonedOptions
+    if (listenOptions.host === '127.0.0.1' || listenOptions.host === '::1') {
+      clonedOptions = Object.assign({}, listenOptions, { host: '::1' })
+      secondHost = getServerInstance(httpHandler, options)
+    }
+
+    if (secondHost != null) {
+      bindedListen(this, secondHost, clonedOptions, true)
+    }
+
+    bindedListen(this, server, listenOptions)
+  }
+
+  // `this` is the Fastify object
+  function _listen (httpServer, listenOptions, isBindingServer) {
     const cb = listenOptions.cb
 
     const wrap = err => {
-      server.removeListener('error', wrap)
+      httpServer.removeListener('error', wrap)
       if (!err) {
         const address = logServerAddress()
         cb(null, address)
@@ -87,7 +88,7 @@ function createServer (options, httpHandler) {
     const listenPromise = (listenOptions) => {
       if (this[kState].listening && this[kState].closing) {
         return Promise.reject(new FST_ERR_REOPENED_CLOSE_SERVER())
-      } else if (this[kState].listening) {
+      } else if (this[kState].listening || this[kBindingServerListening]) {
         return Promise.reject(new FST_ERR_REOPENED_SERVER())
       }
 
@@ -98,15 +99,17 @@ function createServer (options, httpHandler) {
             this[kState].listening = false
             reject(err)
           }
-          server.once('error', errEventHandler)
+          httpServer.once('error', errEventHandler)
         })
         const listen = new Promise((resolve, reject) => {
-          server.listen(listenOptions, () => {
-            server.removeListener('error', errEventHandler)
+          httpServer.listen(listenOptions, () => {
+            httpServer.removeListener('error', errEventHandler)
             resolve(logServerAddress())
           })
           // we set it afterwards because listen can throw
-          this[kState].listening = true
+          // TODO: use kState instead
+          this[kState].listening = isBindingServer ? this[kState].listening : true
+          this[kBindingServerListening] = isBindingServer && true
         })
 
         return Promise.race([
@@ -117,7 +120,7 @@ function createServer (options, httpHandler) {
     }
 
     const logServerAddress = () => {
-      let address = server.address()
+      let address = httpServer.address()
       const isUnixSocket = typeof address === 'string'
       /* istanbul ignore next */
       if (!isUnixSocket) {
@@ -144,12 +147,41 @@ function createServer (options, httpHandler) {
         return cb(new FST_ERR_REOPENED_SERVER(), null)
       }
 
-      server.once('error', wrap)
-      server.listen(listenOptions, wrap)
+      httpServer.once('error', wrap)
 
-      this[kState].listening = true
+      httpServer.listen(listenOptions, wrap)
+
+      this[kState].listening = isBindingServer ? this[kState].listening : true
+      this[kBindingServerListening] = isBindingServer && true
     })
   }
+}
+
+function getServerInstance (httpHandler, serverOptions) {
+  let server = null
+  if (serverOptions.serverFactory) {
+    server = serverOptions.serverFactory(httpHandler, serverOptions)
+  } else if (serverOptions.http2) {
+    server = http2(httpHandler, serverOptions.https)
+    server.on('session', sessionTimeout(serverOptions.http2SessionTimeout))
+  } else {
+    // this is http1
+    server = http(httpHandler, serverOptions.https)
+    server.keepAliveTimeout = serverOptions.keepAliveTimeout
+    server.requestTimeout = serverOptions.requestTimeout
+    // we treat zero as null
+    // and null is the default setting from nodejs
+    // so we do not pass the option to server
+    if (serverOptions.maxRequestsPerSocket > 0) {
+      server.maxRequestsPerSocket = serverOptions.maxRequestsPerSocket
+    }
+  }
+
+  if (!serverOptions.serverFactory) {
+    server.setTimeout(serverOptions.connectionTimeout)
+  }
+
+  return server
 }
 
 function http (httpHandler, httpsOpts) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -56,22 +56,28 @@ function createServer (options, httpHandler) {
 
     const bindedListen = _listen.bind(this)
     const listenOptions = normalizeListenArgs(Array.from(arguments))
+    const isLocalHost = listenOptions.host === 'localhost'
 
     let secondHost
-    let clonedOptions
-    if (listenOptions.host === '127.0.0.1' || listenOptions.host === '::1') {
-      const bindingHost = listenOptions.host === '127.0.0.1' ? '::1' : '127.0.0.1'
-      clonedOptions = Object.assign({}, listenOptions, { host: bindingHost })
+    let clonedListenOptions
+    if (isLocalHost) {
+      listenOptions.host = '127.0.0.1'
+      clonedListenOptions = Object.assign({}, listenOptions, { host: '::1' })
       secondHost = getServerInstance(httpHandler, options)
     }
 
-    // Main host
-    bindedListen(server, listenOptions)
-
-    // Secondary host
     if (secondHost != null) {
       this[kBindingServer] = secondHost
-      bindedListen(secondHost, clonedOptions, true)
+      // NOTE: If following this, we can completely ignore the error
+      // of ::1 not supported, but not sure if it is a good idea
+      return Promise.any([
+        // Main host
+        bindedListen(server, listenOptions),
+        // Binding host
+        bindedListen(secondHost, clonedListenOptions, true)
+      ])
+    } else {
+      return bindedListen(server, listenOptions)
     }
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -59,8 +59,6 @@ function createServer (options, httpHandler) {
 
     let secondHost
     let clonedOptions
-    // TODO: Remove once finished
-    process._rawDebug('Binding second host:', listenOptions.host === '127.0.0.1' || listenOptions.host === '::1')
     if (listenOptions.host === '127.0.0.1' || listenOptions.host === '::1') {
       const bindingHost = listenOptions.host === '127.0.0.1' ? '::1' : '127.0.0.1'
       clonedOptions = Object.assign({}, listenOptions, { host: bindingHost })
@@ -73,11 +71,6 @@ function createServer (options, httpHandler) {
     // Secondary host
     if (secondHost != null) {
       this[kBindingServer] = secondHost
-      // TODO: Remove once finished
-
-      secondHost.on('close', () => {
-        process._rawDebug('Secondary host closed', this[kState])
-      })
       bindedListen(secondHost, clonedOptions, true)
     }
   }
@@ -85,9 +78,6 @@ function createServer (options, httpHandler) {
   // `this` is the Fastify object
   function _listen (httpServer, listenOptions, isBindingServer) {
     const cb = listenOptions.cb
-
-    // TODO: Remove when finished
-    process._rawDebug('Binding server to', listenOptions.host, listenOptions.port)
 
     const wrap = err => {
       httpServer.removeListener('error', wrap)
@@ -102,8 +92,6 @@ function createServer (options, httpHandler) {
     }
 
     const listenPromise = (listenOptions, isBinding) => {
-      process._rawDebug('Listening server to', listenOptions.host, listenOptions.port)
-
       if (this[kState].listening && this[kState].bindingListening && this[kState].closing) {
         return Promise.reject(new FST_ERR_REOPENED_CLOSE_SERVER())
       } else if (this[kState].listening && this[kState].bindingListening) {
@@ -139,8 +127,6 @@ function createServer (options, httpHandler) {
 
     const logServerAddress = () => {
       let address = httpServer.address()
-      // TODO: remove once finished
-      process._rawDebug('Address object', address)
       const isUnixSocket = typeof address === 'string'
       /* istanbul ignore next */
       if (!isUnixSocket) {
@@ -152,8 +138,6 @@ function createServer (options, httpHandler) {
       }
       /* istanbul ignore next */
       address = (isUnixSocket ? '' : ('http' + (this[kOptions].https ? 's' : '') + '://')) + address
-      // TODO: Remove when finished
-      process._rawDebug('Server listening', address)
       this.log.info('Server listening at ' + address)
       return address
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { kState, kOptions, kBindingServerListening } = require('./symbols')
+const { kState, kOptions } = require('./symbols')
 const { FST_ERR_CREATE_SERVER_MISSING_OPTIONS, FST_ERR_CREATE_SERVER_MISSING_HTTP_HANDLER } = require('./errors')
 const { FST_ERR_HTTP2_INVALID_VERSION, FST_ERR_REOPENED_CLOSE_SERVER, FST_ERR_REOPENED_SERVER } = require('./errors')
 
@@ -17,6 +17,7 @@ function createServer (options, httpHandler) {
 
   return { server, listen }
 
+  // `this` is the Fastify object
   function listen () {
     const normalizeListenArgs = (args) => {
       const defaultHost = '127.0.0.1'
@@ -58,21 +59,28 @@ function createServer (options, httpHandler) {
 
     let secondHost
     let clonedOptions
+    // TODO: Remove once finished
+    process._rawDebug('Binding second host:', listenOptions.host === '127.0.0.1' || listenOptions.host === '::1')
     if (listenOptions.host === '127.0.0.1' || listenOptions.host === '::1') {
       clonedOptions = Object.assign({}, listenOptions, { host: '::1' })
       secondHost = getServerInstance(httpHandler, options)
     }
 
-    if (secondHost != null) {
-      bindedListen(this, secondHost, clonedOptions, true)
-    }
+    // Main host
+    bindedListen(server, listenOptions)
 
-    bindedListen(this, server, listenOptions)
+    // Secundary host
+    if (secondHost != null) {
+      bindedListen(secondHost, clonedOptions, true)
+    }
   }
 
   // `this` is the Fastify object
   function _listen (httpServer, listenOptions, isBindingServer) {
     const cb = listenOptions.cb
+
+    // TODO: Remove when finished
+    process._rawDebug('Binding server to', listenOptions.host, listenOptions.port)
 
     const wrap = err => {
       httpServer.removeListener('error', wrap)
@@ -80,15 +88,18 @@ function createServer (options, httpHandler) {
         const address = logServerAddress()
         cb(null, address)
       } else {
-        this[kState].listening = false
+        this[kState].listening = isBindingServer ? this[kState].listening : false
+        this[kState].bindingListening = isBindingServer ? false : this[kState].bindingListening
         cb(err, null)
       }
     }
 
-    const listenPromise = (listenOptions) => {
-      if (this[kState].listening && this[kState].closing) {
+    const listenPromise = (listenOptions, isBinding) => {
+      process._rawDebug('Listening server to', listenOptions.host, listenOptions.port)
+
+      if (this[kState].listening && this[kState].bindingListening && this[kState].closing) {
         return Promise.reject(new FST_ERR_REOPENED_CLOSE_SERVER())
-      } else if (this[kState].listening || this[kBindingServerListening]) {
+      } else if (this[kState].listening && this[kState].bindingListening) {
         return Promise.reject(new FST_ERR_REOPENED_SERVER())
       }
 
@@ -96,7 +107,8 @@ function createServer (options, httpHandler) {
         let errEventHandler
         const errEvent = new Promise((resolve, reject) => {
           errEventHandler = (err) => {
-            this[kState].listening = false
+            this[kState].listening = isBinding ? this[kState].listening : false
+            this[kState].bindingListening = isBinding ? false : this[kState].bindingListening
             reject(err)
           }
           httpServer.once('error', errEventHandler)
@@ -108,8 +120,8 @@ function createServer (options, httpHandler) {
           })
           // we set it afterwards because listen can throw
           // TODO: use kState instead
-          this[kState].listening = isBindingServer ? this[kState].listening : true
-          this[kBindingServerListening] = isBindingServer && true
+          this[kState].listening = isBinding ? this[kState].listening : true
+          this[kState].bindingListening = isBinding ? true : this[kState].bindingListening
         })
 
         return Promise.race([
@@ -136,14 +148,14 @@ function createServer (options, httpHandler) {
       return address
     }
 
-    if (cb === undefined) return listenPromise(listenOptions)
+    if (cb === undefined) return listenPromise(listenOptions, isBindingServer)
 
     this.ready(err => {
       if (err != null) return cb(err)
 
-      if (this[kState].listening && this[kState].closing) {
+      if (this[kState].listening && this[kState].bindingListening && this[kState].closing) {
         return cb(new FST_ERR_REOPENED_CLOSE_SERVER(), null)
-      } else if (this[kState].listening) {
+      } else if (this[kState].listening && this[kState].bindingListening) {
         return cb(new FST_ERR_REOPENED_SERVER(), null)
       }
 
@@ -152,7 +164,7 @@ function createServer (options, httpHandler) {
       httpServer.listen(listenOptions, wrap)
 
       this[kState].listening = isBindingServer ? this[kState].listening : true
-      this[kBindingServerListening] = isBindingServer && true
+      this[kState].bindingListening = isBindingServer ? true : this[kState].bindingListening
     })
   }
 }

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -44,6 +44,7 @@ const keys = {
   kTestInternals: Symbol('fastify.testInternals'),
   kErrorHandler: Symbol('fastify.errorHandler'),
   kHasBeenDecorated: Symbol('fastify.hasBeenDecorated'),
+  kBindingServer: Symbol('fastify.bindingServerListening'),
   kBindingServerListening: Symbol('fastify.bindingServerListening')
 }
 

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -43,7 +43,8 @@ const keys = {
   // This symbol is only meant to be used for fastify tests and should not be used for any other purpose
   kTestInternals: Symbol('fastify.testInternals'),
   kErrorHandler: Symbol('fastify.errorHandler'),
-  kHasBeenDecorated: Symbol('fastify.hasBeenDecorated')
+  kHasBeenDecorated: Symbol('fastify.hasBeenDecorated'),
+  kBindingServerListening: Symbol('fastify.bindingServerListening')
 }
 
 module.exports = keys

--- a/test/hooks.on-ready.test.js
+++ b/test/hooks.on-ready.test.js
@@ -278,7 +278,6 @@ t.test('onReady cannot add lifecycle hooks', t => {
     } catch (error) {
       t.ok(error)
       t.equal(error.message, 'Root plugin has already booted')
-      // TODO: look where the error pops up
       t.equal(error.code, 'AVV_ERR_PLUGIN_NOT_VALID')
       done(error)
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

**WIP**
Closes #3536 

The goal of the PR is to allow `fastify` to listen at `127.0.0.0` and `::1` by default if not `host` passed through the options.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
