### PR TITLE
docs(guides): fix page name style

### DIFF
--- a/docs/Guides/Index.md
+++ b/docs/Guides/Index.md
@@ -10,7 +10,7 @@ This table of contents is in alphabetical order.
 + [Contributing](./Contributing.md): Details how to participate in the
   development of Fastify, and shows how to setup an environment compatible with
   the project's code style.
-+ [`Delay Accepting Requests`](./Delay-Accepting-Requests.md): A practical guide
++ [Delay Accepting Requests](./Delay-Accepting-Requests.md): A practical guide
   on how to delay serving requests to specific routes until some condition is
   met in your application. This guide focuses on solving the problem using
   [`Hooks`](../Reference/Hooks.md), [`Decorators`](../Reference/Decorators.md),


### PR DESCRIPTION
Back ticks meant the guide was not appearing on the website:

![image](https://user-images.githubusercontent.com/43814140/171139628-35dc8f74-878a-4dc8-befd-cdfd12e02d58.png)


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
