### PR TITLE
types: re-export `FastifyListenOptions` in top-level types

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -194,7 +194,7 @@ export type { Chain as LightMyRequestChain, InjectOptions, Response as LightMyRe
 export { FastifyRequest, RequestGenericInterface } from './types/request'
 export { FastifyReply } from './types/reply'
 export { FastifyPluginCallback, FastifyPluginAsync, FastifyPluginOptions, FastifyPlugin } from './types/plugin'
-export { FastifyInstance, PrintRoutesOptions } from './types/instance'
+export { FastifyListenOptions, FastifyInstance, PrintRoutesOptions } from './types/instance'
 export { FastifyLoggerOptions, FastifyBaseLogger, FastifyLoggerInstance, FastifyLogFn, LogLevel } from './types/logger'
 export { FastifyContext, FastifyContextConfig } from './types/context'
 export { RouteHandler, RouteHandlerMethod, RouteOptions, RouteShorthandMethod, RouteShorthandOptions, RouteShorthandOptionsWithHandler } from './types/route'

--- a/test/types/import.ts
+++ b/test/types/import.ts
@@ -1,1 +1,1 @@
-import { FastifyLogFn } from '../../fastify'
+import { FastifyListenOptions, FastifyLogFn } from '../../fastify'


### PR DESCRIPTION
Follow-up to #4013, I missed that the exports in each file were manual and not `export *`'d as I'm used to, sorry for that 😅

This patch allows developers to import `FastifyListenOptions` from `fastify` instead of `fastify/types/instance`.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
