### PR TITLE
Serialization errors will be send to errorHandler

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -365,17 +365,27 @@ function preserializeHookEnd (err, request, reply, payload) {
     return
   }
 
-  if (reply[kReplySerializer] !== null) {
-    payload = reply[kReplySerializer](payload)
-  } else if (reply.context && reply.context[kReplySerializerDefault]) {
-    payload = reply.context[kReplySerializerDefault](payload, reply.raw.statusCode)
-  } else {
-    payload = serialize(reply.context, payload, reply.raw.statusCode)
+  try {
+    if (reply[kReplySerializer] !== null) {
+      payload = reply[kReplySerializer](payload)
+    } else if (reply.context && reply.context[kReplySerializerDefault]) {
+      payload = reply.context[kReplySerializerDefault](payload, reply.raw.statusCode)
+    } else {
+      payload = serialize(reply.context, payload, reply.raw.statusCode)
+    }
+  } catch (e) {
+    wrapSeralizationError(e, reply)
+    onErrorHook(reply, e)
+    return
   }
 
   flatstr(payload)
 
   onSendHook(reply, payload)
+}
+
+function wrapSeralizationError (error, reply) {
+  error.serialization = reply.context.config
 }
 
 function onSendHook (reply, payload) {


### PR DESCRIPTION
I have found that fastify sometimes can throw errors not caught by `errorHandler` and it's difficult to understand where it comes from.

Reduced Example you can find in the committed test:
Response schema with required field throws an error from `fast-json-stringify` when a required field is not found.
```
fastify.get('/', {
    schema: {
      response: {
        200: {
          type: 'object',
          properties: {
            name: { type: 'string' }
          },
          required: ['name']
        }
      }
    }

  }, function (req, reply) {
    reply.code(200).send({ no: 'thing' })
  })
```

So I decided that it will be ok idea to send the captured error to `errorHandler` like validation error, and add a sign that the error comes from serialization.

But here I need your advice on how to envelop error propely.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
