### PR TITLE
Variadic listen signature allows string port

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -319,7 +319,7 @@ function normalizeListenArgs (args) {
     options.backlog = argsLength > 1 ? lastArg : undefined
   } else {
     /* Deal with listen ([port[, host[, backlog]]]) */
-    options.port = argsLength >= 1 && Number.isInteger(firstArg) ? firstArg : 0
+    options.port = argsLength >= 1 && Number.isInteger(firstArg) ? firstArg : normalizePort(firstArg)
     // This will listen to what localhost is.
     // It can be 127.0.0.1 or ::1, depending on the operating system.
     // Fixes https://github.com/fastify/fastify/issues/1022.
@@ -328,6 +328,11 @@ function normalizeListenArgs (args) {
   }
 
   return options
+}
+
+function normalizePort (firstArg) {
+  const port = parseInt(firstArg, 10)
+  return port >= 0 && !Number.isNaN(port) ? port : 0
 }
 
 function logServerAddress (server) {

--- a/test/listen.deprecated.test.js
+++ b/test/listen.deprecated.test.js
@@ -200,3 +200,26 @@ test('listen when firstArg is { path: string(pipe) } and with backlog and callba
     t.equal(address, '\\\\.\\pipe\\testPipe3')
   })
 })
+
+test('listen accepts a port as string, and callback', t => {
+  t.plan(2)
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+  const port = 3000
+  fastify.listen(port.toString(), localhost, (err) => {
+    t.equal(fastify.server.address().port, port)
+    t.error(err)
+  })
+})
+
+test('listen accepts a port as string, address and callback', t => {
+  t.plan(3)
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+  const port = 3000
+  fastify.listen(port.toString(), localhost, (err) => {
+    t.equal(fastify.server.address().port, port)
+    t.equal(fastify.server.address().address, localhost)
+    t.error(err)
+  })
+})

--- a/test/listen.deprecated.test.js
+++ b/test/listen.deprecated.test.js
@@ -223,3 +223,13 @@ test('listen accepts a port as string, address and callback', t => {
     t.error(err)
   })
 })
+
+test('listen with invalid port string without callback with (address)', t => {
+  t.plan(1)
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+  fastify.listen('-1')
+    .then(address => {
+      t.equal(address, `http://${localhostForURL}:${fastify.server.address().port}`)
+    })
+})


### PR DESCRIPTION
resolves: https://github.com/fastify/fastify/issues/4267

At the moment when using  the variadic signature of `listen` and passing the `port` as a `string`, the `port` is converted to `0`  even though the signature allows `string` as type.
With this PR it is possible to convert the `port` from `string` to `number`, and only in case the `string` cannot be parsed to a valid integer it converts it to `0`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
