### PR TITLE
fix: tiny-lru usage

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -94,9 +94,8 @@ ContentTypeParser.prototype.getParser = function (contentType) {
     return this.customParsers.get(contentType)
   }
 
-  if (this.cache.has(contentType)) {
-    return this.cache.get(contentType)
-  }
+  const parser = this.cache.get(contentType)
+  if (parser !== undefined) return parser
 
   // eslint-disable-next-line no-var
   for (var i = 0; i !== this.parserList.length; ++i) {

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "rfdc": "^1.3.0",
     "secure-json-parse": "^2.5.0",
     "semver": "^7.3.7",
-    "tiny-lru": "^9.0.2"
+    "tiny-lru": "^10.0.0"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
Fix the usage on `tiny-lru`.
The `.has` method do not means to be public use and it does not respect the `ttl` field.

Refs https://github.com/avoidwork/tiny-lru/pull/56
Closes #4389

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
