### PR TITLE
chore: fix test skips for nodejs prereleases

### DIFF
--- a/test/close-pipelining.test.js
+++ b/test/close-pipelining.test.js
@@ -36,7 +36,7 @@ test('Should return 503 while closing - pipelining', async t => {
   await instance.close()
 })
 
-const isV19plus = semver.satisfies(process.version, '>= v19.0.0')
+const isV19plus = semver.gte(process.version, '19.0.0')
 test('Should not return 503 while closing - pipelining - return503OnClosing: false, skip Node >= v19.x', { skip: isV19plus }, async t => {
   const fastify = Fastify({
     return503OnClosing: false,

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -203,7 +203,7 @@ test('Should return error while closing (callback) - injection', t => {
   })
 })
 
-const isV19plus = semver.satisfies(process.version, '>= v19.0.0')
+const isV19plus = semver.gte(process.version, '19.0.0')
 t.test('Current opened connection should continue to work after closing and return "connection: close" header - return503OnClosing: false, skip Node >= v19.x', { skip: isV19plus }, t => {
   const fastify = Fastify({
     return503OnClosing: false,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

These tests are intended to be skipped on any node version >= 19.0.0, however due to using `semver.satisfies()` without the `includePrerelease` option this means that prereleases of nodejs will never match. In order to simplify this and get the appropriate behavior in prereleases of node, I simplified the semver check to use `gte` which is what we really want here.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
