### PR TITLE
Support prior version plugins during the release candidate phase

### DIFF
--- a/lib/pluginUtils.js
+++ b/lib/pluginUtils.js
@@ -104,7 +104,17 @@ function checkVersion (fn) {
   const requiredVersion = meta.fastify
 
   const fastifyRc = /-rc.+$/.test(this.version)
+  if (fastifyRc === true && semver.gt(this.version, semver.coerce(requiredVersion)) === true) {
+    // A Fastify release candidate phase is taking place. In order to reduce
+    // the effort needed to test plugins with the RC, we allow plugins targeting
+    // the prior Fastify release to be loaded.
+    return
+  }
   if (requiredVersion && semver.satisfies(this.version, requiredVersion, { includePrerelease: fastifyRc }) === false) {
+    // We are not in a release candidate phase. Thus, we must honor the semver
+    // ranges defined by the plugin's metadata. Which is to say, if the plugin
+    // expects an older version of Fastify than the _current_ version, we will
+    // throw an error.
     throw new FST_ERR_PLUGIN_VERSION_MISMATCH(meta.name, requiredVersion, this.version)
   }
 }

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1068,6 +1068,10 @@ test('fastify-rc loads prior version plugins', t => {
     name: 'plugin',
     fastify: '^98.1.0'
   }
+  plugin2[Symbol.for('plugin-meta')] = {
+    name: 'plugin2',
+    fastify: '98.x'
+  }
 
   fastify.register(plugin)
 
@@ -1077,6 +1081,10 @@ test('fastify-rc loads prior version plugins', t => {
   })
 
   function plugin (instance, opts, done) {
+    done()
+  }
+
+  function plugin2 (instance, opts, done) {
     done()
   }
 })

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1057,6 +1057,30 @@ test('plugin metadata - release candidate', t => {
   }
 })
 
+test('fastify-rc loads prior version plugins', t => {
+  t.plan(2)
+  const fastify = Fastify()
+  Object.defineProperty(fastify, 'version', {
+    value: '99.0.0-rc.1'
+  })
+
+  plugin[Symbol.for('plugin-meta')] = {
+    name: 'plugin',
+    fastify: '^98.1.0'
+  }
+
+  fastify.register(plugin)
+
+  fastify.ready((err) => {
+    t.error(err)
+    t.pass('everything right')
+  })
+
+  function plugin (instance, opts, done) {
+    done()
+  }
+})
+
 test('hasPlugin method exists as a function', t => {
   t.plan(1)
 


### PR DESCRIPTION
This PR addresses my comment at https://github.com/fastify/fastify/pull/3879/files#r865519397

The result is that a Fastify release candidate will load any existing plugins as if they target the RC. This should reduce the noise during the RC phase (e.g. reduce the amount of issue people file about a new plugin version not loading).

Notice that the first commit is a failing test and the second commit adds the code needed to implement the feature.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
