### PR TITLE
docs(reference): grammar and conciseness changes

### DIFF
--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -2,7 +2,7 @@
 
 ## `Content-Type` Parser
 Natively, Fastify only supports `'application/json'` and `'text/plain'` content
-types. If the content type is not one of these, a `FST_ERR_CTP_INVALID_MEDIA_TYPE` 
+types. If the content type is not one of these, an `FST_ERR_CTP_INVALID_MEDIA_TYPE` 
 error will be thrown.
 
 The default charset is `utf-8`. If you need to support different content
@@ -115,7 +115,7 @@ fastify.removeContentTypeParser(['application/json', 'text/plain'])
 In the example from just above, it is noticeable that we need to specify each
 content type that we want to remove. To solve this problem Fastify provides the
 `removeAllContentTypeParsers` API. This can be used to remove all currently
-existing content type parsers. In the example below we achieve exactly the same
+existing content type parsers. In the example below we achieve the same
 as in the example above except that we do not need to specify each content type
 to delete. Just like `removeContentTypeParser`, this API supports encapsulation.
 The API is especially useful if you want to register a [catch-all content type
@@ -223,12 +223,12 @@ fastify.route({
 For piping file uploads you may want to check out [this
 plugin](https://github.com/fastify/fastify-multipart).
 
-If you really want the content type parser to be executed on all content types
+If you want the content type parser to be executed on all content types
 and not only on those that don't have a specific one, you should call the
 `removeAllContentTypeParsers` method first.
 
 ```js
-// Without this call, the request body with the content type application/json would be processed by the built in json parser
+// Without this call, the request body with the content type application/json would be processed by the built-in JSON parser
 fastify.removeAllContentTypeParsers()
 
 fastify.addContentTypeParser('*', function (request, payload, done) {

--- a/docs/Reference/Encapsulation.md
+++ b/docs/Reference/Encapsulation.md
@@ -134,7 +134,7 @@ context is available to the containing parent context.
 
 Assuming the `publicContext` needs access to the `bar` decorator defined
 within the `grandchildContext` in the previous example, the code can be
-rewritten to:
+rewritten as:
 
 ```js
 'use strict'

--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -183,7 +183,7 @@ executed, and only if the `customErrorHandler` sends an error back to the user
 *(Note that the default `customErrorHandler` always sends the error back to the
 user)*.
 
-**Notice:** unlike the other hooks, pass an error to the `done` function is not
+**Notice:** unlike the other hooks, passing an error to the `done` function is not
 supported.
 
 ### onSend
@@ -656,13 +656,13 @@ fastify.route({
 > versions of Node.js supported by Fastify where `diagnostics_channel` is
 > unavailable, the hook will use the
 > [polyfill](https://www.npmjs.com/package/diagnostics_channel) if it is
-> available. Otherwise this feature will not be present.
+> available. Otherwise, this feature will not be present.
 
 Currently, one
 [`diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html) publish
 event, `'fastify.initialization'`, happens at initialization time. The Fastify
 instance is passed into the hook as a property of the object passed in. At this
-point, the instance can be interacted with to add hooks, plugins, routes or any
+point, the instance can be interacted with to add hooks, plugins, routes, or any
 other sort of modification.
 
 For example, a tracing package might do something like the following (which is,

--- a/docs/Reference/Middleware.md
+++ b/docs/Reference/Middleware.md
@@ -34,7 +34,7 @@ Remember that middleware can be encapsulated; this means that you can decide
 where your middleware should run by using `register` as explained in the
 [plugins guide](../Guides/Plugins-Guide.md).
 
-Fastify middleware do not expose the `send` method or other methods specific to
+Fastify middleware does not expose the `send` method or other methods specific to
 the Fastify [Reply](./Reply.md#reply) instance. This is because Fastify wraps
 the incoming `req` and `res` Node instances using the
 [Request](./Request.md#request) and [Reply](./Reply.md#reply) objects

--- a/docs/Reference/Plugins.md
+++ b/docs/Reference/Plugins.md
@@ -7,13 +7,12 @@ that you will need to use one or more plugins, is `register`.
 
 By default, `register` creates a *new scope*, this means that if you make some
 changes to the Fastify instance (via `decorate`), this change will not be
-reflected by the current context ancestors, but only to its descendants. This
+reflected by the current context ancestors, but only by its descendants. This
 feature allows us to achieve plugin *encapsulation* and *inheritance*, in this
 way we create a *direct acyclic graph* (DAG) and we will not have issues caused
 by cross dependencies.
 
-You already see in the [getting started](../Guides/Getting-Started.md#your-first-plugin)
-section how using this API is pretty straightforward.
+You may have already seen in the [Getting Started]((../Guides/Getting-Started.md#your-first-plugin)) guide how easy it is to use this API:
 ```
 fastify.register(plugin, [options])
 ```
@@ -132,7 +131,7 @@ fastify.listen({ port: 3000 }, (err, address) => {
 ### async/await
 <a id="async-await"></a>
 
-*async/await* is supported by `after`, `ready` and `listen`, as well as
+*async/await* is supported by `after`, `ready`, and `listen`, as well as
 `fastify` being a [Thenable](https://promisesaplus.com/).
 
 ```js

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -208,9 +208,9 @@ Returns a boolean indicating if the specified header has been set.
 ### .trailer(key, function)
 <a id="trailer"></a>
 
-Sets a response trailer. Trailer usually used when you want some header that require heavy resources to be sent after the `data`, for example `Server-Timing`, `Etag`. It can ensure the client get the response data as soon as possible.
+Sets a response trailer. Trailer is usually used when you need a header that requires heavy resources to be sent after the `data`, for example, `Server-Timing` and `Etag`. It can ensure the client receives the response data as soon as possible.
 
-*Note: The header `Transfer-Encoding: chunked` will be added once you use the trailer. It is a hard requipment for using trailer in Node.js.*
+*Note: The header `Transfer-Encoding: chunked` will be added once you use the trailer. It is a hard requirement for using trailer in Node.js.*
 
 *Note: Currently, the computation function only supports synchronous function. That means `async-await` and `promise` are not supported.*
 
@@ -315,8 +315,8 @@ If the `Content-Type` has a JSON subtype, and the charset parameter is not set, 
 ### .serializer(func)
 <a id="serializer"></a>
 
-`.send()` will by default JSON-serialize any value that is not one of: `Buffer`,
-`stream`, `string`, `undefined`, `Error`. If you need to replace the default
+By default, `.send()` will JSON-serialize any value that is not one of `Buffer`,
+`stream`, `string`, `undefined`, or `Error`. If you need to replace the default
 serializer with a custom serializer for a particular request, you can do so with
 the `.serializer()` utility. Be aware that if you are using a custom serializer,
 you must set a custom `'Content-Type'` header.
@@ -375,7 +375,7 @@ invocation of `reply.send()` once the handler promise resolve should be skipped.
 By calling `reply.hijack()`, an application claims full responsibility for
 the low-level request and response. Moreover, hooks will not be invoked.
 
-*Modifying the `.sent` property directly is deprecated. Please use the aformentioned
+*Modifying the `.sent` property directly is deprecated. Please use the aforementioned
 `.hijack()` method to achieve the same effect.*
 
 <a name="hijack"></a>

--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -2,8 +2,8 @@
 
 ## Routes
 
-The routes methods will configure the endpoints of your application. You have
-two ways to declare a route with Fastify, the shorthand method and the full
+The route methods will configure the endpoints of your application. You have
+two ways to declare a route with Fastify: the shorthand method and the full
 declaration.
 
 - [Full declaration](#full-declaration)
@@ -54,8 +54,8 @@ fastify.route(options)
 * `attachValidation`: attach `validationError` to request, if there is a schema
   validation error, instead of sending the error to the error handler.
   The default [error format](https://ajv.js.org/api.html#error-objects) is the Ajv one.
-* `onRequest(request, reply, done)`: a [function](./Hooks.md#onrequest) as soon
-  that a request is received, it could also be an array of functions.
+* `onRequest(request, reply, done)`: a [function](./Hooks.md#onrequest) called
+  as soon as a request is received, it could also be an array of functions.
 * `preParsing(request, reply, done)`: a [function](./Hooks.md#preparsing) called
   before parsing the request, it could also be an array of functions.
 * `preValidation(request, reply, done)`: a [function](./Hooks.md#prevalidation)
@@ -76,7 +76,7 @@ fastify.route(options)
 * `onTimeout(request, reply, done)`: a [function](./Hooks.md#ontimeout) called
   when a request is timed out and the HTTP socket has been hanged up.
 * `onError(request, reply, error, done)`: a [function](./Hooks.md#onerror)
-  called when an Error is thrown or send to the client by the route handler.
+  called when an Error is thrown or sent to the client by the route handler.
 * `handler(request, reply)`: the function that will handle this request. The
   [Fastify server](./Server.md) will be bound to `this` when the handler is
   called. Note: using an arrow function will break the binding of `this`.
@@ -247,15 +247,15 @@ fastify.get('/example/near/:lat-:lng/radius/:r', (request, reply) => {})
 ```
 *Remember in this case to use the dash ("-") as parameters separator.*
 
-Finally it is possible to have multiple parameters with RegExp.
+Finally, it is possible to have multiple parameters with RegExp:
 ```js
 fastify.get('/example/at/:hour(^\\d{2})h:minute(^\\d{2})m', (request, reply) => {})
 ```
 In this case as parameter separator it is possible to use whatever character is
 not matched by the regular expression.
 
-Having a route with multiple parameters may affect negatively the performance,
-so prefer single parameter approach whenever possible, especially on routes that
+Having a route with multiple parameters may negatively affect performance,
+so prefer a single parameter approach whenever possible, especially on routes that
 are on the hot path of your application. If you are interested in how we handle
 the routing, check out [find-my-way](https://github.com/delvedor/find-my-way).
 
@@ -320,7 +320,7 @@ fastify.get('/', options, async function (request, reply) {
   first one that happens takes precedence, the second value will be discarded,
   and a *warn* log will also be emitted because you tried to send a response
   twice.
-* Calling `reply.send()` outside of the promise is possible, but requires
+* Calling `reply.send()` outside of the promise is possible but requires
   special attention. For more details read
   [promise-resolution](#promise-resolution).
 * You cannot return `undefined`. For more details read
@@ -330,12 +330,12 @@ fastify.get('/', options, async function (request, reply) {
 <a id="promise-resolution"></a>
 
 If your handler is an `async` function or returns a promise, you should be aware of
-a special behaviour which is necessary to support the callback and promise
+the special behavior that is necessary to support the callback and promise
 control-flow. When the handler's promise is resolved, the reply will be
 automatically sent with its value unless you explicitly await or return `reply`
 in your handler.
 
-1. If you want to use `async/await` or promises but respond a value with `reply.send`:
+1. If you want to use `async/await` or promises but respond with a value with `reply.send`:
     - **Do** `return reply` / `await reply`.
     - **Do not** forget to call `reply.send`.
 2. If you want to use `async/await` or promises:
@@ -343,7 +343,7 @@ in your handler.
     - **Do** return the value that you want to send.
 
 In this way, we can support both `callback-style` and `async-await`, with the
-minimum trade-off. In spite of so much freedom we highly recommend to go with
+minimum trade-off. Despite so much freedom we highly recommend going with
 only one style because error handling should be handled in a consistent way
 within your application.
 
@@ -391,14 +391,14 @@ Now your clients will have access to the following routes:
 - `/v1/user`
 - `/v2/user`
 
-You can do this as many times as you want, it works also for nested `register`
-and routes parameter are supported as well. Be aware that if you use
+You can do this as many times as you want, it also works for nested `register`,
+and route parameters are supported as well. Be aware that if you use
 [`fastify-plugin`](https://github.com/fastify/fastify-plugin) this option will
 not work.
 
 #### Handling of / route inside prefixed plugins
 
-The `/` route has a different behavior depending on if the prefix ends with `/`
+The `/` route has different behavior depending on if the prefix ends with `/`
 or not. As an example, if we consider a prefix `/something/`, adding a `/` route
 will only match `/something/`. If we consider a prefix `/something`, adding a
 `/` route will match both `/something` and `/something/`.
@@ -408,7 +408,7 @@ See the `prefixTrailingSlash` route option above to change this behavior.
 ### Custom Log Level
 <a id="custom-log-level"></a>
 
-It could happen that you need different log levels in your routes; Fastify
+You might need different log levels in your routes; Fastify
 achieves this in a very straightforward way.
 
 You just need to pass the option `logLevel` to the plugin option or the route
@@ -442,9 +442,9 @@ the global Fastify Logger, accessible with `fastify.log`*
 ### Custom Log Serializer
 <a id="custom-log-serializer"></a>
 
-In some context, you may need to log a large object but it could be a waste of
-resources for some routes. In this case, you can define some
-[`serializer`](https://github.com/pinojs/pino/blob/master/docs/api.md#serializers-object)
+In some contexts, you may need to log a large object but it could be a waste of
+resources for some routes. In this case, you can define custom
+[`serializers`](https://github.com/pinojs/pino/blob/master/docs/api.md#serializers-object)
 and attach them in the right context!
 
 ```js

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -208,7 +208,7 @@ You can set a custom length for parameters in parametric (standard, regex, and
 multi) routes by using `maxParamLength` option; the default value is 100
 characters.
 
-This can be useful especially if you have some regex based route, protecting you
+This can be useful especially if you have a regex-based route, protecting you
 against [DoS
 attacks](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS).
 
@@ -432,7 +432,7 @@ way query strings are handled take a look at
 ### `allowUnsafeRegex`
 <a id="factory-allow-unsafe-regex"></a>
 
-The allowUnsafeRegex setting is false by default, so routes only allow safe regular expressionss. To use unsafe expressions, set allowUnsafeRegex to true.
+The allowUnsafeRegex setting is false by default, so routes only allow safe regular expressions. To use unsafe expressions, set allowUnsafeRegex to true.
 
 ```js
 fastify.get('/user/:id(^([0-9]+){4}$)', (request, reply) => {

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -166,8 +166,7 @@ variation in which the `type` and `properties` attributes are forgone and the
 parameters are listed at the top level (see the example below).
 
 > ℹ If you need to use the latest version of Ajv (v8) you should read how to do
-> it in the [`schemaController`](./Server.md#schema-controller) section. It is
-> explained the easier way to avoid to implement a custom validator.
+> it in the [`schemaController`](./Server.md#schema-controller) section.
 
 Example:
 ```js

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -44,7 +44,7 @@ this API is encapsulated.
 
 The shared schemas can be reused through the JSON Schema
 [**`$ref`**](https://tools.ietf.org/html/draft-handrews-json-schema-01#section-8)
-keyword. Here an overview of _how_ references work:
+keyword. Here is an overview of _how_ references work:
 
 + `myField: { $ref: '#foo'}` will search for field with `$id: '#foo'` inside the
   current schema
@@ -165,7 +165,7 @@ of `'object'` and a `'properties'` object containing parameters) or a simpler
 variation in which the `type` and `properties` attributes are forgone and the
 parameters are listed at the top level (see the example below).
 
-> ℹ If you need to use the lastest version of Ajv (v8) you should read how to do
+> ℹ If you need to use the latest version of Ajv (v8) you should read how to do
 > it in the [`schemaController`](./Server.md#schema-controller) section. It is
 > explained the easier way to avoid to implement a custom validator.
 
@@ -489,13 +489,13 @@ Fastify's validation error messages are tightly coupled to the default
 validation engine: errors returned from `ajv` are eventually run through the
 `schemaErrorFormatter` function which is responsible for building human-friendly
 error messages. However, the `schemaErrorFormatter` function is written with `ajv`
-in mind : as a result, you may run into odd or incomplete error messages when
+in mind. As a result, you may run into odd or incomplete error messages when
 using other validation libraries.
 
 To circumvent this issue, you have 2 main options :
 
 1. make sure your validation function (returned by your custom `schemaCompiler`)
-   returns errors in the exact same structure and format as `ajv` (although this
+   returns errors in the same structure and format as `ajv` (although this
    could prove to be difficult and tricky due to differences between validation
    engines)
 2. or use a custom `errorHandler` to intercept and format your 'custom'
@@ -702,8 +702,8 @@ fastify.setErrorHandler(function (error, request, reply) {
 })
 ```
 
-If you want custom error response in schema without headaches and quickly, you
-can take a look at [`ajv-errors`](https://github.com/epoberezkin/ajv-errors).
+If you want a custom error response in the schema without headaches, and quickly, take a
+look at [`ajv-errors`](https://github.com/epoberezkin/ajv-errors).
 Check out the
 [example](https://github.com/fastify/example/blob/HEAD/validation-messages/custom-errors-messages.js)
 usage.
@@ -798,7 +798,7 @@ fastify.setErrorHandler(function (error, request, reply) {
 
 ### JSON Schema support
 
-JSON Schema has some type of utilities in order to optimize your schemas that,
+JSON Schema provides utilities to optimize your schemas that,
 in conjunction with Fastify's shared schema, let you reuse all your schemas
 easily.
 


### PR DESCRIPTION
Reference counterpart to #3876
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
