### PR TITLE
feat (types): add complete `fastify.listen()` typescript definitions

### DIFF
--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -1,3 +1,4 @@
+import { expectAssignable, expectDeprecated, expectError, expectNotDeprecated, expectType } from 'tsd'
 import fastify, {
   FastifyBodyParser,
   FastifyError,
@@ -6,10 +7,9 @@ import fastify, {
   RawRequestDefaultExpression,
   RawServerDefault
 } from '../../fastify'
-import { expectAssignable, expectError, expectType } from 'tsd'
-import { FastifyRequest } from '../../types/request'
-import { FastifyReply } from '../../types/reply'
 import { HookHandlerDoneFunction } from '../../types/hooks'
+import { FastifyReply } from '../../types/reply'
+import { FastifyRequest } from '../../types/request'
 import { FastifySchemaControllerOptions } from '../../types/schema'
 
 const server = fastify()
@@ -194,13 +194,43 @@ expectAssignable<PromiseLike<string>>(server.listen('3000', '', 0))
 expectAssignable<PromiseLike<string>>(server.listen(3000, ''))
 expectAssignable<PromiseLike<string>>(server.listen('3000', ''))
 
+// Test variadic listen signatures Typescript deprecation
+expectDeprecated(server.listen(3000))
+expectDeprecated(server.listen('3000'))
+expectDeprecated(server.listen(3000, '', 0))
+expectDeprecated(server.listen('3000', '', 0))
+expectDeprecated(server.listen(3000, ''))
+expectDeprecated(server.listen('3000', ''))
+
 // test listen opts objects
+expectAssignable<PromiseLike<string>>(server.listen())
 expectAssignable<PromiseLike<string>>(server.listen({ port: 3000 }))
 expectAssignable<PromiseLike<string>>(server.listen({ port: 3000, host: '0.0.0.0' }))
 expectAssignable<PromiseLike<string>>(server.listen({ port: 3000, host: '0.0.0.0', backlog: 42 }))
+expectAssignable<PromiseLike<string>>(server.listen({ port: 3000, host: '0.0.0.0', backlog: 42, exclusive: true }))
+expectAssignable<PromiseLike<string>>(server.listen({ port: 3000, host: '::/0', ipv6Only: true }))
+
+expectAssignable<void>(server.listen(() => {}))
 expectAssignable<void>(server.listen({ port: 3000 }, () => {}))
 expectAssignable<void>(server.listen({ port: 3000, host: '0.0.0.0' }, () => {}))
 expectAssignable<void>(server.listen({ port: 3000, host: '0.0.0.0', backlog: 42 }, () => {}))
+expectAssignable<void>(server.listen({ port: 3000, host: '0.0.0.0', backlog: 42, exclusive: true }, () => {}))
+expectAssignable<void>(server.listen({ port: 3000, host: '::/0', ipv6Only: true }, () => {}))
+
+// test listen opts objects Typescript deprectation exclusion
+expectNotDeprecated(server.listen())
+expectNotDeprecated(server.listen({ port: 3000 }))
+expectNotDeprecated(server.listen({ port: 3000, host: '0.0.0.0' }))
+expectNotDeprecated(server.listen({ port: 3000, host: '0.0.0.0', backlog: 42 }))
+expectNotDeprecated(server.listen({ port: 3000, host: '0.0.0.0', backlog: 42, exclusive: true }))
+expectNotDeprecated(server.listen({ port: 3000, host: '::/0', ipv6Only: true }))
+
+expectNotDeprecated(server.listen(() => {}))
+expectNotDeprecated(server.listen({ port: 3000 }, () => {}))
+expectNotDeprecated(server.listen({ port: 3000, host: '0.0.0.0' }, () => {}))
+expectNotDeprecated(server.listen({ port: 3000, host: '0.0.0.0', backlog: 42 }, () => {}))
+expectNotDeprecated(server.listen({ port: 3000, host: '0.0.0.0', backlog: 42, exclusive: true }, () => {}))
+expectNotDeprecated(server.listen({ port: 3000, host: '::/0', ipv6Only: true }, () => {}))
 
 expectAssignable<void>(server.routing({} as RawRequestDefaultExpression, {} as RawReplyDefaultExpression))
 

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -1,21 +1,21 @@
-import { Chain as LightMyRequestChain, InjectOptions, Response as LightMyRequestResponse, CallbackFunc as LightMyRequestCallback } from 'light-my-request'
-import { RouteOptions, RouteShorthandMethod, RouteGenericInterface, DefaultRoute } from './route'
+import { FastifyError } from 'fastify-error'
+import { CallbackFunc as LightMyRequestCallback, Chain as LightMyRequestChain, InjectOptions, Response as LightMyRequestResponse } from 'light-my-request'
+import { AddContentTypeParser, ConstructorAction, FastifyBodyParser, getDefaultJsonParser, hasContentTypeParser, ProtoAction, removeAllContentTypeParsers, removeContentTypeParser } from './content-type-parser'
+import { onCloseAsyncHookHandler, onCloseHookHandler, onErrorAsyncHookHandler, onErrorHookHandler, onReadyAsyncHookHandler, onReadyHookHandler, onRegisterHookHandler, onRequestAsyncHookHandler, onRequestHookHandler, onResponseAsyncHookHandler, onResponseHookHandler, onRouteHookHandler, onSendAsyncHookHandler, onSendHookHandler, onTimeoutAsyncHookHandler, onTimeoutHookHandler, preHandlerAsyncHookHandler, preHandlerHookHandler, preParsingAsyncHookHandler, preParsingHookHandler, preSerializationAsyncHookHandler, preSerializationHookHandler, preValidationAsyncHookHandler, preValidationHookHandler } from './hooks'
+import { FastifyLoggerInstance } from './logger'
+import { FastifyRegister } from './register'
+import { FastifyReply } from './reply'
+import { FastifyRequest } from './request'
+import { DefaultRoute, RouteGenericInterface, RouteOptions, RouteShorthandMethod } from './route'
 import {
   FastifySchema,
   FastifySchemaCompiler,
+  FastifySchemaControllerOptions,
   FastifySchemaValidationError,
-  FastifySerializerCompiler,
-  FastifySchemaControllerOptions
+  FastifySerializerCompiler
 } from './schema'
-import { RawServerBase, RawRequestDefaultExpression, RawServerDefault, RawReplyDefaultExpression, ContextConfigDefault } from './utils'
-import { FastifyLoggerInstance } from './logger'
-import { FastifyRegister } from './register'
-import { onRequestHookHandler, preParsingHookHandler, onSendHookHandler, preValidationHookHandler, preHandlerHookHandler, preSerializationHookHandler, onResponseHookHandler, onErrorHookHandler, onRouteHookHandler, onRegisterHookHandler, onCloseHookHandler, onCloseAsyncHookHandler, onReadyHookHandler, onTimeoutHookHandler, preParsingAsyncHookHandler, preValidationAsyncHookHandler, preHandlerAsyncHookHandler, preSerializationAsyncHookHandler, onSendAsyncHookHandler, onResponseAsyncHookHandler, onTimeoutAsyncHookHandler, onErrorAsyncHookHandler, onReadyAsyncHookHandler, onRequestAsyncHookHandler } from './hooks'
-import { FastifyRequest } from './request'
-import { FastifyReply } from './reply'
-import { FastifyError } from 'fastify-error'
-import { AddContentTypeParser, hasContentTypeParser, getDefaultJsonParser, ProtoAction, ConstructorAction, FastifyBodyParser, removeContentTypeParser, removeAllContentTypeParsers } from './content-type-parser'
 import { FastifyTypeProvider, FastifyTypeProviderDefault } from './type-provider'
+import { ContextConfigDefault, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RawServerDefault } from './utils'
 
 export interface PrintRoutesOptions {
   includeMeta?: boolean | (string | symbol)[]
@@ -82,12 +82,118 @@ export interface FastifyInstance<
   inject(opts: InjectOptions | string): Promise<LightMyRequestResponse>;
   inject(): LightMyRequestChain;
 
+  listen(opts: {
+    /**
+     * Default to `0` (picks the first available open port).
+     */
+    port?: number;
+    /**
+     * Default to `localhost`.
+     */
+    host?: string;
+    /**
+     * Will be ignored if `port` is specified.
+     * @see [Identifying paths for IPC connections](https://nodejs.org/api/net.html#identifying-paths-for-ipc-connections).
+    */
+    path?: string;
+    /**
+     * Specify the maximum length of the queue of pending connections.
+     * The actual length will be determined by the OS through sysctl settings such as `tcp_max_syn_backlog` and `somaxconn` on Linux.
+     * Default to `511`.
+     */
+    backlog?: number;
+    /**
+     * Default to `false`.
+     */
+    exclusive?: boolean;
+    /**
+     * For IPC servers makes the pipe readable for all users.
+     * Default to `false`.
+     */
+    readableAll?: boolean;
+    /**
+     * For IPC servers makes the pipe writable for all users.
+     * Default to `false`.
+     */
+    writableAll?: boolean;
+    /**
+     * For TCP servers, setting `ipv6Only` to `true` will disable dual-stack support, i.e., binding to host `::` won't make `0.0.0.0` be bound.
+     * Default to `false`.
+     */
+    ipv6Only?: boolean;
+    /**
+     * An AbortSignal that may be used to close a listening server.
+     * @since This option is available only in Node.js v15.6.0 and greater
+     */
+    signal?: AbortSignal;
+  }, callback: (err: Error|null, address: string) => void): void;
+  listen(opts?: {
+    /**
+     * Default to `0` (picks the first available open port).
+     */
+    port?: number;
+    /**
+     * Default to `localhost`.
+     */
+    host?: string;
+    /**
+     * Will be ignored if `port` is specified.
+     * @see [Identifying paths for IPC connections](https://nodejs.org/api/net.html#identifying-paths-for-ipc-connections).
+    */
+    path?: string;
+    /**
+     * Specify the maximum length of the queue of pending connections.
+     * The actual length will be determined by the OS through sysctl settings such as `tcp_max_syn_backlog` and `somaxconn` on Linux.
+     * Default to `511`.
+     */
+    backlog?: number;
+    /**
+     * Default to `false`.
+     */
+    exclusive?: boolean;
+    /**
+     * For IPC servers makes the pipe readable for all users.
+     * Default to `false`.
+     */
+    readableAll?: boolean;
+    /**
+     * For IPC servers makes the pipe writable for all users.
+     * Default to `false`.
+     */
+    writableAll?: boolean;
+    /**
+     * For TCP servers, setting `ipv6Only` to `true` will disable dual-stack support, i.e., binding to host `::` won't make `0.0.0.0` be bound.
+     * Default to `false`.
+     */
+    ipv6Only?: boolean;
+    /**
+     * An AbortSignal that may be used to close a listening server.
+     * @since This option is available only in Node.js v15.6.0 and greater
+     */
+    signal?: AbortSignal;
+  }): Promise<string>;
+  listen(callback: (err: Error | null, address: string) => void): void;
+
+  /**
+   * @deprecated Variadic listen method is deprecated. Please use `.listen(optionsObject, callback)` instead. The variadic signature will be removed in `fastify@5`
+   * @see https://github.com/fastify/fastify/pull/3712
+   */
   listen(port: number | string, address: string, backlog: number, callback: (err: Error|null, address: string) => void): void;
+  /**
+   * @deprecated Variadic listen method is deprecated. Please use `.listen(optionsObject, callback)` instead. The variadic signature will be removed in `fastify@5`
+   * @see https://github.com/fastify/fastify/pull/3712
+   */
   listen(port: number | string, address: string, callback: (err: Error|null, address: string) => void): void;
+  /**
+   * @deprecated Variadic listen method is deprecated. Please use `.listen(optionsObject, callback)` instead. The variadic signature will be removed in `fastify@5`
+   * @see https://github.com/fastify/fastify/pull/3712
+   */
   listen(port: number | string, callback: (err: Error|null, address: string) => void): void;
+  /**
+   * @deprecated Variadic listen method is deprecated. Please use `.listen(optionsObject)` instead. The variadic signature will be removed in `fastify@5`
+   * @see https://github.com/fastify/fastify/pull/3712
+   */
   listen(port: number | string, address?: string, backlog?: number): Promise<string>;
-  listen(opts: { port: number; host?: string; backlog?: number }, callback: (err: Error|null, address: string) => void): void;
-  listen(opts: { port: number; host?: string; backlog?: number }): Promise<string>;
 
   ready(): FastifyInstance<RawServer, RawRequest, RawReply, FastifyLoggerInstance, TypeProvider> & PromiseLike<undefined>;
   ready(readyListener: (err: Error) => void): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;


### PR DESCRIPTION
Hello.

This PR aims to :
- add complete `fastify.listen()` typescript definitions (cf.: https://github.com/fastify/fastify/pull/3712#issuecomment-1058015854)
- add deprecations on typescript side to promote the use of the object options

(same PR as https://github.com/fastify/fastify/pull/3746 - automatically closed when the branch was deleted here https://github.com/fastify/fastify/pull/3712)

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)