### PR TITLE
fix: propagate generics from FastifyRegister to plugin type

### DIFF
--- a/test/types/plugin.test-d.ts
+++ b/test/types/plugin.test-d.ts
@@ -66,21 +66,3 @@ async function testAsync (): Promise<void> {
     .register(testPluginOpts)
     .register(testPluginOpts)
 }
-
-// With Type Provider
-type TestTypeProvider = { input: 'test', output: 'test' }
-const serverWithTypeProvider = fastify().withTypeProvider<TestTypeProvider>()
-const testPluginWithTypeProvider: FastifyPluginCallback<TestOptions, RawServerDefault, TestTypeProvider> = function (instance, opts, done) { }
-const testPluginWithTypeProviderAsync: FastifyPluginAsync<TestOptions, RawServerDefault, TestTypeProvider> = async function (instance, opts) { }
-const testPluginWithTypeProviderWithType = (instance: typeof serverWithTypeProvider, opts: FastifyPluginOptions, done: (error?: FastifyError) => void) => { }
-const testPluginWithTypeProviderWithTypeAsync = async (instance: typeof serverWithTypeProvider, opts: FastifyPluginOptions) => { }
-serverWithTypeProvider.register(testPluginCallback)
-serverWithTypeProvider.register(testPluginAsync)
-serverWithTypeProvider.register(testPluginOpts)
-serverWithTypeProvider.register(testPluginOptsAsync)
-serverWithTypeProvider.register(testPluginOptsWithType)
-serverWithTypeProvider.register(testPluginOptsWithTypeAsync)
-serverWithTypeProvider.register(testPluginWithTypeProvider)
-serverWithTypeProvider.register(testPluginWithTypeProviderAsync)
-serverWithTypeProvider.register(testPluginWithTypeProviderWithType)
-serverWithTypeProvider.register(testPluginWithTypeProviderWithTypeAsync)

--- a/test/types/plugin.test-d.ts
+++ b/test/types/plugin.test-d.ts
@@ -1,4 +1,4 @@
-import fastify, { FastifyInstance, FastifyPluginOptions } from '../../fastify'
+import fastify, { FastifyInstance, FastifyPluginOptions, RawServerDefault } from '../../fastify'
 import * as http from 'http'
 import * as https from 'https'
 import { expectType, expectError, expectAssignable } from 'tsd'
@@ -66,3 +66,21 @@ async function testAsync (): Promise<void> {
     .register(testPluginOpts)
     .register(testPluginOpts)
 }
+
+// With Type Provider
+type TestTypeProvider = { input: 'test', output: 'test' }
+const serverWithTypeProvider = fastify().withTypeProvider<TestTypeProvider>()
+const testPluginWithTypeProvider: FastifyPluginCallback<TestOptions, RawServerDefault, TestTypeProvider> = function (instance, opts, done) { }
+const testPluginWithTypeProviderAsync: FastifyPluginAsync<TestOptions, RawServerDefault, TestTypeProvider> = async function (instance, opts) { }
+const testPluginWithTypeProviderWithType = (instance: typeof serverWithTypeProvider, opts: FastifyPluginOptions, done: (error?: FastifyError) => void) => { }
+const testPluginWithTypeProviderWithTypeAsync = async (instance: typeof serverWithTypeProvider, opts: FastifyPluginOptions) => { }
+serverWithTypeProvider.register(testPluginCallback)
+serverWithTypeProvider.register(testPluginAsync)
+serverWithTypeProvider.register(testPluginOpts)
+serverWithTypeProvider.register(testPluginOptsAsync)
+serverWithTypeProvider.register(testPluginOptsWithType)
+serverWithTypeProvider.register(testPluginOptsWithTypeAsync)
+serverWithTypeProvider.register(testPluginWithTypeProvider)
+serverWithTypeProvider.register(testPluginWithTypeProviderAsync)
+serverWithTypeProvider.register(testPluginWithTypeProviderWithType)
+serverWithTypeProvider.register(testPluginWithTypeProviderWithTypeAsync)

