### PR TITLE
fix: Fastify.listen({path: '...'}) should not also listen on a port

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -41,7 +41,15 @@ function createServer (options, httpHandler) {
       listenOptions.cb = cb
     }
 
-    const { host = listenOptions.path == null ? 'localhost' : null } = listenOptions
+    // If we have a path specified, don't default host to 'localhost' so we don't end up listening
+    // on both path and host
+    // See https://github.com/fastify/fastify/issues/4007
+    let host
+    if (listenOptions.path == null) {
+      host = listenOptions.host ?? 'localhost'
+    } else {
+      host = listenOptions.host
+    }
     if (Object.prototype.hasOwnProperty.call(listenOptions, 'host') === false) {
       listenOptions.host = host
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -41,7 +41,7 @@ function createServer (options, httpHandler) {
       listenOptions.cb = cb
     }
 
-    const { host = 'localhost' } = listenOptions
+    const { host = listenOptions.path == null ? 'localhost' : null } = listenOptions
     if (Object.prototype.hasOwnProperty.call(listenOptions, 'host') === false) {
       listenOptions.host = host
     }

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -196,14 +196,28 @@ if (os.platform() !== 'win32') {
     const fastify = Fastify()
     t.teardown(fastify.close.bind(fastify))
 
-    const sockFile = path.join(os.tmpdir(), `${(Math.random().toString(16) + '0000000').substr(2, 8)}-server.sock`)
+    const sockFile = path.join(os.tmpdir(), `${(Math.random().toString(16) + '0000000').slice(2, 10)}-server.sock`)
     try {
       fs.unlinkSync(sockFile)
     } catch (e) { }
 
     fastify.listen({ path: sockFile }, (err, address) => {
       t.error(err)
-      t.equal(sockFile, fastify.server.address())
+      t.strictSame(fastify.addresses(), [sockFile])
+      t.equal(address, sockFile)
+    })
+  })
+} else {
+  test('listen on socket', t => {
+    t.plan(3)
+    const fastify = Fastify()
+    t.teardown(fastify.close.bind(fastify))
+
+    const sockFile = `\\\\.\\pipe\\${(Math.random().toString(16) + '0000000').slice(2, 10)}-server-sock`
+
+    fastify.listen({ path: sockFile }, (err, address) => {
+      t.error(err)
+      t.strictSame(fastify.addresses(), [sockFile])
       t.equal(address, sockFile)
     })
   })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
Fixes #4007

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
