### PR TITLE
chore (ci): run lint only once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,26 @@ on:
       - '*.md'
 
 jobs:
+  linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Install
+        run: |
+          npm install --ignore-scripts
+      
+      - name: Lint code
+        run: |
+          npm run lint
+
   test:
+    needs: linter
     runs-on: ${{ matrix.os }}
     outputs:
       COVERALLS: ${{ steps.coveralls-trigger.outputs.COVERALLS_TRIGGER }}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:typescript": "eslint -c types/.eslintrc.json types/**/*.d.ts test/types/**/*.test-d.ts",
     "prepublishOnly": "tap --no-check-coverage test/internals/version.test.js",
     "test": "npm run lint && npm run unit && npm run test:typescript",
-    "test:ci": "npm run lint && npm run unit -- --cov --coverage-report=lcovonly && npm run test:typescript",
+    "test:ci": "npm run unit -- --cov --coverage-report=lcovonly && npm run test:typescript",
     "test:report": "npm run lint && npm run unit:report && npm run test:typescript",
     "test:typescript": "tsd",
     "unit": "tap -J test/*.test.js test/*/*.test.js",


### PR DESCRIPTION
Hello.

This PR aims to :
- Run the code linting once when a CI run is triggered (It will fail fast if linting needs to be fixed). (close https://github.com/fastify/fastify/issues/3621)

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
