### PR TITLE
fix: content-type parserRegExpList when plugin override

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -308,6 +308,7 @@ function buildContentTypeParser (c) {
   contentTypeParser[kDefaultJsonParse] = c[kDefaultJsonParse]
   contentTypeParser.customParsers = new Map(c.customParsers.entries())
   contentTypeParser.parserList = c.parserList.slice()
+  contentTypeParser.parserRegExpList = c.parserRegExpList.slice()
   return contentTypeParser
 }
 


### PR DESCRIPTION
Fixes: #4495 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
