### PR TITLE
fix: onRequestAbort hook request pending

### DIFF
--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -284,7 +284,7 @@ fastify.addHook('onRequestAbort', async (request, reply) => {
 })
 ```
 The `onRequestAbort` hook is executed when a client closes the connection before
-the entire request has been received. Therefore, you will not be able to send
+the entire request has been processed. Therefore, you will not be able to send
 data to the client.
 
 **Notice:** client abort detection is not completely reliable. See: [`Detecting-When-Clients-Abort.md`](../Guides/Detecting-When-Clients-Abort.md)

--- a/lib/route.js
+++ b/lib/route.js
@@ -513,6 +513,7 @@ function handleOnRequestAbortHooksErrors (reply, err) {
   if (err) {
     reply.log.error({ err }, 'onRequestAborted hook failed')
   }
+  reply[kReplyIsError] = true
 }
 
 function handleTimeout () {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -3413,13 +3413,29 @@ test('onRequestAbort should be triggered', t => {
   const fastify = Fastify()
   let order = 0
 
-  t.plan(6)
+  t.plan(9)
   t.teardown(() => fastify.close())
 
   fastify.addHook('onRequestAbort', function (req, done) {
     t.equal(++order, 1, 'called in hook')
     t.ok(req.pendingResolve, 'request has pendingResolve')
     req.pendingResolve()
+    done()
+  })
+
+  fastify.addHook('onError', function hook (request, reply, error, done) {
+    t.same(error, { hello: 'world' }, 'onError should be called')
+    t.ok(request.raw.aborted, 'request should be aborted')
+    done()
+  })
+
+  fastify.addHook('onSend', function hook (request, reply, payload, done) {
+    t.equal(payload, '{"hello":"world"}', 'onSend should be called')
+    done(null, payload)
+  })
+
+  fastify.addHook('onResponse', function hook (request, reply, done) {
+    t.fail('onResponse should not be called')
     done()
   })
 


### PR DESCRIPTION
This PR shows that:

- the handler is executed (ref: https://twitter.com/kibertoad/status/1631687720769658882 )
- the onError hook is called if the handler is resolved after the request is aborted
- the onSend hook is called

