### PR TITLE
fix: remove duplicate require(http-errors)

### DIFF
--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -3,7 +3,6 @@
 const t = require('tap')
 const test = t.test
 const fp = require('fastify-plugin')
-const httpErrors = require('http-errors')
 const sget = require('simple-get').concat
 const errors = require('http-errors')
 const split = require('split2')
@@ -1097,7 +1096,7 @@ test('recognizes errors from the http-errors module', t => {
   const fastify = Fastify()
 
   fastify.get('/', function (req, reply) {
-    reply.send(httpErrors.NotFound())
+    reply.send(new errors.NotFound())
   })
 
   t.teardown(fastify.close.bind(fastify))
@@ -1132,7 +1131,7 @@ test('the default 404 handler can be invoked inside a prefixed plugin', t => {
 
   fastify.register(function (instance, opts, done) {
     instance.get('/path', function (request, reply) {
-      reply.send(httpErrors.NotFound())
+      reply.send(new errors.NotFound())
     })
 
     done()
@@ -1160,7 +1159,7 @@ test('an inherited custom 404 handler can be invoked inside a prefixed plugin', 
 
   fastify.register(function (instance, opts, done) {
     instance.get('/path', function (request, reply) {
-      reply.send(httpErrors.NotFound())
+      reply.send(new errors.NotFound())
     })
 
     done()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

`test/404s.test.js` required `http-errors` twice.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [na] tests and/or benchmarks are included
- [na] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
