### PR TITLE
chore: export RouteGenericInterface

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -197,7 +197,7 @@ export { FastifyPluginCallback, FastifyPluginAsync, FastifyPluginOptions, Fastif
 export { FastifyListenOptions, FastifyInstance, PrintRoutesOptions } from './types/instance'
 export { FastifyLoggerOptions, FastifyBaseLogger, FastifyLoggerInstance, FastifyLogFn, LogLevel } from './types/logger'
 export { FastifyContext, FastifyContextConfig } from './types/context'
-export { RouteHandler, RouteHandlerMethod, RouteOptions, RouteShorthandMethod, RouteShorthandOptions, RouteShorthandOptionsWithHandler } from './types/route'
+export { RouteHandler, RouteHandlerMethod, RouteOptions, RouteShorthandMethod, RouteShorthandOptions, RouteShorthandOptionsWithHandler, RouteGenericInterface } from './types/route'
 export * from './types/register'
 export { FastifyBodyParser, FastifyContentTypeParser, AddContentTypeParser, hasContentTypeParser, getDefaultJsonParser, ProtoAction, ConstructorAction } from './types/content-type-parser'
 export { FastifyError } from '@fastify/error'

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -8,6 +8,7 @@ import fastify, {
   LightMyRequestResponse,
   LightMyRequestCallback,
   InjectOptions, FastifyBaseLogger,
+  RouteGenericInterface,
   ValidationResult
 } from '../../fastify'
 import { ErrorObject as AjvErrorObject } from 'ajv'
@@ -232,3 +233,6 @@ const ajvErrorObject: AjvErrorObject = {
   message: ''
 }
 expectAssignable<ValidationResult>(ajvErrorObject)
+
+const routeGeneric: RouteGenericInterface = {}
+expectType<RouteGenericInterface>(routeGeneric)

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -235,4 +235,8 @@ const ajvErrorObject: AjvErrorObject = {
 expectAssignable<ValidationResult>(ajvErrorObject)
 
 const routeGeneric: RouteGenericInterface = {}
-expectType<RouteGenericInterface>(routeGeneric)
+expectType<unknown>(routeGeneric.Body)
+expectType<unknown>(routeGeneric.Headers)
+expectType<unknown>(routeGeneric.Params)
+expectType<unknown>(routeGeneric.Querystring)
+expectType<unknown>(routeGeneric.Reply)


### PR DESCRIPTION
This is a very small change just to re-export RouteGenericInterface which is needed by typescript 4.8.x for implementations of RouteHandlerMethod
I created an issue for this https://github.com/fastify/fastify/issues/4235 that will be solved by this PR.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
