### PR TITLE
Improve doc about configuring pino-pretty with TypeScript

### DIFF
--- a/docs/Reference/Logging.md
+++ b/docs/Reference/Logging.md
@@ -22,21 +22,24 @@ const fastify = require('fastify')({
 ```
 
 Enabling the logger with appropriate configuration for both local development
-and production environment requires bit more configuration:
+and production and test environment requires bit more configuration:
+
 ```js
+const envToLogger = {
+  development: {
+    transport: {
+      target: 'pino-pretty',
+      options: {
+        translateTime: 'HH:MM:ss Z',
+        ignore: 'pid,hostname',
+      },
+    },
+  },
+  production: true,
+  test: false,
+}
 const fastify = require('fastify')({
-  logger: {
-      transport:
-        environment === 'development'
-          ? {
-              target: 'pino-pretty',
-              options: {
-                translateTime: 'HH:MM:ss Z',
-                ignore: 'pid,hostname'
-              }
-            }
-          : undefined
-    }
+  logger: envToLogger[process.env.NODE_ENV]
 })
 ```
 ⚠️ `pino-pretty` needs to be installed as a dev dependency, it is not included

--- a/docs/Reference/Logging.md
+++ b/docs/Reference/Logging.md
@@ -39,7 +39,7 @@ const envToLogger = {
   test: false,
 }
 const fastify = require('fastify')({
-  logger: envToLogger[process.env.NODE_ENV]
+  logger: envToLogger[environment] || true // defaults to true if no entry matches in the map
 })
 ```
 ⚠️ `pino-pretty` needs to be installed as a dev dependency, it is not included


### PR DESCRIPTION
https://github.com/fastify/fastify/issues/4184

I am using the configurations described in the change in TypeScript project and works without type errors.
Of course in TypeScript I am importing Fastify using ESM syntax to have typings properly working.

Please let me know if you would use a different strategy for picking a logging configuration, I personally like to use an object to map the logger configuration for each environment.

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
