### PR TITLE
feat: allow default as status code

### DIFF
--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -567,10 +567,17 @@ fastify.post('/the/url', { schema }, handler)
 ```
 
 As you can see, the response schema is based on the status code. If you want to
-use the same schema for multiple status codes, you can use `'2xx'`, for example:
+use the same schema for multiple status codes, you can use `'2xx'` or `default`,
+for example:
 ```js
 const schema = {
   response: {
+    default: {
+      type: 'object',
+      properties: {
+        isError: { type: 'boolean' }
+      }
+    },
     '2xx': {
       type: 'object',
       properties: {

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -575,7 +575,10 @@ const schema = {
     default: {
       type: 'object',
       properties: {
-        isError: { type: 'boolean' }
+        error: { 
+          type: 'boolean', 
+          default: true 
+        }
       }
     },
     '2xx': {

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -143,6 +143,9 @@ function getSchemaSerializer (context, statusCode) {
   if (responseSchemaDef[fallbackStatusCode]) {
     return responseSchemaDef[fallbackStatusCode]
   }
+  if (responseSchemaDef.default) {
+    return responseSchemaDef.default
+  }
   return false
 }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -7,7 +7,7 @@ const {
   kSchemaBody: bodySchema,
   kSchemaResponse: responseSchema
 } = require('./symbols')
-const scChecker = /^[1-5]{1}[0-9]{2}$|^[1-5]xx$/
+const scChecker = /^[1-5]{1}[0-9]{2}$|^[1-5]xx$|^default$/
 
 function compileSchemasForSerialization (context, compile) {
   if (!context.schema || !context.schema.response) {

--- a/test/schema-serialization.test.js
+++ b/test/schema-serialization.test.js
@@ -738,3 +738,33 @@ test('capital X', t => {
     t.equal(res.statusCode, 200)
   })
 })
+
+test('allow default as status code and used as last fallback', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.route({
+    url: '/',
+    method: 'GET',
+    schema: {
+      response: {
+        default: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            work: { type: 'string' }
+          }
+        }
+      }
+    },
+    handler: (req, reply) => {
+      reply.code(200).send({ name: 'Foo', work: 'Bar', nick: 'Boo' })
+    }
+  })
+
+  fastify.inject('/', (err, res) => {
+    t.error(err)
+    t.same(res.json(), { name: 'Foo', work: 'Bar' })
+    t.equal(res.statusCode, 200)
+  })
+})


### PR DESCRIPTION
Fixes https://github.com/fastify/fastify-swagger/issues/611

allow passing `default` as status code and treat it as the last fallback.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
