### PR TITLE
ci(package-manager): update ubuntu os to latest

### DIFF
--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # Maintenance and active LTS
         node-version: [14, 16]
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
       matrix:
         # Maintenance and active LTS
         node-version: [14, 16]
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/docs/Reference/LTS.md
+++ b/docs/Reference/LTS.md
@@ -62,7 +62,7 @@ YAML workflow labels below:
 | OS      | YAML Workflow Label    | Package Manager           | Node.js      |
 |---------|------------------------|---------------------------|--------------|
 | Linux   | `ubuntu-latest`        | npm                       | 14,16,18     |
-| Linux   | `ubuntu-18.04`         | yarn,pnpm                 | 14,16,18     |
+| Linux   | `ubuntu-latest`         | yarn,pnpm                 | 14,16,18     |
 | Windows | `windows-latest`       | npm                       | 14,16,18     |
 | MacOS   | `macos-latest`         | npm                       | 14,16,18     |
 

--- a/docs/Reference/LTS.md
+++ b/docs/Reference/LTS.md
@@ -62,7 +62,7 @@ YAML workflow labels below:
 | OS      | YAML Workflow Label    | Package Manager           | Node.js      |
 |---------|------------------------|---------------------------|--------------|
 | Linux   | `ubuntu-latest`        | npm                       | 14,16,18     |
-| Linux   | `ubuntu-latest`         | yarn,pnpm                 | 14,16,18     |
+| Linux   | `ubuntu-latest`        | yarn,pnpm                 | 14,16,18     |
 | Windows | `windows-latest`       | npm                       | 14,16,18     |
 | MacOS   | `macos-latest`         | npm                       | 14,16,18     |
 


### PR DESCRIPTION
closes #4590 by updating the OS used from `ubuntu-18.04` to `ubuntu-latest` (20.04), which also brings it into line with the OSes used by the other CI workflows.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
