### PR TITLE
Fix: response type of serialize method in FastifyReply interface

### DIFF
--- a/test/types/reply.test-d.ts
+++ b/test/types/reply.test-d.ts
@@ -4,6 +4,7 @@ import { RawServerDefault, RawReplyDefaultExpression, ContextConfigDefault } fro
 import { FastifyLoggerInstance } from '../../types/logger'
 import { RouteGenericInterface } from '../../types/route'
 import { FastifyInstance } from '../../types/instance'
+import { Buffer } from 'buffer'
 
 const getHandler: RouteHandlerMethod = function (_request, reply) {
   expectType<RawReplyDefaultExpression>(reply.raw)
@@ -28,7 +29,7 @@ const getHandler: RouteHandlerMethod = function (_request, reply) {
   expectType<() => number>(reply.getResponseTime)
   expectType<(contentType: string) => FastifyReply>(reply.type)
   expectType<(fn: (payload: any) => string) => FastifyReply>(reply.serializer)
-  expectType<(payload: any) => string>(reply.serialize)
+  expectType<(payload: any) => string | ArrayBuffer | Buffer>(reply.serialize)
   expectType<(fulfilled: () => void, rejected: (err: Error) => void) => void>(reply.then)
   expectType<FastifyInstance>(reply.server)
 }

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -6,6 +6,7 @@ import { FastifyRequest } from './request'
 import { RouteGenericInterface } from './route'
 import { FastifyInstance } from './instance'
 import { FastifySchema } from './schema'
+import { Buffer } from 'buffer'
 
 export interface ReplyGenericInterface {
   Reply?: ReplyDefault;
@@ -52,6 +53,6 @@ export interface FastifyReply<
   getResponseTime(): number;
   type(contentType: string): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
   serializer(fn: (payload: any) => string): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
-  serialize(payload: any): string;
+  serialize(payload: any): string | ArrayBuffer | Buffer;
   then(fulfilled: () => void, rejected: (err: Error) => void): void;
 }


### PR DESCRIPTION
Added response type of `ArrayBuffer` and `Buffer` to the serialize method in FastifyReply interface.
