### PR TITLE
fix: TypeScript route Handlers

### DIFF
--- a/test/types/reply.test-d.ts
+++ b/test/types/reply.test-d.ts
@@ -31,6 +31,7 @@ const getHandler: RouteHandlerMethod = function (_request, reply) {
   expectType<(payload: any) => string>(reply.serialize)
   expectType<(fulfilled: () => void, rejected: (err: Error) => void) => void>(reply.then)
   expectType<FastifyInstance>(reply.server)
+  return 'something'
 }
 
 interface ReplyPayload {
@@ -41,19 +42,20 @@ interface ReplyPayload {
 
 const typedHandler: RouteHandler<ReplyPayload> = async (request, reply) => {
   expectType<((payload?: ReplyPayload['Reply']) => FastifyReply<RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>, ReplyPayload>)>(reply.send)
+  return { test: true }
 }
 
 const server = fastify()
 server.get('/get', getHandler)
 server.get('/typed', typedHandler)
 server.get<ReplyPayload>('/get-generic-send', async function handler (request, reply) {
-  reply.send({ test: true })
+  return reply.send({ test: true })
 })
 server.get<ReplyPayload>('/get-generic-return', async function handler (request, reply) {
   return { test: false }
 })
 expectError(server.get<ReplyPayload>('/get-generic-return-error', async function handler (request, reply) {
-  reply.send({ foo: 'bar' })
+  return reply.send({ foo: 'bar' })
 }))
 expectError(server.get<ReplyPayload>('/get-generic-return-error', async function handler (request, reply) {
   return { foo: 'bar' }

--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -243,33 +243,33 @@ expectError(fastify().route({
 }))
 
 expectError(fastify().route({
-  url:'/',
-  method:'GET',
-  handler: (req,reply)=>{
-    return
+  url: '/',
+  method: 'GET',
+  handler: (req, reply) => {
+
   }
 }))
 
 expectError(fastify().route({
-  url:'/',
-  method:'GET',
-  handler: async (req,reply) => {
-    return
+  url: '/',
+  method: 'GET',
+  handler: async (req, reply) => {
+
   }
 }))
 
 expectError(fastify().route({
-  url:'/',
-  method:'GET',
-  handler: (req,reply) => {
+  url: '/',
+  method: 'GET',
+  handler: (req, reply) => {
     return undefined
   }
 }))
 
 expectError(fastify().route({
-  url:'/',
-  method:'GET',
-  handler: async (req,reply) => {
+  url: '/',
+  method: 'GET',
+  handler: async (req, reply) => {
     return undefined
   }
 }))

--- a/types/type-provider.d.ts
+++ b/types/type-provider.d.ts
@@ -1,5 +1,6 @@
 
 import { RouteGenericInterface } from './route'
+import { FastifyReply } from '../'
 import { FastifySchema } from './schema'
 
 // -----------------------------------------------------------------------------------------------
@@ -93,7 +94,7 @@ TypeProvider,
 SchemaCompiler,
 RouteGeneric
 > extends infer Return ?
-  (void | Promise<Return | void>)
+  (FastifyReply | Return | Promise<Return | FastifyReply>)
 // review: support both async and sync return types
 // (Promise<Return> | Return | Promise<void> | void)
   : unknown


### PR DESCRIPTION
fix: https://github.com/fastify/fastify/issues/3803

This is unfortunately not working yet. I fixed the assertions in the tests.
So basically a handler should either return a Typed value or the `FastifyReply`; it should never return `void`.

Returning `undefined` or `void` should be prohibited.

mention @climba03003 @sinclairzx81 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
