### PR TITLE
Support Node.js v19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [14, 16, 18, 19]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/test/helper.js
+++ b/test/helper.js
@@ -337,6 +337,7 @@ module.exports.payloadMethod = function (method, t, isSetErrorHandler = false) {
       sget({
         method: upMethod,
         url: `http://localhost:${fastify.server.address().port}`,
+        agent: false,
         headers: {
           'Content-Type': 'application/json'
         }
@@ -370,6 +371,7 @@ module.exports.payloadMethod = function (method, t, isSetErrorHandler = false) {
       sget({
         method: upMethod,
         url: `http://localhost:${fastify.server.address().port}`,
+        agent: false,
         headers: {
           'Content-Type': 'application/json'
         },
@@ -404,6 +406,7 @@ module.exports.payloadMethod = function (method, t, isSetErrorHandler = false) {
       sget({
         method: upMethod,
         url: `http://localhost:${fastify.server.address().port}`,
+        agent: false,
         headers: {
           'Content-Type': 'application/json'
         },


### PR DESCRIPTION
Apparently, the `semver-major` that affects Fastify is only https://github.com/nodejs/node/pull/43522.

However, it's leading to some weird inconsistencies. The remaining failing tests are:

- `test/close-pipelining.test.js`
- `test/close.test.js`

I did a quick investigation and looks like the original behaviour of graceful shutdown has changed. For instance, the following snippet is not returning `503` for the second request as expected:

```js
  const fastify = Fastify({
    return503OnClosing: true,
    forceCloseConnections: false
  })

  fastify.get('/', (req, reply) => {
    // once it's called, the next request will throw a `UND_ERR_SOCKET` even trying to reutilize the connection
    fastify.close() 
    reply.send({ hello: 'world' })
  })

  fastify.listen({ port: 0 }, async err => {
    t.error(err)

    const instance = new Client('http://localhost:' + fastify.server.address().port, {
      pipelining: 1
    })

    const codes = [200, 503]
    for (const code of codes) {
      // the first request works fine
      // the second request throws UND_ERR_SOCKET
      instance.request(
        { path: '/', method: 'GET' }
      ).then(data => {
        t.equal(data.statusCode, code)
      }).catch((e) => {
        t.fail(e)
      })
    }
    instance.close(() => {
      t.end('Done')
    })
  })
```

cc: @ShogunPanda 