### PR TITLE
ci: reduce ci test when linting fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,12 @@ jobs:
           npm run lint
 
   coverage-nix:
-    needs: [linter]
+    needs: linter
     permissions:
       contents: read
     uses: ./.github/workflows/coverage-nix.yml
   coverage-win:
-    needs: [linter]
+    needs: linter
     permissions:
       contents: read
     uses: ./.github/workflows/coverage-win.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,12 @@ jobs:
           npm run lint
 
   coverage-nix:
+    needs: [linter]
     permissions:
       contents: read
     uses: ./.github/workflows/coverage-nix.yml
   coverage-win:
+    needs: [linter]
     permissions:
       contents: read
     uses: ./.github/workflows/coverage-win.yml


### PR DESCRIPTION

Right now we run the test for the coverage check.

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/11404065/190458272-f05477ad-84ac-4aa2-b94c-2d7c6715452c.png">

We could run them only after the linting