### PR TITLE
Add coverage reporting per OS type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
-  pull_request:
+  pull_request_target:
     paths-ignore:
       - 'docs/**'
       - '*.md'
@@ -19,18 +19,23 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 'lts/*'
 
       - name: Install
         run: |
           npm install --ignore-scripts
-      
+
       - name: Lint code
         run: |
           npm run lint
 
+  coverage-nix:
+    uses: ./.github/workflows/coverage-nix.yml
+  coverage-win:
+    uses: ./.github/workflows/coverage-win.yml
+
   test:
-    needs: linter
+    needs: [linter, coverage-nix, coverage-win]
     runs-on: ${{ matrix.os }}
     outputs:
       COVERALLS: ${{ steps.coveralls-trigger.outputs.COVERALLS_TRIGGER }}
@@ -47,6 +52,14 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+
+      - uses: actions/cache@v2
+        id: check-cache
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-
 
       - name: Install
         run: |
@@ -76,9 +89,9 @@ jobs:
         if: steps.coveralls-parallel.conclusion == 'success' && steps.coveralls-parallel.outcome != 'success'
         run: |
           echo "::set-output name=COVERALLS_TRIGGER::failure"
-          
 
-  coverage:
+
+  coveralls-coverage:
     needs: test
     runs-on: ubuntu-latest
     if: needs.test.outputs.COVERALLS != 'failure'
@@ -109,7 +122,14 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 'lts/*'
+      - uses: actions/cache@v2
+        id: check-cache
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
       - name: install fastify
         run: |
           npm install --ignore-scripts

--- a/.github/workflows/coverage-nix.yml
+++ b/.github/workflows/coverage-nix.yml
@@ -1,0 +1,36 @@
+name: Code Coverage (*nix)
+
+on:
+  workflow_call:
+
+jobs:
+  check-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 'lts/*'
+
+      - uses: actions/cache@v2
+        id: check-cache
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install
+        run: |
+          npm install --ignore-scripts
+
+      - name: Generate coverage report
+        run: |
+          npm run coverage:ci
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ success() }}
+        with:
+          name: coverage-report-nix
+          path: ./coverage/lcov-report/

--- a/.github/workflows/coverage-win.yml
+++ b/.github/workflows/coverage-win.yml
@@ -1,4 +1,4 @@
-name: Code Coverage (*nix)
+name: Code Coverage (win)
 
 on:
   workflow_call:

--- a/.github/workflows/coverage-win.yml
+++ b/.github/workflows/coverage-win.yml
@@ -1,0 +1,36 @@
+name: Code Coverage (*nix)
+
+on:
+  workflow_call:
+
+jobs:
+  check-coverage:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 'lts/*'
+
+      - uses: actions/cache@v2
+        id: check-cache
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install
+        run: |
+          npm install --ignore-scripts
+
+      - name: Generate coverage report
+        run: |
+          npm run coverage:ci
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ success() }}
+        with:
+          name: coverage-report-win
+          path: ./coverage/lcov-report/

--- a/.taprc
+++ b/.taprc
@@ -4,3 +4,6 @@ flow: false
 check-coverage: true
 coverage: true
 node-arg: --allow-natives-syntax
+
+files:
+  - 'test/**/*.test.js'

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "bench": "branchcmp -r 2 -g -s \"npm run benchmark\"",
     "benchmark": "npx concurrently -k -s first \"node ./examples/benchmark/simple.js\" \"npx autocannon -c 100 -d 30 -p 10 localhost:3000/\"",
     "coverage": "npm run unit -- --cov --coverage-report=html",
+    "coverage:ci": "npm run unit -- --cov --coverage-report=html --no-browser -R terse",
     "license-checker": "license-checker --production --onlyAllow=\"MIT;ISC;BSD-3-Clause;BSD-2-Clause\"",
     "lint": "npm run lint:standard && npm run lint:typescript",
     "lint:fix": "standard --fix",
@@ -19,9 +20,9 @@
     "test:ci": "npm run unit -- -R terse --cov --coverage-report=lcovonly && npm run test:typescript",
     "test:report": "npm run lint && npm run unit:report && npm run test:typescript",
     "test:typescript": "tsc test/types/import.ts && tsd",
-    "unit": "tap -J test/*.test.js test/*/*.test.js",
+    "unit": "tap",
     "unit:junit": "tap-mocha-reporter xunit < out.tap > test/junit-testresults.xml",
-    "unit:report": "tap -J test/*.test.js test/*/*.test.js --cov --coverage-report=html --coverage-report=cobertura | tee out.tap"
+    "unit:report": "tap --cov --coverage-report=html --coverage-report=cobertura | tee out.tap"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently, our CI code coverage reporting depends upon the unit tests succeeding. Which means if a unit run fails, no coverage report is uploaded to Coveralls for that suite. When the suite fails due to missing coverage, we have no easy way of seeing what coverage loss generated the error. In particular, non-Windows people cannot see the coverage report in https://github.com/fastify/fastify/runs/5259373178?check_suite_focus=true

This pull request adds a new step to our CI that generates coverage reports subsequent to linting and _prior_ to unit testing. The result of this coverage report will be attached to the Actions panel for the CI run as a zip file. This zip file can be downloaded and explored with a web browser.

I think this step could also be used to generate an `lcov` file to upload to Coveralls and thus skip the final Coveralls step. But I'm not sure how to accomplish that with the various OS and Node.js matrices we use along with Coveralls's "parallel" feature. Probably not worth the effort to figure it out, so I haven't. 

The coverage reports generated by this new CI flow target the current Node.js LTS _only_. This is done to simply the setup, and reduce the CI run time.

This PR also tweaks a couple items in the `ci.yml` to speed up multiple runs within a single PR lifecycle, and to use the LTS version of Node in the jobs where we were using a single Node version.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
