### PR TITLE
feat: make sure all validation errors have a statusCode set

### DIFF
--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -484,6 +484,17 @@ fastify.post('/the/url', {
 }, handler)
 ```
 
+##### .statusCode property
+
+All validation errors will be added a `.statusCode` property set to `400`. This guarantees
+that the default error handler will set the status code of the response to `400`.
+
+```js
+fastify.setErrorHandler(function (error, request, reply) {
+  request.log.error(error, `This error has status code ${error.statusCode}`)
+  reply.status(error.statusCode).send(error)
+})
+```
 
 ##### Validation messages with other validation libraries
 

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -90,7 +90,7 @@ function preValidationCallback (err, request, reply) {
   const result = validateSchema(reply.context, request)
   if (result) {
     if (reply.context.attachValidation === false) {
-      reply.code(400).send(result)
+      reply.send(result)
       return
     }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -106,11 +106,13 @@ function validate (context, request) {
 
 function wrapValidationError (result, dataVar, schemaErrorFormatter) {
   if (result instanceof Error) {
+    result.statusCode = result.statusCode || 400
     result.validationContext = result.validationContext || dataVar
     return result
   }
 
   const error = schemaErrorFormatter(result, dataVar)
+  error.statusCode = error.statusCode || 400
   error.validation = result
   error.validationContext = dataVar
   return error

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -324,7 +324,7 @@ test('invalid schema - ajv', t => {
 
   fastify.setErrorHandler((err, request, reply) => {
     t.ok(Array.isArray(err.validation))
-    reply.send('error')
+    reply.code(400).send('error')
   })
 
   fastify.inject({

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -826,7 +826,7 @@ test('Validation context in validation result', t => {
     t.equal(err instanceof Error, true)
     t.ok(err.validation, 'detailed errors')
     t.equal(err.validationContext, 'body')
-    reply.send()
+    reply.code(400).send()
   })
   fastify.post('/', {
     handler: echoParams,

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -97,6 +97,38 @@ test('should be able to use setErrorHandler specify custom validation error', t 
   })
 })
 
+test('validation error has 400 statusCode set', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  fastify.setErrorHandler((error, request, reply) => {
+    const errorResponse = {
+      message: error.message,
+      statusCode: error.statusCode || 500
+    }
+
+    reply.code(errorResponse.statusCode).send(errorResponse)
+  })
+
+  fastify.post('/', { schema }, echoBody)
+
+  fastify.inject({
+    method: 'POST',
+    payload: {
+      hello: 'michelangelo'
+    },
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.same(res.json(), {
+      statusCode: 400,
+      message: "body must have required property 'name'"
+    })
+    t.equal(res.statusCode, 400)
+  })
+})
+
 test('error inside custom error handler should have validationContext', t => {
   t.plan(1)
 


### PR DESCRIPTION
As part of the error handling refactoring of #3261, we should
not be setting a custom status code for validation routes.
We should rely only on the error.statusCode property instead and
leave the user full customization capabilities. Unfortunately
a change was missed.

Fixes: https://github.com/fastify/fastify/issues/4048
Ref: https://github.com/fastify/fastify/pull/3261
Signed-off-by: Matteo Collina <hello@matteocollina.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
