### PR TITLE
Documentation: replace `fastify.decorate` arrow functions with function expressions

### DIFF
--- a/docs/Reference/Plugins.md
+++ b/docs/Reference/Plugins.md
@@ -181,7 +181,7 @@ callback.
 Example:
 ```js
 module.exports = function (fastify, opts, done) {
-  fastify.decorate('utility', () => {})
+  fastify.decorate('utility', function () {})
 
   fastify.get('/', handler)
 
@@ -191,7 +191,7 @@ module.exports = function (fastify, opts, done) {
 You can also use `register` inside another `register`:
 ```js
 module.exports = function (fastify, opts, done) {
-  fastify.decorate('utility', () => {})
+  fastify.decorate('utility', function () {})
 
   fastify.get('/', handler)
 
@@ -226,7 +226,7 @@ plugin will support.
 const fp = require('fastify-plugin')
 
 module.exports = fp(function (fastify, opts, done) {
-  fastify.decorate('utility', () => {})
+  fastify.decorate('utility', function () {})
   done()
 }, '0.x')
 ```
@@ -239,7 +239,7 @@ changes it will be your responsibility to update the module, while if you use
 `fastify-plugin`, you can be sure about backward compatibility.
 ```js
 function yourPlugin (fastify, opts, done) {
-  fastify.decorate('utility', () => {})
+  fastify.decorate('utility', function () {})
   done()
 }
 yourPlugin[Symbol.for('skip-override')] = true


### PR DESCRIPTION
>This is a change I disagreed with. I will likely revert all such declarations to full function declarations as I update the documentation. In this specific case, it is clearly wrong. A PR to fix this one would be quite welcome. - @jsumners 

Replace arrow functions with function expressions in the `Plugins` documentation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x ] documentation is changed or added
