### PR TITLE
package.json: change pino's version for fastify

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "avvio": "^8.1.0",
     "find-my-way": "^5.3.0",
     "light-my-request": "^4.7.0",
-    "pino": "^7.5.1",
+    "pino": "^7.11.0",
     "process-warning": "^1.0.0",
     "proxy-addr": "^2.0.7",
     "rfdc": "^1.1.4",


### PR DESCRIPTION
ref: https://github.com/fastify/fastify/pull/3823 . If `yarn.lock` or `package-lock.json` exists, the failure can't be fixed until update `pino` version. So I think update `pino`'s version is needed.
![image](https://user-images.githubusercontent.com/5475069/167994809-d12e2d6f-99cc-4d06-b1f6-b8a0f914db4b.png)


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
