### PR TITLE
fix: custom validator should not mutate headers schema

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -327,7 +327,7 @@ function buildRouting (options) {
               schemaController.setupValidator(this[kOptions])
             }
             try {
-              const isCustom = typeof opts?.validatorCompiler === 'function' || schemaController.customValidatorCompiler
+              const isCustom = typeof opts?.validatorCompiler === 'function' || schemaController.isCustomValidatorCompiler
               compileSchemasForValidation(context, opts.validatorCompiler || schemaController.validatorCompiler, isCustom)
             } catch (error) {
               throw new FST_ERR_SCH_VALIDATION_BUILD(opts.method, url, error.message)

--- a/lib/route.js
+++ b/lib/route.js
@@ -327,7 +327,8 @@ function buildRouting (options) {
               schemaController.setupValidator(this[kOptions])
             }
             try {
-              compileSchemasForValidation(context, opts.validatorCompiler || schemaController.validatorCompiler)
+              const isCustom = typeof opts?.validatorCompiler === 'function' || schemaController.customValidatorCompiler
+              compileSchemasForValidation(context, opts.validatorCompiler || schemaController.validatorCompiler, isCustom)
             } catch (error) {
               throw new FST_ERR_SCH_VALIDATION_BUILD(opts.method, url, error.message)
             }

--- a/lib/schema-controller.js
+++ b/lib/schema-controller.js
@@ -25,7 +25,9 @@ function buildSchemaController (parentSchemaCtrl, opts) {
 
   const option = {
     bucket: (opts && opts.bucket) || buildSchemas,
-    compilersFactory
+    compilersFactory,
+    customValidatorCompiler: typeof opts?.compilersFactory?.buildValidator === 'object',
+    customSerializerCompiler: typeof opts?.compilersFactory?.buildValidator === 'object'
   }
 
   return new SchemaController(undefined, option)
@@ -37,6 +39,8 @@ class SchemaController {
     this.addedSchemas = false
 
     this.compilersFactory = this.opts.compilersFactory
+    this.customValidatorCompiler = this.opts.customValidatorCompiler || false
+    this.customSerializerCompiler = this.opts.customSerializerCompiler || false
 
     if (parent) {
       this.schemaBucket = this.opts.bucket(parent.getSchemas())
@@ -65,10 +69,12 @@ class SchemaController {
   // Schema Controller compilers holder
   setValidatorCompiler (validatorCompiler) {
     this.validatorCompiler = validatorCompiler
+    this.customValidatorCompiler = true
   }
 
   setSerializerCompiler (serializerCompiler) {
     this.serializerCompiler = serializerCompiler
+    this.customSerializerCompiler = true
   }
 
   getValidatorCompiler () {

--- a/lib/schema-controller.js
+++ b/lib/schema-controller.js
@@ -26,8 +26,8 @@ function buildSchemaController (parentSchemaCtrl, opts) {
   const option = {
     bucket: (opts && opts.bucket) || buildSchemas,
     compilersFactory,
-    customValidatorCompiler: typeof opts?.compilersFactory?.buildValidator === 'function',
-    customSerializerCompiler: typeof opts?.compilersFactory?.buildValidator === 'function'
+    isCustomValidatorCompiler: typeof opts?.compilersFactory?.buildValidator === 'function',
+    isCustomSerializerCompiler: typeof opts?.compilersFactory?.buildValidator === 'function'
   }
 
   return new SchemaController(undefined, option)
@@ -39,8 +39,8 @@ class SchemaController {
     this.addedSchemas = false
 
     this.compilersFactory = this.opts.compilersFactory
-    this.customValidatorCompiler = this.opts.customValidatorCompiler || false
-    this.customSerializerCompiler = this.opts.customSerializerCompiler || false
+    this.isCustomValidatorCompiler = this.opts.isCustomValidatorCompiler || false
+    this.isCustomSerializerCompiler = this.opts.isCustomSerializerCompiler || false
 
     if (parent) {
       this.schemaBucket = this.opts.bucket(parent.getSchemas())
@@ -69,12 +69,12 @@ class SchemaController {
   // Schema Controller compilers holder
   setValidatorCompiler (validatorCompiler) {
     this.validatorCompiler = validatorCompiler
-    this.customValidatorCompiler = true
+    this.isCustomValidatorCompiler = true
   }
 
   setSerializerCompiler (serializerCompiler) {
     this.serializerCompiler = serializerCompiler
-    this.customSerializerCompiler = true
+    this.isCustomSerializerCompiler = true
   }
 
   getValidatorCompiler () {

--- a/lib/schema-controller.js
+++ b/lib/schema-controller.js
@@ -26,8 +26,8 @@ function buildSchemaController (parentSchemaCtrl, opts) {
   const option = {
     bucket: (opts && opts.bucket) || buildSchemas,
     compilersFactory,
-    customValidatorCompiler: typeof opts?.compilersFactory?.buildValidator === 'object',
-    customSerializerCompiler: typeof opts?.compilersFactory?.buildValidator === 'object'
+    customValidatorCompiler: typeof opts?.compilersFactory?.buildValidator === 'function',
+    customSerializerCompiler: typeof opts?.compilersFactory?.buildValidator === 'function'
   }
 
   return new SchemaController(undefined, option)

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -32,7 +32,7 @@ function compileSchemasForSerialization (context, compile) {
     }, {})
 }
 
-function compileSchemasForValidation (context, compile) {
+function compileSchemasForValidation (context, compile, isCustom) {
   const { schema } = context
   if (!schema) {
     return
@@ -41,8 +41,9 @@ function compileSchemasForValidation (context, compile) {
   const { method, url } = context.config || {}
 
   const headers = schema.headers
-  if (headers && Object.getPrototypeOf(headers) !== Object.prototype) {
-    // do not mess with non-literals, e.g. Joi schemas
+  // the or part is used for backward compatibility
+  if (headers && (isCustom || Object.getPrototypeOf(headers) !== Object.prototype)) {
+    // do not mess with schema when custom validator applied, e.g. Joi, Typebox
     context[headersSchema] = compile({ schema: headers, method, url, httpPart: 'headers' })
   } else if (headers) {
     // The header keys are case insensitive

--- a/test/internals/validation.test.js
+++ b/test/internals/validation.test.js
@@ -268,6 +268,21 @@ test('build schema - headers are not lowercased in case of custom object', t => 
   })
 })
 
+test('build schema - headers are not lowercased in case of custom validator provided', t => {
+  t.plan(1)
+
+  class Headers {}
+  const opts = {
+    schema: {
+      headers: new Headers()
+    }
+  }
+  validation.compileSchemasForValidation(opts, ({ schema, method, url, httpPart }) => {
+    t.type(schema, Headers)
+    return () => {}
+  }, true)
+})
+
 test('build schema - uppercased headers are not included', t => {
   t.plan(1)
   const opts = {

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -1779,3 +1779,28 @@ test('Should return a human-friendly error if response status codes are not spec
     t.match(err.message, 'Failed building the serialization schema for GET: /, due to error response schemas should be nested under a valid status code, e.g { 2xx: { type: "object" } }')
   })
 })
+
+test('setSchemaController: custom validator instance should not mutate headers schema', async t => {
+  t.plan(2)
+  class Headers {}
+  const fastify = Fastify()
+
+  fastify.setSchemaController({
+    compilersFactory: {
+      buildValidator: function () {
+        return ({ schema, method, url, httpPart }) => {
+          t.type(schema, Headers)
+          return () => {}
+        }
+      }
+    }
+  })
+
+  fastify.get('/', {
+    schema: {
+      headers: new Headers()
+    }
+  }, () => {})
+
+  await fastify.ready()
+})

--- a/test/schema-validation.test.js
+++ b/test/schema-validation.test.js
@@ -1017,3 +1017,22 @@ test("The same $id in route's schema must not overwrite others", t => {
     t.same(res.payload, 'ok')
   })
 })
+
+test('Custom validator compiler should not mutate schema', async t => {
+  t.plan(2)
+  class Headers {}
+  const fastify = Fastify()
+
+  fastify.setValidatorCompiler(({ schema, method, url, httpPart }) => {
+    t.type(schema, Headers)
+    return () => {}
+  })
+
+  fastify.get('/', {
+    schema: {
+      headers: new Headers()
+    }
+  }, () => {})
+
+  await fastify.ready()
+})


### PR DESCRIPTION
We should not take any assumption that `object` is something we want and mutate the `headers` schema.
Instead, whenever the `user` pass custom validator. All the responsibility should be given to the user and that library to handle.

Fixes https://github.com/fastify/fastify-type-provider-typebox/issues/42

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
