### PR TITLE
[WIP] Compare content type charsets case-insensitively

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -397,7 +397,7 @@ function compareRegExpContentType (contentType, essenceMIMEType, regexp) {
   }
 }
 
-function downcaseCharsetInContentType(contentType, parsed = null) {
+function downcaseCharsetInContentType (contentType, parsed) {
   if (parsed.parameters.charset) {
     const indices = parsed.parametersIndices.charset
     const valueEndsAt = indices.valueAt + parsed.parameters.charset.length

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -67,7 +67,12 @@ ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
     this.customParsers.set('', parser)
   } else {
     if (contentTypeIsString) {
-      this.parserList.unshift(new ParserListItem(contentType))
+      // we pre-calculate all the needed information
+      // before content-type comparison
+      const parsed = safeParseContentType(contentType)
+      contentType = downcaseCharsetInContentType(contentType, parsed)
+      const parserItem = new ParserListItem(contentType, parsed)
+      this.parserList.unshift(parserItem)
     } else {
       contentType.isEssence = contentType.source.indexOf(';') === -1
       this.parserRegExpList.unshift(contentType)
@@ -92,14 +97,15 @@ ContentTypeParser.prototype.existingParser = function (contentType) {
 }
 
 ContentTypeParser.prototype.getParser = function (contentType) {
+  const parsed = safeParseContentType(contentType)
+  contentType = downcaseCharsetInContentType(contentType, parsed)
+
   if (this.hasParser(contentType)) {
     return this.customParsers.get(contentType)
   }
 
   const parser = this.cache.get(contentType)
   if (parser !== undefined) return parser
-
-  const parsed = safeParseContentType(contentType)
 
   // dummyContentType always the same object
   // we can use === for the comparsion and return early
@@ -391,11 +397,24 @@ function compareRegExpContentType (contentType, essenceMIMEType, regexp) {
   }
 }
 
-function ParserListItem (contentType) {
-  this.name = contentType
+function downcaseCharsetInContentType(contentType, parsed = null) {
+  if (parsed.parameters.charset) {
+    const indices = parsed.parametersIndices.charset
+    const valueEndsAt = indices.valueAt + parsed.parameters.charset.length
+
+    return contentType.slice(0, indices.valueAt) +
+      contentType.slice(indices.valueAt, valueEndsAt).toLowerCase() +
+      contentType.slice(valueEndsAt)
+  }
+
+  return contentType
+}
+
+function ParserListItem (contentType, parsed = null) {
   // we pre-calculate all the needed information
   // before content-type comparsion
-  const parsed = safeParseContentType(contentType)
+  parsed = parsed || safeParseContentType(contentType)
+  this.name = contentType
   this.isEssence = contentType.indexOf(';') === -1
   // we should not allow empty string for parser list item
   // because it would become a match-all handler

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -750,3 +750,69 @@ test('edge case content-type - ;', async t => {
 
   t.pass('end')
 })
+
+test('header charset is matched in a case-insensitive manner', async t => {
+  const fastify = Fastify()
+
+  fastify.addContentTypeParser('text/plain; charset=UTF-8',
+    { parseAs: 'string' },
+    fastify.getDefaultJsonParser('ignore', 'ignore'))
+
+  fastify.post('/', async (req) => {
+    t.equal(typeof req.body, 'object')
+    t.same(JSON.parse(req.body), { x: 'y' })
+
+    return 'ok'
+  })
+
+  await fastify.inject({
+    method: 'POST',
+    path: '/',
+    headers: {
+      'content-type': 'text/plain; charset=UTF-8'
+    },
+    body: '{"x":"y"}'
+  })
+
+  await fastify.inject({
+    method: 'POST',
+    path: '/',
+    headers: {
+      'content-type': 'text/plain; charset=utf-8'
+    },
+    body: '{"x":"y"}'
+  })
+})
+
+test('header charset is matched in a case-insensitive manner', async t => {
+  const fastify = Fastify()
+
+  fastify.addContentTypeParser('text/plain; charset=utf-8',
+    { parseAs: 'string' },
+    fastify.getDefaultJsonParser('ignore', 'ignore'))
+
+  fastify.post('/', async (req) => {
+    t.equal(typeof req.body, 'object')
+    t.same(JSON.parse(req.body), { x: 'y' })
+
+    return 'ok'
+  })
+
+  await fastify.inject({
+    method: 'POST',
+    path: '/',
+    headers: {
+      'content-type': 'text/plain; charset=UTF-8'
+    },
+    body: '{"x":"y"}'
+  })
+
+  await fastify.inject({
+    method: 'POST',
+    path: '/',
+    headers: {
+      'content-type': 'text/plain; charset=utf-8'
+    },
+    body: '{"x":"y"}'
+  })
+})


### PR DESCRIPTION
Work In Progress. The solution depends on changes https://github.com/fastify/fast-content-type-parse/pull/11

Refs: https://github.com/fastify/fastify/issues/4583

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