--- a/test/types/plugin.test-d.ts
+++ b/test/types/plugin.test-d.ts
@@ -1,4 +1,4 @@
-import fastify, { FastifyInstance, FastifyPluginOptions, RawServerDefault } from '../../fastify'
+import fastify, { FastifyInstance, FastifyPluginOptions } from '../../fastify'
 import * as http from 'http'
 import * as https from 'https'
 import { expectType, expectError, expectAssignable } from 'tsd'

--- a/test/types/register.test-d.ts
+++ b/test/types/register.test-d.ts
@@ -1,5 +1,7 @@
 import { expectAssignable, expectError, expectType } from 'tsd'
-import fastify, { FastifyInstance, FastifyError, FastifyPluginAsync, FastifyPluginCallback, FastifyPluginOptions, RawServerDefault } from '../../fastify'
+import { IncomingMessage, Server, ServerResponse } from 'http'
+import { Http2Server, Http2ServerRequest, Http2ServerResponse } from 'http2'
+import fastify, { FastifyInstance, FastifyError, FastifyLoggerInstance, FastifyPluginAsync, FastifyPluginCallback, FastifyPluginOptions, RawServerDefault } from '../../fastify'
 
 const testPluginCallback: FastifyPluginCallback = function (instance, opts, done) { }
 const testPluginAsync: FastifyPluginAsync = async function (instance, opts) { }
@@ -9,6 +11,11 @@ const testPluginOptsAsync: FastifyPluginAsync = async function (instance, opts) 
 
 const testPluginOptsWithType = (instance: FastifyInstance, opts: FastifyPluginOptions, done: (error?: FastifyError) => void) => { }
 const testPluginOptsWithTypeAsync = async (instance: FastifyInstance, opts: FastifyPluginOptions) => { }
+
+interface TestOptions extends FastifyPluginOptions {
+  option1: string;
+  option2: boolean;
+}
 
 // Type validation
 expectError(fastify().register(testPluginOptsAsync, { prefix: 1 }))
@@ -34,24 +41,63 @@ expectAssignable<FastifyInstance>(
   })
 )
 
+// With Http2
+const serverWithHttp2 = fastify({ http2: true })
+type ServerWithHttp2 = FastifyInstance<Http2Server, Http2ServerRequest, Http2ServerResponse>
+const testPluginWithHttp2: FastifyPluginCallback<TestOptions, RawServerDefault> = function (instance, opts, done) { }
+const testPluginWithHttp2Async: FastifyPluginAsync<TestOptions, RawServerDefault> = async function (instance, opts) { }
+const testPluginWithHttp2WithType = (instance: ServerWithHttp2, opts: FastifyPluginOptions, done: (error?: FastifyError) => void) => { }
+const testPluginWithHttp2WithTypeAsync = async (instance: ServerWithHttp2, opts: FastifyPluginOptions) => { }
+expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginCallback))
+expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginAsync))
+expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginOpts))
+expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginOptsAsync))
+expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginOptsWithType))
+expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginOptsWithTypeAsync))
+expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginWithHttp2))
+expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginWithHttp2Async))
+expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginWithHttp2WithType))
+expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginWithHttp2WithTypeAsync))
+expectAssignable<ServerWithHttp2>(serverWithHttp2.register((instance) => {
+  expectAssignable<FastifyInstance>(instance)
+}))
+expectAssignable<ServerWithHttp2>(serverWithHttp2.register((instance: ServerWithHttp2) => {
+  expectAssignable<ServerWithHttp2>(instance)
+}))
+expectAssignable<ServerWithHttp2>(serverWithHttp2.register(async (instance) => {
+  expectAssignable<FastifyInstance>(instance)
+}))
+expectAssignable<ServerWithHttp2>(serverWithHttp2.register(async (instance: ServerWithHttp2) => {
+  expectAssignable<ServerWithHttp2>(instance)
+}))
+
 // With Type Provider
-interface TestOptions extends FastifyPluginOptions {
-  option1: string;
-  option2: boolean;
-}
 type TestTypeProvider = { input: 'test', output: 'test' }
 const serverWithTypeProvider = fastify().withTypeProvider<TestTypeProvider>()
