### PR TITLE
test: prepare for network interfaces family change

### DIFF
--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -372,12 +372,19 @@ test('addresses getter', async t => {
   const localAddresses = await dns.lookup('localhost', { all: true })
   for (const address of localAddresses) {
     address.port = port
-    if (semver.lt(process.versions.node, '18.0.0')) {
+    if (typeof address.family === 'number') {
+      address.family = 'IPv' + address.family
+    }
+  }
+  const appAddresses = app.addresses()
+  for (const address of appAddresses) {
+    if (typeof address.family === 'number') {
       address.family = 'IPv' + address.family
     }
   }
   localAddresses.sort((a, b) => a.address.localeCompare(b.address))
-  t.same(app.addresses().sort((a, b) => a.address.localeCompare(b.address)), localAddresses, 'after listen')
+  appAddresses.sort((a, b) => a.address.localeCompare(b.address))
+  t.same(appAddresses, localAddresses, 'after listen')
 
   await app.close()
   t.same(app.addresses(), [], 'after close')

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -7,7 +7,6 @@ const { test, before } = require('tap')
 const dns = require('dns').promises
 const dnsCb = require('dns')
 const sget = require('simple-get').concat
-const semver = require('semver')
 const Fastify = require('..')
 
 let localhost


### PR DESCRIPTION
This PR prepare for the upcoming changes for https://github.com/nodejs/node/pull/43054
We can handle both `number` and `string` network interfaces and should not be failed even the local node is fall between `18.0.0-18.2.0` (assume that fix will released in `18.3.0`).

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
