### PR TITLE
Move errors to @fastify/errors - contentTypeParser

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -24,7 +24,8 @@ const {
   FST_ERR_CTP_BODY_TOO_LARGE,
   FST_ERR_CTP_INVALID_MEDIA_TYPE,
   FST_ERR_CTP_INVALID_CONTENT_LENGTH,
-  FST_ERR_CTP_EMPTY_JSON_BODY
+  FST_ERR_CTP_EMPTY_JSON_BODY,
+  FST_ERR_CTP_INSTANCE_ALREADY_STARTED
 } = require('./errors')
 
 function ContentTypeParser (bodyLimit, onProtoPoisoning, onConstructorPoisoning) {
@@ -314,7 +315,7 @@ function buildContentTypeParser (c) {
 
 function addContentTypeParser (contentType, opts, parser) {
   if (this[kState].started) {
-    throw new Error('Cannot call "addContentTypeParser" when fastify instance is already started!')
+    throw new FST_ERR_CTP_INSTANCE_ALREADY_STARTED('addContentTypeParser')
   }
 
   if (typeof opts === 'function') {
@@ -340,7 +341,7 @@ function hasContentTypeParser (contentType) {
 
 function removeContentTypeParser (contentType) {
   if (this[kState].started) {
-    throw new Error('Cannot call "removeContentTypeParser" when fastify instance is already started!')
+    throw new FST_ERR_CTP_INSTANCE_ALREADY_STARTED('removeContentTypeParser')
   }
 
   if (Array.isArray(contentType)) {
@@ -354,7 +355,7 @@ function removeContentTypeParser (contentType) {
 
 function removeAllContentTypeParsers () {
   if (this[kState].started) {
-    throw new Error('Cannot call "removeAllContentTypeParsers" when fastify instance is already started!')
+    throw new FST_ERR_CTP_INSTANCE_ALREADY_STARTED('removeAllContentTypeParsers')
   }
 
   this[kContentTypeParser].removeAll()

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -65,6 +65,11 @@ const codes = {
     "Body cannot be empty when content-type is set to 'application/json'",
     400
   ),
+  FST_ERR_CTP_INSTANCE_ALREADY_STARTED: createError(
+    'FST_ERR_CTP_INSTANCE_ALREADY_STARTED',
+    'Cannot call "%s" when fastify instance is already started!',
+    400
+  ),
 
   /**
    * decorate


### PR DESCRIPTION
This PR addresses https://github.com/fastify/fastify/issues/4521 by replacing native errors (and where needed generalizing them) with `@fastify/errors`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
