### PR TITLE
fix: trailers async race condition

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -570,8 +570,6 @@ function onSendEnd (reply, payload) {
 
     res.writeHead(statusCode, reply[kReplyHeaders])
     sendTrailer(payload, res, reply)
-    // avoid ArgumentsAdaptorTrampoline from V8
-    res.end(null, null, null)
     return
   }
 
@@ -600,8 +598,6 @@ function onSendEnd (reply, payload) {
   res.write(payload)
   // then send trailers
   sendTrailer(payload, res, reply)
-  // avoid ArgumentsAdaptorTrampoline from V8
-  res.end(null, null, null)
 }
 
 function logStreamError (logger, err, res) {
@@ -670,12 +666,29 @@ function sendStream (payload, res, reply) {
 }
 
 function sendTrailer (payload, res, reply) {
-  if (reply[kReplyTrailers] === null) return
+  if (reply[kReplyTrailers] === null) {
+    // when no trailer, we close the stream
+    res.end(null, null, null)
+    return
+  }
   const trailerHeaders = Object.keys(reply[kReplyTrailers])
   const trailers = {}
   let handled = 0
+  let skiped = true
+  function send () {
+    // add trailers when all handler handled
+    /* istanbul ignore else */
+    if (handled === 0) {
+      res.addTrailers(trailers)
+      // we need to properly close the stream
+      // after trailers sent
+      res.end(null, null, null)
+    }
+  }
+
   for (const trailerName of trailerHeaders) {
     if (typeof reply[kReplyTrailers][trailerName] !== 'function') continue
+    skiped = false
     handled--
 
     function cb (err, value) {
@@ -689,11 +702,10 @@ function sendTrailer (payload, res, reply) {
       if (err) reply.log.debug(err)
       else trailers[trailerName] = value
 
-      // add trailers when all handler handled
-      /* istanbul ignore else */
-      if (handled === 0) {
-        res.addTrailers(trailers)
-      }
+      // we push the check to the end of event
+      // loop, so the registration continue to
+      // process.
+      process.nextTick(send)
     }
 
     const result = reply[kReplyTrailers][trailerName](reply, payload, cb)
@@ -705,6 +717,10 @@ function sendTrailer (payload, res, reply) {
       cb(null, result)
     }
   }
+
+  // when all trailers are skipped
+  // we need to close the stream
+  if (skiped) res.end(null, null, null)
 }
 
 function sendStreamTrailer (payload, res, reply) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -668,13 +668,13 @@ function sendStream (payload, res, reply) {
 function sendTrailer (payload, res, reply) {
   if (reply[kReplyTrailers] === null) {
     // when no trailer, we close the stream
-    res.end(null, null, null)
+    res.end(null, null, null) // avoid ArgumentsAdaptorTrampoline from V8
     return
   }
   const trailerHeaders = Object.keys(reply[kReplyTrailers])
   const trailers = {}
   let handled = 0
-  let skiped = true
+  let skipped = true
   function send () {
     // add trailers when all handler handled
     /* istanbul ignore else */
@@ -682,13 +682,13 @@ function sendTrailer (payload, res, reply) {
       res.addTrailers(trailers)
       // we need to properly close the stream
       // after trailers sent
-      res.end(null, null, null)
+      res.end(null, null, null) // avoid ArgumentsAdaptorTrampoline from V8
     }
   }
 
   for (const trailerName of trailerHeaders) {
     if (typeof reply[kReplyTrailers][trailerName] !== 'function') continue
-    skiped = false
+    skipped = false
     handled--
 
     function cb (err, value) {
@@ -720,7 +720,7 @@ function sendTrailer (payload, res, reply) {
 
   // when all trailers are skipped
   // we need to close the stream
-  if (skiped) res.end(null, null, null)
+  if (skipped) res.end(null, null, null) // avoid ArgumentsAdaptorTrampoline from V8
 }
 
 function sendStreamTrailer (payload, res, reply) {

--- a/test/reply-trailers.test.js
+++ b/test/reply-trailers.test.js
@@ -5,6 +5,7 @@ const test = t.test
 const Fastify = require('..')
 const { Readable } = require('stream')
 const { createHash } = require('crypto')
+const { setTimeout: sleep } = require('timers/promises')
 
 test('send trailers when payload is empty string', t => {
   t.plan(5)
@@ -216,6 +217,82 @@ test('should emit deprecation warning when using direct return', t => {
   })
 })
 
+test('trailer handler counter', t => {
+  t.plan(2)
+
+  const data = JSON.stringify({ hello: 'world' })
+  const hash = createHash('md5')
+  hash.update(data)
+  const md5 = hash.digest('hex')
+
+  t.test('callback with timeout', t => {
+    t.plan(9)
+    const fastify = Fastify()
+
+    fastify.get('/', function (request, reply) {
+      reply.trailer('Return-Early', function (reply, payload, done) {
+        t.equal(data, payload)
+        done(null, 'return')
+      })
+      reply.trailer('Content-MD5', function (reply, payload, done) {
+        t.equal(data, payload)
+        const hash = createHash('md5')
+        hash.update(payload)
+        setTimeout(() => {
+          done(null, hash.digest('hex'))
+        }, 500)
+      })
+      reply.send(data)
+    })
+
+    fastify.inject({
+      method: 'GET',
+      url: '/'
+    }, (error, res) => {
+      t.error(error)
+      t.equal(res.statusCode, 200)
+      t.equal(res.headers['transfer-encoding'], 'chunked')
+      t.equal(res.headers.trailer, 'return-early content-md5')
+      t.equal(res.trailers['return-early'], 'return')
+      t.equal(res.trailers['content-md5'], md5)
+      t.notHas(res.headers, 'content-length')
+    })
+  })
+
+  t.test('async-await', t => {
+    t.plan(9)
+    const fastify = Fastify()
+
+    fastify.get('/', function (request, reply) {
+      reply.trailer('Return-Early', async function (reply, payload) {
+        t.equal(data, payload)
+        return 'return'
+      })
+      reply.trailer('Content-MD5', async function (reply, payload) {
+        t.equal(data, payload)
+        const hash = createHash('md5')
+        hash.update(payload)
+        await sleep(500)
+        return hash.digest('hex')
+      })
+      reply.send(data)
+    })
+
+    fastify.inject({
+      method: 'GET',
+      url: '/'
+    }, (error, res) => {
+      t.error(error)
+      t.equal(res.statusCode, 200)
+      t.equal(res.headers['transfer-encoding'], 'chunked')
+      t.equal(res.headers.trailer, 'return-early content-md5')
+      t.equal(res.trailers['return-early'], 'return')
+      t.equal(res.trailers['content-md5'], md5)
+      t.notHas(res.headers, 'content-length')
+    })
+  })
+})
+
 test('removeTrailer', t => {
   t.plan(6)
 
@@ -242,6 +319,38 @@ test('removeTrailer', t => {
     t.equal(res.statusCode, 200)
     t.equal(res.headers.trailer, 'etag')
     t.equal(res.trailers.etag, 'custom-etag')
+    t.notOk(res.trailers['should-not-call'])
+    t.notHas(res.headers, 'content-length')
+  })
+})
+
+test('remove all trailers', t => {
+  t.plan(6)
+
+  const fastify = Fastify()
+
+  fastify.get('/', function (request, reply) {
+    reply.trailer('ETag', function (reply, payload, done) {
+      t.fail('it should not called as this trailer is removed')
+      done(null, 'custom-etag')
+    })
+    reply.removeTrailer('ETag')
+    reply.trailer('Should-Not-Call', function (reply, payload, done) {
+      t.fail('it should not called as this trailer is removed')
+      done(null, 'should-not-call')
+    })
+    reply.removeTrailer('Should-Not-Call')
+    reply.send('')
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (error, res) => {
+    t.error(error)
+    t.equal(res.statusCode, 200)
+    t.notOk(res.headers.trailer)
+    t.notOk(res.trailers.etag)
     t.notOk(res.trailers['should-not-call'])
     t.notHas(res.headers, 'content-length')
   })

--- a/test/reply-trailers.test.js
+++ b/test/reply-trailers.test.js
@@ -5,7 +5,8 @@ const test = t.test
 const Fastify = require('..')
 const { Readable } = require('stream')
 const { createHash } = require('crypto')
-const { setTimeout: sleep } = require('timers/promises')
+const { promisify } = require('util')
+const sleep = promisify(setTimeout)
 
 test('send trailers when payload is empty string', t => {
   t.plan(5)


### PR DESCRIPTION
Quick fix for the last PR #4380 
I spot the race-condition when using a single variables and `res.end`.

I use `process.nextTick` to allow all trailers function called and check the `handled` value later.
The next part is the `res.end` will call faster than `res.addTrailers`.
I move it inside the `sendTrailers` function.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
