### PR TITLE
docs(Reference/Logging): update suggested pino-pretty configuration

### DIFF
--- a/docs/Guides/Testing.md
+++ b/docs/Guides/Testing.md
@@ -43,7 +43,9 @@ module.exports = build
 const server = require('./app')({
   logger: {
     level: 'info',
-    prettyPrint: true
+    transport: {
+      target: 'pino-pretty'
+    }
   }
 })
 

--- a/docs/Reference/Logging.md
+++ b/docs/Reference/Logging.md
@@ -122,7 +122,9 @@ below (even if it is *not recommended*):
 ```js
 const fastify = require('fastify')({
   logger: {
-    prettyPrint: true,
+    transport: {
+      target: 'pino-pretty'
+    },
     serializers: {
       res (reply) {
         // The default

--- a/docs/Reference/Logging.md
+++ b/docs/Reference/Logging.md
@@ -26,13 +26,16 @@ and production environment requires bit more configuration:
 ```js
 const fastify = require('fastify')({
   logger: {
-      prettyPrint:
+      transport:
         environment === 'development'
           ? {
-              translateTime: 'HH:MM:ss Z',
-              ignore: 'pid,hostname'
+              target: 'pino-pretty',
+              options: {
+                translateTime: 'HH:MM:ss Z',
+                ignore: 'pid,hostname'
+              }
             }
-          : false
+          : undefined
     }
 })
 ```


### PR DESCRIPTION
Passing prettyPrint: true/false/{} at the top level to pino configuration is deprecated.

Update docs to configure pino-pretty as a transport when in development, as suggested here — https://github.com/pinojs/pino-pretty#programmatic-integration

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
