### PR TITLE
fix(types): bad naming of `validateInput`

### DIFF
--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -64,8 +64,8 @@ export interface FastifyRequest<RouteGeneric extends RouteGenericInterface = Rou
   getValidationFunction(httpPart: HTTPRequestPart): (input: any) => boolean
   getValidationFunction(schema: {[key: string]: any}): (input: any) => boolean
   compileValidationSchema(schema: {[key: string]: any}, httpPart?: HTTPRequestPart): (input: any) => boolean
-  validate(input: any, schema: {[key: string]: any}, httpPart?: HTTPRequestPart): boolean
-  validate(input: any, httpPart?: HTTPRequestPart): boolean
+  validateInput(input: any, schema: {[key: string]: any}, httpPart?: HTTPRequestPart): boolean
+  validateInput(input: any, httpPart?: HTTPRequestPart): boolean
 
   // Prefer `socket` over deprecated `connection` property in node 13.0.0 or higher
   // @deprecated


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

**Note**: Thanks to @conioX for the heads up.

The PR fixes a bad naming of the function `validateInput` in the TS Types.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
