### PR TITLE
Add eslintrc to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 .editorconfig
+.eslintrc
 .gitattributes
 .gitignore
 .github

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 .editorconfig
 .eslintrc
+.eslintrc.json
 .gitattributes
 .gitignore
 .github


### PR DESCRIPTION
The .eslintrc file is currently included in the published package. In most situations this is harmless, though unnecessary (linting code in a dependency doesn't make much sense).

Unfortunately, eslint configuration can be a bit tricky, especially with a monorepo and the VSC eslint plugin, and I've noticed that VSC keeps trying and failing to load the `standard` eslint config specified in fastify's .eslintrc. Since I don't have `standard` as a dependency, this keeps failing, resulting in log spam that looks like this:

```
[Error - 10:10:46 AM] ESLint stack trace:
[Error - 10:10:46 AM] Error: Failed to load config "standard" to extend from.
Referenced from: /home/user/code/project/node_modules/.pnpm/fastify@3.27.4/node_modules/fastify/types/.eslintrc.json
```

Of course, the best solution here is get the VSC eslint plugin to stop trying to load lint configurations in node_modules, but that's proven more difficult than it should be. Since including the .eslintrc file in the published package doesn't add value, I'm wondering if maintainers would be amenable to adding it to the .npmignore file?
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [N/A] tests and/or benchmarks are included
- [N/A] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
