### PR TITLE
feat: loosen content-type checking

### DIFF
--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -29,6 +29,13 @@ is given in the content-type header. If it is not given, the
 [catch-all](#catch-all) parser is not executed as with `POST`, `PUT` and
 `PATCH`, but the payload is simply not parsed.
 
+> ## ⚠  Security Notice
+> When using with RegExp to detect `Content-Type`, you should beware of
+> how to properly detect the `Content-Type`. For example, if you need
+> `application/*`, you should use `/^application\/([\w-]+);?/` to match the
+> [essence MIME type](https://mimesniff.spec.whatwg.org/#mime-type-miscellaneous)
+> only.
+
 ### Usage
 ```js
 fastify.addContentTypeParser('application/jsoff', function (request, payload, done) {
@@ -52,7 +59,7 @@ fastify.addContentTypeParser('application/jsoff', async function (request, paylo
 })
 
 // Handle all content types that matches RegExp
-fastify.addContentTypeParser(/^image\/.*/, function (request, payload, done) {
+fastify.addContentTypeParser(/^image\/([\w-]+);?/, function (request, payload, done) {
   imageParser(payload, function (err, body) {
     done(err, body)
   })

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -2,7 +2,6 @@
 
 const { AsyncResource } = require('node:async_hooks')
 const { FifoMap: Fifo } = require('toad-cache')
-const { safeParse: safeParseContentType, defaultContentType } = require('fast-content-type-parse')
 const secureJson = require('secure-json-parse')
 const {
   kDefaultJsonParse,
@@ -27,6 +26,7 @@ const {
   FST_ERR_CTP_EMPTY_JSON_BODY,
   FST_ERR_CTP_INSTANCE_ALREADY_STARTED
 } = require('./errors')
+const { FSTSEC001 } = require('./warnings')
 
 function ContentTypeParser (bodyLimit, onProtoPoisoning, onConstructorPoisoning) {
   this[kDefaultJsonParse] = getDefaultJsonParser(onProtoPoisoning, onConstructorPoisoning)
@@ -34,7 +34,7 @@ function ContentTypeParser (bodyLimit, onProtoPoisoning, onConstructorPoisoning)
   this.customParsers = new Map()
   this.customParsers.set('application/json', new Parser(true, false, bodyLimit, this[kDefaultJsonParse]))
   this.customParsers.set('text/plain', new Parser(true, false, bodyLimit, defaultPlainTextParser))
-  this.parserList = [new ParserListItem('application/json'), new ParserListItem('text/plain')]
+  this.parserList = ['application/json', 'text/plain']
   this.parserRegExpList = []
   this.cache = new Fifo(100)
 }
@@ -67,9 +67,9 @@ ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
     this.customParsers.set('', parser)
   } else {
     if (contentTypeIsString) {
-      this.parserList.unshift(new ParserListItem(contentType))
+      this.parserList.unshift(contentType)
     } else {
-      contentType.isEssence = contentType.source.indexOf(';') === -1
+      validateRegExp(contentType)
       this.parserRegExpList.unshift(contentType)
     }
     this.customParsers.set(contentType.toString(), parser)
@@ -99,20 +99,11 @@ ContentTypeParser.prototype.getParser = function (contentType) {
   const parser = this.cache.get(contentType)
   if (parser !== undefined) return parser
 
-  const parsed = safeParseContentType(contentType)
-
-  // dummyContentType always the same object
-  // we can use === for the comparison and return early
-  if (parsed === defaultContentType) {
-    return this.customParsers.get('')
-  }
-
   // eslint-disable-next-line no-var
   for (var i = 0; i !== this.parserList.length; ++i) {
     const parserListItem = this.parserList[i]
-    if (compareContentType(parsed, parserListItem)) {
-      const parser = this.customParsers.get(parserListItem.name)
-      // we set request content-type in cache to reduce parsing of MIME type
+    if (contentType.indexOf(parserListItem) === 0) {
+      const parser = this.customParsers.get(parserListItem)
       this.cache.set(contentType, parser)
       return parser
     }
@@ -121,9 +112,8 @@ ContentTypeParser.prototype.getParser = function (contentType) {
   // eslint-disable-next-line no-var
   for (var j = 0; j !== this.parserRegExpList.length; ++j) {
     const parserRegExp = this.parserRegExpList[j]
-    if (compareRegExpContentType(contentType, parsed.type, parserRegExp)) {
+    if (parserRegExp.test(contentType)) {
       const parser = this.customParsers.get(parserRegExp.toString())
-      // we set request content-type in cache to reduce parsing of MIME type
       this.cache.set(contentType, parser)
       return parser
     }
@@ -373,58 +363,13 @@ function removeAllContentTypeParsers () {
   this[kContentTypeParser].removeAll()
 }
 
-function compareContentType (contentType, parserListItem) {
-  if (parserListItem.isEssence) {
-    // we do essence check
-    return contentType.type.indexOf(parserListItem) !== -1
-  } else {
-    // when the content-type includes parameters
-    // we do a full-text search
-    // reject essence content-type before checking parameters
-    if (contentType.type.indexOf(parserListItem.type) === -1) return false
-    for (const key of parserListItem.parameterKeys) {
-      // reject when missing parameters
-      if (!(key in contentType.parameters)) return false
-      // reject when parameters do not match
-      if (contentType.parameters[key] !== parserListItem.parameters[key]) return false
-    }
-    return true
+function validateRegExp (regexp) {
+  // RegExp should either start with ^ or include ;?
+  // It can ensure the user is properly detect the essence
+  // MIME types.
+  if (regexp.source[0] !== '^' && regexp.source.includes(';?') === false) {
+    FSTSEC001(regexp.source)
   }
-}
-
-function compareRegExpContentType (contentType, essenceMIMEType, regexp) {
-  if (regexp.isEssence) {
-    // we do essence check
-    return regexp.test(essenceMIMEType)
-  } else {
-    // when the content-type includes parameters
-    // we do a full-text match
-    return regexp.test(contentType)
-  }
-}
-
-function ParserListItem (contentType) {
-  this.name = contentType
-  // we pre-calculate all the needed information
-  // before content-type comparison
-  const parsed = safeParseContentType(contentType)
-  this.isEssence = contentType.indexOf(';') === -1
-  // we should not allow empty string for parser list item
-  // because it would become a match-all handler
-  if (this.isEssence === false && parsed.type === '') {
-    // handle semicolon or empty string
-    const tmp = contentType.split(';', 1)[0]
-    this.type = tmp === '' ? contentType : tmp
-  } else {
-    this.type = parsed.type
-  }
-  this.parameters = parsed.parameters
-  this.parameterKeys = Object.keys(parsed.parameters)
-}
-
-// used in ContentTypeParser.remove
-ParserListItem.prototype.toString = function () {
-  return this.name
 }
 
 module.exports = ContentTypeParser

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -18,6 +18,7 @@ const { createDeprecation, createWarning } = require('process-warning')
  *   - FSTDEP018
  *   - FSTDEP019
  *   - FSTWRN001
+ *   - FSTSEC001
  */
 
 const FSTDEP005 = createDeprecation({
@@ -97,6 +98,13 @@ const FSTWRN001 = createWarning({
   unlimited: true
 })
 
+const FSTSEC001 = createWarning({
+  name: 'FastifySecurity',
+  code: 'FSTSEC001',
+  message: 'You are using /%s/ Content-Type which may be vulnerable to CORS attack. Please make sure your RegExp start with "^" or include ";?" to proper detection of the essence MIME type.',
+  unlimited: true
+})
+
 module.exports = {
   FSTDEP005,
   FSTDEP006,
@@ -112,5 +120,6 @@ module.exports = {
   FSTDEP018,
   FSTDEP019,
   FSTDEP020,
-  FSTWRN001
+  FSTWRN001,
+  FSTSEC001
 }


### PR DESCRIPTION
This PR target to `next` branch.
If we need to loosen the check for `main` or `v3`, we can easily backport to those branch.

#### Notable Changes
1. Remove `Content-Type` parsing which also remove the ability to check `un-ordered` parameters.
2. Add `FastifySecurity` warning for `RegExp`. I use the word `Security` instead of `Warning` to bring attention to the user.

Please carefully review this PR, so we don't expose any security problem.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
