### PR TITLE
chore: Fix types for child loggers

### DIFF
--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType } from 'tsd'
+import { expectError, expectType } from 'tsd'
 import fastify, {
   FastifyLogFn,
   LogLevel,
@@ -212,3 +212,16 @@ const passPinoOption = fastify({
 })
 
 expectType<FastifyBaseLogger>(passPinoOption.log)
+
+
+const childParent = fastify().log
+// we test different option variant here
+expectType<FastifyLoggerInstance>(childParent.child({}, { level: 'info' }))
+expectType<FastifyLoggerInstance>(childParent.child({}, { redact: ['pass', 'pin'] }))
+expectType<FastifyLoggerInstance>(childParent.child({}, { serializers: { key: () => {} } }))
+expectType<FastifyLoggerInstance>(childParent.child({}, { level: 'info', redact: ['pass', 'pin'], serializers: { key: () => {} } }))
+
+// no option pass
+expectError(childParent.child())
+// wrong option
+expectError(childParent.child({}, { nonExist: true }))

--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -213,7 +213,6 @@ const passPinoOption = fastify({
 
 expectType<FastifyBaseLogger>(passPinoOption.log)
 
-
 const childParent = fastify().log
 // we test different option variant here
 expectType<FastifyLoggerInstance>(childParent.child({}, { level: 'info' }))

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -23,7 +23,7 @@ export type FastifyLoggerInstance = pino.Logger
 // TODO make pino export BaseLogger again
 // export type FastifyBaseLogger = pino.BaseLogger & {
 export type FastifyBaseLogger = pino.Logger & {
-  child(bindings: Bindings, options?: ChildLoggerOptions): FastifyLoggerInstance;
+  child(bindings: Bindings, options?: ChildLoggerOptions): FastifyBaseLogger;
 }
 
 export interface FastifyLoggerStreamDestination {

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -17,11 +17,13 @@ export type LogLevel = pino.Level
 
 export type Bindings = pino.Bindings
 
+export type ChildLoggerOptions = pino.ChildLoggerOptions
+
 export type FastifyLoggerInstance = pino.Logger
 // TODO make pino export BaseLogger again
 // export type FastifyBaseLogger = pino.BaseLogger & {
 export type FastifyBaseLogger = pino.Logger & {
-  child(bindings: Bindings): FastifyBaseLogger
+  child(bindings: Bindings, options?: ChildLoggerOptions): FastifyLoggerInstance;
 }
 
 export interface FastifyLoggerStreamDestination {

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -23,7 +23,7 @@ export type FastifyLoggerInstance = pino.Logger
 // TODO make pino export BaseLogger again
 // export type FastifyBaseLogger = pino.BaseLogger & {
 export type FastifyBaseLogger = pino.Logger & {
-  child(bindings: Bindings, options?: ChildLoggerOptions): FastifyBaseLogger;
+  child(bindings: Bindings, options?: ChildLoggerOptions): FastifyBaseLogger
 }
 
 export interface FastifyLoggerStreamDestination {


### PR DESCRIPTION
forward-port of #3896

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
