### PR TITLE
feat: Use new Node.js' connection closing API if available

### DIFF
--- a/build/build-validation.js
+++ b/build/build-validation.js
@@ -24,7 +24,7 @@ module.exports.defaultInitOptions = ${JSON.stringify(defaultInitOptions)}
 const defaultInitOptions = {
   connectionTimeout: 0, // 0 sec
   keepAliveTimeout: 72000, // 72 seconds
-  forceCloseConnections: false, // keep-alive connections
+  forceCloseConnections: undefined, // keep-alive connections
   maxRequestsPerSocket: 0, // no limit
   requestTimeout: 0, // no limit
   bodyLimit: 1024 * 1024, // 1 MiB
@@ -50,7 +50,17 @@ const schema = {
   properties: {
     connectionTimeout: { type: 'integer', default: defaultInitOptions.connectionTimeout },
     keepAliveTimeout: { type: 'integer', default: defaultInitOptions.keepAliveTimeout },
-    forceCloseConnections: { type: 'boolean', default: defaultInitOptions.forceCloseConnections },
+    forceCloseConnections: {
+      oneOf: [
+        {
+          type: 'string',
+          pattern: 'idle'
+        },
+        {
+          type: 'boolean'
+        }
+      ]
+    },
     maxRequestsPerSocket: { type: 'integer', default: defaultInitOptions.maxRequestsPerSocket, nullable: true },
     requestTimeout: { type: 'integer', default: defaultInitOptions.requestTimeout },
     bodyLimit: { type: 'integer', default: defaultInitOptions.bodyLimit },

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -135,15 +135,18 @@ use. Also, when `serverFactory` option is specified, this option is ignored.
 ### `forceCloseConnections`
 <a id="forcecloseconnections"></a>
 
-When set to `true` requests with the header `connection: keep-alive` will be
-tracked by the server. Upon [`close`](#close), the server will iterate the
-current persistent connections and [destroy their
-sockets](https://nodejs.org/dist/latest-v16.x/docs/api/net.html#socketdestroyerror).
-This means the server will shutdown immediately instead of waiting for existing
-persistent connections to timeout first. Important: connections are not
-inspected to determine if requests have been completed.
+When set to `true`, upon [`close`](#close) the server will iterate the
+current persistent connections and [destroy their sockets](https://nodejs.org/dist/latest-v16.x/docs/api/net.html#socketdestroyerror).
 
-+ Default: `false`
+> Important: connections are not inspected to determine if requests have been completed.
+
+Fastify will prefer the HTTP server's [`closeAllConnections`](https://nodejs.org/dist/latest-v18.x/docs/api/http.html#servercloseallconnections) method if supported, otherwise it will use internal connection tracking.
+
+When set to `"idle"`, upon [`close`](#close) the server will iterate the
+current persistent connections which are not sending a request or waiting for a response and destroy their sockets.
+The value is supported only if the HTTP server supports the [`closeIdleConnections`](https://nodejs.org/dist/latest-v18.x/docs/api/http.html#servercloseidleconnections) method, otherwise attempting to set it will throw an exception.
+
++ Default: `"idle"` if the HTTP server allows it, `false` otherwise
 
 ### `maxRequestsPerSocket`
 <a id="factory-max-requests-per-socket"></a>

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -110,7 +110,7 @@ export type FastifyServerOptions<
   connectionTimeout?: number,
   keepAliveTimeout?: number,
   maxRequestsPerSocket?: number,
-  forceCloseConnections?: boolean,
+  forceCloseConnections?: boolean | 'idle',
   requestTimeout?: number,
   pluginTimeout?: number,
   bodyLimit?: number,

--- a/fastify.js
+++ b/fastify.js
@@ -52,6 +52,7 @@ const { defaultInitOptions } = getSecuredInitialConfig
 
 const {
   FST_ERR_BAD_URL,
+  FST_ERR_FORCE_CLOSE_CONNECTIONS_IDLE_NOT_AVAILABLE,
   AVVIO_ERRORS_MAP,
   appendStackTrace
 } = require('./lib/errors')
@@ -123,7 +124,6 @@ function fastify (options) {
   // Update the options with the fixed values
   options.connectionTimeout = options.connectionTimeout || defaultInitOptions.connectionTimeout
   options.keepAliveTimeout = options.keepAliveTimeout || defaultInitOptions.keepAliveTimeout
-  options.forceCloseConnections = typeof options.forceCloseConnections === 'boolean' ? options.forceCloseConnections : defaultInitOptions.forceCloseConnections
   options.maxRequestsPerSocket = options.maxRequestsPerSocket || defaultInitOptions.maxRequestsPerSocket
   options.requestTimeout = options.requestTimeout || defaultInitOptions.requestTimeout
   options.logger = logger
@@ -135,7 +135,6 @@ function fastify (options) {
   options.clientErrorHandler = options.clientErrorHandler || defaultClientErrorHandler
 
   const initialConfig = getSecuredInitialConfig(options)
-  const keepAliveConnections = options.forceCloseConnections === true ? new Set() : noopSet()
 
   // exposeHeadRoutes have its default set from the validator
   options.exposeHeadRoutes = initialConfig.exposeHeadRoutes
@@ -172,8 +171,7 @@ function fastify (options) {
       allowUnsafeRegex: options.allowUnsafeRegex || defaultInitOptions.allowUnsafeRegex,
       buildPrettyMeta: defaultBuildPrettyMeta,
       querystringParser: options.querystringParser
-    },
-    keepAliveConnections
+    }
   })
 
   // 404 router, used for handling encapsulated 404 handlers
@@ -185,6 +183,19 @@ function fastify (options) {
   // we need to set this before calling createServer
   options.http2SessionTimeout = initialConfig.http2SessionTimeout
   const { server, listen } = createServer(options, httpHandler)
+
+  const serverHasCloseAllConnections = typeof server.closeAllConnections === 'function'
+  const serverHasCloseIdleConnections = typeof server.closeIdleConnections === 'function'
+
+  let forceCloseConnections = options.forceCloseConnections
+  if (forceCloseConnections === 'idle' && !serverHasCloseIdleConnections) {
+    throw new FST_ERR_FORCE_CLOSE_CONNECTIONS_IDLE_NOT_AVAILABLE()
+  } else if (typeof forceCloseConnections !== 'boolean') {
+    /* istanbul ignore next: only one branch can be valid in a given Node.js version */
+    forceCloseConnections = serverHasCloseIdleConnections ? 'idle' : false
+  }
+
+  const keepAliveConnections = !serverHasCloseAllConnections && forceCloseConnections === true ? new Set() : noopSet()
 
   const setupResponseListeners = Reply.setupResponseListeners
   const schemaController = SchemaController.buildSchemaController(null, options.schemaController)
@@ -386,13 +397,21 @@ function fastify (options) {
         // No new TCP connections are accepted
         instance.server.close(done)
 
-        for (const conn of fastify[kKeepAliveConnections]) {
-          // We must invoke the destroy method instead of merely unreffing
-          // the sockets. If we only unref, then the callback passed to
-          // `fastify.close` will never be invoked; nor will any of the
-          // registered `onClose` hooks.
-          conn.destroy()
-          fastify[kKeepAliveConnections].delete(conn)
+        /* istanbul ignore next: Cannot test this without Node.js core support */
+        if (forceCloseConnections === 'idle') {
+          instance.server.closeIdleConnections()
+        /* istanbul ignore next: Cannot test this without Node.js core support */
+        } else if (serverHasCloseAllConnections && forceCloseConnections) {
+          instance.server.closeAllConnections()
+        } else {
+          for (const conn of fastify[kKeepAliveConnections]) {
+            // We must invoke the destroy method instead of merely unreffing
+            // the sockets. If we only unref, then the callback passed to
+            // `fastify.close` will never be invoked; nor will any of the
+            // registered `onClose` hooks.
+            conn.destroy()
+            fastify[kKeepAliveConnections].delete(conn)
+          }
         }
       } else {
         done(null)
@@ -411,7 +430,8 @@ function fastify (options) {
     hasLogger,
     setupResponseListeners,
     throwIfAlreadyStarted,
-    validateHTTPVersion: compileValidateHTTPVersion(options)
+    validateHTTPVersion: compileValidateHTTPVersion(options),
+    keepAliveConnections
   })
 
   // Delay configuring clientError handler so that it can access fastify state.

--- a/lib/configValidator.js
+++ b/lib/configValidator.js
@@ -3,8 +3,9 @@
 "use strict";
 module.exports = validate10;
 module.exports.default = validate10;
-const schema11 = {"type":"object","additionalProperties":false,"properties":{"connectionTimeout":{"type":"integer","default":0},"keepAliveTimeout":{"type":"integer","default":72000},"forceCloseConnections":{"type":"boolean","default":false},"maxRequestsPerSocket":{"type":"integer","default":0,"nullable":true},"requestTimeout":{"type":"integer","default":0},"bodyLimit":{"type":"integer","default":1048576},"caseSensitive":{"type":"boolean","default":true},"allowUnsafeRegex":{"type":"boolean","default":false},"http2":{"type":"boolean"},"https":{"if":{"not":{"oneOf":[{"type":"boolean"},{"type":"null"},{"type":"object","additionalProperties":false,"required":["allowHTTP1"],"properties":{"allowHTTP1":{"type":"boolean"}}}]}},"then":{"setDefaultValue":true}},"ignoreTrailingSlash":{"type":"boolean","default":false},"ignoreDuplicateSlashes":{"type":"boolean","default":false},"disableRequestLogging":{"type":"boolean","default":false},"jsonShorthand":{"type":"boolean","default":true},"maxParamLength":{"type":"integer","default":100},"onProtoPoisoning":{"type":"string","default":"error"},"onConstructorPoisoning":{"type":"string","default":"error"},"pluginTimeout":{"type":"integer","default":10000},"requestIdHeader":{"type":"string","default":"request-id"},"requestIdLogLabel":{"type":"string","default":"reqId"},"http2SessionTimeout":{"type":"integer","default":72000},"exposeHeadRoutes":{"type":"boolean","default":true},"versioning":{"type":"object","additionalProperties":true,"required":["storage","deriveVersion"],"properties":{"storage":{},"deriveVersion":{}}},"constraints":{"type":"object","additionalProperties":{"type":"object","required":["name","storage","validate","deriveConstraint"],"additionalProperties":true,"properties":{"name":{"type":"string"},"storage":{},"validate":{},"deriveConstraint":{}}}}}};
+const schema11 = {"type":"object","additionalProperties":false,"properties":{"connectionTimeout":{"type":"integer","default":0},"keepAliveTimeout":{"type":"integer","default":72000},"forceCloseConnections":{"oneOf":[{"type":"string","pattern":"idle"},{"type":"boolean"}]},"maxRequestsPerSocket":{"type":"integer","default":0,"nullable":true},"requestTimeout":{"type":"integer","default":0},"bodyLimit":{"type":"integer","default":1048576},"caseSensitive":{"type":"boolean","default":true},"allowUnsafeRegex":{"type":"boolean","default":false},"http2":{"type":"boolean"},"https":{"if":{"not":{"oneOf":[{"type":"boolean"},{"type":"null"},{"type":"object","additionalProperties":false,"required":["allowHTTP1"],"properties":{"allowHTTP1":{"type":"boolean"}}}]}},"then":{"setDefaultValue":true}},"ignoreTrailingSlash":{"type":"boolean","default":false},"ignoreDuplicateSlashes":{"type":"boolean","default":false},"disableRequestLogging":{"type":"boolean","default":false},"jsonShorthand":{"type":"boolean","default":true},"maxParamLength":{"type":"integer","default":100},"onProtoPoisoning":{"type":"string","default":"error"},"onConstructorPoisoning":{"type":"string","default":"error"},"pluginTimeout":{"type":"integer","default":10000},"requestIdHeader":{"type":"string","default":"request-id"},"requestIdLogLabel":{"type":"string","default":"reqId"},"http2SessionTimeout":{"type":"integer","default":72000},"exposeHeadRoutes":{"type":"boolean","default":true},"versioning":{"type":"object","additionalProperties":true,"required":["storage","deriveVersion"],"properties":{"storage":{},"deriveVersion":{}}},"constraints":{"type":"object","additionalProperties":{"type":"object","required":["name","storage","validate","deriveConstraint"],"additionalProperties":true,"properties":{"name":{"type":"string"},"storage":{},"validate":{},"deriveConstraint":{}}}}}};
 const func2 = Object.prototype.hasOwnProperty;
+const pattern0 = new RegExp("idle", "u");
 
 function validate10(data, {instancePath="", parentData, parentDataProperty, rootData=data}={}){
 let vErrors = null;
@@ -16,9 +17,6 @@ data.connectionTimeout = 0;
 }
 if(data.keepAliveTimeout === undefined){
 data.keepAliveTimeout = 72000;
-}
-if(data.forceCloseConnections === undefined){
-data.forceCloseConnections = false;
 }
 if(data.maxRequestsPerSocket === undefined){
 data.maxRequestsPerSocket = 0;
@@ -126,209 +124,25 @@ data["keepAliveTimeout"] = coerced1;
 }
 var valid0 = _errs4 === errors;
 if(valid0){
+if(data.forceCloseConnections !== undefined){
 let data2 = data.forceCloseConnections;
 const _errs6 = errors;
-if(typeof data2 !== "boolean"){
+const _errs7 = errors;
+let valid1 = false;
+let passing0 = null;
+const _errs8 = errors;
+if(typeof data2 !== "string"){
+let dataType2 = typeof data2;
 let coerced2 = undefined;
 if(!(coerced2 !== undefined)){
-if(data2 === "false" || data2 === 0 || data2 === null){
-coerced2 = false;
+if(dataType2 == "number" || dataType2 == "boolean"){
+coerced2 = "" + data2;
 }
-else if(data2 === "true" || data2 === 1){
-coerced2 = true;
-}
-else {
-validate10.errors = [{instancePath:instancePath+"/forceCloseConnections",schemaPath:"#/properties/forceCloseConnections/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
-return false;
-}
-}
-if(coerced2 !== undefined){
-data2 = coerced2;
-if(data !== undefined){
-data["forceCloseConnections"] = coerced2;
-}
-}
-}
-var valid0 = _errs6 === errors;
-if(valid0){
-let data3 = data.maxRequestsPerSocket;
-const _errs8 = errors;
-if((!(((typeof data3 == "number") && (!(data3 % 1) && !isNaN(data3))) && (isFinite(data3)))) && (data3 !== null)){
-let dataType3 = typeof data3;
-let coerced3 = undefined;
-if(!(coerced3 !== undefined)){
-if(dataType3 === "boolean" || data3 === null
-              || (dataType3 === "string" && data3 && data3 == +data3 && !(data3 % 1))){
-coerced3 = +data3;
-}
-else if(data3 === "" || data3 === 0 || data3 === false){
-coerced3 = null;
+else if(data2 === null){
+coerced2 = "";
 }
 else {
-validate10.errors = [{instancePath:instancePath+"/maxRequestsPerSocket",schemaPath:"#/properties/maxRequestsPerSocket/type",keyword:"type",params:{type: "integer"},message:"must be integer"}];
-return false;
-}
-}
-if(coerced3 !== undefined){
-data3 = coerced3;
-if(data !== undefined){
-data["maxRequestsPerSocket"] = coerced3;
-}
-}
-}
-var valid0 = _errs8 === errors;
-if(valid0){
-let data4 = data.requestTimeout;
-const _errs11 = errors;
-if(!(((typeof data4 == "number") && (!(data4 % 1) && !isNaN(data4))) && (isFinite(data4)))){
-let dataType4 = typeof data4;
-let coerced4 = undefined;
-if(!(coerced4 !== undefined)){
-if(dataType4 === "boolean" || data4 === null
-              || (dataType4 === "string" && data4 && data4 == +data4 && !(data4 % 1))){
-coerced4 = +data4;
-}
-else {
-validate10.errors = [{instancePath:instancePath+"/requestTimeout",schemaPath:"#/properties/requestTimeout/type",keyword:"type",params:{type: "integer"},message:"must be integer"}];
-return false;
-}
-}
-if(coerced4 !== undefined){
-data4 = coerced4;
-if(data !== undefined){
-data["requestTimeout"] = coerced4;
-}
-}
-}
-var valid0 = _errs11 === errors;
-if(valid0){
-let data5 = data.bodyLimit;
-const _errs13 = errors;
-if(!(((typeof data5 == "number") && (!(data5 % 1) && !isNaN(data5))) && (isFinite(data5)))){
-let dataType5 = typeof data5;
-let coerced5 = undefined;
-if(!(coerced5 !== undefined)){
-if(dataType5 === "boolean" || data5 === null
-              || (dataType5 === "string" && data5 && data5 == +data5 && !(data5 % 1))){
-coerced5 = +data5;
-}
-else {
-validate10.errors = [{instancePath:instancePath+"/bodyLimit",schemaPath:"#/properties/bodyLimit/type",keyword:"type",params:{type: "integer"},message:"must be integer"}];
-return false;
-}
-}
-if(coerced5 !== undefined){
-data5 = coerced5;
-if(data !== undefined){
-data["bodyLimit"] = coerced5;
-}
-}
-}
-var valid0 = _errs13 === errors;
-if(valid0){
-let data6 = data.caseSensitive;
-const _errs15 = errors;
-if(typeof data6 !== "boolean"){
-let coerced6 = undefined;
-if(!(coerced6 !== undefined)){
-if(data6 === "false" || data6 === 0 || data6 === null){
-coerced6 = false;
-}
-else if(data6 === "true" || data6 === 1){
-coerced6 = true;
-}
-else {
-validate10.errors = [{instancePath:instancePath+"/caseSensitive",schemaPath:"#/properties/caseSensitive/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
-return false;
-}
-}
-if(coerced6 !== undefined){
-data6 = coerced6;
-if(data !== undefined){
-data["caseSensitive"] = coerced6;
-}
-}
-}
-var valid0 = _errs15 === errors;
-if(valid0){
-let data7 = data.allowUnsafeRegex;
-const _errs17 = errors;
-if(typeof data7 !== "boolean"){
-let coerced7 = undefined;
-if(!(coerced7 !== undefined)){
-if(data7 === "false" || data7 === 0 || data7 === null){
-coerced7 = false;
-}
-else if(data7 === "true" || data7 === 1){
-coerced7 = true;
-}
-else {
-validate10.errors = [{instancePath:instancePath+"/allowUnsafeRegex",schemaPath:"#/properties/allowUnsafeRegex/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
-return false;
-}
-}
-if(coerced7 !== undefined){
-data7 = coerced7;
-if(data !== undefined){
-data["allowUnsafeRegex"] = coerced7;
-}
-}
-}
-var valid0 = _errs17 === errors;
-if(valid0){
-if(data.http2 !== undefined){
-let data8 = data.http2;
-const _errs19 = errors;
-if(typeof data8 !== "boolean"){
-let coerced8 = undefined;
-if(!(coerced8 !== undefined)){
-if(data8 === "false" || data8 === 0 || data8 === null){
-coerced8 = false;
-}
-else if(data8 === "true" || data8 === 1){
-coerced8 = true;
-}
-else {
-validate10.errors = [{instancePath:instancePath+"/http2",schemaPath:"#/properties/http2/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
-return false;
-}
-}
-if(coerced8 !== undefined){
-data8 = coerced8;
-if(data !== undefined){
-data["http2"] = coerced8;
-}
-}
-}
-var valid0 = _errs19 === errors;
-}
-else {
-var valid0 = true;
-}
-if(valid0){
-if(data.https !== undefined){
-let data9 = data.https;
-const _errs21 = errors;
-const _errs22 = errors;
-let valid1 = true;
-const _errs23 = errors;
-const _errs24 = errors;
-const _errs25 = errors;
-const _errs26 = errors;
-let valid3 = false;
-let passing0 = null;
-const _errs27 = errors;
-if(typeof data9 !== "boolean"){
-let coerced9 = undefined;
-if(!(coerced9 !== undefined)){
-if(data9 === "false" || data9 === 0 || data9 === null){
-coerced9 = false;
-}
-else if(data9 === "true" || data9 === 1){
-coerced9 = true;
-}
-else {
-const err0 = {};
+const err0 = {instancePath:instancePath+"/forceCloseConnections",schemaPath:"#/properties/forceCloseConnections/oneOf/0/type",keyword:"type",params:{type: "string"},message:"must be string"};
 if(vErrors === null){
 vErrors = [err0];
 }
@@ -338,27 +152,17 @@ vErrors.push(err0);
 errors++;
 }
 }
-if(coerced9 !== undefined){
-data9 = coerced9;
+if(coerced2 !== undefined){
+data2 = coerced2;
 if(data !== undefined){
-data["https"] = coerced9;
+data["forceCloseConnections"] = coerced2;
 }
 }
 }
-var _valid1 = _errs27 === errors;
-if(_valid1){
-valid3 = true;
-passing0 = 0;
-}
-const _errs29 = errors;
-if(data9 !== null){
-let coerced10 = undefined;
-if(!(coerced10 !== undefined)){
-if(data9 === "" || data9 === 0 || data9 === false){
-coerced10 = null;
-}
-else {
-const err1 = {};
+if(errors === _errs8){
+if(typeof data2 === "string"){
+if(!pattern0.test(data2)){
+const err1 = {instancePath:instancePath+"/forceCloseConnections",schemaPath:"#/properties/forceCloseConnections/oneOf/0/pattern",keyword:"pattern",params:{pattern: "idle"},message:"must match pattern \""+"idle"+"\""};
 if(vErrors === null){
 vErrors = [err1];
 }
@@ -368,29 +172,24 @@ vErrors.push(err1);
 errors++;
 }
 }
-if(coerced10 !== undefined){
-data9 = coerced10;
-if(data !== undefined){
-data["https"] = coerced10;
 }
+var _valid0 = _errs8 === errors;
+if(_valid0){
+valid1 = true;
+passing0 = 0;
 }
+const _errs10 = errors;
+if(typeof data2 !== "boolean"){
+let coerced3 = undefined;
+if(!(coerced3 !== undefined)){
+if(data2 === "false" || data2 === 0 || data2 === null){
+coerced3 = false;
 }
-var _valid1 = _errs29 === errors;
-if(_valid1 && valid3){
-valid3 = false;
-passing0 = [passing0, 1];
+else if(data2 === "true" || data2 === 1){
+coerced3 = true;
 }
 else {
-if(_valid1){
-valid3 = true;
-passing0 = 1;
-}
-const _errs31 = errors;
-if(errors === _errs31){
-if(data9 && typeof data9 == "object" && !Array.isArray(data9)){
-let missing0;
-if((data9.allowHTTP1 === undefined) && (missing0 = "allowHTTP1")){
-const err2 = {};
+const err2 = {instancePath:instancePath+"/forceCloseConnections",schemaPath:"#/properties/forceCloseConnections/oneOf/1/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"};
 if(vErrors === null){
 vErrors = [err2];
 }
@@ -399,27 +198,27 @@ vErrors.push(err2);
 }
 errors++;
 }
-else {
-const _errs33 = errors;
-for(const key1 in data9){
-if(!(key1 === "allowHTTP1")){
-delete data9[key1];
+}
+if(coerced3 !== undefined){
+data2 = coerced3;
+if(data !== undefined){
+data["forceCloseConnections"] = coerced3;
 }
 }
-if(_errs33 === errors){
-if(data9.allowHTTP1 !== undefined){
-let data10 = data9.allowHTTP1;
-if(typeof data10 !== "boolean"){
-let coerced11 = undefined;
-if(!(coerced11 !== undefined)){
-if(data10 === "false" || data10 === 0 || data10 === null){
-coerced11 = false;
 }
-else if(data10 === "true" || data10 === 1){
-coerced11 = true;
+var _valid0 = _errs10 === errors;
+if(_valid0 && valid1){
+valid1 = false;
+passing0 = [passing0, 1];
 }
 else {
-const err3 = {};
+if(_valid0){
+valid1 = true;
+passing0 = 1;
+}
+}
+if(!valid1){
+const err3 = {instancePath:instancePath+"/forceCloseConnections",schemaPath:"#/properties/forceCloseConnections/oneOf",keyword:"oneOf",params:{passingSchemas: passing0},message:"must match exactly one schema in oneOf"};
 if(vErrors === null){
 vErrors = [err3];
 }
@@ -427,18 +226,201 @@ else {
 vErrors.push(err3);
 }
 errors++;
+validate10.errors = vErrors;
+return false;
+}
+else {
+errors = _errs7;
+if(vErrors !== null){
+if(_errs7){
+vErrors.length = _errs7;
+}
+else {
+vErrors = null;
 }
 }
-if(coerced11 !== undefined){
-data10 = coerced11;
-if(data9 !== undefined){
-data9["allowHTTP1"] = coerced11;
+}
+var valid0 = _errs6 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+let data3 = data.maxRequestsPerSocket;
+const _errs12 = errors;
+if((!(((typeof data3 == "number") && (!(data3 % 1) && !isNaN(data3))) && (isFinite(data3)))) && (data3 !== null)){
+let dataType4 = typeof data3;
+let coerced4 = undefined;
+if(!(coerced4 !== undefined)){
+if(dataType4 === "boolean" || data3 === null
+              || (dataType4 === "string" && data3 && data3 == +data3 && !(data3 % 1))){
+coerced4 = +data3;
+}
+else if(data3 === "" || data3 === 0 || data3 === false){
+coerced4 = null;
+}
+else {
+validate10.errors = [{instancePath:instancePath+"/maxRequestsPerSocket",schemaPath:"#/properties/maxRequestsPerSocket/type",keyword:"type",params:{type: "integer"},message:"must be integer"}];
+return false;
+}
+}
+if(coerced4 !== undefined){
+data3 = coerced4;
+if(data !== undefined){
+data["maxRequestsPerSocket"] = coerced4;
 }
 }
 }
+var valid0 = _errs12 === errors;
+if(valid0){
+let data4 = data.requestTimeout;
+const _errs15 = errors;
+if(!(((typeof data4 == "number") && (!(data4 % 1) && !isNaN(data4))) && (isFinite(data4)))){
+let dataType5 = typeof data4;
+let coerced5 = undefined;
+if(!(coerced5 !== undefined)){
+if(dataType5 === "boolean" || data4 === null
+              || (dataType5 === "string" && data4 && data4 == +data4 && !(data4 % 1))){
+coerced5 = +data4;
+}
+else {
+validate10.errors = [{instancePath:instancePath+"/requestTimeout",schemaPath:"#/properties/requestTimeout/type",keyword:"type",params:{type: "integer"},message:"must be integer"}];
+return false;
+}
+}
+if(coerced5 !== undefined){
+data4 = coerced5;
+if(data !== undefined){
+data["requestTimeout"] = coerced5;
 }
 }
 }
+var valid0 = _errs15 === errors;
+if(valid0){
+let data5 = data.bodyLimit;
+const _errs17 = errors;
+if(!(((typeof data5 == "number") && (!(data5 % 1) && !isNaN(data5))) && (isFinite(data5)))){
+let dataType6 = typeof data5;
+let coerced6 = undefined;
+if(!(coerced6 !== undefined)){
+if(dataType6 === "boolean" || data5 === null
+              || (dataType6 === "string" && data5 && data5 == +data5 && !(data5 % 1))){
+coerced6 = +data5;
+}
+else {
+validate10.errors = [{instancePath:instancePath+"/bodyLimit",schemaPath:"#/properties/bodyLimit/type",keyword:"type",params:{type: "integer"},message:"must be integer"}];
+return false;
+}
+}
+if(coerced6 !== undefined){
+data5 = coerced6;
+if(data !== undefined){
+data["bodyLimit"] = coerced6;
+}
+}
+}
+var valid0 = _errs17 === errors;
+if(valid0){
+let data6 = data.caseSensitive;
+const _errs19 = errors;
+if(typeof data6 !== "boolean"){
+let coerced7 = undefined;
+if(!(coerced7 !== undefined)){
+if(data6 === "false" || data6 === 0 || data6 === null){
+coerced7 = false;
+}
+else if(data6 === "true" || data6 === 1){
+coerced7 = true;
+}
+else {
+validate10.errors = [{instancePath:instancePath+"/caseSensitive",schemaPath:"#/properties/caseSensitive/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
+return false;
+}
+}
+if(coerced7 !== undefined){
+data6 = coerced7;
+if(data !== undefined){
+data["caseSensitive"] = coerced7;
+}
+}
+}
+var valid0 = _errs19 === errors;
+if(valid0){
+let data7 = data.allowUnsafeRegex;
+const _errs21 = errors;
+if(typeof data7 !== "boolean"){
+let coerced8 = undefined;
+if(!(coerced8 !== undefined)){
+if(data7 === "false" || data7 === 0 || data7 === null){
+coerced8 = false;
+}
+else if(data7 === "true" || data7 === 1){
+coerced8 = true;
+}
+else {
+validate10.errors = [{instancePath:instancePath+"/allowUnsafeRegex",schemaPath:"#/properties/allowUnsafeRegex/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
+return false;
+}
+}
+if(coerced8 !== undefined){
+data7 = coerced8;
+if(data !== undefined){
+data["allowUnsafeRegex"] = coerced8;
+}
+}
+}
+var valid0 = _errs21 === errors;
+if(valid0){
+if(data.http2 !== undefined){
+let data8 = data.http2;
+const _errs23 = errors;
+if(typeof data8 !== "boolean"){
+let coerced9 = undefined;
+if(!(coerced9 !== undefined)){
+if(data8 === "false" || data8 === 0 || data8 === null){
+coerced9 = false;
+}
+else if(data8 === "true" || data8 === 1){
+coerced9 = true;
+}
+else {
+validate10.errors = [{instancePath:instancePath+"/http2",schemaPath:"#/properties/http2/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
+return false;
+}
+}
+if(coerced9 !== undefined){
+data8 = coerced9;
+if(data !== undefined){
+data["http2"] = coerced9;
+}
+}
+}
+var valid0 = _errs23 === errors;
+}
+else {
+var valid0 = true;
+}
+if(valid0){
+if(data.https !== undefined){
+let data9 = data.https;
+const _errs25 = errors;
+const _errs26 = errors;
+let valid2 = true;
+const _errs27 = errors;
+const _errs28 = errors;
+const _errs29 = errors;
+const _errs30 = errors;
+let valid4 = false;
+let passing1 = null;
+const _errs31 = errors;
+if(typeof data9 !== "boolean"){
+let coerced10 = undefined;
+if(!(coerced10 !== undefined)){
+if(data9 === "false" || data9 === 0 || data9 === null){
+coerced10 = false;
+}
+else if(data9 === "true" || data9 === 1){
+coerced10 = true;
 }
 else {
 const err4 = {};
@@ -451,19 +433,26 @@ vErrors.push(err4);
 errors++;
 }
 }
-var _valid1 = _errs31 === errors;
-if(_valid1 && valid3){
-valid3 = false;
-passing0 = [passing0, 2];
+if(coerced10 !== undefined){
+data9 = coerced10;
+if(data !== undefined){
+data["https"] = coerced10;
+}
+}
+}
+var _valid2 = _errs31 === errors;
+if(_valid2){
+valid4 = true;
+passing1 = 0;
+}
+const _errs33 = errors;
+if(data9 !== null){
+let coerced11 = undefined;
+if(!(coerced11 !== undefined)){
+if(data9 === "" || data9 === 0 || data9 === false){
+coerced11 = null;
 }
 else {
-if(_valid1){
-valid3 = true;
-passing0 = 2;
-}
-}
-}
-if(!valid3){
 const err5 = {};
 if(vErrors === null){
 vErrors = [err5];
@@ -473,19 +462,29 @@ vErrors.push(err5);
 }
 errors++;
 }
-else {
-errors = _errs26;
-if(vErrors !== null){
-if(_errs26){
-vErrors.length = _errs26;
+}
+if(coerced11 !== undefined){
+data9 = coerced11;
+if(data !== undefined){
+data["https"] = coerced11;
+}
+}
+}
+var _valid2 = _errs33 === errors;
+if(_valid2 && valid4){
+valid4 = false;
+passing1 = [passing1, 1];
 }
 else {
-vErrors = null;
+if(_valid2){
+valid4 = true;
+passing1 = 1;
 }
-}
-}
-var valid2 = _errs25 === errors;
-if(valid2){
+const _errs35 = errors;
+if(errors === _errs35){
+if(data9 && typeof data9 == "object" && !Array.isArray(data9)){
+let missing0;
+if((data9.allowHTTP1 === undefined) && (missing0 = "allowHTTP1")){
 const err6 = {};
 if(vErrors === null){
 vErrors = [err6];
@@ -496,34 +495,26 @@ vErrors.push(err6);
 errors++;
 }
 else {
-errors = _errs24;
-if(vErrors !== null){
-if(_errs24){
-vErrors.length = _errs24;
+const _errs37 = errors;
+for(const key1 in data9){
+if(!(key1 === "allowHTTP1")){
+delete data9[key1];
+}
+}
+if(_errs37 === errors){
+if(data9.allowHTTP1 !== undefined){
+let data10 = data9.allowHTTP1;
+if(typeof data10 !== "boolean"){
+let coerced12 = undefined;
+if(!(coerced12 !== undefined)){
+if(data10 === "false" || data10 === 0 || data10 === null){
+coerced12 = false;
+}
+else if(data10 === "true" || data10 === 1){
+coerced12 = true;
 }
 else {
-vErrors = null;
-}
-}
-}
-var _valid0 = _errs23 === errors;
-errors = _errs22;
-if(vErrors !== null){
-if(_errs22){
-vErrors.length = _errs22;
-}
-else {
-vErrors = null;
-}
-}
-if(_valid0){
-const _errs36 = errors;
-data["https"] = true;
-var _valid0 = _errs36 === errors;
-valid1 = _valid0;
-}
-if(!valid1){
-const err7 = {instancePath:instancePath+"/https",schemaPath:"#/properties/https/if",keyword:"if",params:{failingKeyword: "then"},message:"must match \"then\" schema"};
+const err7 = {};
 if(vErrors === null){
 vErrors = [err7];
 }
@@ -531,320 +522,424 @@ else {
 vErrors.push(err7);
 }
 errors++;
+}
+}
+if(coerced12 !== undefined){
+data10 = coerced12;
+if(data9 !== undefined){
+data9["allowHTTP1"] = coerced12;
+}
+}
+}
+}
+}
+}
+}
+else {
+const err8 = {};
+if(vErrors === null){
+vErrors = [err8];
+}
+else {
+vErrors.push(err8);
+}
+errors++;
+}
+}
+var _valid2 = _errs35 === errors;
+if(_valid2 && valid4){
+valid4 = false;
+passing1 = [passing1, 2];
+}
+else {
+if(_valid2){
+valid4 = true;
+passing1 = 2;
+}
+}
+}
+if(!valid4){
+const err9 = {};
+if(vErrors === null){
+vErrors = [err9];
+}
+else {
+vErrors.push(err9);
+}
+errors++;
+}
+else {
+errors = _errs30;
+if(vErrors !== null){
+if(_errs30){
+vErrors.length = _errs30;
+}
+else {
+vErrors = null;
+}
+}
+}
+var valid3 = _errs29 === errors;
+if(valid3){
+const err10 = {};
+if(vErrors === null){
+vErrors = [err10];
+}
+else {
+vErrors.push(err10);
+}
+errors++;
+}
+else {
+errors = _errs28;
+if(vErrors !== null){
+if(_errs28){
+vErrors.length = _errs28;
+}
+else {
+vErrors = null;
+}
+}
+}
+var _valid1 = _errs27 === errors;
+errors = _errs26;
+if(vErrors !== null){
+if(_errs26){
+vErrors.length = _errs26;
+}
+else {
+vErrors = null;
+}
+}
+if(_valid1){
+const _errs40 = errors;
+data["https"] = true;
+var _valid1 = _errs40 === errors;
+valid2 = _valid1;
+}
+if(!valid2){
+const err11 = {instancePath:instancePath+"/https",schemaPath:"#/properties/https/if",keyword:"if",params:{failingKeyword: "then"},message:"must match \"then\" schema"};
+if(vErrors === null){
+vErrors = [err11];
+}
+else {
+vErrors.push(err11);
+}
+errors++;
 validate10.errors = vErrors;
 return false;
 }
-var valid0 = _errs21 === errors;
+var valid0 = _errs25 === errors;
 }
 else {
 var valid0 = true;
 }
 if(valid0){
 let data11 = data.ignoreTrailingSlash;
-const _errs37 = errors;
+const _errs41 = errors;
 if(typeof data11 !== "boolean"){
-let coerced12 = undefined;
-if(!(coerced12 !== undefined)){
+let coerced13 = undefined;
+if(!(coerced13 !== undefined)){
 if(data11 === "false" || data11 === 0 || data11 === null){
-coerced12 = false;
+coerced13 = false;
 }
 else if(data11 === "true" || data11 === 1){
-coerced12 = true;
+coerced13 = true;
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/ignoreTrailingSlash",schemaPath:"#/properties/ignoreTrailingSlash/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
 return false;
 }
 }
-if(coerced12 !== undefined){
-data11 = coerced12;
+if(coerced13 !== undefined){
+data11 = coerced13;
 if(data !== undefined){
-data["ignoreTrailingSlash"] = coerced12;
+data["ignoreTrailingSlash"] = coerced13;
 }
 }
 }
-var valid0 = _errs37 === errors;
+var valid0 = _errs41 === errors;
 if(valid0){
 let data12 = data.ignoreDuplicateSlashes;
-const _errs39 = errors;
+const _errs43 = errors;
 if(typeof data12 !== "boolean"){
-let coerced13 = undefined;
-if(!(coerced13 !== undefined)){
+let coerced14 = undefined;
+if(!(coerced14 !== undefined)){
 if(data12 === "false" || data12 === 0 || data12 === null){
-coerced13 = false;
+coerced14 = false;
 }
 else if(data12 === "true" || data12 === 1){
-coerced13 = true;
+coerced14 = true;
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/ignoreDuplicateSlashes",schemaPath:"#/properties/ignoreDuplicateSlashes/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
 return false;
 }
 }
-if(coerced13 !== undefined){
-data12 = coerced13;
+if(coerced14 !== undefined){
+data12 = coerced14;
 if(data !== undefined){
-data["ignoreDuplicateSlashes"] = coerced13;
+data["ignoreDuplicateSlashes"] = coerced14;
 }
 }
 }
-var valid0 = _errs39 === errors;
+var valid0 = _errs43 === errors;
 if(valid0){
 let data13 = data.disableRequestLogging;
-const _errs41 = errors;
+const _errs45 = errors;
 if(typeof data13 !== "boolean"){
-let coerced14 = undefined;
-if(!(coerced14 !== undefined)){
+let coerced15 = undefined;
+if(!(coerced15 !== undefined)){
 if(data13 === "false" || data13 === 0 || data13 === null){
-coerced14 = false;
+coerced15 = false;
 }
 else if(data13 === "true" || data13 === 1){
-coerced14 = true;
+coerced15 = true;
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/disableRequestLogging",schemaPath:"#/properties/disableRequestLogging/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
 return false;
 }
 }
-if(coerced14 !== undefined){
-data13 = coerced14;
+if(coerced15 !== undefined){
+data13 = coerced15;
 if(data !== undefined){
-data["disableRequestLogging"] = coerced14;
+data["disableRequestLogging"] = coerced15;
 }
 }
 }
-var valid0 = _errs41 === errors;
+var valid0 = _errs45 === errors;
 if(valid0){
 let data14 = data.jsonShorthand;
-const _errs43 = errors;
+const _errs47 = errors;
 if(typeof data14 !== "boolean"){
-let coerced15 = undefined;
-if(!(coerced15 !== undefined)){
+let coerced16 = undefined;
+if(!(coerced16 !== undefined)){
 if(data14 === "false" || data14 === 0 || data14 === null){
-coerced15 = false;
+coerced16 = false;
 }
 else if(data14 === "true" || data14 === 1){
-coerced15 = true;
+coerced16 = true;
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/jsonShorthand",schemaPath:"#/properties/jsonShorthand/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
 return false;
 }
 }
-if(coerced15 !== undefined){
-data14 = coerced15;
+if(coerced16 !== undefined){
+data14 = coerced16;
 if(data !== undefined){
-data["jsonShorthand"] = coerced15;
+data["jsonShorthand"] = coerced16;
 }
 }
 }
-var valid0 = _errs43 === errors;
+var valid0 = _errs47 === errors;
 if(valid0){
 let data15 = data.maxParamLength;
-const _errs45 = errors;
+const _errs49 = errors;
 if(!(((typeof data15 == "number") && (!(data15 % 1) && !isNaN(data15))) && (isFinite(data15)))){
-let dataType16 = typeof data15;
-let coerced16 = undefined;
-if(!(coerced16 !== undefined)){
-if(dataType16 === "boolean" || data15 === null
-              || (dataType16 === "string" && data15 && data15 == +data15 && !(data15 % 1))){
-coerced16 = +data15;
+let dataType17 = typeof data15;
+let coerced17 = undefined;
+if(!(coerced17 !== undefined)){
+if(dataType17 === "boolean" || data15 === null
+              || (dataType17 === "string" && data15 && data15 == +data15 && !(data15 % 1))){
+coerced17 = +data15;
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/maxParamLength",schemaPath:"#/properties/maxParamLength/type",keyword:"type",params:{type: "integer"},message:"must be integer"}];
 return false;
 }
 }
-if(coerced16 !== undefined){
-data15 = coerced16;
+if(coerced17 !== undefined){
+data15 = coerced17;
 if(data !== undefined){
-data["maxParamLength"] = coerced16;
+data["maxParamLength"] = coerced17;
 }
 }
 }
-var valid0 = _errs45 === errors;
+var valid0 = _errs49 === errors;
 if(valid0){
 let data16 = data.onProtoPoisoning;
-const _errs47 = errors;
+const _errs51 = errors;
 if(typeof data16 !== "string"){
-let dataType17 = typeof data16;
-let coerced17 = undefined;
-if(!(coerced17 !== undefined)){
-if(dataType17 == "number" || dataType17 == "boolean"){
-coerced17 = "" + data16;
+let dataType18 = typeof data16;
+let coerced18 = undefined;
+if(!(coerced18 !== undefined)){
+if(dataType18 == "number" || dataType18 == "boolean"){
+coerced18 = "" + data16;
 }
 else if(data16 === null){
-coerced17 = "";
+coerced18 = "";
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/onProtoPoisoning",schemaPath:"#/properties/onProtoPoisoning/type",keyword:"type",params:{type: "string"},message:"must be string"}];
 return false;
 }
 }
-if(coerced17 !== undefined){
-data16 = coerced17;
+if(coerced18 !== undefined){
+data16 = coerced18;
 if(data !== undefined){
-data["onProtoPoisoning"] = coerced17;
+data["onProtoPoisoning"] = coerced18;
 }
 }
 }
-var valid0 = _errs47 === errors;
+var valid0 = _errs51 === errors;
 if(valid0){
 let data17 = data.onConstructorPoisoning;
-const _errs49 = errors;
+const _errs53 = errors;
 if(typeof data17 !== "string"){
-let dataType18 = typeof data17;
-let coerced18 = undefined;
-if(!(coerced18 !== undefined)){
-if(dataType18 == "number" || dataType18 == "boolean"){
-coerced18 = "" + data17;
+let dataType19 = typeof data17;
+let coerced19 = undefined;
+if(!(coerced19 !== undefined)){
+if(dataType19 == "number" || dataType19 == "boolean"){
+coerced19 = "" + data17;
 }
 else if(data17 === null){
-coerced18 = "";
+coerced19 = "";
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/onConstructorPoisoning",schemaPath:"#/properties/onConstructorPoisoning/type",keyword:"type",params:{type: "string"},message:"must be string"}];
 return false;
 }
 }
-if(coerced18 !== undefined){
-data17 = coerced18;
+if(coerced19 !== undefined){
+data17 = coerced19;
 if(data !== undefined){
-data["onConstructorPoisoning"] = coerced18;
+data["onConstructorPoisoning"] = coerced19;
 }
 }
 }
-var valid0 = _errs49 === errors;
+var valid0 = _errs53 === errors;
 if(valid0){
 let data18 = data.pluginTimeout;
-const _errs51 = errors;
+const _errs55 = errors;
 if(!(((typeof data18 == "number") && (!(data18 % 1) && !isNaN(data18))) && (isFinite(data18)))){
-let dataType19 = typeof data18;
-let coerced19 = undefined;
-if(!(coerced19 !== undefined)){
-if(dataType19 === "boolean" || data18 === null
-              || (dataType19 === "string" && data18 && data18 == +data18 && !(data18 % 1))){
-coerced19 = +data18;
+let dataType20 = typeof data18;
+let coerced20 = undefined;
+if(!(coerced20 !== undefined)){
+if(dataType20 === "boolean" || data18 === null
+              || (dataType20 === "string" && data18 && data18 == +data18 && !(data18 % 1))){
+coerced20 = +data18;
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/pluginTimeout",schemaPath:"#/properties/pluginTimeout/type",keyword:"type",params:{type: "integer"},message:"must be integer"}];
 return false;
 }
 }
-if(coerced19 !== undefined){
-data18 = coerced19;
+if(coerced20 !== undefined){
+data18 = coerced20;
 if(data !== undefined){
-data["pluginTimeout"] = coerced19;
+data["pluginTimeout"] = coerced20;
 }
 }
 }
-var valid0 = _errs51 === errors;
+var valid0 = _errs55 === errors;
 if(valid0){
 let data19 = data.requestIdHeader;
-const _errs53 = errors;
+const _errs57 = errors;
 if(typeof data19 !== "string"){
-let dataType20 = typeof data19;
-let coerced20 = undefined;
-if(!(coerced20 !== undefined)){
-if(dataType20 == "number" || dataType20 == "boolean"){
-coerced20 = "" + data19;
+let dataType21 = typeof data19;
+let coerced21 = undefined;
+if(!(coerced21 !== undefined)){
+if(dataType21 == "number" || dataType21 == "boolean"){
+coerced21 = "" + data19;
 }
 else if(data19 === null){
-coerced20 = "";
+coerced21 = "";
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/requestIdHeader",schemaPath:"#/properties/requestIdHeader/type",keyword:"type",params:{type: "string"},message:"must be string"}];
 return false;
 }
 }
-if(coerced20 !== undefined){
-data19 = coerced20;
+if(coerced21 !== undefined){
+data19 = coerced21;
 if(data !== undefined){
-data["requestIdHeader"] = coerced20;
+data["requestIdHeader"] = coerced21;
 }
 }
 }
-var valid0 = _errs53 === errors;
+var valid0 = _errs57 === errors;
 if(valid0){
 let data20 = data.requestIdLogLabel;
-const _errs55 = errors;
+const _errs59 = errors;
 if(typeof data20 !== "string"){
-let dataType21 = typeof data20;
-let coerced21 = undefined;
-if(!(coerced21 !== undefined)){
-if(dataType21 == "number" || dataType21 == "boolean"){
-coerced21 = "" + data20;
+let dataType22 = typeof data20;
+let coerced22 = undefined;
+if(!(coerced22 !== undefined)){
+if(dataType22 == "number" || dataType22 == "boolean"){
+coerced22 = "" + data20;
 }
 else if(data20 === null){
-coerced21 = "";
+coerced22 = "";
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/requestIdLogLabel",schemaPath:"#/properties/requestIdLogLabel/type",keyword:"type",params:{type: "string"},message:"must be string"}];
 return false;
 }
 }
-if(coerced21 !== undefined){
-data20 = coerced21;
+if(coerced22 !== undefined){
+data20 = coerced22;
 if(data !== undefined){
-data["requestIdLogLabel"] = coerced21;
+data["requestIdLogLabel"] = coerced22;
 }
 }
 }
-var valid0 = _errs55 === errors;
+var valid0 = _errs59 === errors;
 if(valid0){
 let data21 = data.http2SessionTimeout;
-const _errs57 = errors;
+const _errs61 = errors;
 if(!(((typeof data21 == "number") && (!(data21 % 1) && !isNaN(data21))) && (isFinite(data21)))){
-let dataType22 = typeof data21;
-let coerced22 = undefined;
-if(!(coerced22 !== undefined)){
-if(dataType22 === "boolean" || data21 === null
-              || (dataType22 === "string" && data21 && data21 == +data21 && !(data21 % 1))){
-coerced22 = +data21;
+let dataType23 = typeof data21;
+let coerced23 = undefined;
+if(!(coerced23 !== undefined)){
+if(dataType23 === "boolean" || data21 === null
+              || (dataType23 === "string" && data21 && data21 == +data21 && !(data21 % 1))){
+coerced23 = +data21;
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/http2SessionTimeout",schemaPath:"#/properties/http2SessionTimeout/type",keyword:"type",params:{type: "integer"},message:"must be integer"}];
 return false;
 }
 }
-if(coerced22 !== undefined){
-data21 = coerced22;
+if(coerced23 !== undefined){
+data21 = coerced23;
 if(data !== undefined){
-data["http2SessionTimeout"] = coerced22;
+data["http2SessionTimeout"] = coerced23;
 }
 }
 }
-var valid0 = _errs57 === errors;
+var valid0 = _errs61 === errors;
 if(valid0){
 let data22 = data.exposeHeadRoutes;
-const _errs59 = errors;
+const _errs63 = errors;
 if(typeof data22 !== "boolean"){
-let coerced23 = undefined;
-if(!(coerced23 !== undefined)){
+let coerced24 = undefined;
+if(!(coerced24 !== undefined)){
 if(data22 === "false" || data22 === 0 || data22 === null){
-coerced23 = false;
+coerced24 = false;
 }
 else if(data22 === "true" || data22 === 1){
-coerced23 = true;
+coerced24 = true;
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/exposeHeadRoutes",schemaPath:"#/properties/exposeHeadRoutes/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
 return false;
 }
 }
-if(coerced23 !== undefined){
-data22 = coerced23;
+if(coerced24 !== undefined){
+data22 = coerced24;
 if(data !== undefined){
-data["exposeHeadRoutes"] = coerced23;
+data["exposeHeadRoutes"] = coerced24;
 }
 }
 }
-var valid0 = _errs59 === errors;
+var valid0 = _errs63 === errors;
 if(valid0){
 if(data.versioning !== undefined){
 let data23 = data.versioning;
-const _errs61 = errors;
-if(errors === _errs61){
+const _errs65 = errors;
+if(errors === _errs65){
 if(data23 && typeof data23 == "object" && !Array.isArray(data23)){
 let missing1;
 if(((data23.storage === undefined) && (missing1 = "storage")) || ((data23.deriveVersion === undefined) && (missing1 = "deriveVersion"))){
@@ -857,7 +952,7 @@ validate10.errors = [{instancePath:instancePath+"/versioning",schemaPath:"#/prop
 return false;
 }
 }
-var valid0 = _errs61 === errors;
+var valid0 = _errs65 === errors;
 }
 else {
 var valid0 = true;
@@ -865,13 +960,13 @@ var valid0 = true;
 if(valid0){
 if(data.constraints !== undefined){
 let data24 = data.constraints;
-const _errs64 = errors;
-if(errors === _errs64){
+const _errs68 = errors;
+if(errors === _errs68){
 if(data24 && typeof data24 == "object" && !Array.isArray(data24)){
 for(const key2 in data24){
 let data25 = data24[key2];
-const _errs67 = errors;
-if(errors === _errs67){
+const _errs71 = errors;
+if(errors === _errs71){
 if(data25 && typeof data25 == "object" && !Array.isArray(data25)){
 let missing2;
 if(((((data25.name === undefined) && (missing2 = "name")) || ((data25.storage === undefined) && (missing2 = "storage"))) || ((data25.validate === undefined) && (missing2 = "validate"))) || ((data25.deriveConstraint === undefined) && (missing2 = "deriveConstraint"))){
@@ -882,24 +977,24 @@ else {
 if(data25.name !== undefined){
 let data26 = data25.name;
 if(typeof data26 !== "string"){
-let dataType24 = typeof data26;
-let coerced24 = undefined;
-if(!(coerced24 !== undefined)){
-if(dataType24 == "number" || dataType24 == "boolean"){
-coerced24 = "" + data26;
+let dataType25 = typeof data26;
+let coerced25 = undefined;
+if(!(coerced25 !== undefined)){
+if(dataType25 == "number" || dataType25 == "boolean"){
+coerced25 = "" + data26;
 }
 else if(data26 === null){
-coerced24 = "";
+coerced25 = "";
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/constraints/" + key2.replace(/~/g, "~0").replace(/\//g, "~1")+"/name",schemaPath:"#/properties/constraints/additionalProperties/properties/name/type",keyword:"type",params:{type: "string"},message:"must be string"}];
 return false;
 }
 }
-if(coerced24 !== undefined){
-data26 = coerced24;
+if(coerced25 !== undefined){
+data26 = coerced25;
 if(data25 !== undefined){
-data25["name"] = coerced24;
+data25["name"] = coerced25;
 }
 }
 }
@@ -911,8 +1006,8 @@ validate10.errors = [{instancePath:instancePath+"/constraints/" + key2.replace(/
 return false;
 }
 }
-var valid5 = _errs67 === errors;
-if(!valid5){
+var valid6 = _errs71 === errors;
+if(!valid6){
 break;
 }
 }
@@ -922,7 +1017,7 @@ validate10.errors = [{instancePath:instancePath+"/constraints",schemaPath:"#/pro
 return false;
 }
 }
-var valid0 = _errs64 === errors;
+var valid0 = _errs68 === errors;
 }
 else {
 var valid0 = true;
@@ -962,4 +1057,4 @@ return errors === 0;
 }
 
 
-module.exports.defaultInitOptions = {"connectionTimeout":0,"keepAliveTimeout":72000,"forceCloseConnections":false,"maxRequestsPerSocket":0,"requestTimeout":0,"bodyLimit":1048576,"caseSensitive":true,"allowUnsafeRegex":false,"disableRequestLogging":false,"jsonShorthand":true,"ignoreTrailingSlash":false,"ignoreDuplicateSlashes":false,"maxParamLength":100,"onProtoPoisoning":"error","onConstructorPoisoning":"error","pluginTimeout":10000,"requestIdHeader":"request-id","requestIdLogLabel":"reqId","http2SessionTimeout":72000,"exposeHeadRoutes":true}
+module.exports.defaultInitOptions = {"connectionTimeout":0,"keepAliveTimeout":72000,"maxRequestsPerSocket":0,"requestTimeout":0,"bodyLimit":1048576,"caseSensitive":true,"allowUnsafeRegex":false,"disableRequestLogging":false,"jsonShorthand":true,"ignoreTrailingSlash":false,"ignoreDuplicateSlashes":false,"maxParamLength":100,"onProtoPoisoning":"error","onConstructorPoisoning":"error","pluginTimeout":10000,"requestIdHeader":"request-id","requestIdLogLabel":"reqId","http2SessionTimeout":72000,"exposeHeadRoutes":true}

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -200,6 +200,10 @@ const codes = {
     'FST_ERR_INIT_OPTS_INVALID',
     "Invalid initialization options: '%s'"
   ),
+  FST_ERR_FORCE_CLOSE_CONNECTIONS_IDLE_NOT_AVAILABLE: createError(
+    'FST_ERR_FORCE_CLOSE_CONNECTIONS_IDLE_NOT_AVAILABLE',
+    "Cannot set forceCloseConnections to 'idle' as your HTTP server does not support closeIdleConnections method"
+  ),
 
   /**
    * router

--- a/lib/route.js
+++ b/lib/route.js
@@ -42,7 +42,6 @@ const {
 const { buildErrorHandler } = require('./error-handler')
 
 function buildRouting (options) {
-  const { keepAliveConnections } = options
   const router = FindMyWay(options.config)
 
   let avvio
@@ -60,6 +59,7 @@ function buildRouting (options) {
   let return503OnClosing
   let globalExposeHeadRoutes
   let validateHTTPVersion
+  let keepAliveConnections
 
   let closing = false
 
@@ -81,6 +81,7 @@ function buildRouting (options) {
       ignoreTrailingSlash = options.ignoreTrailingSlash
       ignoreDuplicateSlashes = options.ignoreDuplicateSlashes
       return503OnClosing = Object.prototype.hasOwnProperty.call(options, 'return503OnClosing') ? options.return503OnClosing : true
+      keepAliveConnections = fastifyArgs.keepAliveConnections
     },
     routing: router.lookup.bind(router), // router func to find the right handler to call
     route, // configure a route in the fastify instance

--- a/test/close-pipelining.test.js
+++ b/test/close-pipelining.test.js
@@ -7,7 +7,8 @@ const { Client } = require('undici')
 
 test('Should return 503 while closing - pipelining', t => {
   const fastify = Fastify({
-    return503OnClosing: true
+    return503OnClosing: true,
+    forceCloseConnections: false
   })
 
   fastify.get('/', (req, reply) => {
@@ -40,7 +41,8 @@ test('Should return 503 while closing - pipelining', t => {
 
 test('Should not return 503 while closing - pipelining - return503OnClosing', t => {
   const fastify = Fastify({
-    return503OnClosing: false
+    return503OnClosing: false,
+    forceCloseConnections: false
   })
 
   fastify.get('/', (req, reply) => {

--- a/test/custom-http-server.test.js
+++ b/test/custom-http-server.test.js
@@ -4,6 +4,7 @@ const t = require('tap')
 const test = t.test
 const Fastify = require('..')
 const http = require('http')
+const { FST_ERR_FORCE_CLOSE_CONNECTIONS_IDLE_NOT_AVAILABLE } = require('../lib/errors')
 const sget = require('simple-get').concat
 const dns = require('dns').promises
 
@@ -48,4 +49,25 @@ test('Should support a custom http server', async t => {
       resolve()
     })
   })
+})
+
+test('Should not allow forceCloseConnection=idle if the server does not support closeIdleConnections', t => {
+  t.plan(1)
+
+  t.throws(
+    () => {
+      Fastify({
+        forceCloseConnections: 'idle',
+        serverFactory (handler, opts) {
+          return {
+            on () {
+
+            }
+          }
+        }
+      })
+    },
+    FST_ERR_FORCE_CLOSE_CONNECTIONS_IDLE_NOT_AVAILABLE,
+    "Cannot set forceCloseConnections to 'idle' as your HTTP server does not support closeIdleConnections method"
+  )
 })

--- a/test/internals/initialConfig.test.js
+++ b/test/internals/initialConfig.test.js
@@ -32,7 +32,6 @@ test('without options passed to Fastify, initialConfig should expose default val
   const fastifyDefaultOptions = {
     connectionTimeout: 0,
     keepAliveTimeout: 72000,
-    forceCloseConnections: false,
     maxRequestsPerSocket: 0,
     requestTimeout: 0,
     bodyLimit: 1024 * 1024,
@@ -265,7 +264,6 @@ test('Should not have issues when passing stream options to Pino.js', t => {
     t.same(fastify.initialConfig, {
       connectionTimeout: 0,
       keepAliveTimeout: 72000,
-      forceCloseConnections: false,
       maxRequestsPerSocket: 0,
       requestTimeout: 0,
       bodyLimit: 1024 * 1024,


### PR DESCRIPTION
This PR aims to leverage the new Node.js 18.2.0 APIs if available and changes the `forceCloseConnection` option as follows:

* `forceCloseConnection=false` - No connection handling is done
* `forceCloseConnection=true` - Use `closeAllConnections` if available, otherwise the fastify connection handling.
* `forceCloseConnection="idle"` - Use `closeIdleConnections` if available, otherwise throws an error.

The option defaults to `"idle"` if the server supports `closeIdleConnections`, otherwise to `false`.

Fixes #3924.