### PR TITLE
Removes old note about named imports in ESM

### DIFF
--- a/docs/Guides/Plugins-Guide.md
+++ b/docs/Guides/Plugins-Guide.md
@@ -439,24 +439,6 @@ async function plugin (fastify, opts) {
 
 export default plugin
 ```
-__Note__: Fastify does not support named imports within an ESM context. Instead,
-the `default` export is available.
-
-```js
-// server.mjs
-import Fastify from 'fastify'
-
-const fastify = Fastify()
-
-///...
-
-fastify.listen({ port: 3000 }, (err, address) => {
-  if (err) {
-    fastify.log.error(err)
-    process.exit(1)
-  }
-})
-```
 
 ## Handle errors
 <a id="handle-errors"></a>


### PR DESCRIPTION
As of today, you can import the named Fastify import in the ESM context with no issues.

Namely, this works as expected:
```
import { fastify } from "fastify";

const app = fastify({
  logger: true,
});

await app.listen({ port: 3000 });
```
#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
