### PR TITLE
replaced semver check code per recommendation

### DIFF
--- a/lib/pluginUtils.js
+++ b/lib/pluginUtils.js
@@ -103,9 +103,8 @@ function checkVersion (fn) {
 
   const requiredVersion = meta.fastify
 
-  const sanitizedVersion = this.version.replace(/-rc.\d+$/, '')
   const fastifyRc = /-rc.+$/.test(this.version)
-  if (requiredVersion && semver.satisfies(sanitizedVersion, requiredVersion, { includePrerelease: fastifyRc }) === false) {
+  if (requiredVersion && semver.satisfies(this.version, requiredVersion, { includePrerelease: fastifyRc }) === false) {
     throw new FST_ERR_PLUGIN_VERSION_MISMATCH(meta.name, requiredVersion, this.version)
   }
 }

--- a/lib/pluginUtils.js
+++ b/lib/pluginUtils.js
@@ -104,7 +104,8 @@ function checkVersion (fn) {
   const requiredVersion = meta.fastify
 
   const sanitizedVersion = this.version.replace(/-rc.\d+$/, '')
-  if (requiredVersion && !semver.satisfies(sanitizedVersion, requiredVersion)) {
+  const fastifyRc = /-rc.+$/.test(this.version)
+  if (requiredVersion && semver.satisfies(sanitizedVersion, requiredVersion, { includePrerelease: fastifyRc }) === false) {
     throw new FST_ERR_PLUGIN_VERSION_MISMATCH(meta.name, requiredVersion, this.version)
   }
 }


### PR DESCRIPTION
Added fastifyRc const and replaced conditional.


                         
  🌈 SUMMARY RESULTS 🌈  
                         
 SKIP ​ test/stream.test.js 1 skip of 75 435.886ms
 ~ should support send module 200 and 404


Suites:   ​104 passed​, ​104 of 104 completed​
Asserts:  ​​​5812 passed​, ​1 skip​, ​of 5813​
Time:​   ​28s​
-----------------------------|---------|----------|---------|---------|-------------------
File                         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------------|---------|----------|---------|---------|-------------------
All files                    |     100 |      100 |     100 |     100 |                   
 fastify                     |     100 |      100 |     100 |     100 |                   
  fastify.js                 |     100 |      100 |     100 |     100 |                   
 fastify/lib                 |     100 |      100 |     100 |     100 |                   
  contentTypeParser.js       |     100 |      100 |     100 |     100 |                   
  context.js                 |     100 |      100 |     100 |     100 |                   
  decorate.js                |     100 |      100 |     100 |     100 |                   
  error-handler.js           |     100 |      100 |     100 |     100 |                   
  errors.js                  |     100 |      100 |     100 |     100 |                   
  fourOhFour.js              |     100 |      100 |     100 |     100 |                   
  handleRequest.js           |     100 |      100 |     100 |     100 |                   
  headRoute.js               |     100 |      100 |     100 |     100 |                   
  hooks.js                   |     100 |      100 |     100 |     100 |                   
  initialConfigValidation.js |     100 |      100 |     100 |     100 |                   
  logger.js                  |     100 |      100 |     100 |     100 |                   
  noop-set.js                |     100 |      100 |     100 |     100 |                   
  pluginOverride.js          |     100 |      100 |     100 |     100 |                   
  pluginUtils.js             |     100 |      100 |     100 |     100 |                   
  reply.js                   |     100 |      100 |     100 |     100 |                   
  reqIdGenFactory.js         |     100 |      100 |     100 |     100 |                   
  request.js                 |     100 |      100 |     100 |     100 |                   
  route.js                   |     100 |      100 |     100 |     100 |                   
  schema-controller.js       |     100 |      100 |     100 |     100 |                   
  schemas.js                 |     100 |      100 |     100 |     100 |                   
  server.js                  |     100 |      100 |     100 |     100 |                   
  symbols.js                 |     100 |      100 |     100 |     100 |                   
  validation.js              |     100 |      100 |     100 |     100 |                   
  warnings.js                |     100 |      100 |     100 |     100 |                   
  wrapThenable.js            |     100 |      100 |     100 |     100 |                   
-----------------------------|---------|----------|---------|---------|-------------------
[semver_fix bab37e1a] replaced semver check code per recommendation
 1 file changed, 2 insertions(+), 1 deletion(-)



[1] npm WARN exec The following package was not found and will be installed: autocannon
[1] Running 30s test @ http://localhost:3000/
[1] 100 connections with 10 pipelining factor
[1] 
[1] 
[1] ┌─────────┬──────┬───────┬───────┬───────┬──────────┬─────────┬────────┐
[1] │ Stat    │ 2.5% │ 50%   │ 97.5% │ 99%   │ Avg      │ Stdev   │ Max    │
[1] ├─────────┼──────┼───────┼───────┼───────┼──────────┼─────────┼────────┤
[1] │ Latency │ 8 ms │ 17 ms │ 19 ms │ 20 ms │ 14.14 ms │ 4.93 ms │ 102 ms │
[1] └─────────┴──────┴───────┴───────┴───────┴──────────┴─────────┴────────┘
[1] ┌───────────┬─────────┬─────────┬───────┬─────────┬─────────┬─────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%   │ 97.5%   │ Avg     │ Stdev   │ Min     │
[1] ├───────────┼─────────┼─────────┼───────┼─────────┼─────────┼─────────┼─────────┤
[1] │ Req/Sec   │ 54655   │ 54655   │ 69055 │ 69631   │ 68420.8 │ 2652.97 │ 54626   │
[1] ├───────────┼─────────┼─────────┼───────┼─────────┼─────────┼─────────┼─────────┤
[1] │ Bytes/Sec │ 10.3 MB │ 10.3 MB │ 13 MB │ 13.1 MB │ 12.9 MB │ 499 kB  │ 10.3 MB │
[1] └───────────┴─────────┴─────────┴───────┴─────────┴─────────┴─────────┴─────────┘
[1] 
[1] Req/Bytes counts sampled once per second.
[1] # of samples: 30
[1] 
[1] 2054k requests in 30.03s, 386 MB read
[1] npx autocannon -c 100 -d 30 -p 10 localhost:3000/ exited with code 0
--> Sending SIGTERM to other processes..
[0] node ./examples/benchmark/simple.js exited with code SIGTERM

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
