### PR TITLE
fix: Pass Logger generic type to route function of FastifyInstance

### DIFF
--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -185,7 +185,7 @@ export interface FastifyInstance<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
     ContextConfig = ContextConfigDefault,
     SchemaCompiler extends FastifySchema = FastifySchema,
-  >(opts: RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  >(opts: RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
 
   get: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider>;
   head: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider>;


### PR DESCRIPTION
Allows `request.log` to use the Logger type inferred from the `server` instance that `.route` is used on.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`

```
Suites:   125 passed, 125 of 125 completed
Asserts:  6820 passed, 5 skip, of 6825
```
```
[1] Running 30s test @ http://localhost:3000/
[1] 100 connections with 10 pipelining factor
[1]
[1]
[1] ┌─────────┬──────┬──────┬───────┬──────┬─────────┬─────────┬───────┐
[1] │ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%  │ Avg     │ Stdev   │ Max   │
[1] ├─────────┼──────┼──────┼───────┼──────┼─────────┼─────────┼───────┤
[1] │ Latency │ 3 ms │ 6 ms │ 7 ms  │ 8 ms │ 5.64 ms │ 1.63 ms │ 75 ms │
[1] └─────────┴──────┴──────┴───────┴──────┴─────────┴─────────┴───────┘
[1] ┌───────────┬─────────┬─────────┬─────────┬─────────┬───────────┬─────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg       │ Stdev   │ Min     │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼───────────┼─────────┼─────────┤
[1] │ Req/Sec   │ 139903  │ 139903  │ 161791  │ 165375  │ 160900.27 │ 4639.63 │ 139835  │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼───────────┼─────────┼─────────┤
[1] │ Bytes/Sec │ 26.3 MB │ 26.3 MB │ 30.4 MB │ 31.1 MB │ 30.3 MB   │ 874 kB  │ 26.3 MB │
[1] └───────────┴─────────┴─────────┴─────────┴─────────┴───────────┴─────────┴─────────┘
[1]
[1] Req/Bytes counts sampled once per second.
[1] # of samples: 30
[1]
[1] 4828k requests in 30.02s, 908 MB read
[1] npx autocannon -c 100 -d 30 -p 10 localhost:3000/ exited with code 0
```
- [ ] tests and/or benchmarks are included
  - (not relevant due to change being super-minor imo)
- [ ] documentation is changed or added
  - (not relevant due to change being super-minor imo)
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
  - (the links don't include any information about commit messages, I just went with the style I saw in other commits)
