### PR TITLE
docs(reference-typescript): fix formatting

### DIFF
--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -1384,7 +1384,7 @@ body parsing happens before the `preHandler` hook.
 
 [src](https://github.com/fastify/fastify/blob/main/types/hooks.d.ts#L35)
 
-preParsing` is the second hook to be executed in the request lifecycle. The
+`preParsing` is the second hook to be executed in the request lifecycle. The
 previous hook was `onRequest`, the next hook will be `preValidation`.
 
 Notice: in the `preParsing` hook, request.body will always be null, because the


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
