### PR TITLE
fix: all hooks should handle undefined error

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -231,6 +231,10 @@ function onSendHookRunner (functions, request, reply, payload, cb) {
   }
 
   function handleReject (err) {
+    if (!err) {
+      err = new FST_ERR_SEND_UNDEFINED_ERR()
+    }
+
     cb(err, request, reply, payload)
   }
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -20,7 +20,8 @@ const {
   FST_ERR_SCH_SERIALIZATION_BUILD,
   FST_ERR_DEFAULT_ROUTE_INVALID_TYPE,
   FST_ERR_DUPLICATED_ROUTE,
-  FST_ERR_INVALID_URL
+  FST_ERR_INVALID_URL,
+  FST_ERR_SEND_UNDEFINED_ERR
 } = require('./errors')
 
 const {
@@ -489,6 +490,10 @@ function preParsingHookRunner (functions, request, reply, cb) {
   }
 
   function handleReject (err) {
+    if (!err) {
+      err = new FST_ERR_SEND_UNDEFINED_ERR()
+    }
+
     next(err)
   }
 

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -3146,6 +3146,64 @@ test('reply.send should throw if undefined error is thrown', t => {
   })
 })
 
+test('reply.send should throw if undefined error is thrown at preParsing hook', t => {
+  /* eslint prefer-promise-reject-errors: ["error", {"allowEmptyReject": true}] */
+
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.addHook('preParsing', function (req, reply, done) {
+    return Promise.reject()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.send('hello')
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 500)
+    t.same(JSON.parse(res.payload), {
+      error: 'Internal Server Error',
+      code: 'FST_ERR_SEND_UNDEFINED_ERR',
+      message: 'Undefined error has occurred',
+      statusCode: 500
+    })
+  })
+})
+
+test('reply.send should throw if undefined error is thrown at onSend hook', t => {
+  /* eslint prefer-promise-reject-errors: ["error", {"allowEmptyReject": true}] */
+
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.addHook('onSend', function (req, reply, done) {
+    return Promise.reject()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.send('hello')
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 500)
+    t.same(JSON.parse(res.payload), {
+      error: 'Internal Server Error',
+      code: 'FST_ERR_SEND_UNDEFINED_ERR',
+      message: 'Undefined error has occurred',
+      statusCode: 500
+    })
+  })
+})
+
 test('onTimeout should be triggered', t => {
   t.plan(6)
   const fastify = Fastify({ connectionTimeout: 500 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
      
Maybe this behavior is expected, but "preParsing" and "onSend" hooks don't handle undefined/null errors when other hooks do. 
