### PR TITLE
Fix 3893: return 505 if the request http version is not supported

### DIFF
--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -656,6 +656,6 @@ fastify.route({
 
 ### ⚠  HTTP version check
 
-The fasatify server will run a check on the HTTP version of the request on every call.
+The fastify server will run a check on the HTTP version of the request on every call.
 Based on the fastify configuration the check is against one or all the following versions: `2.0`, `1.1`, `1.0` .
 These are the only versions supported, if your fastify server receives a different HTTP version in the request, it will return a `505 HTTP Version Not Supported` error.

--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -653,3 +653,9 @@ fastify.route({
   }
 })
 ```
+
+### ⚠  HTTP version check
+
+The fasatify server will run a check on the HTTP version of the request on every call.
+Based on the fastify configuration the check is against one or all the following versions: `2.0`, `1.1`, `1.0` .
+These are the only versions supported, if your fastify server receive a different HTTP version in the request, it will return a `505 HTTP Version Not Supported` error.

--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -656,4 +656,4 @@ fastify.route({
 
 ### ⚠  HTTP version check
 
-Fastify will check the HTTP version of every request and, based on [configuration options](./Server.md#http2), will check against one or all of the following versions: `2.0`, `1.1`, and `1.0`. If Fastify receives a different HTTP version in the request it will return a `505 HTTP Version Not Supported` error.
+Fastify will check the HTTP version of every request, based on [configuration options](./Server.md#http2), to determine if it matches one or all of the following versions: `2.0`, `1.1`, and `1.0`. If Fastify receives a different HTTP version in the request it will return a `505 HTTP Version Not Supported` error.

--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -656,6 +656,4 @@ fastify.route({
 
 ### ⚠  HTTP version check
 
-The fastify server will run a check on the HTTP version of the request on every call.
-Based on the fastify configuration the check is against one or all the following versions: `2.0`, `1.1`, `1.0` .
-These are the only versions supported, if your fastify server receives a different HTTP version in the request, it will return a `505 HTTP Version Not Supported` error.
+Fastify will check the HTTP version of every request and, based on [configuration options](./Server.md#http2), will check against one or all of the following versions: `2.0`, `1.1`, and `1.0`. If Fastify receives a different HTTP version in the request it will return a `505 HTTP Version Not Supported` error.

--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -658,4 +658,4 @@ fastify.route({
 
 The fasatify server will run a check on the HTTP version of the request on every call.
 Based on the fastify configuration the check is against one or all the following versions: `2.0`, `1.1`, `1.0` .
-These are the only versions supported, if your fastify server receive a different HTTP version in the request, it will return a `505 HTTP Version Not Supported` error.
+These are the only versions supported, if your fastify server receives a different HTTP version in the request, it will return a `505 HTTP Version Not Supported` error.

--- a/lib/route.js
+++ b/lib/route.js
@@ -323,13 +323,14 @@ function buildRouting (options) {
 
   // HTTP request entry point, the routing has already been executed
   function routeHandler (req, res, params, context) {
-    if (isHttpVersionInvalid(req, context)) {
+    if (!isHttpVersionValid(req, context)) {
+      const message = '{"error":"HTTP Version Not Supported","message":"HTTP Version Not Supported","statusCode":505}'
       const headers = {
         'Content-Type': 'application/json',
-        'Content-Length': '94'
+        'Content-Length': message.length
       }
       res.writeHead(505, headers)
-      res.end('{"error":"HTTP Version Not Supported","message":"HTTP Version Not Supported","statusCode":505}')
+      res.end(message)
       return
     }
 
@@ -341,12 +342,13 @@ function buildRouting (options) {
       }
 
       if (return503OnClosing) {
+        const message = '{"error":"Service Unavailable","message":"Service Unavailable","statusCode":503}'
         const headers = {
           'Content-Type': 'application/json',
-          'Content-Length': '80'
+          'Content-Length': message.length
         }
         res.writeHead(503, headers)
-        res.end('{"error":"Service Unavailable","message":"Service Unavailable","statusCode":503}')
+        res.end(message)
         return
       }
     }
@@ -514,17 +516,17 @@ function removeTrackedSocket () {
   this.keepAliveConnections.delete(this.socket)
 }
 
-function isHttpVersionInvalid (req, context) {
+function isHttpVersionValid (req, context) {
   const { http2, https } = context.server.initialConfig
   if (http2 === true && https && https.allowHTTP1 === true) {
-    return !['1.0', '1.1', '2.0'].includes(req.httpVersion)
+    return ['1.0', '1.1', '2.0'].includes(req.httpVersion)
   }
 
   if (http2 === true && (!https || https.allowHTTP1 !== true)) {
-    return req.httpVersion !== '2.0'
+    return req.httpVersion === '2.0'
   }
 
-  return !['1.0', '1.1'].includes(req.httpVersion)
+  return ['1.0', '1.1'].includes(req.httpVersion)
 }
 
 function noop () { }

--- a/lib/route.js
+++ b/lib/route.js
@@ -323,6 +323,16 @@ function buildRouting (options) {
 
   // HTTP request entry point, the routing has already been executed
   function routeHandler (req, res, params, context) {
+    if (isHttpVersionInvalid(req, context)) {
+      const headers = {
+        'Content-Type': 'application/json',
+        'Content-Length': '94'
+      }
+      res.writeHead(505, headers)
+      res.end('{"error":"HTTP Version Not Supported","message":"HTTP Version Not Supported","statusCode":505}')
+      return
+    }
+
     if (closing === true) {
       /* istanbul ignore next mac, windows */
       if (req.httpVersionMajor !== 2) {
@@ -502,6 +512,19 @@ function preParsingHookRunner (functions, request, reply, cb) {
  */
 function removeTrackedSocket () {
   this.keepAliveConnections.delete(this.socket)
+}
+
+function isHttpVersionInvalid (req, context) {
+  const { http2, https } = context.server.initialConfig
+  if (http2 === true && https && https.allowHTTP1 === true) {
+    return !['1.0', '1.1', '2.0'].includes(req.httpVersion)
+  }
+
+  if (http2 === true && (!https || https.allowHTTP1 !== true)) {
+    return req.httpVersion !== '2.0'
+  }
+
+  return !['1.0', '1.1'].includes(req.httpVersion)
 }
 
 function noop () { }

--- a/test/unsupported-httpversion.test.js
+++ b/test/unsupported-httpversion.test.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const net = require('net')
+const t = require('tap')
+const Fastify = require('../fastify')
+
+t.test('Will return 505 HTTP error if HTTP version (default) is not supported', t => {
+  const fastify = Fastify()
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/', (req, reply) => {
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    const port = fastify.server.address().port
+    const client = net.createConnection({ port }, () => {
+      client.write('GET / HTTP/5.1\r\n\r\n')
+
+      client.once('data', data => {
+        t.match(data.toString(), /505 HTTP Version Not Supported/i)
+        client.end(() => {
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+t.test('Will return 505 HTTP error if HTTP version (2.0 when server is 1.1) is not supported', t => {
+  const fastify = Fastify()
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/', (req, reply) => {
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    const port = fastify.server.address().port
+    const client = net.createConnection({ port }, () => {
+      client.write('GET / HTTP/2.0\r\n\r\n')
+
+      client.once('data', data => {
+        t.match(data.toString(), /505 HTTP Version Not Supported/i)
+        client.end(() => {
+          t.end()
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR adds a check on the HTTP version when a call is made to the server.
This check is run before the handler is called but after the routing has been executed [1]. The check is based on the initial config for the fastify server and the request http version.

The assumption is to consider `1.0`, `1.1` and `2.0` the only valid HTTP versions. 
This PR adds also some documentation in the routes section [2].

This PR should be fixing both the issues raised in #3893 . The 404 handler will not be called if there is an HTTP version mismatch.

The 505 response will be a json response [3]

```
{"error":"HTTP Version Not Supported","message":"HTTP Version Not Supported","statusCode":505}
```

Notes:
[1] I'm not 100% sure if running the check on the http version would be better placed in the [`preRouting`](https://github.com/fastify/fastify/blob/main/fastify.js#L706) function
[2] Is there a better place in the documentation?
[3] Should it be another content type?

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
