### PR TITLE
docs: add notes about Fastify not allowing adding more routes/plugins once `ready` is called

### DIFF
--- a/docs/Guides/Serverless.md
+++ b/docs/Guides/Serverless.md
@@ -42,6 +42,17 @@ To integrate with AWS, you have two choices of library:
 
 So you can decide which option is best for you, but you can test both libraries.
 
+**Note**:
+
+Fastify will not allow adding more routes or registering plugins once `ready()` is called. See [here](https://github.com/fastify/fastify/issues/1771#issuecomment-515339364)
+
+In some serverless environment, codes outside the exported handlers could be cached. This means you
+cannot add routes or register plugins inside the exported handlers because it will be added more than once
+to the cached Fastify instance.
+
+Either declare all your routes and register all your plugins outside the handlers
+or initialize new instance of Fastify inside the handlers instead. See [here](https://github.com/fastify/fastify/issues/4328)
+
 ### Using @fastify/aws-lambda
 
 The sample provided allows you to easily build serverless web


### PR DESCRIPTION
Related discussion: https://github.com/fastify/fastify/issues/4328


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
