### PR TITLE
Docs: Fixing #schema-validator url at ./Reference/Server/#ajv

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -668,7 +668,7 @@ the incoming request as usual.
 
 Configure the Ajv v8 instance used by Fastify without providing a custom one.
 The default configuration is explained in the
-[#schema-validator](Validation-and-Serialization.md#schema-validator) section.
+[#schema-validator](./Validation-and-Serialization.md#schema-validator) section.
 
 ```js
 const fastify = require('fastify')({


### PR DESCRIPTION
Fixing #schema-validator url at https://www.fastify.io/docs/latest/Reference/Server/#ajv

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
