### PR TITLE
add generic logger to route handler & FastifyRequest

### DIFF
--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -10,7 +10,7 @@ import fastify, {
   RouteOptions,
   RegisterOptions,
   FastifyPluginOptions,
-  FastifyContextConfig
+  FastifyContextConfig, RawServerDefault
 } from '../../fastify'
 import { preHandlerAsyncHookHandler, RequestPayload } from '../../types/hooks'
 import { RouteGenericInterface } from '../../types/route'
@@ -215,7 +215,7 @@ server.addHook('onClose', async (instance) => {
 // Use case to monitor any regression on issue #3620
 // ref.: https://github.com/fastify/fastify/issues/3620
 const customTypedHook: preHandlerAsyncHookHandler<
-RawServerBase,
+RawServerDefault,
 RawRequestDefaultExpression,
 RawReplyDefaultExpression,
 Record<string, unknown>

--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -1,5 +1,14 @@
 import { expectType } from 'tsd'
-import fastify, { RouteHandler, RawRequestDefaultExpression, RequestBodyDefault, RequestGenericInterface, FastifyContext, ContextConfigDefault, FastifyContextConfig } from '../../fastify'
+import fastify, {
+  RouteHandler,
+  RawRequestDefaultExpression,
+  RequestBodyDefault,
+  RequestGenericInterface,
+  FastifyContext,
+  ContextConfigDefault,
+  FastifyContextConfig,
+  FastifyLogFn
+} from '../../fastify'
 import { RequestParamsDefault, RequestHeadersDefault, RequestQuerystringDefault } from '../../types/utils'
 import { FastifyLoggerInstance } from '../../types/logger'
 import { FastifyRequest } from '../../types/request'
@@ -64,6 +73,11 @@ const getHandler: RouteHandler = function (request, _reply) {
   expectType<FastifyInstance>(request.server)
 }
 
+const getHandlerWithCustomLogger: RouteHandler = function (request, _reply) {
+  expectType<FastifyLoggerInstance>(request.log)
+  expectType<FastifyLogFn>((request.log as FastifyLoggerInstance & { foo: FastifyLogFn }).foo)
+}
+
 const postHandler: Handler = function (request) {
   expectType<RequestBody>(request.body)
   expectType<RequestParams>(request.params)
@@ -96,3 +110,17 @@ const server = fastify()
 server.get('/get', getHandler)
 server.post('/post', postHandler)
 server.put('/put', putHandler)
+
+const customLogger = {
+  info: () => { },
+  warn: () => { },
+  error: () => { },
+  fatal: () => { },
+  trace: () => { },
+  debug: () => { },
+  foo: () => { }, // custom severity logger method
+  child: () => customLogger
+}
+
+const serverWithCustomLogger = fastify({ logger: customLogger })
+serverWithCustomLogger.get('/get', getHandlerWithCustomLogger)

--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -7,13 +7,17 @@ import fastify, {
   FastifyContext,
   ContextConfigDefault,
   FastifyContextConfig,
-  FastifyLogFn
+  FastifyLogFn,
+  RawServerDefault,
+  RawReplyDefaultExpression,
+  RouteHandlerMethod
 } from '../../fastify'
 import { RequestParamsDefault, RequestHeadersDefault, RequestQuerystringDefault } from '../../types/utils'
 import { FastifyLoggerInstance } from '../../types/logger'
 import { FastifyRequest } from '../../types/request'
 import { FastifyReply } from '../../types/reply'
 import { FastifyInstance } from '../../types/instance'
+import { RouteGenericInterface } from '../../types/route'
 
 interface RequestBody {
   content: string;
@@ -77,8 +81,8 @@ const getHandler: RouteHandler = function (request, _reply) {
   expectType<FastifyInstance>(request.server)
 }
 
-const getHandlerWithCustomLogger: RouteHandler = function (request, _reply) {
-  expectType<FastifyLoggerInstance>(request.log)
+const getHandlerWithCustomLogger: RouteHandlerMethod<RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, RouteGenericInterface, ContextConfigDefault, CustomLoggerInterface> = function (request: FastifyRequest<RouteGenericInterface, RawServerDefault, RawRequestDefaultExpression, ContextConfigDefault, CustomLoggerInterface>, _reply) {
+  expectType<CustomLoggerInterface>(request.log)
 }
 
 const postHandler: Handler = function (request) {
@@ -126,4 +130,9 @@ const customLogger: CustomLoggerInterface = {
 }
 
 const serverWithCustomLogger = fastify({ logger: customLogger })
+expectType<
+FastifyInstance<RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, CustomLoggerInterface>
+& PromiseLike<FastifyInstance<RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, CustomLoggerInterface>>
+>(serverWithCustomLogger)
+
 serverWithCustomLogger.get('/get', getHandlerWithCustomLogger)

--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -47,6 +47,10 @@ type CustomRequest = FastifyRequest<{
   Headers: RequestHeaders;
 }>
 
+interface CustomLoggerInterface extends FastifyLoggerInstance {
+  foo: FastifyLogFn; // custom severity logger method
+}
+
 const getHandler: RouteHandler = function (request, _reply) {
   expectType<string>(request.url)
   expectType<string>(request.method)
@@ -75,7 +79,6 @@ const getHandler: RouteHandler = function (request, _reply) {
 
 const getHandlerWithCustomLogger: RouteHandler = function (request, _reply) {
   expectType<FastifyLoggerInstance>(request.log)
-  expectType<FastifyLogFn>((request.log as FastifyLoggerInstance & { foo: FastifyLogFn }).foo)
 }
 
 const postHandler: Handler = function (request) {
@@ -111,7 +114,7 @@ server.get('/get', getHandler)
 server.post('/post', postHandler)
 server.put('/put', putHandler)
 
-const customLogger = {
+const customLogger: CustomLoggerInterface = {
   info: () => { },
   warn: () => { },
   error: () => { },

--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -81,7 +81,7 @@ const getHandler: RouteHandler = function (request, _reply) {
   expectType<FastifyInstance>(request.server)
 }
 
-const getHandlerWithCustomLogger: RouteHandlerMethod<RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, RouteGenericInterface, ContextConfigDefault, CustomLoggerInterface> = function (request: FastifyRequest<RouteGenericInterface, RawServerDefault, RawRequestDefaultExpression, ContextConfigDefault, CustomLoggerInterface>, _reply) {
+const getHandlerWithCustomLogger: RouteHandlerMethod<RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, RouteGenericInterface, ContextConfigDefault, CustomLoggerInterface> = function (request, _reply) {
   expectType<CustomLoggerInterface>(request.log)
 }
 

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -26,11 +26,12 @@ export interface onRequestHookHandler<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-  ContextConfig = ContextConfigDefault
+  ContextConfig = ContextConfigDefault,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
   ): void;
@@ -41,11 +42,12 @@ export interface onRequestAsyncHookHandler<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-  ContextConfig = ContextConfigDefault
+  ContextConfig = ContextConfigDefault,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
   ): Promise<unknown>;
 }
@@ -59,11 +61,12 @@ export interface preParsingHookHandler<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-  ContextConfig = ContextConfigDefault
+  ContextConfig = ContextConfigDefault,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: RequestPayload,
     done: <TError extends Error = FastifyError>(err?: TError | null, res?: RequestPayload) => void
@@ -75,11 +78,12 @@ export interface preParsingAsyncHookHandler<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-  ContextConfig = ContextConfigDefault
+  ContextConfig = ContextConfigDefault,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: RequestPayload,
   ): Promise<RequestPayload | unknown>;
@@ -93,11 +97,12 @@ export interface preValidationHookHandler<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-  ContextConfig = ContextConfigDefault
+  ContextConfig = ContextConfigDefault,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
   ): void;
@@ -108,11 +113,12 @@ export interface preValidationAsyncHookHandler<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-  ContextConfig = ContextConfigDefault
+  ContextConfig = ContextConfigDefault,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
   ): Promise<unknown>;
 }
@@ -125,11 +131,12 @@ export interface preHandlerHookHandler<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-  ContextConfig = ContextConfigDefault
+  ContextConfig = ContextConfigDefault,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
   ): void;
@@ -140,11 +147,12 @@ export interface preHandlerAsyncHookHandler<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-  ContextConfig = ContextConfigDefault
+  ContextConfig = ContextConfigDefault,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
   ): Promise<unknown>;
 }
@@ -166,11 +174,12 @@ export interface preSerializationHookHandler<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-  ContextConfig = ContextConfigDefault
+  ContextConfig = ContextConfigDefault,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: PreSerializationPayload,
     done: DoneFuncWithErrOrRes
@@ -183,11 +192,12 @@ export interface preSerializationAsyncHookHandler<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-  ContextConfig = ContextConfigDefault
+  ContextConfig = ContextConfigDefault,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: PreSerializationPayload
   ): Promise<unknown>;
@@ -203,11 +213,12 @@ export interface onSendHookHandler<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-  ContextConfig = ContextConfigDefault
+  ContextConfig = ContextConfigDefault,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: OnSendPayload,
     done: DoneFuncWithErrOrRes
@@ -220,11 +231,12 @@ export interface onSendAsyncHookHandler<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-  ContextConfig = ContextConfigDefault
+  ContextConfig = ContextConfigDefault,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: OnSendPayload,
   ): Promise<unknown>;
