### PR TITLE
test: fix request terminated should not crash fastify test

### DIFF
--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -770,7 +770,7 @@ test('request terminated should not crash fastify', t => {
 
     reply.send(stream)
 
-    await new Promise((resolve) => { setTimeout(resolve, 6).unref() })
+    await new Promise((resolve) => { setTimeout(resolve, 100).unref() })
 
     stream.push('<h1>should disply on second stream</h1>')
     stream.push(null)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

I increased the timeout. CI fails sometimes.
https://github.com/fastify/fastify/runs/6907766958?check_suite_focus=true
https://github.com/fastify/fastify/runs/6907546308?check_suite_focus=true