### PR TITLE
make FastifySchemaValidationError.params wider

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -20,15 +20,15 @@ import { FastifyRegister, FastifyRegisterOptions, RegisterOptions } from './type
 import { FastifyReply } from './types/reply'
 import { FastifyRequest, RequestGenericInterface } from './types/request'
 import { RouteHandler, RouteHandlerMethod, RouteOptions, RouteShorthandMethod, RouteShorthandOptions, RouteShorthandOptionsWithHandler, RouteGenericInterface } from './types/route'
-import { FastifySchema, FastifySchemaCompiler, SchemaErrorDataVar, SchemaErrorFormatter } from './types/schema'
+import { FastifySchema, FastifySchemaCompiler, FastifySchemaValidationError, SchemaErrorDataVar, SchemaErrorFormatter } from './types/schema'
 import { FastifyServerFactory, FastifyServerFactoryHandler } from './types/serverFactory'
 import { FastifyTypeProvider, FastifyTypeProviderDefault } from './types/type-provider'
 import { HTTPMethods, RawServerBase, RawRequestDefaultExpression, RawReplyDefaultExpression, RawServerDefault, ContextConfigDefault, RequestBodyDefault, RequestQuerystringDefault, RequestParamsDefault, RequestHeadersDefault } from './types/utils'
 
 declare module '@fastify/error' {
   interface FastifyError {
-    validation?: fastify.ValidationResult[];
     validationContext?: SchemaErrorDataVar;
+    validation?: FastifySchemaValidationError[];
   }
 }
 
@@ -154,14 +154,6 @@ declare namespace fastify {
      * listener to error events emitted by client connections
      */
     clientErrorHandler?: (error: ConnectionError, socket: Socket) => void
-  }
-
-  export interface ValidationResult {
-    keyword: string;
-    instancePath: string;
-    schemaPath: string;
-    params: Record<string, string | string[]>;
-    message?: string;
   }
 
   /* Export additional types */

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -156,6 +156,11 @@ declare namespace fastify {
     clientErrorHandler?: (error: ConnectionError, socket: Socket) => void
   }
 
+  /**
+   * @deprecated use {@link FastifySchemaValidationError}
+   */
+  export type ValidationResult = FastifySchemaValidationError;
+
   /* Export additional types */
   export type {
     LightMyRequestChain, InjectOptions, LightMyRequestResponse, LightMyRequestCallback, // 'light-my-request'

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -16,7 +16,7 @@ import { ErrorObject as AjvErrorObject } from 'ajv'
 import * as http from 'http'
 import * as https from 'https'
 import * as http2 from 'http2'
-import { expectType, expectError, expectAssignable } from 'tsd'
+import { expectType, expectError, expectAssignable, expectNotAssignable } from 'tsd'
 import { FastifyLoggerInstance } from '../../types/logger'
 import { Socket } from 'net'
 
@@ -234,6 +234,13 @@ const ajvErrorObject: AjvErrorObject = {
   params: {},
   message: ''
 }
+expectNotAssignable<AjvErrorObject>({
+  keyword: '',
+  instancePath: '',
+  schemaPath: '',
+  params: '',
+  message: ''
+})
 
 expectAssignable<FastifyError['validation']>([ajvErrorObject])
 expectAssignable<FastifyError['validationContext']>('body')

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -9,7 +9,6 @@ import fastify, {
   LightMyRequestCallback,
   InjectOptions, FastifyBaseLogger,
   RouteGenericInterface,
-  ValidationResult,
   FastifyErrorCodes,
   FastifyError
 } from '../../fastify'
@@ -235,7 +234,6 @@ const ajvErrorObject: AjvErrorObject = {
   params: {},
   message: ''
 }
-expectAssignable<ValidationResult>(ajvErrorObject)
 
 expectAssignable<FastifyError['validation']>([ajvErrorObject])
 expectAssignable<FastifyError['validationContext']>('body')

--- a/types/schema.d.ts
+++ b/types/schema.d.ts
@@ -28,7 +28,7 @@ export interface FastifySchemaValidationError {
   keyword: string;
   instancePath: string;
   schemaPath: string;
-  params: Record<string, string | string[]>;
+  params: Record<string, unknown>;
   message?: string;
 }
 


### PR DESCRIPTION
[`FastifySchemaValidationError`](https://github.com/learnwiz/fastify/blob/4bde0e0b259b8df6495ae93c91e06615b61be9c6/types/schema.d.ts#L26) seems to originate from [`ErrorObject` from Ajv](https://github.com/ajv-validator/ajv/blob/main/lib/types/index.ts#L85).  
However, while property `params` in `FastifySchemaValidationError` has type `Record<string | string[]>`, possible values that are created in Ajv are wider than this; see [`LimitNumberError`](https://github.com/ajv-validator/ajv/blob/main/lib/vocabularies/validation/limitNumber.ts#L18-L22) and [`ConstError`](https://github.com/ajv-validator/ajv/blob/main/lib/vocabularies/validation/const.ts#L7). Note that `allowedValue` defined in `ConstError` could be literally any; see [JSON Schema Validation Specification](https://json-schema.org/draft/2020-12/json-schema-validation.html#name-const).  
Property `params` in `FastifySchemaValidationError` should be wider as `Record<string, unknown>` (or `Record<string, any>` for better coding experience?) to accept those values.

By the way, there were duplicated definition (`ValidationResult`) for this, so I refactored them here.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
