### PR TITLE
fix: remove server.unref from tests (#3790)

### DIFF
--- a/test/async-await.test.js
+++ b/test/async-await.test.js
@@ -48,7 +48,7 @@ test('async await', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -410,7 +410,7 @@ test('promise was fulfilled with undefined', t => {
 
   fastify.listen({ port: 0 }, (err) => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -452,7 +452,7 @@ test('error is not logged because promise was fulfilled with undefined but respo
 
   fastify.listen({ port: 0 }, (err) => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',

--- a/test/bodyLimit.test.js
+++ b/test/bodyLimit.test.js
@@ -30,7 +30,7 @@ test('bodyLimit', t => {
 
   fastify.listen({ port: 0 }, function (err) {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'POST',

--- a/test/custom-parser.test.js
+++ b/test/custom-parser.test.js
@@ -124,7 +124,7 @@ test('contentTypeParser should handle multiple custom parsers', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'POST',
@@ -176,7 +176,7 @@ test('contentTypeParser should handle an array of custom contentTypes', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'POST',
@@ -966,7 +966,7 @@ test('Should parse empty bodies as a string', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'POST',

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -134,7 +134,7 @@ test('decorateReply inside register', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -182,7 +182,7 @@ test('decorateReply as plugin (inside .after)', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -230,7 +230,7 @@ test('decorateReply as plugin (outside .after)', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -276,7 +276,7 @@ test('decorateRequest inside register', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -324,7 +324,7 @@ test('decorateRequest as plugin (inside .after)', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -372,7 +372,7 @@ test('decorateRequest as plugin (outside .after)', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -951,7 +951,7 @@ test('decorateRequest/decorateReply empty string', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -980,7 +980,7 @@ test('decorateRequest/decorateReply is undefined', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -1009,7 +1009,7 @@ test('decorateRequest/decorateReply is not set to a value', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',

--- a/test/delete.test.js
+++ b/test/delete.test.js
@@ -159,7 +159,7 @@ test('body - delete', t => {
 
 fastify.listen({ port: 0 }, err => {
   t.error(err)
-  fastify.server.unref()
+  t.teardown(() => { fastify.close() })
 
   test('shorthand - request delete', t => {
     t.plan(4)

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -205,7 +205,7 @@ test('send a falsy boolean', t => {
 
 fastify.listen({ port: 0 }, err => {
   t.error(err)
-  fastify.server.unref()
+  t.teardown(() => { fastify.close() })
 
   test('shorthand - request get', t => {
     t.plan(4)

--- a/test/head.test.js
+++ b/test/head.test.js
@@ -94,7 +94,7 @@ test('missing schema - head', t => {
 
 fastify.listen({ port: 0 }, err => {
   t.error(err)
-  fastify.server.unref()
+  t.teardown(() => { fastify.close() })
 
   test('shorthand - request head', t => {
     t.plan(2)

--- a/test/helper.js
+++ b/test/helper.js
@@ -98,7 +98,7 @@ module.exports.payloadMethod = function (method, t, isSetErrorHandler = false) {
       return
     }
 
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     test(`${upMethod} - correctly replies`, t => {
       t.plan(3)

--- a/test/hooks-async.test.js
+++ b/test/hooks-async.test.js
@@ -58,7 +58,7 @@ test('async hooks', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -140,7 +140,7 @@ test('hooks', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -263,7 +263,7 @@ test('onRequest hook should support encapsulation / 3', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -324,7 +324,7 @@ test('preHandler hook should support encapsulation / 5', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -735,7 +735,7 @@ test('onRoute hook should able to change the route url', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -920,7 +920,7 @@ test('onResponse hook should support encapsulation / 3', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -997,7 +997,7 @@ test('onSend hook should support encapsulation / 2', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -1261,7 +1261,8 @@ test('onSend hook throws', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
+
     sget({
       method: 'GET',
       url: 'http://localhost:' + fastify.server.address().port
@@ -2391,7 +2392,7 @@ test('preValidation hook should support encapsulation / 3', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -2538,7 +2539,7 @@ test('preParsing hook should run before parsing and be able to modify the payloa
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'POST',
@@ -2581,7 +2582,7 @@ test('preParsing hooks should run in the order in which they are defined', t => 
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'POST',
@@ -2631,7 +2632,7 @@ test('preParsing hooks should support encapsulation', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'POST',
@@ -2752,7 +2753,7 @@ test('preParsing hook should support encapsulation / 3', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -2814,7 +2815,7 @@ test('preSerialization hook should run before serialization and be able to modif
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -2865,7 +2866,7 @@ test('preSerialization hook should be able to throw errors which are validated a
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -2899,7 +2900,7 @@ test('preSerialization hook which returned error should still run onError hooks'
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -2933,7 +2934,7 @@ test('preSerialization hooks should run in the order in which they are defined',
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -2977,7 +2978,7 @@ test('preSerialization hooks should support encapsulation', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',

--- a/test/http2/closing.test.js
+++ b/test/http2/closing.test.js
@@ -34,7 +34,7 @@ t.test('http/2 request while fastify closing', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     t.test('return 200', t => {
       const url = getUrl(fastify)
@@ -81,7 +81,7 @@ t.test('http/2 request while fastify closing - return503OnClosing: false', t => 
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     t.test('return 200', t => {
       const url = getUrl(fastify)

--- a/test/http2/constraint.test.js
+++ b/test/http2/constraint.test.js
@@ -48,7 +48,7 @@ test('A route supports host constraints under http2 protocol and secure connecti
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     t.test('https get request - no constrain', async (t) => {
       t.plan(3)

--- a/test/http2/head.test.js
+++ b/test/http2/head.test.js
@@ -22,7 +22,7 @@ fastify.all('/', function (req, reply) {
 
 fastify.listen({ port: 0 }, err => {
   t.error(err)
-  fastify.server.unref()
+  t.teardown(() => { fastify.close() })
 
   test('http HEAD request', async (t) => {
     t.plan(1)

--- a/test/http2/plain.test.js
+++ b/test/http2/plain.test.js
@@ -26,7 +26,7 @@ fastify.get('/hostname', function (req, reply) {
 
 fastify.listen({ port: 0 }, err => {
   t.error(err)
-  fastify.server.unref()
+  t.teardown(() => { fastify.close() })
 
   test('http get request', async (t) => {
     t.plan(3)

--- a/test/http2/secure-with-fallback.test.js
+++ b/test/http2/secure-with-fallback.test.js
@@ -42,7 +42,7 @@ test('secure with fallback', (t) => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     t.test('https get error', async (t) => {
       t.plan(1)

--- a/test/http2/secure.test.js
+++ b/test/http2/secure.test.js
@@ -35,7 +35,7 @@ test('secure', (t) => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     t.test('https get request', async (t) => {
       t.plan(3)

--- a/test/http2/unknown-http-method.test.js
+++ b/test/http2/unknown-http-method.test.js
@@ -16,7 +16,7 @@ fastify.get('/', function (req, reply) {
 
 fastify.listen({ port: 0 }, err => {
   t.error(err)
-  fastify.server.unref()
+  t.teardown(() => { fastify.close() })
 
   test('http UNKNOWN_METHOD request', async (t) => {
     t.plan(2)

--- a/test/https/https.test.js
+++ b/test/https/https.test.js
@@ -34,7 +34,7 @@ test('https', (t) => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     t.test('https get request', t => {
       t.plan(4)

--- a/test/input-validation.js
+++ b/test/input-validation.js
@@ -139,7 +139,7 @@ module.exports.payloadMethod = function (method, t) {
       t.error(err)
     }
 
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     test(`${upMethod} - correctly replies`, t => {
       if (upMethod === 'HEAD') {

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -140,8 +140,9 @@ test('request should be defined in onSend Hook on post request with content type
     reply.send(200)
   })
   fastify.listen({ port: 0 }, err => {
-    fastify.server.unref()
     t.error(err)
+    t.teardown(() => { fastify.close() })
+
     sget({
       method: 'POST',
       url: 'http://localhost:' + fastify.server.address().port,
@@ -171,8 +172,9 @@ test('request should be defined in onSend Hook on post request with content type
     reply.send(200)
   })
   fastify.listen({ port: 0 }, err => {
-    fastify.server.unref()
     t.error(err)
+    t.teardown(() => { fastify.close() })
+
     sget({
       method: 'POST',
       url: 'http://localhost:' + fastify.server.address().port,
@@ -202,8 +204,9 @@ test('request should be defined in onSend Hook on options request with content t
     reply.send(200)
   })
   fastify.listen({ port: 0 }, err => {
-    fastify.server.unref()
     t.error(err)
+    t.teardown(() => { fastify.close() })
+
     sget({
       method: 'OPTIONS',
       url: 'http://localhost:' + fastify.server.address().port,

--- a/test/internals/initialConfig.test.js
+++ b/test/internals/initialConfig.test.js
@@ -310,7 +310,7 @@ test('Should not have issues when passing stream options to Pino.js', t => {
 
   fastify.listen({ port: 0, host: localhost }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     http.get(`http://${localhostForURL}:${fastify.server.address().port}`)
   })

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -58,7 +58,7 @@ test('defaults to info level', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     dns.lookup('localhost', { all: true }, function (err, addresses) {
       t.error(err)
@@ -120,7 +120,7 @@ test('test log stream', t => {
 
   fastify.listen({ port: 0, host: localhost }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     http.get(`http://${localhostForURL}:` + fastify.server.address().port)
     stream.once('data', listenAtLogLine => {
@@ -167,7 +167,7 @@ test('test error log stream', t => {
 
   fastify.listen({ port: 0, host: localhost }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     http.get(`http://${localhostForURL}:` + fastify.server.address().port + '/error')
     stream.once('data', listenAtLogLine => {
@@ -461,7 +461,7 @@ test('The logger should accept custom serializer', t => {
 
   fastify.listen({ port: 0, host: localhost }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     http.get(`http://${localhostForURL}:` + fastify.server.address().port + '/custom')
     stream.once('data', listenAtLogLine => {
@@ -1226,7 +1226,7 @@ test('file option', t => {
 
   fastify.listen({ port: 0, host: localhost }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     http.get(`http://${localhostForURL}:` + fastify.server.address().port, () => {
       const stream = fs.createReadStream(dest).pipe(split(JSON.parse))
@@ -1271,7 +1271,8 @@ test('should log the error if no error handler is defined', t => {
   })
   fastify.listen({ port: 0, host: localhost }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
+
     http.get(`http://${localhostForURL}:` + fastify.server.address().port + '/error')
     stream.once('data', listenAtLogLine => {
       t.ok(listenAtLogLine, 'listen at log message is ok')
@@ -1309,7 +1310,8 @@ test('should log as info if error status code >= 400 and < 500 if no error handl
   })
   fastify.listen({ port: 0, host: localhost }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
+
     http.get(`http://${localhostForURL}:` + fastify.server.address().port + '/400')
     stream.once('data', listenAtLogLine => {
       t.ok(listenAtLogLine, 'listen at log message is ok')
@@ -1343,7 +1345,8 @@ test('should log as error if error status code >= 500 if no error handler is def
   })
   fastify.listen({ port: 0, host: localhost }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
+
     http.get(`http://${localhostForURL}:` + fastify.server.address().port + '/503')
     stream.once('data', listenAtLogLine => {
       t.ok(listenAtLogLine, 'listen at log message is ok')
@@ -1381,7 +1384,8 @@ test('should not log the error if error handler is defined and it does not error
   })
   fastify.listen({ port: 0, host: localhost }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
+
     http.get(`http://${localhostForURL}:` + fastify.server.address().port + '/error')
     stream.once('data', listenAtLogLine => {
       t.ok(listenAtLogLine, 'listen at log message is ok')
@@ -1412,7 +1416,8 @@ test('should not rely on raw request to log errors', t => {
   })
   fastify.listen({ port: 0, host: localhost }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
+
     http.get(`http://${localhostForURL}:` + fastify.server.address().port + '/error')
     stream.once('data', listenAtLogLine => {
       t.ok(listenAtLogLine, 'listen at log message is ok')
@@ -1462,7 +1467,8 @@ test('should redact the authorization header if so specified', t => {
   })
   fastify.listen({ port: 0, host: localhost }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
+
     sget({
       method: 'GET',
       url: `http://${localhostForURL}:` + fastify.server.address().port,

--- a/test/nullable-validation.test.js
+++ b/test/nullable-validation.test.js
@@ -89,8 +89,8 @@ test('object or null body', t => {
   })
 
   fastify.listen({ port: 0 }, (err) => {
-    fastify.server.unref()
     t.error(err)
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'POST',
@@ -141,8 +141,8 @@ test('nullable body', t => {
   })
 
   fastify.listen({ port: 0 }, (err) => {
-    fastify.server.unref()
     t.error(err)
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'POST',
@@ -182,8 +182,8 @@ test('Nullable body with 204', t => {
   })
 
   fastify.listen({ port: 0 }, (err) => {
-    fastify.server.unref()
     t.error(err)
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'POST',

--- a/test/output-validation.test.js
+++ b/test/output-validation.test.js
@@ -92,7 +92,7 @@ test('unlisted response code', t => {
 
 fastify.listen({ port: 0 }, err => {
   t.error(err)
-  fastify.server.unref()
+  t.teardown(() => { fastify.close() })
 
   test('shorthand - string get ok', t => {
     t.plan(4)

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -91,7 +91,7 @@ test('fastify.register with fastify-plugin should not encapsulate his code', t =
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -170,7 +170,7 @@ test('fastify.register with fastify-plugin should provide access to external fas
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -225,7 +225,7 @@ test('fastify.register with fastify-plugin registers root level plugins', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -287,7 +287,7 @@ test('check dependencies - should not throw', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -339,7 +339,7 @@ test('check dependencies - should throw', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -537,7 +537,7 @@ test('plugin encapsulation', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',

--- a/test/promises.test.js
+++ b/test/promises.test.js
@@ -62,7 +62,7 @@ fastify.get('/return-reply', opts, function (req, reply) {
 
 fastify.listen({ port: 0 }, err => {
   t.error(err)
-  fastify.server.unref()
+  t.teardown(() => { fastify.close() })
 
   test('shorthand - sget return promise es6 get', t => {
     t.plan(4)

--- a/test/register.test.js
+++ b/test/register.test.js
@@ -40,7 +40,7 @@ test('register', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     makeRequest('first')
     makeRequest('second')

--- a/test/request-error.test.js
+++ b/test/request-error.test.js
@@ -107,7 +107,7 @@ test('default clientError handler ignores ECONNRESET', t => {
 
   fastify.listen({ port: 0 }, function (err) {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     const client = connect(fastify.server.address().port)
 

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -115,7 +115,7 @@ test('route', t => {
 
   fastify.listen({ port: 0 }, function (err) {
     if (err) t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     test('cannot add another route after binding', t => {
       t.plan(1)
@@ -1441,7 +1441,7 @@ test('route with non-english characters', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',

--- a/test/router-options.test.js
+++ b/test/router-options.test.js
@@ -25,7 +25,7 @@ test('Should honor ignoreTrailingSlash option', t => {
   })
 
   fastify.listen({ port: 0 }, (err) => {
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
     if (err) t.threw(err)
 
     const baseUrl = getUrl(fastify)

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -37,7 +37,7 @@ test('should respond with a stream', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget(`http://localhost:${fastify.server.address().port}`, function (err, response, data) {
       t.error(err)
@@ -63,7 +63,7 @@ test('should respond with a stream (error)', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget(`http://localhost:${fastify.server.address().port}/error`, function (err, response) {
       t.error(err)
@@ -118,8 +118,7 @@ test('should trigger the onSend hook only twice if pumping the stream fails, fir
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget(`http://localhost:${fastify.server.address().port}`, function (err, response) {
       t.error(err)
@@ -281,7 +280,7 @@ test('Destroying streams prematurely', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     const port = fastify.server.address().port
 
@@ -344,7 +343,7 @@ test('Destroying streams prematurely should call close method', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     const port = fastify.server.address().port
 
@@ -406,7 +405,7 @@ test('Destroying streams prematurely should call close method when destroy is no
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     const port = fastify.server.address().port
 
@@ -469,7 +468,7 @@ test('Destroying streams prematurely should call abort method', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     const port = fastify.server.address().port
 
@@ -519,7 +518,7 @@ test('Destroying streams prematurely, log is disabled', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     const port = fastify.server.address().port
 
@@ -549,7 +548,7 @@ test('should respond with a stream1', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget(`http://localhost:${fastify.server.address().port}`, function (err, response, body) {
       t.error(err)
@@ -581,7 +580,7 @@ test('return a 404 if the stream emits a 404 error', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     const port = fastify.server.address().port
 
@@ -609,7 +608,7 @@ test('should support send module 200 and 404', { skip: semver.gte(process.versio
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     const url = getUrl(fastify)
 
@@ -650,7 +649,7 @@ test('should destroy stream when response is ended', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget(`http://localhost:${fastify.server.address().port}/error`, function (err, response) {
       t.error(err)
@@ -727,7 +726,7 @@ test('reply.send handles aborted requests', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     const port = fastify.server.address().port
     const http = require('http')

--- a/test/versioned-routes.test.js
+++ b/test/versioned-routes.test.js
@@ -244,7 +244,7 @@ test('Should register a versioned route', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -409,7 +409,7 @@ test('Bas accept version (server)', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -451,7 +451,7 @@ test('test log stream', t => {
 
   fastify.listen({ port: 0, host: localhost }, err => {
     t.error(err)
-    fastify.server.unref()
+    t.teardown(() => { fastify.close() })
 
     http.get({
       hostname: fastify.server.address().hostname,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Closes https://github.com/fastify/fastify/issues/3790

1. Replacing in `/test` files calls to `fastify.server.unref()` with `t.teardown(() => { fastify.close() })` as detailed in the issue.
2. Most existing test files called `t.error` before `t.teardown`. Normalising to this pattern where it wasn't.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [na] tests and/or benchmarks are included
- [na] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
