### PR TITLE
Node.js V19 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [14, 16, 18, 19]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/fastify.js
+++ b/fastify.js
@@ -410,11 +410,12 @@ function fastify (options) {
 
         /* istanbul ignore next: Cannot test this without Node.js core support */
         if (forceCloseConnections === 'idle') {
+          // Not needed in Node 19
           instance.server.closeIdleConnections()
         /* istanbul ignore next: Cannot test this without Node.js core support */
         } else if (serverHasCloseAllConnections && forceCloseConnections) {
           instance.server.closeAllConnections()
-        } else {
+        } else if (forceCloseConnections === true) {
           for (const conn of fastify[kKeepAliveConnections]) {
             // We must invoke the destroy method instead of merely unreffing
             // the sockets. If we only unref, then the callback passed to

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -190,6 +190,9 @@ function rawBody (request, reply, options, parser, done) {
     : Number(request.headers['content-length'])
 
   if (contentLength > limit) {
+    // We must close the connection as the client is going
+    // to send this data anyway
+    reply.header('connection', 'close')
     reply.send(new FST_ERR_CTP_BODY_TOO_LARGE())
     return
   }
@@ -243,6 +246,7 @@ function rawBody (request, reply, options, parser, done) {
     }
 
     if (!Number.isNaN(contentLength) && (payload.receivedEncodedLength || receivedLength) !== contentLength) {
+      reply.header('connection', 'close')
       reply.send(new FST_ERR_CTP_INVALID_CONTENT_LENGTH())
       return
     }

--- a/lib/route.js
+++ b/lib/route.js
@@ -398,7 +398,6 @@ function buildRouting (options) {
     if (closing === true) {
       /* istanbul ignore next mac, windows */
       if (req.httpVersionMajor !== 2) {
-        // res.once('finish', () => req.destroy())
         res.setHeader('Connection', 'close')
       }
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -398,11 +398,15 @@ function buildRouting (options) {
     if (closing === true) {
       /* istanbul ignore next mac, windows */
       if (req.httpVersionMajor !== 2) {
-        res.once('finish', () => req.destroy())
+        // res.once('finish', () => req.destroy())
         res.setHeader('Connection', 'close')
       }
 
+      /* istanbul ignore else */
       if (return503OnClosing) {
+        // On Node v19 we cannot test this behavior as it won't be necessary
+        // anymore. It will close all the idle connections before they reach this
+        // stage.
         const headers = {
           'Content-Type': 'application/json',
           'Content-Length': '80'

--- a/lib/route.js
+++ b/lib/route.js
@@ -401,6 +401,7 @@ function buildRouting (options) {
         res.setHeader('Connection', 'close')
       }
 
+      // TODO remove return503OnClosing after Node v18 goes EOL
       /* istanbul ignore else */
       if (return503OnClosing) {
         // On Node v19 we cannot test this behavior as it won't be necessary

--- a/test/close-pipelining.test.js
+++ b/test/close-pipelining.test.js
@@ -4,42 +4,40 @@ const t = require('tap')
 const test = t.test
 const Fastify = require('..')
 const { Client } = require('undici')
+const semver = require('semver')
 
-test('Should return 503 while closing - pipelining', t => {
+test('Should return 503 while closing - pipelining', async t => {
   const fastify = Fastify({
     return503OnClosing: true,
     forceCloseConnections: false
   })
 
-  fastify.get('/', (req, reply) => {
+  fastify.get('/', async (req, reply) => {
     fastify.close()
-    reply.send({ hello: 'world' })
+    return { hello: 'world' }
   })
 
-  fastify.listen({ port: 0 }, async err => {
-    t.error(err)
+  await fastify.listen({ port: 0 })
 
-    const instance = new Client('http://localhost:' + fastify.server.address().port, {
-      pipelining: 1
-    })
-
-    const codes = [200, 503]
-    for (const code of codes) {
-      instance.request(
-        { path: '/', method: 'GET' }
-      ).then(data => {
-        t.equal(data.statusCode, code)
-      }).catch((e) => {
-        t.fail(e)
-      })
-    }
-    instance.close(() => {
-      t.end('Done')
-    })
+  const instance = new Client('http://localhost:' + fastify.server.address().port, {
+    pipelining: 2
   })
+
+  const codes = [200, 200, 503]
+  const responses = await Promise.all([
+    instance.request({ path: '/', method: 'GET' }),
+    instance.request({ path: '/', method: 'GET' }),
+    instance.request({ path: '/', method: 'GET' })
+  ])
+  const actual = responses.map(r => r.statusCode)
+
+  t.same(actual, codes)
+
+  await instance.close()
 })
 
-test('Should not return 503 while closing - pipelining - return503OnClosing', t => {
+const isV19plus = semver.satisfies(process.version, '>= v19.0.0')
+test('Should not return 503 while closing - pipelining - return503OnClosing: false, skip Node >= v19.x', { skip: isV19plus }, async t => {
   const fastify = Fastify({
     return503OnClosing: false,
     forceCloseConnections: false
@@ -50,25 +48,52 @@ test('Should not return 503 while closing - pipelining - return503OnClosing', t 
     reply.send({ hello: 'world' })
   })
 
-  fastify.listen({ port: 0 }, err => {
-    t.error(err)
+  await fastify.listen({ port: 0 })
 
-    const instance = new Client('http://localhost:' + fastify.server.address().port, {
-      pipelining: 1
-    })
-
-    const codes = [200, 200]
-    for (const code of codes) {
-      instance.request(
-        { path: '/', method: 'GET' }
-      ).then(data => {
-        t.equal(data.statusCode, code)
-      }).catch((e) => {
-        t.fail(e)
-      })
-    }
-    instance.close(() => {
-      t.end('Done')
-    })
+  const instance = new Client('http://localhost:' + fastify.server.address().port, {
+    pipelining: 2
   })
+
+  const codes = [200, 200, 200]
+  const responses = await Promise.all([
+    instance.request({ path: '/', method: 'GET' }),
+    instance.request({ path: '/', method: 'GET' }),
+    instance.request({ path: '/', method: 'GET' })
+  ])
+  const actual = responses.map(r => r.statusCode)
+
+  t.same(actual, codes)
+
+  await instance.close()
+})
+
+test('Should close the socket abruptly - pipelining - return503OnClosing: false, skip Node < v19.x', { skip: !isV19plus }, async t => {
+  // Since Node v19, we will always invoke server.closeIdleConnections()
+  // therefore our socket will be closed
+  const fastify = Fastify({
+    return503OnClosing: false,
+    forceCloseConnections: false
+  })
+
+  fastify.get('/', (req, reply) => {
+    fastify.close()
+    reply.send({ hello: 'world' })
+  })
+
+  await fastify.listen({ port: 0 })
+
+  const instance = new Client('http://localhost:' + fastify.server.address().port, {
+    pipelining: 2
+  })
+
+  const responses = await Promise.allSettled([
+    instance.request({ path: '/', method: 'GET' }),
+    instance.request({ path: '/', method: 'GET' }),
+    instance.request({ path: '/', method: 'GET' })
+  ])
+  t.equal(responses[0].status, 'fulfilled')
+  t.equal(responses[1].status, 'rejected')
+  t.equal(responses[2].status, 'rejected')
+
+  await instance.close()
 })

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -6,6 +6,7 @@ const t = require('tap')
 const test = t.test
 const Fastify = require('..')
 const { Client } = require('undici')
+const semver = require('semver')
 
 test('close callback', t => {
   t.plan(4)
@@ -202,7 +203,8 @@ test('Should return error while closing (callback) - injection', t => {
   })
 })
 
-t.test('Current opened connection should continue to work after closing and return "connection: close" header - return503OnClosing: false', t => {
+const isV19plus = semver.satisfies(process.version, '>= v19.0.0')
+t.test('Current opened connection should continue to work after closing and return "connection: close" header - return503OnClosing: false', { skip: isV19plus }, t => {
   const fastify = Fastify({
     return503OnClosing: false,
     forceCloseConnections: false
@@ -235,6 +237,39 @@ t.test('Current opened connection should continue to work after closing and retu
             t.end()
           })
         })
+      })
+    })
+  })
+})
+
+t.test('Current opened connection should NOT continue to work after closing and return "connection: close" header - return503OnClosing: false', { skip: !isV19plus }, t => {
+  t.plan(4)
+  const fastify = Fastify({
+    return503OnClosing: false,
+    forceCloseConnections: false
+  })
+
+  fastify.get('/', (req, reply) => {
+    fastify.close()
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    const port = fastify.server.address().port
+    const client = net.createConnection({ port }, () => {
+      client.write('GET / HTTP/1.1\r\n\r\n')
+
+      client.on('error', function (err) {
+        t.ok(err)
+      })
+
+      client.once('data', data => {
+        t.match(data.toString(), /Connection:\s*keep-alive/i)
+        t.match(data.toString(), /200 OK/i)
+
+        client.write('GET / HTTP/1.1\r\n\r\n')
       })
     })
   })

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -204,7 +204,7 @@ test('Should return error while closing (callback) - injection', t => {
 })
 
 const isV19plus = semver.satisfies(process.version, '>= v19.0.0')
-t.test('Current opened connection should continue to work after closing and return "connection: close" header - return503OnClosing: false', { skip: isV19plus }, t => {
+t.test('Current opened connection should continue to work after closing and return "connection: close" header - return503OnClosing: false, skip Node >= v19.x', { skip: isV19plus }, t => {
   const fastify = Fastify({
     return503OnClosing: false,
     forceCloseConnections: false
@@ -242,7 +242,7 @@ t.test('Current opened connection should continue to work after closing and retu
   })
 })
 
-t.test('Current opened connection should NOT continue to work after closing and return "connection: close" header - return503OnClosing: false', { skip: !isV19plus }, t => {
+t.test('Current opened connection should NOT continue to work after closing and return "connection: close" header - return503OnClosing: false, skip Node < v19.x', { skip: !isV19plus }, t => {
   t.plan(4)
   const fastify = Fastify({
     return503OnClosing: false,

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -261,8 +261,14 @@ t.test('Current opened connection should NOT continue to work after closing and 
     const client = net.createConnection({ port }, () => {
       client.write('GET / HTTP/1.1\r\n\r\n')
 
-      client.on('error', function (err) {
-        t.ok(err)
+      client.on('error', function () {
+        // Dependending on the Operating System
+        // the socket could error or not.
+        // However, it will always be closed.
+      })
+
+      client.on('close', function () {
+        t.pass('close')
       })
 
       client.once('data', data => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This PR makes all our tests pass on Node v19.
There is a significant behavior change in https://github.com/nodejs/node/pull/43522 which makes our `forceCloseConnection: false` behavior redundant as it will always be at least `'idle'` in v19. I've updated the tests to reflect this change.

This PR also fixes a bug in our codebase that was highlighted by the new keep-alive behavior:
we did not close the socket in case of a body was too large. 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
