### PR TITLE
fix: `FastifySchemaValidationError` type insufficient

### DIFF
--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -194,7 +194,18 @@ expectAssignable<FastifyInstance>(fastify({ frameworkErrors: () => { } }))
 expectAssignable<FastifyInstance>(fastify({
   rewriteUrl: (req) => req.url === '/hi' ? '/hello' : req.url!
 }))
-expectAssignable<FastifyInstance>(fastify({ schemaErrorFormatter: (errors, dataVar) => new Error() }))
+expectAssignable<FastifyInstance>(fastify({
+  schemaErrorFormatter: (errors, dataVar) => {
+    console.log(
+      errors[0].keyword.toLowerCase(),
+      errors[0].message?.toLowerCase(),
+      errors[0].params,
+      errors[0].instancePath.toLowerCase(),
+      errors[0].schemaPath.toLowerCase()
+    )
+    return new Error()
+  }
+}))
 expectAssignable<FastifyInstance>(fastify({
   clientErrorHandler: (err, socket) => {
     expectType<ConnectionError>(err)

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -494,12 +494,17 @@ test('the custom error formatter context must be the server instance in options'
 })
 
 test('should call custom error formatter', t => {
-  t.plan(6)
+  t.plan(9)
 
   const fastify = Fastify({
     schemaErrorFormatter: (errors, dataVar) => {
       t.equal(errors.length, 1)
       t.equal(errors[0].message, "must have required property 'name'")
+      t.equal(errors[0].keyword, 'required')
+      t.equal(errors[0].schemaPath, '#/required')
+      t.same(errors[0].params, {
+        missingProperty: 'name'
+      })
       t.equal(dataVar, 'body')
       return new Error('my error')
     }

--- a/types/schema.d.ts
+++ b/types/schema.d.ts
@@ -23,8 +23,11 @@ export interface FastifyRouteSchemaDef<T> {
 }
 
 export interface FastifySchemaValidationError {
-  message?: string;
+  keyword: string;
   instancePath: string;
+  schemaPath: string;
+  params: Record<string, string | string[]>;
+  message?: string;
 }
 
 export interface FastifyValidationResult {


### PR DESCRIPTION
Fix: #4093

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
