### PR TITLE
Add action to lock threads

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,0 +1,31 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v3
+        with:
+          issue-inactive-days: '90'
+          exclude-any-issue-labels: 'discussion,good first issue,help wanted'
+          issue-comment: >
+            This issue has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.
+          pr-comment: >
+            This pull request has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.
+


### PR DESCRIPTION
This PR adds a new GitHub Action that will run once per day and lock any issue or pull requests that have not had any activity in the prior 90 days. I opted for 90 days here out of an abundance of caution. We added this same action to Pino with a 30 day window. I'm not opposed to the 30 day window here.

The docs for the action can be found at -- https://github.com/dessant/lock-threads

This action will take a several days to process the current history due to -- https://github.com/dessant/lock-threads#why-are-only-some-issues-and-pull-requests-processed

We _will_ see a lot of notifications that things have been locked. There's no way around that. We can speed up the initial processing by manually running the action through the [Actions](https://github.com/fastify/fastify/actions) tab.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