+type ServerWithTypeProvider = FastifyInstance<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance, TestTypeProvider>
 const testPluginWithTypeProvider: FastifyPluginCallback<TestOptions, RawServerDefault, TestTypeProvider> = function (instance, opts, done) { }
 const testPluginWithTypeProviderAsync: FastifyPluginAsync<TestOptions, RawServerDefault, TestTypeProvider> = async function (instance, opts) { }
-const testPluginWithTypeProviderWithType = (instance: typeof serverWithTypeProvider, opts: FastifyPluginOptions, done: (error?: FastifyError) => void) => { }
-const testPluginWithTypeProviderWithTypeAsync = async (instance: typeof serverWithTypeProvider, opts: FastifyPluginOptions) => { }
-expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginCallback))
-expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginAsync))
-expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginOpts))
-expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginOptsAsync))
-expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginOptsWithType))
-expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginOptsWithTypeAsync))
-expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProvider))
-expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProviderAsync))
-expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProviderWithType))
-expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProviderWithTypeAsync))
+const testPluginWithTypeProviderWithType = (instance: ServerWithTypeProvider, opts: FastifyPluginOptions, done: (error?: FastifyError) => void) => { }
+const testPluginWithTypeProviderWithTypeAsync = async (instance: ServerWithTypeProvider, opts: FastifyPluginOptions) => { }
+expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginCallback))
+expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginAsync))
+expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginOpts))
+expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginOptsAsync))
+expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginOptsWithType))
+expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginOptsWithTypeAsync))
+expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProvider))
+expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProviderAsync))
+expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProviderWithType))
+expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProviderWithTypeAsync))
+expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register((instance) => {
+  expectAssignable<FastifyInstance>(instance)
+}))
+expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register((instance: ServerWithTypeProvider) => {
+  expectAssignable<ServerWithTypeProvider>(instance)
+}))
+expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(async (instance) => {
+  expectAssignable<FastifyInstance>(instance)
+}))
+expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(async (instance: ServerWithTypeProvider) => {
+  expectAssignable<ServerWithTypeProvider>(instance)
+}))

--- a/test/types/register.test-d.ts
+++ b/test/types/register.test-d.ts
@@ -1,7 +1,14 @@
 import { expectAssignable, expectError, expectType } from 'tsd'
-import fastify, { FastifyInstance, FastifyPluginAsync } from '../../fastify'
+import fastify, { FastifyInstance, FastifyError, FastifyPluginAsync, FastifyPluginCallback, FastifyPluginOptions, RawServerDefault } from '../../fastify'
 
-const testPluginOptsAsync: FastifyPluginAsync = async function (_instance, _opts) { }
+const testPluginCallback: FastifyPluginCallback = function (instance, opts, done) { }
+const testPluginAsync: FastifyPluginAsync = async function (instance, opts) { }
+
+const testPluginOpts: FastifyPluginCallback = function (instance, opts, done) { }
+const testPluginOptsAsync: FastifyPluginAsync = async function (instance, opts) { }
+
+const testPluginOptsWithType = (instance: FastifyInstance, opts: FastifyPluginOptions, done: (error?: FastifyError) => void) => { }
+const testPluginOptsWithTypeAsync = async (instance: FastifyInstance, opts: FastifyPluginOptions) => { }
 
 // Type validation
 expectError(fastify().register(testPluginOptsAsync, { prefix: 1 }))
@@ -26,3 +33,25 @@ expectAssignable<FastifyInstance>(
     expectType<FastifyInstance>(instance)
   })
 )
+
+// With Type Provider
+interface TestOptions extends FastifyPluginOptions {
+  option1: string;
+  option2: boolean;
+}
+type TestTypeProvider = { input: 'test', output: 'test' }
+const serverWithTypeProvider = fastify().withTypeProvider<TestTypeProvider>()
+const testPluginWithTypeProvider: FastifyPluginCallback<TestOptions, RawServerDefault, TestTypeProvider> = function (instance, opts, done) { }
+const testPluginWithTypeProviderAsync: FastifyPluginAsync<TestOptions, RawServerDefault, TestTypeProvider> = async function (instance, opts) { }
+const testPluginWithTypeProviderWithType = (instance: typeof serverWithTypeProvider, opts: FastifyPluginOptions, done: (error?: FastifyError) => void) => { }
+const testPluginWithTypeProviderWithTypeAsync = async (instance: typeof serverWithTypeProvider, opts: FastifyPluginOptions) => { }
+expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginCallback))
+expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginAsync))
+expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginOpts))
+expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginOptsAsync))
+expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginOptsWithType))
+expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginOptsWithTypeAsync))
+expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProvider))
+expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProviderAsync))
+expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProviderWithType))
+expectAssignable<typeof serverWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProviderWithTypeAsync))

