### PR TITLE
docs(server): config is lost when reply.call not found() is called

### DIFF
--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -311,6 +311,11 @@ reply.code(303).redirect(302, '/home')
 Invokes the custom not found handler. Note that it will only call `preHandler`
 hook specified in [`setNotFoundHandler`](./Server.md#set-not-found-handler).
 
+
+> Note: Be aware that some config properties from the request object will be undefined inside the custom not found handler. E.g:
+> request.routerPath, routerMethod and context.config. 
+> This method design goal is to allow calling the common not found route. If you want to return a per-route customized 404 response, you can just do it in the response itself.
+
 ```js
 reply.callNotFound()
 ```

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -312,10 +312,6 @@ Invokes the custom not found handler. Note that it will only call `preHandler`
 hook specified in [`setNotFoundHandler`](./Server.md#set-not-found-handler).
 
 
-> Note: Be aware that some config properties from the request object will be undefined inside the custom not found handler. E.g:
-> request.routerPath, routerMethod and context.config. 
-> This method design goal is to allow calling the common not found route. If you want to return a per-route customized 404 response, you can just do it in the response itself.
-
 ```js
 reply.callNotFound()
 ```

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -311,7 +311,6 @@ reply.code(303).redirect(302, '/home')
 Invokes the custom not found handler. Note that it will only call `preHandler`
 hook specified in [`setNotFoundHandler`](./Server.md#set-not-found-handler).
 
-
 ```js
 reply.callNotFound()
 ```

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1426,9 +1426,12 @@ plugins are registered. If you would like to augment the behavior of the default
 arguments `fastify.setNotFoundHandler()` within the context of these registered
 plugins.
 
-> Note: Be aware that some config properties from the request object will be undefined inside the custom not found handler. E.g:
+> Note: Be aware that some config properties from the request object will be 
+> undefined inside the custom not found handler. E.g:
 > request.routerPath, routerMethod and context.config. 
-> This method design goal is to allow calling the common not found route. If you want to return a per-route customized 404 response, you can just do it in the response itself.
+> This method design goal is to allow calling the common not found route. If
+> you want to return a per-route customized 404 response, you can just do it in
+> the response itself.
 
 #### setErrorHandler
 <a id="set-error-handler"></a>

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1426,6 +1426,10 @@ plugins are registered. If you would like to augment the behavior of the default
 arguments `fastify.setNotFoundHandler()` within the context of these registered
 plugins.
 
+> Note: Be aware that some config properties from the request object will be undefined inside the custom not found handler. E.g:
+> request.routerPath, routerMethod and context.config. 
+> This method design goal is to allow calling the common not found route. If you want to return a per-route customized 404 response, you can just do it in the response itself.
+
 #### setErrorHandler
 <a id="set-error-handler"></a>
 

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1426,11 +1426,11 @@ plugins are registered. If you would like to augment the behavior of the default
 arguments `fastify.setNotFoundHandler()` within the context of these registered
 plugins.
 
-> Note: Be aware that some config properties from the request object will be 
+> Note: Some config properties from the request object will be 
 > undefined inside the custom not found handler. E.g:
-> request.routerPath, routerMethod and context.config. 
-> This method design goal is to allow calling the common not found route. If
-> you want to return a per-route customized 404 response, you can just do it in
+> `request.routerPath`, `routerMethod` and `context.config`. 
+> This method design goal is to allow calling the common not found route.
+> To return a per-route customized 404 response, you can do it in
 > the response itself.
 
 #### setErrorHandler


### PR DESCRIPTION

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
