### PR TITLE
fix: prevent reuse mutated route option for head

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -155,6 +155,12 @@ function buildRouting (options) {
     // Since we are mutating/assigning only top level props, it is fine to have a shallow copy using the spread operator
     const opts = { ...options }
 
+    const { exposeHeadRoute } = opts
+    const hasRouteExposeHeadRouteFlag = exposeHeadRoute != null
+    const shouldExposeHead = hasRouteExposeHeadRouteFlag ? exposeHeadRoute : globalExposeHeadRoutes
+    // we need to clone a set of initial options for HEAD route
+    const headOpts = shouldExposeHead && options.method === 'GET' ? { ...options } : null
+
     throwIfAlreadyStarted('Cannot add route when fastify instance is already started!')
 
     const path = opts.url || opts.path || ''
@@ -342,13 +348,10 @@ function buildRouting (options) {
 
       // register head route in sync
       // we must place it after the `this.after`
-      const { exposeHeadRoute } = opts
-      const hasRouteExposeHeadRouteFlag = exposeHeadRoute != null
-      const shouldExposeHead = hasRouteExposeHeadRouteFlag ? exposeHeadRoute : globalExposeHeadRoutes
 
       if (shouldExposeHead && options.method === 'GET' && !hasHEADHandler) {
-        const onSendHandlers = parseHeadOnSendHandlers(opts.onSend)
-        prepareRoute.call(this, { method: 'HEAD', url: path, options: { ...opts, onSend: onSendHandlers }, isFastify: true })
+        const onSendHandlers = parseHeadOnSendHandlers(headOpts.onSend)
+        prepareRoute.call(this, { method: 'HEAD', url: path, options: { ...headOpts, onSend: onSendHandlers }, isFastify: true })
       } else if (hasHEADHandler && exposeHeadRoute) {
         warning.emit('FSTDEP007')
       }

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -1474,15 +1474,15 @@ test('exposeHeadRoute should not reuse the same route option', async t => {
   // if we reuse the same route option
   // that means we will append another function inside the array
   fastify.addHook('onRoute', function (routeOption) {
-    if (Array.isArray(routeOption.onRequset)) {
-      routeOption.onRequset.push(() => {})
+    if (Array.isArray(routeOption.onRequest)) {
+      routeOption.onRequest.push(() => {})
     } else {
-      routeOption.onRequset = [() => {}]
+      routeOption.onRequest = [() => {}]
     }
   })
 
   fastify.addHook('onRoute', function (routeOption) {
-    t.equal(routeOption.onRequset.length, 1)
+    t.equal(routeOption.onRequest.length, 1)
   })
 
   fastify.route({

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -1464,3 +1464,32 @@ test('invalid url attribute - non string URL', t => {
     t.equal(error.code, FST_ERR_INVALID_URL().code)
   }
 })
+
+test('exposeHeadRoute should not reuse the same route option', async t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  // we update the onRequest hook in onRoute hook
+  // if we reuse the same route option
+  // that means we will append another function inside the array
+  fastify.addHook('onRoute', function (routeOption) {
+    if (Array.isArray(routeOption.onRequset)) {
+      routeOption.onRequset.push(() => {})
+    } else {
+      routeOption.onRequset = [() => {}]
+    }
+  })
+
+  fastify.addHook('onRoute', function (routeOption) {
+    t.equal(routeOption.onRequset.length, 1)
+  })
+
+  fastify.route({
+    method: 'GET',
+    path: '/more-coffee',
+    async handler () {
+      return 'hello world'
+    }
+  })
+})


### PR DESCRIPTION
Fixes: #4271 

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
