### PR TITLE
Fix getDefaultRoute type

### DIFF
--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -10,6 +10,7 @@ import fastify, {
 import { HookHandlerDoneFunction } from '../../types/hooks'
 import { FastifyReply } from '../../types/reply'
 import { FastifyRequest } from '../../types/request'
+import { DefaultRoute } from '../../types/route'
 import { FastifySchemaControllerOptions } from '../../types/schema'
 
 const server = fastify()
@@ -321,3 +322,5 @@ const versionConstraintStrategy = {
 }
 expectType<void>(server.addConstraintStrategy(versionConstraintStrategy))
 expectType<boolean>(server.hasConstraintStrategy(versionConstraintStrategy.name))
+
+expectAssignable<DefaultRoute<RawRequestDefaultExpression, RawReplyDefaultExpression>>(server.getDefaultRoute())

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -212,7 +212,7 @@ export interface FastifyInstance<
   register: FastifyRegister<FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider> & PromiseLike<undefined>>;
 
   routing(req: RawRequest, res: RawReply): void;
-  getDefaultRoute: DefaultRoute<RawRequest, RawReply>;
+  getDefaultRoute(): DefaultRoute<RawRequest, RawReply>;
   setDefaultRoute(defaultRoute: DefaultRoute<RawRequest, RawReply>): void;
 
   route<


### PR DESCRIPTION
getDefaultRoute is currently declared as a field, this PR changes it into a method. Fixes #3919.