### PR TITLE
feat: use internal trees for prettyPrint

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "abstract-logging": "^2.0.1",
     "avvio": "^8.2.0",
     "fast-content-type-parse": "^1.0.0",
-    "find-my-way": "^7.3.0",
+    "find-my-way": "delvedor/find-my-way#use-internal-trees-for-pretty-printing",
     "light-my-request": "^5.6.1",
     "pino": "^8.5.0",
     "process-warning": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "abstract-logging": "^2.0.1",
     "avvio": "^8.2.0",
     "fast-content-type-parse": "^1.0.0",
-    "find-my-way": "delvedor/find-my-way#use-internal-trees-for-pretty-printing",
+    "find-my-way": "^7.6.0",
     "light-my-request": "^5.6.1",
     "pino": "^8.5.0",
     "process-warning": "^2.0.0",

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -15,7 +15,8 @@ test('pretty print - static routes', t => {
   fastify.ready(() => {
     const tree = fastify.printRoutes()
 
-    const expected = `└── /
+    const expected = `\
+└── /
     ├── test (GET)
     │   └── /hello (GET)
     └── hello/world (GET)
@@ -37,10 +38,13 @@ test('pretty print - parametric routes', t => {
   fastify.ready(() => {
     const tree = fastify.printRoutes()
 
-    const expected = `└── /
+    const expected = `\
+└── /
     ├── test (GET)
-    │   └── /:hello (GET)
-    └── hello/:world (GET)
+    │   └── /
+    │       └── :hello (GET)
+    └── hello/
+        └── :world (GET)
 `
 
     t.equal(typeof tree, 'string')
@@ -60,11 +64,12 @@ test('pretty print - mixed parametric routes', t => {
   fastify.ready(() => {
     const tree = fastify.printRoutes()
 
-    const expected = `└── /test (GET)
-    └── /
-        └── :hello (GET)
-            :hello (POST)
-            └── /world (GET)
+    const expected = `\
+└── /
+    └── test (GET)
+        └── /
+            └── :hello (GET, POST)
+                └── /world (GET)
 `
 
     t.equal(typeof tree, 'string')
@@ -83,10 +88,13 @@ test('pretty print - wildcard routes', t => {
   fastify.ready(() => {
     const tree = fastify.printRoutes()
 
-    const expected = `└── /
+    const expected = `\
+└── /
     ├── test (GET)
-    │   └── /* (GET)
-    └── hello/* (GET)
+    │   └── /
+    │       └── * (GET)
+    └── hello/
+        └── * (GET)
 `
 
     t.equal(typeof tree, 'string')
@@ -134,17 +142,15 @@ test('pretty print - commonPrefix', t => {
     const radixTree = fastify.printRoutes()
     const flatTree = fastify.printRoutes({ commonPrefix: false })
 
-    const radixExpected = `└── /
-    ├── hel
-    │   ├── lo (GET)
-    │   │   lo (HEAD)
-    │   └── icopter (GET)
-    │       icopter (HEAD)
-    └── hello (PUT)
+    const radixExpected = `\
+└── /
+    └── hel
+        ├── lo (GET, HEAD, PUT)
+        └── icopter (GET, HEAD)
 `
-    const flatExpected = `└── / (-)
-    ├── helicopter (GET, HEAD)
-    └── hello (GET, HEAD, PUT)
+    const flatExpected = `\
+├── /hello (GET, HEAD, PUT)
+└── /helicopter (GET, HEAD)
 `
     t.equal(typeof radixTree, 'string')
     t.equal(typeof flatTree, 'string')
@@ -170,49 +176,64 @@ test('pretty print - includeMeta, includeHooks', t => {
     const flatTree = fastify.printRoutes({ commonPrefix: false, includeHooks: true, includeMeta: ['errorHandler'] })
     const hooksOnly = fastify.printRoutes({ commonPrefix: false, includeHooks: true })
 
-    const radixExpected = `└── /
-    ├── hel
-    │   ├── lo (GET)
-    │   │   • (onTimeout) ["onTimeout()"]
-    │   │   • (onRequest) ["anonymous()"]
-    │   │   • (errorHandler) "defaultErrorHandler()"
-    │   │   lo (HEAD)
-    │   │   • (onTimeout) ["onTimeout()"]
-    │   │   • (onRequest) ["anonymous()"]
-    │   │   • (onSend) ["headRouteOnSendHandler()"]
-    │   │   • (errorHandler) "defaultErrorHandler()"
-    │   └── icopter (GET)
-    │       • (onTimeout) ["onTimeout()"]
-    │       • (onRequest) ["anonymous()"]
-    │       • (errorHandler) "defaultErrorHandler()"
-    │       icopter (HEAD)
-    │       • (onTimeout) ["onTimeout()"]
-    │       • (onRequest) ["anonymous()"]
-    │       • (onSend) ["headRouteOnSendHandler()"]
-    │       • (errorHandler) "defaultErrorHandler()"
-    └── hello (PUT)
-        • (onTimeout) ["onTimeout()"]
-        • (onRequest) ["anonymous()"]
-        • (errorHandler) "defaultErrorHandler()"
+    const radixExpected = `\
+└── /
+    └── hel
+        ├── lo (GET, PUT)
+        │   • (onTimeout) ["onTimeout()"]
+        │   • (onRequest) ["anonymous()"]
+        │   • (errorHandler) "defaultErrorHandler()"
+        │   lo (HEAD)
+        │   • (onTimeout) ["onTimeout()"]
+        │   • (onRequest) ["anonymous()"]
+        │   • (onSend) ["headRouteOnSendHandler()"]
+        │   • (errorHandler) "defaultErrorHandler()"
+        └── icopter (GET)
+            • (onTimeout) ["onTimeout()"]
+            • (onRequest) ["anonymous()"]
+            • (errorHandler) "defaultErrorHandler()"
+            icopter (HEAD)
+            • (onTimeout) ["onTimeout()"]
+            • (onRequest) ["anonymous()"]
+            • (onSend) ["headRouteOnSendHandler()"]
+            • (errorHandler) "defaultErrorHandler()"
 `
-    const flatExpected = `└── / (-)
-    ├── helicopter (GET, HEAD)
-    │   • (onTimeout) ["onTimeout()"]
-    │   • (onRequest) ["anonymous()"]
-    │   • (errorHandler) "defaultErrorHandler()"
-    └── hello (GET, HEAD, PUT)
-        • (onTimeout) ["onTimeout()"]
-        • (onRequest) ["anonymous()"]
-        • (errorHandler) "defaultErrorHandler()"
+    const flatExpected = `\
+├── /hello (GET, PUT)
+│   • (onTimeout) ["onTimeout()"]
+│   • (onRequest) ["anonymous()"]
+│   • (errorHandler) "defaultErrorHandler()"
+│   /hello (HEAD)
+│   • (onTimeout) ["onTimeout()"]
+│   • (onRequest) ["anonymous()"]
+│   • (onSend) ["headRouteOnSendHandler()"]
+│   • (errorHandler) "defaultErrorHandler()"
+└── /helicopter (GET)
+    • (onTimeout) ["onTimeout()"]
+    • (onRequest) ["anonymous()"]
+    • (errorHandler) "defaultErrorHandler()"
+    /helicopter (HEAD)
+    • (onTimeout) ["onTimeout()"]
+    • (onRequest) ["anonymous()"]
+    • (onSend) ["headRouteOnSendHandler()"]
+    • (errorHandler) "defaultErrorHandler()"
 `
 
-    const hooksOnlyExpected = `└── / (-)
-    ├── helicopter (GET, HEAD)
-    │   • (onTimeout) ["onTimeout()"]
-    │   • (onRequest) ["anonymous()"]
-    └── hello (GET, HEAD, PUT)
-        • (onTimeout) ["onTimeout()"]
-        • (onRequest) ["anonymous()"]
+    const hooksOnlyExpected = `\
+├── /hello (GET, PUT)
+│   • (onTimeout) ["onTimeout()"]
+│   • (onRequest) ["anonymous()"]
+│   /hello (HEAD)
+│   • (onTimeout) ["onTimeout()"]
+│   • (onRequest) ["anonymous()"]
+│   • (onSend) ["headRouteOnSendHandler()"]
+└── /helicopter (GET)
+    • (onTimeout) ["onTimeout()"]
+    • (onRequest) ["anonymous()"]
+    /helicopter (HEAD)
+    • (onTimeout) ["onTimeout()"]
+    • (onRequest) ["anonymous()"]
+    • (onSend) ["headRouteOnSendHandler()"]
 `
     t.equal(typeof radixTree, 'string')
     t.equal(typeof flatTree, 'string')


### PR DESCRIPTION
It's not ready: need to expose a new pretty print param: `method`.

Now you can see pretty print tests updates.