### PR TITLE
doc: remove RafaelGSS from plugins team

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,8 +344,6 @@ listed in alphabetical order.
 * [__Frazer Smith__](https://github.com/Fdawgs), <https://www.npmjs.com/~fdawgs>
 * [__Manuel Spigolon__](https://github.com/eomm),
   <https://twitter.com/manueomm>, <https://www.npmjs.com/~eomm>
-* [__Rafael Gonzaga__](https://github.com/rafaelgss),
-  <https://twitter.com/_rafaelgss>, <https://www.npmjs.com/~rafaelgss>
 * [__Simone Busoli__](https://github.com/simoneb),
   <https://twitter.com/simonebu>, <https://www.npmjs.com/~simoneb>
 


### PR DESCRIPTION
I'm currently overwhelmed by notifications from different repositories and given the fact I'm not actively contributing to the fastify plugins, I prefer to remove myself from this team.

Note: I'm still at fastify core.