### PR TITLE
improve `setErrorHandler` example

### DIFF
--- a/docs/Reference/Errors.md
+++ b/docs/Reference/Errors.md
@@ -114,7 +114,7 @@ fastify.setErrorHandler(function (error, request, reply) {
     reply.status(500).send({ ok: false })
   } else {
     // fastify will use parent error handler to handle this
-    reply.send(err)
+    reply.send(error)
   }
 })
 

--- a/docs/Reference/Errors.md
+++ b/docs/Reference/Errors.md
@@ -111,8 +111,7 @@ fastify.setErrorHandler(function (error, request, reply) {
     // Log error
     this.log.error(error)
     // Send error response
-    reply.status(500).send({ ok: false })
-    return
+    return reply.status(500).send({ ok: false })
   }
   
   // pop error to default error handler

--- a/docs/Reference/Errors.md
+++ b/docs/Reference/Errors.md
@@ -112,7 +112,11 @@ fastify.setErrorHandler(function (error, request, reply) {
     this.log.error(error)
     // Send error response
     reply.status(500).send({ ok: false })
+    return
   }
+  
+  // pop error to default error handler
+  return error
 })
 
 // Run the server!

--- a/docs/Reference/Errors.md
+++ b/docs/Reference/Errors.md
@@ -111,11 +111,11 @@ fastify.setErrorHandler(function (error, request, reply) {
     // Log error
     this.log.error(error)
     // Send error response
-    return reply.status(500).send({ ok: false })
+    reply.status(500).send({ ok: false })
+  } else {
+    // fastify will use parent error handler to handle this
+    reply.send(err)
   }
-  
-  // pop error to default error handler
-  return error
 })
 
 // Run the server!


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


The example in document will make fastify never send a response if handle throw a error which is not expected error. For example if a handle `throw new Error(...)`. Original document is not clear about this and example doesn't handle it.

Original document make me confused, I assumed that rest of errors will be handled automatically without returning them, but turns out it doesn't.  I'm not sure if "error handler return unhanded error and pop them to parent handler" it expected behavior, but looks like it is, so I create this pr to fix them example. And if it's, I hope the document of `setErrorHandler` could be updated to o, so users can know they can pop error to default error handler. https://www.fastify.io/docs/latest/Reference/Server/#seterrorhandler

like this: `GET /bad-case`

```js
fastify.get('/', function(request, reply) {
  reply.code('bad status code').send({ hello: 'world' })
});

fastify.get('/bad-case', function(request, reply) {
  throw new Error("");
});


fastify.setErrorHandler(function(error, request, reply) {
  if (error instanceof Fastify.errorCodes.FST_ERR_BAD_STATUS_CODE) {
    // Log error
    this.log.error(error);
    // Send error response
    reply.status(500).send({ ok: false });
  }
});
```