### PR TITLE
ContentTypeParser remove(): Return false when content type parser was not present for removal

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -141,7 +141,7 @@ ContentTypeParser.prototype.removeAll = function () {
 ContentTypeParser.prototype.remove = function (contentType) {
   if (!(typeof contentType === 'string' || contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()
 
-  this.customParsers.delete(contentType.toString())
+  const removed = this.customParsers.delete(contentType.toString())
 
   const parsers = typeof contentType === 'string' ? this.parserList : this.parserRegExpList
 
@@ -150,6 +150,8 @@ ContentTypeParser.prototype.remove = function (contentType) {
   if (idx > -1) {
     parsers.splice(idx, 1)
   }
+
+  return removed || idx > -1
 }
 
 ContentTypeParser.prototype.run = function (contentType, handler, request, reply) {

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -256,27 +256,25 @@ test('Error thrown 415 from content type is null and make post request to server
 
 test('remove', t => {
   test('should remove default parser', t => {
-    t.plan(2)
+    t.plan(3)
 
     const fastify = Fastify()
     const contentTypeParser = fastify[keys.kContentTypeParser]
 
-    contentTypeParser.remove('application/json')
-
+    t.ok(contentTypeParser.remove('application/json'))
     t.notOk(contentTypeParser.customParsers['application/json'])
     t.notOk(contentTypeParser.parserList.find(parser => parser === 'application/json'))
   })
 
   test('should remove RegExp parser', t => {
-    t.plan(2)
+    t.plan(3)
 
     const fastify = Fastify()
     fastify.addContentTypeParser(/^text\/*/, first)
 
     const contentTypeParser = fastify[keys.kContentTypeParser]
 
-    contentTypeParser.remove(/^text\/*/)
-
+    t.ok(contentTypeParser.remove(/^text\/*/))
     t.notOk(contentTypeParser.customParsers[/^text\/*/])
     t.notOk(contentTypeParser.parserRegExpList.find(parser => parser.toString() === /^text\/*/.toString()))
   })
@@ -289,23 +287,22 @@ test('remove', t => {
     t.throws(() => fastify[keys.kContentTypeParser].remove(12), FST_ERR_CTP_INVALID_TYPE)
   })
 
-  test('should not throw error if content type does not exist', t => {
+  test('should return false if content type does not exist', t => {
     t.plan(1)
 
     const fastify = Fastify()
 
-    t.doesNotThrow(() => fastify[keys.kContentTypeParser].remove('image/png'))
+    t.notOk(fastify[keys.kContentTypeParser].remove('image/png'))
   })
 
   test('should not remove any content type parser if content type does not exist', t => {
-    t.plan(1)
+    t.plan(2)
 
     const fastify = Fastify()
 
     const contentTypeParser = fastify[keys.kContentTypeParser]
 
-    contentTypeParser.remove('image/png')
-
+    t.notOk(contentTypeParser.remove('image/png'))
     t.same(contentTypeParser.customParsers.size, 2)
   })
 


### PR DESCRIPTION
It's not clear whether this behavior is desired for the current version, but threw together a quick PR in case it is.

Closes https://github.com/fastify/fastify/issues/4482