### PR TITLE
Move querystring parsing to the router

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -4,7 +4,6 @@ const VERSION = '4.0.0-rc.2'
 
 const Avvio = require('avvio')
 const http = require('http')
-const querystring = require('querystring')
 let lightMyRequest
 
 const {
@@ -99,7 +98,6 @@ function fastify (options) {
   validateBodyLimitOption(options.bodyLimit)
 
   const requestIdHeader = options.requestIdHeader || defaultInitOptions.requestIdHeader
-  const querystringParser = options.querystringParser || querystring.parse
   const genReqId = options.genReqId || reqIdGenFactory()
   const requestIdLogLabel = options.requestIdLogLabel || 'reqId'
   const bodyLimit = options.bodyLimit || defaultInitOptions.bodyLimit
@@ -131,7 +129,6 @@ function fastify (options) {
   options.logger = logger
   options.genReqId = genReqId
   options.requestIdHeader = requestIdHeader
-  options.querystringParser = querystringParser
   options.requestIdLogLabel = requestIdLogLabel
   options.disableRequestLogging = disableRequestLogging
   options.ajv = ajvOptions
@@ -172,7 +169,8 @@ function fastify (options) {
       maxParamLength: options.maxParamLength || defaultInitOptions.maxParamLength,
       caseSensitive: options.caseSensitive,
       allowUnsafeRegex: options.allowUnsafeRegex || defaultInitOptions.allowUnsafeRegex,
-      buildPrettyMeta: defaultBuildPrettyMeta
+      buildPrettyMeta: defaultBuildPrettyMeta,
+      querystringParser: options.querystringParser
     },
     keepAliveConnections
   })

--- a/lib/route.js
+++ b/lib/route.js
@@ -47,7 +47,6 @@ function buildRouting (options) {
   let avvio
   let fourOhFour
   let requestIdHeader
-  let querystringParser
   let requestIdLogLabel
   let logger
   let hasLogger
@@ -72,7 +71,6 @@ function buildRouting (options) {
 
       globalExposeHeadRoutes = options.exposeHeadRoutes
       requestIdHeader = options.requestIdHeader
-      querystringParser = options.querystringParser
       requestIdLogLabel = options.requestIdLogLabel
       genReqId = options.genReqId
       disableRequestLogging = options.disableRequestLogging
@@ -322,7 +320,7 @@ function buildRouting (options) {
   }
 
   // HTTP request entry point, the routing has already been executed
-  function routeHandler (req, res, params, context) {
+  function routeHandler (req, res, params, context, query) {
     if (closing === true) {
       /* istanbul ignore next mac, windows */
       if (req.httpVersionMajor !== 2) {
@@ -374,8 +372,6 @@ function buildRouting (options) {
     const childLogger = logger.child(loggerBinding, loggerOpts)
     childLogger[kDisableRequestLogging] = disableRequestLogging
 
-    const queryPrefix = req.url.indexOf('?')
-    const query = querystringParser(queryPrefix > -1 ? req.url.slice(queryPrefix + 1) : '')
     const request = new context.Request(id, params, req, query, childLogger, context)
     const reply = new context.Reply(res, request, childLogger)
 

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "@fastify/fast-json-stringify-compiler": "^1.0.0",
     "abstract-logging": "^2.0.1",
     "avvio": "^8.1.0",
-    "find-my-way": "^5.3.0",
+    "find-my-way": "^6.0.0",
     "light-my-request": "^4.7.0",
     "pino": "^7.5.1",
     "process-warning": "^1.0.0",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Moved querystring parsing to the find-my-way router, where it parsed more efficiently. https://github.com/delvedor/find-my-way/pull/284