### PR TITLE
refactor(types): deduplicate `listen` options and export it

### DIFF
--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -1,6 +1,6 @@
-import * as http from 'http'
 import { FastifyError } from '@fastify/error'
 import { ConstraintStrategy, HTTPVersion } from 'find-my-way'
+import * as http from 'http'
 import { CallbackFunc as LightMyRequestCallback, Chain as LightMyRequestChain, InjectOptions, Response as LightMyRequestResponse } from 'light-my-request'
 import { AddContentTypeParser, ConstructorAction, FastifyBodyParser, getDefaultJsonParser, hasContentTypeParser, ProtoAction, removeAllContentTypeParsers, removeContentTypeParser } from './content-type-parser'
 import { onCloseAsyncHookHandler, onCloseHookHandler, onErrorAsyncHookHandler, onErrorHookHandler, onReadyAsyncHookHandler, onReadyHookHandler, onRegisterHookHandler, onRequestAsyncHookHandler, onRequestHookHandler, onResponseAsyncHookHandler, onResponseHookHandler, onRouteHookHandler, onSendAsyncHookHandler, onSendHookHandler, onTimeoutAsyncHookHandler, onTimeoutHookHandler, preHandlerAsyncHookHandler, preHandlerHookHandler, preParsingAsyncHookHandler, preParsingHookHandler, preSerializationAsyncHookHandler, preSerializationHookHandler, preValidationAsyncHookHandler, preValidationHookHandler } from './hooks'
@@ -28,6 +28,52 @@ export interface PrintRoutesOptions {
   includeMeta?: boolean | (string | symbol)[]
   commonPrefix?: boolean
   includeHooks?: boolean
+}
+
+export interface FastifyListenOptions {
+  /**
+   * Default to `0` (picks the first available open port).
+   */
+  port?: number;
+  /**
+   * Default to `localhost`.
+   */
+  host?: string;
+  /**
+   * Will be ignored if `port` is specified.
+   * @see [Identifying paths for IPC connections](https://nodejs.org/api/net.html#identifying-paths-for-ipc-connections).
+   */
+  path?: string;
+  /**
+   * Specify the maximum length of the queue of pending connections.
+   * The actual length will be determined by the OS through sysctl settings such as `tcp_max_syn_backlog` and `somaxconn` on Linux.
+   * Default to `511`.
+   */
+  backlog?: number;
+  /**
+   * Default to `false`.
+   */
+  exclusive?: boolean;
+  /**
+   * For IPC servers makes the pipe readable for all users.
+   * Default to `false`.
+   */
+  readableAll?: boolean;
+  /**
+   * For IPC servers makes the pipe writable for all users.
+   * Default to `false`.
+   */
+  writableAll?: boolean;
+  /**
+   * For TCP servers, setting `ipv6Only` to `true` will disable dual-stack support, i.e., binding to host `::` won't make `0.0.0.0` be bound.
+   * Default to `false`.
+   */
+  ipv6Only?: boolean;
+  /**
+   * An AbortSignal that may be used to close a listening server.
+   * @since This option is available only in Node.js v15.6.0 and greater
+   */
+  signal?: AbortSignal;
 }
 
 type NotInInterface<Key, _Interface> = Key extends keyof _Interface ? never : Key
@@ -117,96 +163,8 @@ export interface FastifyInstance<
   inject(opts: InjectOptions | string): Promise<LightMyRequestResponse>;
   inject(): LightMyRequestChain;
 
