### PR TITLE
test: remove assert to invalid HTTP version

### DIFF
--- a/test/unsupported-httpversion.test.js
+++ b/test/unsupported-httpversion.test.js
@@ -4,32 +4,6 @@ const net = require('net')
 const t = require('tap')
 const Fastify = require('../fastify')
 
-t.test('Will return 505 HTTP error if HTTP version (default) is not supported', t => {
-  const fastify = Fastify()
-
-  t.teardown(fastify.close.bind(fastify))
-
-  fastify.get('/', (req, reply) => {
-    reply.send({ hello: 'world' })
-  })
-
-  fastify.listen({ port: 0 }, err => {
-    t.error(err)
-
-    const port = fastify.server.address().port
-    const client = net.createConnection({ port }, () => {
-      client.write('GET / HTTP/5.1\r\n\r\n')
-
-      client.once('data', data => {
-        t.match(data.toString(), /505 HTTP Version Not Supported/i)
-        client.end(() => {
-          t.end()
-        })
-      })
-    })
-  })
-})
-
 t.test('Will return 505 HTTP error if HTTP version (2.0 when server is 1.1) is not supported', t => {
   const fastify = Fastify()
 


### PR DESCRIPTION
This behaviour has changed on v18.9. It's now validating and returning `400 Bad Request`.

For further information, see: https://github.com/nodejs/node/pull/44344