### PR TITLE
Support different content-type typed reply with TypeProvider

### DIFF
--- a/test/types/type-provider.test-d.ts
+++ b/test/types/type-provider.test-d.ts
@@ -232,6 +232,40 @@ expectAssignable(server.withTypeProvider<TypeBoxProvider>().get(
 ))
 
 // -------------------------------------------------------------------
+// TypeBox Reply Type (Different Content-types)
+// -------------------------------------------------------------------
+
+expectAssignable(server.withTypeProvider<TypeBoxProvider>().get(
+  '/',
+  {
+    schema: {
+      response: {
+        200: {
+          content: {
+            'text/string': {
+              schema: Type.String()
+            },
+            'application/json': {
+              schema: Type.Object({
+                msg: Type.String()
+              })
+            }
+          }
+        },
+        500: Type.Object({
+          error: Type.String()
+        })
+      }
+    }
+  },
+  async (_, res) => {
+    res.send('hello')
+    res.send({ msg: 'hello' })
+    res.send({ error: 'error' })
+  }
+))
+
+// -------------------------------------------------------------------
 // TypeBox Reply Type: Non Assignable
 // -------------------------------------------------------------------
 
@@ -242,6 +276,38 @@ expectError(server.withTypeProvider<TypeBoxProvider>().get(
       response: {
         200: Type.String(),
         400: Type.Number(),
+        500: Type.Object({
+          error: Type.String()
+        })
+      }
+    }
+  },
+  async (_, res) => {
+    res.send(false)
+  }
+))
+
+// -------------------------------------------------------------------
+// TypeBox Reply Type: Non Assignable (Different Content-types)
+// -------------------------------------------------------------------
+
+expectError(server.withTypeProvider<TypeBoxProvider>().get(
+  '/',
+  {
+    schema: {
+      response: {
+        200: {
+          content: {
+            'text/string': {
+              schema: Type.String()
+            },
+            'application/json': {
+              schema: Type.Object({
+                msg: Type.String()
+              })
+            }
+          }
+        },
         500: Type.Object({
           error: Type.String()
         })
@@ -281,6 +347,43 @@ expectAssignable(server.withTypeProvider<TypeBoxProvider>().get(
 ))
 
 // -------------------------------------------------------------------
+// TypeBox Reply Return Type (Different Content-types)
+// -------------------------------------------------------------------
+
+expectAssignable(server.withTypeProvider<TypeBoxProvider>().get(
+  '/',
+  {
+    schema: {
+      response: {
+        200: {
+          content: {
+            'text/string': {
+              schema: Type.String()
+            },
+            'application/json': {
+              schema: Type.Object({
+                msg: Type.String()
+              })
+            }
+          }
+        },
+        500: Type.Object({
+          error: Type.String()
+        })
+      }
+    }
+  },
+  async (_, res) => {
+    const option = 1 as 1 | 2 | 3
+    switch (option) {
+      case 1: return 'hello'
+      case 2: return { msg: 'hello' }
+      case 3: return { error: 'error' }
+    }
+  }
+))
+
+// -------------------------------------------------------------------
 // TypeBox Reply Return Type: Non Assignable
 // -------------------------------------------------------------------
 
@@ -291,6 +394,38 @@ expectError(server.withTypeProvider<TypeBoxProvider>().get(
       response: {
         200: Type.String(),
         400: Type.Number(),
+        500: Type.Object({
+          error: Type.String()
+        })
+      }
+    }
+  },
+  async (_, res) => {
+    return false
+  }
+))
+
+// -------------------------------------------------------------------
+// TypeBox Reply Return Type: Non Assignable (Different Content-types)
+// -------------------------------------------------------------------
+
+expectError(server.withTypeProvider<TypeBoxProvider>().get(
+  '/',
+  {
+    schema: {
+      response: {
+        200: {
+          content: {
+            'text/string': {
+              schema: Type.String()
+            },
+            'application/json': {
+              schema: Type.Object({
+                msg: Type.String()
+              })
+            }
+          }
+        },
         500: Type.Object({
           error: Type.String()
         })
@@ -325,6 +460,36 @@ expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
 ))
 
 // -------------------------------------------------------------------
+// JsonSchemaToTs Reply Type (Different Content-types)
+// -------------------------------------------------------------------
+
+expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
+  '/',
+  {
+    schema: {
+      response: {
+        200: {
+          content: {
+            'text/string': {
+              schema: { type: 'string' }
+            },
+            'application/json': {
+              schema: { type: 'object', properties: { msg: { type: 'string' } } }
+            }
+          }
+        },
+        500: { type: 'object', properties: { error: { type: 'string' } } }
+      } as const
+    }
+  },
+  (_, res) => {
+    res.send('hello')
+    res.send({ msg: 'hello' })
+    res.send({ error: 'error' })
+  }
+))
+
+// -------------------------------------------------------------------
 // JsonSchemaToTs Reply Type: Non Assignable
 // -------------------------------------------------------------------
 
@@ -335,6 +500,34 @@ expectError(server.withTypeProvider<JsonSchemaToTsProvider>().get(
       response: {
         200: { type: 'string' },
         400: { type: 'number' },
+        500: { type: 'object', properties: { error: { type: 'string' } } }
+      } as const
+    }
+  },
+  async (_, res) => {
+    res.send(false)
+  }
+))
+
+// -------------------------------------------------------------------
+// JsonSchemaToTs Reply Type: Non Assignable (Different Content-types)
+// -------------------------------------------------------------------
+
+expectError(server.withTypeProvider<JsonSchemaToTsProvider>().get(
+  '/',
+  {
+    schema: {
+      response: {
+        200: {
+          content: {
+            'text/string': {
+              schema: { type: 'string' }
+            },
+            'application/json': {
+              schema: { type: 'object', properties: { msg: { type: 'string' } } }
+            }
+          }
+        },
         500: { type: 'object', properties: { error: { type: 'string' } } }
       } as const
     }
@@ -368,6 +561,40 @@ expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
     }
   }
 ))
+
+// -------------------------------------------------------------------
+// JsonSchemaToTs Reply Type Return (Different Content-types)
+// -------------------------------------------------------------------
+
+expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
+  '/',
+  {
+    schema: {
+      response: {
+        200: {
+          content: {
+            'text/string': {
+              schema: { type: 'string' }
+            },
+            'application/json': {
+              schema: { type: 'object', properties: { msg: { type: 'string' } } }
+            }
+          }
+        },
+        500: { type: 'object', properties: { error: { type: 'string' } } }
+      } as const
+    }
+  },
+  async (_, res) => {
+    const option = 1 as 1 | 2 | 3
+    switch (option) {
+      case 1: return 'hello'
+      case 2: return { msg: 'hello' }
+      case 3: return { error: 'error' }
+    }
+  }
+))
+
 // -------------------------------------------------------------------
 // JsonSchemaToTs Reply Type Return: Non Assignable
 // -------------------------------------------------------------------
