### PR TITLE
content-type: return undefined when content-type is ''

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -141,7 +141,7 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
   const resource = new AsyncResource('content-type-parser:run', request)
 
   if (parser === undefined) {
-    reply.send(new FST_ERR_CTP_INVALID_MEDIA_TYPE(contentType))
+    reply.send(new FST_ERR_CTP_INVALID_MEDIA_TYPE(contentType || undefined))
   } else if (parser.asString === true || parser.asBuffer === true) {
     rawBody(
       request,

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "@fastify/fast-json-stringify-compiler": "^1.0.0",
     "abstract-logging": "^2.0.1",
     "avvio": "^8.1.0",
-    "fastify-error": "^1.0.0",
+    "fastify-error": "^1.1.0",
     "find-my-way": "^5.3.0",
     "light-my-request": "^4.7.0",
     "pino": "^7.5.1",

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -4,7 +4,7 @@ const t = require('tap')
 const test = t.test
 const Fastify = require('..')
 const keys = require('../lib/symbols')
-const { FST_ERR_CTP_ALREADY_PRESENT, FST_ERR_CTP_INVALID_TYPE } = require('../lib/errors')
+const { FST_ERR_CTP_ALREADY_PRESENT, FST_ERR_CTP_INVALID_TYPE, FST_ERR_CTP_INVALID_MEDIA_TYPE } = require('../lib/errors')
 
 const first = function (req, payload, done) {}
 const second = function (req, payload, done) {}
@@ -216,6 +216,26 @@ test('non-Error thrown from content parser is properly handled', t => {
   }, (err, res) => {
     t.error(err)
     t.equal(res.payload, payload)
+  })
+})
+
+test('Error thrown 415 from content type is null and make post request to server', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+  const errMsg = new FST_ERR_CTP_INVALID_MEDIA_TYPE(undefined).message
+
+  fastify.post('/', (req, reply) => {
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    body: 'some text'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 415)
+    t.equal(JSON.parse(res.body).message, errMsg)
   })
 })
 


### PR DESCRIPTION
Due to https://github.com/fastify/fastify-error/pull/69/. When content-type is empty, it will return :
```js
{
  statusCode: 415,
  code: 'FST_ERR_CTP_INVALID_MEDIA_TYPE',
  error: 'Unsupported Media Type',
  message: 'Unsupported Media Type: '
}
```

after change:
```js
{
  statusCode: 415,
  code: 'FST_ERR_CTP_INVALID_MEDIA_TYPE',
  error: 'Unsupported Media Type',
  message: 'Unsupported Media Type: undefined'
}
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
