### PR TITLE
fix(types): add opts param to onRegister hook handler signature

### DIFF
--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -7,7 +7,9 @@ import fastify, {
   RawReplyDefaultExpression,
   RawRequestDefaultExpression,
   RawServerBase,
-  RouteOptions
+  RouteOptions,
+  RegisterOptions,
+  FastifyPluginOptions
 } from '../../fastify'
 import { preHandlerAsyncHookHandler, RequestPayload } from '../../types/hooks'
 
@@ -113,8 +115,9 @@ server.addHook('onRoute', function (opts) {
   expectType<RouteOptions & { routePath: string; path: string; prefix: string}>(opts)
 })
 
-server.addHook('onRegister', (instance, done) => {
+server.addHook('onRegister', (instance, opts, done) => {
   expectType<FastifyInstance>(instance)
+  expectType<RegisterOptions & FastifyPluginOptions>(opts)
   expectAssignable<(err?: FastifyError) => void>(done)
   expectAssignable<(err?: NodeJS.ErrnoException) => void>(done)
   expectType<void>(done(new Error()))
@@ -194,8 +197,9 @@ server.addHook('onError', async function (request, reply, error) {
   expectType<FastifyError>(error)
 })
 
-server.addHook('onRegister', async (instance) => {
+server.addHook('onRegister', async (instance, opts) => {
   expectType<FastifyInstance>(instance)
+  expectType<RegisterOptions & FastifyPluginOptions>(opts)
 })
 
 server.addHook('onReady', async function () {

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -6,6 +6,8 @@ import { FastifyRequest } from './request'
 import { FastifyReply } from './reply'
 import { FastifyError } from 'fastify-error'
 import { FastifyLoggerInstance } from './logger'
+import { RegisterOptions } from './register'
+import { FastifyPluginOptions } from './plugin'
 
 type HookHandlerDoneFunction = <TError extends Error = FastifyError>(err?: TError) => void
 
@@ -360,10 +362,12 @@ export interface onRegisterHookHandler<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
-  Logger = FastifyLoggerInstance
+  Logger = FastifyLoggerInstance,
+  Options extends FastifyPluginOptions = FastifyPluginOptions
 > {
   (
     instance: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
+    opts: RegisterOptions & Options,
     done: HookHandlerDoneFunction
   ): Promise<unknown> | void; // documentation is missing the `done` method
 }

--- a/types/register.d.ts
+++ b/types/register.d.ts
@@ -2,7 +2,7 @@ import { FastifyPluginOptions, FastifyPluginCallback, FastifyPluginAsync } from 
 import { LogLevel } from './logger'
 import { FastifyInstance } from './instance'
 
-interface RegisterOptions {
+export interface RegisterOptions {
   prefix?: string;
   logLevel?: LogLevel;
   logSerializers?: Record<string, (value: any) => string>;


### PR DESCRIPTION
This fix the `onRegister` hook handler’s Typescript signature with an `options` parameters, as demonstrated in the [`onRegister` hook documentation](https://github.com/fastify/fastify/blob/main/docs/Reference/Hooks.md?plain=1#L480-L489).

I run into the issue as I was working on a (Typescript) plugin. I needed to hook on register to involve some logic with encapsulated contexts. This hook handler had to access the options the register function was given, but the type definition given after the `FastifyInstance` was a `HookHandlerDoneFunction`. 

Given the documentation and the tests I’ve conducted before making this pull request, I’m fairly confident this `options` parameter was mistakenly omitted in the `onRegister` hook handler signature.

#### Notable Changes

- Export `RegisterOptions` interface in `types/register.d.ts` (BTW makes it easier to merge type declarations in plugins when new options are added to the `Fastify.register()` function).

- Add a generic in `onRegisterHookHandler` (`Options extends FastifyPluginOptions = FastifyPluginOptions`). I put it after the `Logger` generic in order to not break any consumer code. 
  The `Logger` generic usually comes last in other hook handler type definitions... thus this would make an exception. 
  _If that was a matter of concern, TBH, if nobody has ever complained about this typing issue, then IMHO a change over here on those generics order are unlikely to cause any trouble at all (since the current type definition makes the `onRegister` hook barely usable at all)._

- The type of the `opts` parameter for the `onRegister` hook handler becomes: `opts: RegisterOptions & Options`. Is that correct?


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [N/A] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