@@ -400,6 +627,34 @@ expectError(server.withTypeProvider<JsonSchemaToTsProvider>().get('/', {
 }))
 
 // -------------------------------------------------------------------
+// JsonSchemaToTs Reply Type Return: Non Assignable (Different Content-types)
+// -------------------------------------------------------------------
+
+expectError(server.withTypeProvider<JsonSchemaToTsProvider>().get(
+  '/',
+  {
+    schema: {
+      response: {
+        200: {
+          content: {
+            'text/string': {
+              schema: { type: 'string' }
+            },
+            'application/json': {
+              schema: { type: 'object', properties: { msg: { type: 'string' } } }
+            }
+          }
+        },
+        500: { type: 'object', properties: { error: { type: 'string' } } }
+      } as const
+    }
+  },
+  async (_, res) => {
+    return false
+  }
+))
+
+// -------------------------------------------------------------------
 // Reply Type Override
 // -------------------------------------------------------------------
 
@@ -420,6 +675,34 @@ expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get<{Reply: b
 ))
 
 // -------------------------------------------------------------------
+// Reply Type Override (Different Content-types)
+// -------------------------------------------------------------------
+
+expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get<{Reply: boolean}>(
+  '/',
+  {
+    schema: {
+      response: {
+        200: {
+          content: {
+            'text/string': {
+              schema: { type: 'string' }
+            },
+            'application/json': {
+              schema: { type: 'object', properties: { msg: { type: 'string' } } }
+            }
+          }
+        },
+        500: { type: 'object', properties: { error: { type: 'string' } } }
+      } as const
+    }
+  },
+  async (_, res) => {
+    res.send(true)
+  }
+))
+
+// -------------------------------------------------------------------
 // Reply Type Return Override
 // -------------------------------------------------------------------
 
@@ -430,6 +713,34 @@ expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get<{Reply: b
       response: {
         200: { type: 'string' },
         400: { type: 'number' },
+        500: { type: 'object', properties: { error: { type: 'string' } } }
+      } as const
+    }
+  },
+  async (_, res) => {
+    return true
+  }
+))
+
+// -------------------------------------------------------------------
+// Reply Type Return Override (Different Content-types)
+// -------------------------------------------------------------------
+
+expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get<{Reply: boolean}>(
+  '/',
+  {
+    schema: {
+      response: {
+        200: {
+          content: {
+            'text/string': {
+              schema: { type: 'string' }
+            },
+            'application/json': {
+              schema: { type: 'object', properties: { msg: { type: 'string' } } }
+            }
+          }
+        },
         500: { type: 'object', properties: { error: { type: 'string' } } }
       } as const
     }

--- a/types/type-provider.d.ts
+++ b/types/type-provider.d.ts
@@ -60,10 +60,12 @@ export interface ResolveFastifyRequestType<TypeProvider extends FastifyTypeProvi
 // FastifyReplyType
 // -----------------------------------------------------------------------------------------------
 
-// Resolves the Reply type by taking a union of response status codes
+// Resolves the Reply type by taking a union of response status codes and content-types
 type ResolveReplyFromSchemaCompiler<TypeProvider extends FastifyTypeProvider, SchemaCompiler extends FastifySchema> = {
-  [K in keyof SchemaCompiler['response']]: CallTypeProvider<TypeProvider, SchemaCompiler['response'][K]>
-} extends infer Result ? Result[keyof Result] : unknown
+  [K1 in keyof SchemaCompiler['response']]: SchemaCompiler['response'][K1] extends { content: { [keyof: string]: { schema: unknown } } } ? ({
+    [K2 in keyof SchemaCompiler['response'][K1]['content']]: CallTypeProvider<TypeProvider, SchemaCompiler['response'][K1]['content'][K2]['schema']>
+  } extends infer Result ? Result[keyof Result] : unknown) : CallTypeProvider<TypeProvider, SchemaCompiler['response'][K1]>
+} extends infer Result ? Result[keyof Result] : unknown;
 
 // The target reply type. This type is inferenced on fastify 'replies' via generic argument assignment
 export type FastifyReplyType<Reply = unknown> = Reply


### PR DESCRIPTION
At first, I really appreciate for #4264 (feat: Supporting different content-type responses).

I tried this feature with typescript, and realized type of response payload became unknown when using  different content-type schema. 
So I would suggest to update `ResolveReplyFromSchemaCompiler` to recognize diffrent content-types schema.

Thank you.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
