### PR TITLE
(v3.x) Allow custom Context Config types for hooks' `request` properties

### DIFF
--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -9,9 +9,11 @@ import fastify, {
   RawServerBase,
   RouteOptions,
   RegisterOptions,
-  FastifyPluginOptions
+  FastifyPluginOptions,
+  FastifyContextConfig
 } from '../../fastify'
 import { preHandlerAsyncHookHandler, RequestPayload } from '../../types/hooks'
+import { RouteGenericInterface } from '../../types/route'
 
 const server = fastify()
 
@@ -225,4 +227,52 @@ Record<string, unknown>
 
 server.register(async (instance) => {
   instance.addHook('preHandler', customTypedHook)
+})
+
+// Test custom Context Config types for hooks
+type CustomContextConfig = FastifyContextConfig & {
+  foo: string;
+  bar: number;
+}
+
+server.route<RouteGenericInterface, CustomContextConfig>({
+  method: 'GET',
+  url: '/',
+  handler: () => {},
+  onRequest: (request, reply) => {
+    expectType<CustomContextConfig>(request.context.config)
+    expectType<CustomContextConfig>(reply.context.config)
+  },
+  preParsing: (request, reply) => {
+    expectType<CustomContextConfig>(request.context.config)
+    expectType<CustomContextConfig>(reply.context.config)
+  },
+  preValidation: (request, reply) => {
+    expectType<CustomContextConfig>(request.context.config)
+    expectType<CustomContextConfig>(reply.context.config)
+  },
+  preHandler: (request, reply) => {
+    expectType<CustomContextConfig>(request.context.config)
+    expectType<CustomContextConfig>(reply.context.config)
+  },
+  preSerialization: (request, reply) => {
+    expectType<CustomContextConfig>(request.context.config)
+    expectType<CustomContextConfig>(reply.context.config)
+  },
+  onSend: (request, reply) => {
+    expectType<CustomContextConfig>(request.context.config)
+    expectType<CustomContextConfig>(reply.context.config)
+  },
+  onResponse: (request, reply) => {
+    expectType<CustomContextConfig>(request.context.config)
+    expectType<CustomContextConfig>(reply.context.config)
+  },
+  onTimeout: (request, reply) => {
+    expectType<CustomContextConfig>(request.context.config)
+    expectType<CustomContextConfig>(reply.context.config)
+  },
+  onError: (request, reply) => {
+    expectType<CustomContextConfig>(request.context.config)
+    expectType<CustomContextConfig>(reply.context.config)
+  }
 })

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -30,7 +30,7 @@ export interface onRequestHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
   ): void;
@@ -45,7 +45,7 @@ export interface onRequestAsyncHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
   ): Promise<unknown>;
 }
@@ -63,7 +63,7 @@ export interface preParsingHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: RequestPayload,
     done: <TError extends Error = FastifyError>(err?: TError | null, res?: RequestPayload) => void
@@ -79,7 +79,7 @@ export interface preParsingAsyncHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: RequestPayload,
   ): Promise<RequestPayload | unknown>;
@@ -97,7 +97,7 @@ export interface preValidationHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
   ): void;
@@ -112,7 +112,7 @@ export interface preValidationAsyncHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
   ): Promise<unknown>;
 }
@@ -129,7 +129,7 @@ export interface preHandlerHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
   ): void;
@@ -144,7 +144,7 @@ export interface preHandlerAsyncHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
   ): Promise<unknown>;
 }
@@ -170,7 +170,7 @@ export interface preSerializationHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: PreSerializationPayload,
     done: DoneFuncWithErrOrRes
@@ -187,7 +187,7 @@ export interface preSerializationAsyncHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: PreSerializationPayload
   ): Promise<unknown>;
@@ -207,7 +207,7 @@ export interface onSendHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: OnSendPayload,
     done: DoneFuncWithErrOrRes
@@ -224,7 +224,7 @@ export interface onSendAsyncHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     payload: OnSendPayload,
   ): Promise<unknown>;
@@ -243,7 +243,7 @@ export interface onResponseHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
   ): void;
@@ -258,7 +258,7 @@ export interface onResponseAsyncHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
   ): Promise<unknown>;
 }
@@ -276,7 +276,7 @@ export interface onTimeoutHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     done: HookHandlerDoneFunction
   ): void;
@@ -291,7 +291,7 @@ export interface onTimeoutAsyncHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
   ): Promise<unknown>;
 }
@@ -312,7 +312,7 @@ export interface onErrorHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     error: TError,
     done: () => void
@@ -329,7 +329,7 @@ export interface onErrorAsyncHookHandler<
 > {
   (
     this: FastifyInstance,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, ContextConfig>,
     reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
     error: TError
   ): Promise<unknown>;


### PR DESCRIPTION
**This PR is based on #3786 for v3.x.**

By now, hooks use default Context Config for the `request` property. This PR implies using a custom Context Config for `request` in a hook if it was sent (repeats the same logic as for `reply`).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
