### PR TITLE
(v3.x) perf: only check for isEssence once in RegExp for  content-type-parser (#4481)

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -72,6 +72,7 @@ ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
     if (contentTypeIsString) {
       this.parserList.unshift(new ParserListItem(contentType))
     } else {
+      contentType.isEssence = contentType.source.indexOf(';') === -1
       this.parserRegExpList.unshift(contentType)
     }
     this.customParsers.set(contentType.toString(), parser)
@@ -395,7 +396,7 @@ function compareContentType (contentType, parserListItem) {
 }
 
 function compareRegExpContentType (contentType, essenceMIMEType, regexp) {
-  if (regexp.source.indexOf(';') === -1) {
+  if (regexp.isEssence) {
     // we do essence check
     return regexp.test(essenceMIMEType)
   } else {


### PR DESCRIPTION
Backport #4481


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
