### PR TITLE
docs(reference/reply): When using async-await, need return

### DIFF
--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -674,8 +674,7 @@ fastify.get('/streams', function (request, reply) {
   reply.send(stream)
 })
 ```
-When using async-await, please return the reply object to signal fastify wait 
-for your further response.
+When using async-await you will need to return the reply object:
 ```js
 fastify.get('/streams', async function (request, reply) {
   const fs = require('fs')

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -674,6 +674,16 @@ fastify.get('/streams', function (request, reply) {
   reply.send(stream)
 })
 ```
+When using async-await, please return the reply object to signal fastify wait 
+for your further response.
+```js
+fastify.get('/streams', async function (request, reply) {
+  const fs = require('fs')
+  const stream = fs.createReadStream('some-file', 'utf8')
+  reply.header('Content-Type', 'application/octet-stream')
+  return reply.send(stream)
+})
+```
 
 #### Buffers
 <a id="send-buffers"></a>
@@ -689,6 +699,17 @@ fastify.get('/streams', function (request, reply) {
 })
 ```
 
+When using async-await, please return the reply object to signal fastify wait 
+for your further response.
+```js
+const fs = require('fs')
+fastify.get('/streams', function (request, reply) {
+  fs.readFile('some-file', (err, fileBuffer) => {
+    reply.send(err || fileBuffer)
+  })
+  return reply
+})
+```
 #### Errors
 <a id="errors"></a>
 

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -698,8 +698,7 @@ fastify.get('/streams', function (request, reply) {
 })
 ```
 
-When using async-await, please return the reply object to signal fastify wait 
-for your further response.
+When using async-await you will need to return or await the reply object:
 ```js
 const fs = require('fs')
 fastify.get('/streams', async function (request, reply) {

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -674,7 +674,7 @@ fastify.get('/streams', function (request, reply) {
   reply.send(stream)
 })
 ```
-When using async-await you will need to return the reply object:
+When using async-await you will need to return or await the reply object:
 ```js
 fastify.get('/streams', async function (request, reply) {
   const fs = require('fs')

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -703,7 +703,7 @@ When using async-await, please return the reply object to signal fastify wait
 for your further response.
 ```js
 const fs = require('fs')
-fastify.get('/streams', function (request, reply) {
+fastify.get('/streams', async function (request, reply) {
   fs.readFile('some-file', (err, fileBuffer) => {
     reply.send(err || fileBuffer)
   })

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
     "@sinclair/typebox": "^0.25.2",
-    "@sinonjs/fake-timers": "^9.1.2",
+    "@sinonjs/fake-timers": "^10.0.0",
     "@types/node": "^18.7.18",
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",


### PR DESCRIPTION
…y object to signal fastify wait for your further response.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