--- a/test/types/register.test-d.ts
+++ b/test/types/register.test-d.ts
@@ -44,8 +44,8 @@ expectAssignable<FastifyInstance>(
 // With Http2
 const serverWithHttp2 = fastify({ http2: true })
 type ServerWithHttp2 = FastifyInstance<Http2Server, Http2ServerRequest, Http2ServerResponse>
-const testPluginWithHttp2: FastifyPluginCallback<TestOptions, RawServerDefault> = function (instance, opts, done) { }
-const testPluginWithHttp2Async: FastifyPluginAsync<TestOptions, RawServerDefault> = async function (instance, opts) { }
+const testPluginWithHttp2: FastifyPluginCallback<TestOptions, Http2Server> = function (instance, opts, done) { }
+const testPluginWithHttp2Async: FastifyPluginAsync<TestOptions, Http2Server> = async function (instance, opts) { }
 const testPluginWithHttp2WithType = (instance: ServerWithHttp2, opts: FastifyPluginOptions, done: (error?: FastifyError) => void) => { }
 const testPluginWithHttp2WithTypeAsync = async (instance: ServerWithHttp2, opts: FastifyPluginOptions) => { }
 expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginCallback))

--- a/types/register.d.ts
+++ b/types/register.d.ts
@@ -1,6 +1,8 @@
 import { FastifyPluginOptions, FastifyPluginCallback, FastifyPluginAsync } from './plugin'
 import { LogLevel } from './logger'
 import { FastifyInstance } from './instance'
