### PR TITLE
fix: bad headers characters

### DIFF
--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -123,6 +123,8 @@ fastify.get('/', async function (req, rep) {
 Sets a response header. If the value is omitted or undefined, it is coerced to
 `''`.
 
+> Note: the header's value must be properly encoded using [`encodeURI`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI) or similar modules such as [`encodeurl`](https://www.npmjs.com/package/encodeurl). Invalid characters will result in a 500 `TypeError` response.
+
 For more information, see
 [`http.ServerResponse#setHeader`](https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_response_setheader_name_value).
 
@@ -202,6 +204,8 @@ Returns a boolean indicating if the specified header has been set.
 
 Redirects a request to the specified URL, the status code is optional, default
 to `302` (if status code is not already set by calling `code`).
+
+> Note: the input URL must be properly encoded using [`encodeURI`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI) or similar modules such as [`encodeurl`](https://www.npmjs.com/package/encodeurl). Invalid URLs will result in a 500 `TypeError` response.
 
 Example (no `reply.code()` call) sets status code to `302` and redirects to
 `/home`

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -27,7 +27,15 @@ function handleError (reply, error, cb) {
   const context = reply.context
   if (reply[kReplyNextErrorHandler] === false) {
     fallbackErrorHandler(error, reply, function (reply, payload) {
-      reply.raw.writeHead(reply.raw.statusCode, reply[kReplyHeaders])
+      try {
+        reply.raw.writeHead(reply.raw.statusCode, reply[kReplyHeaders])
+      } catch (error) {
+        reply.log.warn(
+          { req: reply.request, res: reply, err: error },
+          error && error.message
+        )
+        reply.raw.writeHead(reply.raw.statusCode)
+      }
       reply.raw.end(payload)
     })
     return

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -19,6 +19,18 @@ const fs = require('fs')
 const path = require('path')
 const warning = require('../../lib/warnings')
 
+const doGet = function (url) {
+  return new Promise((resolve, reject) => {
+    sget({ method: 'GET', url, followRedirects: false }, (err, response, body) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve({ response, body })
+      }
+    })
+  })
+}
+
 test('Once called, Reply should return an object with methods', t => {
   t.plan(13)
   const response = { res: 'res' }
@@ -40,7 +52,7 @@ test('Once called, Reply should return an object with methods', t => {
   t.equal(reply.request, request)
 })
 
-test('reply.send will logStream error and destroy the stream', { only: true }, t => {
+test('reply.send will logStream error and destroy the stream', t => {
   t.plan(1)
   let destroyCalled
   const payload = new EventEmitter()
@@ -1807,4 +1819,90 @@ test('reply.sent should read from response.writableEnded if it is defined', t =>
   const reply = new Reply({ writableEnded: true }, {}, {})
 
   t.equal(reply.sent, true)
+})
+
+test('redirect to an invalid URL should not crash the server', async t => {
+  const fastify = require('../..')()
+  fastify.route({
+    method: 'GET',
+    url: '/redirect',
+    handler: (req, reply) => {
+      reply.log.warn = function mockWarn (obj, message) {
+        t.equal(message, 'Invalid character in header content ["location"]')
+      }
+
+      switch (req.query.useCase) {
+        case '1':
+          reply.redirect('/?key=a’b')
+          break
+
+        case '2':
+          reply.redirect(encodeURI('/?key=a’b'))
+          break
+
+        default:
+          reply.redirect('/?key=ab')
+          break
+      }
+    }
+  })
+
+  await fastify.listen(0)
+
+  {
+    const { response, body } = await doGet(`http://localhost:${fastify.server.address().port}/redirect?useCase=1`)
+    t.equal(response.statusCode, 500)
+    t.same(JSON.parse(body), {
+      statusCode: 500,
+      code: 'ERR_INVALID_CHAR',
+      error: 'Internal Server Error',
+      message: 'Invalid character in header content ["location"]'
+    })
+  }
+  {
+    const { response } = await doGet(`http://localhost:${fastify.server.address().port}/redirect?useCase=2`)
+    t.equal(response.statusCode, 302)
+    t.equal(response.headers.location, '/?key=a%E2%80%99b')
+  }
+
+  {
+    const { response } = await doGet(`http://localhost:${fastify.server.address().port}/redirect?useCase=3`)
+    t.equal(response.statusCode, 302)
+    t.equal(response.headers.location, '/?key=ab')
+  }
+
+  await fastify.close()
+})
+
+test('invalid response headers should not crash the server', async t => {
+  const fastify = require('../..')()
+  fastify.route({
+    method: 'GET',
+    url: '/bad-headers',
+    handler: (req, reply) => {
+      reply.log.warn = function mockWarn (obj, message) {
+        t.equal(message, 'Invalid character in header content ["smile-encoded"]', 'only the first invalid header is logged')
+      }
+
+      reply.header('foo', '$')
+      reply.header('smile-encoded', '\uD83D\uDE00')
+      reply.header('smile', '😄')
+      reply.header('bar', 'ƒ∂å')
+
+      reply.send({})
+    }
+  })
+
+  await fastify.listen(0)
+
+  const { response, body } = await doGet(`http://localhost:${fastify.server.address().port}/bad-headers`)
+  t.equal(response.statusCode, 500)
+  t.same(JSON.parse(body), {
+    statusCode: 500,
+    code: 'ERR_INVALID_CHAR',
+    error: 'Internal Server Error',
+    message: 'Invalid character in header content ["smile-encoded"]'
+  })
+
+  await fastify.close()
 })


### PR DESCRIPTION
fix https://github.com/fastify/fastify/issues/3217
closes https://github.com/fastify/fastify/pull/3220

In the `next` branch, the server was crashing when the dev set non-ascii chars as response headers.

This fix logs the error and bubbles it up to the client as a 500 error

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

