### PR TITLE
chore: add test-compare action

### DIFF
--- a/.github/workflows/test-compare.yml
+++ b/.github/workflows/test-compare.yml
@@ -1,0 +1,18 @@
+name: Test compare
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+
+jobs:
+  run:
+    if: contains(github.event.pull_request.labels.*.name, 'test-compare')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Test compare
+        uses: nearform-actions/github-action-test-compare@v1
+        with:
+          label: test-compare
+          testCommand: 'npm run test:ci'


### PR DESCRIPTION
Whenever we add the label `test-compare` to a PR it will revert all the changes made outside of `test/` folder and run the tests again. The objective is pretty simple, guarantee the PR is testing the right thing.

Example: https://github.com/RafaelGSS/testing-the-right-thing/pull/2