### PR TITLE
feat: Add `fastify.url` to return the current url of the application

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -326,6 +326,7 @@ function fastify (options) {
       binded.push(this.server.address())
       return binded.filter(adr => adr)
     },
+    url: null,
     // extend fastify objects
     decorate: decorator.add,
     hasDecorator: decorator.exist,
@@ -377,6 +378,19 @@ function fastify (options) {
       configurable: true,
       get () {
         return this[kErrorHandler].func
+      }
+    },
+    url: {
+      configurable: true,
+      get () {
+        const primaryAddress = this.server.address()
+        if (primaryAddress === null) {
+          return null
+        }
+        const { address, port } = primaryAddress
+        const protocol = this[kOptions].https ? 'https' : 'http'
+        const addressString = address === '::1' ? 'localhost' : address
+        return `${protocol}://${addressString}:${port}`
       }
     }
   })

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -612,4 +612,9 @@ export interface FastifyInstance<
     requestIdLogLabel?: string,
     http2SessionTimeout?: number
   }>
+
+  /**
+   * Application url
+   */
+  url: string | null
 }


### PR DESCRIPTION
This PR fixes the issue https://github.com/fastify/fastify/issues/4586. This is my very first contribution, please advice if anything is missed. Thanks!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
