### PR TITLE
docs(Prototype-Poisoning): invalid content link

### DIFF
--- a/docs/Guides/Prototype-Poisoning.md
+++ b/docs/Guides/Prototype-Poisoning.md
@@ -117,7 +117,7 @@ an `id` ), and then pass it to our validation library, anything passed through
 via `__proto__` would sneak in undetected.
 
 ### Oh joi!
-<a id="pp-oh-joi">
+<a id="pp-oh-joi"></a>
 
 The first question is, of course, why does the validation module **joi** ignore
 the prototype and let potentially harmful data through? We asked ourselves the


### PR DESCRIPTION
#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
