### PR TITLE
fix: visit schemas with custom prototype

### DIFF
--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -62,6 +62,7 @@ function normalizeSchema (routeSchemas, serverOptions) {
   // let's check if our schemas have a custom prototype
   for (const key of ['headers', 'querystring', 'params', 'body']) {
     if (typeof routeSchemas[key] === 'object' && Object.getPrototypeOf(routeSchemas[key]) !== Object.prototype) {
+      routeSchemas[kSchemaVisited] = true
       return routeSchemas
     }
   }


### PR DESCRIPTION
Fix https://stackoverflow.com/questions/73549034/error-with-route-validation-after-upgrading-fastify

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
