### PR TITLE
chore: fastify branch list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,17 +36,19 @@ There are a few basic ground-rules for contributors:
 1. In case it is not possible to reach consensus in a pull-request, the decision
    is left to the lead maintainer's team.
 
-### Fastify v1.x
+### Fastify previous versions
 
-Code for Fastify's **v1.x** is in [branch
-1.x](https://github.com/fastify/fastify/tree/1.x), so all Fastify 1.x related
-changes should be based on **`branch 1.x`**.
+Every Fastify's version is on its own branch. All Fastify related
+changes should be based on the corresponding branch.
 
-### Fastify v2.x
+We have a [Long Term Support](./docs/Reference/LTS.md) policy that defines
+the organization efforts for each Fastify's version.
 
-Code for Fastify's **v2.x** is in [branch
-2.x](https://github.com/fastify/fastify/tree/2.x), so all Fastify 2.x related
-changes should be based on **`branch 2.x`**.
+|Version|Branch|
+|-------|------|
+**v1.x**|[branch 1.x](https://github.com/fastify/fastify/tree/1.x)|
+**v2.x**|[branch 2.x](https://github.com/fastify/fastify/tree/2.x)|
+**v3.x**|[branch 3.x](https://github.com/fastify/fastify/tree/3.x)|
 
 ## Releases
 


### PR DESCRIPTION
v3 was missing, so a table seems more readable
