### PR TITLE
feat: reply trailers support

### DIFF
--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -212,7 +212,7 @@ Sets a response trailer. Trailer usually used when you want some header that req
 
 *Note: The header `Transfer-Encoding: chunked` will be added once you use the trailer. It is a hard requipment for using trailer in Node.js.*
 
-*Note: Currently, the computation function only support synchronous function. That means `async-await` and `promise` is not supported.*
+*Note: Currently, the computation function only supports synchronous function. That means `async-await` and `promise` are not supported.*
 
 ```js
 reply.trailer('server-timing', function() {
@@ -225,12 +225,10 @@ const { createHash } = require('crypto')
 // @param {string|Buffer|null} payload payload that already sent, note that it will be null when stream is sent
 reply.trailer('content-md5', function(reply, payload) {
   const hash = createHash('md5')
-  hash.update(payload);
+  hash.update(payload)
   return hash.disgest('hex')
 })
 ```
-
-
 
 ### .hasTrailer(key)
 <a id="hasTrailer"></a>

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -13,6 +13,9 @@
   - [.getHeaders()](#getheaders)
   - [.removeHeader(key)](#removeheaderkey)
   - [.hasHeader(key)](#hasheaderkey)
+  - [.trailer(key, function)](#trailerkey-function)
+  - [.hasTrailer(key)](#hastrailerkey)
+  - [.removeTrailer(key)](#removetrailerkey)
   - [.redirect([code,] dest)](#redirectcode--dest)
   - [.callNotFound()](#callnotfound)
   - [.getResponseTime()](#getresponsetime)
@@ -198,6 +201,37 @@ reply.getHeader('x-foo') // undefined
 <a id="hasHeader"></a>
 
 Returns a boolean indicating if the specified header has been set.
+
+### .trailer(key, function)
+<a id="trailer"></a>
+
+Sets a response trailer.
+
+> Note: The header `Transfer-Encoding: chunked` will be added once you use the trailer. It is a hard requipment for using trailer in Node.js.
+
+```js
+reply.trailer('server-timing', function() {
+  return 'db;dur=53, app;dur=47.2'
+})
+```
+
+### .hasTrailer(key)
+<a id="hasTrailer"></a>
+
+Returns a boolean indicating if the specified trailer has been set.
+
+### .removeTrailer(key)
+<a id="removeTrailer"></a>
+
+Remove the value of a previously set trailer.
+```js
+reply.trailer('server-timing', function() {
+  return 'db;dur=53, app;dur=47.2'
+})
+reply.removeTrailer('server-timing')
+reply.getTrailer('server-timing') // undefined
+```
+
 
 ### .redirect([code ,] dest)
 <a id="redirect"></a>

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -213,6 +213,16 @@ Sets a response trailer.
 reply.trailer('server-timing', function() {
   return 'db;dur=53, app;dur=47.2'
 })
+
+const { createHash } = require('crypto')
+// trailer function also recieve two argument
+// @param {object} reply fastify reply
+// @param {string|Buffer|null} payload payload that already sent, note that it will be null when stream is sent
+reply.trailer('content-md5', function(reply, payload) {
+  const hash = createHash('md5')
+  hash.update(payload);
+  return hash.disgest('hex')
+})
 ```
 
 ### .hasTrailer(key)

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -50,6 +50,9 @@ object that exposes the following functions and properties:
 - `.getHeaders()` - Gets a shallow copy of all current response headers.
 - `.removeHeader(key)` - Remove the value of a previously set header.
 - `.hasHeader(name)` - Determine if a header has been set.
+- `.trailer(key, function)` - Sets a response trailer.
+- `.hasTrailer(key)` - Determine if a trailer has been set.
+- `.removeTrailer(key)` - Remove the value of a previously set trailer.
 - `.type(value)` - Sets the header `Content-Type`.
 - `.redirect([code,] dest)` - Redirect to the specified url, the status code is
   optional (default to `302`).
@@ -205,9 +208,12 @@ Returns a boolean indicating if the specified header has been set.
 ### .trailer(key, function)
 <a id="trailer"></a>
 
-Sets a response trailer.
+Sets a response trailer. Trailer usually used when you want some header that require heavy resources to be sent after the `data`,
+for example `Server-Timing`, `Etag`. It can ensure the client get the response data as soon as possible.
 
-> Note: The header `Transfer-Encoding: chunked` will be added once you use the trailer. It is a hard requipment for using trailer in Node.js.
+*Note: The header `Transfer-Encoding: chunked` will be added once you use the trailer. It is a hard requipment for using trailer in Node.js.*
+
+*Note: Currently, the computation function only support synchronous function. That means `async-await` and `promise` is not supported.*
 
 ```js
 reply.trailer('server-timing', function() {
@@ -224,6 +230,8 @@ reply.trailer('content-md5', function(reply, payload) {
   return hash.disgest('hex')
 })
 ```
+
+
 
 ### .hasTrailer(key)
 <a id="hasTrailer"></a>

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -208,8 +208,7 @@ Returns a boolean indicating if the specified header has been set.
 ### .trailer(key, function)
 <a id="trailer"></a>
 
-Sets a response trailer. Trailer usually used when you want some header that require heavy resources to be sent after the `data`,
-for example `Server-Timing`, `Etag`. It can ensure the client get the response data as soon as possible.
+Sets a response trailer. Trailer usually used when you want some header that require heavy resources to be sent after the `data`, for example `Server-Timing`, `Etag`. It can ensure the client get the response data as soon as possible.
 
 *Note: The header `Transfer-Encoding: chunked` will be added once you use the trailer. It is a hard requipment for using trailer in Node.js.*
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -152,6 +152,10 @@ const codes = {
     'FST_ERR_BAD_STATUS_CODE',
     'Called reply with an invalid status code: %s'
   ),
+  FST_ERR_BAD_TRAILER_NAME: createError(
+    'FST_ERR_BAD_TRAILER_NAME',
+    'Called reply.addTrailer with an invalid header name: %s'
+  ),
 
   /**
    * schemas

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -154,7 +154,11 @@ const codes = {
   ),
   FST_ERR_BAD_TRAILER_NAME: createError(
     'FST_ERR_BAD_TRAILER_NAME',
-    'Called reply.addTrailer with an invalid header name: %s'
+    'Called reply.trailer with an invalid header name: %s'
+  ),
+  FST_ERR_BAD_TRAILER_VALUE: createError(
+    'FST_ERR_BAD_TRAILER_VALUE',
+    "Called reply.trailer('%s', fn) with an invalid type: %s. Expected a function."
   ),
 
   /**

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -450,7 +450,7 @@ function onSendEnd (reply, payload) {
   // we check if we need to update the trailers header and set it
   const trailerHeaders = Object.keys(reply[kReplyTrailers])
   const isTEAllowed = req.headers && typeof req.headers.te === 'string' && req.headers.te.includes('trailers')
-  reply[kReplyShouldSendTrailers] = trailerHeaders.length > 0 && isTEAllowed && payload !== undefined && payload !== null && payload !== ''
+  reply[kReplyShouldSendTrailers] = trailerHeaders.length > 0 && isTEAllowed && (typeof payload.pipe === 'function' || payload.length)
   if (reply[kReplyShouldSendTrailers]) {
     // it must be chunked for trailer to work
     reply.header('Transfer-Encoding', 'chunked')

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -449,7 +449,7 @@ function onSendEnd (reply, payload) {
   // there is no meanings for a dynamic trailers
   // we check if we need to update the trailers header and set it
   const trailerHeaders = Object.keys(reply[kReplyTrailers])
-  const isTEAllowed = typeof req.headers.te === 'string' && req.headers.te.includes('trailers')
+  const isTEAllowed = req.headers && typeof req.headers.te === 'string' && req.headers.te.includes('trailers')
   reply[kReplyShouldSendTrailers] = trailerHeaders.length > 0 && isTEAllowed && payload !== undefined && payload !== null && payload !== ''
   if (reply[kReplyShouldSendTrailers]) {
     // it must be chunked for trailer to work

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -50,7 +50,7 @@ function Reply (res, request, log) {
   this[kReplyIsRunningOnErrorHook] = false
   this.request = request
   this[kReplyHeaders] = {}
-  this[kReplyTrailers] = {}
+  this[kReplyTrailers] = null
   this[kReplyHasStatusCode] = false
   this[kReplyStartTime] = undefined
   this.log = log
@@ -273,15 +273,18 @@ Reply.prototype.trailer = function (key, fn) {
   if (typeof fn !== 'function') {
     throw new FST_ERR_BAD_TRAILER_VALUE(_key, typeof fn)
   }
+  if (this[kReplyTrailers] === null) this[kReplyTrailers] = {}
   this[kReplyTrailers][_key] = fn
   return this
 }
 
 Reply.prototype.hasTrailer = function (key) {
+  if (this[kReplyTrailers] === null) return false
   return this[kReplyTrailers][key.toLowerCase()] !== undefined
 }
 
 Reply.prototype.removeTrailer = function (key) {
+  if (this[kReplyTrailers] === null) return this
   this[kReplyTrailers][key.toLowerCase()] = undefined
   return this
 }
@@ -439,8 +442,8 @@ function onSendEnd (reply, payload) {
   const statusCode = res.statusCode
 
   // we check if we need to update the trailers header and set it
-  const trailerHeaders = Object.keys(reply[kReplyTrailers])
-  if (trailerHeaders.length) {
+  if (reply[kReplyTrailers] !== null) {
+    const trailerHeaders = Object.keys(reply[kReplyTrailers])
     let header = ''
     for (const trailerName of trailerHeaders) {
       if (typeof reply[kReplyTrailers][trailerName] !== 'function') continue
@@ -558,8 +561,8 @@ function sendStream (payload, res, reply) {
 }
 
 function sendTrailer (payload, res, reply) {
+  if (reply[kReplyTrailers] === null) return
   const trailerHeaders = Object.keys(reply[kReplyTrailers])
-  if (trailerHeaders.length === 0) return
   const trailers = {}
   for (const trailerName of trailerHeaders) {
     if (typeof reply[kReplyTrailers][trailerName] !== 'function') continue
@@ -569,8 +572,7 @@ function sendTrailer (payload, res, reply) {
 }
 
 function sendStreamTrailer (payload, res, reply) {
-  const trailerHeaders = Object.keys(reply[kReplyTrailers])
-  if (trailerHeaders.length === 0) return
+  if (reply[kReplyTrailers] === null) return
   payload.on('end', () => sendTrailer(null, res, reply))
 }
 
@@ -653,7 +655,7 @@ function buildReply (R) {
     this[kReplySerializer] = null
     this.request = request
     this[kReplyHeaders] = {}
-    this[kReplyTrailers] = {}
+    this[kReplyTrailers] = null
     this[kReplyStartTime] = undefined
     this[kReplyEndTime] = undefined
     this.log = log

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -12,6 +12,7 @@ const {
   kReplySerializerDefault,
   kReplyIsError,
   kReplyHeaders,
+  kReplyTrailers,
   kReplyHasStatusCode,
   kReplyIsRunningOnErrorHook,
   kReplyNextErrorHandler,
@@ -47,6 +48,7 @@ function Reply (res, request, log) {
   this[kReplyIsRunningOnErrorHook] = false
   this.request = request
   this[kReplyHeaders] = {}
+  this[kReplyTrailers] = {}
   this[kReplyHasStatusCode] = false
   this[kReplyStartTime] = undefined
   this.log = log
@@ -244,6 +246,11 @@ Reply.prototype.headers = function (headers) {
   return this
 }
 
+Reply.prototype.addTrailer = function (key, fn) {
+  this[kReplyTrailers][key] = fn
+  return this
+}
+
 Reply.prototype.code = function (code) {
   const intValue = parseInt(code)
   if (isNaN(intValue) || intValue < 100 || intValue > 600) {
@@ -406,9 +413,22 @@ function onSendEnd (reply, payload) {
     }
 
     res.writeHead(statusCode, reply[kReplyHeaders])
+
     // avoid ArgumentsAdaptorTrampoline from V8
     res.end(null, null, null)
     return
+  }
+
+  // it is intended to not sending trailers when payload is not set
+  // the reason behind is when there is no payload
+  // there is no meanings for a dynamic trailers
+  // we check if we need to update the trailers header and set it
+  const trailerHeaders = Object.keys(reply[kReplyTrailers])
+  const shouldSetTrailer = trailerHeaders.length > 0 && payload !== undefined && payload !== null && payload !== ''
+  if (shouldSetTrailer) {
+    // it must be chunked for trailer to work
+    reply.header('Transfer-Encoding', 'chunked')
+    reply.header('Trailer', trailerHeaders.join(' '))
   }
 
   if (typeof payload.pipe === 'function') {
@@ -427,9 +447,20 @@ function onSendEnd (reply, payload) {
   }
 
   res.writeHead(statusCode, reply[kReplyHeaders])
+  // write payload first
+  res.write(payload)
+
+  if (shouldSetTrailer) {
+    // compute the trailers
+    const trailers = {}
+    for (const trailerName of trailerHeaders) {
+      trailers[trailerName] = reply[kReplyTrailers][trailerName](reply, payload)
+    }
+    res.addTrailers(trailers)
+  }
 
   // avoid ArgumentsAdaptorTrampoline from V8
-  res.end(payload, null, null)
+  res.end(null, null, null)
 }
 
 function logStreamError (logger, err, res) {
@@ -445,6 +476,20 @@ function logStreamError (logger, err, res) {
 function sendStream (payload, res, reply) {
   let sourceOpen = true
   let errorLogged = false
+
+  // set trailer when stream ended
+  const trailerHeaders = Object.keys(reply[kReplyTrailers])
+  const shouldSetTrailer = trailerHeaders.length > 0
+  if (shouldSetTrailer) {
+    payload.on('end', function () {
+      // compute the trailers
+      const trailers = {}
+      for (const trailerName of trailerHeaders) {
+        trailers[trailerName] = reply[kReplyTrailers][trailerName](reply, null)
+      }
+      res.addTrailers(trailers)
+    })
+  }
 
   eos(payload, { readable: true, writable: false }, function (err) {
     sourceOpen = false
@@ -573,6 +618,7 @@ function buildReply (R) {
     this[kReplySerializer] = null
     this.request = request
     this[kReplyHeaders] = {}
+    this[kReplyTrailers] = {}
     this[kReplyStartTime] = undefined
     this[kReplyEndTime] = undefined
     this.log = log

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -13,7 +13,6 @@ const {
   kReplyIsError,
   kReplyHeaders,
   kReplyTrailers,
-  kReplyShouldSendTrailers,
   kReplyHasStatusCode,
   kReplyIsRunningOnErrorHook,
   kReplyNextErrorHandler,
@@ -38,7 +37,8 @@ const {
   FST_ERR_REP_SENT_VALUE,
   FST_ERR_SEND_INSIDE_ONERR,
   FST_ERR_BAD_STATUS_CODE,
-  FST_ERR_BAD_TRAILER_NAME
+  FST_ERR_BAD_TRAILER_NAME,
+  FST_ERR_BAD_TRAILER_VALUE
 } = require('./errors')
 const warning = require('./warnings')
 
@@ -51,7 +51,6 @@ function Reply (res, request, log) {
   this.request = request
   this[kReplyHeaders] = {}
   this[kReplyTrailers] = {}
-  this[kReplyShouldSendTrailers] = false
   this[kReplyHasStatusCode] = false
   this[kReplyStartTime] = undefined
   this.log = log
@@ -266,13 +265,24 @@ const INVALID_TRAILERS = new Set([
   'trailer'
 ])
 
-Reply.prototype.addTrailer = function (key, fn) {
+Reply.prototype.trailer = function (key, fn) {
   const _key = key.toLowerCase()
   if (INVALID_TRAILERS.has(_key)) {
     throw new FST_ERR_BAD_TRAILER_NAME(_key)
   }
-
+  if (typeof fn !== 'function') {
+    throw new FST_ERR_BAD_TRAILER_VALUE(_key, typeof fn)
+  }
   this[kReplyTrailers][_key] = fn
+  return this
+}
+
+Reply.prototype.hasTrailer = function (key) {
+  return this[kReplyTrailers][key.toLowerCase()] !== undefined
+}
+
+Reply.prototype.removeTrailer = function (key) {
+  this[kReplyTrailers][key.toLowerCase()] = undefined
   return this
 }
 
@@ -428,6 +438,20 @@ function onSendEnd (reply, payload) {
   const req = reply.request
   const statusCode = res.statusCode
 
+  // we check if we need to update the trailers header and set it
+  const trailerHeaders = Object.keys(reply[kReplyTrailers])
+  if (trailerHeaders.length) {
+    let header = ''
+    for (const trailerName of trailerHeaders) {
+      if (typeof reply[kReplyTrailers][trailerName] !== 'function') continue
+      header += ' '
+      header += trailerName
+    }
+    // it must be chunked for trailer to work
+    reply.header('Transfer-Encoding', 'chunked')
+    reply.header('Trailer', header.trim())
+  }
+
   if (payload === undefined || payload === null) {
     // according to https://tools.ietf.org/html/rfc7230#section-3.3.2
     // we cannot send a content-length for 304 and 204, and all status code
@@ -438,23 +462,10 @@ function onSendEnd (reply, payload) {
     }
 
     res.writeHead(statusCode, reply[kReplyHeaders])
-
+    sendTrailer(payload, res, reply)
     // avoid ArgumentsAdaptorTrampoline from V8
     res.end(null, null, null)
     return
-  }
-
-  // it is intended to not sending trailers when payload is not set
-  // the reason behind is when there is no payload
-  // there is no meanings for a dynamic trailers
-  // we check if we need to update the trailers header and set it
-  const trailerHeaders = Object.keys(reply[kReplyTrailers])
-  const isTEAllowed = req.headers && typeof req.headers.te === 'string' && req.headers.te.includes('trailers')
-  reply[kReplyShouldSendTrailers] = trailerHeaders.length > 0 && isTEAllowed && (typeof payload.pipe === 'function' || payload.length)
-  if (reply[kReplyShouldSendTrailers]) {
-    // it must be chunked for trailer to work
-    reply.header('Transfer-Encoding', 'chunked')
-    reply.header('Trailer', trailerHeaders.join(' '))
   }
 
   if (typeof payload.pipe === 'function') {
@@ -475,16 +486,8 @@ function onSendEnd (reply, payload) {
   res.writeHead(statusCode, reply[kReplyHeaders])
   // write payload first
   res.write(payload)
-
-  if (reply[kReplyShouldSendTrailers]) {
-    // compute the trailers
-    const trailers = {}
-    for (const trailerName of trailerHeaders) {
-      trailers[trailerName] = reply[kReplyTrailers][trailerName](reply, payload)
-    }
-    res.addTrailers(trailers)
-  }
-
+  // then send trailers
+  sendTrailer(payload, res, reply)
   // avoid ArgumentsAdaptorTrampoline from V8
   res.end(null, null, null)
 }
@@ -504,17 +507,7 @@ function sendStream (payload, res, reply) {
   let errorLogged = false
 
   // set trailer when stream ended
-  if (reply[kReplyShouldSendTrailers]) {
-    const trailerHeaders = Object.keys(reply[kReplyTrailers])
-    payload.on('end', function () {
-      // compute the trailers
-      const trailers = {}
-      for (const trailerName of trailerHeaders) {
-        trailers[trailerName] = reply[kReplyTrailers][trailerName](reply, null)
-      }
-      res.addTrailers(trailers)
-    })
-  }
+  sendStreamTrailer(payload, res, reply)
 
   eos(payload, { readable: true, writable: false }, function (err) {
     sourceOpen = false
@@ -562,6 +555,23 @@ function sendStream (payload, res, reply) {
     reply.log.warn('response will send, but you shouldn\'t use res.writeHead in stream mode')
   }
   payload.pipe(res)
+}
+
+function sendTrailer (payload, res, reply) {
+  const trailerHeaders = Object.keys(reply[kReplyTrailers])
+  if (trailerHeaders.length === 0) return
+  const trailers = {}
+  for (const trailerName of trailerHeaders) {
+    if (typeof reply[kReplyTrailers][trailerName] !== 'function') continue
+    trailers[trailerName] = reply[kReplyTrailers][trailerName](reply, payload)
+  }
+  res.addTrailers(trailers)
+}
+
+function sendStreamTrailer (payload, res, reply) {
+  const trailerHeaders = Object.keys(reply[kReplyTrailers])
+  if (trailerHeaders.length === 0) return
+  payload.on('end', () => sendTrailer(null, res, reply))
 }
 
 function onErrorHook (reply, error, cb) {
@@ -640,7 +650,6 @@ function buildReply (R) {
     this[kReplyIsError] = false
     this[kReplyErrorHandlerCalled] = false
     this[kReplyHijacked] = false
-    this[kReplyShouldSendTrailers] = false
     this[kReplySerializer] = null
     this.request = request
     this[kReplyHeaders] = {}

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -266,7 +266,7 @@ const INVALID_TRAILERS = new Set([
 ])
 
 Reply.prototype.trailer = function (key, fn) {
-  const _key = key.toLowerCase()
+  key = key.toLowerCase()
   if (INVALID_TRAILERS.has(_key)) {
     throw new FST_ERR_BAD_TRAILER_NAME(_key)
   }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -267,14 +267,14 @@ const INVALID_TRAILERS = new Set([
 
 Reply.prototype.trailer = function (key, fn) {
   key = key.toLowerCase()
-  if (INVALID_TRAILERS.has(_key)) {
-    throw new FST_ERR_BAD_TRAILER_NAME(_key)
+  if (INVALID_TRAILERS.has(key)) {
+    throw new FST_ERR_BAD_TRAILER_NAME(key)
   }
   if (typeof fn !== 'function') {
-    throw new FST_ERR_BAD_TRAILER_VALUE(_key, typeof fn)
+    throw new FST_ERR_BAD_TRAILER_VALUE(key, typeof fn)
   }
   if (this[kReplyTrailers] === null) this[kReplyTrailers] = {}
-  this[kReplyTrailers][_key] = fn
+  this[kReplyTrailers][key] = fn
   return this
 }
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -251,7 +251,7 @@ Reply.prototype.headers = function (headers) {
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Trailer#directives
 // https://httpwg.org/specs/rfc7230.html#chunked.trailer.part
-const INVALID_TRAILERS = [
+const INVALID_TRAILERS = new Set([
   'transfer-encoding',
   'content-length',
   'host',
@@ -264,11 +264,11 @@ const INVALID_TRAILERS = [
   'content-type',
   'content-range',
   'trailer'
-]
+])
 
 Reply.prototype.addTrailer = function (key, fn) {
   const _key = key.toLowerCase()
-  if (INVALID_TRAILERS.includes(_key)) {
+  if (INVALID_TRAILERS.has(_key)) {
     throw new FST_ERR_BAD_TRAILER_NAME(_key)
   }
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -13,6 +13,7 @@ const {
   kReplyIsError,
   kReplyHeaders,
   kReplyTrailers,
+  kReplyShouldSendTrailers,
   kReplyHasStatusCode,
   kReplyIsRunningOnErrorHook,
   kReplyNextErrorHandler,
@@ -36,7 +37,8 @@ const {
   FST_ERR_REP_ALREADY_SENT,
   FST_ERR_REP_SENT_VALUE,
   FST_ERR_SEND_INSIDE_ONERR,
-  FST_ERR_BAD_STATUS_CODE
+  FST_ERR_BAD_STATUS_CODE,
+  FST_ERR_BAD_TRAILER_NAME
 } = require('./errors')
 const warning = require('./warnings')
 
@@ -49,6 +51,7 @@ function Reply (res, request, log) {
   this.request = request
   this[kReplyHeaders] = {}
   this[kReplyTrailers] = {}
+  this[kReplyShouldSendTrailers] = false
   this[kReplyHasStatusCode] = false
   this[kReplyStartTime] = undefined
   this.log = log
@@ -246,8 +249,30 @@ Reply.prototype.headers = function (headers) {
   return this
 }
 
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Trailer#directives
+// https://httpwg.org/specs/rfc7230.html#chunked.trailer.part
+const INVALID_TRAILERS = [
+  'transfer-encoding',
+  'content-length',
+  'host',
+  'cache-control',
+  'max-forwards',
+  'te',
+  'authorization',
+  'set-cookie',
+  'content-encoding',
+  'content-type',
+  'content-range',
+  'trailer'
+]
+
 Reply.prototype.addTrailer = function (key, fn) {
-  this[kReplyTrailers][key] = fn
+  const _key = key.toLowerCase()
+  if (INVALID_TRAILERS.includes(_key)) {
+    throw new FST_ERR_BAD_TRAILER_NAME(_key)
+  }
+
+  this[kReplyTrailers][_key] = fn
   return this
 }
 
@@ -424,8 +449,9 @@ function onSendEnd (reply, payload) {
   // there is no meanings for a dynamic trailers
   // we check if we need to update the trailers header and set it
   const trailerHeaders = Object.keys(reply[kReplyTrailers])
-  const shouldSetTrailer = trailerHeaders.length > 0 && payload !== undefined && payload !== null && payload !== ''
-  if (shouldSetTrailer) {
+  const isTEAllowed = typeof req.headers.te === 'string' && req.headers.te.includes('trailers')
+  reply[kReplyShouldSendTrailers] = trailerHeaders.length > 0 && isTEAllowed && payload !== undefined && payload !== null && payload !== ''
+  if (reply[kReplyShouldSendTrailers]) {
     // it must be chunked for trailer to work
     reply.header('Transfer-Encoding', 'chunked')
     reply.header('Trailer', trailerHeaders.join(' '))
@@ -450,7 +476,7 @@ function onSendEnd (reply, payload) {
   // write payload first
   res.write(payload)
 
-  if (shouldSetTrailer) {
+  if (reply[kReplyShouldSendTrailers]) {
     // compute the trailers
     const trailers = {}
     for (const trailerName of trailerHeaders) {
@@ -478,9 +504,8 @@ function sendStream (payload, res, reply) {
   let errorLogged = false
 
   // set trailer when stream ended
-  const trailerHeaders = Object.keys(reply[kReplyTrailers])
-  const shouldSetTrailer = trailerHeaders.length > 0
-  if (shouldSetTrailer) {
+  if (reply[kReplyShouldSendTrailers]) {
+    const trailerHeaders = Object.keys(reply[kReplyTrailers])
     payload.on('end', function () {
       // compute the trailers
       const trailers = {}
@@ -615,6 +640,7 @@ function buildReply (R) {
     this[kReplyIsError] = false
     this[kReplyErrorHandlerCalled] = false
     this[kReplyHijacked] = false
+    this[kReplyShouldSendTrailers] = false
     this[kReplySerializer] = null
     this.request = request
     this[kReplyHeaders] = {}

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -30,6 +30,7 @@ const keys = {
   kReplySerializer: Symbol('fastify.reply.serializer'),
   kReplyIsError: Symbol('fastify.reply.isError'),
   kReplyHeaders: Symbol('fastify.reply.headers'),
+  kReplyTrailers: Symbol('fastify.reply.trailers'),
   kReplyHasStatusCode: Symbol('fastify.reply.hasStatusCode'),
   kReplyHijacked: Symbol('fastify.reply.hijacked'),
   kReplyStartTime: Symbol('fastify.reply.startTime'),

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -31,7 +31,6 @@ const keys = {
   kReplyIsError: Symbol('fastify.reply.isError'),
   kReplyHeaders: Symbol('fastify.reply.headers'),
   kReplyTrailers: Symbol('fastify.reply.trailers'),
-  kReplyShouldSendTrailers: Symbol('fastify.reply.shouldSendTrailers'),
   kReplyHasStatusCode: Symbol('fastify.reply.hasStatusCode'),
   kReplyHijacked: Symbol('fastify.reply.hijacked'),
   kReplyStartTime: Symbol('fastify.reply.startTime'),

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -31,6 +31,7 @@ const keys = {
   kReplyIsError: Symbol('fastify.reply.isError'),
   kReplyHeaders: Symbol('fastify.reply.headers'),
   kReplyTrailers: Symbol('fastify.reply.trailers'),
+  kReplyShouldSendTrailers: Symbol('fastify.reply.shouldSendTrailers'),
   kReplyHasStatusCode: Symbol('fastify.reply.hasStatusCode'),
   kReplyHijacked: Symbol('fastify.reply.hijacked'),
   kReplyStartTime: Symbol('fastify.reply.startTime'),

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -68,6 +68,7 @@ test('reply.send will logStream error and destroy the stream', t => {
     hasHeader: () => false,
     getHeader: () => undefined,
     writeHead: () => {},
+    write: () => {},
     headersSent: true
   })
 
@@ -89,6 +90,7 @@ test('reply.send throw with circular JSON', t => {
     hasHeader: () => false,
     getHeader: () => undefined,
     writeHead: () => {},
+    write: () => {},
     end: () => {}
   }
   const reply = new Reply(response, { context: { onSend: [] } })
@@ -106,6 +108,7 @@ test('reply.send returns itself', t => {
     hasHeader: () => false,
     getHeader: () => undefined,
     writeHead: () => {},
+    write: () => {},
     end: () => {}
   }
   const reply = new Reply(response, { context: { onSend: [] } })

--- a/test/reply-trailers.test.js
+++ b/test/reply-trailers.test.js
@@ -5,6 +5,30 @@ const test = t.test
 const Fastify = require('..')
 const { Readable } = require('stream')
 
+test('do not send trailers when request do not contain correct te', t => {
+  t.plan(4)
+
+  const fastify = Fastify()
+
+  fastify.get('/', function (request, reply) {
+    reply.addTrailer('ETag', function (reply, payload) {
+      t.fail('trailer should not be called.')
+      return 'custom-etag'
+    })
+    reply.send(JSON.stringify({ hello: 'world' }))
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (error, res) => {
+    t.error(error)
+    t.equal(res.statusCode, 200)
+    t.notOk(res.headers.trailer)
+    t.notOk(res.trailers.etag)
+  })
+})
+
 test('do not send trailers when payload is empty', t => {
   t.plan(4)
 
@@ -20,7 +44,10 @@ test('do not send trailers when payload is empty', t => {
 
   fastify.inject({
     method: 'GET',
-    url: '/'
+    url: '/',
+    headers: {
+      TE: 'trailers'
+    }
   }, (error, res) => {
     t.error(error)
     t.equal(res.statusCode, 200)
@@ -45,12 +72,15 @@ test('send trailers when payload is json', t => {
 
   fastify.inject({
     method: 'GET',
-    url: '/'
+    url: '/',
+    headers: {
+      TE: 'trailers'
+    }
   }, (error, res) => {
     t.error(error)
     t.equal(res.statusCode, 200)
     t.equal(res.headers['transfer-encoding'], 'chunked')
-    t.equal(res.headers.trailer, 'ETag')
+    t.equal(res.headers.trailer, 'etag')
     t.equal(res.trailers.etag, 'custom-etag')
   })
 })
@@ -71,12 +101,57 @@ test('send trailers when payload is stream', t => {
 
   fastify.inject({
     method: 'GET',
-    url: '/'
+    url: '/',
+    headers: {
+      TE: 'trailers'
+    }
   }, (error, res) => {
     t.error(error)
     t.equal(res.statusCode, 200)
     t.equal(res.headers['transfer-encoding'], 'chunked')
-    t.equal(res.headers.trailer, 'ETag')
+    t.equal(res.headers.trailer, 'etag')
     t.equal(res.trailers.etag, 'custom-etag')
+  })
+})
+
+test('throw error when trailer header name is not allowed', t => {
+  const INVALID_TRAILERS = [
+    'transfer-encoding',
+    'content-length',
+    'host',
+    'cache-control',
+    'max-forwards',
+    'te',
+    'authorization',
+    'set-cookie',
+    'content-encoding',
+    'content-type',
+    'content-range',
+    'trailer'
+  ]
+  t.plan(INVALID_TRAILERS.length + 2)
+
+  const fastify = Fastify()
+
+  fastify.get('/', function (request, reply) {
+    for (const key of INVALID_TRAILERS) {
+      try {
+        reply.addTrailer(key, () => {})
+      } catch (err) {
+        t.equal(err.message, `Called reply.addTrailer with an invalid header name: ${key}`)
+      }
+    }
+    reply.send('')
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      TE: 'trailers'
+    }
+  }, (error, res) => {
+    t.error(error)
+    t.equal(res.statusCode, 200)
   })
 })

--- a/test/reply-trailers.test.js
+++ b/test/reply-trailers.test.js
@@ -29,7 +29,7 @@ test('do not send trailers when request do not contain correct te', t => {
   })
 })
 
-test('do not send trailers when payload is empty', t => {
+test('do not send trailers when payload is empty string', t => {
   t.plan(4)
 
   const fastify = Fastify()
@@ -40,6 +40,60 @@ test('do not send trailers when payload is empty', t => {
       return 'custom-etag'
     })
     reply.send('')
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      TE: 'trailers'
+    }
+  }, (error, res) => {
+    t.error(error)
+    t.equal(res.statusCode, 200)
+    t.notOk(res.headers.trailer)
+    t.notOk(res.trailers.etag)
+  })
+})
+
+test('do not send trailers when payload is empty buffer', t => {
+  t.plan(4)
+
+  const fastify = Fastify()
+
+  fastify.get('/', function (request, reply) {
+    reply.addTrailer('ETag', function (reply, payload) {
+      t.fail('trailer should not be called.')
+      return 'custom-etag'
+    })
+    reply.send(Buffer.alloc(0))
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      TE: 'trailers'
+    }
+  }, (error, res) => {
+    t.error(error)
+    t.equal(res.statusCode, 200)
+    t.notOk(res.headers.trailer)
+    t.notOk(res.trailers.etag)
+  })
+})
+
+test('do not send trailers when payload is undefined', t => {
+  t.plan(4)
+
+  const fastify = Fastify()
+
+  fastify.get('/', function (request, reply) {
+    reply.addTrailer('ETag', function (reply, payload) {
+      t.fail('trailer should not be called.')
+      return 'custom-etag'
+    })
+    reply.send(undefined)
   })
 
   fastify.inject({

--- a/test/reply-trailers.test.js
+++ b/test/reply-trailers.test.js
@@ -1,0 +1,82 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('..')
+const { Readable } = require('stream')
+
+test('do not send trailers when payload is empty', t => {
+  t.plan(4)
+
+  const fastify = Fastify()
+
+  fastify.get('/', function (request, reply) {
+    reply.addTrailer('ETag', function (reply, payload) {
+      t.fail('trailer should not be called.')
+      return 'custom-etag'
+    })
+    reply.send('')
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (error, res) => {
+    t.error(error)
+    t.equal(res.statusCode, 200)
+    t.notOk(res.headers.trailer)
+    t.notOk(res.trailers.etag)
+  })
+})
+
+test('send trailers when payload is json', t => {
+  t.plan(6)
+
+  const fastify = Fastify()
+  const data = JSON.stringify({ hello: 'world' })
+
+  fastify.get('/', function (request, reply) {
+    reply.addTrailer('ETag', function (reply, payload) {
+      t.equal(data, payload)
+      return 'custom-etag'
+    })
+    reply.send(data)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (error, res) => {
+    t.error(error)
+    t.equal(res.statusCode, 200)
+    t.equal(res.headers['transfer-encoding'], 'chunked')
+    t.equal(res.headers.trailer, 'ETag')
+    t.equal(res.trailers.etag, 'custom-etag')
+  })
+})
+
+test('send trailers when payload is stream', t => {
+  t.plan(6)
+
+  const fastify = Fastify()
+
+  fastify.get('/', function (request, reply) {
+    reply.addTrailer('ETag', function (reply, payload) {
+      t.same(payload, null)
+      return 'custom-etag'
+    })
+    const stream = Readable.from([JSON.stringify({ hello: 'world' })])
+    reply.send(stream)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (error, res) => {
+    t.error(error)
+    t.equal(res.statusCode, 200)
+    t.equal(res.headers['transfer-encoding'], 'chunked')
+    t.equal(res.headers.trailer, 'ETag')
+    t.equal(res.trailers.etag, 'custom-etag')
+  })
+})

--- a/test/reply-trailers.test.js
+++ b/test/reply-trailers.test.js
@@ -138,6 +138,7 @@ test('removeTrailer', t => {
   const fastify = Fastify()
 
   fastify.get('/', function (request, reply) {
+    reply.removeTrailer('ETag') // remove nothing
     reply.trailer('ETag', function (reply, payload) {
       return 'custom-etag'
     })
@@ -162,11 +163,12 @@ test('removeTrailer', t => {
 })
 
 test('hasTrailer', t => {
-  t.plan(8)
+  t.plan(9)
 
   const fastify = Fastify()
 
   fastify.get('/', function (request, reply) {
+    t.equal(reply.hasTrailer('ETag'), false)
     reply.trailer('ETag', function (reply, payload) {
       return 'custom-etag'
     })


### PR DESCRIPTION
Closes #630

Some question
1. Is it fine for the `payload` as `null` when `stream` is sent?
2. Is `payload.on('end')` correct for `stream` handling and add trailers?
3. Is it fine for `trailer` only support sync function?

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
