### PR TITLE
Docs: onResponse hook error logging

### DIFF
--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -290,7 +290,7 @@ fastify.addHook('preHandler', (request, reply, done) => {
 
 Or if you're using `async/await` you can just throw an error:
 ```js
-fastify.addHook('onResponse', async (request, reply) => {
+fastify.addHook('onRequest', async (request, reply) => {
   throw new Error('Some error')
 })
 ```

--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -244,6 +244,8 @@ The `onResponse` hook is executed when a response has been sent, so you will not
 be able to send more data to the client. It can however be useful for sending
 data to external services, for example, to gather statistics.
 
+**Note:** setting `disableRequestLogging` to `true` will disable any error log inside the `onResponse` hook. In this case use `try - catch` to log errors. 
+
 ### onTimeout
 
 ```js

--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -244,7 +244,8 @@ The `onResponse` hook is executed when a response has been sent, so you will not
 be able to send more data to the client. It can however be useful for sending
 data to external services, for example, to gather statistics.
 
-**Note:** setting `disableRequestLogging` to `true` will disable any error log inside the `onResponse` hook. In this case use `try - catch` to log errors. 
+**Note:** setting `disableRequestLogging` to `true` will disable any error log 
+inside the `onResponse` hook. In this case use `try - catch` to log errors. 
 
 ### onTimeout
 

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1402,6 +1402,8 @@ handlers. *async-await* is supported as well.
 *Note: If the error `statusCode` is less than 400, Fastify will automatically
 set it at 500 before calling the error handler.*
 
+*Also note* that `setErrorHandler` will ***not*** catch any error inside `onResponse` hook
+
 ```js
 fastify.setErrorHandler(function (error, request, reply) {
   // Log error

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1403,7 +1403,7 @@ handlers. *async-await* is supported as well.
 set it at 500 before calling the error handler.*
 
 *Also note* that `setErrorHandler` will ***not*** catch any error inside
-`onResponse` hook
+`onResponse` hook because the response is already sent to the client.
 
 ```js
 fastify.setErrorHandler(function (error, request, reply) {

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1403,7 +1403,7 @@ handlers. *async-await* is supported as well.
 set it at 500 before calling the error handler.*
 
 *Also note* that `setErrorHandler` will ***not*** catch any error inside
-`onResponse` hook because the response is already sent to the client.
+an `onResponse` hook because the response has already been sent to the client.
 
 ```js
 fastify.setErrorHandler(function (error, request, reply) {

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1402,7 +1402,8 @@ handlers. *async-await* is supported as well.
 *Note: If the error `statusCode` is less than 400, Fastify will automatically
 set it at 500 before calling the error handler.*
 
-*Also note* that `setErrorHandler` will ***not*** catch any error inside `onResponse` hook
+*Also note* that `setErrorHandler` will ***not*** catch any error inside
+`onResponse` hook
 
 ```js
 fastify.setErrorHandler(function (error, request, reply) {


### PR DESCRIPTION
### Description

Integrated docs for `setErrorHandler` and `onResponse` hook.
Related to Issue #4173 

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
