### PR TITLE
test: fix flaky test

### DIFF
--- a/test/build/error-serializer.test.js
+++ b/test/build/error-serializer.test.js
@@ -7,6 +7,10 @@ const path = require('path')
 
 const { code } = require('../../build/build-error-serializer')
 
+function unifyLineBreak(str) {
+  return str.toString().replace(/\r\n/g, '\n')
+}
+
 test('check generated code syntax', async (t) => {
   t.plan(1)
 
@@ -24,5 +28,6 @@ test('ensure the current error serializer is latest', async (t) => {
 
   const current = await fs.promises.readFile(path.resolve('lib/error-serializer.js'))
 
-  t.equal(current.toString(), code)
+  // line break should not be a problem depends on system
+  t.equal(unifyLineBreak(current), unifyLineBreak(code))
 })

--- a/test/build/error-serializer.test.js
+++ b/test/build/error-serializer.test.js
@@ -7,7 +7,7 @@ const path = require('path')
 
 const { code } = require('../../build/build-error-serializer')
 
-function unifyLineBreak(str) {
+function unifyLineBreak (str) {
   return str.toString().replace(/\r\n/g, '\n')
 }
 


### PR DESCRIPTION
Related #4049 

When targeting branch to `github`, it may install the repo using `CRLF` as line break.
The line break should not be the cause for test failure.
This PR fixes the false negative signal based on line break.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
