### PR TITLE
test: error serializer

### DIFF
--- a/build/build-error-serializer.js
+++ b/build/build-error-serializer.js
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 'use strict'
 
 const FJS = require('fast-json-stringify')

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:markdown": "markdownlint-cli2",
     "lint:standard": "standard | snazzy",
     "lint:typescript": "eslint -c types/.eslintrc.json types/**/*.d.ts test/types/**/*.test-d.ts",
-    "prepublishOnly": "tap --no-check-coverage test/internals/version.test.js",
+    "prepublishOnly": "tap --no-check-coverage test/build/**.test.js",
     "test": "npm run lint && npm run unit && npm run test:typescript",
     "test:ci": "npm run unit -- -R terse --cov --coverage-report=lcovonly && npm run test:typescript",
     "test:report": "npm run lint && npm run unit:report && npm run test:typescript",

--- a/test/build/error-serializer.test.js
+++ b/test/build/error-serializer.test.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const fs = require('fs')
+const path = require('path')
+
+const { code } = require('../../build/build-error-serializer')
+
+test('check generated code syntax', async (t) => {
+  t.plan(1)
+
+  // standard is a esm, we import it like this
+  const { default: standard } = await import('standard')
+  const result = await standard.lintText(code)
+
+  // if there are any invalid syntax
+  // fatal count will be greater than 0
+  t.equal(result[0].fatalErrorCount, 0)
+})
+
+test('ensure the current error serializer is latest', async (t) => {
+  t.plan(1)
+
+  const current = await fs.promises.readFile(path.resolve('lib/error-serializer.js'))
+
+  t.equal(current.toString(), code)
+})

--- a/test/build/version.test.js
+++ b/test/build/version.test.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const path = require('path')
 const t = require('tap')
 const test = t.test
-const fastify = require('../..')()
+const fastify = require('../../fastify')()
 
 test('should be the same as package.json', t => {
   t.plan(1)


### PR DESCRIPTION
Follow Up #3996 

I decide to use `standard` to check the code syntax.
And we should check if the `error-serializer.js` out-dated before release.
We don't identify the breaking from `fast-json-stringify` because we never validate if it is the latest code.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
