### PR TITLE
add missing types workflow

### DIFF
--- a/.github/workflows/missing_types.yml
+++ b/.github/workflows/missing_types.yml
@@ -1,0 +1,29 @@
+name: Missing Types
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  create_issue:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'missing-types')
+    steps:
+      - name: Create an issue
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/{owner}/{repo}/issues
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          title: add missing types to [${{ github.event.pull_request.title }}]
+          body: |
+            PR [${{ github.event.pull_request.number }}](${{ github.event.pull_request.url }}) has introduced a new feature that requires updating Fastify's typings and tests.
+
+
+            Learn how to [contribute](https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md)
+
+            Get inspired by [this example PR](https://github.com/fastify/fastify/pull/3231)
+          labels: |
+            ["good-first-issue", "typescript"]
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Checklist

- [NA] run `npm run test` and `npm run benchmark`
- [NA] tests and/or benchmarks are included
- [NA] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

As per the issue https://github.com/fastify/fastify/issues/3664 I've introduced a new workflows that automatically create an issue for missing typescript for specific labeled PR.

@Eomm I did not got your last comment, about the title, please, review the workflow and let me know if something is not like you expect.