### PR TITLE
Schema error formatter type

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -20,7 +20,7 @@ import { FastifyRegister, FastifyRegisterOptions, RegisterOptions } from './type
 import { FastifyReply } from './types/reply'
 import { FastifyRequest, RequestGenericInterface } from './types/request'
 import { RouteHandler, RouteHandlerMethod, RouteOptions, RouteShorthandMethod, RouteShorthandOptions, RouteShorthandOptionsWithHandler, RouteGenericInterface } from './types/route'
-import { FastifySchema, FastifySchemaCompiler, SchemaErrorFormatter } from './types/schema'
+import { FastifySchema, FastifySchemaCompiler, SchemaErrorDataVar, SchemaErrorFormatter } from './types/schema'
 import { FastifyServerFactory, FastifyServerFactoryHandler } from './types/serverFactory'
 import { FastifyTypeProvider, FastifyTypeProviderDefault } from './types/type-provider'
 import { HTTPMethods, RawServerBase, RawRequestDefaultExpression, RawReplyDefaultExpression, RawServerDefault, ContextConfigDefault, RequestBodyDefault, RequestQuerystringDefault, RequestParamsDefault, RequestHeadersDefault } from './types/utils'
@@ -28,7 +28,7 @@ import { HTTPMethods, RawServerBase, RawRequestDefaultExpression, RawReplyDefaul
 declare module '@fastify/error' {
   interface FastifyError {
     validation?: fastify.ValidationResult[];
-    validationContext?: 'body' | 'headers' | 'parameters' | 'querystring';
+    validationContext?: SchemaErrorDataVar;
   }
 }
 

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -20,7 +20,7 @@ import { FastifyRegister, FastifyRegisterOptions, RegisterOptions } from './type
 import { FastifyReply } from './types/reply'
 import { FastifyRequest, RequestGenericInterface } from './types/request'
 import { RouteHandler, RouteHandlerMethod, RouteOptions, RouteShorthandMethod, RouteShorthandOptions, RouteShorthandOptionsWithHandler, RouteGenericInterface } from './types/route'
-import { FastifySchema, FastifySchemaCompiler, FastifySchemaValidationError } from './types/schema'
+import { FastifySchema, FastifySchemaCompiler, SchemaErrorFormatter } from './types/schema'
 import { FastifyServerFactory, FastifyServerFactoryHandler } from './types/serverFactory'
 import { FastifyTypeProvider, FastifyTypeProviderDefault } from './types/type-provider'
 import { HTTPMethods, RawServerBase, RawRequestDefaultExpression, RawReplyDefaultExpression, RawServerDefault, ContextConfigDefault, RequestBodyDefault, RequestQuerystringDefault, RequestParamsDefault, RequestHeadersDefault } from './types/utils'
@@ -142,7 +142,7 @@ declare namespace fastify {
       res: FastifyReply<RawServer, RawRequestDefaultExpression<RawServer>, RawReplyDefaultExpression<RawServer>, RequestGeneric, FastifyContextConfig, SchemaCompiler, TypeProvider>
     ) => void,
     rewriteUrl?: (req: RawRequestDefaultExpression<RawServer>) => string,
-    schemaErrorFormatter?: (errors: FastifySchemaValidationError[], dataVar: string) => Error,
+    schemaErrorFormatter?: SchemaErrorFormatter,
     /**
      * listener to error events emitted by client connections
      */

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -239,7 +239,7 @@ expectAssignable<ValidationResult>(ajvErrorObject)
 expectAssignable<FastifyError['validation']>([ajvErrorObject])
 expectAssignable<FastifyError['validationContext']>('body')
 expectAssignable<FastifyError['validationContext']>('headers')
-expectAssignable<FastifyError['validationContext']>('parameters')
+expectAssignable<FastifyError['validationContext']>('params')
 expectAssignable<FastifyError['validationContext']>('querystring')
 
 const routeGeneric: RouteGenericInterface = {}

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -13,8 +13,8 @@ import {
   FastifySchema,
   FastifySchemaCompiler,
   FastifySchemaControllerOptions,
-  FastifySchemaValidationError,
-  FastifySerializerCompiler
+  FastifySerializerCompiler,
+  SchemaErrorFormatter
 } from './schema'
 import {
   FastifyTypeProvider,
@@ -530,7 +530,7 @@ export interface FastifyInstance<
   /*
   * Set the schema error formatter for all routes.
   */
-  setSchemaErrorFormatter(errorFormatter: (errors: FastifySchemaValidationError[], dataVar: string) => Error): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  setSchemaErrorFormatter(errorFormatter: SchemaErrorFormatter): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
   /**
    * Add a content type parser
    */

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance } from './instance'
 import { FastifyRequest, RequestGenericInterface } from './request'
 import { FastifyReply, ReplyGenericInterface } from './reply'
-import { FastifySchema, FastifySchemaCompiler, FastifySchemaValidationError, FastifySerializerCompiler } from './schema'
+import { FastifySchema, FastifySchemaCompiler, FastifySerializerCompiler, SchemaErrorFormatter } from './schema'
 import { HTTPMethods, RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, ContextConfigDefault } from './utils'
 import { preValidationHookHandler, preHandlerHookHandler, preSerializationHookHandler, onRequestHookHandler, preParsingHookHandler, onResponseHookHandler, onSendHookHandler, onErrorHookHandler, onTimeoutHookHandler } from './hooks'
 import { FastifyError } from '@fastify/error'
@@ -41,8 +41,7 @@ export interface RouteShorthandOptions<
   constraints?: { [name: string]: any },
   prefixTrailingSlash?: 'slash'|'no-slash'|'both';
   errorHandler?: (this: FastifyInstance, error: FastifyError, request: FastifyRequest, reply: FastifyReply) => void;
-  // TODO: Change to actual type.
-  schemaErrorFormatter?: (errors: FastifySchemaValidationError[], dataVar: string) => Error;
+  schemaErrorFormatter?: SchemaErrorFormatter;
 
   // hooks
   onRequest?: onRequestHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> | onRequestHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];

