### PR TITLE
Child log level in bindings is deprecated

### DIFF
--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -1,4 +1,4 @@
-import {expectError, expectType} from 'tsd'
+import { expectError, expectType } from 'tsd'
 import fastify, { FastifyLogFn, LogLevel, FastifyLoggerInstance, FastifyError, FastifyRequest, FastifyReply } from '../../fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
 import pino from 'pino'
@@ -189,7 +189,7 @@ const childParent = fastify().log
 expectType<FastifyLoggerInstance>(childParent.child({}, { level: 'info' }))
 expectType<FastifyLoggerInstance>(childParent.child({}, { redact: ['pass', 'pin'] }))
 expectType<FastifyLoggerInstance>(childParent.child({}, { serializers: { key: () => {} } }))
-expectType<FastifyLoggerInstance>(childParent.child({}, { level:  'info', redact: ['pass', 'pin'], serializers: { key: () => {} } }))
+expectType<FastifyLoggerInstance>(childParent.child({}, { level: 'info', redact: ['pass', 'pin'], serializers: { key: () => {} } }))
 
 // no option pass
 expectError(childParent.child())

--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType } from 'tsd'
+import {expectError, expectType} from 'tsd'
 import fastify, { FastifyLogFn, LogLevel, FastifyLoggerInstance, FastifyError, FastifyRequest, FastifyReply } from '../../fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
 import pino from 'pino'
@@ -183,3 +183,15 @@ const passStreamAsOption = fastify({
     stream: fs.createWriteStream('/tmp/stream.out')
   }
 })
+
+const childParent = fastify().log
+// we test different option variant here
+expectType<FastifyLoggerInstance>(childParent.child({}, { level: 'info' }))
+expectType<FastifyLoggerInstance>(childParent.child({}, { redact: ['pass', 'pin'] }))
+expectType<FastifyLoggerInstance>(childParent.child({}, { serializers: { key: () => {} } }))
+expectType<FastifyLoggerInstance>(childParent.child({}, { level:  'info', redact: ['pass', 'pin'], serializers: { key: () => {} } }))
+
+// no option pass
+expectError(childParent.child())
+// wrong option
+expectError(childParent.child({}, { nonExist: true }))

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -36,10 +36,21 @@ export type LogLevel = 'info' | 'error' | 'debug' | 'fatal' | 'warn' | 'trace'
 
 export type SerializerFn = (value: unknown) => unknown;
 
+export interface redactOptions {
+  paths: string[];
+  censor?: string | ((v: any) => any) | undefined;
+  remove?: boolean | undefined;
+}
 export interface Bindings {
   level?: LogLevel | string;
   serializers?: { [key: string]: SerializerFn };
   [key: string]: unknown;
+}
+
+export interface ChildLoggerOptions {
+  level?: LogLevel | string;
+  redact?: string[] | redactOptions | undefined;
+  serializers?: { [key: string]: SerializerFn } | undefined;
 }
 
 export interface FastifyLoggerInstance {
@@ -49,7 +60,7 @@ export interface FastifyLoggerInstance {
   fatal: FastifyLogFn;
   trace: FastifyLogFn;
   debug: FastifyLogFn;
-  child(bindings: Bindings): FastifyLoggerInstance;
+  child(bindings: Bindings, options?: ChildLoggerOptions): FastifyLoggerInstance;
 }
 
 // This interface is accurate for pino 6.3 and was copied from the following permalink:


### PR DESCRIPTION
Update Logger types to add options to the child function.

ChildLoggerOptions and redactOptions interface was copied from the pino library types.

logger test runs.
