### PR TITLE
fix types after pino 8.7.0 change

### DIFF
--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -123,35 +123,6 @@ const serverAutoInferredFileOption = fastify({
 
 expectType<FastifyBaseLogger>(serverAutoInferredFileOption.log)
 
-const serverAutoInferredPinoPrettyBooleanOption = fastify({
-  logger: {
-    prettyPrint: true
-  }
-})
-
-expectType<FastifyBaseLogger>(serverAutoInferredPinoPrettyBooleanOption.log)
-
-const serverAutoInferredPinoPrettyObjectOption = fastify({
-  logger: {
-    prettyPrint: {
-      translateTime: true,
-      levelFirst: false,
-      messageKey: 'msg',
-      timestampKey: 'time',
-      messageFormat: false,
-      colorize: true,
-      crlf: false,
-      errorLikeObjectKeys: ['err', 'error'],
-      errorProps: '',
-      search: 'foo == `bar`',
-      ignore: 'pid,hostname',
-      suppressFlushSyncWarning: true
-    }
-  }
-})
-
-expectType<FastifyBaseLogger>(serverAutoInferredPinoPrettyObjectOption.log)
-
 const serverAutoInferredSerializerObjectOption = fastify({
   logger: {
     serializers: {
@@ -200,9 +171,6 @@ const passPinoOption = fastify({
     redact: ['custom'],
     messageKey: 'msg',
     nestedKey: 'nested',
-    prettyPrint: {
-
-    },
     enabled: true
   }
 })


### PR DESCRIPTION
Signed-off-by: Matteo Collina <hello@matteocollina.com>

pino v8 dropped the `prettyPrint` option but it didn't drop it from its types. It did it in v8.7.0.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
