### PR TITLE
Make ResolveFastifyReplyType union-aware

### DIFF
--- a/test/types/reply.test-d.ts
+++ b/test/types/reply.test-d.ts
@@ -40,6 +40,14 @@ interface ReplyPayload {
   };
 }
 
+interface ReplyUnion {
+  Reply: {
+    success: boolean;
+  } | {
+    error: string;
+  }
+}
+
 const typedHandler: RouteHandler<ReplyPayload> = async (request, reply) => {
   expectType<((payload?: ReplyPayload['Reply']) => FastifyReply<RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>, ReplyPayload>)>(reply.send)
 }
@@ -53,9 +61,35 @@ server.get<ReplyPayload>('/get-generic-send', async function handler (request, r
 server.get<ReplyPayload>('/get-generic-return', async function handler (request, reply) {
   return { test: false }
 })
-expectError(server.get<ReplyPayload>('/get-generic-return-error', async function handler (request, reply) {
+expectError(server.get<ReplyPayload>('/get-generic-send-error', async function handler (request, reply) {
   reply.send({ foo: 'bar' })
 }))
 expectError(server.get<ReplyPayload>('/get-generic-return-error', async function handler (request, reply) {
   return { foo: 'bar' }
+}))
+server.get<ReplyUnion>('/get-generic-union-send', async function handler (request, reply) {
+  if (0 as number === 0) {
+    reply.send({ success: true })
+  } else {
+    reply.send({ error: 'error' })
+  }
+})
+server.get<ReplyUnion>('/get-generic-union-return', async function handler (request, reply) {
+  if (0 as number === 0) {
+    return { success: true }
+  } else {
+    return { error: 'error' }
+  }
+})
+expectError(server.get<ReplyUnion>('/get-generic-union-send-error-1', async function handler (request, reply) {
+  reply.send({ successes: true })
+}))
+expectError(server.get<ReplyUnion>('/get-generic-union-send-error-2', async function handler (request, reply) {
+  reply.send({ error: 500 })
+}))
+expectError(server.get<ReplyUnion>('/get-generic-union-return-error-1', async function handler (request, reply) {
+  return { successes: true }
+}))
+expectError(server.get<ReplyUnion>('/get-generic-union-return-error-2', async function handler (request, reply) {
+  return { error: 500 }
 }))

--- a/test/types/type-provider.test-d.ts
+++ b/test/types/type-provider.test-d.ts
@@ -391,7 +391,9 @@ expectError(server.withTypeProvider<JsonSchemaToTsProvider>().get(
 // https://github.com/fastify/fastify/issues/4088
 expectError(server.withTypeProvider<JsonSchemaToTsProvider>().get('/', {
   schema: {
-    response: { type: 'string' }
+    response: {
+      200: { type: 'string' }
+    }
   } as const
 }, (_, res) => {
   return { foo: 555 }

--- a/types/type-provider.d.ts
+++ b/types/type-provider.d.ts
@@ -60,15 +60,6 @@ export interface ResolveFastifyRequestType<TypeProvider extends FastifyTypeProvi
 // FastifyReplyType
 // -----------------------------------------------------------------------------------------------
 
-// Tests if the user has specified a generic argument for Reply
-type UseReplyFromRouteGeneric<RouteGeneric extends RouteGenericInterface> = keyof RouteGeneric['Reply'] extends never ? false : true
-
-// Tests if the user has specified a response schema.
-type UseReplyFromSchemaCompiler<SchemaCompiler extends FastifySchema> = keyof SchemaCompiler['response'] extends never ? false : true
-
-// Resolves the Reply type from the generic argument
-type ResolveReplyFromRouteGeneric<RouteGeneric extends RouteGenericInterface> = RouteGeneric['Reply']
-
 // Resolves the Reply type by taking a union of response status codes
 type ResolveReplyFromSchemaCompiler<TypeProvider extends FastifyTypeProvider, SchemaCompiler extends FastifySchema> = {
   [K in keyof SchemaCompiler['response']]: CallTypeProvider<TypeProvider, SchemaCompiler['response'][K]>
@@ -80,11 +71,7 @@ export type FastifyReplyType<Reply = unknown> = Reply
 // Resolves the Reply type either via generic argument or from response schema. This type uses a different
 // resolution strategy to Requests where the Reply will infer a union of each status code type specified
 // by the user. The Reply can be explicitly overriden by users providing a generic Reply type on the route.
-export type ResolveFastifyReplyType<TypeProvider extends FastifyTypeProvider, SchemaCompiler extends FastifySchema, RouteGeneric extends RouteGenericInterface> = FastifyReplyType<
-UseReplyFromRouteGeneric<RouteGeneric> extends true ? ResolveReplyFromRouteGeneric<RouteGeneric> :
-  UseReplyFromSchemaCompiler<SchemaCompiler> extends true ? ResolveReplyFromSchemaCompiler<TypeProvider, SchemaCompiler> :
-    unknown
->
+export type ResolveFastifyReplyType<TypeProvider extends FastifyTypeProvider, SchemaCompiler extends FastifySchema, RouteGeneric extends RouteGenericInterface> = UndefinedToUnknown<KeysOf<RouteGeneric['Reply']> extends never ? ResolveReplyFromSchemaCompiler<TypeProvider, SchemaCompiler> : RouteGeneric['Reply']>
 
 // -----------------------------------------------------------------------------------------------
 // FastifyReplyReturnType


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Along with #4076, fixed a problem that when union type passed as Reply to RouteGeneric.

This fix revealed that the test added in #4089, and includes fix for that.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
