### PR TITLE
Revert "Re-add typed decorators (#4111)"

### DIFF
--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -284,59 +284,29 @@ expectType<string>(server.printRoutes({ includeMeta: ['key1', Symbol('key2')] })
 
 expectType<string>(server.printRoutes())
 
-server.decorate('nonexistent', () => {})
-server.decorateRequest('nonexistent', () => {})
-server.decorateReply('nonexistent', () => {})
-
-declare module '../../fastify' {
-  interface FastifyInstance {
-    functionWithTypeDefinition: (foo: string, bar: number) => Promise<boolean>
-  }
-  interface FastifyRequest {
-    numberWithTypeDefinition: number
-  }
-  interface FastifyReply {
-    stringWithTypeDefinition: 'foo' | 'bar'
-  }
-}
-expectError(server.decorate('functionWithTypeDefinition', (foo: any, bar: any) => {})) // error because invalid return type
-expectError(server.decorate('functionWithTypeDefinition', (foo: any, bar: any) => true)) // error because doesn't return a promise
-expectError(server.decorate('functionWithTypeDefinition', async (foo: any, bar: any, qwe: any) => true)) // error because too many args
-expectAssignable<FastifyInstance>(server.decorate('functionWithTypeDefinition', async (foo, bar) => {
-  expectType<string>(foo)
-  expectType<number>(bar)
-  return true
-}))
-
-expectError(server.decorateRequest('numberWithTypeDefinition', 'not a number')) // error because invalid type
-expectAssignable<FastifyInstance>(server.decorateRequest('numberWithTypeDefinition', 10))
-
-expectError(server.decorateReply('stringWithTypeDefinition', 'not in enum')) // error because invalid type
-expectAssignable<FastifyInstance>(server.decorateReply('stringWithTypeDefinition', 'foo'))
-
-server.decorate<'test', (x: string) => void>('test', function (x: string): void {
+server.decorate<(x: string) => void>('test', function (x: string): void {
   expectType<FastifyInstance>(this)
 })
 server.decorate('test', function (x: string): void {
   expectType<FastifyInstance>(this)
 })
 
-server.decorateRequest<'test', (x: string, y: number) => void>('test', function (x: string, y: number): void {
+server.decorateRequest<(x: string, y: number) => void>('test', function (x: string, y: number): void {
   expectType<FastifyRequest>(this)
 })
 server.decorateRequest('test', function (x: string, y: number): void {
   expectType<FastifyRequest>(this)
 })
 
-server.decorateReply<'test', (x: string) => void>('test', function (x: string): void {
+server.decorateReply<(x: string) => void>('test', function (x: string): void {
   expectType<FastifyReply>(this)
 })
 server.decorateReply('test', function (x: string): void {
   expectType<FastifyReply>(this)
 })
 
-expectError(server.decorate<'test', string>('test', true))
-expectError(server.decorate<'test', (myNumber: number) => number>('test', function (myNumber: number): string {
+expectError(server.decorate<string>('test', true))
+expectError(server.decorate<(myNumber: number) => number>('test', function (myNumber: number): string {
   return ''
 }))
 

--- a/types/.eslintrc.json
+++ b/types/.eslintrc.json
@@ -17,8 +17,6 @@
   "rules": {
     "no-console": "off",
     "@typescript-eslint/indent": ["error", 2],
-    "func-call-spacing": "off",
-    "@typescript-eslint/func-call-spacing": ["error"],
     "semi": ["error", "never"],
     "import/export": "off" // this errors on multiple exports (overload interfaces)
   },

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -107,45 +107,21 @@ export interface FastifyInstance<
   close(closeListener: () => void): undefined;
 
   // should be able to define something useful with the decorator getter/setter pattern using Generics to enforce the users function returns what they expect it to
-  decorate<K extends keyof FastifyInstance>(
-    property: K,
-    value: FastifyInstance[K] extends (...args: any[]) => any
-      ? (this: FastifyInstance, ...args: Parameters<FastifyInstance[K]>) => ReturnType<FastifyInstance[K]>
-      : FastifyInstance[K],
-    dependencies?: string[]
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
-  decorate<K extends string | symbol, T>(
-    property: NotInInterface<K, FastifyInstance>,
+  decorate<T>(property: string | symbol,
     value: T extends (...args: any[]) => any
       ? (this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>, ...args: Parameters<T>) => ReturnType<T>
       : T,
     dependencies?: string[]
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
 
-  decorateRequest<K extends keyof FastifyRequest>(
-    property: K,
-    value: FastifyRequest[K] extends (...args: any[]) => any
-      ? (this: FastifyRequest, ...args: Parameters<FastifyRequest[K]>) => ReturnType<FastifyRequest[K]>
-      : FastifyRequest[K],
-    dependencies?: string[]
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
-  decorateRequest<K extends string | symbol, T>(
-    property: NotInInterface<K, FastifyRequest>,
+  decorateRequest<T>(property: string | symbol,
     value: T extends (...args: any[]) => any
       ? (this: FastifyRequest, ...args: Parameters<T>) => ReturnType<T>
       : T,
     dependencies?: string[]
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
 
-  decorateReply<K extends keyof FastifyReply>(
-    property: K,
-    value: FastifyReply[K] extends (...args: any[]) => any
-      ? (this: FastifyReply, ...args: Parameters<FastifyReply[K]>) => ReturnType<FastifyReply[K]>
-      : FastifyReply[K],
-    dependencies?: string[]
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
-  decorateReply<K extends string | symbol, T>(
-    property: NotInInterface<K, FastifyReply>,
+  decorateReply<T>(property: string | symbol,
     value: T extends (...args: any[]) => any
       ? (this: FastifyReply, ...args: Parameters<T>) => ReturnType<T>
       : T,
@@ -171,17 +147,17 @@ export interface FastifyInstance<
    * @deprecated Variadic listen method is deprecated. Please use `.listen(optionsObject, callback)` instead. The variadic signature will be removed in `fastify@5`
    * @see https://github.com/fastify/fastify/pull/3712
    */
-  listen(port: number | string, address: string, backlog: number, callback: (err: Error | null, address: string) => void): void;
+  listen(port: number | string, address: string, backlog: number, callback: (err: Error|null, address: string) => void): void;
   /**
    * @deprecated Variadic listen method is deprecated. Please use `.listen(optionsObject, callback)` instead. The variadic signature will be removed in `fastify@5`
    * @see https://github.com/fastify/fastify/pull/3712
    */
-  listen(port: number | string, address: string, callback: (err: Error | null, address: string) => void): void;
+  listen(port: number | string, address: string, callback: (err: Error|null, address: string) => void): void;
   /**
    * @deprecated Variadic listen method is deprecated. Please use `.listen(optionsObject, callback)` instead. The variadic signature will be removed in `fastify@5`
    * @see https://github.com/fastify/fastify/pull/3712
    */
-  listen(port: number | string, callback: (err: Error | null, address: string) => void): void;
+  listen(port: number | string, callback: (err: Error|null, address: string) => void): void;
   /**
    * @deprecated Variadic listen method is deprecated. Please use `.listen(optionsObject)` instead. The variadic signature will be removed in `fastify@5`
    * @see https://github.com/fastify/fastify/pull/3712
@@ -508,11 +484,11 @@ export interface FastifyInstance<
   /**
    * Set the 404 handler
    */
-  setNotFoundHandler<RouteGeneric extends RouteGenericInterface = RouteGenericInterface, TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault, SchemaCompiler extends FastifySchema = FastifySchema>(
+  setNotFoundHandler<RouteGeneric extends RouteGenericInterface = RouteGenericInterface, TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault, SchemaCompiler extends FastifySchema = FastifySchema> (
     handler: (request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>, reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfigDefault, SchemaCompiler, TypeProvider>) => void | Promise<RouteGeneric['Reply'] | void>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
 
-  setNotFoundHandler<RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig extends ContextConfigDefault = ContextConfigDefault, TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault, SchemaCompiler extends FastifySchema = FastifySchema>(
+  setNotFoundHandler<RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig extends ContextConfigDefault = ContextConfigDefault, TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault, SchemaCompiler extends FastifySchema = FastifySchema> (
     opts: {
       preValidation?: preValidationHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider> | preValidationHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>[];
       preHandler?: preHandlerHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider> | preHandlerHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>[];


### PR DESCRIPTION
This reverts commit 20263a1bf8c8195d4692c634ecba86baa918b2d5.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

I don't think we can land this change. Moreover I don't think the change is correct.
After applying that change, I did not find a way to make https://github.com/fastify/fastify-passport/blob/4b912074ad2273172b65eb44e52201e37583226e/src/CreateInitializePlugin.ts#L9-L13 compile.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