-  listen(opts: {
-    /**
-     * Default to `0` (picks the first available open port).
-     */
-    port?: number;
-    /**
-     * Default to `localhost`.
-     */
-    host?: string;
-    /**
-     * Will be ignored if `port` is specified.
-     * @see [Identifying paths for IPC connections](https://nodejs.org/api/net.html#identifying-paths-for-ipc-connections).
-    */
-    path?: string;
-    /**
-     * Specify the maximum length of the queue of pending connections.
-     * The actual length will be determined by the OS through sysctl settings such as `tcp_max_syn_backlog` and `somaxconn` on Linux.
-     * Default to `511`.
-     */
-    backlog?: number;
-    /**
-     * Default to `false`.
-     */
-    exclusive?: boolean;
-    /**
-     * For IPC servers makes the pipe readable for all users.
-     * Default to `false`.
-     */
-    readableAll?: boolean;
-    /**
-     * For IPC servers makes the pipe writable for all users.
-     * Default to `false`.
-     */
-    writableAll?: boolean;
-    /**
-     * For TCP servers, setting `ipv6Only` to `true` will disable dual-stack support, i.e., binding to host `::` won't make `0.0.0.0` be bound.
-     * Default to `false`.
-     */
-    ipv6Only?: boolean;
-    /**
-     * An AbortSignal that may be used to close a listening server.
-     * @since This option is available only in Node.js v15.6.0 and greater
-     */
-    signal?: AbortSignal;
-  }, callback: (err: Error | null, address: string) => void): void;
-  listen(opts?: {
-    /**
-     * Default to `0` (picks the first available open port).
-     */
-    port?: number;
-    /**
-     * Default to `localhost`.
-     */
-    host?: string;
-    /**
-     * Will be ignored if `port` is specified.
-     * @see [Identifying paths for IPC connections](https://nodejs.org/api/net.html#identifying-paths-for-ipc-connections).
-    */
-    path?: string;
-    /**
-     * Specify the maximum length of the queue of pending connections.
-     * The actual length will be determined by the OS through sysctl settings such as `tcp_max_syn_backlog` and `somaxconn` on Linux.
-     * Default to `511`.
-     */
-    backlog?: number;
-    /**
-     * Default to `false`.
-     */
-    exclusive?: boolean;
-    /**
-     * For IPC servers makes the pipe readable for all users.
-     * Default to `false`.
-     */
-    readableAll?: boolean;
-    /**
-     * For IPC servers makes the pipe writable for all users.
-     * Default to `false`.
-     */
-    writableAll?: boolean;
-    /**
-     * For TCP servers, setting `ipv6Only` to `true` will disable dual-stack support, i.e., binding to host `::` won't make `0.0.0.0` be bound.
-     * Default to `false`.
-     */
-    ipv6Only?: boolean;
-    /**
-     * An AbortSignal that may be used to close a listening server.
-     * @since This option is available only in Node.js v15.6.0 and greater
-     */
-    signal?: AbortSignal;
-  }): Promise<string>;
+  listen(opts: FastifyListenOptions, callback: (err: Error | null, address: string) => void): void;
+  listen(opts?: FastifyListenOptions): Promise<string>;
   listen(callback: (err: Error | null, address: string) => void): void;
 
   /**


### PR DESCRIPTION
The options interface for `FastifyInstance.listen` was duplicated, which could potentially lead to type signature and documentation differences between the two instances. To solve this, I have made a new interface to unify the two, so there's only one source of truth for both overloads.

I also added `export` to it because I found it useful - I maintain a library that uses Fastify and it allows users to configure it by passing an object with all the options, which is one of the supported (and non-deprecated) overloads of the `listen` function. Currently, we would need a [very hacky type](https://github.com/microsoft/TypeScript/issues/32164#issuecomment-811608386) to get said options from the overloads.

<details>
<summary>Click to see the code</summary>

```typescript
import type { FastifyInstance } from 'fastify';

export type FastifyObjectOptions = Omit<Exclude<OverloadedParameters<FastifyInstance['listen']>[0], FastifyUnnecessaryUnionTypes>, 'host'>;

/**
 * The union types extracted by {@link Overloads}
 * that we do not want to include in {@link FastifyObjectOptions}
 */
type FastifyUnnecessaryUnionTypes = string | number | ((...args: any[]) => any) | undefined;

/**
 * Extracts the overloads from methods and transforms them into a union
 * source: {@link https://github.com/microsoft/TypeScript/issues/32164#issuecomment-811608386}
 */
type Overloads<T extends (...args: any[]) => any> = T extends {
	(...args: infer A1): infer R1;
	(...args: infer A2): infer R2;
	(...args: infer A3): infer R3;
	(...args: infer A4): infer R4;
	(...args: infer A5): infer R5;
	(...args: infer A6): infer R6;
}
	? ((...args: A1) => R1) | ((...args: A2) => R2) | ((...args: A3) => R3) | ((...args: A4) => R4) | ((...args: A5) => R5) | ((...args: A6) => R6)
	: T extends {
			(...args: infer A1): infer R1;
			(...args: infer A2): infer R2;
			(...args: infer A3): infer R3;
			(...args: infer A4): infer R4;
			(...args: infer A5): infer R5;
	  }
	? ((...args: A1) => R1) | ((...args: A2) => R2) | ((...args: A3) => R3) | ((...args: A4) => R4) | ((...args: A5) => R5)
	: T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; (...args: infer A4): infer R4 }
	? ((...args: A1) => R1) | ((...args: A2) => R2) | ((...args: A3) => R3) | ((...args: A4) => R4)
	: T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3 }
	? ((...args: A1) => R1) | ((...args: A2) => R2) | ((...args: A3) => R3)
	: T extends { (...args: infer A1): infer R1; (...args: infer A2): infer R2 }
	? ((...args: A1) => R1) | ((...args: A2) => R2)
	: T extends { (...args: infer A1): infer R1 }
	? (...args: A1) => R1
	: never;

/**
 * Extracts the overloaded parameters from methods
 * source: {@link https://github.com/microsoft/TypeScript/issues/32164#issuecomment-811608386}
 */
type OverloadedParameters<T extends (...args: any[]) => any> = Parameters<Overloads<T>>;
```

</details>

So for ease of development, I think this export would be beneficial, not for us, but quite possibly for a lot of people as well.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
