### PR TITLE
Fix link to OpenJS Foundation Image in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Great contributors on a specific area in the Fastify ecosystem will be invited t
 
 ## Hosted by
 
-[<img src="https://github.com/openjs-foundation/artwork/blob/main/openjs_foundation/openjs_foundation-logo-horizontal-color-dark_background.png?raw=true" width="250px;"/>](https://openjsf.org/projects/#growth)
+[<img src="https://github.com/openjs-foundation/artwork/blob/main/openjs_foundation/openjs_foundation-logo-horizontal-color.png?raw=true" width="250px;"/>](https://openjsf.org/projects/#growth)
 
 We are a [Growth Project](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/PROJECT_PROGRESSION.md#growth-stage) in the [OpenJS Foundation](https://openjsf.org/).
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Great contributors on a specific area in the Fastify ecosystem will be invited t
 
 ## Hosted by
 
-[<img src="https://github.com/openjs-foundation/cross-project-council/blob/HEAD/logos/openjsf-color.png?raw=true" width="250px;"/>](https://openjsf.org/projects/#growth)
+[<img src="https://github.com/openjs-foundation/artwork/blob/main/openjs_foundation/openjs_foundation-logo-horizontal-color-dark_background.png?raw=true" width="250px;"/>](https://openjsf.org/projects/#growth)
 
 We are a [Growth Project](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/PROJECT_PROGRESSION.md#growth-stage) in the [OpenJS Foundation](https://openjsf.org/).
 


### PR DESCRIPTION
It seems hat the openjs foundation extracted the logo from the council repo to a special artworks repo.