### PR TITLE
fix: handler return reply type

### DIFF
--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -27,6 +27,14 @@ const routeHandler: RouteHandlerMethod = function (request, reply) {
   expectType<FastifyReply>(reply)
 }
 
+const routeHandlerWithReturnValue: RouteHandlerMethod = function (request, reply) {
+  expectType<FastifyInstance>(this)
+  expectType<FastifyRequest>(request)
+  expectType<FastifyReply>(reply)
+
+  return reply.send()
+}
+
 type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete' | 'options'
 
 ;['GET', 'POST', 'PUT', 'PATCH', 'HEAD', 'DELETE', 'OPTIONS'].forEach(method => {
@@ -215,4 +223,10 @@ expectType<FastifyInstance>(fastify().route({
 
 expectError(fastify().route({
   prefixTrailingSlash: true // Not a valid value
+}))
+
+expectType<FastifyInstance>(fastify().route({
+  url: '/',
+  method: 'GET',
+  handler: routeHandlerWithReturnValue
 }))

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -154,7 +154,7 @@ export type RouteHandler<
   this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
   request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig, RequestType, Logger>,
   reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>
-) => void | Promise<RouteGeneric['Reply'] | void>
+) => RouteGeneric['Reply'] | void | Promise<RouteGeneric['Reply'] | void>
 
 export type DefaultRoute<Request, Reply> = (
   req: Request,

--- a/types/type-provider.d.ts
+++ b/types/type-provider.d.ts
@@ -93,7 +93,7 @@ TypeProvider,
 SchemaCompiler,
 RouteGeneric
 > extends infer Return ?
-  (void | Promise<Return | void>)
+  (Return | void | Promise<Return | void>)
 // review: support both async and sync return types
 // (Promise<Return> | Return | Promise<void> | void)
   : unknown


### PR DESCRIPTION
Fix: https://github.com/fastify/fastify/issues/3923

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

## Reply Types
This PR fixes the problem when returning the `Reply` parameter on the `Handler`.

### Current
The current implementation allow us to return the `Replay` parameter only on async `Handlers`.
```typescript
const routeHandler: RouteHandlerMethod = async (request, reply) => {
  return reply.send();
}
```
But it is not the same for sync `Handlers`.

### Proposed
Add the `Reply` parameter type on the `Handlers` return types, to both (async and sync) have the same behavior.
```typescript
const routeHandler: RouteHandlerMethod = (request, reply) => {
  return reply.send();
}
```