### PR TITLE
Allow custom Context Config types for hooks' `request` properties

### DIFF
--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -9,9 +9,11 @@ import fastify, {
   RawServerBase,
   RouteOptions,
   RegisterOptions,
-  FastifyPluginOptions
+  FastifyPluginOptions,
+  FastifyContextConfig
 } from '../../fastify'
 import { preHandlerAsyncHookHandler, RequestPayload } from '../../types/hooks'
+import { RouteGenericInterface } from '../../types/route'
 
 const server = fastify()
 
@@ -225,4 +227,52 @@ Record<string, unknown>
 
 server.register(async (instance) => {
   instance.addHook('preHandler', customTypedHook)
+})
+
+// Test custom Context Config types for hooks
+type CustomContextConfig = FastifyContextConfig & {
+  foo: string;
+  bar: number;
+}
+
+server.route<RouteGenericInterface, CustomContextConfig>({
+  method: 'GET',
+  url: '/',
+  handler: () => {},
+  onRequest: (request, reply) => {
+    expectType<CustomContextConfig>(request.context.config)
+    expectType<CustomContextConfig>(reply.context.config)
+  },
+  preParsing: (request, reply) => {
+    expectType<CustomContextConfig>(request.context.config)
+    expectType<CustomContextConfig>(reply.context.config)
+  },
+  preValidation: (request, reply) => {
+    expectType<CustomContextConfig>(request.context.config)
+    expectType<CustomContextConfig>(reply.context.config)
+  },
+  preHandler: (request, reply) => {
+    expectType<CustomContextConfig>(request.context.config)
+    expectType<CustomContextConfig>(reply.context.config)
+  },
+  preSerialization: (request, reply) => {
+    expectType<CustomContextConfig>(request.context.config)
+    expectType<CustomContextConfig>(reply.context.config)
+  },
+  onSend: (request, reply) => {
+    expectType<CustomContextConfig>(request.context.config)
+    expectType<CustomContextConfig>(reply.context.config)
+  },
+  onResponse: (request, reply) => {
+    expectType<CustomContextConfig>(request.context.config)
+    expectType<CustomContextConfig>(reply.context.config)
+  },
+  onTimeout: (request, reply) => {
+    expectType<CustomContextConfig>(request.context.config)
+    expectType<CustomContextConfig>(reply.context.config)
+  },
+  onError: (request, reply) => {
+    expectType<CustomContextConfig>(request.context.config)
+    expectType<CustomContextConfig>(reply.context.config)
+  }
 })

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -35,7 +35,7 @@ export interface onRequestHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>,
     done: HookHandlerDoneFunction
   ): void;
@@ -52,7 +52,7 @@ export interface onRequestAsyncHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>,
   ): Promise<unknown>;
 }
@@ -72,7 +72,7 @@ export interface preParsingHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>,
     payload: RequestPayload,
     done: <TError extends Error = FastifyError>(err?: TError | null, res?: RequestPayload) => void
@@ -90,7 +90,7 @@ export interface preParsingAsyncHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>,
     payload: RequestPayload,
   ): Promise<RequestPayload | unknown>;
@@ -110,7 +110,7 @@ export interface preValidationHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>,
     done: HookHandlerDoneFunction
   ): void;
@@ -127,7 +127,7 @@ export interface preValidationAsyncHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>,
   ): Promise<unknown>;
 }
@@ -146,7 +146,7 @@ export interface preHandlerHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>,
     done: HookHandlerDoneFunction
   ): void;
@@ -163,7 +163,7 @@ export interface preHandlerAsyncHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>,
   ): Promise<unknown>;
 }
@@ -191,7 +191,7 @@ export interface preSerializationHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>,
     payload: PreSerializationPayload,
     done: DoneFuncWithErrOrRes
@@ -210,7 +210,7 @@ export interface preSerializationAsyncHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>,
     payload: PreSerializationPayload
   ): Promise<unknown>;
@@ -232,7 +232,7 @@ export interface onSendHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>,
     payload: OnSendPayload,
     done: DoneFuncWithErrOrRes
@@ -251,7 +251,7 @@ export interface onSendAsyncHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>,
     payload: OnSendPayload,
   ): Promise<unknown>;
@@ -272,7 +272,7 @@ export interface onResponseHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>,
     done: HookHandlerDoneFunction
   ): void;
@@ -289,7 +289,7 @@ export interface onResponseAsyncHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>
   ): Promise<unknown>;
 }
@@ -309,7 +309,7 @@ export interface onTimeoutHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>,
     done: HookHandlerDoneFunction
   ): void;
@@ -326,7 +326,7 @@ export interface onTimeoutAsyncHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>
   ): Promise<unknown>;
 }
@@ -349,7 +349,7 @@ export interface onErrorHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>,
     error: TError,
     done: () => void
@@ -368,7 +368,7 @@ export interface onErrorAsyncHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>,
     error: TError
   ): Promise<unknown>;


### PR DESCRIPTION
By now, hooks use default Context Config for the `request` property. This PR implies using a custom Context Config for `request` in a hook if it was sent (repeats the same logic as for `reply`).
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
