### PR TITLE
fix(type-providers): assignability of instance with enabled type provider

### DIFF
--- a/docs/Guides/Write-Type-Provider.md
+++ b/docs/Guides/Write-Type-Provider.md
@@ -1,0 +1,32 @@
+<h1 align="center">Fastify</h1>
+
+## How to write your own type provider
+
+Things to keep in mind when implementing a custom [type provider](../Reference/Type-Providers.md):
+
+### Type Contravariance
+
+Whereas exhaustive type narrowing checks normally rely on `never` to represent
+an unreachable state, reduction in type provider interfaces should only be done
+up to `unknown`.
+
+The reasoning is that certain methods of `FastifyInstance` are 
+contravariant on `TypeProvider`, which can lead to TypeScript surfacing 
+assignability issues unless the custom type provider interface is 
+substitutible with `FastifyTypeProviderDefault`.
+
+For example, `FastifyTypeProviderDefault` will not be assignable to the following:
+```ts
+export interface NotSubstitutibleTypeProvider extends FastifyTypeProvider {
+   // bad, nothing is assignable to `never` (except for itself)
+  output: this['input'] extends /** custom check here**/ ? /** narrowed type here **/ : never;
+}
+```
+
+Unless changed to:
+```ts
+export interface SubstitutibleTypeProvider extends FastifyTypeProvider {
+  // good, anything can be assigned to `unknown`
+  output: this['input'] extends /** custom check here**/ ? /** narrowed type here **/ : unknown; 
+}
+```

--- a/test/types/type-provider.test-d.ts
+++ b/test/types/type-provider.test-d.ts
@@ -68,7 +68,7 @@ expectAssignable(server.withTypeProvider<OverriddenProvider>().get<{ Body: 'over
 // TypeBox
 // -------------------------------------------------------------------
 
-interface TypeBoxProvider extends FastifyTypeProvider { output: this['input'] extends TSchema ? Static<this['input']> : never }
+interface TypeBoxProvider extends FastifyTypeProvider { output: this['input'] extends TSchema ? Static<this['input']> : unknown }
 
 expectAssignable(server.withTypeProvider<TypeBoxProvider>().get(
   '/',
@@ -94,7 +94,7 @@ expectAssignable<FastifyInstance>(server.withTypeProvider<TypeBoxProvider>())
 // JsonSchemaToTs
 // -------------------------------------------------------------------
 
-interface JsonSchemaToTsProvider extends FastifyTypeProvider { output: this['input'] extends JSONSchema ? FromSchema<this['input']> : never }
+interface JsonSchemaToTsProvider extends FastifyTypeProvider { output: this['input'] extends JSONSchema ? FromSchema<this['input']> : unknown }
 
 expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
   '/',

--- a/test/types/type-provider.test-d.ts
+++ b/test/types/type-provider.test-d.ts
@@ -88,6 +88,8 @@ expectAssignable(server.withTypeProvider<TypeBoxProvider>().get(
   }
 ))
 
+expectAssignable<FastifyInstance>(server.withTypeProvider<TypeBoxProvider>())
+
 // -------------------------------------------------------------------
 // JsonSchemaToTs
 // -------------------------------------------------------------------
@@ -114,6 +116,8 @@ expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
     expectType<boolean | undefined>(req.body.z)
   }
 ))
+
+expectAssignable<FastifyInstance>(server.withTypeProvider<JsonSchemaToTsProvider>())
 
 // -------------------------------------------------------------------
 // Instance Type Remappable


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Closes #4342 by changing narrowing checks inside `TypeProvider` interfaces to only reduce to `unknown` instead of `never`.

Note that this pull request serves as a way to coordinate proposed changes across all type-provider repos.

Constituent PRs which mirror the fix in each type provider package:
- [ ] fastify/fastify-type-provider-typebox#43
- [ ] fastify/fastify-type-provider-json-schema-to-ts#21
