### PR TITLE
docs: add type provider encapsulation

### DIFF
--- a/docs/Type-Providers.md
+++ b/docs/Type-Providers.md
@@ -88,3 +88,111 @@ server.get('/route', {
 TypeBox uses the properties `kind` and `modifier` internally. These properties are not strictly valid JSON schema which will cause `AJV@7` and newer versions to throw an invalid schema error. To remove the error it's either necessary to omit the properties by using [`Type.Strict()`](https://github.com/sinclairzx81/typebox#strict) or use the AJV options for adding custom keywords.
 
 See also the [TypeBox documentation](https://github.com/sinclairzx81/typebox#validation) on how to set up AJV to work with TypeBox.
+
+### Scoped Type-Provider
+
+The provider types don't propagate globally. In encapsulated usage, one can remap the context to use one or more providers (for example, `typebox` and `json-schema-to-ts` can be used in the same application).
+
+Example:
+
+```ts
+import Fastify from 'fastify'
+import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox'
+import { JsonSchemaToTsProvider } from '@fastify/type-provider-json-schema-to-ts'
+import { Type } from '@sinclair/typebox'
+
+const fastify = Fastify()
+
+function pluginWithTypebox(fastify: FastifyInstance, _opts, done): void {
+  fastify.withTypeProvider<TypeBoxTypeProvider>()
+    .get('/', {
+      schema: {
+        body: Type.Object({
+          x: Type.String(),
+          y: Type.Number(),
+          z: Type.Boolean()
+        })
+      }
+    }, (req) => {
+        const { x, y, z } = req.body // type safe
+    });
+  done()
+}
+
+function pluginWithJsonSchema(fastify: FastifyInstance, _opts, done): void {
+  fastify.withTypeProvider<JsonSchemaToTsProvider>()
+    .get('/', {
+      schema: {
+        body: {
+          type: 'object',
+          properties: {
+            x: { type: 'string' },
+            y: { type: 'number' },
+            z: { type: 'boolean' }
+          },
+        } as const
+      }
+    }, (req) => {
+      const { x, y, z } = req.body // type safe
+    });
+  done()
+}
+
+fastify.register(pluginWithJsonSchema)
+fastify.register(pluginWithTypebox)
+```
+
+It's also important to mention that once the types don't propagate globally, _currently_ is not possible to avoid multiple registrations on routes when dealing with several scopes, see bellow:
+
+```ts
+import Fastify from 'fastify'
+import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox'
+import { Type } from '@sinclair/typebox'
+
+const server = Fastify({
+    ajv: {
+        customOptions: {
+            strict: 'log',
+            keywords: ['kind', 'modifier'],
+        },
+    },
+}).withTypeProvider<TypeBoxTypeProvider>()
+
+server.register(plugin1) // wrong
+server.register(plugin2) // correct
+
+function plugin1(fastify: FastifyInstance, _opts, done): void {
+  fastify.get('/', {
+    schema: {
+      body: Type.Object({
+        x: Type.String(),
+        y: Type.Number(),
+        z: Type.Boolean()
+      })
+    }
+  }, (req) => {
+    // it doesn't works! in a new scope needs to call `withTypeProvider` again
+    const { x, y, z } = req.body
+  });
+  done()
+}
+
+function plugin2(fastify: FastifyInstance, _opts, done): void {
+  const server = fastify.withTypeProvider<TypeBoxTypeProvider>()
+
+  server.get('/', {
+    schema: {
+      body: Type.Object({
+        x: Type.String(),
+        y: Type.Number(),
+        z: Type.Boolean()
+      })
+    }
+  }, (req) => {
+    // it doesn't works! in a new scope needs to call `withTypeProvider` again
+    const { x, y, z } = req.body
+  });
+  done()
+}
+```
+


### PR DESCRIPTION
Address: https://github.com/fastify/fastify-type-provider-typebox/issues/2

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
