### PR TITLE
doc: Remove Ajv configuration for TypeBox in TS examples

### DIFF
--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -254,18 +254,6 @@ can do it as follows:
     )
     ```
 
-     **Note** For Ajv version 7 and above is required to use the `ajvTypeBoxPlugin`:
-
-    ```typescript
-    import Fastify from 'fastify'
-    import { ajvTypeBoxPlugin, TypeBoxTypeProvider } from '@fastify/type-provider-typebox'
-
-    const fastify = Fastify({
-      ajv: {
-        plugins: [ajvTypeBoxPlugin]
-      }
-    }).withTypeProvider<TypeBoxTypeProvider>()
-    ```
 
 #### Schemas in JSON Files
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Remove Ajv configuration from the example code in the Type Providers documentation.

As described in https://github.com/fastify/fastify/pull/4249, TypeBox no longer requires explicitly configuring Ajv to recognize the kind and modifier keywords. I got confused while reading the docs and noticed that `ajvTypeBoxPlugin` is not available in `@fastify/type-provider-typebox`. A few searches through the different repos and commits got me to realise that this part of the doc wasn't updated and also the merged PR #4249 is not yet reflected in the documentation.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
