### PR TITLE
feat: manage display-name meta plugin

### DIFF
--- a/lib/pluginUtils.js
+++ b/lib/pluginUtils.js
@@ -14,6 +14,11 @@ function getMeta (fn) {
 }
 
 function getPluginName (func) {
+  const display = getDisplayName(func)
+  if (display) {
+    return display
+  }
+
   // let's see if this is a file, and in that case use that
   // this is common for plugins
   const cache = require.cache

--- a/test/plugin.name.display.js
+++ b/test/plugin.name.display.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const assert = require('assert')
+
+module.exports = function (fastify, opts, done) {
+  assert.strictEqual(fastify.pluginName, 'test-plugin')
+  done()
+}
+
+module.exports[Symbol.for('fastify.display-name')] = 'test-plugin'

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -41,6 +41,24 @@ test('plugin metadata - ignore prefix', t => {
   }
 })
 
+test('plugin metadata - naming plugins', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.register(require('./plugin.name.display'))
+  fastify.register(function (fastify, opts, done) {
+    // one line
+    t.equal(fastify.pluginName, 'function (fastify, opts, done) { -- // one line')
+    done()
+  })
+  fastify.register(function fooBar (fastify, opts, done) {
+    t.equal(fastify.pluginName, 'fooBar')
+    done()
+  })
+
+  await fastify.ready()
+})
+
 test('fastify.register with fastify-plugin should not encapsulate his code', t => {
   t.plan(10)
   const fastify = Fastify()


### PR DESCRIPTION
This PR gives to the user the ability to set the plugin name in encapsulated context.

It is useful for debugging purposes when using `fastify-autoload` that is now using the absolute file path as `pluginName` only.

Ref https://github.com/Eomm/fastify-overview/pull/23

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
