### PR TITLE
chore: improve `Ecosystem.md` linter to check for improper module name patterns

### DIFF
--- a/.github/scripts/lint-ecosystem.js
+++ b/.github/scripts/lint-ecosystem.js
@@ -19,29 +19,15 @@ module.exports = async function ({ core }) {
   let inCommunitySection = false
   let modules = []
   let hasImproperFormat = false
-  let moduleName
 
   for await (const line of rl) {
     lineNumber += 1
-
-    if (line.startsWith('- [') === true) {
-      moduleName = moduleNameRegex.exec(line)?.[1]
-      if (moduleName === undefined)
-      {
-        core.error(`line ${lineNumber}: improper pattern, module name should be enclosed with backticks`)
-        hasImproperFormat = true
-      }
-      continue
-    }
-
     if (line.startsWith('#### [Community]')) {
       inCommunitySection = true
     }
-
     if (line.startsWith('#### [Community Tools]')) {
       inCommunitySection = false
     }
-
     if (inCommunitySection === false) {
       continue
     }
@@ -50,6 +36,16 @@ module.exports = async function ({ core }) {
       continue
     }
 
+    const moduleNameTest = moduleNameRegex.exec(line)
+    
+    if (moduleNameTest === null)
+    {
+      core.error(`line ${lineNumber}: improper pattern, module name should be enclosed with backticks`)
+      hasImproperFormat = true
+      continue
+    }
+
+    const moduleName = moduleNameTest[1]
     if (modules.length > 0) {
       if (compare(moduleName, modules.at(-1)) > 0) {
         core.error(`line ${lineNumber}: ${moduleName} not listed in alphabetical order`)

--- a/.github/scripts/lint-ecosystem.js
+++ b/.github/scripts/lint-ecosystem.js
@@ -31,6 +31,7 @@ module.exports = async function ({ core }) {
         core.error(`line ${lineNumber}: improper pattern, module name should be enclosed with backticks`)
         hasImproperFormat = true
       }
+      continue
     }
 
     if (line.startsWith('#### [Community]')) {
@@ -49,7 +50,7 @@ module.exports = async function ({ core }) {
       continue
     }
 
-    if (moduleName && modules.at(-1) && modules.length > 0) {
+    if (modules.length > 0) {
       if (compare(moduleName, modules.at(-1)) > 0) {
         core.error(`line ${lineNumber}: ${moduleName} not listed in alphabetical order`)
         hasOutOfOrderItem = true

--- a/.github/scripts/lint-ecosystem.js
+++ b/.github/scripts/lint-ecosystem.js
@@ -18,6 +18,7 @@ module.exports = async function ({ core }) {
   let lineNumber = 0
   let inCommunitySection = false
   let modules = []
+  let hasImproperFormat = false
 
   for await (const line of rl) {
     lineNumber += 1
@@ -35,15 +36,15 @@ module.exports = async function ({ core }) {
       continue
     }
 
-    const moduleNameTest = moduleNameRegex.exec(line)
+    const moduleName = moduleNameRegex.exec(line)?.[1]
     
-    if (moduleNameTest === null)
+    if (moduleName === undefined)
     {
-      return core.setFailed(`line ${lineNumber}: improper pattern, module name should be enclosed with backticks`)
+      core.error(`line ${lineNumber}: improper pattern, module name should be enclosed with backticks`)
+      hasImproperFormat = true
     }
 
-    const moduleName = moduleNameTest[1]
-    if (modules.length > 0) {
+    if (moduleName && modules.at(-1) && modules.length > 0) {
       if (compare(moduleName, modules.at(-1)) > 0) {
         core.error(`line ${lineNumber}: ${moduleName} not listed in alphabetical order`)
         hasOutOfOrderItem = true
@@ -54,6 +55,10 @@ module.exports = async function ({ core }) {
 
   if (hasOutOfOrderItem === true) {
     core.setFailed('Some ecosystem modules are not in alphabetical order.')
+  }
+  
+  if (hasImproperFormat === true) {
+    core.setFailed('Some ecosystem modules are improperly formatted.')
   }
 }
 

--- a/.github/scripts/lint-ecosystem.js
+++ b/.github/scripts/lint-ecosystem.js
@@ -19,29 +19,34 @@ module.exports = async function ({ core }) {
   let inCommunitySection = false
   let modules = []
   let hasImproperFormat = false
+  let moduleName
 
   for await (const line of rl) {
     lineNumber += 1
+
+    if (line.startsWith('- [') === true) {
+      moduleName = moduleNameRegex.exec(line)?.[1]
+      if (moduleName === undefined)
+      {
+        core.error(`line ${lineNumber}: improper pattern, module name should be enclosed with backticks`)
+        hasImproperFormat = true
+      }
+    }
+
     if (line.startsWith('#### [Community]')) {
       inCommunitySection = true
     }
+
     if (line.startsWith('#### [Community Tools]')) {
       inCommunitySection = false
     }
+
     if (inCommunitySection === false) {
       continue
     }
 
     if (line.startsWith('- [') !== true) {
       continue
-    }
-
-    const moduleName = moduleNameRegex.exec(line)?.[1]
-    
-    if (moduleName === undefined)
-    {
-      core.error(`line ${lineNumber}: improper pattern, module name should be enclosed with backticks`)
-      hasImproperFormat = true
     }
 
     if (moduleName && modules.at(-1) && modules.length > 0) {

--- a/.github/scripts/lint-ecosystem.js
+++ b/.github/scripts/lint-ecosystem.js
@@ -16,26 +16,33 @@ module.exports = async function ({ core }) {
   const moduleNameRegex = /^\- \[\`(.+)\`\]/
   let hasOutOfOrderItem = false
   let lineNumber = 0
-  let inCommmunitySection = false
+  let inCommunitySection = false
   let modules = []
 
   for await (const line of rl) {
     lineNumber += 1
     if (line.startsWith('#### [Community]')) {
-      inCommmunitySection = true
+      inCommunitySection = true
     }
     if (line.startsWith('#### [Community Tools]')) {
-      inCommmunitySection = false
+      inCommunitySection = false
     }
-    if (inCommmunitySection === false) {
+    if (inCommunitySection === false) {
       continue
     }
 
-    if (line.startsWith('- [`') !== true) {
+    if (line.startsWith('- [') !== true) {
       continue
     }
 
-    const moduleName = moduleNameRegex.exec(line)[1]
+    const moduleNameTest = moduleNameRegex.exec(line)
+    
+    if (moduleNameTest === null)
+    {
+      return core.setFailed(`line ${lineNumber}: improper pattern, module name should be enclosed with backticks`)
+    }
+
+    const moduleName = moduleNameTest[1]
     if (modules.length > 0) {
       if (compare(moduleName, modules.at(-1)) > 0) {
         core.error(`line ${lineNumber}: ${moduleName} not listed in alphabetical order`)


### PR DESCRIPTION
Improve ecosystem linting script by returning an error in case of an improperly added module name pattern (i.e., not enclosed with backticks)

Resolves #4256 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
