### PR TITLE
feat(logger): use pino.BaseLogger as main interface for fastify logger

### DIFF
--- a/docs/Reference/Logging.md
+++ b/docs/Reference/Logging.md
@@ -170,7 +170,7 @@ app.addHook('preHandler', function (req, reply, done) {
 You can also supply your own logger instance. Instead of passing configuration
 options, pass the instance. The logger you supply must conform to the Pino
 interface; that is, it must have the following methods: `info`, `error`,
-`debug`, `fatal`, `warn`, `trace`, `child`.
+`debug`, `fatal`, `warn`, `trace`, `silent`, `child` and a string property `level`.
 
 Example:
 

--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -24,13 +24,10 @@ class Foo {}
   expectType<void>(fastify<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>().log[logLevel as LogLevel](new Foo()))
 })
 
-/*
-// TODO make pino export BaseLogger again
 interface CustomLogger extends FastifyBaseLogger {
   customMethod(msg: string, ...args: unknown[]): void;
 }
 
-//   // ToDo https://github.com/pinojs/pino/issues/1100
 class CustomLoggerImpl implements CustomLogger {
   level = 'info'
   customMethod (msg: string, ...args: unknown[]) { console.log(msg, args) }
@@ -60,7 +57,6 @@ CustomLoggerImpl
 >({ logger: customLogger })
 
 expectType<CustomLoggerImpl>(serverWithCustomLogger.log)
-*/
 
 const serverWithPino = fastify<
 Server,

--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -1,4 +1,4 @@
-import { expectError, expectType } from 'tsd'
+import { expectDeprecated, expectError, expectType } from 'tsd'
 import fastify, {
   FastifyLogFn,
   LogLevel,
@@ -208,6 +208,9 @@ const passPinoOption = fastify({
 })
 
 expectType<FastifyBaseLogger>(passPinoOption.log)
+
+// FastifyLoggerInstance is deprecated
+expectDeprecated({} as FastifyLoggerInstance)
 
 const childParent = fastify().log
 // we test different option variant here

--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -21,7 +21,6 @@ import { FastifyRequest } from '../../types/request'
 import { FastifyReply } from '../../types/reply'
 import { FastifyInstance } from '../../types/instance'
 import { RouteGenericInterface } from '../../types/route'
-import { ResolveFastifyReplyReturnType, ResolveFastifyRequestType } from '../../types/type-provider'
 
 interface RequestBody {
   content: string;
@@ -128,17 +127,6 @@ server.put('/put', putHandler)
 
 const customLogger: CustomLoggerInterface = {
   level: 'info',
-  version: '5.0',
-  useOnlyCustomLevels: false,
-  useLevelLabels: false,
-  levels: { labels: [], values: {} },
-  eventNames: () => [],
-  listenerCount: (eventName: string | symbol) => 0,
-  bindings: () => ({}),
-  flush: () => () => {},
-  customLevels: { foo: 1 },
-  isLevelEnabled: () => false,
-  levelVal: 0,
   silent: () => { },
   info: () => { },
   warn: () => { },
@@ -147,21 +135,7 @@ const customLogger: CustomLoggerInterface = {
   trace: () => { },
   debug: () => { },
   foo: () => { }, // custom severity logger method
-  on: (event, listener) => customLogger,
-  emit: (event, listener) => false,
-  off: (event, listener) => customLogger,
-  addListener: (event, listener) => customLogger,
-  prependListener: (event, listener) => customLogger,
-  prependOnceListener: (event, listener) => customLogger,
-  removeListener: (event, listener) => customLogger,
-  removeAllListeners: (event) => customLogger,
-  setMaxListeners: (n) => customLogger,
-  getMaxListeners: () => 0,
-  listeners: () => [],
-  rawListeners: () => [],
-  once: (event, listener) => customLogger,
-  child: () => customLogger as pino.Logger<never>,
-  setBindings: (bindings) => { }
+  child: () => customLogger as pino.Logger<never>
 }
 
 const serverWithCustomLogger = fastify({ logger: customLogger })

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -23,6 +23,10 @@ export type FastifyBaseLogger = pino.BaseLogger & {
   child(bindings: Bindings, options?: ChildLoggerOptions): FastifyBaseLogger
 }
 
+// TODO delete FastifyLoggerInstance in the next major release. It seems that it is enough to have only FastifyBaseLogger.
+/**
+ * @deprecated Use FastifyBaseLogger instead
+ */
 export type FastifyLoggerInstance = FastifyBaseLogger
 
 export interface FastifyLoggerStreamDestination {

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -19,12 +19,11 @@ export type Bindings = pino.Bindings
 
 export type ChildLoggerOptions = pino.ChildLoggerOptions
 
-export type FastifyLoggerInstance = pino.Logger
-// TODO make pino export BaseLogger again
-// export type FastifyBaseLogger = pino.BaseLogger & {
-export type FastifyBaseLogger = pino.Logger & {
+export type FastifyBaseLogger = pino.BaseLogger & {
   child(bindings: Bindings, options?: ChildLoggerOptions): FastifyBaseLogger
 }
+
+export type FastifyLoggerInstance = FastifyBaseLogger
 
 export interface FastifyLoggerStreamDestination {
   write(msg: string): void;


### PR DESCRIPTION
Using pino.BaseLogger allows to use an own logger implementation in fastify.
The interface describes only base properties unlike pino.Logger that requires
to implement all properties of pino.

Closes #4148

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
