### PR TITLE
localhost binds to ipv4 and ipv6

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -805,7 +805,7 @@ fastify.ready().then(() => {
 Starts the server on the given port after all the plugins are loaded, internally
 waits for the `.ready()` event. The callback is the same as the Node core.
 
-By default, the server will listen on the address resolved by `localhost` when no
+By default, the server will listen on the address(es) resolved by `localhost` when no
 specific address is provided. If listening on any available interface is desired,
 then specifying `0.0.0.0` for the address will listen on all IPv4 addresses.
 

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -803,14 +803,25 @@ fastify.ready().then(() => {
 <a id="listen"></a>
 
 Starts the server on the given port after all the plugins are loaded, internally
-waits for the `.ready()` event. The callback is the same as the Node core. By
-default, the server will listen on the address resolved by `localhost` when no
-specific address is provided (`127.0.0.1` or `::1` depending on the operating
-system). If listening on any available interface is desired, then specifying
-`0.0.0.0` for the address will listen on all IPv4 addresses. Using `::` for the
-address will listen on all IPv6 addresses and, depending on OS, may also listen
-on all IPv4 addresses. Be careful when deciding to listen on all interfaces; it
-comes with inherent [security
+waits for the `.ready()` event. The callback is the same as the Node core.
+
+By default, the server will listen on the address resolved by `localhost` when no
+specific address is provided. If listening on any available interface is desired,
+then specifying `0.0.0.0` for the address will listen on all IPv4 addresses.
+
+ Host          | IPv4 | IPv6
+ --------------|------|-------
+ `::`            | ✅<sup>*</sup> | ✅
+ `::` + [`ipv6Only`](https://nodejs.org/api/net.html#serverlistenoptions-callback) | 🚫 | ✅
+ `0.0.0.0`       | ✅ | 🚫
+ `localhost`     | ✅ | ✅
+ `127.0.0.1`     | ✅ | 🚫
+ `::1`           | 🚫 | ✅
+
+<sup>*</sup> Using `::` for the address will listen on all IPv6 addresses and, depending on OS,
+may also listen on [all IPv4 addresses](https://nodejs.org/api/net.html#serverlistenport-host-backlog-callback).
+
+Be careful when deciding to listen on all interfaces; it comes with inherent [security
 risks](https://web.archive.org/web/20170831174611/https://snyk.io/blog/mongodb-hack-and-secure-defaults/).
 
 ```js

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -46,6 +46,7 @@ describes the properties available in that options object.
     - [after](#after)
     - [ready](#ready)
     - [listen](#listen)
+    - [addresses](#addresses)
     - [getDefaultRoute](#getdefaultroute)
     - [setDefaultRoute](#setdefaultroute)
     - [routing](#routing)
@@ -929,6 +930,24 @@ fastify.listen({
   ipv6Only: false
 }, (err) => {})
 ```
+
+#### addresses
+<a id="addresses"></a>
+
+This method returns an array of addresses that the server is listening on.
+If you call it before `listen()` is called or after the `close()` function,
+it will return an empty array.
+
+```js
+await fastify.listen(8080)
+const addresses = fastify.addresses()
+// [
+//   { port: 8080, family: 'IPv6', address: '::1' },
+//   { port: 8080, family: 'IPv4', address: '127.0.0.1' }
+// ]
+```
+
+Note that the array contains the `fastify.server.address()` too.
 
 #### getDefaultRoute
 <a id="getDefaultRoute"></a>

--- a/fastify.js
+++ b/fastify.js
@@ -10,6 +10,7 @@ let lightMyRequest
 const {
   kAvvioBoot,
   kChildren,
+  kServerBindings,
   kBodyLimit,
   kRoutePrefix,
   kLogLevel,
@@ -190,6 +191,7 @@ function fastify (options) {
     },
     [kOptions]: options,
     [kChildren]: [],
+    [kServerBindings]: [],
     [kBodyLimit]: bodyLimit,
     [kRoutePrefix]: '',
     [kLogLevel]: '',
@@ -277,6 +279,11 @@ function fastify (options) {
     // http server
     listen: listen,
     server: server,
+    addresses: function () {
+      const binded = this[kServerBindings].map(b => b.address())
+      binded.push(this.server.address())
+      return binded.filter(adr => adr)
+    },
     // extend fastify objects
     decorate: decorator.add,
     hasDecorator: decorator.exist,

--- a/fastify.js
+++ b/fastify.js
@@ -28,7 +28,7 @@ const {
   kErrorHandler
 } = require('./lib/symbols.js')
 
-const { createServer } = require('./lib/server')
+const createServer = require('./lib/server')
 const Reply = require('./lib/reply')
 const Request = require('./lib/request')
 const supportedMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,16 +1,129 @@
 'use strict'
 
-const assert = require('assert')
 const http = require('http')
 const https = require('https')
+const dns = require('dns')
 
 const { kState, kOptions } = require('./symbols')
 const { FST_ERR_HTTP2_INVALID_VERSION, FST_ERR_REOPENED_CLOSE_SERVER, FST_ERR_REOPENED_SERVER } = require('./errors')
 
 function createServer (options, httpHandler) {
-  assert(options, 'Missing options')
-  assert(httpHandler, 'Missing http handler')
+  const server = getServerInstance(options, httpHandler)
 
+  return { server, listen }
+
+  // `this` is the Fastify object
+  function listen () {
+    const listenOptions = normalizeListenArgs(Array.from(arguments))
+    const { cb } = listenOptions
+
+    // if (host === 'localhost') {
+    //   dns.lookup(host, {
+    //     family: 0,
+    //     all: true
+    //   }, (err, addresses) => {
+    //     if (err) {
+    //       this.log.warn('dns.lookup error:', err)
+    //     }
+
+    //     for (const adr of addresses) {
+    //       const listenOpts = Object.assign({}, listenOptions, { host: adr.address })
+    //       const otherInterface = getServerInstance(httpHandler, options)
+    //     }
+    //   })
+    // }
+
+    // https://github.com/nodejs/node/issues/9390
+    // If listening to 'localhost', listen to both 127.0.0.1 or ::1 if they are available.
+    // If listening to 127.0.0.1, only listen to 127.0.0.1.
+    // If listening to ::1, only listen to ::1.
+
+    if (cb === undefined) {
+      return listenPromise.call(this, server, listenOptions)
+    }
+
+    this.ready(listenCallback.call(this, server, listenOptions))
+  }
+}
+
+function listenCallback (server, listenOptions) {
+  const wrap = err => {
+    server.removeListener('error', wrap)
+    if (!err) {
+      const address = logServerAddress.call(this, server)
+      listenOptions.cb(null, address)
+    } else {
+      this[kState].listening = false
+      listenOptions.cb(err, null)
+    }
+  }
+
+  return (err) => {
+    if (err != null) return listenOptions.cb(err)
+
+    if (this[kState].listening && this[kState].closing) {
+      return listenOptions.cb(new FST_ERR_REOPENED_CLOSE_SERVER(), null)
+    } else if (this[kState].listening) {
+      return listenOptions.cb(new FST_ERR_REOPENED_SERVER(), null)
+    }
+
+    server.once('error', wrap)
+    server.listen(listenOptions, wrap)
+
+    this[kState].listening = true
+  }
+}
+
+function logServerAddress (server) {
+  let address = server.address()
+  const isUnixSocket = typeof address === 'string'
+  /* istanbul ignore next */
+  if (!isUnixSocket) {
+    if (address.address.indexOf(':') === -1) {
+      address = address.address + ':' + address.port
+    } else {
+      address = '[' + address.address + ']:' + address.port
+    }
+  }
+  /* istanbul ignore next */
+  address = (isUnixSocket ? '' : ('http' + (this[kOptions].https ? 's' : '') + '://')) + address
+  this.log.info('Server listening at ' + address)
+  return address
+}
+
+function listenPromise (server, listenOptions) {
+  if (this[kState].listening && this[kState].closing) {
+    return Promise.reject(new FST_ERR_REOPENED_CLOSE_SERVER())
+  } else if (this[kState].listening) {
+    return Promise.reject(new FST_ERR_REOPENED_SERVER())
+  }
+
+  return this.ready().then(() => {
+    let errEventHandler
+    const errEvent = new Promise((resolve, reject) => {
+      errEventHandler = (err) => {
+        this[kState].listening = false
+        reject(err)
+      }
+      server.once('error', errEventHandler)
+    })
+    const listen = new Promise((resolve, reject) => {
+      server.listen(listenOptions, () => {
+        server.removeListener('error', errEventHandler)
+        resolve(logServerAddress.call(this, server))
+      })
+      // we set it afterwards because listen can throw
+      this[kState].listening = true
+    })
+
+    return Promise.race([
+      errEvent, // e.g invalid port range error is always emitted before the server listening
+      listen
+    ])
+  })
+}
+
+function getServerInstance (options, httpHandler) {
   let server = null
   if (options.serverFactory) {
     server = options.serverFactory(httpHandler, options)
@@ -41,123 +154,39 @@ function createServer (options, httpHandler) {
   if (!options.serverFactory) {
     server.setTimeout(options.connectionTimeout)
   }
+  return server
+}
 
-  return { server, listen }
-
-  // `this` is the Fastify object
-  function listen () {
-    const normalizeListenArgs = (args) => {
-      if (args.length === 0) {
-        return { port: 0, host: 'localhost' }
-      }
-
-      const cb = typeof args[args.length - 1] === 'function' ? args.pop() : undefined
-      const options = { cb: cb }
-
-      const firstArg = args[0]
-      const argsLength = args.length
-      const lastArg = args[argsLength - 1]
-      /* Deal with listen (options) || (handle[, backlog]) */
-      if (typeof firstArg === 'object' && firstArg !== null) {
-        options.backlog = argsLength > 1 ? lastArg : undefined
-        Object.assign(options, firstArg)
-      } else if (typeof firstArg === 'string' && isNaN(firstArg)) {
-        /* Deal with listen (pipe[, backlog]) */
-        options.path = firstArg
-        options.backlog = argsLength > 1 ? lastArg : undefined
-      } else {
-        /* Deal with listen ([port[, host[, backlog]]]) */
-        options.port = argsLength >= 1 && firstArg ? firstArg : 0
-        // This will listen to what localhost is.
-        // It can be 127.0.0.1 or ::1, depending on the operating system.
-        // Fixes https://github.com/fastify/fastify/issues/1022.
-        options.host = argsLength >= 2 && args[1] ? args[1] : 'localhost'
-        options.backlog = argsLength >= 3 ? args[2] : undefined
-      }
-
-      return options
-    }
-
-    const listenOptions = normalizeListenArgs(Array.from(arguments))
-    const cb = listenOptions.cb
-
-    const wrap = err => {
-      server.removeListener('error', wrap)
-      if (!err) {
-        const address = logServerAddress()
-        cb(null, address)
-      } else {
-        this[kState].listening = false
-        cb(err, null)
-      }
-    }
-
-    const listenPromise = (listenOptions) => {
-      if (this[kState].listening && this[kState].closing) {
-        return Promise.reject(new FST_ERR_REOPENED_CLOSE_SERVER())
-      } else if (this[kState].listening) {
-        return Promise.reject(new FST_ERR_REOPENED_SERVER())
-      }
-
-      return this.ready().then(() => {
-        let errEventHandler
-        const errEvent = new Promise((resolve, reject) => {
-          errEventHandler = (err) => {
-            this[kState].listening = false
-            reject(err)
-          }
-          server.once('error', errEventHandler)
-        })
-        const listen = new Promise((resolve, reject) => {
-          server.listen(listenOptions, () => {
-            server.removeListener('error', errEventHandler)
-            resolve(logServerAddress())
-          })
-          // we set it afterwards because listen can throw
-          this[kState].listening = true
-        })
-
-        return Promise.race([
-          errEvent, // e.g invalid port range error is always emitted before the server listening
-          listen
-        ])
-      })
-    }
-
-    const logServerAddress = () => {
-      let address = server.address()
-      const isUnixSocket = typeof address === 'string'
-      /* istanbul ignore next */
-      if (!isUnixSocket) {
-        if (address.address.indexOf(':') === -1) {
-          address = address.address + ':' + address.port
-        } else {
-          address = '[' + address.address + ']:' + address.port
-        }
-      }
-      /* istanbul ignore next */
-      address = (isUnixSocket ? '' : ('http' + (this[kOptions].https ? 's' : '') + '://')) + address
-      this.log.info('Server listening at ' + address)
-      return address
-    }
-
-    if (cb === undefined) return listenPromise(listenOptions)
-
-    this.ready(err => {
-      if (err != null) return cb(err)
-
-      if (this[kState].listening && this[kState].closing) {
-        return cb(new FST_ERR_REOPENED_CLOSE_SERVER(), null)
-      } else if (this[kState].listening) {
-        return cb(new FST_ERR_REOPENED_SERVER(), null)
-      }
-
-      server.once('error', wrap)
-      server.listen(listenOptions, wrap)
-
-      this[kState].listening = true
-    })
+function normalizeListenArgs (args) {
+  if (args.length === 0) {
+    return { port: 0, host: 'localhost' }
   }
+
+  const cb = typeof args[args.length - 1] === 'function' ? args.pop() : undefined
+  const options = { cb: cb }
+
+  const firstArg = args[0]
+  const argsLength = args.length
+  const lastArg = args[argsLength - 1]
+  /* Deal with listen (options) || (handle[, backlog]) */
+  if (typeof firstArg === 'object' && firstArg !== null) {
+    options.backlog = argsLength > 1 ? lastArg : undefined
+    Object.assign(options, firstArg)
+  } else if (typeof firstArg === 'string' && isNaN(firstArg)) {
+    /* Deal with listen (pipe[, backlog]) */
+    options.path = firstArg
+    options.backlog = argsLength > 1 ? lastArg : undefined
+  } else {
+    /* Deal with listen ([port[, host[, backlog]]]) */
+    options.port = argsLength >= 1 && firstArg ? firstArg : 0
+    // This will listen to what localhost is.
+    // It can be 127.0.0.1 or ::1, depending on the operating system.
+    // Fixes https://github.com/fastify/fastify/issues/1022.
+    options.host = argsLength >= 2 && args[1] ? args[1] : 'localhost'
+    options.backlog = argsLength >= 3 ? args[2] : undefined
+  }
+
+  return options
 }
 
 function http2 () {

--- a/lib/server.js
+++ b/lib/server.js
@@ -76,7 +76,6 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
     const primaryAddress = mainServer.address()
     for (const adr of addresses) {
       if (adr.address !== primaryAddress.address) {
-        // this.log.info('binding %s', adr.address)
         binding++
         const secondaryOpts = Object.assign({}, listenOptions, {
           host: adr.address,

--- a/lib/server.js
+++ b/lib/server.js
@@ -110,7 +110,8 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
     }
 
     // in test files we are using unref so we need to propagate the unref event
-    // to the secondary servers
+    // to the secondary servers. It is valid only when the user is
+    // listening on localhost
     const originUnref = mainServer.unref
     mainServer.unref = function () {
       originUnref.call(mainServer)

--- a/lib/server.js
+++ b/lib/server.js
@@ -61,10 +61,7 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
   this[kState].listening = false
 
   // let's check if we need to bind additional addresses
-  dns.lookup(listenOptions.host, {
-    family: 0,
-    all: true
-  }, (dnsErr, addresses) => {
+  dns.lookup(listenOptions.host, { all: true }, (dnsErr, addresses) => {
     if (dnsErr) {
       // not blocking the main server listening
       // this.log.warn('dns.lookup error:', dnsErr)
@@ -286,4 +283,4 @@ function close () {
   this.close()
 }
 
-module.exports = { createServer }
+module.exports = createServer

--- a/lib/server.js
+++ b/lib/server.js
@@ -92,7 +92,6 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
         })
 
         const secondaryServer = getServerInstance(serverOpts, httpHandler)
-        secondaryServer.isSecondary = true
         const closeSecondary = () => { secondaryServer.close(() => {}) }
         mainServer.on('unref', closeSecondary)
         mainServer.on('close', closeSecondary)
@@ -258,9 +257,7 @@ function logServerAddress (server) {
   /* istanbul ignore next */
   address = (isUnixSocket ? '' : ('http' + (this[kOptions].https ? 's' : '') + '://')) + address
 
-  if (server.isSecondary !== true) {
-    this.log.info('Server listening at ' + address)
-  }
+  this.log.info('Server listening at ' + address)
   return address
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -17,21 +17,16 @@ function createServer (options, httpHandler) {
     const listenOptions = normalizeListenArgs(Array.from(arguments))
     const { cb, host } = listenOptions
 
-    const onFailure = () => { this[kState].listening = false }
-    const onListen = () => { this[kState].listening = true }
-
     if (host === 'localhost') {
-      // TODO promise interface
       listenOptions.cb = (err, address) => {
         if (err) {
           // the server did not start
-          // onFailure()
           cb(err, address)
           return
         }
 
         multipleBindings.call(this, server, httpHandler, options, listenOptions, () => {
-          onListen()
+          this[kState].listening = true
           cb(null, address)
         })
       }
@@ -43,18 +38,28 @@ function createServer (options, httpHandler) {
     // If listening to ::1, only listen to ::1.
 
     if (cb === undefined) {
-      return listenPromise.call(this, server, listenOptions, onListen, onFailure)
+      const listening = listenPromise.call(this, server, listenOptions)
+      if (host === 'localhost') {
+        return listening.then(address => {
+          return new Promise((resolve, reject) => {
+            multipleBindings.call(this, server, httpHandler, options, listenOptions, () => {
+              this[kState].listening = true
+              resolve(address)
+            })
+          })
+        })
+      }
+      return listening
     }
 
-    if (host === 'localhost') {
-      this.ready(listenCallback.call(this, server, listenOptions))
-    } else {
-      this.ready(listenCallback.call(this, server, listenOptions, onListen, onFailure))
-    }
+    this.ready(listenCallback.call(this, server, listenOptions))
   }
 }
 
 function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, onListen) {
+  // the main server is started, we need to start the secondary servers
+  this[kState].listening = false
+
   // let's check if we need to bind additional addresses
   dns.lookup(listenOptions.host, {
     family: 0,
@@ -67,23 +72,16 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
       return
     }
 
-    // in test files we are using unref 😱
-    const originUnref = mainServer.unref
-    mainServer.unref = function () {
-      originUnref.call(mainServer)
-      mainServer.emit('unref')
-    }
-
     let binding = 0
     let binded = 0
-    const alreadyBinded = mainServer.address().address
+    const primaryAddress = mainServer.address()
     for (const adr of addresses) {
-      if (adr.address !== alreadyBinded) {
+      if (adr.address !== primaryAddress.address) {
         // this.log.info('binding %s', adr.address)
         binding++
         const secondaryOpts = Object.assign({}, listenOptions, {
-          isSecondary: true,
           host: adr.address,
+          port: primaryAddress.port,
           cb: (err) => {
             binded++
 
@@ -111,11 +109,20 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
     // no extra bindings are necessary
     if (binding === 0) {
       onListen()
+      return
+    }
+
+    // in test files we are using unref so we need to propagate the unref event
+    // to the secondary servers
+    const originUnref = mainServer.unref
+    mainServer.unref = function () {
+      originUnref.call(mainServer)
+      mainServer.emit('unref')
     }
   })
 }
 
-function listenCallback (server, listenOptions, onListen, onFailure) {
+function listenCallback (server, listenOptions) {
   const wrap = (err) => {
     server.removeListener('error', wrap)
     if (!err) {
@@ -139,11 +146,11 @@ function listenCallback (server, listenOptions, onListen, onFailure) {
     server.once('error', wrap)
     server.listen(listenOptions, wrap)
 
-    onListen && onListen()
+    this[kState].listening = true
   }
 }
 
-function listenPromise (server, listenOptions, onListen, onFailure) {
+function listenPromise (server, listenOptions) {
   if (this[kState].listening && this[kState].closing) {
     return Promise.reject(new FST_ERR_REOPENED_CLOSE_SERVER())
   } else if (this[kState].listening) {
@@ -154,7 +161,7 @@ function listenPromise (server, listenOptions, onListen, onFailure) {
     let errEventHandler
     const errEvent = new Promise((resolve, reject) => {
       errEventHandler = (err) => {
-        onFailure && onFailure()
+        this[kState].listening = false
         reject(err)
       }
       server.once('error', errEventHandler)
@@ -165,7 +172,7 @@ function listenPromise (server, listenOptions, onListen, onFailure) {
         resolve(logServerAddress.call(this, server))
       })
       // we set it afterwards because listen can throw
-      onListen && onListen()
+      this[kState].listening = true
     })
 
     return Promise.race([

--- a/lib/server.js
+++ b/lib/server.js
@@ -15,23 +15,27 @@ function createServer (options, httpHandler) {
   // `this` is the Fastify object
   function listen () {
     const listenOptions = normalizeListenArgs(Array.from(arguments))
-    const { cb } = listenOptions
+    const { cb, host } = listenOptions
 
-    // if (host === 'localhost') {
-    //   dns.lookup(host, {
-    //     family: 0,
-    //     all: true
-    //   }, (err, addresses) => {
-    //     if (err) {
-    //       this.log.warn('dns.lookup error:', err)
-    //     }
+    const onFailure = () => { this[kState].listening = false }
+    const onListen = () => { this[kState].listening = true }
 
-    //     for (const adr of addresses) {
-    //       const listenOpts = Object.assign({}, listenOptions, { host: adr.address })
-    //       const otherInterface = getServerInstance(httpHandler, options)
-    //     }
-    //   })
-    // }
+    if (host === 'localhost') {
+      // TODO promise interface
+      listenOptions.cb = (err, address) => {
+        if (err) {
+          // the server did not start
+          // onFailure()
+          cb(err, address)
+          return
+        }
+
+        multipleBindings.call(this, server, httpHandler, options, listenOptions, () => {
+          onListen()
+          cb(null, address)
+        })
+      }
+    }
 
     // https://github.com/nodejs/node/issues/9390
     // If listening to 'localhost', listen to both 127.0.0.1 or ::1 if they are available.
@@ -39,15 +43,80 @@ function createServer (options, httpHandler) {
     // If listening to ::1, only listen to ::1.
 
     if (cb === undefined) {
-      return listenPromise.call(this, server, listenOptions)
+      return listenPromise.call(this, server, listenOptions, onListen, onFailure)
     }
 
-    this.ready(listenCallback.call(this, server, listenOptions))
+    if (host === 'localhost') {
+      this.ready(listenCallback.call(this, server, listenOptions))
+    } else {
+      this.ready(listenCallback.call(this, server, listenOptions, onListen, onFailure))
+    }
   }
 }
 
-function listenCallback (server, listenOptions) {
-  const wrap = err => {
+function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, onListen) {
+  // let's check if we need to bind additional addresses
+  dns.lookup(listenOptions.host, {
+    family: 0,
+    all: true
+  }, (dnsErr, addresses) => {
+    if (dnsErr) {
+      // not blocking the main server listening
+      // this.log.warn('dns.lookup error:', dnsErr)
+      onListen()
+      return
+    }
+
+    // in test files we are using unref 😱
+    const originUnref = mainServer.unref
+    mainServer.unref = function () {
+      originUnref.call(mainServer)
+      mainServer.emit('unref')
+    }
+
+    let binding = 0
+    let binded = 0
+    const alreadyBinded = mainServer.address().address
+    for (const adr of addresses) {
+      if (adr.address !== alreadyBinded) {
+        // this.log.info('binding %s', adr.address)
+        binding++
+        const secondaryOpts = Object.assign({}, listenOptions, {
+          isSecondary: true,
+          host: adr.address,
+          cb: (err) => {
+            binded++
+
+            if (err) {
+              // this.log.warn(err, 'Fail listening to %s', secondaryOpts.host)
+            }
+
+            if (binded === binding) {
+              // regardless of the error, we are done
+              onListen()
+            }
+          }
+        })
+
+        const secondaryServer = getServerInstance(httpHandler, serverOpts)
+        secondaryServer.isSecondary = true
+        const closeSecondary = () => { secondaryServer.close(() => {}) }
+        mainServer.on('unref', closeSecondary)
+        mainServer.on('close', closeSecondary)
+        mainServer.on('error', closeSecondary)
+        listenCallback.call(this, secondaryServer, secondaryOpts)()
+      }
+    }
+
+    // no extra bindings are necessary
+    if (binding === 0) {
+      onListen()
+    }
+  })
+}
+
+function listenCallback (server, listenOptions, onListen, onFailure) {
+  const wrap = (err) => {
     server.removeListener('error', wrap)
     if (!err) {
       const address = logServerAddress.call(this, server)
@@ -70,28 +139,11 @@ function listenCallback (server, listenOptions) {
     server.once('error', wrap)
     server.listen(listenOptions, wrap)
 
-    this[kState].listening = true
+    onListen && onListen()
   }
 }
 
-function logServerAddress (server) {
-  let address = server.address()
-  const isUnixSocket = typeof address === 'string'
-  /* istanbul ignore next */
-  if (!isUnixSocket) {
-    if (address.address.indexOf(':') === -1) {
-      address = address.address + ':' + address.port
-    } else {
-      address = '[' + address.address + ']:' + address.port
-    }
-  }
-  /* istanbul ignore next */
-  address = (isUnixSocket ? '' : ('http' + (this[kOptions].https ? 's' : '') + '://')) + address
-  this.log.info('Server listening at ' + address)
-  return address
-}
-
-function listenPromise (server, listenOptions) {
+function listenPromise (server, listenOptions, onListen, onFailure) {
   if (this[kState].listening && this[kState].closing) {
     return Promise.reject(new FST_ERR_REOPENED_CLOSE_SERVER())
   } else if (this[kState].listening) {
@@ -102,7 +154,7 @@ function listenPromise (server, listenOptions) {
     let errEventHandler
     const errEvent = new Promise((resolve, reject) => {
       errEventHandler = (err) => {
-        this[kState].listening = false
+        onFailure && onFailure()
         reject(err)
       }
       server.once('error', errEventHandler)
@@ -113,7 +165,7 @@ function listenPromise (server, listenOptions) {
         resolve(logServerAddress.call(this, server))
       })
       // we set it afterwards because listen can throw
-      this[kState].listening = true
+      onListen && onListen()
     })
 
     return Promise.race([
@@ -187,6 +239,26 @@ function normalizeListenArgs (args) {
   }
 
   return options
+}
+
+function logServerAddress (server) {
+  let address = server.address()
+  const isUnixSocket = typeof address === 'string'
+  /* istanbul ignore next */
+  if (!isUnixSocket) {
+    if (address.address.indexOf(':') === -1) {
+      address = address.address + ':' + address.port
+    } else {
+      address = '[' + address.address + ']:' + address.port
+    }
+  }
+  /* istanbul ignore next */
+  address = (isUnixSocket ? '' : ('http' + (this[kOptions].https ? 's' : '') + '://')) + address
+
+  if (server.isSecondary !== true) {
+    this.log.info('Server listening at ' + address)
+  }
+  return address
 }
 
 function http2 () {

--- a/lib/server.js
+++ b/lib/server.js
@@ -4,7 +4,7 @@ const http = require('http')
 const https = require('https')
 const dns = require('dns')
 
-const { kState, kOptions } = require('./symbols')
+const { kState, kOptions, kServerBindings } = require('./symbols')
 const { FST_ERR_HTTP2_INVALID_VERSION, FST_ERR_REOPENED_CLOSE_SERVER, FST_ERR_REOPENED_SERVER } = require('./errors')
 
 module.exports = createServer
@@ -83,6 +83,10 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
           port: primaryAddress.port,
           cb: (_ignoreErr) => {
             binded++
+
+            if (!_ignoreErr) {
+              this[kServerBindings].push(secondaryServer)
+            }
 
             if (binded === binding) {
               // regardless of the error, we are done

--- a/lib/server.js
+++ b/lib/server.js
@@ -93,7 +93,7 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
           }
         })
 
-        const secondaryServer = getServerInstance(httpHandler, serverOpts)
+        const secondaryServer = getServerInstance(serverOpts, httpHandler)
         secondaryServer.isSecondary = true
         const closeSecondary = () => { secondaryServer.close(() => {}) }
         mainServer.on('unref', closeSecondary)

--- a/lib/server.js
+++ b/lib/server.js
@@ -79,12 +79,8 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
         const secondaryOpts = Object.assign({}, listenOptions, {
           host: adr.address,
           port: primaryAddress.port,
-          cb: (err) => {
+          cb: (_ignoreErr) => {
             binded++
-
-            if (err) {
-              // this.log.warn(err, 'Fail listening to %s', secondaryOpts.host)
-            }
 
             if (binded === binding) {
               // regardless of the error, we are done

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,6 +7,8 @@ const dns = require('dns')
 const { kState, kOptions } = require('./symbols')
 const { FST_ERR_HTTP2_INVALID_VERSION, FST_ERR_REOPENED_CLOSE_SERVER, FST_ERR_REOPENED_SERVER } = require('./errors')
 
+module.exports = createServer
+
 function createServer (options, httpHandler) {
   const server = getServerInstance(options, httpHandler)
 
@@ -279,5 +281,3 @@ function sessionTimeout (timeout) {
 function close () {
   this.close()
 }
-
-module.exports = createServer

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -3,6 +3,7 @@
 const keys = {
   kAvvioBoot: Symbol('fastify.avvioBoot'),
   kChildren: Symbol('fastify.children'),
+  kServerBindings: Symbol('fastify.serverBindings'),
   kBodyLimit: Symbol('fastify.bodyLimit'),
   kRoutePrefix: Symbol('fastify.routePrefix'),
   kLogLevel: Symbol('fastify.logLevel'),

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:typescript": "eslint -c types/.eslintrc.json types/**/*.d.ts test/types/**/*.test-d.ts",
     "prepublishOnly": "tap --no-check-coverage test/internals/version.test.js",
     "test": "npm run lint && npm run unit && npm run test:typescript",
-    "test:ci": "npm run lint && npm run unit -- -R terse --cov --coverage-report=lcovonly && npm run test:typescript",
+    "test:ci": "npm run lint && npm run unit -- --cov --coverage-report=lcovonly && npm run test:typescript",
     "test:report": "npm run lint && npm run unit:report && npm run test:typescript",
     "test:typescript": "tsc test/types/import.ts && tsd",
     "unit": "tap -J test/*.test.js test/*/*.test.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:typescript": "eslint -c types/.eslintrc.json types/**/*.d.ts test/types/**/*.test-d.ts",
     "prepublishOnly": "tap --no-check-coverage test/internals/version.test.js",
     "test": "npm run lint && npm run unit && npm run test:typescript",
-    "test:ci": "npm run lint && npm run unit -- --cov --coverage-report=lcovonly && npm run test:typescript",
+    "test:ci": "npm run lint && npm run unit -- -R terse --cov --coverage-report=lcovonly && npm run test:typescript",
     "test:report": "npm run lint && npm run unit:report && npm run test:typescript",
     "test:typescript": "tsc test/types/import.ts && tsd",
     "unit": "tap -J test/*.test.js test/*/*.test.js",

--- a/test/custom-http-server.test.js
+++ b/test/custom-http-server.test.js
@@ -7,10 +7,10 @@ const http = require('http')
 const sget = require('simple-get').concat
 
 test('Should support a custom http server', t => {
-  t.plan(6)
+  t.plan(7)
 
   const serverFactory = (handler, opts) => {
-    t.ok(opts.serverFactory)
+    t.ok(opts.serverFactory, 'it is called twice for every HOST interface')
 
     const server = http.createServer((req, res) => {
       req.custom = true

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const sget = require('simple-get').concat
+const dns = require('dns').promises
 const stream = require('stream')
 const symbols = require('../lib/symbols')
 
@@ -418,4 +419,18 @@ module.exports.payloadMethod = function (method, t, isSetErrorHandler = false) {
       })
     })
   })
+}
+
+module.exports.getLoopbackHost = async () => {
+  let localhostForURL
+
+  const lookup = await dns.lookup('localhost')
+  const localhost = lookup.address
+  if (lookup.family === 6) {
+    localhostForURL = `[${lookup.address}]`
+  } else {
+    localhostForURL = localhost
+  }
+
+  return [localhost, localhostForURL]
 }

--- a/test/https/custom-https-server.test.js
+++ b/test/https/custom-https-server.test.js
@@ -10,10 +10,10 @@ const { buildCertificate } = require('../build-certificate')
 t.before(buildCertificate)
 
 test('Should support a custom https server', t => {
-  t.plan(6)
+  t.plan(7)
 
   const serverFactory = (handler, opts) => {
-    t.ok(opts.serverFactory)
+    t.ok(opts.serverFactory, 'it is called twice for every HOST interface')
 
     const options = {
       key: global.context.key,

--- a/test/internals/initialConfig.test.js
+++ b/test/internals/initialConfig.test.js
@@ -298,7 +298,7 @@ test('Should not have issues when passing stream options to Pino.js', t => {
     })
   })
 
-  fastify.listen(0, err => {
+  fastify.listen(0, '127.0.0.1', err => {
     t.error(err)
     fastify.server.unref()
 

--- a/test/internals/initialConfig.test.js
+++ b/test/internals/initialConfig.test.js
@@ -2,6 +2,7 @@
 
 const { test, before } = require('tap')
 const Fastify = require('../..')
+const helper = require('../helper')
 const http = require('http')
 const pino = require('pino')
 const split = require('split2')
@@ -9,9 +10,16 @@ const deepClone = require('rfdc')({ circles: true, proto: false })
 const { deepFreezeObject } = require('../../lib/initialConfigValidation').utils
 
 const { buildCertificate } = require('../build-certificate')
-before(buildCertificate)
 
 process.removeAllListeners('warning')
+
+let localhost
+let localhostForURL
+
+before(async function () {
+  await buildCertificate();
+  [localhost, localhostForURL] = await helper.getLoopbackHost()
+})
 
 test('Fastify.initialConfig is an object', t => {
   t.plan(1)
@@ -298,11 +306,11 @@ test('Should not have issues when passing stream options to Pino.js', t => {
     })
   })
 
-  fastify.listen(0, '127.0.0.1', err => {
+  fastify.listen(0, localhost, err => {
     t.error(err)
     fastify.server.unref()
 
-    http.get('http://localhost:' + fastify.server.address().port)
+    http.get(`http://${localhostForURL}:${fastify.server.address().port}`)
   })
 })
 

--- a/test/internals/server.test.js
+++ b/test/internals/server.test.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const { test } = require('tap')
+const proxyquire = require('proxyquire')
+
+const Fastify = require('../../fastify')
+const createServer = require('../../lib/server')
+
+const handler = (req, res) => {
+  res.writeHead(200, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify({ data: 'Hello World!' }))
+}
+
+test('start listening', async t => {
+  const { server, listen } = createServer({}, handler)
+  await listen.call(Fastify(), 0, 'localhost')
+  server.close()
+  t.pass('server started')
+})
+
+test('DNS errors does not stop the main server on localhost - promise interface', async t => {
+  const createServer = proxyquire('../../lib/server', {
+    dns: {
+      lookup: (hostname, options, cb) => {
+        cb(new Error('DNS error'))
+      }
+    }
+  })
+  const { server, listen } = createServer({}, handler)
+  await listen.call(Fastify(), 0, 'localhost')
+  server.close()
+  t.pass('server started')
+})
+
+test('DNS errors does not stop the main server on localhost - callback interface', t => {
+  t.plan(2)
+  const createServer = proxyquire('../../lib/server', {
+    dns: {
+      lookup: (hostname, options, cb) => {
+        cb(new Error('DNS error'))
+      }
+    }
+  })
+  const { server, listen } = createServer({}, handler)
+  listen.call(Fastify(), 0, 'localhost', (err) => {
+    t.error(err)
+    server.close()
+    t.pass('server started')
+  })
+})

--- a/test/internals/server.test.js
+++ b/test/internals/server.test.js
@@ -48,3 +48,41 @@ test('DNS errors does not stop the main server on localhost - callback interface
     t.pass('server started')
   })
 })
+
+test('DNS returns empty binding', t => {
+  t.plan(2)
+  const createServer = proxyquire('../../lib/server', {
+    dns: {
+      lookup: (hostname, options, cb) => {
+        cb(null, [])
+      }
+    }
+  })
+  const { server, listen } = createServer({}, handler)
+  listen.call(Fastify(), 0, 'localhost', (err) => {
+    t.error(err)
+    server.close()
+    t.pass('server started')
+  })
+})
+
+test('DNS returns more than two binding', t => {
+  t.plan(2)
+  const createServer = proxyquire('../../lib/server', {
+    dns: {
+      lookup: (hostname, options, cb) => {
+        cb(null, [
+          { address: '::1', family: 6 },
+          { address: '127.0.0.1', family: 4 },
+          { address: '0.0.0.0', family: 4 }
+        ])
+      }
+    }
+  })
+  const { server, listen } = createServer({}, handler)
+  listen.call(Fastify(), 0, 'localhost', (err) => {
+    t.error(err)
+    server.close()
+    t.pass('server started')
+  })
+})

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -458,7 +458,7 @@ test('addresses getter', async t => {
   t.same(app.addresses(), [], 'after ready')
   await app.listen(0, 'localhost')
   const { port } = app.server.address()
-  t.same(app.addresses().sort(), [
+  t.same(app.addresses().sort((a, b) => a.address.localeCompare(b.address)), [
     {
       address: '::1',
       family: 'IPv6',

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -403,7 +403,6 @@ test('listen on localhost binds IPv4 and IPv6 promise interface', async t => {
   await app.listen(0, 'localhost')
 
   const lookups = await dns.lookup('localhost', { all: true })
-  console.log(lookups)
   t.plan(1 + (lookups.length * 2))
   t.notSame(lookups.length, 1, 'localhost should resolve to multiple addresses')
 

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -397,13 +397,13 @@ test('listen when firstArg is string(pipe) and with backlog', async t => {
 })
 
 test('listen on localhost binds IPv4 and IPv6 - promise interface', async t => {
+  t.plan(1 + 2 + 2)
   const app = Fastify()
   app.get('/', async () => 'hello localhost')
   t.teardown(app.close.bind(app))
   await app.listen(0, 'localhost')
 
   const lookups = await dns.lookup('localhost', { all: true })
-  t.plan(1 + (lookups.length * 2))
   t.notSame(lookups.length, 1, 'localhost should resolve to multiple addresses')
 
   for (const lookup of lookups) {
@@ -422,13 +422,13 @@ test('listen on localhost binds IPv4 and IPv6 - promise interface', async t => {
 })
 
 test('listen on localhost binds IPv4 and IPv6 - callback interface', t => {
+  t.plan(3 + 3 + 3)
   const app = Fastify()
   app.get('/', async () => 'hello localhost')
 
   app.listen(0, 'localhost', (err) => {
     t.error(err)
     dnsCb.lookup('localhost', { all: true }, (err, lookups) => {
-      t.plan(3 + (lookups.length * 3))
       t.error(err)
       t.notSame(lookups.length, 1, 'localhost should resolve to multiple addresses')
       t.teardown(app.close.bind(app))

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -396,7 +396,7 @@ test('listen when firstArg is string(pipe) and with backlog', async t => {
   t.equal(address, '\\\\.\\pipe\\testPipe')
 })
 
-test('listen on localhost binds IPv4 and IPv6 promise interface', async t => {
+test('listen on localhost binds IPv4 and IPv6 - promise interface', async t => {
   const app = Fastify()
   app.get('/', async () => 'hello localhost')
   t.teardown(app.close.bind(app))
@@ -421,7 +421,7 @@ test('listen on localhost binds IPv4 and IPv6 promise interface', async t => {
   }
 })
 
-test('listen on localhost binds IPv4 and IPv6 callback interface', t => {
+test('listen on localhost binds IPv4 and IPv6 - callback interface', t => {
   const app = Fastify()
   app.get('/', async () => 'hello localhost')
 

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -403,6 +403,7 @@ test('listen on localhost binds IPv4 and IPv6 promise interface', async t => {
   await app.listen(0, 'localhost')
 
   const lookups = await dns.lookup('localhost', { all: true })
+  console.log(lookups)
   t.plan(1 + (lookups.length * 2))
   t.notSame(lookups.length, 1, 'localhost should resolve to multiple addresses')
 

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -447,6 +447,34 @@ test('listen on localhost binds IPv4 and IPv6 - callback interface', t => {
   })
 })
 
+test('addresses getter', async t => {
+  t.plan(4)
+  const app = Fastify()
+  app.get('/', async () => 'hello localhost')
+
+  t.same(app.addresses(), [], 'before ready')
+  await app.ready()
+
+  t.same(app.addresses(), [], 'after ready')
+  await app.listen(0, 'localhost')
+  const { port } = app.server.address()
+  t.same(app.addresses().sort(), [
+    {
+      address: '::1',
+      family: 'IPv6',
+      port
+    },
+    {
+      address: '127.0.0.1',
+      family: 'IPv4',
+      port
+    }
+  ], 'after listen')
+
+  await app.close()
+  t.same(app.addresses(), [], 'after close')
+})
+
 function getUrl (fastify, lookup) {
   const { port } = fastify.server.address()
   if (lookup.family === 6) {

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1188,7 +1188,7 @@ test('Do not wrap IPv4 address', t => {
       level: 'info'
     }
   })
-  fastify.listen(0, localhost, err => {
+  fastify.listen(0, '127.0.0.1', err => {
     t.error(err)
     stream.once('data', line => {
       const expected = 'Server listening at http://127.0.0.1:' +

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -31,7 +31,7 @@ teardown(() => {
 })
 
 test('defaults to info level', t => {
-  t.plan(13)
+  t.plan(14)
   let fastify = null
   const stream = split(JSON.parse)
   try {
@@ -52,20 +52,24 @@ test('defaults to info level', t => {
   stream.once('data', listenAtLogLine => {
     t.ok(listenAtLogLine, 'listen at log message is ok')
 
-    stream.once('data', line => {
-      const id = line.reqId
-      t.ok(line.reqId, 'reqId is defined')
-      t.ok(line.req, 'req is defined')
-      t.equal(line.msg, 'incoming request', 'message is set')
-      t.equal(line.req.method, 'GET', 'method is get')
+    stream.once('data', listenAtLogLine => {
+      t.ok(listenAtLogLine, 'listen at log message is ok: localhost bind IPv4 and IPv6')
 
       stream.once('data', line => {
-        t.equal(line.reqId, id)
+        const id = line.reqId
         t.ok(line.reqId, 'reqId is defined')
-        t.ok(line.res, 'res is defined')
-        t.equal(line.msg, 'request completed', 'message is set')
-        t.equal(line.res.statusCode, 200, 'statusCode is 200')
-        t.ok(line.responseTime, 'responseTime is defined')
+        t.ok(line.req, 'req is defined')
+        t.equal(line.msg, 'incoming request', 'message is set')
+        t.equal(line.req.method, 'GET', 'method is get')
+
+        stream.once('data', line => {
+          t.equal(line.reqId, id)
+          t.ok(line.reqId, 'reqId is defined')
+          t.ok(line.res, 'res is defined')
+          t.equal(line.msg, 'request completed', 'message is set')
+          t.equal(line.res.statusCode, 200, 'statusCode is 200')
+          t.ok(line.responseTime, 'responseTime is defined')
+        })
       })
     })
   })
@@ -98,7 +102,7 @@ test('test log stream', t => {
     reply.send({ hello: 'world' })
   })
 
-  fastify.listen(0, err => {
+  fastify.listen(0, '127.0.0.1', err => {
     t.error(err)
     fastify.server.unref()
 
@@ -145,7 +149,7 @@ test('test error log stream', t => {
     reply.send(new Error('kaboom'))
   })
 
-  fastify.listen(0, err => {
+  fastify.listen(0, '127.0.0.1', err => {
     t.error(err)
     fastify.server.unref()
 
@@ -190,7 +194,7 @@ test('can use external logger instance', t => {
     reply.send({ hello: 'world' })
   })
 
-  localFastify.listen(0, err => {
+  localFastify.listen(0, '127.0.0.1', err => {
     t.error(err)
     http.get('http://localhost:' + localFastify.server.address().port + '/foo', (res) => {
       res.resume()
@@ -235,7 +239,7 @@ test('can use external logger instance with custom serializer', t => {
     reply.send({ hello: 'world' })
   })
 
-  localFastify.listen(0, err => {
+  localFastify.listen(0, '127.0.0.1', err => {
     t.error(err)
     http.get('http://localhost:' + localFastify.server.address().port + '/foo', (res) => {
       res.resume()
@@ -439,7 +443,7 @@ test('The logger should accept custom serializer', t => {
     reply.send(new Error('kaboom'))
   })
 
-  fastify.listen(0, err => {
+  fastify.listen(0, '127.0.0.1', err => {
     t.error(err)
     fastify.server.unref()
 
@@ -1204,7 +1208,7 @@ test('file option', t => {
     reply.send({ hello: 'world' })
   })
 
-  fastify.listen(0, err => {
+  fastify.listen(0, '127.0.0.1', err => {
     t.error(err)
     fastify.server.unref()
 
@@ -1249,7 +1253,7 @@ test('should log the error if no error handler is defined', t => {
     t.ok(req.log)
     reply.send(new Error('a generic error'))
   })
-  fastify.listen(0, err => {
+  fastify.listen(0, '127.0.0.1', err => {
     t.error(err)
     fastify.server.unref()
     http.get('http://localhost:' + fastify.server.address().port + '/error')
@@ -1287,7 +1291,7 @@ test('should log as info if error status code >= 400 and < 500 if no error handl
     t.ok(req.log)
     reply.send(Object.assign(new Error('a 503 error'), { statusCode: 503 }))
   })
-  fastify.listen(0, err => {
+  fastify.listen(0, '127.0.0.1', err => {
     t.error(err)
     fastify.server.unref()
     http.get('http://localhost:' + fastify.server.address().port + '/400')
@@ -1321,7 +1325,7 @@ test('should log as error if error status code >= 500 if no error handler is def
     t.ok(req.log)
     reply.send(Object.assign(new Error('a 503 error'), { statusCode: 503 }))
   })
-  fastify.listen(0, err => {
+  fastify.listen(0, '127.0.0.1', err => {
     t.error(err)
     fastify.server.unref()
     http.get('http://localhost:' + fastify.server.address().port + '/503')
@@ -1359,7 +1363,7 @@ test('should not log the error if error handler is defined and it does not error
     t.ok(err)
     reply.send('something bad happened')
   })
-  fastify.listen(0, err => {
+  fastify.listen(0, '127.0.0.1', err => {
     t.error(err)
     fastify.server.unref()
     http.get('http://localhost:' + fastify.server.address().port + '/error')
@@ -1390,7 +1394,7 @@ test('should not rely on raw request to log errors', t => {
     t.ok(req.log)
     reply.status(415).send(new Error('something happened'))
   })
-  fastify.listen(0, err => {
+  fastify.listen(0, '127.0.0.1', err => {
     t.error(err)
     fastify.server.unref()
     http.get('http://localhost:' + fastify.server.address().port + '/error')
@@ -1440,7 +1444,7 @@ test('should redact the authorization header if so specified', t => {
       t.equal(line.req.headers.authorization, '[Redacted]', 'authorization is redacted')
     })
   })
-  fastify.listen(0, err => {
+  fastify.listen(0, '127.0.0.1', err => {
     t.error(err)
     fastify.server.unref()
     sget({

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { test, teardown } = require('tap')
+const { test, teardown, before } = require('tap')
+const helper = require('./helper')
 const http = require('http')
 const stream = require('stream')
 const split = require('split2')
@@ -13,12 +14,18 @@ const sget = require('simple-get').concat
 
 const files = []
 let count = 0
+let localhost
+let localhostForURL
 
 function file () {
   const file = path.join(os.tmpdir(), `sonic-boom-${process.pid}-${process.hrtime().toString()}-${count++}`)
   files.push(file)
   return file
 }
+
+before(async function () {
+  [localhost, localhostForURL] = await helper.getLoopbackHost()
+})
 
 teardown(() => {
   files.forEach((file) => {
@@ -78,7 +85,7 @@ test('defaults to info level', t => {
     t.error(err)
     fastify.server.unref()
 
-    http.get('http://localhost:' + fastify.server.address().port)
+    http.get(`http://${localhostForURL}:` + fastify.server.address().port)
   })
 })
 
@@ -102,11 +109,11 @@ test('test log stream', t => {
     reply.send({ hello: 'world' })
   })
 
-  fastify.listen(0, '127.0.0.1', err => {
+  fastify.listen(0, localhost, err => {
     t.error(err)
     fastify.server.unref()
 
-    http.get('http://localhost:' + fastify.server.address().port)
+    http.get(`http://${localhostForURL}:` + fastify.server.address().port)
     stream.once('data', listenAtLogLine => {
       t.ok(listenAtLogLine, 'listen at log message is ok')
 
@@ -149,11 +156,11 @@ test('test error log stream', t => {
     reply.send(new Error('kaboom'))
   })
 
-  fastify.listen(0, '127.0.0.1', err => {
+  fastify.listen(0, localhost, err => {
     t.error(err)
     fastify.server.unref()
 
-    http.get('http://localhost:' + fastify.server.address().port + '/error')
+    http.get(`http://${localhostForURL}:` + fastify.server.address().port + '/error')
     stream.once('data', listenAtLogLine => {
       t.ok(listenAtLogLine, 'listen at log message is ok')
 
@@ -194,9 +201,9 @@ test('can use external logger instance', t => {
     reply.send({ hello: 'world' })
   })
 
-  localFastify.listen(0, '127.0.0.1', err => {
+  localFastify.listen(0, localhost, err => {
     t.error(err)
-    http.get('http://localhost:' + localFastify.server.address().port + '/foo', (res) => {
+    http.get(`http://${localhostForURL}:` + localFastify.server.address().port + '/foo', (res) => {
       res.resume()
       res.on('end', () => {
         localFastify.server.close()
@@ -239,9 +246,9 @@ test('can use external logger instance with custom serializer', t => {
     reply.send({ hello: 'world' })
   })
 
-  localFastify.listen(0, '127.0.0.1', err => {
+  localFastify.listen(0, localhost, err => {
     t.error(err)
-    http.get('http://localhost:' + localFastify.server.address().port + '/foo', (res) => {
+    http.get(`http://${localhostForURL}:` + localFastify.server.address().port + '/foo', (res) => {
       res.resume()
       res.on('end', () => {
         localFastify.server.close()
@@ -443,11 +450,11 @@ test('The logger should accept custom serializer', t => {
     reply.send(new Error('kaboom'))
   })
 
-  fastify.listen(0, '127.0.0.1', err => {
+  fastify.listen(0, localhost, err => {
     t.error(err)
     fastify.server.unref()
 
-    http.get('http://localhost:' + fastify.server.address().port + '/custom')
+    http.get(`http://${localhostForURL}:` + fastify.server.address().port + '/custom')
     stream.once('data', listenAtLogLine => {
       t.ok(listenAtLogLine, 'listen at log message is ok')
 
@@ -1181,7 +1188,7 @@ test('Do not wrap IPv4 address', t => {
       level: 'info'
     }
   })
-  fastify.listen(0, '127.0.0.1', err => {
+  fastify.listen(0, localhost, err => {
     t.error(err)
     stream.once('data', line => {
       const expected = 'Server listening at http://127.0.0.1:' +
@@ -1208,11 +1215,11 @@ test('file option', t => {
     reply.send({ hello: 'world' })
   })
 
-  fastify.listen(0, '127.0.0.1', err => {
+  fastify.listen(0, localhost, err => {
     t.error(err)
     fastify.server.unref()
 
-    http.get('http://localhost:' + fastify.server.address().port, () => {
+    http.get(`http://${localhostForURL}:` + fastify.server.address().port, () => {
       const stream = fs.createReadStream(dest).pipe(split(JSON.parse))
 
       stream.once('data', listenAtLogLine => {
@@ -1253,10 +1260,10 @@ test('should log the error if no error handler is defined', t => {
     t.ok(req.log)
     reply.send(new Error('a generic error'))
   })
-  fastify.listen(0, '127.0.0.1', err => {
+  fastify.listen(0, localhost, err => {
     t.error(err)
     fastify.server.unref()
-    http.get('http://localhost:' + fastify.server.address().port + '/error')
+    http.get(`http://${localhostForURL}:` + fastify.server.address().port + '/error')
     stream.once('data', listenAtLogLine => {
       t.ok(listenAtLogLine, 'listen at log message is ok')
       stream.once('data', line => {
@@ -1291,10 +1298,10 @@ test('should log as info if error status code >= 400 and < 500 if no error handl
     t.ok(req.log)
     reply.send(Object.assign(new Error('a 503 error'), { statusCode: 503 }))
   })
-  fastify.listen(0, '127.0.0.1', err => {
+  fastify.listen(0, localhost, err => {
     t.error(err)
     fastify.server.unref()
-    http.get('http://localhost:' + fastify.server.address().port + '/400')
+    http.get(`http://${localhostForURL}:` + fastify.server.address().port + '/400')
     stream.once('data', listenAtLogLine => {
       t.ok(listenAtLogLine, 'listen at log message is ok')
       stream.once('data', line => {
@@ -1325,10 +1332,10 @@ test('should log as error if error status code >= 500 if no error handler is def
     t.ok(req.log)
     reply.send(Object.assign(new Error('a 503 error'), { statusCode: 503 }))
   })
-  fastify.listen(0, '127.0.0.1', err => {
+  fastify.listen(0, localhost, err => {
     t.error(err)
     fastify.server.unref()
-    http.get('http://localhost:' + fastify.server.address().port + '/503')
+    http.get(`http://${localhostForURL}:` + fastify.server.address().port + '/503')
     stream.once('data', listenAtLogLine => {
       t.ok(listenAtLogLine, 'listen at log message is ok')
       stream.once('data', line => {
@@ -1363,10 +1370,10 @@ test('should not log the error if error handler is defined and it does not error
     t.ok(err)
     reply.send('something bad happened')
   })
-  fastify.listen(0, '127.0.0.1', err => {
+  fastify.listen(0, localhost, err => {
     t.error(err)
     fastify.server.unref()
-    http.get('http://localhost:' + fastify.server.address().port + '/error')
+    http.get(`http://${localhostForURL}:` + fastify.server.address().port + '/error')
     stream.once('data', listenAtLogLine => {
       t.ok(listenAtLogLine, 'listen at log message is ok')
       stream.once('data', line => {
@@ -1394,10 +1401,10 @@ test('should not rely on raw request to log errors', t => {
     t.ok(req.log)
     reply.status(415).send(new Error('something happened'))
   })
-  fastify.listen(0, '127.0.0.1', err => {
+  fastify.listen(0, localhost, err => {
     t.error(err)
     fastify.server.unref()
-    http.get('http://localhost:' + fastify.server.address().port + '/error')
+    http.get(`http://${localhostForURL}:` + fastify.server.address().port + '/error')
     stream.once('data', listenAtLogLine => {
       t.ok(listenAtLogLine, 'listen at log message is ok')
       stream.once('data', line => {
@@ -1444,12 +1451,12 @@ test('should redact the authorization header if so specified', t => {
       t.equal(line.req.headers.authorization, '[Redacted]', 'authorization is redacted')
     })
   })
-  fastify.listen(0, '127.0.0.1', err => {
+  fastify.listen(0, localhost, err => {
     t.error(err)
     fastify.server.unref()
     sget({
       method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port,
+      url: `http://${localhostForURL}:` + fastify.server.address().port,
       headers: {
         authorization: 'Bearer abcde'
       }

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -14,6 +14,7 @@ const JSONStream = require('JSONStream')
 const send = require('send')
 const Readable = require('stream').Readable
 const split = require('split2')
+const semver = require('semver')
 const { kDisableRequestLogging } = require('../lib/symbols.js')
 
 function getUrl (app) {
@@ -592,7 +593,7 @@ test('return a 404 if the stream emits a 404 error', t => {
   })
 })
 
-test('should support send module 200 and 404', { only: true }, t => {
+test('should support send module 200 and 404', { skip: semver.gte(process.versions.node, '17.0.0') }, t => {
   t.plan(8)
   const fastify = Fastify()
 

--- a/test/versioned-routes.test.js
+++ b/test/versioned-routes.test.js
@@ -12,9 +12,8 @@ const proxyquire = require('proxyquire')
 process.removeAllListeners('warning')
 
 let localhost
-let localhostForURL
 before(async function () {
-  [localhost, localhostForURL] = await helper.getLoopbackHost()
+  [localhost] = await helper.getLoopbackHost()
 })
 
 test('Should register a versioned route', t => {
@@ -431,7 +430,7 @@ test('test log stream', t => {
     fastify.server.unref()
 
     http.get({
-      hostname: localhostForURL,
+      hostname: fastify.server.address().hostname,
       port: fastify.server.address().port,
       path: '/',
       method: 'GET',

--- a/test/versioned-routes.test.js
+++ b/test/versioned-routes.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test, before } = require('tap')
+const helper = require('./helper')
 const Fastify = require('..')
 const sget = require('simple-get').concat
 const http = require('http')
@@ -10,6 +10,12 @@ const append = require('vary').append
 const proxyquire = require('proxyquire')
 
 process.removeAllListeners('warning')
+
+let localhost
+let localhostForURL
+before(async function () {
+  [localhost, localhostForURL] = await helper.getLoopbackHost()
+})
 
 test('Should register a versioned route', t => {
   t.plan(11)
@@ -420,12 +426,12 @@ test('test log stream', t => {
     reply.send(new Error('kaboom'))
   })
 
-  fastify.listen(0, '127.0.0.1', err => {
+  fastify.listen(0, localhost, err => {
     t.error(err)
     fastify.server.unref()
 
     http.get({
-      hostname: 'localhost',
+      hostname: localhostForURL,
       port: fastify.server.address().port,
       path: '/',
       method: 'GET',

--- a/test/versioned-routes.test.js
+++ b/test/versioned-routes.test.js
@@ -420,7 +420,7 @@ test('test log stream', t => {
     reply.send(new Error('kaboom'))
   })
 
-  fastify.listen(0, err => {
+  fastify.listen(0, '127.0.0.1', err => {
     t.error(err)
     fastify.server.unref()
 


### PR DESCRIPTION
Supersedes https://github.com/fastify/fastify/pull/3546
Opening draft PR to close #3536 

## Questions:

1. Should the extra host binding block the Fastify application if an error is thrown?
    - The actual implementation ignores all the extra hosts' errors if the OS default interface has started successfully.
2. Should the Fastify application be considered started when the default host and the extra ones are listening?
    - The actual implementation consider the application started when all the `listen` calls are completed. The default host must be successful.
3. Should I remove all the `unref` calls in tests or the custom `emit` event is fine?

Todo:

- [x] clean code
- [x] support the Promise interface
- [x] add tests to cover the 100% coverage: the actual tests are all green

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


Fixes https://github.com/fastify/fastify/issues/3027