### PR TITLE
docs: improved migration guide for onRoute

### DIFF
--- a/docs/Guides/Migration-Guide-V4.md
+++ b/docs/Guides/Migration-Guide-V4.md
@@ -71,28 +71,48 @@ The route registration has been made synchronous from v4.
 This change was done to provide better error reporting for route definition.
 As a result if you specify an `onRoute` hook in a plugin you should either:
 * wrap your routes in a plugin (recommended)
+
+  For example refactor your server to this:
+
+  ```
+  import Fastify from 'fastify'
+  import FP from 'fastify-plugin'
+
+  fastify.register(FP(function(fastify, option, done) {
+    fastify.addHook('onRoute', function() {
+      console.log('onRoute')
+    })
+    done()
+  }))
+
+  fastify.register(function(fastify, option, done) {
+    fastify.get('/', () => 'hello')
+    done()
+  })
+  ```
+  
 * use `await register(...)`
 
-For example refactor this:
-```
-fastify.register((instance, opts, done) => {
-  instance.addHook('onRoute', (routeOptions) => {
-    const { path, method } = routeOptions;
-    console.log({ path, method });
+  For example refactor this:
+  ```
+  fastify.register((instance, opts, done) => {
+    instance.addHook('onRoute', (routeOptions) => {
+      const { path, method } = routeOptions;
+      console.log({ path, method });
+    });
+    done();
   });
-  done();
-});
-```
-Into this:
-```
-await fastify.register((instance, opts, done) => {
-  instance.addHook('onRoute', (routeOptions) => {
-    const { path, method } = routeOptions;
-    console.log({ path, method });
+  ```
+  Into this:
+  ```
+  await fastify.register((instance, opts, done) => {
+    instance.addHook('onRoute', (routeOptions) => {
+      const { path, method } = routeOptions;
+      console.log({ path, method });
+    });
+    done();
   });
-  done();
-});
-```
+  ```
 
 ## Non Breaking Changes
 

--- a/docs/Guides/Migration-Guide-V4.md
+++ b/docs/Guides/Migration-Guide-V4.md
@@ -72,25 +72,37 @@ This change was done to provide better error reporting for route definition.
 As a result if you specify an `onRoute` hook in a plugin you should either:
 * wrap your routes in a plugin (recommended)
 
-  For example refactor your server to this:
+  For example refactor this:
 
   ```
-  import Fastify from 'fastify'
-  import FP from 'fastify-plugin'
+  fastify.register((instance, opts, done) => {
+    instance.addHook('onRoute', (routeOptions) => {
+      const { path, method } = routeOptions;
+      console.log({ path, method });
+      done();
+    });
+  });
 
-  fastify.register(FP(function(fastify, option, done) {
-    fastify.addHook('onRoute', function() {
-      console.log('onRoute')
-    })
-    done()
-  }))
-
-  fastify.register(function(fastify, option, done) {
-    fastify.get('/', () => 'hello')
-    done()
-  })
+  fastify.get('/', () => 'hello');
   ```
-  
+
+  Into this:
+
+  ```
+  fastify.register((instance, opts, done) => {
+    instance.addHook('onRoute', (routeOptions) => {
+      const { path, method } = routeOptions;
+      console.log({ path, method });
+      done();
+    });
+  });
+
+  fastify.register((instance, opts, done) => {
+    instance.get('/', () => 'hello');
+    done();
+  });
+  ```
+
 * use `await register(...)`
 
   For example refactor this:


### PR DESCRIPTION
This PR improves the migration guide to explicit how to define routes when `onRoute` is also used.