### PR TITLE
Maintain custom response schema

### DIFF
--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -44,24 +44,14 @@ Schemas.prototype.getSchema = function (schemaId) {
   return this.store[schemaId]
 }
 
+/**
+ * Checks whether a schema is a non-plain object.
+ *
+ * @param {*} schema the schema to check
+ * @returns {boolean} true if schema has a custom prototype
+ */
 function isCustomSchemaPrototype (schema) {
   return typeof schema === 'object' && Object.getPrototypeOf(schema) !== Object.prototype
-}
-
-function hasCustomSchemaPrototype (routeSchemas) {
-  for (const key in routeSchemas) {
-    if (key === 'response') {
-      for (const statusCode in routeSchemas.response) {
-        if (isCustomSchemaPrototype(routeSchemas.response[statusCode])) {
-          return true
-        }
-      }
-    } else if (isCustomSchemaPrototype(routeSchemas[key])) {
-      return true
-    }
-  }
-
-  return false
 }
 
 function normalizeSchema (routeSchemas, serverOptions) {
@@ -80,31 +70,20 @@ function normalizeSchema (routeSchemas, serverOptions) {
 
   generateFluentSchema(routeSchemas)
 
-  // let's check if our schemas have a custom prototype
-  if (hasCustomSchemaPrototype(routeSchemas)) {
-    routeSchemas[kSchemaVisited] = true
-    return routeSchemas
-  }
-
-  if (routeSchemas.body) {
-    routeSchemas.body = getSchemaAnyway(routeSchemas.body, serverOptions.jsonShorthand)
-  }
-
-  if (routeSchemas.headers) {
-    routeSchemas.headers = getSchemaAnyway(routeSchemas.headers, serverOptions.jsonShorthand)
-  }
-
-  if (routeSchemas.querystring) {
-    routeSchemas.querystring = getSchemaAnyway(routeSchemas.querystring, serverOptions.jsonShorthand)
-  }
-
-  if (routeSchemas.params) {
-    routeSchemas.params = getSchemaAnyway(routeSchemas.params, serverOptions.jsonShorthand)
+  for (const key of SCHEMAS_SOURCE) {
+    const schema = routeSchemas[key]
+    if (schema && !isCustomSchemaPrototype(schema)) {
+      routeSchemas[key] = getSchemaAnyway(schema, serverOptions.jsonShorthand)
+    }
   }
 
   if (routeSchemas.response) {
     const httpCodes = Object.keys(routeSchemas.response)
     for (const code of httpCodes) {
+      if (isCustomSchemaPrototype(routeSchemas.response[code])) {
+        continue
+      }
+
       const contentProperty = routeSchemas.response[code].content
 
       let hasContentMultipleContentTypes = false

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -44,6 +44,26 @@ Schemas.prototype.getSchema = function (schemaId) {
   return this.store[schemaId]
 }
 
+function isCustomSchemaPrototype (schema) {
+  return typeof schema === 'object' && Object.getPrototypeOf(schema) !== Object.prototype
+}
+
+function hasCustomSchemaPrototype (routeSchemas) {
+  for (const key in routeSchemas) {
+    if (key === 'response') {
+      for (const statusCode in routeSchemas.response) {
+        if (isCustomSchemaPrototype(routeSchemas.response[statusCode])) {
+          return true
+        }
+      }
+    } else if (isCustomSchemaPrototype(routeSchemas[key])) {
+      return true
+    }
+  }
+
+  return false
+}
+
 function normalizeSchema (routeSchemas, serverOptions) {
   if (routeSchemas[kSchemaVisited]) {
     return routeSchemas
@@ -61,11 +81,9 @@ function normalizeSchema (routeSchemas, serverOptions) {
   generateFluentSchema(routeSchemas)
 
   // let's check if our schemas have a custom prototype
-  for (const key of ['headers', 'querystring', 'params', 'body']) {
-    if (typeof routeSchemas[key] === 'object' && Object.getPrototypeOf(routeSchemas[key]) !== Object.prototype) {
-      routeSchemas[kSchemaVisited] = true
-      return routeSchemas
-    }
+  if (hasCustomSchemaPrototype(routeSchemas)) {
+    routeSchemas[kSchemaVisited] = true
+    return routeSchemas
   }
 
   if (routeSchemas.body) {

--- a/test/internals/validation.test.js
+++ b/test/internals/validation.test.js
@@ -300,3 +300,18 @@ test('build schema - uppercased headers are not included', t => {
     return () => {}
   })
 })
+
+test('build schema - maintain custom response schema', t => {
+  t.plan(1)
+
+  class CustomSchema {}
+  const opts = {
+    schema: {
+      response: {
+        200: new CustomSchema()
+      }
+    }
+  }
+  opts.schema = normalizeSchema(opts.schema)
+  t.type(opts.schema.response['200'], CustomSchema)
+})


### PR DESCRIPTION
If a schema has a custom prototype (like when using a Zod schema), normalization will be skipped. Currently this does not work in the case where there are only response schemas.

This PR accounts for that case and adds a test.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
