### PR TITLE
fix (types): `this` is `FastifyInstance`

### DIFF
--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -1221,7 +1221,7 @@ test('preHandler option for setNotFoundHandler', t => {
   })
 
   // https://github.com/fastify/fastify/issues/2229
-  t.test('preHandler hook in setNotFoundHandler should be called when callNotFound', t => {
+  t.test('preHandler hook in setNotFoundHandler should be called when callNotFound', { timeout: 40000 }, t => {
     t.plan(2)
     const fastify = Fastify()
 

--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -205,7 +205,7 @@ const customTypedHook: preHandlerAsyncHookHandler<
   RawServerBase,
   RawRequestDefaultExpression<RawServerBase>,
   RawReplyDefaultExpression<RawServerBase>,
-  unknown
+  Record<string, unknown>
 > = async function (_request, _reply) {
   expectType<FastifyInstance>(this)
 }

--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -1,8 +1,8 @@
-import fastify, { RouteOptions, FastifyReply, FastifyRequest } from '../../fastify'
-import { expectType, expectError, expectAssignable } from 'tsd'
-import { FastifyInstance } from '../../types/instance'
 import { FastifyError } from 'fastify-error'
-import { RequestPayload } from '../../types/hooks'
+import { expectAssignable, expectError, expectType } from 'tsd'
+import fastify, { FastifyReply, FastifyRequest, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RouteOptions } from '../../fastify'
+import { preHandlerAsyncHookHandler, RequestPayload } from '../../types/hooks'
+import { FastifyInstance } from '../../types/instance'
 
 const server = fastify()
 
@@ -197,4 +197,19 @@ server.addHook('onReady', async function () {
 
 server.addHook('onClose', async (instance) => {
   expectType<FastifyInstance>(instance)
+})
+
+// Use case to monitor any regression on issue #3620
+// ref.: https://github.com/fastify/fastify/issues/3620
+const customTypedHook: preHandlerAsyncHookHandler<
+  RawServerBase,
+  RawRequestDefaultExpression<RawServerBase>,
+  RawReplyDefaultExpression<RawServerBase>,
+  {}
+> = async function (_request, _reply) {
+  expectType<FastifyInstance>(this)
+}
+
+server.register(async (instance) => {
+  instance.addHook('preHandler', customTypedHook)
 })

--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -215,8 +215,8 @@ RawReplyDefaultExpression,
 Record<string, unknown>
 > = async function (request, reply) {
   expectType<FastifyInstance>(this)
-  expectType<FastifyRequest>(request)
-  expectType<FastifyReply>(reply)
+  expectAssignable<FastifyRequest>(request)
+  expectAssignable<FastifyReply>(reply)
 }
 
 server.register(async (instance) => {

--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -1,8 +1,15 @@
 import { FastifyError } from 'fastify-error'
 import { expectAssignable, expectError, expectType } from 'tsd'
-import fastify, { FastifyReply, FastifyRequest, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RouteOptions } from '../../fastify'
+import fastify, {
+  FastifyInstance,
+  FastifyReply,
+  FastifyRequest,
+  RawReplyDefaultExpression,
+  RawRequestDefaultExpression,
+  RawServerBase,
+  RouteOptions
+} from '../../fastify'
 import { preHandlerAsyncHookHandler, RequestPayload } from '../../types/hooks'
-import { FastifyInstance } from '../../types/instance'
 
 const server = fastify()
 

--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -205,7 +205,7 @@ const customTypedHook: preHandlerAsyncHookHandler<
   RawServerBase,
   RawRequestDefaultExpression<RawServerBase>,
   RawReplyDefaultExpression<RawServerBase>,
-  {}
+  unknown
 > = async function (_request, _reply) {
   expectType<FastifyInstance>(this)
 }

--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -210,11 +210,13 @@ server.addHook('onClose', async (instance) => {
 // ref.: https://github.com/fastify/fastify/issues/3620
 const customTypedHook: preHandlerAsyncHookHandler<
 RawServerBase,
-RawRequestDefaultExpression<RawServerBase>,
-RawReplyDefaultExpression<RawServerBase>,
+RawRequestDefaultExpression,
+RawReplyDefaultExpression,
 Record<string, unknown>
-> = async function (_request, _reply) {
+> = async function (request, reply) {
   expectType<FastifyInstance>(this)
+  expectType<FastifyRequest>(request)
+  expectType<FastifyReply>(reply)
 }
 
 server.register(async (instance) => {

--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -202,10 +202,10 @@ server.addHook('onClose', async (instance) => {
 // Use case to monitor any regression on issue #3620
 // ref.: https://github.com/fastify/fastify/issues/3620
 const customTypedHook: preHandlerAsyncHookHandler<
-  RawServerBase,
-  RawRequestDefaultExpression<RawServerBase>,
-  RawReplyDefaultExpression<RawServerBase>,
-  Record<string, unknown>
+RawServerBase,
+RawRequestDefaultExpression<RawServerBase>,
+RawReplyDefaultExpression<RawServerBase>,
+Record<string, unknown>
 > = async function (_request, _reply) {
   expectType<FastifyInstance>(this)
 }

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -27,7 +27,7 @@ export interface onRequestHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
-    this: FastifyInstance<RawServer, RawRequest, RawReply>,
+    this: FastifyInstance,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
@@ -42,7 +42,7 @@ export interface onRequestAsyncHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
-    this: FastifyInstance<RawServer, RawRequest, RawReply>,
+    this: FastifyInstance,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
   ): Promise<unknown>;
@@ -60,7 +60,7 @@ export interface preParsingHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
-    this: FastifyInstance<RawServer, RawRequest, RawReply>,
+    this: FastifyInstance,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: RequestPayload,
@@ -76,7 +76,7 @@ export interface preParsingAsyncHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
-    this: FastifyInstance<RawServer, RawRequest, RawReply>,
+    this: FastifyInstance,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: RequestPayload,
@@ -94,7 +94,7 @@ export interface preValidationHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
-    this: FastifyInstance<RawServer, RawRequest, RawReply>,
+    this: FastifyInstance,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
@@ -109,7 +109,7 @@ export interface preValidationAsyncHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
-    this: FastifyInstance<RawServer, RawRequest, RawReply>,
+    this: FastifyInstance,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
   ): Promise<unknown>;
@@ -126,7 +126,7 @@ export interface preHandlerHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
-    this: FastifyInstance<RawServer, RawRequest, RawReply>,
+    this: FastifyInstance,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
@@ -141,7 +141,7 @@ export interface preHandlerAsyncHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
-    this: FastifyInstance<RawServer, RawRequest, RawReply>,
+    this: FastifyInstance,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
   ): Promise<unknown>;
@@ -167,7 +167,7 @@ export interface preSerializationHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
-    this: FastifyInstance<RawServer, RawRequest, RawReply>,
+    this: FastifyInstance,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: PreSerializationPayload,
@@ -184,7 +184,7 @@ export interface preSerializationAsyncHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
-    this: FastifyInstance<RawServer, RawRequest, RawReply>,
+    this: FastifyInstance,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: PreSerializationPayload
@@ -204,7 +204,7 @@ export interface onSendHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
-    this: FastifyInstance<RawServer, RawRequest, RawReply>,
+    this: FastifyInstance,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: OnSendPayload,
@@ -221,7 +221,7 @@ export interface onSendAsyncHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
-    this: FastifyInstance<RawServer, RawRequest, RawReply>,
+    this: FastifyInstance,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: OnSendPayload,
@@ -240,7 +240,7 @@ export interface onResponseHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
-    this: FastifyInstance<RawServer, RawRequest, RawReply>,
+    this: FastifyInstance,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
@@ -255,7 +255,7 @@ export interface onResponseAsyncHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
-    this: FastifyInstance<RawServer, RawRequest, RawReply>,
+    this: FastifyInstance,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
   ): Promise<unknown>;
@@ -273,7 +273,7 @@ export interface onTimeoutHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
-    this: FastifyInstance<RawServer, RawRequest, RawReply>,
+    this: FastifyInstance,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
@@ -288,7 +288,7 @@ export interface onTimeoutAsyncHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
-    this: FastifyInstance<RawServer, RawRequest, RawReply>,
+    this: FastifyInstance,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
   ): Promise<unknown>;
@@ -309,7 +309,7 @@ export interface onErrorHookHandler<
   TError extends Error = FastifyError
 > {
   (
-    this: FastifyInstance<RawServer, RawRequest, RawReply>,
+    this: FastifyInstance,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     error: TError,
@@ -326,7 +326,7 @@ export interface onErrorAsyncHookHandler<
   TError extends Error = FastifyError
 > {
   (
-    this: FastifyInstance<RawServer, RawRequest, RawReply>,
+    this: FastifyInstance,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     error: TError
@@ -346,7 +346,7 @@ export interface onRouteHookHandler<
   ContextConfig = ContextConfigDefault
 > {
   (
-    this: FastifyInstance<RawServer, RawRequest, RawReply>,
+    this: FastifyInstance,
     opts: RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> & { routePath: string; path: string; prefix: string }
   ): Promise<unknown> | void;
 }


### PR DESCRIPTION
Hello.

This PR aims to :
- change typescript definitions of `this`to `FastifyInstance` (fix https://github.com/fastify/fastify/issues/3620)
- add a typescript test to avoid regressions
- fix a flaky `404s.test.js` test randomly timing out

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
