### PR TITLE
reply: remove content-length when Transfer-Encoding is added

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -458,9 +458,11 @@ function onSendEnd (reply, payload) {
   if (payload === undefined || payload === null) {
     // according to https://tools.ietf.org/html/rfc7230#section-3.3.2
     // we cannot send a content-length for 304 and 204, and all status code
-    // < 200.
+    // < 200
+    // A sender MUST NOT send a Content-Length header field in any message
+    // that contains a Transfer-Encoding header field.
     // For HEAD we don't overwrite the `content-length`
-    if (statusCode >= 200 && statusCode !== 204 && statusCode !== 304 && req.method !== 'HEAD') {
+    if (statusCode >= 200 && statusCode !== 204 && statusCode !== 304 && req.method !== 'HEAD' && reply[kReplyTrailers] === null) {
       reply[kReplyHeaders]['content-length'] = '0'
     }
 
@@ -480,10 +482,12 @@ function onSendEnd (reply, payload) {
     throw new FST_ERR_REP_INVALID_PAYLOAD_TYPE(typeof payload)
   }
 
-  if (!reply[kReplyHeaders]['content-length']) {
-    reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)
-  } else if (req.raw.method !== 'HEAD' && reply[kReplyHeaders]['content-length'] !== Buffer.byteLength(payload)) {
-    reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)
+  if (reply[kReplyTrailers] === null) {
+    if (!reply[kReplyHeaders]['content-length']) {
+      reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)
+    } else if (req.raw.method !== 'HEAD' && reply[kReplyHeaders]['content-length'] !== Buffer.byteLength(payload)) {
+      reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)
+    }
   }
 
   res.writeHead(statusCode, reply[kReplyHeaders])

--- a/test/reply-trailers.test.js
+++ b/test/reply-trailers.test.js
@@ -7,7 +7,7 @@ const { Readable } = require('stream')
 const { createHash } = require('crypto')
 
 test('send trailers when payload is empty string', t => {
-  t.plan(4)
+  t.plan(5)
 
   const fastify = Fastify()
 
@@ -26,11 +26,12 @@ test('send trailers when payload is empty string', t => {
     t.equal(res.statusCode, 200)
     t.equal(res.headers.trailer, 'etag')
     t.equal(res.trailers.etag, 'custom-etag')
+    t.notHas(res.headers, 'content-length')
   })
 })
 
 test('send trailers when payload is empty buffer', t => {
-  t.plan(4)
+  t.plan(5)
 
   const fastify = Fastify()
 
@@ -49,11 +50,12 @@ test('send trailers when payload is empty buffer', t => {
     t.equal(res.statusCode, 200)
     t.equal(res.headers.trailer, 'etag')
     t.equal(res.trailers.etag, 'custom-etag')
+    t.notHas(res.headers, 'content-length')
   })
 })
 
 test('send trailers when payload is undefined', t => {
-  t.plan(4)
+  t.plan(5)
 
   const fastify = Fastify()
 
@@ -72,11 +74,12 @@ test('send trailers when payload is undefined', t => {
     t.equal(res.statusCode, 200)
     t.equal(res.headers.trailer, 'etag')
     t.equal(res.trailers.etag, 'custom-etag')
+    t.notHas(res.headers, 'content-length')
   })
 })
 
 test('send trailers when payload is json', t => {
-  t.plan(6)
+  t.plan(7)
 
   const fastify = Fastify()
   const data = JSON.stringify({ hello: 'world' })
@@ -103,11 +106,12 @@ test('send trailers when payload is json', t => {
     t.equal(res.headers['transfer-encoding'], 'chunked')
     t.equal(res.headers.trailer, 'content-md5')
     t.equal(res.trailers['content-md5'], md5)
+    t.notHas(res.headers, 'content-length')
   })
 })
 
 test('send trailers when payload is stream', t => {
-  t.plan(6)
+  t.plan(7)
 
   const fastify = Fastify()
 
@@ -129,11 +133,12 @@ test('send trailers when payload is stream', t => {
     t.equal(res.headers['transfer-encoding'], 'chunked')
     t.equal(res.headers.trailer, 'etag')
     t.equal(res.trailers.etag, 'custom-etag')
+    t.notHas(res.headers, 'content-length')
   })
 })
 
 test('removeTrailer', t => {
-  t.plan(5)
+  t.plan(6)
 
   const fastify = Fastify()
 
@@ -159,11 +164,12 @@ test('removeTrailer', t => {
     t.equal(res.headers.trailer, 'etag')
     t.equal(res.trailers.etag, 'custom-etag')
     t.notOk(res.trailers['should-not-call'])
+    t.notHas(res.headers, 'content-length')
   })
 })
 
 test('hasTrailer', t => {
-  t.plan(9)
+  t.plan(10)
 
   const fastify = Fastify()
 
@@ -192,6 +198,7 @@ test('hasTrailer', t => {
     t.equal(res.headers.trailer, 'etag')
     t.equal(res.trailers.etag, 'custom-etag')
     t.notOk(res.trailers['should-not-call'])
+    t.notHas(res.headers, 'content-length')
   })
 })
 


### PR DESCRIPTION
> A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field.

Due to https://tools.ietf.org/html/rfc7230#section-3.3.2


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
