### PR TITLE
fix: fix schema controller types

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1278,7 +1278,7 @@ const fastify = Fastify({
      */
     bucket: function factory (parentSchemas) {
       return {
-        addSchema (inputSchema) {
+        add (inputSchema) {
           // This function must store the schema added by the user.
           // This function is invoked when `fastify.addSchema()` is called.
         },

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -146,7 +146,7 @@ export type FastifyServerOptions<
   },
   schemaController?: {
     bucket?: (parentSchemas?: unknown) => {
-      addSchema(schema: unknown): FastifyInstance;
+      add(schema: unknown): FastifyInstance;
       getSchema(schemaId: string): unknown;
       getSchemas(): Record<string, unknown>;
     };

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -133,7 +133,7 @@ expectError(server.setErrorHandler(invalidErrorHandler))
 server.setSchemaController({
   bucket: (parentSchemas: unknown) => {
     return {
-      addSchema (schema: unknown) {
+      add (schema: unknown) {
         expectType<unknown>(schema)
         expectType<FastifyInstance>(server.addSchema({ type: 'null' }))
         return server.addSchema({ type: 'null' })

--- a/types/schema.d.ts
+++ b/types/schema.d.ts
@@ -41,7 +41,7 @@ export type FastifySerializerCompiler<T> = (routeSchema: FastifyRouteSchemaDef<T
 
 export interface FastifySchemaControllerOptions{
   bucket?: (parentSchemas?: unknown) => {
-    addSchema(schema: unknown): FastifyInstance;
+    add(schema: unknown): FastifyInstance;
     getSchema(schemaId: string): unknown;
     getSchemas(): Record<string, unknown>;
   };


### PR DESCRIPTION
Fixes https://github.com/fastify/fastify/issues/4002

The `schemaController` bucket interface from [here](https://github.com/fastify/fastify/blob/main/lib/schema-controller.js#L54) uses `add` not `addSchema`. This PR ensures that the docs + types reflect the correct name.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
