### PR TITLE
refactor: use object as internal route args

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -237,35 +237,35 @@ function fastify (options) {
     getDefaultRoute: router.getDefaultRoute.bind(router),
     setDefaultRoute: router.setDefaultRoute.bind(router),
     // routes shorthand methods
-    delete: function _delete (url, opts, handler) {
-      return router.prepareRoute.call(this, 'DELETE', url, opts, handler)
+    delete: function _delete (url, options, handler) {
+      return router.prepareRoute.call(this, { method: 'DELETE', url, options, handler })
     },
-    get: function _get (url, opts, handler) {
-      return router.prepareRoute.call(this, 'GET', url, opts, handler)
+    get: function _get (url, options, handler) {
+      return router.prepareRoute.call(this, { method: 'GET', url, options, handler })
     },
-    head: function _head (url, opts, handler) {
-      return router.prepareRoute.call(this, 'HEAD', url, opts, handler)
+    head: function _head (url, options, handler) {
+      return router.prepareRoute.call(this, { method: 'HEAD', url, options, handler })
     },
-    patch: function _patch (url, opts, handler) {
-      return router.prepareRoute.call(this, 'PATCH', url, opts, handler)
+    patch: function _patch (url, options, handler) {
+      return router.prepareRoute.call(this, { method: 'PATCH', url, options, handler })
     },
-    post: function _post (url, opts, handler) {
-      return router.prepareRoute.call(this, 'POST', url, opts, handler)
+    post: function _post (url, options, handler) {
+      return router.prepareRoute.call(this, { method: 'POST', url, options, handler })
     },
-    put: function _put (url, opts, handler) {
-      return router.prepareRoute.call(this, 'PUT', url, opts, handler)
+    put: function _put (url, options, handler) {
+      return router.prepareRoute.call(this, { method: 'PUT', url, options, handler })
     },
-    options: function _options (url, opts, handler) {
-      return router.prepareRoute.call(this, 'OPTIONS', url, opts, handler)
+    options: function _options (url, options, handler) {
+      return router.prepareRoute.call(this, { method: 'OPTIONS', url, options, handler })
     },
-    all: function _all (url, opts, handler) {
-      return router.prepareRoute.call(this, supportedMethods, url, opts, handler)
+    all: function _all (url, options, handler) {
+      return router.prepareRoute.call(this, { method: supportedMethods, url, options, handler })
     },
     // extended route
-    route: function _route (opts) {
+    route: function _route (options) {
       // we need the fastify object that we are producing so we apply a lazy loading of the function,
       // otherwise we should bind it after the declaration
-      return router.route.call(this, opts)
+      return router.route.call(this, { options })
     },
     // expose logger instance
     log: logger,

--- a/lib/route.js
+++ b/lib/route.js
@@ -113,7 +113,7 @@ function buildRouting (options) {
   }
 
   // Convert shorthand to extended route declaration
-  function prepareRoute (method, url, options, handler) {
+  function prepareRoute ({ method, url, options, handler }) {
     if (typeof url !== 'string') {
       throw new FST_ERR_INVALID_URL(typeof url)
     }
@@ -140,11 +140,11 @@ function buildRouting (options) {
       handler: handler || (options && options.handler)
     })
 
-    return route.call(this, options)
+    return route.call(this, { options })
   }
 
   // Route management
-  function route (options) {
+  function route ({ options }) {
     // Since we are mutating/assigning only top level props, it is fine to have a shallow copy using the spread operator
     const opts = { ...options }
 
@@ -176,30 +176,30 @@ function buildRouting (options) {
     if (path === '/' && prefix.length > 0 && opts.method !== 'HEAD') {
       switch (opts.prefixTrailingSlash) {
         case 'slash':
-          addNewRoute.call(this, path)
+          addNewRoute.call(this, { path })
           break
         case 'no-slash':
-          addNewRoute.call(this, '')
+          addNewRoute.call(this, { path: '' })
           break
         case 'both':
         default:
-          addNewRoute.call(this, '')
+          addNewRoute.call(this, { path: '' })
           // If ignoreTrailingSlash is set to true we need to add only the '' route to prevent adding an incomplete one.
           if (ignoreTrailingSlash !== true && (ignoreDuplicateSlashes !== true || !prefix.endsWith('/'))) {
-            addNewRoute.call(this, path, true)
+            addNewRoute.call(this, { path, prefixing: true })
           }
       }
     } else if (path[0] === '/' && prefix.endsWith('/')) {
       // Ensure that '/prefix/' + '/route' gets registered as '/prefix/route'
-      addNewRoute.call(this, path.slice(1))
+      addNewRoute.call(this, { path: path.slice(1) })
     } else {
-      addNewRoute.call(this, path)
+      addNewRoute.call(this, { path })
     }
 
     // chainable api
     return this
 
-    function addNewRoute (path, prefixing = false) {
+    function addNewRoute ({ path, prefixing = false }) {
       const url = prefix + path
 
       opts.url = url
@@ -326,7 +326,7 @@ function buildRouting (options) {
 
         if (shouldExposeHead && options.method === 'GET' && !headRouteExists) {
           const onSendHandlers = parseHeadOnSendHandlers(opts.onSend)
-          prepareRoute.call(this, 'HEAD', path, { ...opts, onSend: onSendHandlers })
+          prepareRoute.call(this, { method: 'HEAD', url: path, options: { ...opts, onSend: onSendHandlers } })
         } else if (headRouteExists && exposeHeadRoute) {
           warning.emit('FSTDEP007')
         }


### PR DESCRIPTION
See #4052 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
