### PR TITLE
fix: re-thrown error crash

### DIFF
--- a/lib/wrapThenable.js
+++ b/lib/wrapThenable.js
@@ -35,7 +35,13 @@ function wrapThenable (thenable, reply) {
     }
 
     reply[kReplyIsError] = true
-    reply.send(err)
+
+    // try-catch allow to re-throw error in error handler for async handler
+    try {
+      reply.send(err)
+    } catch (err) {
+      reply.send(err)
+    }
   })
 }
 


### PR DESCRIPTION
When using `async route handler` with `sync custom error handler`. Re-thrown inside the `custom error handler` would crash the problem.

The edge-case discovered in https://github.com/fastify/fastify/pull/4484#issuecomment-1367301750

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
