### PR TITLE
chore(deps): replace tiny-lru with toad-cache

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { AsyncResource } = require('async_hooks')
-const lru = require('tiny-lru').lru
+const { Lru } = require('toad-cache')
 const { safeParse: safeParseContentType, defaultContentType } = require('fast-content-type-parse')
 const secureJson = require('secure-json-parse')
 const {
@@ -36,7 +36,7 @@ function ContentTypeParser (bodyLimit, onProtoPoisoning, onConstructorPoisoning)
   this.customParsers.set('text/plain', new Parser(true, false, bodyLimit, defaultPlainTextParser))
   this.parserList = [new ParserListItem('application/json'), new ParserListItem('text/plain')]
   this.parserRegExpList = []
-  this.cache = lru(100)
+  this.cache = new Lru(100)
 }
 
 ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
@@ -136,7 +136,7 @@ ContentTypeParser.prototype.removeAll = function () {
   this.customParsers = new Map()
   this.parserRegExpList = []
   this.parserList = []
-  this.cache = lru(100)
+  this.cache = new Lru(100)
 }
 
 ContentTypeParser.prototype.remove = function (contentType) {

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "rfdc": "^1.3.0",
     "secure-json-parse": "^2.5.0",
     "semver": "^7.3.7",
-    "tiny-lru": "^10.0.0"
+    "toad-cache": "^3.0.1"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
`toad-cache` is a polished fork of `tiny-lru`, sporting following advantages:

* Faster gets - https://github.com/kibertoad/nodejs-benchmark-tournament/blob/master/cache-get-inmemory/_results/results.md
* Slightly faster sets - https://github.com/kibertoad/nodejs-benchmark-tournament/blob/master/cache-set-inmemory/_results/results.md
* 100% code coverage
* Tests for TS types

It's a drop-in replacement, observable behaviour is exactly the same. The only difference in public API is that class constructor is used instead of a factory function.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
