### PR TITLE
Updates to docs and types regarding the `res` serializer

### DIFF
--- a/docs/Reference/Logging.md
+++ b/docs/Reference/Logging.md
@@ -109,7 +109,6 @@ by `req` is the Fastify [`Request`](./Request.md) object, while the object
 received by `res` is the Fastify [`Reply`](./Reply.md) object. This behaviour
 can be customized by specifying custom serializers.
 
-
 ```js
 const fastify = require('fastify')({
   logger: {
@@ -181,7 +180,6 @@ const fastify = require('fastify')({
   }
 });
 ```
-
 
 **Note**: The body cannot be serialized inside a `req` method because the
 request is serialized when we create the child logger. At that time, the body is

--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -1,15 +1,17 @@
-import { expectDeprecated, expectError, expectType } from 'tsd'
+import { expectAssignable, expectDeprecated, expectError, expectNotAssignable, expectType } from 'tsd'
 import fastify, {
   FastifyLogFn,
   LogLevel,
   FastifyLoggerInstance,
   FastifyRequest,
   FastifyReply,
-  FastifyBaseLogger
+  FastifyBaseLogger,
+  FastifyInstance
 } from '../../fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
 import * as fs from 'fs'
 import P from 'pino'
+import { ResSerializerReply } from '../../types/logger'
 
 expectType<FastifyLoggerInstance>(fastify().log)
 
@@ -127,7 +129,9 @@ const serverAutoInferredSerializerResponseObjectOption = fastify({
   logger: {
     serializers: {
       res (ServerResponse) {
-        expectType<FastifyReply>(ServerResponse)
+        expectType<ResSerializerReply<Server, FastifyReply>>(ServerResponse)
+        expectAssignable<Partial<FastifyReply> & Pick<FastifyReply, 'statusCode'>>(ServerResponse)
+        expectNotAssignable<FastifyReply>(ServerResponse)
         return {
           status: '200'
         }
@@ -154,7 +158,9 @@ const serverAutoInferredSerializerObjectOption = fastify({
         }
       },
       res (ServerResponse) {
-        expectType<FastifyReply>(ServerResponse)
+        expectType<ResSerializerReply<Server, FastifyReply>>(ServerResponse)
+        expectAssignable<Partial<FastifyReply> & Pick<FastifyReply, 'statusCode'>>(ServerResponse)
+        expectNotAssignable<FastifyReply>(ServerResponse)
         return {
           statusCode: 'statusCode'
         }

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -41,7 +41,7 @@ export type PinoLoggerOptions = pino.LoggerOptions
  */
 export type ResSerializerReply<
   RawServer extends RawServerBase,
-  RawReply extends FastifyReply<RawServer, RawRequestDefaultExpression<RawServer>, RawReplyDefaultExpression<RawServer>, RouteGenericInterface, ContextConfigDefault, FastifySchema, FastifyTypeProvider>
+  RawReply extends FastifyReply<RawServer>
 > = Partial<RawReply> & Pick<RawReply, 'statusCode'>;
 
 /**

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -35,6 +35,15 @@ export interface FastifyLoggerStreamDestination {
 
 export type PinoLoggerOptions = pino.LoggerOptions
 
+// TODO: once node 18 is EOL, this type can be replaced with plain FastifyReply.
+/**
+ * Specialized reply type used for the `res` log serializer, since only `statusCode` is passed in certain cases.
+ */
+export type ResSerializerReply<
+  RawServer extends RawServerBase,
+  RawReply extends FastifyReply<RawServer, RawRequestDefaultExpression<RawServer>, RawReplyDefaultExpression<RawServer>, RouteGenericInterface, ContextConfigDefault, FastifySchema, FastifyTypeProvider>
+> = Partial<RawReply> & Pick<RawReply, 'statusCode'>;
+
 /**
  * Fastify Custom Logger options.
  */
@@ -59,7 +68,7 @@ export interface FastifyLoggerOptions<
       stack: string;
       [key: string]: unknown;
     };
-    res?: (res: RawReply) => {
+    res?: (res: ResSerializerReply<RawServer, RawReply>) => {
       statusCode?: string | number;
       [key: string]: unknown;
     };


### PR DESCRIPTION
closes #4706

- Updated the logging documentation to clarify that `reply` is not guaranteed to be a fully-formed reply object in the `res` log serializer. also added a link out to pino's docs about the `serializers` option + mentioned serializers should never throw
- Updated the types to reflect the same

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
