### PR TITLE
deprecate preParsing hook

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -514,10 +514,8 @@ function fastify (options) {
       this[kHooks].validate(name, fn)
       this.onClose(fn)
     } else if (name === 'onReady') {
-      this[kHooks].validate(name, fn)
       this[kHooks].add(name, fn)
     } else if (name === 'onRoute') {
-      this[kHooks].validate(name, fn)
       this[kHooks].add(name, fn)
     } else {
       this.after((err, done) => {

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -31,11 +31,13 @@ const warning = require('./warnings')
 const {
   kChildren,
   kHooks,
-  kHooksPreParsingInterface
+  kHooksPreParsingInterface,
+  kRequestPayloadStream
 } = require('./symbols')
 
 function Hooks () {
   this.onRequest = []
+  this.preParsing = [] // @deprecated
   this.preValidation = []
   this.preSerialization = []
   this.preHandler = []
@@ -51,7 +53,7 @@ function Hooks () {
 Hooks.prototype.validate = function (hook, fn) {
   if (typeof hook !== 'string') throw new FST_ERR_HOOK_INVALID_TYPE()
   if (typeof fn !== 'function') throw new FST_ERR_HOOK_INVALID_HANDLER()
-  if (supportedHooks.indexOf(hook) === -1) {
+  if (supportedHooks.indexOf(hook) === -1 && hook !== 'preParsing') {
     throw new Error(`${hook} hook not supported!`)
   }
 }
@@ -59,9 +61,8 @@ Hooks.prototype.validate = function (hook, fn) {
 Hooks.prototype.add = function (hook, fn) {
   this.validate(hook, fn)
   if (hook === 'preParsing') {
-    hook = 'onRequest'
-    warning.emit('FSTDEP011')
     fn[kHooksPreParsingInterface] = true
+    warning.emit('FSTDEP011')
   }
   this[hook].push(fn)
 }
@@ -69,6 +70,7 @@ Hooks.prototype.add = function (hook, fn) {
 function buildHooks (h) {
   const hooks = new Hooks()
   hooks.onRequest = h.onRequest.slice()
+  hooks.preParsing = h.preParsing.slice()
   hooks.preValidation = h.preValidation.slice()
   hooks.preSerialization = h.preSerialization.slice()
   hooks.preHandler = h.preHandler.slice()
@@ -201,10 +203,16 @@ function hookRunner (functions, runner, request, reply, cb) {
   next()
 }
 
+// This hookRunner manage the onRequest and (deprecated) preParsing hook interfaces.
+// It differs from the other hookRunner for the `newStreamPayload` management.
 function onRequestHookRunner (functions, runner, request, reply, cb) {
   let i = 0
 
   function next (err, newStreamPayload) {
+    if (typeof newStreamPayload !== 'undefined' && typeof newStreamPayload.pipe === 'function') {
+      request[kRequestPayloadStream] = newStreamPayload
+    }
+
     if (err || i === functions.length) {
       cb(err, request, reply)
       return
@@ -212,7 +220,7 @@ function onRequestHookRunner (functions, runner, request, reply, cb) {
 
     let result
     try {
-      result = runner(functions[i++], request, reply, newStreamPayload, next)
+      result = runner(functions[i++], request, reply, next)
     } catch (error) {
       next(error)
       return
@@ -287,6 +295,15 @@ function hookIterator (fn, request, reply, next) {
   return fn(request, reply, next)
 }
 
+function streamHookIterator (fn, request, reply, next) {
+  if (reply.sent === true) return undefined
+  if (!fn[kHooksPreParsingInterface]) {
+    return fn(request, reply, next)
+  } else {
+    return fn(request, reply, request[kRequestPayloadStream], next)
+  }
+}
+
 module.exports = {
   Hooks,
   buildHooks,
@@ -294,6 +311,7 @@ module.exports = {
   onSendHookRunner,
   onRequestHookRunner,
   hookIterator,
+  streamHookIterator,
   hookRunnerApplication,
   lifecycleHooks,
   supportedHooks

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -9,7 +9,6 @@ const applicationHooks = [
 const lifecycleHooks = [
   'onTimeout',
   'onRequest',
-  'preParsing',
   'preValidation',
   'preSerialization',
   'preHandler',
@@ -27,14 +26,16 @@ const {
   appendStackTrace
 } = require('./errors')
 
+const warning = require('./warnings')
+
 const {
   kChildren,
-  kHooks
+  kHooks,
+  kHooksPreParsingInterface
 } = require('./symbols')
 
 function Hooks () {
   this.onRequest = []
-  this.preParsing = []
   this.preValidation = []
   this.preSerialization = []
   this.preHandler = []
@@ -57,13 +58,17 @@ Hooks.prototype.validate = function (hook, fn) {
 
 Hooks.prototype.add = function (hook, fn) {
   this.validate(hook, fn)
+  if (hook === 'preParsing') {
+    hook = 'onRequest'
+    warning.emit('FSTDEP011')
+    fn[kHooksPreParsingInterface] = true
+  }
   this[hook].push(fn)
 }
 
 function buildHooks (h) {
   const hooks = new Hooks()
   hooks.onRequest = h.onRequest.slice()
-  hooks.preParsing = h.preParsing.slice()
   hooks.preValidation = h.preValidation.slice()
   hooks.preSerialization = h.preSerialization.slice()
   hooks.preHandler = h.preHandler.slice()
@@ -196,6 +201,42 @@ function hookRunner (functions, runner, request, reply, cb) {
   next()
 }
 
+function onRequestHookRunner (functions, runner, request, reply, cb) {
+  let i = 0
+
+  function next (err, newStreamPayload) {
+    if (err || i === functions.length) {
+      cb(err, request, reply)
+      return
+    }
+
+    let result
+    try {
+      result = runner(functions[i++], request, reply, newStreamPayload, next)
+    } catch (error) {
+      next(error)
+      return
+    }
+    if (result && typeof result.then === 'function') {
+      result.then(handleResolve, handleReject)
+    }
+  }
+
+  function handleResolve (newStreamPayload) {
+    next(null, newStreamPayload)
+  }
+
+  function handleReject (err) {
+    if (!err) {
+      err = new FST_ERR_SEND_UNDEFINED_ERR()
+    }
+
+    cb(err, request, reply)
+  }
+
+  next(null, request.raw)
+}
+
 function onSendHookRunner (functions, request, reply, payload, cb) {
   let i = 0
 
@@ -251,6 +292,7 @@ module.exports = {
   buildHooks,
   hookRunner,
   onSendHookRunner,
+  onRequestHookRunner,
   hookIterator,
   hookRunnerApplication,
   lifecycleHooks,

--- a/lib/route.js
+++ b/lib/route.js
@@ -3,7 +3,7 @@
 const FindMyWay = require('find-my-way')
 const Context = require('./context')
 const handleRequest = require('./handleRequest')
-const { hookRunner, hookIterator, lifecycleHooks } = require('./hooks')
+const { hookRunner, onRequestHookRunner, hookIterator, lifecycleHooks } = require('./hooks')
 const supportedMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']
 const { normalizeSchema } = require('./schemas')
 const { parseHeadOnSendHandlers } = require('./headRoute')
@@ -26,10 +26,10 @@ const {
   kLogLevel,
   kLogSerializers,
   kHooks,
+  kHooksPreParsingInterface,
   kSchemaController,
   kOptions,
   kReplySerializerDefault,
-  kReplyIsError,
   kRequestPayloadStream,
   kDisableRequestLogging,
   kSchemaErrorFormatter,
@@ -363,16 +363,29 @@ function buildRouting (options) {
       setupResponseListeners(reply)
     }
 
+    request[kRequestPayloadStream] = request.raw
+
     if (context.onRequest !== null) {
-      hookRunner(
+      onRequestHookRunner(
         context.onRequest,
-        hookIterator,
+        function hookIterator (fn, request, reply, stream, next) {
+          if (reply.sent === true) return undefined
+          if (typeof stream !== 'undefined' && typeof stream.pipe === 'function') {
+            request[kRequestPayloadStream] = stream
+          }
+
+          if (!fn[kHooksPreParsingInterface]) {
+            return fn(request, reply, next)
+          } else {
+            return fn(request, reply, request[kRequestPayloadStream], next)
+          }
+        },
         request,
         reply,
-        runPreParsing
+        handleRequest
       )
     } else {
-      runPreParsing(null, request, reply)
+      handleRequest(null, request, reply)
     }
 
     if (context.onTimeout !== null) {
@@ -410,65 +423,6 @@ function validateBodyLimitOption (bodyLimit) {
   if (!Number.isInteger(bodyLimit) || bodyLimit <= 0) {
     throw new TypeError(`'bodyLimit' option must be an integer > 0. Got '${bodyLimit}'`)
   }
-}
-
-function runPreParsing (err, request, reply) {
-  if (reply.sent === true) return
-  if (err != null) {
-    reply[kReplyIsError] = true
-    reply.send(err)
-    return
-  }
-
-  request[kRequestPayloadStream] = request.raw
-
-  if (reply.context.preParsing !== null) {
-    preParsingHookRunner(reply.context.preParsing, request, reply, handleRequest)
-  } else {
-    handleRequest(null, request, reply)
-  }
-}
-
-function preParsingHookRunner (functions, request, reply, cb) {
-  let i = 0
-
-  function next (err, stream) {
-    if (reply.sent) {
-      return
-    }
-
-    if (typeof stream !== 'undefined') {
-      request[kRequestPayloadStream] = stream
-    }
-
-    if (err || i === functions.length) {
-      cb(err, request, reply)
-      return
-    }
-
-    const fn = functions[i++]
-    let result
-    try {
-      result = fn(request, reply, request[kRequestPayloadStream], next)
-    } catch (error) {
-      next(error)
-      return
-    }
-
-    if (result && typeof result.then === 'function') {
-      result.then(handleResolve, handleReject)
-    }
-  }
-
-  function handleResolve (stream) {
-    next(null, stream)
-  }
-
-  function handleReject (err) {
-    next(err)
-  }
-
-  next(null, request[kRequestPayloadStream])
 }
 
 function noop () { }

--- a/lib/route.js
+++ b/lib/route.js
@@ -3,7 +3,13 @@
 const FindMyWay = require('find-my-way')
 const Context = require('./context')
 const handleRequest = require('./handleRequest')
-const { hookRunner, onRequestHookRunner, hookIterator, lifecycleHooks } = require('./hooks')
+const {
+  hookRunner,
+  hookIterator,
+  onRequestHookRunner,
+  streamHookIterator,
+  lifecycleHooks
+} = require('./hooks')
 const supportedMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']
 const { normalizeSchema } = require('./schemas')
 const { parseHeadOnSendHandlers } = require('./headRoute')
@@ -262,6 +268,18 @@ function buildRouting (options) {
             context[hook] = toSet.length ? toSet : null
           }
 
+          // Append all the deprecated preParsing hooks, into the onRequest hook
+          if (opts.preParsing || this[kHooks].preParsing.length > 0) {
+            const toSet = this[kHooks].preParsing
+              .concat(opts.preParsing || [])
+              .map(h => {
+                const fn = h.bind(this)
+                fn[kHooksPreParsingInterface] = true
+                return fn
+              })
+            context.onRequest = (context.onRequest || []).concat(toSet)
+          }
+
           // Optimization: avoid encapsulation if no decoration has been done.
           while (!context.Request[kHasBeenDecorated] && context.Request.parent) {
             context.Request = context.Request.parent
@@ -368,18 +386,7 @@ function buildRouting (options) {
     if (context.onRequest !== null) {
       onRequestHookRunner(
         context.onRequest,
-        function hookIterator (fn, request, reply, stream, next) {
-          if (reply.sent === true) return undefined
-          if (typeof stream !== 'undefined' && typeof stream.pipe === 'function') {
-            request[kRequestPayloadStream] = stream
-          }
-
-          if (!fn[kHooksPreParsingInterface]) {
-            return fn(request, reply, next)
-          } else {
-            return fn(request, reply, request[kRequestPayloadStream], next)
-          }
-        },
+        streamHookIterator,
         request,
         reply,
         handleRequest

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -8,6 +8,7 @@ const keys = {
   kLogLevel: Symbol('fastify.logLevel'),
   kLogSerializers: Symbol('fastify.logSerializers'),
   kHooks: Symbol('fastify.hooks'),
+  kHooksPreParsingInterface: Symbol('fastify.hooks.preParsing'),
   kSchemaController: Symbol('fastify.schemaController'),
   kSchemaHeaders: Symbol('headers-schema'),
   kSchemaParams: Symbol('params-schema'),

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -19,4 +19,6 @@ warning.create('FastifyDeprecation', 'FSTDEP009', 'You are using a custom route 
 
 warning.create('FastifyDeprecation', 'FSTDEP010', 'Modifying the "reply.sent" property is deprecated. Use the "reply.hijack()" method instead.')
 
+warning.create('FastifyDeprecation', 'FSTDEP011', 'You are using the legacy "preParsing" hook which is now an alias of the "onRequest" hook. Use the "onRequest" hook instead.')
+
 module.exports = warning

--- a/test/internals/hooks.test.js
+++ b/test/internals/hooks.test.js
@@ -6,6 +6,8 @@ const test = t.test
 const { Hooks } = require('../../lib/hooks')
 const noop = () => {}
 
+process.removeAllListeners('warning')
+
 test('hooks should have 4 array with the registered hooks', t => {
   const hooks = new Hooks()
   t.equal(typeof hooks, 'object')

--- a/test/route-hooks.test.js
+++ b/test/route-hooks.test.js
@@ -355,12 +355,10 @@ testExecutionHook('onSend')
 testExecutionHook('onRequest')
 testExecutionHook('onResponse')
 testExecutionHook('preValidation')
-testExecutionHook('preParsing')
 // hooks that comes before the handler
 testBeforeHandlerHook('preHandler')
 testBeforeHandlerHook('onRequest')
 testBeforeHandlerHook('preValidation')
-testBeforeHandlerHook('preParsing')
 
 test('preValidation option should be called before preHandler hook', t => {
   t.plan(3)


### PR DESCRIPTION
fixes #3503 

This PR alias the `preParsing` hook into the `onRequest` one.
We must keep two arrays in order to concat them in the right order to support:

> the `preParsing` hooks run after the `onRequest` hook

What is not clear to me is: how the user can change the request's payload using the `onRequest` interface?

### Proposals

1) add a new `Request.stream()` method:

```
fastify.addHook('onRequest', (request, reply, done) => {
  request.stream(request.raw.pipe(decompress))
  done()
})
```

2) the `onRequest` hook may support the `done(null, newPayload)` interface:

```
fastify.addHook('onRequest', (request, reply, done) => {
  done(null, newPayload)
})
```

In this case, all the `onRequest` hooks could change the payload.

----

Right now the (2) proposal is implemented with this PR.

The `preParsing` functions work within the old interface `(request, reply, payload, done) => {}`. I have added a `Symbol` for that, instead of checks like these: `fn.constructor.name === 'AsyncFunction' && fn.length === 3`.

Happy to get feedback.


Todos:

- [ ] warning tests
- [ ] docs


#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