--- a/types/schema.d.ts
+++ b/types/schema.d.ts
@@ -55,4 +55,6 @@ export interface FastifySchemaControllerOptions{
   };
 }
 
-export type SchemaErrorFormatter = (errors: FastifySchemaValidationError[], dataVar: 'body' | 'headers' | 'parameters' | 'querystring') => Error
+export type SchemaErrorDataVar = 'body' | 'headers' | 'params' | 'querystring'
+
+export type SchemaErrorFormatter = (errors: FastifySchemaValidationError[], dataVar: SchemaErrorDataVar) => Error

--- a/types/schema.d.ts
+++ b/types/schema.d.ts
@@ -54,3 +54,5 @@ export interface FastifySchemaControllerOptions{
     buildSerializer?: (externalSchemas: unknown, serializerOptsServerOption: FastifyServerOptions['serializerOpts']) => FastifySerializerCompiler<unknown>;
   };
 }
+
+export type SchemaErrorFormatter = (errors: FastifySchemaValidationError[], dataVar: 'body' | 'headers' | 'parameters' | 'querystring') => Error


### PR DESCRIPTION
Along with the type change in `FastifyError['validationContext']`, type of schemaErrorFormatter should be changed; there are three places to specify them (in `FastifyServerOptions['schemaErrorFormatter']`, `FastifyInstance[setSchemaErrorFormatter']`, and `RouteShorthandOptions['schemaErrorFormatter']`), so I also refactored them.
The type of argument `dataVar` is derived from [the actual invocation](https://github.com/fastify/fastify/blob/main/lib/validation.js#L103-L136). The type in original code of `FastifyError['validationContext']` mismatched from the implementation, so I changed them.

I could not figure out where any test for this change is located (maybe not tested?).

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
