### PR TITLE
removes the if condition if (idx > -1)

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -147,9 +147,6 @@ ContentTypeParser.prototype.remove = function (contentType) {
 
   const idx = parsers.findIndex(ct => ct.toString() === contentType.toString())
 
-  if (idx > -1) {
-    parsers.splice(idx, 1)
-  }
 }
 
 ContentTypeParser.prototype.run = function (contentType, handler, request, reply) {


### PR DESCRIPTION
Hello, fastify maintainers, I have removed that  `if (idx > -1)` condition that was throwing an error. This is my first open-source contribution. So kindly review this and let me know if there is anything else I could do, I would be more than happy to code.