@@ -239,11 +251,12 @@ export interface onResponseHookHandler<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-  ContextConfig = ContextConfigDefault
+  ContextConfig = ContextConfigDefault,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
   ): void;
@@ -254,11 +267,12 @@ export interface onResponseAsyncHookHandler<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-  ContextConfig = ContextConfigDefault
+  ContextConfig = ContextConfigDefault,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
   ): Promise<unknown>;
 }
@@ -272,11 +286,12 @@ export interface onTimeoutHookHandler<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-  ContextConfig = ContextConfigDefault
+  ContextConfig = ContextConfigDefault,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
   ): void;
@@ -287,11 +302,12 @@ export interface onTimeoutAsyncHookHandler<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-  ContextConfig = ContextConfigDefault
+  ContextConfig = ContextConfigDefault,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
   ): Promise<unknown>;
 }
@@ -308,11 +324,12 @@ export interface onErrorHookHandler<
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
   ContextConfig = ContextConfigDefault,
-  TError extends Error = FastifyError
+  TError extends Error = FastifyError,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     error: TError,
     done: () => void
@@ -325,11 +342,12 @@ export interface onErrorAsyncHookHandler<
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
   ContextConfig = ContextConfigDefault,
-  TError extends Error = FastifyError
+  TError extends Error = FastifyError,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     error: TError
   ): Promise<unknown>;
