### PR TITLE
fix: fix outdated type definition in ValidationResult interface

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -183,7 +183,7 @@ declare module '@fastify/error' {
 
 export interface ValidationResult {
   keyword: string;
-  dataPath: string;
+  instancePath: string;
   schemaPath: string;
   params: Record<string, string | string[]>;
   message: string;

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -7,7 +7,8 @@ import fastify, {
   LightMyRequestChain,
   LightMyRequestResponse,
   LightMyRequestCallback,
-  InjectOptions, FastifyBaseLogger
+  InjectOptions, FastifyBaseLogger,
+  ValidationResult
 } from '../../fastify'
 import * as http from 'http'
 import * as https from 'https'
@@ -71,8 +72,8 @@ expectAssignable<FastifyInstance>(fastify({ onProtoPoisoning: 'error' }))
 expectAssignable<FastifyInstance>(fastify({ onConstructorPoisoning: 'error' }))
 expectAssignable<FastifyInstance>(fastify({ serializerOpts: { rounding: 'ceil' } }))
 expectAssignable<FastifyInstance>(fastify({ serializerOpts: { ajv: { missingRefs: 'ignore' } } }))
-expectAssignable<FastifyInstance>(fastify({ serializerOpts: { schema: { } } }))
-expectAssignable<FastifyInstance>(fastify({ serializerOpts: { otherProp: { } } }))
+expectAssignable<FastifyInstance>(fastify({ serializerOpts: { schema: {} } }))
+expectAssignable<FastifyInstance>(fastify({ serializerOpts: { otherProp: {} } }))
 expectAssignable<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse, FastifyBaseLogger>>(fastify({ logger: true }))
 expectAssignable<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse, FastifyBaseLogger>>(fastify({ logger: true }))
 expectAssignable<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse, FastifyBaseLogger>>(fastify({
@@ -141,35 +142,35 @@ expectAssignable<FastifyInstance>(fastify({
     version: {
       name: 'version',
       storage: () => ({
-        get: () => () => {},
+        get: () => () => { },
         set: () => { },
         del: () => { },
         empty: () => { }
       }),
-      validate () {},
+      validate () { },
       deriveConstraint: () => 'foo'
     },
     host: {
       name: 'host',
       storage: () => ({
-        get: () => () => {},
+        get: () => () => { },
         set: () => { },
         del: () => { },
         empty: () => { }
       }),
-      validate () {},
+      validate () { },
       deriveConstraint: () => 'foo'
     },
     withObjectValue: {
       name: 'withObjectValue',
       storage: () => ({
-        get: () => () => {},
+        get: () => () => { },
         set: () => { },
         del: () => { },
         empty: () => { }
       }),
-      validate () {},
-      deriveConstraint: () => {}
+      validate () { },
+      deriveConstraint: () => { }
 
     }
   }
@@ -205,6 +206,22 @@ expectAssignable<FastifyInstance>(fastify({ jsonShorthand: true }))
 expectAssignable<PromiseLike<FastifyInstance>>(fastify({ return503OnClosing: true }))
 fastify().then(fastifyInstance => expectAssignable<FastifyInstance>(fastifyInstance))
 
-expectAssignable<FastifyPluginAsync>(async () => {})
-expectAssignable<FastifyPluginCallback>(() => {})
-expectAssignable<FastifyPlugin>(() => {})
+expectAssignable<FastifyPluginAsync>(async () => { })
+expectAssignable<FastifyPluginCallback>(() => { })
+expectAssignable<FastifyPlugin>(() => { })
+
+expectAssignable<ValidationResult>({
+  keyword: '',
+  instancePath: '',
+  schemaPath: '',
+  params: {},
+  message: ''
+})
+
+expectError<ValidationResult>({
+  keyword: '',
+  dataPath: '',
+  schemaPath: '',
+  params: {},
+  message: ''
+})


### PR DESCRIPTION
Hi there,
this commit fixes fastify#4045. There was an outdated type reference inside of fastify.d.ts that caused a type mismatch with the AJV library.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
