### PR TITLE
fix: Fix typo in docs/Reference/Type-Providers.md

### DIFF
--- a/docs/Reference/Type-Providers.md
+++ b/docs/Reference/Type-Providers.md
@@ -148,7 +148,7 @@ fastify.register(pluginWithTypebox)
 
 It's also important to mention that once the types don't propagate globally,
 _currently_ is not possible to avoid multiple registrations on routes when
-dealing with several scopes, see bellow:
+dealing with several scopes, see below:
 
 ```ts
 import Fastify from 'fastify'


### PR DESCRIPTION
Fix a minor typo

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
