### PR TITLE
fix: should now call default schema compilers

### DIFF
--- a/lib/schema-controller.js
+++ b/lib/schema-controller.js
@@ -15,12 +15,16 @@ function buildSchemaController (parentSchemaCtrl, opts) {
     return new SchemaController(parentSchemaCtrl, opts)
   }
 
-  let compilersFactory = {
-    buildValidator: ValidatorSelector(),
-    buildSerializer: SerializerSelector()
+  const compilersFactory = Object.assign({
+    buildValidator: null,
+    buildSerializer: null
+  }, opts?.compilersFactory)
+
+  if (!compilersFactory.buildValidator) {
+    compilersFactory.buildValidator = ValidatorSelector()
   }
-  if (opts && opts.compilersFactory) {
-    compilersFactory = Object.assign(compilersFactory, opts.compilersFactory)
+  if (!compilersFactory.buildSerializer) {
+    compilersFactory.buildSerializer = SerializerSelector()
   }
 
   const option = {


### PR DESCRIPTION
fixes https://github.com/fastify/fastify/discussions/4339

Let the user remove totally the default compilers.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
