### PR TITLE
chore: fix plugin labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,7 +7,7 @@ typescript:
 - all: ["**/*[.|-]d.ts"]
 
 plugin:
-- all: ["docs/Ecosystem.md"]
+- all: ["docs/Guides/Ecosystem.md"]
 
 test:
 - all: ["test/**/*"]


### PR DESCRIPTION
as titled