### PR TITLE
docs: example how decorators dependencies works

### DIFF
--- a/docs/Reference/Decorators.md
+++ b/docs/Reference/Decorators.md
@@ -135,9 +135,9 @@ async function utilityDecorator (fastify, opts) {
   })
 }
 
-fastify.register(fp(greetDecorator, { name: 'greet' }))
-fastify.register(fp(hiDecorator, { name: 'hi' }))
-fastify.register(fp(utilityDecorator, { dependencies: ['greet', 'hi'] }))
+fastify.register(fastifyPlugin(greetDecorator, { name: 'greet' }))
+fastify.register(fastifyPlugin(hiDecorator, { name: 'hi' }))
+fastify.register(fastifyPlugin(utilityDecorator, { dependencies: ['greet', 'hi'] }))
 
 fastify.get('/', function (req, reply) {
   // Response: {"hello":"greet message | hi message"}

--- a/docs/Reference/Decorators.md
+++ b/docs/Reference/Decorators.md
@@ -114,10 +114,46 @@ fastify.get('/', async function (request, reply) {
 The `dependencies` parameter is an optional list of decorators that the
 decorator being defined relies upon. This list is simply a list of string names
 of other decorators. In the following example, the "utility" decorator depends
-upon "greet" and "log" decorators:
+upon "greet" and "hi" decorators:
 
 ```js
-fastify.decorate('utility', fn, ['greet', 'log'])
+'use strict'
+
+const fastify = require('../fastify')({
+  logger: false
+})
+const fp = require('fastify-plugin')
+
+async function greetDecorator (fastify, opts) {
+  fastify.decorate('greet', () => {
+    return 'greet message'
+  })
+}
+
+async function hiDecorator (fastify, opts) {
+  fastify.decorate('hi', () => {
+    return 'hi message'
+  })
+}
+
+async function utilityDecorator (fastify, opts) {
+  fastify.decorate('utility', () => {
+    return `${fastify.greet()} | ${fastify.hi()}`
+  })
+}
+
+fastify.register(fp(greetDecorator, { name: 'greet' }))
+fastify.register(fp(hiDecorator, { name: 'hi' }))
+fastify.register(fp(utilityDecorator, { dependencies: ['greet', 'hi'] }))
+
+fastify.get('/', function (req, reply) {
+  // Response: {"hello":"greet message | hi message"}
+  reply.send({ hello: fastify.utility() })
+})
+
+fastify.listen({ port: 3000 }, (err, address) => {
+  if (err) throw err
+})
 ```
 
 Note: using an arrow function will break the binding of `this` to the

--- a/docs/Reference/Decorators.md
+++ b/docs/Reference/Decorators.md
@@ -117,13 +117,6 @@ of other decorators. In the following example, the "utility" decorator depends
 upon "greet" and "hi" decorators:
 
 ```js
-'use strict'
-
-const fastify = require('../fastify')({
-  logger: false
-})
-const fp = require('fastify-plugin')
-
 async function greetDecorator (fastify, opts) {
   fastify.decorate('greet', () => {
     return 'greet message'


### PR DESCRIPTION
This PR adds example of how decorators dependency works. Related with issue #4147 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
