### PR TITLE
lint: chang eslint-plugin version to ~5.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@sinclair/typebox": "^0.23.1",
     "@sinonjs/fake-timers": "^9.1.0",
     "@types/node": "^17.0.18",
-    "@typescript-eslint/eslint-plugin": "^5.7.0",
+    "@typescript-eslint/eslint-plugin": "~5.12.1",
     "@typescript-eslint/parser": "^5.7.0",
     "ajv": "^8.10.0",
     "ajv-errors": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@sinclair/typebox": "^0.23.1",
     "@sinonjs/fake-timers": "^9.1.0",
     "@types/node": "^17.0.18",
-    "@typescript-eslint/eslint-plugin": "~5.12.1",
+    "@typescript-eslint/eslint-plugin": "5.13.1-alpha.13",
     "@typescript-eslint/parser": "^5.7.0",
     "ajv": "^8.10.0",
     "ajv-errors": "^3.0.0",

--- a/test/als.test.js
+++ b/test/als.test.js
@@ -31,7 +31,7 @@ app.post('/', function (request, reply) {
   reply.send({ id })
 })
 
-app.listen(0, function (err, address) {
+app.listen(3000, function (err, address) {
   t.error(err)
 
   sget({

--- a/test/als.test.js
+++ b/test/als.test.js
@@ -31,7 +31,7 @@ app.post('/', function (request, reply) {
   reply.send({ id })
 })
 
-app.listen(3000, function (err, address) {
+app.listen(0, function (err, address) {
   t.error(err)
 
   sget({


### PR DESCRIPTION
lint: change version for eslint-plugin until https://github.com/typescript-eslint/typescript-eslint/pull/4620 be merged and publish new version
~~test: change 3000 to random port, prevent local test failed due to port  address already in use~~

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
