### PR TITLE
fix: accept-version on default route

### DIFF
--- a/docs/Reference/Request.md
+++ b/docs/Reference/Request.md
@@ -57,6 +57,9 @@ This operation will add to the request headers the new values that can be read
 calling `request.headers.bar`. Moreover, you can still access the standard
 request's headers with the `request.raw.headers` property.
 
+> Note: For performance reason on `not found` route, you may see that we will add
+an extra property `Symbol('fastify.RequestAcceptVersion')` on the headers.
+
 ```js
 fastify.post('/:params', options, function (request, reply) {
   console.log(request.body)

--- a/fastify.js
+++ b/fastify.js
@@ -579,7 +579,7 @@ function fastify (options) {
     if (req.headers['accept-version'] !== undefined) {
       // we remove the accept-version header for performance result
       // because we do not want to go through the constraint checking
-      // the usage of symbol here to preven any colision on custom header name
+      // the usage of symbol here to prevent any colision on custom header name
       req.headers[kRequestAcceptVersion] = req.headers['accept-version']
       req.headers['accept-version'] = undefined
     }

--- a/fastify.js
+++ b/fastify.js
@@ -16,6 +16,7 @@ const {
   kLogSerializers,
   kHooks,
   kSchemaController,
+  kRequestAcceptVersion,
   kReplySerializerDefault,
   kContentTypeParser,
   kReply,
@@ -576,6 +577,10 @@ function fastify (options) {
   // req and res are Node.js core objects
   function defaultRoute (req, res) {
     if (req.headers['accept-version'] !== undefined) {
+      // we remove the accept-version header for performance result
+      // because we do not want to go through the constraint checking
+      // the usage of symbol here to preven any colision on custom header name
+      req.headers[kRequestAcceptVersion] = req.headers['accept-version']
       req.headers['accept-version'] = undefined
     }
     fourOhFour.router.lookup(req, res)

--- a/lib/route.js
+++ b/lib/route.js
@@ -8,6 +8,7 @@ const supportedMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTI
 const { normalizeSchema } = require('./schemas')
 const { parseHeadOnSendHandlers } = require('./headRoute')
 const warning = require('./warnings')
+const { kRequestAcceptVersion } = require('./symbols')
 
 const {
   compileSchemasForValidation,
@@ -342,6 +343,12 @@ function buildRouting (options) {
         res.end('{"error":"Service Unavailable","message":"Service Unavailable","statusCode":503}')
         return
       }
+    }
+
+    // we revert the changes in defaultRoute
+    if (req.headers[kRequestAcceptVersion] !== undefined) {
+      req.headers['accept-version'] = req.headers[kRequestAcceptVersion]
+      req.headers[kRequestAcceptVersion] = undefined
     }
 
     const id = req.headers[requestIdHeader] || genReqId(req)

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -21,6 +21,7 @@ const keys = {
   kReply: Symbol('fastify.Reply'),
   kRequest: Symbol('fastify.Request'),
   kRequestPayloadStream: Symbol('fastify.RequestPayloadStream'),
+  kRequestAcceptVersion: Symbol('fastify.RequestAcceptVersion'),
   kCanSetNotFoundHandler: Symbol('fastify.canSetNotFoundHandler'),
   kFourOhFour: Symbol('fastify.404'),
   kFourOhFourLevelInstance: Symbol('fastify.404LogLevelInstance'),

--- a/test/versioned-routes.test.js
+++ b/test/versioned-routes.test.js
@@ -310,7 +310,7 @@ test('The not found handler should not use the Accept-Version header', t => {
   })
 
   fastify.setNotFoundHandler(function (req, reply) {
-    t.notOk(req.headers['accept-version'])
+    t.same(req.headers['accept-version'], '2.x')
     reply.code(404).send('not found handler')
   })
 

--- a/test/versioned-routes.test.js
+++ b/test/versioned-routes.test.js
@@ -296,9 +296,24 @@ test('Shorthand route declaration', t => {
   })
 })
 
-test('The not found handler should not use the Accept-Version header', t => {
-  t.plan(4)
+test('The not found handler should not erase the Accept-Version header', t => {
+  t.plan(10)
   const fastify = Fastify()
+
+  fastify.addHook('onRequest', function (req, reply, done) {
+    t.same(req.headers['accept-version'], '2.x')
+    done()
+  })
+
+  fastify.addHook('preValidation', function (req, reply, done) {
+    t.same(req.headers['accept-version'], '2.x')
+    done()
+  })
+
+  fastify.addHook('preHandler', function (req, reply, done) {
+    t.same(req.headers['accept-version'], '2.x')
+    done()
+  })
 
   fastify.route({
     method: 'GET',
@@ -311,6 +326,10 @@ test('The not found handler should not use the Accept-Version header', t => {
 
   fastify.setNotFoundHandler(function (req, reply) {
     t.same(req.headers['accept-version'], '2.x')
+    // we check if the symbol is exposed on key or not
+    for (const key in req.headers) {
+      t.same(typeof key, 'string')
+    }
     reply.code(404).send('not found handler')
   })
 

--- a/test/versioned-routes.test.js
+++ b/test/versioned-routes.test.js
@@ -297,7 +297,7 @@ test('Shorthand route declaration', t => {
 })
 
 test('The not found handler should not erase the Accept-Version header', t => {
-  t.plan(10)
+  t.plan(13)
   const fastify = Fastify()
 
   fastify.addHook('onRequest', function (req, reply, done) {
@@ -330,6 +330,11 @@ test('The not found handler should not erase the Accept-Version header', t => {
     for (const key in req.headers) {
       t.same(typeof key, 'string')
     }
+
+    for (const key of Object.keys(req.headers)) {
+      t.same(typeof key, 'string')
+    }
+
     reply.code(404).send('not found handler')
   })
 


### PR DESCRIPTION
Fixes #3625 

I think as a fast solution and not falling into the `version` constraint check in `find-my-way`. We can use a symbol to temporary store the header and revert it after `find-my-way` pick up the route. 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
