### PR TITLE
replace content-type with fast-content-type-parse

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -2,9 +2,7 @@
 
 const { AsyncResource } = require('async_hooks')
 const lru = require('tiny-lru').lru
-// TODO: find more perforamant solution
-const { parse: parseContentType } = require('content-type')
-
+const { safeParse: safeParseContentType, defaultContentType } = require('fast-content-type-parse')
 const secureJson = require('secure-json-parse')
 const {
   kDefaultJsonParse,
@@ -104,7 +102,7 @@ ContentTypeParser.prototype.getParser = function (contentType) {
 
   // dummyContentType always the same object
   // we can use === for the comparsion and return early
-  if (parsed === dummyContentType) {
+  if (parsed === defaultContentType) {
     return this.customParsers.get('')
   }
 
@@ -358,17 +356,6 @@ function removeAllContentTypeParsers () {
   }
 
   this[kContentTypeParser].removeAll()
-}
-
-// dummy here to prevent repeated object creation
-const dummyContentType = { type: '', parameters: Object.create(null) }
-
-function safeParseContentType (contentType) {
-  try {
-    return parseContentType(contentType)
-  } catch (err) {
-    return dummyContentType
-  }
 }
 
 function compareContentType (contentType, parserListItem) {

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "@fastify/fast-json-stringify-compiler": "^4.1.0",
     "abstract-logging": "^2.0.1",
     "avvio": "^8.2.0",
-    "content-type": "^1.0.4",
+    "fast-content-type-parse": "^1.0.0",
     "find-my-way": "^7.3.0",
     "light-my-request": "^5.6.1",
     "pino": "^8.5.0",


### PR DESCRIPTION
I implemented:

https://github.com/fastify/fast-content-type-parse

Here the benchmarks of fast-content-type-parse:

```sh
Benchmarking: "application/json"
util#MIMEType x 1,988,420 ops/sec ±0.41% (92 runs sampled)
fast-content-type-parse#parse x 18,283,119 ops/sec ±1.01% (86 runs sampled)
fast-content-type-parse#safeParse x 19,182,581 ops/sec ±1.29% (93 runs sampled)
content-type#parse x 12,852,355 ops/sec ±1.56% (93 runs sampled)
busboy#parseContentType x 15,001,593 ops/sec ±0.54% (95 runs sampled)
Fastest is fast-content-type-parse#safeParse

Benchmarking: "  application/json"
util#MIMEType x 1,999,209 ops/sec ±0.62% (89 runs sampled)
fast-content-type-parse#parse x 9,796,196 ops/sec ±0.84% (89 runs sampled)
fast-content-type-parse#safeParse x 10,228,216 ops/sec ±0.83% (92 runs sampled)
content-type#parse x 9,101,663 ops/sec ±0.66% (94 runs sampled)
Fastest is fast-content-type-parse#safeParse

Benchmarking: "application/json; charset=utf-8"
util#MIMEType x 1,155,753 ops/sec ±0.97% (93 runs sampled)
fast-content-type-parse#parse x 3,653,256 ops/sec ±0.30% (96 runs sampled)
fast-content-type-parse#safeParse x 3,646,049 ops/sec ±0.37% (95 runs sampled)
content-type#parse x 1,451,264 ops/sec ±0.33% (94 runs sampled)
busboy#parseContentType x 934,342 ops/sec ±0.39% (92 runs sampled)
Fastest is fast-content-type-parse#parse,fast-content-type-parse#safeParse

Benchmarking: "application/json; charset="utf-8""
util#MIMEType x 1,091,914 ops/sec ±0.18% (97 runs sampled)
fast-content-type-parse#parse x 3,151,799 ops/sec ±0.64% (94 runs sampled)
fast-content-type-parse#safeParse x 3,163,572 ops/sec ±0.42% (93 runs sampled)
content-type#parse x 1,062,880 ops/sec ±0.27% (97 runs sampled)
busboy#parseContentType x 865,271 ops/sec ±0.24% (96 runs sampled)
Fastest is fast-content-type-parse#safeParse,fast-content-type-parse#parse
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
