### PR TITLE
fix: no check on `null` or `undefined` values passed as fn

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -572,15 +572,15 @@ function fastify (options) {
 
     if (name === 'onSend' || name === 'preSerialization' || name === 'onError' || name === 'preParsing') {
       if (fn.constructor.name === 'AsyncFunction' && fn.length === 4) {
-        throw new Error('Async function has too many arguments. Async hooks should not use the \'done\' argument.')
+        throw new errorCodes.FST_ERR_HOOK_INVALID_ASYNC_HANDLER()
       }
     } else if (name === 'onReady') {
       if (fn.constructor.name === 'AsyncFunction' && fn.length !== 0) {
-        throw new Error('Async function has too many arguments. Async hooks should not use the \'done\' argument.')
+        throw new errorCodes.FST_ERR_HOOK_INVALID_ASYNC_HANDLER()
       }
     } else {
       if (fn.constructor.name === 'AsyncFunction' && fn.length === 3) {
-        throw new Error('Async function has too many arguments. Async hooks should not use the \'done\' argument.')
+        throw new errorCodes.FST_ERR_HOOK_INVALID_ASYNC_HANDLER()
       }
     }
 

--- a/fastify.js
+++ b/fastify.js
@@ -566,6 +566,10 @@ function fastify (options) {
   function addHook (name, fn) {
     throwIfAlreadyStarted('Cannot call "addHook" when fastify instance is already started!')
 
+    if (fn == null) {
+      throw new errorCodes.FST_ERR_HOOK_INVALID_HANDLER(name, fn)
+    }
+
     if (name === 'onSend' || name === 'preSerialization' || name === 'onError' || name === 'preParsing') {
       if (fn.constructor.name === 'AsyncFunction' && fn.length === 4) {
         throw new Error('Async function has too many arguments. Async hooks should not use the \'done\' argument.')

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -101,6 +101,12 @@ const codes = {
     500,
     TypeError
   ),
+  FST_ERR_HOOK_INVALID_ASYNC_HANDLER: createError(
+    'FST_ERR_HOOK_INVALID_ASYNC_HANDLER',
+    'Async function has too many arguments. Async hooks should not use the \'done\' argument.',
+    500,
+    TypeError
+  ),
 
   /**
    * Middlewares

--- a/test/hooks-async.test.js
+++ b/test/hooks-async.test.js
@@ -585,33 +585,37 @@ test('preHandler respond with a stream', t => {
 
 test('Should log a warning if is an async function with `done`', t => {
   t.test('3 arguments', t => {
-    t.plan(1)
+    t.plan(2)
     const fastify = Fastify()
 
     try {
       fastify.addHook('onRequest', async (req, reply, done) => {})
     } catch (e) {
+      t.ok(e.code, 'FST_ERR_HOOK_INVALID_ASYNC_HANDLER')
       t.ok(e.message === 'Async function has too many arguments. Async hooks should not use the \'done\' argument.')
     }
   })
 
   t.test('4 arguments', t => {
-    t.plan(3)
+    t.plan(6)
     const fastify = Fastify()
 
     try {
       fastify.addHook('onSend', async (req, reply, payload, done) => {})
     } catch (e) {
+      t.ok(e.code, 'FST_ERR_HOOK_INVALID_ASYNC_HANDLER')
       t.ok(e.message === 'Async function has too many arguments. Async hooks should not use the \'done\' argument.')
     }
     try {
       fastify.addHook('preSerialization', async (req, reply, payload, done) => {})
     } catch (e) {
+      t.ok(e.code, 'FST_ERR_HOOK_INVALID_ASYNC_HANDLER')
       t.ok(e.message === 'Async function has too many arguments. Async hooks should not use the \'done\' argument.')
     }
     try {
       fastify.addHook('onError', async (req, reply, payload, done) => {})
     } catch (e) {
+      t.ok(e.code, 'FST_ERR_HOOK_INVALID_ASYNC_HANDLER')
       t.ok(e.message === 'Async function has too many arguments. Async hooks should not use the \'done\' argument.')
     }
   })

--- a/test/hooks.on-ready.test.js
+++ b/test/hooks.on-ready.test.js
@@ -291,12 +291,13 @@ t.test('onReady cannot add lifecycle hooks', t => {
 })
 
 t.test('onReady throw loading error', t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
 
   try {
     fastify.addHook('onReady', async function (done) {})
   } catch (e) {
+    t.ok(e.code, 'FST_ERR_HOOK_INVALID_ASYNC_HANDLER')
     t.ok(e.message === 'Async function has too many arguments. Async hooks should not use the \'done\' argument.')
   }
 })

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -23,7 +23,7 @@ function getUrl (app) {
 }
 
 test('hooks', t => {
-  t.plan(43)
+  t.plan(49)
   const fastify = Fastify({ exposeHeadRoutes: false })
 
   try {
@@ -39,6 +39,22 @@ test('hooks', t => {
     t.pass()
   } catch (e) {
     t.fail()
+  }
+
+  try {
+    fastify.addHook('preHandler', null)
+  } catch (e) {
+    t.equal(e.code, 'FST_ERR_HOOK_INVALID_HANDLER')
+    t.equal(e.message, 'preHandler hook should be a function, instead got null')
+    t.pass()
+  }
+
+  try {
+    fastify.addHook('preParsing')
+  } catch (e) {
+    t.equal(e.code, 'FST_ERR_HOOK_INVALID_HANDLER')
+    t.equal(e.message, 'preParsing hook should be a function, instead got undefined')
+    t.pass()
   }
 
   try {


### PR DESCRIPTION


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

While reviewing #4359 we noticed that Fastify was not properly checking for values that indicates emptiness (`null` or `undefined`) when adding a new hook using `Fastify#addHook`, this caused the following error:

```txt
/Users/metcoder/Documents/Workspace/MetCoder/Fastify/fastify.js:577
      if (fn.constructor.name === 'AsyncFunction' && fn.length === 3) {
             ^

TypeError: Cannot read properties of null (reading 'constructor')
    at Object.addHook (/Users/metcoder/Documents/Workspace/MetCoder/Fastify/fastify.js:577:14)
    at Object.<anonymous> (/Users/metcoder/Documents/Workspace/MetCoder/Fastify/playground.js:4:9)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12)
    at node:internal/main/run_main_module:17:47
```

**The PR introduces the next changes**:
- fix: handle null or undefined hooks
- refactor: replace generic error for one with code

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
