### PR TITLE
ci: test using pnpm 8

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,8 +18,14 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [16, 18]
         os: [ubuntu-latest]
+        pnpm-version: [8]
+        # pnpm@8 does not support Node.js 14 so include it separately
+        include:
+          - node-version: 14
+            os: ubuntu-latest
+            pnpm-version: 7
 
     steps:
       - uses: actions/checkout@v3
@@ -34,8 +40,7 @@ jobs:
       - name: Install Pnpm
         uses: pnpm/action-setup@v2
         with:
-          # pnpm@8 does not support Node.js 14
-          version: 7
+          version: ${{ matrix.pnpm-version }}
       
       - name: Install Production
         run: |

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Install with pnpm
         uses: pnpm/action-setup@v2
         with:
-          # pnpm@8 does not support Node.js 14
           version: ${{ matrix.pnpm-version }}
 
       - run: pnpm install

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -15,8 +15,14 @@ jobs:
     strategy:
       matrix:
         # Maintenance and active LTS
-        node-version: [14, 16, 18]
+        node-version: [16, 18]
         os: [ubuntu-latest]
+        pnpm-version: [8]
+        # pnpm@8 does not support Node.js 14 so include it separately
+        include:
+          - node-version: 14
+            os: ubuntu-latest
+            pnpm-version: 7
 
     steps:
       - uses: actions/checkout@v3
@@ -32,7 +38,7 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           # pnpm@8 does not support Node.js 14
-          version: 7
+          version: ${{ matrix.pnpm-version }}
 
       - run: pnpm install
 


### PR DESCRIPTION
We can test using pnpm 8 whilst continuing to test on node 14 (with pnpm 7) by moving it to a separate job using `include`, see https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations

 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
