### PR TITLE
fix: disallow reply status code 600

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -291,7 +291,7 @@ Reply.prototype.removeTrailer = function (key) {
 
 Reply.prototype.code = function (code) {
   const intValue = parseInt(code)
-  if (isNaN(intValue) || intValue < 100 || intValue > 600) {
+  if (isNaN(intValue) || intValue < 100 || intValue > 599) {
     throw new FST_ERR_BAD_STATUS_CODE(code || String(code))
   }
 

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -520,7 +520,13 @@ const invalidErrorCodes = [
   undefined,
   null,
   'error_code',
-  700 // out of the 100-600 range
+
+  // out of the 100-599 range:
+  0,
+  1,
+  99,
+  600,
+  700
 ]
 invalidErrorCodes.forEach((invalidCode) => {
   test(`should throw error if error code is ${invalidCode}`, t => {


### PR DESCRIPTION
600 is not a valid HTTP status code, but `reply.code()` currently allows it, likely due to an off-by-one error in its validation.

https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
https://datatracker.ietf.org/doc/html/rfc2616#section-10

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added - _N/A, I couldn't find any docs that describe the accepted range of status codes_
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)