### PR TITLE
fix: Only remove implicit HEAD routes.

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -303,7 +303,7 @@ function buildRouting (options) {
 
       // remove the head route created by fastify
       if (hasHEADHandler && !context[kRouteByFastify] && headHandler.store[kRouteByFastify]) {
-        router.off(opts.method, opts.url, { constraints })
+        router.off('HEAD', opts.url, { constraints })
       }
 
       try {

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -1493,3 +1493,17 @@ test('exposeHeadRoute should not reuse the same route option', async t => {
     }
   })
 })
+
+test('using fastify.all when a catchall is define does not degradate performance', { timeout: 5000 }, async t => {
+  t.plan(1)
+
+  const fastify = Fastify()
+
+  fastify.get('/*', async (_, reply) => reply.json({ ok: true }))
+
+  for (let i = 0; i < 100; i++) {
+    fastify.all(`/${i}`, async (_, reply) => reply.json({ ok: true }))
+  }
+
+  t.pass()
+})

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -1494,7 +1494,7 @@ test('exposeHeadRoute should not reuse the same route option', async t => {
   })
 })
 
-test('using fastify.all when a catchall is define does not degradate performance', { timeout: 5000 }, async t => {
+test('using fastify.all when a catchall is defined does not degrade performance', { timeout: 5000 }, async t => {
   t.plan(1)
 
   const fastify = Fastify()


### PR DESCRIPTION
If you add a lot of routes using `fastify.all` AFTER registering a `/*` route, then each new route addition will need more and more time. This will bring the server boot time to the infinite.

A simple way to reproduce this is to run the following code:

```
const fastify = require('fastify')
const server = fastify()

function addRoute(server, path) {
  console.time(path)
  server.all(path, (req, reply) => {
    return reply.json({ ok: true })
  })
  console.timeEnd(path)
}

server.get('/*', async (req, reply) => {
  return reply.json({ ok: true })
})

for (let i = 0; i < 10; i++) {
  addRoute(server, `/${i}`)
}
```

If you execute it, you should will see a result similar to this:

```
/0: 2.95ms
/1: 4.868ms
/2: 7.092ms
/3: 9.411ms
/4: 9.99ms
/5: 10.978ms
/6: 12.333ms
/7: 14.461ms
/8: 15.892ms
/9: 12.501ms
```

If you increase the maximum value in the for-loop, it becomes even more evident.

I tried to dig the problem and it seems the problem can be traced to attempting to remove the implicit HEAD route added by fastify. The problem is that since we're inside a `fastify.all`, there will be an attempt to remove a route for each supported method. And given that find-my-way `.off` is not really optimized, this makes the operation slower as the number of routes grows.

My PR reduces the problem by only removing the `HEAD` route and not all methods. This does not resolve the problem completely but vastly mitigates it.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