@@ -362,7 +380,7 @@ export interface onRegisterHookHandler<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
-  Logger = FastifyLoggerInstance,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance,
   Options extends FastifyPluginOptions = FastifyPluginOptions
 > {
   (
@@ -394,7 +412,7 @@ export interface onCloseHookHandler<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
-  Logger = FastifyLoggerInstance
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance,
 > {
   (
     instance: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
@@ -406,7 +424,7 @@ export interface onCloseAsyncHookHandler<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
-  Logger = FastifyLoggerInstance
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance,
 > {
   (
     instance: FastifyInstance<RawServer, RawRequest, RawReply, Logger>

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -30,7 +30,7 @@ export interface onRequestHookHandler<
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
@@ -46,7 +46,7 @@ export interface onRequestAsyncHookHandler<
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
   ): Promise<unknown>;
@@ -65,7 +65,7 @@ export interface preParsingHookHandler<
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: RequestPayload,
@@ -82,7 +82,7 @@ export interface preParsingAsyncHookHandler<
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: RequestPayload,
@@ -101,7 +101,7 @@ export interface preValidationHookHandler<
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
@@ -117,7 +117,7 @@ export interface preValidationAsyncHookHandler<
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
   ): Promise<unknown>;
@@ -135,7 +135,7 @@ export interface preHandlerHookHandler<
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
@@ -151,7 +151,7 @@ export interface preHandlerAsyncHookHandler<
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
   ): Promise<unknown>;
@@ -178,7 +178,7 @@ export interface preSerializationHookHandler<
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: PreSerializationPayload,
@@ -196,7 +196,7 @@ export interface preSerializationAsyncHookHandler<
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: PreSerializationPayload
@@ -217,7 +217,7 @@ export interface onSendHookHandler<
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: OnSendPayload,
@@ -235,7 +235,7 @@ export interface onSendAsyncHookHandler<
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: OnSendPayload,
@@ -255,7 +255,7 @@ export interface onResponseHookHandler<
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
@@ -271,7 +271,7 @@ export interface onResponseAsyncHookHandler<
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
   ): Promise<unknown>;
@@ -290,7 +290,7 @@ export interface onTimeoutHookHandler<
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
@@ -306,7 +306,7 @@ export interface onTimeoutAsyncHookHandler<
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
   ): Promise<unknown>;
@@ -328,7 +328,7 @@ export interface onErrorHookHandler<
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     error: TError,
@@ -346,7 +346,7 @@ export interface onErrorAsyncHookHandler<
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     error: TError
@@ -394,9 +394,14 @@ export interface onRegisterHookHandler<
 /**
  * Triggered when fastify.listen() or fastify.ready() is invoked to start the server. It is useful when plugins need a "ready" event, for example to load data before the server start listening for requests.
  */
-export interface onReadyHookHandler {
+export interface onReadyHookHandler<
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance,
+> {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     done: HookHandlerDoneFunction
   ): void;
 }

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -363,10 +363,11 @@ export interface onRouteHookHandler<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-  ContextConfig = ContextConfigDefault
+  ContextConfig = ContextConfigDefault,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   (
-    this: FastifyInstance,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
     opts: RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> & { routePath: string; path: string; prefix: string }
   ): Promise<unknown> | void;
 }

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -83,7 +83,7 @@ export interface FastifyInstance<
   listen(opts: { port: number; host?: string; backlog?: number }, callback: (err: Error|null, address: string) => void): void;
   listen(opts: { port: number; host?: string; backlog?: number }): Promise<string>;
 
