### PR TITLE
Fix crash when onReady hook throws

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -150,10 +150,14 @@ function hookRunnerApplication (hookName, boot, server, cb) {
         return
       }
 
-      const ret = fn.call(server)
-      if (ret && typeof ret.then === 'function') {
-        ret.then(done, done)
-        return
+      try {
+        const ret = fn.call(server)
+        if (ret && typeof ret.then === 'function') {
+          ret.then(done, done)
+          return
+        }
+      } catch (error) {
+        err = error
       }
 
       done(err) // auto done

--- a/test/hooks.on-ready.test.js
+++ b/test/hooks.on-ready.test.js
@@ -372,3 +372,16 @@ t.test('ready return registered', t => {
     .then(instance => { t.same(instance, fastify) })
     .catch(err => { t.fail(err) })
 })
+
+t.test('do not crash with error in follow up onReady hook', async t => {
+  const fastify = Fastify()
+
+  fastify.addHook('onReady', async function () {
+  })
+
+  fastify.addHook('onReady', function () {
+    throw new Error('kaboom')
+  })
+
+  await t.rejects(fastify.ready())
+})


### PR DESCRIPTION
Signed-off-by: Matteo Collina <hello@matteocollina.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
