### PR TITLE
Remove reference to 'ESLint: manage library execution' command

### DIFF
--- a/docs/Guides/Contributing.md
+++ b/docs/Guides/Contributing.md
@@ -181,12 +181,8 @@ into this document, overwriting any text already present, and save it:
 }
 ```
 
-Next, from the menu bar, select "Terminal > New Terminal" to open a new terminal
-in the editor. Run `npm install` to install the Fastify dependencies. Finally,
-we need to tell the eslint plugin to use the Fastify local install of eslint.
-Press `cmd+shift+p` to bring up the VSCode command input, type `eslint: manage
-library execution` and select it from the filtered menu. On the prompt, click
-the "Allow" button.
+Finally, from the menu bar, select "Terminal > New Terminal" to open a new terminal
+in the editor. Run `npm install` to install the Fastify dependencies.
 
 At this point, you are all setup with a custom VSCode instance that can be used
 to work on Fastify contributions. As you edit and save JavaScript files, the


### PR DESCRIPTION
[vscode-eslint](https://github.com/microsoft/vscode-eslint) uses the Fastify local install of ESLint by default, as mentioned at the beginning of their [README.md](https://github.com/microsoft/vscode-eslint/blob/main/README.md):

> The extension uses the ESLint library installed in the opened workspace folder. If the folder doesn't provide one the extension looks for a global install version.

Also, the command: `ESLint: Manage library execution` [has been removed](https://github.com/microsoft/vscode-eslint/issues/1419) from vscode-eslint. This means, we can safely remove the last step from our CONTRIBUTING.md:
> Finally, we need to tell the eslint plugin to use the Fastify local install of eslint.
Press `cmd+shift+p` to bring up the VSCode command input, type `eslint: manage
library execution` and select it from the filtered menu. On the prompt, click
the "Allow" button.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
