### PR TITLE
fix: content-type mis-handling for invalid non-essence content-type

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -366,6 +366,7 @@ function compareContentType (contentType, parserListItem) {
     // we do essence check
     return contentType.type.indexOf(parserListItem) !== -1
   } else {
+    console.log(parserListItem.type)
     // when the content-type includes parameters
     // we do a full-text search
     // reject essence content-type before checking parameters
@@ -396,10 +397,16 @@ function ParserListItem (contentType) {
   // we pre-calculate all the needed information
   // before content-type comparsion
   const parsed = safeParseContentType(contentType)
-  this.type = parsed.type
+  this.isEssence = contentType.indexOf(';') === -1
+  // we should not allow empty string for parser list item
+  // because it would becomes a match-all handler
+  if (this.isEssence === false && parsed.type === '') {
+    this.type = contentType.split(';')[0]
+  } else {
+    this.type = parsed.type
+  }
   this.parameters = parsed.parameters
   this.parameterKeys = Object.keys(parsed.parameters)
-  this.isEssence = contentType.indexOf(';') === -1
 }
 
 // used in ContentTypeParser.remove

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -366,7 +366,6 @@ function compareContentType (contentType, parserListItem) {
     // we do essence check
     return contentType.type.indexOf(parserListItem) !== -1
   } else {
-    console.log(parserListItem.type)
     // when the content-type includes parameters
     // we do a full-text search
     // reject essence content-type before checking parameters

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -400,7 +400,9 @@ function ParserListItem (contentType) {
   // we should not allow empty string for parser list item
   // because it would becomes a match-all handler
   if (this.isEssence === false && parsed.type === '') {
-    this.type = contentType.split(';')[0]
+    // handle semicolon or empty string
+    const tmp = contentType.split(';')[0]
+    this.type = tmp === '' ? contentType : tmp
   } else {
     this.type = parsed.type
   }

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -398,7 +398,7 @@ function ParserListItem (contentType) {
   const parsed = safeParseContentType(contentType)
   this.isEssence = contentType.indexOf(';') === -1
   // we should not allow empty string for parser list item
-  // because it would becomes a match-all handler
+  // because it would become a match-all handler
   if (this.isEssence === false && parsed.type === '') {
     // handle semicolon or empty string
     const tmp = contentType.split(';')[0]

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -649,3 +649,69 @@ test('content-type regexp list should be cloned when plugin override', async t =
     t.same(payload, 'png')
   }
 })
+
+test('allow partial content-type - essence check', async t => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  fastify.removeAllContentTypeParsers()
+  fastify.addContentTypeParser('json', function (request, body, done) {
+    t.pass('should be called')
+    done(null, body)
+  })
+
+  fastify.post('/', async () => {
+    return 'ok'
+  })
+
+  await fastify.inject({
+    method: 'POST',
+    path: '/',
+    headers: {
+      'content-type': 'application/json; foo=bar; charset=utf8'
+    },
+    body: ''
+  })
+
+  await fastify.inject({
+    method: 'POST',
+    path: '/',
+    headers: {
+      'content-type': 'image/jpeg'
+    },
+    body: ''
+  })
+})
+
+test('allow partial content-type - not essence check', async t => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  fastify.removeAllContentTypeParsers()
+  fastify.addContentTypeParser('json;', function (request, body, done) {
+    t.pass('should be called')
+    done(null, body)
+  })
+
+  fastify.post('/', async () => {
+    return 'ok'
+  })
+
+  await fastify.inject({
+    method: 'POST',
+    path: '/',
+    headers: {
+      'content-type': 'application/json; foo=bar; charset=utf8'
+    },
+    body: ''
+  })
+
+  await fastify.inject({
+    method: 'POST',
+    path: '/',
+    headers: {
+      'content-type': 'image/jpeg'
+    },
+    body: ''
+  })
+})

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -750,38 +750,3 @@ test('edge case content-type - ;', async t => {
 
   t.pass('end')
 })
-
-test('edge case content-type - empty string', async t => {
-  t.plan(1)
-
-  const fastify = Fastify()
-  fastify.removeAllContentTypeParsers()
-  fastify.addContentTypeParser('', function (request, body, done) {
-    t.fail('should not be called')
-    done(null, body)
-  })
-
-  fastify.post('/', async () => {
-    return 'ok'
-  })
-
-  await fastify.inject({
-    method: 'POST',
-    path: '/',
-    headers: {
-      'content-type': 'application/json; foo=bar; charset=utf8'
-    },
-    body: ''
-  })
-
-  await fastify.inject({
-    method: 'POST',
-    path: '/',
-    headers: {
-      'content-type': 'image/jpeg'
-    },
-    body: ''
-  })
-
-  t.pass('end')
-})

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -715,3 +715,73 @@ test('allow partial content-type - not essence check', async t => {
     body: ''
   })
 })
+
+test('edge case content-type - ;', async t => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  fastify.removeAllContentTypeParsers()
+  fastify.addContentTypeParser(';', function (request, body, done) {
+    t.fail('should not be called')
+    done(null, body)
+  })
+
+  fastify.post('/', async () => {
+    return 'ok'
+  })
+
+  await fastify.inject({
+    method: 'POST',
+    path: '/',
+    headers: {
+      'content-type': 'application/json; foo=bar; charset=utf8'
+    },
+    body: ''
+  })
+
+  await fastify.inject({
+    method: 'POST',
+    path: '/',
+    headers: {
+      'content-type': 'image/jpeg'
+    },
+    body: ''
+  })
+
+  t.pass('end')
+})
+
+test('edge case content-type - empty string', async t => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  fastify.removeAllContentTypeParsers()
+  fastify.addContentTypeParser('', function (request, body, done) {
+    t.fail('should not be called')
+    done(null, body)
+  })
+
+  fastify.post('/', async () => {
+    return 'ok'
+  })
+
+  await fastify.inject({
+    method: 'POST',
+    path: '/',
+    headers: {
+      'content-type': 'application/json; foo=bar; charset=utf8'
+    },
+    body: ''
+  })
+
+  await fastify.inject({
+    method: 'POST',
+    path: '/',
+    headers: {
+      'content-type': 'image/jpeg'
+    },
+    body: ''
+  })
+
+  t.pass('end')
+})


### PR DESCRIPTION
@Uzlopak 
We do found a bug throughout the conversation on #4477 
I would fix this case first, but left the leading and trailing space support implementation.
It would be a heavy works for supporting it, since it means we need to do a parsing of input anywhere.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
