### PR TITLE
Replace parseInt with Number at get 6% boost

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -189,7 +189,7 @@ function rawBody (request, reply, options, parser, done) {
   const limit = options.limit === null ? parser.bodyLimit : options.limit
   const contentLength = request.headers['content-length'] === undefined
     ? NaN
-    : Number.parseInt(request.headers['content-length'], 10)
+    : Number(request.headers['content-length'])
 
   if (contentLength > limit) {
     reply.send(new FST_ERR_CTP_BODY_TOO_LARGE())

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -292,7 +292,7 @@ Reply.prototype.removeTrailer = function (key) {
 }
 
 Reply.prototype.code = function (code) {
-  const intValue = parseInt(code)
+  const intValue = Number(code)
   if (isNaN(intValue) || intValue < 100 || intValue > 599) {
     throw new FST_ERR_BAD_STATUS_CODE(code || String(code))
   }
@@ -562,7 +562,7 @@ function onSendEnd (reply, payload) {
     const contentLength = reply[kReplyHeaders]['content-length']
     if (!contentLength ||
         (req.raw.method !== 'HEAD' &&
-         parseInt(contentLength, 10) !== Buffer.byteLength(payload)
+         Number(contentLength) !== Buffer.byteLength(payload)
         )
     ) {
       reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)

--- a/lib/server.js
+++ b/lib/server.js
@@ -331,7 +331,7 @@ function normalizeListenArgs (args) {
 }
 
 function normalizePort (firstArg) {
-  const port = parseInt(firstArg, 10)
+  const port = Number(firstArg)
   return port >= 0 && !Number.isNaN(port) ? port : 0
 }
 

--- a/test/internals/reply-serialize.test.js
+++ b/test/internals/reply-serialize.test.js
@@ -231,7 +231,7 @@ test('Reply#getSerializationFunction', t => {
         (req, reply) => {
           const { id } = req.params
 
-          if (parseInt(id) === 1) {
+          if (Number(id) === 1) {
             const serialize4xx = reply.getSerializationFunction('4xx')
             const serialize201 = reply.getSerializationFunction(201)
             const serializeUndefined = reply.getSerializationFunction(undefined)
@@ -308,7 +308,7 @@ test('Reply#getSerializationFunction', t => {
         (req, reply) => {
           const { id } = req.params
 
-          if (parseInt(id) === 1) {
+          if (Number(id) === 1) {
             const serialize = reply.compileSerializationSchema(schemaObj)
 
             t.type(serialize, Function)


### PR DESCRIPTION
Here is a small benchmark for `Number(value)` vs `parseInt(value)`

## Result of micro-benchmark

Number: 67.073ms
parseInt: 206.781ms

### Code

```javascript
var { time, timeEnd } = console
var I = 1e8;
var y;

time("Number")
for (var i = 0; i < I; i++) y = Number(i)
timeEnd("Number")

time("parseInt")
for (var i = 0; i < I; i++) y = parseInt(i)
timeEnd("parseInt")
```

# Before this pull-request:

```
➜  fastify git:(perf/reply) npx concurrently -k -s first "node ./examples/simple.js" "npx autocannon -c 100 -d 10 -p 10 localhost:3000/"
[1] Running 10s test @ http://localhost:3000/
[1] 100 connections with 10 pipelining factor
[1]
[1]
[1] ┌─────────┬──────┬──────┬───────┬───────┬─────────┬─────────┬────────┐
[1] │ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%   │ Avg     │ Stdev   │ Max    │
[1] ├─────────┼──────┼──────┼───────┼───────┼─────────┼─────────┼────────┤
[1] │ Latency │ 4 ms │ 8 ms │ 12 ms │ 13 ms │ 7.54 ms │ 3.44 ms │ 136 ms │
[1] └─────────┴──────┴──────┴───────┴───────┴─────────┴─────────┴────────┘
[1] ┌───────────┬─────────┬─────────┬─────────┬─────────┬───────────┬─────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg       │ Stdev   │ Min     │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼───────────┼─────────┼─────────┤
[1] │ Req/Sec   │ 113663  │ 113663  │ 126911  │ 131199  │ 124666.19 │ 5335.45 │ 113662  │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼───────────┼─────────┼─────────┤
[1] │ Bytes/Sec │ 21.4 MB │ 21.4 MB │ 23.9 MB │ 24.7 MB │ 23.4 MB   │ 999 kB  │ 21.4 MB │
[1] └───────────┴─────────┴─────────┴─────────┴─────────┴───────────┴─────────┴─────────┘
[1]
[1] Req/Bytes counts sampled once per second.
[1] # of samples: 11
[1]
[1] 1372k requests in 11.02s, 258 MB read
[1] npx autocannon -c 100 -d 10 -p 10 localhost:3000/ exited with code 0
--> Sending SIGTERM to other processes..
[0] node ./examples/simple.js exited with code SIGTERM
```

# After this pull request

```
➜  fastify git:(perf/reply) ✗ npx concurrently -k -s first "node ./examples/simple.js" "npx autocannon -c 100 -d 10 -p 10 localhost:3000/"
[1] Running 10s test @ http://localhost:3000/
[1] 100 connections with 10 pipelining factor
[1]
[1]
[1] ┌─────────┬──────┬──────┬───────┬───────┬─────────┬─────────┬────────┐
[1] │ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%   │ Avg     │ Stdev   │ Max    │
[1] ├─────────┼──────┼──────┼───────┼───────┼─────────┼─────────┼────────┤
[1] │ Latency │ 4 ms │ 8 ms │ 11 ms │ 12 ms │ 7.08 ms │ 3.22 ms │ 138 ms │
[1] └─────────┴──────┴──────┴───────┴───────┴─────────┴─────────┴────────┘
[1] ┌───────────┬─────────┬─────────┬─────────┬─────────┬───────────┬─────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg       │ Stdev   │ Min     │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼───────────┼─────────┼─────────┤
[1] │ Req/Sec   │ 123199  │ 123199  │ 134271  │ 136703  │ 132247.28 │ 4149.77 │ 123168  │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼───────────┼─────────┼─────────┤
[1] │ Bytes/Sec │ 23.2 MB │ 23.2 MB │ 25.2 MB │ 25.7 MB │ 24.9 MB   │ 781 kB  │ 23.2 MB │
[1] └───────────┴─────────┴─────────┴─────────┴─────────┴───────────┴─────────┴─────────┘
[1]
[1] Req/Bytes counts sampled once per second.
[1] # of samples: 11
[1]
[1] 1456k requests in 11.01s, 273 MB read
[1] npx autocannon -c 100 -d 10 -p 10 localhost:3000/ exited with code 0
--> Sending SIGTERM to other processes..
[0] node ./examples/simple.js exited with code SIGTERM
```