### PR TITLE
Remove mentions of `make-promises-safe` because it is only needed with Node <=14

### DIFF
--- a/docs/Guides/Getting-Started.md
+++ b/docs/Guides/Getting-Started.md
@@ -56,9 +56,6 @@ fastify.listen({ port: 3000 }, function (err, address) {
 
 Do you prefer to use `async/await`? Fastify supports it out-of-the-box.
 
-*(We also suggest using
-[make-promises-safe](https://github.com/mcollina/make-promises-safe) to avoid
-file descriptor and memory leaks.)*
 ```js
 // ESM
 import Fastify from 'fastify'
@@ -312,7 +309,7 @@ module.exports = fastifyPlugin(dbConnector)
 **our-first-route.js**
 ```js
 /**
- * A plugin that provide encapsulated routes 
+ * A plugin that provide encapsulated routes
  * @param {FastifyInstance} fastify encapsulated fastify instance
  * @param {Object} options plugin options, refer to https://www.fastify.io/docs/latest/Reference/Plugins/#plugin-options
  */
@@ -441,7 +438,7 @@ Schema](https://json-schema.org/).
 
 Let's look at an example demonstrating validation for routes:
 ```js
-/** 
+/**
  * @type {import('fastify').RouteShorthandOptions}
  * @const
  */
@@ -477,7 +474,7 @@ JSON bodies and serialize JSON output.
 To speed up JSON serialization (yes, it is slow!) use the `response` key of the
 schema option as shown in the following example:
 ```js
-/** 
+/**
  * @type {import('fastify').RouteShorthandOptions}
  * @const
  */

--- a/docs/Reference/Errors.md
+++ b/docs/Reference/Errors.md
@@ -17,13 +17,6 @@ way to deal with them is to
 [crash](https://nodejs.org/api/process.html#process_warning_using_uncaughtexception_correctly).
 
 #### Catching Errors In Promises
-In Node.js, unhandled promise rejections (that is, without a `.catch()` handler)
-can also cause memory and file descriptor leaks. While `unhandledRejection` is
-deprecated in Node.js, unhandled rejections will not throw, and still
-potentially leak. You should use a module like
-[`make-promises-safe`](https://github.com/mcollina/make-promises-safe) to ensure
-unhandled rejections _always_ throw.
-
 If you are using promises, you should attach a `.catch()` handler synchronously.
 
 ### Errors In Fastify


### PR DESCRIPTION
In the Getting Started guide, it is suggested that we should use `make-promises-safe`, but after clicking through and reading a bit, it became clear that it doesn't apply if you're already on the latest Node version.

In the first version of this PR I added a bit of text explaining that you only need this module if you use Node <=14. After some feedback in the comments it was suggested that any mention of `make-promises-safe` could be removed.

---

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] ~run `npm run test` and `npm run benchmark`~ 
- [x] ~tests and/or benchmarks are included~
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
