### PR TITLE
Use a union-aware keyof operator

### DIFF
--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -49,7 +49,7 @@ interface RequestData extends RequestGenericInterface {
 type Handler = RouteHandler<RequestData>
 
 type CustomRequest = FastifyRequest<{
-  Body: RequestBody | {content2: string};
+  Body: RequestBody | undefined;
   Querystring: RequestQuerystring;
   Params: RequestParams;
   Headers: RequestHeaders;
@@ -104,14 +104,14 @@ const postHandler: Handler = function (request) {
 }
 
 function putHandler (request: CustomRequest, reply: FastifyReply) {
-  expectType<RequestBody | {content2: string}>(request.body)
+  expectType<RequestBody | undefined>(request.body)
   expectType<RequestParams>(request.params)
   expectType<RequestHeaders & RawRequestDefaultExpression['headers']>(request.headers)
   expectType<RequestQuerystring>(request.query)
-  if ('content' in request.body) {
-    expectType<string>(request.body.content)
+  if (typeof request.body === 'undefined') {
+    expectType<undefined>(request.body)
   } else {
-    expectType<string>(request.body.content2)
+    expectType<string>(request.body.content)
   }
   expectType<string>(request.query.from)
   expectType<number>(request.params.id)

--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -49,7 +49,7 @@ interface RequestData extends RequestGenericInterface {
 type Handler = RouteHandler<RequestData>
 
 type CustomRequest = FastifyRequest<{
-  Body: RequestBody;
+  Body: RequestBody | {content2: string};
   Querystring: RequestQuerystring;
   Params: RequestParams;
   Headers: RequestHeaders;
@@ -104,11 +104,15 @@ const postHandler: Handler = function (request) {
 }
 
 function putHandler (request: CustomRequest, reply: FastifyReply) {
-  expectType<RequestBody>(request.body)
+  expectType<RequestBody | {content2: string}>(request.body)
   expectType<RequestParams>(request.params)
   expectType<RequestHeaders & RawRequestDefaultExpression['headers']>(request.headers)
   expectType<RequestQuerystring>(request.query)
-  expectType<string>(request.body.content)
+  if ('content' in request.body) {
+    expectType<string>(request.body.content)
+  } else {
+    expectType<string>(request.body.content2)
+  }
   expectType<string>(request.query.from)
   expectType<number>(request.params.id)
   expectType<string>(request.headers['x-foobar'])

--- a/types/type-provider.d.ts
+++ b/types/type-provider.d.ts
@@ -21,7 +21,8 @@ export type CallTypeProvider<F extends FastifyTypeProvider, I> = (F & { input: I
 // -----------------------------------------------------------------------------------------------
 
 // Used to map undefined SchemaCompiler properties to unknown
-type UndefinedToUnknown<T> = T extends undefined ? unknown : T
+//   Without brackets, UndefinedToUnknown<undefined | null> => unknown
+type UndefinedToUnknown<T> = [T] extends [undefined] ? unknown : T
 
 // union-aware keyof operator
 //    keyof ({ a: number} | { b: number}) => never

--- a/types/type-provider.d.ts
+++ b/types/type-provider.d.ts
@@ -23,15 +23,21 @@ export type CallTypeProvider<F extends FastifyTypeProvider, I> = (F & { input: I
 // Used to map undefined SchemaCompiler properties to unknown
 type UndefinedToUnknown<T> = T extends undefined ? unknown : T
 
+// union-aware keyof operator
+//    keyof ({ a: number} | { b: number}) => never
+//    KeysOf<{a: number} | {b: number}>   => "a" | "b"
+// this exists to allow users to override faulty type-provider logic.
+type KeysOf<T> = T extends any ? keyof T : never
+
 // Resolves Request types either from generic argument or Type Provider.
 type ResolveRequestParams<TypeProvider extends FastifyTypeProvider, SchemaCompiler extends FastifySchema, RouteGeneric extends RouteGenericInterface> =
-  UndefinedToUnknown<keyof RouteGeneric['Params'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['params']> : RouteGeneric['Params']>
+  UndefinedToUnknown<KeysOf<RouteGeneric['Params']> extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['params']> : RouteGeneric['Params']>
 type ResolveRequestQuerystring<TypeProvider extends FastifyTypeProvider, SchemaCompiler extends FastifySchema, RouteGeneric extends RouteGenericInterface> =
-  UndefinedToUnknown<keyof RouteGeneric['Querystring'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['querystring']> : RouteGeneric['Querystring']>
+  UndefinedToUnknown<KeysOf<RouteGeneric['Querystring']> extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['querystring']> : RouteGeneric['Querystring']>
 type ResolveRequestHeaders<TypeProvider extends FastifyTypeProvider, SchemaCompiler extends FastifySchema, RouteGeneric extends RouteGenericInterface> =
-  UndefinedToUnknown<keyof RouteGeneric['Headers'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['headers']> : RouteGeneric['Headers']>
+  UndefinedToUnknown<KeysOf<RouteGeneric['Headers']> extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['headers']> : RouteGeneric['Headers']>
 type ResolveRequestBody<TypeProvider extends FastifyTypeProvider, SchemaCompiler extends FastifySchema, RouteGeneric extends RouteGenericInterface> =
-  UndefinedToUnknown<keyof RouteGeneric['Body'] extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['body']> : RouteGeneric['Body']>
+  UndefinedToUnknown<KeysOf<RouteGeneric['Body']> extends never ? CallTypeProvider<TypeProvider, SchemaCompiler['body']> : RouteGeneric['Body']>
 
 // The target request type. This type is inferenced on fastify 'requests' via generic argument assignment
 export interface FastifyRequestType<Params = unknown, Querystring = unknown, Headers = unknown, Body = unknown> {


### PR DESCRIPTION
Fixes #4063 

Based off of https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types.

I believe this still satisfies the initial reason these `keyof`s were here. As a previous comment on `ResolveFastifyRequestContext` (the previous generation of this) said:
```ts
/**
 * This type handles request context resolution either via generic arguments
 * or type provider. If the user specifies both generic arguments as well as
 * a type provider, this type will override the type provider and use the
 * generic arguments. This enables users to override undesirable inference
 * behaviours in the type provider.
 */
 ```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
