### PR TITLE
Emit a warning when validating undefined schemas

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -83,25 +83,25 @@ function compileSchemasForValidation (context, compile, isCustom) {
     }
     context[headersSchema] = compile({ schema: headersSchemaLowerCase, method, url, httpPart: 'headers' })
   } else if (Object.hasOwnProperty.call(schema, 'headers')) {
-    warning.emit('FSTDEP015', 'headers', method, url)
+    warning.emit('FSTWRN001', 'headers', method, url)
   }
 
   if (schema.body) {
     context[bodySchema] = compile({ schema: schema.body, method, url, httpPart: 'body' })
   } else if (Object.hasOwnProperty.call(schema, 'body')) {
-    warning.emit('FSTDEP015', 'body', method, url)
+    warning.emit('FSTWRN001', 'body', method, url)
   }
 
   if (schema.querystring) {
     context[querystringSchema] = compile({ schema: schema.querystring, method, url, httpPart: 'querystring' })
   } else if (Object.hasOwnProperty.call(schema, 'querystring')) {
-    warning.emit('FSTDEP015', 'querystring', method, url)
+    warning.emit('FSTWRN001', 'querystring', method, url)
   }
 
   if (schema.params) {
     context[paramsSchema] = compile({ schema: schema.params, method, url, httpPart: 'params' })
   } else if (Object.hasOwnProperty.call(schema, 'params')) {
-    warning.emit('FSTDEP015', 'params', method, url)
+    warning.emit('FSTWRN001', 'params', method, url)
   }
 }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -13,6 +13,8 @@ const {
   FST_ERR_SCH_RESPONSE_SCHEMA_NOT_NESTED_2XX
 } = require('./errors')
 
