### PR TITLE
Fixes overwrite of avvio plugin timeout of 0

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -353,8 +353,8 @@ function fastify (options) {
     validateSchemaErrorFormatter(options.schemaErrorFormatter)
     fastify[kSchemaErrorFormatter] = options.schemaErrorFormatter.bind(fastify)
   }
-  
-  const avvioPluginTimeout = Number(options.pluginTimeout);
+
+  const avvioPluginTimeout = Number(options.pluginTimeout)
   // Install and configure Avvio
   // Avvio will update the following Fastify methods:
   // - register

--- a/fastify.js
+++ b/fastify.js
@@ -353,7 +353,8 @@ function fastify (options) {
     validateSchemaErrorFormatter(options.schemaErrorFormatter)
     fastify[kSchemaErrorFormatter] = options.schemaErrorFormatter.bind(fastify)
   }
-
+  
+  const avvioPluginTimeout = Number(options.pluginTimeout);
   // Install and configure Avvio
   // Avvio will update the following Fastify methods:
   // - register
@@ -363,7 +364,7 @@ function fastify (options) {
   // - close
   const avvio = Avvio(fastify, {
     autostart: false,
-    timeout: Number(options.pluginTimeout) || defaultInitOptions.pluginTimeout,
+    timeout: !isNaN(avvioPluginTimeout) ? avvioPluginTimeout : defaultInitOptions.pluginTimeout,
     expose: {
       use: 'register'
     }


### PR DESCRIPTION
`0` disables avvio plugin timeout. Unfortunately this was overwritten by the default timeout.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
