### PR TITLE
Remove redundant docs on TypeBox properties

### DIFF
--- a/docs/Reference/Type-Providers.md
+++ b/docs/Reference/Type-Providers.md
@@ -94,13 +94,6 @@ server.get('/route', {
 })
 ```
 
-TypeBox uses the properties `kind` and `modifier` internally. These properties
-are not strictly valid JSON schema which will cause `AJV@7` and newer versions
-to throw an invalid schema error. To remove the error it's either necessary to
-omit the properties by using
-[`Type.Strict()`](https://github.com/sinclairzx81/typebox#strict) or use the AJV
-options for adding custom keywords.
-
 See also the [TypeBox
 documentation](https://github.com/sinclairzx81/typebox#validation) on how to set
 up AJV to work with TypeBox.

--- a/docs/Reference/Type-Providers.md
+++ b/docs/Reference/Type-Providers.md
@@ -70,14 +70,7 @@ import { Type } from '@sinclair/typebox'
 
 import fastify from 'fastify'
 
-const server = fastify({
-    ajv: {
-        customOptions: {
-            strict: 'log',
-            keywords: ['kind', 'modifier'],
-        },
-    },
-}).withTypeProvider<TypeBoxTypeProvider>()
+const server = fastify().withTypeProvider<TypeBoxTypeProvider>()
 
 server.get('/route', {
     schema: {


### PR DESCRIPTION
TypeBox no longer requires the `kind` and `modifier` keywords to be added to Ajv (since v0.24.0).

See:

- https://github.com/sinclairzx81/typebox/blob/master/changelog.md#0240
- https://github.com/fastify/fastify-type-provider-typebox/issues/19

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