+import { RawServerBase } from './utils'
+import { FastifyTypeProvider } from '../fastify'
 
 export interface RegisterOptions {
   prefix?: string;
@@ -16,16 +18,16 @@ export type FastifyRegisterOptions<Options> = (RegisterOptions & Options) | ((in
  * Function for adding a plugin to fastify. The options are inferred from the passed in FastifyPlugin parameter.
  */
 export interface FastifyRegister<T = void> {
-  <Options extends FastifyPluginOptions>(
-    plugin: FastifyPluginCallback<Options>,
+  <Options extends FastifyPluginOptions, RawServer extends RawServerBase, TypeProvider extends FastifyTypeProvider>(
+    plugin: FastifyPluginCallback<Options, RawServer, TypeProvider>,
     opts?: FastifyRegisterOptions<Options>
   ): T;
-  <Options extends FastifyPluginOptions>(
-    plugin: FastifyPluginAsync<Options>,
+  <Options extends FastifyPluginOptions, RawServer extends RawServerBase, TypeProvider extends FastifyTypeProvider>(
+    plugin: FastifyPluginAsync<Options, RawServer, TypeProvider>,
     opts?: FastifyRegisterOptions<Options>
   ): T;
-  <Options extends FastifyPluginOptions>(
-    plugin: FastifyPluginCallback<Options> | FastifyPluginAsync<Options> | Promise<{ default: FastifyPluginCallback<Options> }> | Promise<{ default: FastifyPluginAsync<Options> }>,
+  <Options extends FastifyPluginOptions, RawServer extends RawServerBase, TypeProvider extends FastifyTypeProvider>(
+    plugin: FastifyPluginCallback<Options, RawServer, TypeProvider> | FastifyPluginAsync<Options, RawServer, TypeProvider> | Promise<{ default: FastifyPluginCallback<Options, RawServer, TypeProvider> }> | Promise<{ default: FastifyPluginAsync<Options, RawServer, TypeProvider> }>,
     opts?: FastifyRegisterOptions<Options>
   ): T;
 }

--- a/types/register.d.ts
+++ b/types/register.d.ts
@@ -27,7 +27,7 @@ export interface FastifyRegister<T = void, RawServer extends RawServerBase = Raw
     opts?: FastifyRegisterOptions<Options>
   ): T;
   <Options extends FastifyPluginOptions, Server extends RawServerBase = RawServer, TypeProvider extends FastifyTypeProvider = TypeProviderDefault>(
-    plugin: FastifyPluginCallback<Options, Server, TypeProvider> | FastifyPluginAsync<Options, RawServer, TypeProvider> | Promise<{ default: FastifyPluginCallback<Options, RawServer, TypeProvider> }> | Promise<{ default: FastifyPluginAsync<Options, RawServer, TypeProvider> }>,
+    plugin: FastifyPluginCallback<Options, Server, TypeProvider> | FastifyPluginAsync<Options, Server, TypeProvider> | Promise<{ default: FastifyPluginCallback<Options, Server, TypeProvider> }> | Promise<{ default: FastifyPluginAsync<Options, Server, TypeProvider> }>,
     opts?: FastifyRegisterOptions<Options>
   ): T;
 }

--- a/types/register.d.ts
+++ b/types/register.d.ts
@@ -2,7 +2,7 @@ import { FastifyPluginOptions, FastifyPluginCallback, FastifyPluginAsync } from 
 import { LogLevel } from './logger'
 import { FastifyInstance } from './instance'
 import { RawServerBase } from './utils'
-import { FastifyTypeProvider } from '../fastify'
+import { FastifyTypeProvider, RawServerDefault } from '../fastify'
 
 export interface RegisterOptions {
   prefix?: string;
@@ -17,17 +17,17 @@ export type FastifyRegisterOptions<Options> = (RegisterOptions & Options) | ((in
  *
  * Function for adding a plugin to fastify. The options are inferred from the passed in FastifyPlugin parameter.
  */
-export interface FastifyRegister<T = void> {
-  <Options extends FastifyPluginOptions, RawServer extends RawServerBase, TypeProvider extends FastifyTypeProvider>(
-    plugin: FastifyPluginCallback<Options, RawServer, TypeProvider>,
+export interface FastifyRegister<T = void, RawServer extends RawServerBase = RawServerDefault, TypeProviderDefault extends FastifyTypeProvider = FastifyTypeProvider> {
+  <Options extends FastifyPluginOptions, Server extends RawServerBase = RawServer, TypeProvider extends FastifyTypeProvider = TypeProviderDefault>(
+    plugin: FastifyPluginCallback<Options, Server, TypeProvider>,
     opts?: FastifyRegisterOptions<Options>
   ): T;
-  <Options extends FastifyPluginOptions, RawServer extends RawServerBase, TypeProvider extends FastifyTypeProvider>(
-    plugin: FastifyPluginAsync<Options, RawServer, TypeProvider>,
+  <Options extends FastifyPluginOptions, Server extends RawServerBase = RawServer, TypeProvider extends FastifyTypeProvider = TypeProviderDefault>(
+    plugin: FastifyPluginAsync<Options, Server, TypeProvider>,
     opts?: FastifyRegisterOptions<Options>
   ): T;
-  <Options extends FastifyPluginOptions, RawServer extends RawServerBase, TypeProvider extends FastifyTypeProvider>(
-    plugin: FastifyPluginCallback<Options, RawServer, TypeProvider> | FastifyPluginAsync<Options, RawServer, TypeProvider> | Promise<{ default: FastifyPluginCallback<Options, RawServer, TypeProvider> }> | Promise<{ default: FastifyPluginAsync<Options, RawServer, TypeProvider> }>,
+  <Options extends FastifyPluginOptions, Server extends RawServerBase = RawServer, TypeProvider extends FastifyTypeProvider = TypeProviderDefault>(
+    plugin: FastifyPluginCallback<Options, Server, TypeProvider> | FastifyPluginAsync<Options, RawServer, TypeProvider> | Promise<{ default: FastifyPluginCallback<Options, RawServer, TypeProvider> }> | Promise<{ default: FastifyPluginAsync<Options, RawServer, TypeProvider> }>,
     opts?: FastifyRegisterOptions<Options>
   ): T;
 }


### PR DESCRIPTION
Closes #4032

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
