### PR TITLE
run error serializer check only before release

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:markdown": "markdownlint-cli2",
     "lint:standard": "standard | snazzy",
     "lint:typescript": "eslint -c types/.eslintrc.json types/**/*.d.ts test/types/**/*.test-d.ts",
-    "prepublishOnly": "tap --no-check-coverage test/build/**.test.js",
+    "prepublishOnly": "PREPUBLISH=true tap --no-check-coverage test/build/**.test.js",
     "test": "npm run lint && npm run unit && npm run test:typescript",
     "test:ci": "npm run unit -- -R terse --cov --coverage-report=lcovonly && npm run test:typescript",
     "test:report": "npm run lint && npm run unit:report && npm run test:typescript",

--- a/test/build/error-serializer.test.js
+++ b/test/build/error-serializer.test.js
@@ -23,7 +23,9 @@ test('check generated code syntax', async (t) => {
   t.equal(result[0].fatalErrorCount, 0)
 })
 
-test('ensure the current error serializer is latest', async (t) => {
+const isPrebublish = !!process.env.PREPUBLISH
+
+test('ensure the current error serializer is latest', { skip: !isPrebublish }, async (t) => {
   t.plan(1)
 
   const current = await fs.promises.readFile(path.resolve('lib/error-serializer.js'))


### PR DESCRIPTION
Signed-off-by: Matteo Collina <hello@matteocollina.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Otherwise CI will _always_ be red after a new release of fast-json-stringify is issued. This is quite annoying.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
