### PR TITLE
fix: backport reused connection fix

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const VERSION = '3.29.0'
+const VERSION = '3.29.1'
 
 const Avvio = require('avvio')
 const http = require('http')
@@ -584,7 +584,7 @@ function fastify (options) {
     // https://github.com/nodejs/node/blob/6ca23d7846cb47e84fd344543e394e50938540be/lib/_http_server.js#L666
 
     // If the socket is not writable, there is no reason to try to send data.
-    if (socket.writable && socket.bytesWritten === 0) {
+    if (socket.writable) {
       socket.write(`HTTP/1.1 400 Bad Request\r\nContent-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n${body}`)
     }
     socket.destroy(err)

--- a/test/request-error.test.js
+++ b/test/request-error.test.js
@@ -2,6 +2,7 @@
 
 const { connect } = require('net')
 const t = require('tap')
+const semver = require('semver')
 const test = t.test
 const Fastify = require('..')
 const { kRequest } = require('../lib/symbols.js')
@@ -153,7 +154,7 @@ test('default clientError handler ignores sockets in destroyed state', t => {
 })
 
 test('default clientError handler destroys sockets in writable state', t => {
-  t.plan(1)
+  t.plan(2)
 
   const fastify = Fastify({
     bodyLimit: 1,
@@ -169,6 +170,9 @@ test('default clientError handler destroys sockets in writable state', t => {
     },
     destroy () {
       t.pass('destroy should be called')
+    },
+    write (response) {
+      t.match(response, /^HTTP\/1.1 400 Bad Request/)
     }
   })
 })
@@ -189,6 +193,9 @@ test('default clientError handler destroys http sockets in non-writable state', 
     },
     destroy () {
       t.pass('destroy should be called')
+    },
+    write (response) {
+      t.fail('write should not be called')
     }
   })
 })
@@ -271,5 +278,44 @@ test('encapsulated error handler binding', t => {
       statusCode: 400
     })
     t.equal(fastify.hello, undefined)
+  })
+})
+
+const skip = semver.lt(process.versions.node, '11.0.0')
+
+test('default clientError replies with bad request on reused keep-alive connection', { skip }, t => {
+  t.plan(2)
+
+  let response = ''
+
+  const fastify = Fastify({
+    bodyLimit: 1,
+    keepAliveTimeout: 100
+  })
+
+  fastify.get('/', (request, reply) => {
+    reply.send('OK\n')
+  })
+
+  fastify.listen({ port: 0 }, function (err) {
+    t.error(err)
+    fastify.server.unref()
+
+    const client = connect(fastify.server.address().port)
+
+    client.on('data', chunk => {
+      response += chunk.toString('utf-8')
+    })
+
+    client.on('end', () => {
+      t.match(response, /^HTTP\/1.1 200 OK.*HTTP\/1.1 400 Bad Request/s)
+    })
+
+    client.resume()
+    client.write('GET / HTTP/1.1\r\n')
+    client.write('\r\n\r\n')
+    client.write('GET /?a b HTTP/1.1\r\n')
+    client.write('Connection: close\r\n')
+    client.write('\r\n\r\n')
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
this PR is a back-port of the work done in [this](https://github.com/fastify/fastify/pull/4133) PR to the 3.x branch
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
