### PR TITLE
fix: error handler content-type guessing

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -50,8 +50,8 @@ function handleError (reply, error, cb) {
   reply[kReplyNextErrorHandler] = Object.getPrototypeOf(errorHandler)
 
   // we need to remove content-type to allow content-type guessing for serialization
-  reply.removeHeader('content-type')
-  reply.removeHeader('content-length')
+  delete reply[kReplyHeaders]['content-type']
+  delete reply[kReplyHeaders]['content-length']
 
   const func = errorHandler.func
 

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -49,7 +49,9 @@ function handleError (reply, error, cb) {
   // In case the error handler throws, we set the next errorHandler so we can error again
   reply[kReplyNextErrorHandler] = Object.getPrototypeOf(errorHandler)
 
-  delete reply[kReplyHeaders]['content-length']
+  // we need to remove content-type to allow content-type guessing for serialization
+  reply.removeHeader('content-type')
+  reply.removeHeader('content-length')
 
   const func = errorHandler.func
 

--- a/test/content-type.test.js
+++ b/test/content-type.test.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('..')
+
+test('should remove content-type for setErrorHandler', async t => {
+  t.plan(6)
+  let count = 0
+
+  const fastify = Fastify()
+  fastify.setErrorHandler(function (error, request, reply) {
+    t.same(error.message, 'kaboom')
+    t.same(reply.hasHeader('content-type'), false)
+    reply.code(400).send({ foo: 'bar' })
+  })
+  fastify.addHook('onSend', async function (request, reply, payload) {
+    count++
+    t.same(typeof payload, 'string')
+    switch (count) {
+      case 1: {
+        throw Error('kaboom')
+      }
+      case 2: {
+        return payload
+      }
+      default: {
+        t.fail('should not reach')
+      }
+    }
+  })
+  fastify.get('/', function (request, reply) {
+    reply.send('plain-text')
+  })
+
+  const { statusCode, body } = await fastify.inject({ method: 'GET', path: '/' })
+  t.same(statusCode, 400)
+  t.same(body, JSON.stringify({ foo: 'bar' }))
+})

--- a/test/content-type.test.js
+++ b/test/content-type.test.js
@@ -5,7 +5,7 @@ const test = t.test
 const Fastify = require('..')
 
 test('should remove content-type for setErrorHandler', async t => {
-  t.plan(6)
+  t.plan(8)
   let count = 0
 
   const fastify = Fastify()
@@ -19,9 +19,13 @@ test('should remove content-type for setErrorHandler', async t => {
     t.same(typeof payload, 'string')
     switch (count) {
       case 1: {
+        // should guess the correct content-type based on payload
+        t.same(reply.getHeader('content-type'), 'text/plain; charset=utf-8')
         throw Error('kaboom')
       }
       case 2: {
+        // should guess the correct content-type based on payload
+        t.same(reply.getHeader('content-type'), 'application/json; charset=utf-8')
         return payload
       }
       default: {


### PR DESCRIPTION
Resolve #4327 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
