### PR TITLE
Remove .writableEnded fallbacks for node12

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -68,14 +68,7 @@ Object.defineProperties(Reply.prototype, {
     enumerable: true,
     get () {
       // We are checking whether reply was hijacked or the response has ended.
-      // The response.writableEnded property was added in Node.js v12.9.0. Since
-      // fastify supports older Node.js versions as well, we have to take
-      // response.finished property in consideration when applicable. The
-      // response.finished will be always true when the request method is HEAD
-      // and http2 is used, so we have to combine that with
-      // response.headersSent.
-      // TODO: remove fallback when the lowest supported Node.js version >= v12.9.0
-      return (this[kReplyHijacked] || (typeof this.raw.writableEnded !== 'undefined' ? this.raw.writableEnded : (this.raw.headersSent && this.raw.finished))) === true
+      return (this[kReplyHijacked] || this.raw.writableEnded) === true
     },
     set (value) {
       warning.emit('FSTDEP010')

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -125,33 +125,6 @@ test('handler function - preValidationCallback with finished response', t => {
   internals.handler({}, new Reply(res, { context }))
 })
 
-test('handler function - preValidationCallback with finished response (< v12.9.0)', t => {
-  t.plan(0)
-  const res = {}
-  // Be sure to check only `writableEnded` where is available
-  res.headersSent = true
-  res.finished = true
-
-  res.end = () => {
-    t.fail()
-  }
-  res.writeHead = () => {}
-  const context = {
-    handler: (req, reply) => {
-      t.fail()
-      reply.send(undefined)
-    },
-    Reply: Reply,
-    Request: Request,
-    preValidation: null,
-    preHandler: [],
-    onSend: [],
-    onError: []
-  }
-  buildSchema(context, schemaValidator)
-  internals.handler({}, new Reply(res, { context }))
-})
-
 test('request should be defined in onSend Hook on post request with content type application/json', t => {
   t.plan(8)
   const fastify = require('../..')()

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -1808,11 +1808,3 @@ test('reply.sent should read from response.writableEnded if it is defined', t =>
 
   t.equal(reply.sent, true)
 })
-
-test('reply.sent should read from response.headersSent and response.finished if response.writableEnded is not defined', t => {
-  t.plan(1)
-
-  const reply = new Reply({ headersSent: true, finished: true }, {}, {})
-
-  t.equal(reply.sent, true)
-})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Closes https://github.com/fastify/fastify/issues/3589. I decided to remove those tests since testing that fallbacks for writableEnded don't exist would be kinda useless.