### PR TITLE
Run automerge in ci only if we have a pull-request or got a pr-number provided

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
           npm run test:ci
 
   automerge:
+    if: ${{ github.event_name == 'pull_request' || github.event.inputs.pr-number != '' }}
     needs: test
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
I think we can avoid running automerge, if we simply check if we are in a pull-request or have a pr-number provided. 

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
