### PR TITLE
chore: fix typo in docs for typescript chapter

### DIFF
--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -1237,8 +1237,8 @@ const plugin: FastifyPlugin<{
   option2: boolean;
 }> = function (instance, opts, done) { }
 
-fastify().register(plugin, {}) // Error - options object is missing required properties
-fastify().register(plugin, { option1: '', option2: true }) // OK - options object contains required properties
+server().register(plugin, {}) // Error - options object is missing required properties
+server().register(plugin, { option1: '', option2: true }) // OK - options object contains required properties
 ```
 
 See the Learn By Example, [Plugins](#plugins) section for more detailed examples


### PR DESCRIPTION
in reading docs I found a typo issue to change.
it seems 'server' not 'fastify'.

```typescript
const server = fastify()
// stuffs...
server().register(plugin, {}) // Error - options object is missing required properties
server().register(plugin, { option1: '', option2: true }) // OK - options object contains required properties
```

#### Checklist

- [x] documentation is changed or added
