### PR TITLE
Docs(Reference): remove "Type" from imported name

### DIFF
--- a/docs/Reference/Type-Providers.md
+++ b/docs/Reference/Type-Providers.md
@@ -30,11 +30,11 @@ $ npm i @fastify/type-provider-json-schema-to-ts
 ```
 
 ```typescript
-import { JsonSchemaToTsTypeProvider } from '@fastify/type-provider-json-schema-to-ts'
+import { JsonSchemaToTsProvider } from '@fastify/type-provider-json-schema-to-ts'
 
 import fastify from 'fastify'
 
-const server = fastify().withTypeProvider<JsonSchemaToTsTypeProvider>()
+const server = fastify().withTypeProvider<JsonSchemaToTsProvider>()
 
 server.get('/route', {
     schema: {


### PR DESCRIPTION
wrong imported name in json schema to ts type provider example which will lead to `no exported member named` error, if anyone trying to just copy-paste the example

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [*] documentation is changed or added
- [*] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
