### PR TITLE
Fix Internal Links Check action permissions

### DIFF
--- a/.github/workflows/links-check.yml
+++ b/.github/workflows/links-check.yml
@@ -1,7 +1,7 @@
 name: Internal Links Check
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - 'docs/**'
       - '*.md'

--- a/.github/workflows/links-check.yml
+++ b/.github/workflows/links-check.yml
@@ -2,6 +2,7 @@ name: Internal Links Check
 
 on:
   pull_request_target:
+    types: [opened, synchronize, reopened]
     paths:
       - 'docs/**'
       - '*.md'

--- a/docs/Guides/Database.md
+++ b/docs/Guides/Database.md
@@ -13,7 +13,7 @@ plugins maintained within the Fastify organization.
 > a plugin can be written for the missing database engine. 
 
 > If you would like to write your own Fastify plugin 
-> please take a look at the [plugins guide](./Plugins-Guide.md)
+> please take a look at the [plugins guide](./Plugins-Gu.md)
 
 ### [MySQL](https://github.com/fastify/fastify-mysql)
 

--- a/docs/Guides/Database.md
+++ b/docs/Guides/Database.md
@@ -13,7 +13,7 @@ plugins maintained within the Fastify organization.
 > a plugin can be written for the missing database engine. 
 
 > If you would like to write your own Fastify plugin 
-> please take a look at the [plugins guide](./Plugins-Gu.md)
+> please take a look at the [plugins guide](./Plugins-Guide.md)
 
 ### [MySQL](https://github.com/fastify/fastify-mysql)
 


### PR DESCRIPTION
I have changed the event type to `pull_request_target` as suggested by the `create or update comments` action. As seen in the Github docs:

> This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. This event allows your workflow to do things like label or comment on pull requests from forks. Avoid using this event if you need to build or run code from the pull request.

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
