### PR TITLE
fix: add type support for instance has plugin

### DIFF
--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -326,6 +326,8 @@ const versionConstraintStrategy = {
 expectType<void>(server.addConstraintStrategy(versionConstraintStrategy))
 expectType<boolean>(server.hasConstraintStrategy(versionConstraintStrategy.name))
 
+expectType<boolean>(server.hasPlugin(''))
+
 expectAssignable<DefaultRoute<RawRequestDefaultExpression, RawReplyDefaultExpression>>(server.getDefaultRoute())
 
 expectType<FastifySchemaCompiler<any> | undefined>(server.validatorCompiler)

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -131,6 +131,7 @@ export interface FastifyInstance<
   hasDecorator(decorator: string | symbol): boolean;
   hasRequestDecorator(decorator: string | symbol): boolean;
   hasReplyDecorator(decorator: string | symbol): boolean;
+  hasPlugin(name: string): boolean;
 
   addConstraintStrategy(strategy: ConstraintStrategy<FindMyWayVersion<RawServer>, unknown>): void;
   hasConstraintStrategy(strategyName: string): boolean;


### PR DESCRIPTION
This PR add typing to the fastify instance hasPlugin method.

**Checklist**

- [x]  run npm run test and npm run benchmark
- [x]  tests and/or benchmarks are included
- [x]  documentation is changed or added
- [x]  commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
- [x] and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)