### PR TITLE
docs(guides): add two v4 breaking changes

### DIFF
--- a/docs/Guides/Migration-Guide-V4.md
+++ b/docs/Guides/Migration-Guide-V4.md
@@ -21,7 +21,7 @@ there and maintained. Use Fastify's [hooks](../Reference/Hooks.md) instead.
 If you previously used the `reply.res` attribute to access the underlying Request
 object you'll instead need to depend on `reply.raw`.
 
-### Need to `return reply` in some instances
+### Need to `return reply` to signal a "fork" of the promise chain
 
 In some situations, like when a response is sent asynchronously or when you're
 just not explicitly returning a response, you'll need to return the `reply`

--- a/docs/Guides/Migration-Guide-V4.md
+++ b/docs/Guides/Migration-Guide-V4.md
@@ -16,6 +16,17 @@ have decided not to support the use of middlewares. Both
 [`@fastify/express`](https://github.com/fastify/fastify-express) will still be
 there and maintained. Use Fastify's [hooks](../Reference/Hooks.md) instead.
 
+### `reply.res` moved to `reply.raw`
+
+If you previously used the `reply.res` attribute to access the underlying Request
+object you'll instead need to depend on `reply.raw`.
+
+### Need to `return reply` in some instances
+
+In some situations, like when a response is sent asynchronously or when you're
+just not explicitly returning a response, you'll need to return the `reply`
+argument from your router handler.
+
 ## Non Breaking Changes
 
 ### Change of schema for multiple types


### PR DESCRIPTION
Adding two notes from an application update of mine where I needed to make the following changes:

```diff
-      reply.res.setHeader('Content-Type', 'image/png');
-      qrcode.toFileStream(reply.res, dest.url);
+      reply.raw.setHeader('Content-Type', 'image/png');
+      qrcode.toFileStream(reply.raw, dest.url);
+
+      return reply;
```

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
