### PR TITLE
docs(Guides/Plugins-Guide.md) : add reminder

### DIFF
--- a/docs/Guides/Plugins-Guide.md
+++ b/docs/Guides/Plugins-Guide.md
@@ -196,7 +196,7 @@ fastify.get('/html', (request, reply) => {
   reply.html({ hello: 'world' })
 })
 ```
-Reminder that the `this` keyword is not available on *arrow functions*, when passing functions in *`decorateReply`* and *`decorateRequest`* as a utility, always use a function that is defined using the `function` keyword instead of an *arrow function expression*.
+Reminder that the `this` keyword is not available on *arrow functions*, so when passing functions in *`decorateReply`* and *`decorateRequest`* as a utility that also needs access to the `request` and `reply` instance, a function that is defined using the `function` keyword is needed instead of an *arrow function expression*.
 
 In the same way you can do this for the `request` object:
 ```js

--- a/docs/Guides/Plugins-Guide.md
+++ b/docs/Guides/Plugins-Guide.md
@@ -196,7 +196,11 @@ fastify.get('/html', (request, reply) => {
   reply.html({ hello: 'world' })
 })
 ```
-Reminder that the `this` keyword is not available on *arrow functions*, so when passing functions in *`decorateReply`* and *`decorateRequest`* as a utility that also needs access to the `request` and `reply` instance, a function that is defined using the `function` keyword is needed instead of an *arrow function expression*.
+Reminder that the `this` keyword is not available on *arrow functions*,
+so when passing functions in *`decorateReply`* and *`decorateRequest`* as
+a utility that also needs access to the `request` and `reply` instance,
+a function that is defined using the `function` keyword is needed instead
+of an *arrow function expression*.
 
 In the same way you can do this for the `request` object:
 ```js

--- a/docs/Guides/Plugins-Guide.md
+++ b/docs/Guides/Plugins-Guide.md
@@ -196,6 +196,7 @@ fastify.get('/html', (request, reply) => {
   reply.html({ hello: 'world' })
 })
 ```
+Reminder that the `this` keyword is not available on *arrow functions*, when passing functions in *`decorateReply`* and *`decorateRequest`* as a utility, always use a function that is defined using the `function` keyword instead of an *arrow function expression*.
 
 In the same way you can do this for the `request` object:
 ```js


### PR DESCRIPTION
Added a reminder note when using decorateReply and decorateRequest to use functions defined using the `function` keyword instead of *arrow function expressions*.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
