### PR TITLE
 Add reference to FST_ERR_CTP_INVALID_MEDIA_TYPE error in the docs for validation & content type parser

### DIFF
--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -2,7 +2,10 @@
 
 ## `Content-Type` Parser
 Natively, Fastify only supports `'application/json'` and `'text/plain'` content
-types. The default charset is `utf-8`. If you need to support different content
+types. If the content type is not one of these, a `FST_ERR_CTP_INVALID_MEDIA_TYPE` 
+error will be thrown.
+
+The default charset is `utf-8`. If you need to support different content
 types, you can use the `addContentTypeParser` API. *The default JSON and/or
 plain text parser can be changed or removed.*
 

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -4,7 +4,10 @@
 Fastify uses a schema-based approach, and even if it is not mandatory we
 recommend using [JSON Schema](https://json-schema.org/) to validate your routes
 and serialize your outputs. Internally, Fastify compiles the schema into a
-highly performant function.
+highly performant function. 
+
+Validation will only be attempted if the content type is `application-json`,
+as described in the documentation for the [content type parser](./ContentTypeParser.md).
 
 > ## ⚠  Security Notice
 > Treat the schema definition as application code. Validation and serialization


### PR DESCRIPTION
As `application-json` is not a default content-type for fetch- it's a foreseeably common error for new users to experience. And googling FST_ERR_CTP_INVALID_MEDIA_TYPE is not especially helpful. This PR adds a reference to the error to the relevant page, and to the concept of ContentTypeParser in the validation page. 