### PR TITLE
fix node 19.1.0 port validation test

### DIFF
--- a/test/server.test.js
+++ b/test/server.test.js
@@ -46,7 +46,7 @@ test('listen should reject string port', async (t) => {
     if (semver.lt(process.version, '19.1.0')) {
       t.same(error.message, 'options.port should be >= 0 and < 65536. Received hello-world.')
     } else {
-      t.same(error.message, 'options.port should be >= 0 and < 65536. Received type string (\'hello-world\').')
+      t.same(error.message, "options.port should be >= 0 and < 65536. Received type string ('hello-world').")
     }
   }
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -3,6 +3,7 @@
 const t = require('tap')
 const test = t.test
 const Fastify = require('..')
+const semver = require('semver')
 
 test('listen should accept null port', t => {
   t.plan(1)
@@ -36,19 +37,26 @@ test('listen should accept stringified number port', t => {
 
 test('listen should reject string port', async (t) => {
   t.plan(2)
-
   const fastify = Fastify()
   t.teardown(fastify.close.bind(fastify))
 
   try {
     await fastify.listen({ port: 'hello-world' })
   } catch (error) {
-    t.same(error.message, 'options.port should be >= 0 and < 65536. Received hello-world.')
+    if (semver.lt(process.version, '19.1.0')) {
+      t.same(error.message, 'options.port should be >= 0 and < 65536. Received hello-world.')
+    } else {
+      t.same(error.message, 'options.port should be >= 0 and < 65536. Received type string (\'hello-world\').')
+    }
   }
 
   try {
     await fastify.listen({ port: '1234hello' })
   } catch (error) {
-    t.same(error.message, 'options.port should be >= 0 and < 65536. Received 1234hello.')
+    if (semver.lt(process.version, '19.1.0')) {
+      t.same(error.message, 'options.port should be >= 0 and < 65536. Received 1234hello.')
+    } else {
+      t.same(error.message, "options.port should be >= 0 and < 65536. Received type string ('1234hello').")
+    }
   }
 })

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -3,7 +3,6 @@
 const t = require('tap')
 const test = t.test
 const Fastify = require('..')
-const semver = require('semver')
 
 test('listen should accept null port', t => {
   t.plan(1)
@@ -43,20 +42,12 @@ test('listen should reject string port', async (t) => {
   try {
     await fastify.listen({ port: 'hello-world' })
   } catch (error) {
-    if (semver.lt(process.version, '19.1.0')) {
-      t.same(error.message, 'options.port should be >= 0 and < 65536. Received hello-world.')
-    } else {
-      t.same(error.message, "options.port should be >= 0 and < 65536. Received type string ('hello-world').")
-    }
+    t.equal(error.code, 'ERR_SOCKET_BAD_PORT')
   }
 
   try {
     await fastify.listen({ port: '1234hello' })
   } catch (error) {
-    if (semver.lt(process.version, '19.1.0')) {
-      t.same(error.message, 'options.port should be >= 0 and < 65536. Received 1234hello.')
-    } else {
-      t.same(error.message, "options.port should be >= 0 and < 65536. Received type string ('1234hello').")
-    }
+    t.equal(error.code, 'ERR_SOCKET_BAD_PORT')
   }
 })


### PR DESCRIPTION
With https://github.com/nodejs/node/pull/45135 the output for validating a port changed and landed in node 19.1.0.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
