### PR TITLE
Add workflow for benchmarking POST with custom parsers

### DIFF
--- a/.github/workflows/benchmark-parser.yml
+++ b/.github/workflows/benchmark-parser.yml
@@ -1,0 +1,96 @@
+name: Benchmark-parser
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  benchmark:
+    if: ${{ github.event.label.name == 'benchmark' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      PR-BENCH-14: ${{ steps.benchmark-pr.outputs.BENCH_RESULT14 }}
+      PR-BENCH-16: ${{ steps.benchmark-pr.outputs.BENCH_RESULT16 }}
+      PR-BENCH-18: ${{ steps.benchmark-pr.outputs.BENCH_RESULT18 }}
+      MAIN-BENCH-14: ${{ steps.benchmark-main.outputs.BENCH_RESULT14 }}
+      MAIN-BENCH-16: ${{ steps.benchmark-main.outputs.BENCH_RESULT16 }}
+      MAIN-BENCH-18: ${{ steps.benchmark-main.outputs.BENCH_RESULT18 }}
+    strategy:
+      matrix:
+        node-version: [14, 16, 18]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          ref: ${{github.event.pull_request.head.sha}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install
+        run: |
+          npm install --only=production --ignore-scripts
+
+      - name: Run benchmark
+        id: benchmark-pr
+        run: |
+          npm run --silent benchmark:parser > ./bench-result.md
+          result=$(awk '/requests in/' ./bench-result.md)
+          echo "::set-output name=BENCH_RESULT${{matrix.node-version}}::$result"
+
+      # main benchmark
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          ref: 'main'
+
+      - name: Install
+        run: |
+          npm install --only=production --ignore-scripts
+
+      - name: Run benchmark
+        id: benchmark-main
+        run: |
+          npm run --silent benchmark:parser > ./bench-result.md
+          result=$(awk '/requests in/' ./bench-result.md)
+          echo "::set-output name=BENCH_RESULT${{matrix.node-version}}::$result"
+
+  output-benchmark:
+    needs: [benchmark]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          message: |
+            **Node**: 14
+            **Type**: Parser
+            **PR**: ${{ needs.benchmark.outputs.PR-BENCH-14 }}
+            **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-14 }}
+            
+            ---
+            
+            **Node**: 16
+            **Type**: Parser
+            **PR**: ${{ needs.benchmark.outputs.PR-BENCH-16 }}
+            **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-16 }}
+            
+            ---
+            
+            **Node**: 18
+            **Type**: Parser
+            **PR**: ${{ needs.benchmark.outputs.PR-BENCH-18 }}
+            **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-18 }}
+
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: |
+            benchmark
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/benchmark/parser.js
+++ b/examples/benchmark/parser.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const fastify = require('../../fastify')({
+  logger: false
+})
+
+const jsonParser = require('fast-json-body')
+const querystring = require('querystring')
+
+// Handled by fastify
+// curl -X POST -d '{"hello":"world"}' -H'Content-type: application/json' http://localhost:3000/
+
+// curl -X POST -d '{"hello":"world"}' -H'Content-type: application/jsoff' http://localhost:3000/
+fastify.addContentTypeParser('application/jsoff', function (request, payload, done) {
+  jsonParser(payload, function (err, body) {
+    done(err, body)
+  })
+})
+
+// curl -X POST -d 'hello=world' -H'Content-type: application/x-www-form-urlencoded' http://localhost:3000/
+fastify.addContentTypeParser('application/x-www-form-urlencoded', function (request, payload, done) {
+  let body = ''
+  payload.on('data', function (data) {
+    body += data
+  })
+  payload.on('end', function () {
+    try {
+      const parsed = querystring.parse(body)
+      done(null, parsed)
+    } catch (e) {
+      done(e)
+    }
+  })
+  payload.on('error', done)
+})
+
+// curl -X POST -d '{"hello":"world"}' -H'Content-type: application/vnd.custom+json' http://localhost:3000/
+fastify.addContentTypeParser(/^application\/.+\+json$/, { parseAs: 'string' }, fastify.getDefaultJsonParser('error', 'ignore'))
+
+fastify
+  .post('/', function (req, reply) {
+    reply.send(req.body)
+  })
+
+fastify.listen({ port: 3000 }, (err, address) => {
+  if (err) throw err
+})

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "bench": "branchcmp -r 2 -g -s \"npm run benchmark\"",
     "benchmark": "npx concurrently -k -s first \"node ./examples/benchmark/simple.js\" \"npx autocannon -c 100 -d 30 -p 10 localhost:3000/\"",
+    "benchmark:parser": "npx concurrently -k -s first \"node ./examples/benchmark/parser.js\" \"npx autocannon -c 100 -d 30 -p 10 -b \"{\"hello\":\"world\"}\" -H \"content-type=application/jsoff\" -m POST localhost:3000/\"",
     "build:validation": "node build/build-error-serializer.js && node build/build-validation.js",
     "coverage": "npm run unit -- --cov --coverage-report=html",
     "coverage:ci": "npm run unit -- --cov --coverage-report=html --no-browser --no-check-coverage -R terse",


### PR DESCRIPTION
We have a gap in our benchmarking right now, as we only execute GET requests in existing benchmark.
This adds another workflow for hitting the execution path, which relies on using content parsers.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
