### PR TITLE
Undefined is a valid value for if set as a single hook

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -252,7 +252,7 @@ function buildRouting (options) {
                 throw new FST_ERR_HOOK_INVALID_HANDLER(hook, typeof func)
               }
             }
-          } else if (typeof opts[hook] !== 'function') {
+          } else if (opts[hook] !== undefined && typeof opts[hook] !== 'function') {
             throw new FST_ERR_HOOK_INVALID_HANDLER(hook, typeof opts[hook])
           }
         }

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -3322,12 +3322,22 @@ test('registering invalid hooks should throw an error', async t => {
     fastify.route({
       method: 'GET',
       path: '/invalidHook',
-      onRequest: undefined,
+      onRequest: null,
       async handler () {
         return 'hello world'
       }
     })
-  }, new Error('onRequest hook should be a function, instead got undefined'))
+  }, new Error('onRequest hook should be a function, instead got object'))
+
+  // undefined is ok
+  fastify.route({
+    method: 'GET',
+    path: '/validhook',
+    onRequest: undefined,
+    async handler () {
+      return 'hello world'
+    }
+  })
 
   t.throws(() => {
     fastify.addHook('onRoute', (routeOptions) => {


### PR DESCRIPTION
Unfortunately https://github.com/fastify/fastify/pull/4332 was too restrictive and it broke quite a few of our modules, e.g. https://github.com/fastify/fastify-http-proxy/blob/72703f28db516652fdd0fd08f17e269f8947b6b3/index.js#L221 has the value as `undefined`. This makes it _less_ restrictive by allowing `undefined` as a value for single-level hooks.

Given that the case mentioned in https://github.com/fastify/fastify/issues/4320 was about arrays I think it's ok to land this.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
