### PR TITLE
docs(ecosystem): add 2 new fastify v3.x+ plugins

### DIFF
--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -144,6 +144,8 @@ section.
   sampling process metrics.
 - [`@dnlup/fastify-traps`](https://github.com/dnlup/fastify-traps) A plugin to
   close the server gracefully on `SIGINT` and `SIGTERM` signals.
+- [`@eropple/fastify-openapi3`](https://github.com/eropple/fastify-openapi3) Provides
+  easy, developer-friendly OpenAPI 3.1 specs + doc explorer based on your routes.
 - [`@ethicdevs/fastify-custom-session`](https://github.com/EthicDevs/fastify-custom-session)
   A plugin that let you use session and decide only where to load/save from/to. Has
   great TypeScript support + built-in adapters for common ORMs/databases (Firebase,
@@ -151,8 +153,6 @@ section.
 - [`@ethicdevs/fastify-git-server`](https://github.com/EthicDevs/fastify-git-server)
   A plugin to easily create git server and make one/many Git repositories available
   for clone/fetch/push through the standard `git` (over http) commands.
-- [`@eropple/fastify-openapi3`](https://github.com/eropple/fastify-openapi3) Provides
-  easy, developer-friendly OpenAPI 3.1 specs + doc explorer based on your routes.
 - [`@gquittet/graceful-server`](https://github.com/gquittet/graceful-server)
   Tiny (~5k), Fast, KISS, and dependency-free Node.JS library to make your
   Fastify API graceful.

--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -144,6 +144,13 @@ section.
   sampling process metrics.
 - [`@dnlup/fastify-traps`](https://github.com/dnlup/fastify-traps) A plugin to
   close the server gracefully on `SIGINT` and `SIGTERM` signals.
+- [`@ethicdevs/fastify-custom-session`](https://github.com/EthicDevs/fastify-custom-session)
+  A plugin that let you use session and decide only where to load/save from/to. Has
+  great TypeScript support + built-in adapters for common ORMs/databases (Firebase,
+  Prisma Client, Postgres (wip), InMemory) and you can easily make your own adapter!
+- [`@ethicdevs/fastify-git-server`](https://github.com/EthicDevs/fastify-git-server)
+  A plugin to easily create git server and make one/many Git repositories available
+  for clone/fetch/push through the standard `git` (over http) commands.
 - [`@eropple/fastify-openapi3`](https://github.com/eropple/fastify-openapi3) Provides
   easy, developer-friendly OpenAPI 3.1 specs + doc explorer based on your routes.
 - [`@gquittet/graceful-server`](https://github.com/gquittet/graceful-server)


### PR DESCRIPTION
This commit/PR adds the following plugins to the community section of the plugins' list:

- [`@ethicdevs/fastify-custom-session`](https://github.com/EthicDevs/fastify-custom-session)
- [`@ethicdevs/fastify-git-server`](https://github.com/EthicDevs/fastify-git-server)

Hope you'll like them 😛

#### Checklist

- [ ] ~run `npm run test` and `npm run benchmark`~ (not applicable)
- [ ] ~tests and/or benchmarks are included~ (not applicable)
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
