### PR TITLE
Add constraint strategies outside Fastify constructor

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -75,6 +75,8 @@ describes the properties available in that options object.
     - [schemaController](#schemacontroller)
     - [setNotFoundHandler](#setnotfoundhandler)
     - [setErrorHandler](#seterrorhandler)
+    - [addConstraintStrategy](#addconstraintstrategy)
+    - [hasConstraintStrategy](#hasconstraintstrategy)
     - [printRoutes](#printroutes)
     - [printPlugins](#printplugins)
     - [addContentTypeParser](#addcontenttypeparser)
@@ -1348,6 +1350,42 @@ if (statusCode >= 500) {
   log.error(error)
 }
 ```
+
+#### addConstraintStrategy
+<a id="addConstraintStrategy"></a>
+
+Function to add a custom constraint strategy. To register a new type of constraint, you must add a new constraint strategy that knows how to match values to handlers, and that knows how to get the constraint value from a request.
+
+Add a custom constraint strategy using the `fastify.addConstraintStrategy` method:
+
+```js
+const customResponseTypeStrategy = {
+  // strategy name for referencing in the route handler `constraints` options
+  name: 'accept',
+  // storage factory for storing routes in the find-my-way route tree
+  storage: function () {
+    let handlers = {}
+    return {
+      get: (type) => { return handlers[type] || null },
+      set: (type, store) => { handlers[type] = store }
+    }
+  },
+  // function to get the value of the constraint from each incoming request
+  deriveConstraint: (req, ctx) => {
+    return req.headers['accept']
+  },
+  // optional flag marking if handlers without constraints can match requests that have a value for this constraint
+  mustMatchWhenDerived: true
+}
+
+const router = Fastify();
+router.addConstraintStrategy(customResponseTypeStrategy);
+```
+
+#### hasConstraintStrategy
+<a id="hasConstraintStrategy"></a>
+
+The `fastify.hasConstraintStrategy(strategyName)` checks if there already exists a custom constraint strategy with the same name.
 
 #### printRoutes
 <a id="print-routes"></a>

--- a/fastify.js
+++ b/fastify.js
@@ -310,7 +310,10 @@ function fastify (options) {
     setNotFoundHandler,
     setErrorHandler,
     // Set fastify initial configuration options read-only object
-    initialConfig
+    initialConfig,
+    // constraint strategies
+    addConstraintStrategy: router.addConstraintStrategy.bind(router),
+    hasConstraintStrategy: router.hasConstraintStrategy.bind(router)
   }
 
   Object.defineProperties(fastify, {

--- a/lib/route.js
+++ b/lib/route.js
@@ -94,7 +94,18 @@ function buildRouting (options) {
     },
     routeHandler,
     closeRoutes: () => { closing = true },
-    printRoutes: router.prettyPrint.bind(router)
+    printRoutes: router.prettyPrint.bind(router),
+    addConstraintStrategy,
+    hasConstraintStrategy
+  }
+
+  function addConstraintStrategy (strategy) {
+    throwIfAlreadyStarted('Cannot add constraint strategy when fastify instance is already started!')
+    return router.addConstraintStrategy(strategy)
+  }
+
+  function hasConstraintStrategy (strategyName) {
+    return router.hasConstraintStrategy(strategyName)
   }
 
   // Convert shorthand to extended route declaration

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "@fastify/fast-json-stringify-compiler": "^1.0.0",
     "abstract-logging": "^2.0.1",
     "avvio": "^8.1.0",
-    "find-my-way": "^5.3.0",
+    "find-my-way": "^6.0.0",
     "light-my-request": "^4.7.0",
     "pino": "^7.5.1",
     "process-warning": "^1.0.0",

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -307,3 +307,17 @@ expectError(server.decorate<string>('test', true))
 expectError(server.decorate<(myNumber: number) => number>('test', function (myNumber: number): string {
   return ''
 }))
+
+const versionConstraintStrategy = {
+  name: 'version',
+  storage: () => ({
+    get: () => () => {},
+    set: () => { },
+    del: () => { },
+    empty: () => { }
+  }),
+  validate () {},
+  deriveConstraint: () => 'foo'
+}
+expectType<void>(server.addConstraintStrategy(versionConstraintStrategy))
+expectType<boolean>(server.hasConstraintStrategy(versionConstraintStrategy.name))

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -1,4 +1,6 @@
+import * as http from 'http'
 import { FastifyError } from '@fastify/error'
+import { ConstraintStrategy, HTTPVersion } from 'find-my-way'
 import { CallbackFunc as LightMyRequestCallback, Chain as LightMyRequestChain, InjectOptions, Response as LightMyRequestResponse } from 'light-my-request'
 import { AddContentTypeParser, ConstructorAction, FastifyBodyParser, getDefaultJsonParser, hasContentTypeParser, ProtoAction, removeAllContentTypeParsers, removeContentTypeParser } from './content-type-parser'
 import { onCloseAsyncHookHandler, onCloseHookHandler, onErrorAsyncHookHandler, onErrorHookHandler, onReadyAsyncHookHandler, onReadyHookHandler, onRegisterHookHandler, onRequestAsyncHookHandler, onRequestHookHandler, onResponseAsyncHookHandler, onResponseHookHandler, onRouteHookHandler, onSendAsyncHookHandler, onSendHookHandler, onTimeoutAsyncHookHandler, onTimeoutHookHandler, preHandlerAsyncHookHandler, preHandlerHookHandler, preParsingAsyncHookHandler, preParsingHookHandler, preSerializationAsyncHookHandler, preSerializationHookHandler, preValidationAsyncHookHandler, preValidationHookHandler } from './hooks'
@@ -29,6 +31,7 @@ export interface PrintRoutesOptions {
 }
 
 type NotInInterface<Key, _Interface> = Key extends keyof _Interface ? never : Key
+type FindMyWayVersion<RawServer extends RawServerBase> = RawServer extends http.Server ? HTTPVersion.V1 : HTTPVersion.V2
 
 /**
  * Fastify server instance. Returned by the core `fastify()` method.
@@ -82,6 +85,9 @@ export interface FastifyInstance<
   hasDecorator(decorator: string | symbol): boolean;
   hasRequestDecorator(decorator: string | symbol): boolean;
   hasReplyDecorator(decorator: string | symbol): boolean;
+
+  addConstraintStrategy(strategy: ConstraintStrategy<FindMyWayVersion<RawServer>, unknown>): void;
+  hasConstraintStrategy(strategyName: string): boolean;
 
   inject(opts: InjectOptions | string, cb: LightMyRequestCallback): void;
   inject(opts: InjectOptions | string): Promise<LightMyRequestResponse>;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

The motivation of this PR was described here https://github.com/delvedor/find-my-way/issues/272 by @matthyk. The main idea is to add an option to add a custom constraint strategy outside the Fastify constructor, in order to define strategies inside plugins. There is a PR that implements this option https://github.com/delvedor/find-my-way/pull/279.

Before merging it, I want to know your opinion:
- Is it option desirable?
- Are there some trouble spots in Fastify with it?

This PR isn't ready. I didn't add tests, docs, types, etc. I want to know if this option is needed before.