+const warning = require('./warnings')
+
 function compileSchemasForSerialization (context, compile) {
   if (!context.schema || !context.schema.response) {
     return
@@ -81,25 +83,25 @@ function compileSchemasForValidation (context, compile, isCustom) {
     }
     context[headersSchema] = compile({ schema: headersSchemaLowerCase, method, url, httpPart: 'headers' })
   } else if (Object.hasOwnProperty.call(schema, 'headers')) {
-    throw new Error('headers schema is undefined')
+    warning.emit('FSTDEP015')
   }
 
   if (schema.body) {
     context[bodySchema] = compile({ schema: schema.body, method, url, httpPart: 'body' })
   } else if (Object.hasOwnProperty.call(schema, 'body')) {
-    throw new Error('body schema is undefined')
+    warning.emit('FSTDEP016')
   }
 
   if (schema.querystring) {
     context[querystringSchema] = compile({ schema: schema.querystring, method, url, httpPart: 'querystring' })
   } else if (Object.hasOwnProperty.call(schema, 'querystring')) {
-    throw new Error('querystring schema is undefined')
+    warning.emit('FSTDEP017')
   }
 
   if (schema.params) {
     context[paramsSchema] = compile({ schema: schema.params, method, url, httpPart: 'params' })
   } else if (Object.hasOwnProperty.call(schema, 'params')) {
-    throw new Error('params schema is undefined')
+    warning.emit('FSTDEP018')
   }
 }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -83,25 +83,25 @@ function compileSchemasForValidation (context, compile, isCustom) {
     }
     context[headersSchema] = compile({ schema: headersSchemaLowerCase, method, url, httpPart: 'headers' })
   } else if (Object.hasOwnProperty.call(schema, 'headers')) {
-    warning.emit('FSTDEP015')
+    warning.emit('FSTDEP015', 'headers')
   }
 
   if (schema.body) {
     context[bodySchema] = compile({ schema: schema.body, method, url, httpPart: 'body' })
   } else if (Object.hasOwnProperty.call(schema, 'body')) {
-    warning.emit('FSTDEP016')
+    warning.emit('FSTDEP015', 'body')
   }
 
   if (schema.querystring) {
     context[querystringSchema] = compile({ schema: schema.querystring, method, url, httpPart: 'querystring' })
   } else if (Object.hasOwnProperty.call(schema, 'querystring')) {
-    warning.emit('FSTDEP017')
+    warning.emit('FSTDEP015', 'querystring')
   }
 
   if (schema.params) {
     context[paramsSchema] = compile({ schema: schema.params, method, url, httpPart: 'params' })
   } else if (Object.hasOwnProperty.call(schema, 'params')) {
-    warning.emit('FSTDEP018')
+    warning.emit('FSTDEP015', 'params')
   }
 }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -83,25 +83,25 @@ function compileSchemasForValidation (context, compile, isCustom) {
     }
     context[headersSchema] = compile({ schema: headersSchemaLowerCase, method, url, httpPart: 'headers' })
   } else if (Object.hasOwnProperty.call(schema, 'headers')) {
-    warning.emit('FSTDEP015', 'headers')
+    warning.emit('FSTDEP015', 'headers', method, url)
   }
 
   if (schema.body) {
     context[bodySchema] = compile({ schema: schema.body, method, url, httpPart: 'body' })
   } else if (Object.hasOwnProperty.call(schema, 'body')) {
-    warning.emit('FSTDEP015', 'body')
+    warning.emit('FSTDEP015', 'body', method, url)
   }
 
   if (schema.querystring) {
     context[querystringSchema] = compile({ schema: schema.querystring, method, url, httpPart: 'querystring' })
   } else if (Object.hasOwnProperty.call(schema, 'querystring')) {
-    warning.emit('FSTDEP015', 'querystring')
+    warning.emit('FSTDEP015', 'querystring', method, url)
   }
 
   if (schema.params) {
     context[paramsSchema] = compile({ schema: schema.params, method, url, httpPart: 'params' })
   } else if (Object.hasOwnProperty.call(schema, 'params')) {
-    warning.emit('FSTDEP015', 'params')
+    warning.emit('FSTDEP015', 'params', method, url)
   }
 }
 

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -27,12 +27,6 @@ warning.create('FastifyDeprecation', 'FSTDEP013', 'Direct return of "trailers" f
 
 warning.create('FastifyDeprecation', 'FSTDEP014', 'You are trying to set/access the default route. This property is deprecated. Please, use setNotFoundHandler if you want to custom a 404 handler or the wildcard (*) to match all routes.')
 
-warning.create('FastifyDeprecation', 'FSTDEP015', 'The headers schema for the route is undefined. This may indicate the schema is not valid or missing.')
-
-warning.create('FastifyDeprecation', 'FSTDEP016', 'The body schema for the route is undefined. This may indicate the schema is not valid or missing.')
-
-warning.create('FastifyDeprecation', 'FSTDEP017', 'The querystring schema for the route is undefined. This may indicate the schema is not valid or missing.')
-
-warning.create('FastifyDeprecation', 'FSTDEP018', 'The params schema for the route is undefined. This may indicate the schema is not valid or missing.')
+warning.create('FastifyDeprecation', 'FSTDEP015', 'The %s schema for the route is undefined. This may indicate the schema is not valid or missing.')
 
 module.exports = warning

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -27,6 +27,6 @@ warning.create('FastifyDeprecation', 'FSTDEP013', 'Direct return of "trailers" f
 
 warning.create('FastifyDeprecation', 'FSTDEP014', 'You are trying to set/access the default route. This property is deprecated. Please, use setNotFoundHandler if you want to custom a 404 handler or the wildcard (*) to match all routes.')
 
-warning.create('FastifyDeprecation', 'FSTDEP015', 'The %s schema for the route is undefined. This may indicate the schema is not valid or missing.')
+warning.create('FastifyDeprecation', 'FSTDEP015', 'The %s schema for %s: %s is undefined. This may indicate the schema is not well specified.')
 
 module.exports = warning

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -27,6 +27,6 @@ warning.create('FastifyDeprecation', 'FSTDEP013', 'Direct return of "trailers" f
 
 warning.create('FastifyDeprecation', 'FSTDEP014', 'You are trying to set/access the default route. This property is deprecated. Please, use setNotFoundHandler if you want to custom a 404 handler or the wildcard (*) to match all routes.')
 
-warning.create('FastifyDeprecation', 'FSTDEP015', 'The %s schema for %s: %s is undefined. This may indicate the schema is not well specified.')
+warning.create('FastifyDeprecation', 'FSTDEP015', 'The %s schema for %s: %s is missed. This may indicate the schema is not well specified.')
 
 module.exports = warning

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -27,6 +27,6 @@ warning.create('FastifyDeprecation', 'FSTDEP013', 'Direct return of "trailers" f
 
 warning.create('FastifyDeprecation', 'FSTDEP014', 'You are trying to set/access the default route. This property is deprecated. Please, use setNotFoundHandler if you want to custom a 404 handler or the wildcard (*) to match all routes.')
 
-warning.create('FastifyDeprecation', 'FSTDEP015', 'The %s schema for %s: %s is missed. This may indicate the schema is not well specified.', { unlimited: true })
+warning.create('FastifyDeprecation', 'FSTDEP015', 'The %s schema for %s: %s is missing. This may indicate the schema is not well specified.', { unlimited: true })
 
 module.exports = warning

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -27,6 +27,6 @@ warning.create('FastifyDeprecation', 'FSTDEP013', 'Direct return of "trailers" f
 
 warning.create('FastifyDeprecation', 'FSTDEP014', 'You are trying to set/access the default route. This property is deprecated. Please, use setNotFoundHandler if you want to custom a 404 handler or the wildcard (*) to match all routes.')
 
-warning.create('FastifyDeprecation', 'FSTDEP015', 'The %s schema for %s: %s is missing. This may indicate the schema is not well specified.', { unlimited: true })
+warning.create('FastifyWarning', 'FSTWRN001', 'The %s schema for %s: %s is missing. This may indicate the schema is not well specified.', { unlimited: true })
 
 module.exports = warning

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -27,4 +27,12 @@ warning.create('FastifyDeprecation', 'FSTDEP013', 'Direct return of "trailers" f
 
 warning.create('FastifyDeprecation', 'FSTDEP014', 'You are trying to set/access the default route. This property is deprecated. Please, use setNotFoundHandler if you want to custom a 404 handler or the wildcard (*) to match all routes.')
 
+warning.create('FastifyDeprecation', 'FSTDEP015', 'The headers schema for the route is undefined. This may indicate the schema is not valid or missing.')
+
+warning.create('FastifyDeprecation', 'FSTDEP016', 'The body schema for the route is undefined. This may indicate the schema is not valid or missing.')
+
+warning.create('FastifyDeprecation', 'FSTDEP017', 'The querystring schema for the route is undefined. This may indicate the schema is not valid or missing.')
+
+warning.create('FastifyDeprecation', 'FSTDEP018', 'The params schema for the route is undefined. This may indicate the schema is not valid or missing.')
+
 module.exports = warning

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -27,6 +27,6 @@ warning.create('FastifyDeprecation', 'FSTDEP013', 'Direct return of "trailers" f
 
 warning.create('FastifyDeprecation', 'FSTDEP014', 'You are trying to set/access the default route. This property is deprecated. Please, use setNotFoundHandler if you want to custom a 404 handler or the wildcard (*) to match all routes.')
 
-warning.create('FastifyDeprecation', 'FSTDEP015', 'The %s schema for %s: %s is missed. This may indicate the schema is not well specified.')
+warning.create('FastifyDeprecation', 'FSTDEP015', 'The %s schema for %s: %s is missed. This may indicate the schema is not well specified.', { unlimited: true })
 
 module.exports = warning

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -255,7 +255,7 @@ test('Should not change the input schemas', t => {
 })
 
 test('Should emit warning if the schema headers is undefined', t => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
 
   process.on('warning', onWarning)
@@ -269,18 +269,24 @@ test('Should emit warning if the schema headers is undefined', t => {
     warning.emitted.set('FSTDEP015', false)
   })
 
-  fastify.get('/:id', {
+  fastify.post('/:id', {
     handler: echoParams,
     schema: {
       headers: undefined
     }
   })
 
-  fastify.ready(err => t.error(err))
+  fastify.inject({
+    method: 'POST',
+    url: '/123'
+  }, (error, res) => {
+    t.error(error)
+    t.equal(res.statusCode, 200)
+  })
 })
 
 test('Should emit warning if the schema body is undefined', t => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
 
   process.on('warning', onWarning)
@@ -294,18 +300,24 @@ test('Should emit warning if the schema body is undefined', t => {
     warning.emitted.set('FSTDEP015', false)
   })
 
-  fastify.get('/:id', {
+  fastify.post('/:id', {
     handler: echoParams,
     schema: {
       body: undefined
     }
   })
 
-  fastify.ready(err => t.error(err))
+  fastify.inject({
+    method: 'POST',
+    url: '/123'
+  }, (error, res) => {
+    t.error(error)
+    t.equal(res.statusCode, 200)
+  })
 })
 
 test('Should emit warning if the schema query is undefined', t => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
 
   process.on('warning', onWarning)
@@ -319,18 +331,24 @@ test('Should emit warning if the schema query is undefined', t => {
     warning.emitted.set('FSTDEP015', false)
   })
 
-  fastify.get('/:id', {
+  fastify.post('/:id', {
     handler: echoParams,
     schema: {
       querystring: undefined
     }
   })
 
-  fastify.ready(err => t.error(err))
+  fastify.inject({
+    method: 'POST',
+    url: '/123'
+  }, (error, res) => {
+    t.error(error)
+    t.equal(res.statusCode, 200)
+  })
 })
 
 test('Should emit warning if the schema params is undefined', t => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
 
   process.on('warning', onWarning)
@@ -344,14 +362,73 @@ test('Should emit warning if the schema params is undefined', t => {
     warning.emitted.set('FSTDEP015', false)
   })
 
-  fastify.get('/:id', {
+  fastify.post('/:id', {
     handler: echoParams,
     schema: {
       params: undefined
     }
   })
 
-  fastify.ready(err => t.error(err))
+  fastify.inject({
+    method: 'POST',
+    url: '/123'
+  }, (error, res) => {
+    t.error(error)
+    t.equal(res.statusCode, 200)
+  })
+})
+
+test('Should emit a warning for every route with undefined schema', t => {
+  t.plan(16)
+  const fastify = Fastify()
+
+  let runs = 0
+  const expectedWarningEmitted = [0, 1, 2, 3]
+  // It emits 4 warnings:
+  // - 2 - GET and HEAD for /undefinedParams/:id
+  // - 2 - GET and HEAD for /undefinedBody/:id
+  // => 3 x 4 assertions = 12 assertions
+  function onWarning (warning) {
+    t.equal(warning.name, 'FastifyDeprecation')
+    t.equal(warning.code, 'FSTDEP015')
+    t.equal(runs++, expectedWarningEmitted.shift())
+  }
+
+  process.on('warning', onWarning)
+  t.teardown(() => {
+    process.removeListener('warning', onWarning)
+    warning.emitted.set('FSTDEP015', false)
+  })
+
+  fastify.get('/undefinedParams/:id', {
+    handler: echoParams,
+    schema: {
+      params: undefined
+    }
+  })
+
+  fastify.get('/undefinedBody/:id', {
+    handler: echoParams,
+    schema: {
+      body: undefined
+    }
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/undefinedParams/123'
+  }, (error, res) => {
+    t.error(error)
+    t.equal(res.statusCode, 200)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/undefinedBody/123'
+  }, (error, res) => {
+    t.error(error)
+    t.equal(res.statusCode, 200)
+  })
 })
 
 test('First level $ref', t => {

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -286,12 +286,12 @@ test('Should emit warning if the schema body is undefined', t => {
   process.on('warning', onWarning)
   function onWarning (warning) {
     t.equal(warning.name, 'FastifyDeprecation')
-    t.equal(warning.code, 'FSTDEP016')
+    t.equal(warning.code, 'FSTDEP015')
   }
 
   t.teardown(() => {
     process.removeListener('warning', onWarning)
-    warning.emitted.set('FSTDEP016', false)
+    warning.emitted.set('FSTDEP015', false)
   })
 
   fastify.get('/:id', {
@@ -311,12 +311,12 @@ test('Should emit warning if the schema query is undefined', t => {
   process.on('warning', onWarning)
   function onWarning (warning) {
     t.equal(warning.name, 'FastifyDeprecation')
-    t.equal(warning.code, 'FSTDEP017')
+    t.equal(warning.code, 'FSTDEP015')
   }
 
   t.teardown(() => {
     process.removeListener('warning', onWarning)
-    warning.emitted.set('FSTDEP017', false)
+    warning.emitted.set('FSTDEP015', false)
   })
 
   fastify.get('/:id', {
@@ -336,12 +336,12 @@ test('Should emit warning if the schema params is undefined', t => {
   process.on('warning', onWarning)
   function onWarning (warning) {
     t.equal(warning.name, 'FastifyDeprecation')
-    t.equal(warning.code, 'FSTDEP018')
+    t.equal(warning.code, 'FSTDEP015')
   }
 
   t.teardown(() => {
     process.removeListener('warning', onWarning)
-    warning.emitted.set('FSTDEP018', false)
+    warning.emitted.set('FSTDEP015', false)
   })
 
   fastify.get('/:id', {

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -6,6 +6,7 @@ const fp = require('fastify-plugin')
 const deepClone = require('rfdc')({ circles: true, proto: false })
 const Ajv = require('ajv')
 const { kSchemaController } = require('../lib/symbols.js')
+const warning = require('../lib/warnings')
 
 const echoParams = (req, reply) => { reply.send(req.params) }
 const echoBody = (req, reply) => { reply.send(req.body) }
@@ -253,26 +254,20 @@ test('Should not change the input schemas', t => {
   })
 })
 
-test('Should throw if the schema body is undefined', t => {
+test('Should emit warning if the schema headers is undefined', t => {
   t.plan(2)
   const fastify = Fastify()
 
-  fastify.get('/:id', {
-    handler: echoParams,
-    schema: {
-      body: undefined
-    }
-  })
+  process.on('warning', onWarning)
+  function onWarning (warning) {
+    t.equal(warning.name, 'FastifyDeprecation')
+    t.equal(warning.code, 'FSTDEP015')
+  }
 
-  fastify.ready(err => {
-    t.equal(err.code, 'FST_ERR_SCH_VALIDATION_BUILD')
-    t.equal(err.message, 'Failed building the validation schema for GET: /:id, due to error body schema is undefined')
+  t.teardown(() => {
+    process.removeListener('warning', onWarning)
+    warning.emitted.set('FSTDEP015', false)
   })
-})
-
-test('Should throw if the schema headers is undefined', t => {
-  t.plan(2)
-  const fastify = Fastify()
 
   fastify.get('/:id', {
     handler: echoParams,
@@ -281,15 +276,73 @@ test('Should throw if the schema headers is undefined', t => {
     }
   })
 
-  fastify.ready(err => {
-    t.equal(err.code, 'FST_ERR_SCH_VALIDATION_BUILD')
-    t.equal(err.message, 'Failed building the validation schema for GET: /:id, due to error headers schema is undefined')
-  })
+  fastify.ready()
 })
 
-test('Should throw if the schema params is undefined', t => {
+test('Should emit warning if the schema body is undefined', t => {
   t.plan(2)
   const fastify = Fastify()
+
+  process.on('warning', onWarning)
+  function onWarning (warning) {
+    t.equal(warning.name, 'FastifyDeprecation')
+    t.equal(warning.code, 'FSTDEP016')
+  }
+
+  t.teardown(() => {
+    process.removeListener('warning', onWarning)
+    warning.emitted.set('FSTDEP016', false)
+  })
+
+  fastify.get('/:id', {
+    handler: echoParams,
+    schema: {
+      body: undefined
+    }
+  })
+
+  fastify.ready()
+})
+
+test('Should emit warning if the schema query is undefined', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  process.on('warning', onWarning)
+  function onWarning (warning) {
+    t.equal(warning.name, 'FastifyDeprecation')
+    t.equal(warning.code, 'FSTDEP017')
+  }
+
+  t.teardown(() => {
+    process.removeListener('warning', onWarning)
+    warning.emitted.set('FSTDEP017', false)
+  })
+
+  fastify.get('/:id', {
+    handler: echoParams,
+    schema: {
+      querystring: undefined
+    }
+  })
+
+  fastify.ready()
+})
+
+test('Should emit warning if the schema params is undefined', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  process.on('warning', onWarning)
+  function onWarning (warning) {
+    t.equal(warning.name, 'FastifyDeprecation')
+    t.equal(warning.code, 'FSTDEP018')
+  }
+
+  t.teardown(() => {
+    process.removeListener('warning', onWarning)
+    warning.emitted.set('FSTDEP018', false)
+  })
 
   fastify.get('/:id', {
     handler: echoParams,
@@ -298,44 +351,7 @@ test('Should throw if the schema params is undefined', t => {
     }
   })
 
-  fastify.ready(err => {
-    t.equal(err.code, 'FST_ERR_SCH_VALIDATION_BUILD')
-    t.equal(err.message, 'Failed building the validation schema for GET: /:id, due to error params schema is undefined')
-  })
-})
-
-test('Should throw if the schema query is undefined', t => {
-  t.plan(2)
-  const fastify = Fastify()
-
-  fastify.get('/:id', {
-    handler: echoParams,
-    schema: {
-      querystring: undefined
-    }
-  })
-
-  fastify.ready(err => {
-    t.equal(err.code, 'FST_ERR_SCH_VALIDATION_BUILD')
-    t.equal(err.message, 'Failed building the validation schema for GET: /:id, due to error querystring schema is undefined')
-  })
-})
-
-test('Should throw if the schema query is undefined', t => {
-  t.plan(2)
-  const fastify = Fastify()
-
-  fastify.get('/:id', {
-    handler: echoParams,
-    schema: {
-      querystring: undefined
-    }
-  })
-
-  fastify.ready(err => {
-    t.equal(err.code, 'FST_ERR_SCH_VALIDATION_BUILD')
-    t.equal(err.message, 'Failed building the validation schema for GET: /:id, due to error querystring schema is undefined')
-  })
+  fastify.ready()
 })
 
 test('First level $ref', t => {

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -260,13 +260,13 @@ test('Should emit warning if the schema headers is undefined', t => {
 
   process.on('warning', onWarning)
   function onWarning (warning) {
-    t.equal(warning.name, 'FastifyDeprecation')
-    t.equal(warning.code, 'FSTDEP015')
+    t.equal(warning.name, 'FastifyWarning')
+    t.equal(warning.code, 'FSTWRN001')
   }
 
   t.teardown(() => {
     process.removeListener('warning', onWarning)
-    warning.emitted.set('FSTDEP015', false)
+    warning.emitted.set('FSTWRN001', false)
   })
 
   fastify.post('/:id', {
@@ -291,13 +291,13 @@ test('Should emit warning if the schema body is undefined', t => {
 
   process.on('warning', onWarning)
   function onWarning (warning) {
-    t.equal(warning.name, 'FastifyDeprecation')
-    t.equal(warning.code, 'FSTDEP015')
+    t.equal(warning.name, 'FastifyWarning')
+    t.equal(warning.code, 'FSTWRN001')
   }
 
   t.teardown(() => {
     process.removeListener('warning', onWarning)
-    warning.emitted.set('FSTDEP015', false)
+    warning.emitted.set('FSTWRN001', false)
   })
 
   fastify.post('/:id', {
@@ -322,13 +322,13 @@ test('Should emit warning if the schema query is undefined', t => {
 
   process.on('warning', onWarning)
   function onWarning (warning) {
-    t.equal(warning.name, 'FastifyDeprecation')
-    t.equal(warning.code, 'FSTDEP015')
+    t.equal(warning.name, 'FastifyWarning')
+    t.equal(warning.code, 'FSTWRN001')
   }
 
   t.teardown(() => {
     process.removeListener('warning', onWarning)
-    warning.emitted.set('FSTDEP015', false)
+    warning.emitted.set('FSTWRN001', false)
   })
 
   fastify.post('/:id', {
@@ -353,13 +353,13 @@ test('Should emit warning if the schema params is undefined', t => {
 
   process.on('warning', onWarning)
   function onWarning (warning) {
-    t.equal(warning.name, 'FastifyDeprecation')
-    t.equal(warning.code, 'FSTDEP015')
+    t.equal(warning.name, 'FastifyWarning')
+    t.equal(warning.code, 'FSTWRN001')
   }
 
   t.teardown(() => {
     process.removeListener('warning', onWarning)
-    warning.emitted.set('FSTDEP015', false)
+    warning.emitted.set('FSTWRN001', false)
   })
 
   fastify.post('/:id', {
@@ -389,15 +389,15 @@ test('Should emit a warning for every route with undefined schema', t => {
   // - 2 - GET and HEAD for /undefinedBody/:id
   // => 3 x 4 assertions = 12 assertions
   function onWarning (warning) {
-    t.equal(warning.name, 'FastifyDeprecation')
-    t.equal(warning.code, 'FSTDEP015')
+    t.equal(warning.name, 'FastifyWarning')
+    t.equal(warning.code, 'FSTWRN001')
     t.equal(runs++, expectedWarningEmitted.shift())
   }
 
   process.on('warning', onWarning)
   t.teardown(() => {
     process.removeListener('warning', onWarning)
-    warning.emitted.set('FSTDEP015', false)
+    warning.emitted.set('FSTWRN001', false)
   })
 
   fastify.get('/undefinedParams/:id', {

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -255,7 +255,7 @@ test('Should not change the input schemas', t => {
 })
 
 test('Should emit warning if the schema headers is undefined', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
 
   process.on('warning', onWarning)
@@ -276,11 +276,11 @@ test('Should emit warning if the schema headers is undefined', t => {
     }
   })
 
-  fastify.ready()
+  fastify.ready(err => t.error(err))
 })
 
 test('Should emit warning if the schema body is undefined', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
 
   process.on('warning', onWarning)
@@ -301,11 +301,11 @@ test('Should emit warning if the schema body is undefined', t => {
     }
   })
 
-  fastify.ready()
+  fastify.ready(err => t.error(err))
 })
 
 test('Should emit warning if the schema query is undefined', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
 
   process.on('warning', onWarning)
@@ -326,11 +326,11 @@ test('Should emit warning if the schema query is undefined', t => {
     }
   })
 
-  fastify.ready()
+  fastify.ready(err => t.error(err))
 })
 
 test('Should emit warning if the schema params is undefined', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
 
   process.on('warning', onWarning)
@@ -351,7 +351,7 @@ test('Should emit warning if the schema params is undefined', t => {
     }
   })
 
-  fastify.ready()
+  fastify.ready(err => t.error(err))
 })
 
 test('First level $ref', t => {


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Emit `FSTWRN001` warning message on the schema validation.

Fix #4634.