### PR TITLE
docs: incorrect example for 'onRequestAbort' hook

### DIFF
--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -278,7 +278,7 @@ fastify.addHook('onRequestAbort', (request, reply, done) => {
 ```
 Or `async/await`:
 ```js
-fastify.addHook('onRequestAbort', async (request, reply) => {
+fastify.addHook('onRequestAbort', async (request) => {
   // Some code
   await asyncMethod()
 })

--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -271,7 +271,7 @@ has been hung up. Therefore, you will not be able to send data to the client.
 ### onRequestAbort
 
 ```js
-fastify.addHook('onRequestAbort', (request, reply, done) => {
+fastify.addHook('onRequestAbort', (request, done) => {
   // Some code
   done()
 })


### PR DESCRIPTION
Fixed incorrect example for `onRequestAbort` hook. According to code, [tests](https://github.com/fastify/fastify/blob/662706bdca4c385616f3f3d1806c4b94a2a97b8a/test/hooks-async.test.js#L592) and [this comment](https://github.com/fastify/fastify/pull/4582#issuecomment-1430451820) the `reply` object is not passed to the hook handler.
The previous example caused this error:
```
FastifyError [Error]: Async function has too many arguments. Async hooks should not use the 'done' argument.
    at Object.addHook (/Users/tim/IdeaProjects/affluent/packages/app-agency-api/node_modules/fastify/fastify.js:593:15) {
  code: 'FST_ERR_HOOK_INVALID_ASYNC_HANDLER',
  statusCode: 500
}
```

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
