### PR TITLE
fix: check if validation schema is undefined

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -80,18 +80,26 @@ function compileSchemasForValidation (context, compile, isCustom) {
       })
     }
     context[headersSchema] = compile({ schema: headersSchemaLowerCase, method, url, httpPart: 'headers' })
+  } else if (Object.hasOwnProperty.call(schema, 'headers')) {
+    throw new Error('headers schema is undefined')
   }
 
   if (schema.body) {
     context[bodySchema] = compile({ schema: schema.body, method, url, httpPart: 'body' })
+  } else if (Object.hasOwnProperty.call(schema, 'body')) {
+    throw new Error('body schema is undefined')
   }
 
   if (schema.querystring) {
     context[querystringSchema] = compile({ schema: schema.querystring, method, url, httpPart: 'querystring' })
+  } else if (Object.hasOwnProperty.call(schema, 'querystring')) {
+    throw new Error('querystring schema is undefined')
   }
 
   if (schema.params) {
     context[paramsSchema] = compile({ schema: schema.params, method, url, httpPart: 'params' })
+  } else if (Object.hasOwnProperty.call(schema, 'params')) {
+    throw new Error('params schema is undefined')
   }
 }
 

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -253,6 +253,91 @@ test('Should not change the input schemas', t => {
   })
 })
 
+test('Should throw if the schema body is undefined', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.get('/:id', {
+    handler: echoParams,
+    schema: {
+      body: undefined
+    }
+  })
+
+  fastify.ready(err => {
+    t.equal(err.code, 'FST_ERR_SCH_VALIDATION_BUILD')
+    t.equal(err.message, 'Failed building the validation schema for GET: /:id, due to error body schema is undefined')
+  })
+})
+
+test('Should throw if the schema headers is undefined', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.get('/:id', {
+    handler: echoParams,
+    schema: {
+      headers: undefined
+    }
+  })
+
+  fastify.ready(err => {
+    t.equal(err.code, 'FST_ERR_SCH_VALIDATION_BUILD')
+    t.equal(err.message, 'Failed building the validation schema for GET: /:id, due to error headers schema is undefined')
+  })
+})
+
+test('Should throw if the schema params is undefined', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.get('/:id', {
+    handler: echoParams,
+    schema: {
+      params: undefined
+    }
+  })
+
+  fastify.ready(err => {
+    t.equal(err.code, 'FST_ERR_SCH_VALIDATION_BUILD')
+    t.equal(err.message, 'Failed building the validation schema for GET: /:id, due to error params schema is undefined')
+  })
+})
+
+test('Should throw if the schema query is undefined', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.get('/:id', {
+    handler: echoParams,
+    schema: {
+      querystring: undefined
+    }
+  })
+
+  fastify.ready(err => {
+    t.equal(err.code, 'FST_ERR_SCH_VALIDATION_BUILD')
+    t.equal(err.message, 'Failed building the validation schema for GET: /:id, due to error querystring schema is undefined')
+  })
+})
+
+test('Should throw if the schema query is undefined', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.get('/:id', {
+    handler: echoParams,
+    schema: {
+      querystring: undefined
+    }
+  })
+
+  fastify.ready(err => {
+    t.equal(err.code, 'FST_ERR_SCH_VALIDATION_BUILD')
+    t.equal(err.message, 'Failed building the validation schema for GET: /:id, due to error querystring schema is undefined')
+  })
+})
+
 test('First level $ref', t => {
   t.plan(2)
   const fastify = Fastify()


### PR DESCRIPTION
this snippet works and I think it should not as it hides the wrong setup and missing schemas

```
const fastify = require('./fastify')({ logger: true })

fastify.post('/', {
  schema: {
    body: undefined
  }
}, async (request, reply) => {
  return request.body
})
fastify.ready()
  .then(() => {
    console.log('ready')
  })

```