### PR TITLE
fix: avoid invoking onError hook when aborted handler resolves

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -513,7 +513,6 @@ function handleOnRequestAbortHooksErrors (reply, err) {
   if (err) {
     reply.log.error({ err }, 'onRequestAborted hook failed')
   }
-  reply[kReplyIsError] = true
 }
 
 function handleTimeout () {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -3413,7 +3413,7 @@ test('onRequestAbort should be triggered', t => {
   const fastify = Fastify()
   let order = 0
 
-  t.plan(9)
+  t.plan(7)
   t.teardown(() => fastify.close())
 
   fastify.addHook('onRequestAbort', function (req, done) {
@@ -3424,8 +3424,7 @@ test('onRequestAbort should be triggered', t => {
   })
 
   fastify.addHook('onError', function hook (request, reply, error, done) {
-    t.same(error, { hello: 'world' }, 'onError should be called')
-    t.ok(request.raw.aborted, 'request should be aborted')
+    t.fail('onError should not be called')
     done()
   })
 


### PR DESCRIPTION
Fixes #4626. When a client aborts the request while the route handler is still processing, this no longer triggers an error when the route handler finishes processing.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