-  ready(): FastifyInstance<RawServer, RawRequest, RawReply> & PromiseLike<undefined>;
+  ready(): FastifyInstance<RawServer, RawRequest, RawReply, Logger> & PromiseLike<undefined>;
   ready(readyListener: (err: Error) => void): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   register: FastifyRegister<FastifyInstance<RawServer, RawRequest, RawReply, Logger> & PromiseLike<undefined>>;
@@ -96,7 +96,7 @@ export interface FastifyInstance<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
     ContextConfig = ContextConfigDefault,
     SchemaCompiler = FastifySchema,
-  >(opts: RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler>): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+  >(opts: RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, Logger>): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   get: RouteShorthandMethod<RawServer, RawRequest, RawReply>;
   head: RouteShorthandMethod<RawServer, RawRequest, RawReply>;
@@ -321,7 +321,7 @@ export interface FastifyInstance<
     Logger extends FastifyLoggerInstance = FastifyLoggerInstance,
   >(
     name: 'onRoute',
-    hook: onRouteHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: onRouteHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -29,7 +29,7 @@ export interface FastifyInstance<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
-  Logger = FastifyLoggerInstance
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   server: RawServer;
   prefix: string;
@@ -117,10 +117,11 @@ export interface FastifyInstance<
    */
   addHook<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-    ContextConfig = ContextConfigDefault
+    ContextConfig = ContextConfigDefault,
+    Logger extends FastifyLoggerInstance = FastifyLoggerInstance
   >(
     name: 'onRequest',
-    hook: onRequestHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: onRequestHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   addHook<
@@ -128,7 +129,7 @@ export interface FastifyInstance<
     ContextConfig = ContextConfigDefault
   >(
     name: 'onRequest',
-    hook: onRequestAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: onRequestAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
@@ -140,7 +141,7 @@ export interface FastifyInstance<
     ContextConfig = ContextConfigDefault
   >(
     name: 'preParsing',
-    hook: preParsingHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: preParsingHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   addHook<
@@ -148,7 +149,7 @@ export interface FastifyInstance<
     ContextConfig = ContextConfigDefault
   >(
     name: 'preParsing',
-    hook: preParsingAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: preParsingAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
@@ -156,18 +157,20 @@ export interface FastifyInstance<
    */
   addHook<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-    ContextConfig = ContextConfigDefault
+    ContextConfig = ContextConfigDefault,
+    Logger extends FastifyLoggerInstance = FastifyLoggerInstance
   >(
     name: 'preValidation',
-    hook: preValidationHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: preValidationHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   addHook<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-    ContextConfig = ContextConfigDefault
+    ContextConfig = ContextConfigDefault,
+    Logger extends FastifyLoggerInstance = FastifyLoggerInstance
   >(
     name: 'preValidation',
-    hook: preValidationAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: preValidationAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
@@ -175,18 +178,20 @@ export interface FastifyInstance<
    */
   addHook<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-    ContextConfig = ContextConfigDefault
+    ContextConfig = ContextConfigDefault,
+    Logger extends FastifyLoggerInstance = FastifyLoggerInstance
   >(
     name: 'preHandler',
-    hook: preHandlerHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: preHandlerHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   addHook<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-    ContextConfig = ContextConfigDefault
+    ContextConfig = ContextConfigDefault,
+    Logger extends FastifyLoggerInstance = FastifyLoggerInstance
   >(
     name: 'preHandler',
-    hook: preHandlerAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: preHandlerAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
@@ -196,19 +201,21 @@ export interface FastifyInstance<
   addHook<
     PreSerializationPayload = unknown,
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-    ContextConfig = ContextConfigDefault
+    ContextConfig = ContextConfigDefault,
+    Logger extends FastifyLoggerInstance = FastifyLoggerInstance
   >(
     name: 'preSerialization',
-    hook: preSerializationHookHandler<PreSerializationPayload, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: preSerializationHookHandler<PreSerializationPayload, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   addHook<
     PreSerializationPayload = unknown,
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-    ContextConfig = ContextConfigDefault
+    ContextConfig = ContextConfigDefault,
+    Logger extends FastifyLoggerInstance = FastifyLoggerInstance
   >(
     name: 'preSerialization',
-    hook: preSerializationAsyncHookHandler<PreSerializationPayload, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: preSerializationAsyncHookHandler<PreSerializationPayload, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
@@ -218,19 +225,21 @@ export interface FastifyInstance<
   addHook<
     OnSendPayload = unknown,
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-    ContextConfig = ContextConfigDefault
+    ContextConfig = ContextConfigDefault,
+    Logger extends FastifyLoggerInstance = FastifyLoggerInstance
   >(
     name: 'onSend',
-    hook: onSendHookHandler<OnSendPayload, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: onSendHookHandler<OnSendPayload, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   addHook<
     OnSendPayload = unknown,
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-    ContextConfig = ContextConfigDefault
+    ContextConfig = ContextConfigDefault,
+    Logger extends FastifyLoggerInstance = FastifyLoggerInstance
   >(
     name: 'onSend',
-    hook: onSendAsyncHookHandler<OnSendPayload, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: onSendAsyncHookHandler<OnSendPayload, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
@@ -239,18 +248,20 @@ export interface FastifyInstance<
    */
   addHook<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-    ContextConfig = ContextConfigDefault
+    ContextConfig = ContextConfigDefault,
+    Logger extends FastifyLoggerInstance = FastifyLoggerInstance,
   >(
     name: 'onResponse',
-    hook: onResponseHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: onResponseHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   addHook<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-    ContextConfig = ContextConfigDefault
+    ContextConfig = ContextConfigDefault,
+    Logger extends FastifyLoggerInstance = FastifyLoggerInstance,
   >(
     name: 'onResponse',
-    hook: onResponseAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: onResponseAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
@@ -259,18 +270,20 @@ export interface FastifyInstance<
    */
   addHook<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-    ContextConfig = ContextConfigDefault
+    ContextConfig = ContextConfigDefault,
+    Logger extends FastifyLoggerInstance = FastifyLoggerInstance,
   >(
     name: 'onTimeout',
-    hook: onTimeoutHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: onTimeoutHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   addHook<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-    ContextConfig = ContextConfigDefault
+    ContextConfig = ContextConfigDefault,
+    Logger extends FastifyLoggerInstance = FastifyLoggerInstance,
   >(
     name: 'onTimeout',
-    hook: onTimeoutAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: onTimeoutAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**
@@ -281,18 +294,20 @@ export interface FastifyInstance<
    */
   addHook<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-    ContextConfig = ContextConfigDefault
+    ContextConfig = ContextConfigDefault,
+    Logger extends FastifyLoggerInstance = FastifyLoggerInstance,
   >(
     name: 'onError',
-    hook: onErrorHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: onErrorHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, FastifyError, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   addHook<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-    ContextConfig = ContextConfigDefault
+    ContextConfig = ContextConfigDefault,
+    Logger extends FastifyLoggerInstance = FastifyLoggerInstance,
   >(
     name: 'onError',
-    hook: onErrorAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: onErrorAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, FastifyError, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   // Application addHooks
@@ -302,10 +317,11 @@ export interface FastifyInstance<
    */
   addHook<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-    ContextConfig = ContextConfigDefault
+    ContextConfig = ContextConfigDefault,
+    Logger extends FastifyLoggerInstance = FastifyLoggerInstance,
   >(
     name: 'onRoute',
-    hook: onRouteHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
+    hook: onRouteHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -321,7 +321,7 @@ export interface FastifyInstance<
     Logger extends FastifyLoggerInstance = FastifyLoggerInstance,
   >(
     name: 'onRoute',
-    hook: onRouteHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
+    hook: onRouteHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 
   /**

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -20,13 +20,14 @@ export interface FastifyRequest<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   ContextConfig = ContextConfigDefault,
+  Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > {
   id: any;
   params: RouteGeneric['Params'];
   raw: RawRequest;
   query: RouteGeneric['Querystring'];
   headers: RawRequest['headers'] & RouteGeneric['Headers']; // this enables the developer to extend the existing http(s|2) headers list
-  log: FastifyLoggerInstance;
+  log: Logger;
   server: FastifyInstance;
   body: RouteGeneric['Body'];
   context: FastifyContext<ContextConfig>;

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -60,7 +60,7 @@ export type RouteHandlerMethod<
   ContextConfig = ContextConfigDefault,
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > = (
-  this: FastifyInstance<RawServer, RawRequest, RawReply>,
+  this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
   request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
   reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
 ) => void | Promise<RouteGeneric['Reply'] | void>
@@ -76,7 +76,7 @@ export interface RouteShorthandOptionsWithHandler<
   ContextConfig = ContextConfigDefault,
   SchemaCompiler = FastifySchema,
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
-> extends RouteShorthandOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler> {
+> extends RouteShorthandOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, Logger> {
   handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>;
 }
 
@@ -88,19 +88,19 @@ export interface RouteShorthandMethod<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
 > {
-  <RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault, SchemaCompiler = FastifySchema>(
+  <RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault, SchemaCompiler = FastifySchema, Logger extends FastifyLoggerInstance = FastifyLoggerInstance>(
     path: string,
-    opts: RouteShorthandOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler>,
-    handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
-  ): FastifyInstance<RawServer, RawRequest, RawReply>;
-  <RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault>(
+    opts: RouteShorthandOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, Logger>,
+    handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+  <RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault, Logger extends FastifyLoggerInstance = FastifyLoggerInstance>(
     path: string,
-    handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
-  ): FastifyInstance<RawServer, RawRequest, RawReply>;
-  <RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault, SchemaCompiler = FastifySchema>(
+    handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+  <RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault, SchemaCompiler = FastifySchema, Logger extends FastifyLoggerInstance = FastifyLoggerInstance>(
     path: string,
-    opts: RouteShorthandOptionsWithHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler>
-  ): FastifyInstance<RawServer, RawRequest, RawReply>;
+    opts: RouteShorthandOptionsWithHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, Logger>
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
 }
 
 /**
@@ -117,7 +117,7 @@ export interface RouteOptions<
 > extends RouteShorthandOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, Logger> {
   method: HTTPMethods | HTTPMethods[];
   url: string;
-  handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
+  handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Logger>;
 }
 
 export type RouteHandler<
@@ -128,7 +128,7 @@ export type RouteHandler<
   ContextConfig = ContextConfigDefault,
   Logger extends FastifyLoggerInstance = FastifyLoggerInstance
 > = (
-  this: FastifyInstance<RawServer, RawRequest, RawReply>,
+  this: FastifyInstance<RawServer, RawRequest, RawReply, Logger>,
   request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig, Logger>,
   reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
 ) => void | Promise<RouteGeneric['Reply'] | void>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


Initiated by this bug: https://github.com/fastify/fastify/issues/3775
I created a PR to fix the typings for the routeHandlers by using the `FastifyRequest` with a generic logger type.
As in the docs mentioned: https://www.fastify.io/docs/latest/Reference/Logging/#logging

> You can also supply your own logger instance. Instead of passing configuration options, pass the instance. The logger you supply must conform to the Pino interface; that is, it must have the following methods: info, error, debug, fatal, warn, trace, child.

However with the implemented type definitions it is not possible to use a custom LoggerInstance as the log property was only restricted to be of type `FastifyLoggerInstance` and no generic.

This is somewhat of an urgent bugfix from our side as it blocks our development and migration from express to fastify. This is also the reason why we set the PR against this branch as we hope to see the fix already in version 3.x. and help other developers as well.

 