### PR TITLE
Adding esbuild bundler to the pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,15 @@ jobs:
       - name: install fastify
         run: |
           npm install --ignore-scripts
-      - name: install bundler stack
+      - name: install webpack stack
         run: |
           cd test/bundler/webpack && npm install
-      - name: Test bundle
+      - name: Test webpack bundle
         run: |
           cd test/bundler/webpack && npm run test
+      - name: install esbuild stack
+        run: |
+          cd test/bundler/esbuild && npm install
+      - name: Test esbuild bundle
+        run: |
+          cd test/bundler/esbuild && npm run test

--- a/test/bundler/esbuild/bundler-test.js
+++ b/test/bundler/esbuild/bundler-test.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const fastifySuccess = require('./dist/success')
+const fastifyFailPlugin = require('./dist/failPlugin')
+
+test('Bundled package should work', t => {
+  t.plan(1)
+  fastifySuccess.ready((err) => {
+    t.error(err)
+  })
+})
+
+test('Bundled package should not work with bad plugin version', t => {
+  t.plan(1)
+  fastifyFailPlugin.ready((err) => {
+    t.ok(err)
+  })
+})

--- a/test/bundler/esbuild/bundler-test.js
+++ b/test/bundler/esbuild/bundler-test.js
@@ -26,6 +26,6 @@ test('Bundled package should work', (t) => {
 test('Bundled package should not work with bad plugin version', (t) => {
   t.plan(1)
   fastifyFailPlugin.ready((err) => {
-    t.ok(err)
+    t.match(err.message, /expected '9.x' fastify version/i)
   })
 })

--- a/test/bundler/esbuild/bundler-test.js
+++ b/test/bundler/esbuild/bundler-test.js
@@ -5,14 +5,25 @@ const test = t.test
 const fastifySuccess = require('./dist/success')
 const fastifyFailPlugin = require('./dist/failPlugin')
 
-test('Bundled package should work', t => {
-  t.plan(1)
+test('Bundled package should work', (t) => {
+  t.plan(4)
   fastifySuccess.ready((err) => {
     t.error(err)
+    fastifySuccess.inject(
+      {
+        method: 'GET',
+        url: '/'
+      },
+      (error, res) => {
+        t.error(error)
+        t.equal(res.statusCode, 200)
+        t.same(res.json(), { hello: 'world' })
+      }
+    )
   })
 })
 
-test('Bundled package should not work with bad plugin version', t => {
+test('Bundled package should not work with bad plugin version', (t) => {
   t.plan(1)
   fastifyFailPlugin.ready((err) => {
     t.ok(err)

--- a/test/bundler/esbuild/package.json
+++ b/test/bundler/esbuild/package.json
@@ -1,0 +1,10 @@
+{
+  "version": "0.0.1",
+  "scripts": {
+    "bundle": "esbuild success=src/index.js failPlugin=src/fail-plugin-version.js --bundle  --outdir=dist --platform=node",
+    "test": "npm run bundle && node bundler-test.js"
+  },
+  "devDependencies": {
+    "esbuild": "^0.14.11"
+  }
+}

--- a/test/bundler/esbuild/src/fail-plugin-version.js
+++ b/test/bundler/esbuild/src/fail-plugin-version.js
@@ -1,0 +1,14 @@
+const fp = require('fastify-plugin')
+const fastify = require('../../../../')({
+  logger: true
+})
+
+fastify.get('/', function (request, reply) {
+  reply.send({ hello: 'world' })
+})
+
+fastify.register(fp((instance, opts, done) => {
+  done()
+}, { fastify: '9.x' }))
+
+module.exports = fastify

--- a/test/bundler/esbuild/src/fail-plugin-version.js
+++ b/test/bundler/esbuild/src/fail-plugin-version.js
@@ -1,7 +1,5 @@
 const fp = require('fastify-plugin')
-const fastify = require('../../../../')({
-  logger: true
-})
+const fastify = require('../../../../')()
 
 fastify.get('/', function (request, reply) {
   reply.send({ hello: 'world' })

--- a/test/bundler/esbuild/src/index.js
+++ b/test/bundler/esbuild/src/index.js
@@ -1,0 +1,9 @@
+const fastify = require('../../../../')({
+  logger: true
+})
+// Declare a route
+fastify.get('/', function (request, reply) {
+  reply.send({ hello: 'world' })
+})
+
+module.exports = fastify

--- a/test/bundler/esbuild/src/index.js
+++ b/test/bundler/esbuild/src/index.js
@@ -1,6 +1,4 @@
-const fastify = require('../../../../')({
-  logger: true
-})
+const fastify = require('../../../../')()
 // Declare a route
 fastify.get('/', function (request, reply) {
   reply.send({ hello: 'world' })

--- a/test/bundler/webpack/bundler-test.js
+++ b/test/bundler/webpack/bundler-test.js
@@ -26,6 +26,6 @@ test('Bundled package should work', (t) => {
 test('Bundled package should not work with bad plugin version', (t) => {
   t.plan(1)
   fastifyFailPlugin.ready((err) => {
-    t.ok(err)
+    t.match(err.message, /expected '9.x' fastify version/i)
   })
 })

--- a/test/bundler/webpack/bundler-test.js
+++ b/test/bundler/webpack/bundler-test.js
@@ -5,14 +5,25 @@ const test = t.test
 const fastifySuccess = require('./dist/success')
 const fastifyFailPlugin = require('./dist/failPlugin')
 
-test('Bundled package should work', t => {
-  t.plan(1)
+test('Bundled package should work', (t) => {
+  t.plan(4)
   fastifySuccess.ready((err) => {
     t.error(err)
+    fastifySuccess.inject(
+      {
+        method: 'GET',
+        url: '/'
+      },
+      (error, res) => {
+        t.error(error)
+        t.equal(res.statusCode, 200)
+        t.same(res.json(), { hello: 'world' })
+      }
+    )
   })
 })
 
-test('Bundled package should not work with bad plugin version', t => {
+test('Bundled package should not work with bad plugin version', (t) => {
   t.plan(1)
   fastifyFailPlugin.ready((err) => {
     t.ok(err)

--- a/test/bundler/webpack/src/fail-plugin-version.js
+++ b/test/bundler/webpack/src/fail-plugin-version.js
@@ -1,7 +1,5 @@
 const fp = require('fastify-plugin')
-const fastify = require('../../../../')({
-  logger: true
-})
+const fastify = require('../../../../')()
 
 fastify.get('/', function (request, reply) {
   reply.send({ hello: 'world' })

--- a/test/bundler/webpack/src/index.js
+++ b/test/bundler/webpack/src/index.js
@@ -1,6 +1,4 @@
-const fastify = require('../../../../')({
-  logger: true
-})
+const fastify = require('../../../../')()
 // Declare a route
 fastify.get('/', function (request, reply) {
   reply.send({ hello: 'world' })


### PR DESCRIPTION
This PR fixes #3377: It includes esbuild tests to the package pipeline.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
