### PR TITLE
docs: Remove Ajv configuration from TypeBox Type Provider examples

### DIFF
--- a/docs/Reference/Type-Providers.md
+++ b/docs/Reference/Type-Providers.md
@@ -155,14 +155,7 @@ import Fastify from 'fastify'
 import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox'
 import { Type } from '@sinclair/typebox'
 
-const server = Fastify({
-    ajv: {
-        customOptions: {
-            strict: 'log',
-            keywords: ['kind', 'modifier'],
-        },
-    },
-}).withTypeProvider<TypeBoxTypeProvider>()
+const server = Fastify().withTypeProvider<TypeBoxTypeProvider>()
 
 server.register(plugin1) // wrong
 server.register(plugin2) // correct
@@ -213,14 +206,7 @@ import Fastify from 'fastify'
 import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox'
 import { registerRoutes } from './routes'
 
-const server = Fastify({
-    ajv: {
-        customOptions: {
-            strict: 'log',
-            keywords: ['kind', 'modifier'],
-        },
-    },
-}).withTypeProvider<TypeBoxTypeProvider>()
+const server = Fastify().withTypeProvider<TypeBoxTypeProvider>()
 
 registerRoutes(server)
 


### PR DESCRIPTION
Remove Ajv configuration from example code in the Type Providers documentation.

As described in https://github.com/fastify/fastify/pull/4095, TypeBox no longer requires explicitly configuring Ajv to recognize the `kind` and `modifier` keywords.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
