### PR TITLE
feat: parse request body for http SEARCH requests

### DIFF
--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -41,8 +41,8 @@ fastify.route(options)
   need to be in [JSON Schema](https://json-schema.org/) format, check
   [here](./Validation-and-Serialization.md) for more info.
 
-  * `body`: validates the body of the request if it is a POST, PUT, PATCH, TRACE, or SEARCH
-    method.
+  * `body`: validates the body of the request if it is a POST, PUT, PATCH,
+    TRACE, or SEARCH method.
   * `querystring` or `query`: validates the querystring. This can be a complete
     JSON Schema object, with the property `type` of `object` and `properties`
     object of parameters, or simply the values of what would be contained in the

--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -41,7 +41,7 @@ fastify.route(options)
   need to be in [JSON Schema](https://json-schema.org/) format, check
   [here](./Validation-and-Serialization.md) for more info.
 
-  * `body`: validates the body of the request if it is a POST, PUT, or PATCH
+  * `body`: validates the body of the request if it is a POST, PUT, PATCH, TRACE, or SEARCH
     method.
   * `querystring` or `query`: validates the querystring. This can be a complete
     JSON Schema object, with the property `type` of `object` and `properties`

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -18,14 +18,14 @@ function handleRequest (err, request, reply) {
   const method = request.raw.method
   const headers = request.headers
 
-  if (method === 'GET' || method === 'HEAD' || method === 'SEARCH') {
+  if (method === 'GET' || method === 'HEAD') {
     handler(request, reply)
     return
   }
 
   const contentType = headers['content-type']
 
-  if (method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'TRACE') {
+  if (method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'TRACE' || method === 'SEARCH') {
     if (contentType === undefined) {
       if (
         headers['transfer-encoding'] === undefined &&

--- a/test/search.test.js
+++ b/test/search.test.js
@@ -1,18 +1,17 @@
 'use strict'
 
 const t = require('tap')
+const sget = require('simple-get').concat
 const test = t.test
 const fastify = require('..')()
 
 const schema = {
-  schema: {
-    response: {
-      '2xx': {
-        type: 'object',
-        properties: {
-          hello: {
-            type: 'string'
-          }
+  response: {
+    '2xx': {
+      type: 'object',
+      properties: {
+        hello: {
+          type: 'string'
         }
       }
     }
@@ -20,35 +19,45 @@ const schema = {
 }
 
 const querySchema = {
-  schema: {
-    querystring: {
-      type: 'object',
-      properties: {
-        hello: {
-          type: 'integer'
-        }
+  querystring: {
+    type: 'object',
+    properties: {
+      hello: {
+        type: 'integer'
       }
     }
   }
 }
 
 const paramsSchema = {
-  schema: {
-    params: {
-      type: 'object',
-      properties: {
-        foo: {
-          type: 'string'
-        },
-        test: {
-          type: 'integer'
-        }
+  params: {
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'string'
+      },
+      test: {
+        type: 'integer'
       }
     }
   }
 }
 
-test('shorthand - search', t => {
+const bodySchema = {
+  body: {
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'string'
+      },
+      test: {
+        type: 'integer'
+      }
+    }
+  }
+}
+
+test('search', t => {
   t.plan(1)
   try {
     fastify.route({
@@ -65,13 +74,13 @@ test('shorthand - search', t => {
   }
 })
 
-test('shorthand - search params', t => {
+test('search, params schema', t => {
   t.plan(1)
   try {
     fastify.route({
       method: 'SEARCH',
       url: '/params/:foo/:test',
-      paramsSchema,
+      schema: paramsSchema,
       handler: function (request, reply) {
         reply.code(200).send(request.params)
       }
@@ -82,13 +91,13 @@ test('shorthand - search params', t => {
   }
 })
 
-test('shorthand - get, querystring schema', t => {
+test('search, querystring schema', t => {
   t.plan(1)
   try {
     fastify.route({
       method: 'SEARCH',
       url: '/query',
-      querySchema,
+      schema: querySchema,
       handler: function (request, reply) {
         reply.code(200).send(request.query)
       }
@@ -97,4 +106,134 @@ test('shorthand - get, querystring schema', t => {
   } catch (e) {
     t.fail()
   }
+})
+
+test('search, body schema', t => {
+  t.plan(1)
+  try {
+    fastify.route({
+      method: 'SEARCH',
+      url: '/body',
+      schema: bodySchema,
+      handler: function (request, reply) {
+        reply.code(200).send(request.body)
+      }
+    })
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+})
+
+fastify.listen({ port: 0 }, err => {
+  t.error(err)
+  t.teardown(() => { fastify.close() })
+
+  const url = `http://localhost:${fastify.server.address().port}`
+
+  test('request - search', t => {
+    t.plan(4)
+    sget({
+      method: 'SEARCH',
+      url
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers['content-length'], '' + body.length)
+      t.same(JSON.parse(body), { hello: 'world' })
+    })
+  })
+
+  test('request search params schema', t => {
+    t.plan(4)
+    sget({
+      method: 'SEARCH',
+      url: `${url}/params/world/123`
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers['content-length'], '' + body.length)
+      t.same(JSON.parse(body), { foo: 'world', test: 123 })
+    })
+  })
+
+  test('request search params schema error', t => {
+    t.plan(3)
+    sget({
+      method: 'SEARCH',
+      url: `${url}/params/world/string`
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 400)
+      t.same(JSON.parse(body), {
+        error: 'Bad Request',
+        message: 'params/test must be integer',
+        statusCode: 400
+      })
+    })
+  })
+
+  test('request search querystring schema', t => {
+    t.plan(4)
+    sget({
+      method: 'SEARCH',
+      url: `${url}/query?hello=123`
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers['content-length'], '' + body.length)
+      t.same(JSON.parse(body), { hello: 123 })
+    })
+  })
+
+  test('request search querystring schema error', t => {
+    t.plan(3)
+    sget({
+      method: 'SEARCH',
+      url: `${url}/query?hello=world`
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 400)
+      t.same(JSON.parse(body), {
+        error: 'Bad Request',
+        message: 'querystring/hello must be integer',
+        statusCode: 400
+      })
+    })
+  })
+
+  test('request search body schema', t => {
+    t.plan(4)
+    const replyBody = { foo: 'bar', test: 5 }
+    sget({
+      method: 'SEARCH',
+      url: `${url}/body`,
+      body: JSON.stringify(replyBody),
+      headers: { 'content-type': 'application/json' }
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers['content-length'], '' + body.length)
+      t.same(JSON.parse(body), replyBody)
+    })
+  })
+
+  test('request search body schema error', t => {
+    t.plan(4)
+    sget({
+      method: 'SEARCH',
+      url: `${url}/body`,
+      body: JSON.stringify({ foo: 'bar', test: 'test' }),
+      headers: { 'content-type': 'application/json' }
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 400)
+      t.equal(response.headers['content-length'], '' + body.length)
+      t.same(JSON.parse(body), {
+        error: 'Bad Request',
+        message: 'body/test must be integer',
+        statusCode: 400
+      })
+    })
+  })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
      
    
 Trying to migrate to fastify over from express, one of the bigger blockers we had is how we treat the SEARCH request. Basically handle it as a GET request with a body, which after digging into your codebase realized SEARCH body was not being parsed at all. The [webDAV SEARCH specs](https://www.rfc-editor.org/rfc/rfc5323#section-2.2.2) specifically mention that SEARCH can have a body so not sure why this wasn't allowed in https://github.com/fastify/fastify/pull/3836 . Also noticed the tests were pretty non existent for the search methods, modified them to hopefully catch any accidental breakage in the future.
