### PR TITLE
fix(#4774): close bindings through the hook system

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -856,6 +856,8 @@ is an instance-wide configuration.
 [server](https://nodejs.org/api/http.html#http_class_http_server) object as
 returned by the [**`Fastify factory function`**](#factory).
 
+>__Warning__: If utilized improperly, certain Fastify features could be disrupted. It is recommended to only use it for attaching listeners.
+
 #### after
 <a id="after"></a>
 

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -856,7 +856,8 @@ is an instance-wide configuration.
 [server](https://nodejs.org/api/http.html#http_class_http_server) object as
 returned by the [**`Fastify factory function`**](#factory).
 
->__Warning__: If utilized improperly, certain Fastify features could be disrupted. It is recommended to only use it for attaching listeners.
+>__Warning__: If utilized improperly, certain Fastify features could be disrupted.
+>It is recommended to only use it for attaching listeners.
 
 #### after
 <a id="after"></a>

--- a/lib/server.js
+++ b/lib/server.js
@@ -132,14 +132,12 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
               /* istanbul ignore next: the else won't be taken unless listening fails */
               if (!_ignoreErr) {
                 this[kServerBindings].push(secondaryServer)
-                /**
-                 * Due to the nature of the feature is not possible to know
-                 * ahead of time the number of bindings that will be made
-                 * For instance, each binding is hooked to be closed at their own
-                 * peace through the `onClose` hook.
-                 * It also allows them to handle possible connections already
-                 * attached to them if any
-                 */
+                // Due to the nature of the feature is not possible to know
+                // ahead of time the number of bindings that will be made
+                // For instance, each binding is hooked to be closed at their own
+                // pace through the `onClose` hook.
+                // It also allows them to handle possible connections already
+                // attached to them if any
                 this.onClose((_, done) => {
                   if (this[kState].listening) {
                     // No new TCP connections are accepted
@@ -152,8 +150,6 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
                     } else if (typeof secondaryServer.closeAllConnections === 'function' && serverOpts.forceCloseConnections) {
                       secondaryServer.closeAllConnections()
                     }
-                  } else {
-                    done(null)
                   }
                 })
               }

--- a/lib/server.js
+++ b/lib/server.js
@@ -133,12 +133,12 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
               if (!_ignoreErr) {
                 this[kServerBindings].push(secondaryServer)
                 // Due to the nature of the feature is not possible to know
-                // ahead of time the number of bindings that will be made
+                // ahead of time the number of bindings that will be made.
                 // For instance, each binding is hooked to be closed at their own
                 // pace through the `onClose` hook.
                 // It also allows them to handle possible connections already
-                // attached to them if any
-                this.onClose((_, done) => {
+                // attached to them if any.
+                this.onClose((error, done) => {
                   if (this[kState].listening) {
                     // No new TCP connections are accepted
                     secondaryServer.close(done)
@@ -150,6 +150,8 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
                     } else if (typeof secondaryServer.closeAllConnections === 'function' && serverOpts.forceCloseConnections) {
                       secondaryServer.closeAllConnections()
                     }
+                  } else {
+                    done(error)
                   }
                 })
               }

--- a/lib/server.js
+++ b/lib/server.js
@@ -132,6 +132,30 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
               /* istanbul ignore next: the else won't be taken unless listening fails */
               if (!_ignoreErr) {
                 this[kServerBindings].push(secondaryServer)
+                /**
+                 * Due to the nature of the feature is not possible to know
+                 * ahead of time the number of bindings that will be made
+                 * For instance, each binding is hooked to be closed at their own
+                 * peace through the `onClose` hook.
+                 * It also allows them to handle possible connections already
+                 * attached to them if any
+                 */
+                this.onClose((_, done) => {
+                  if (this[kState].listening) {
+                    // No new TCP connections are accepted
+                    secondaryServer.close(done)
+                    /* istanbul ignore next: Cannot test this without Node.js core support */
+                    if (serverOpts.forceCloseConnections === 'idle') {
+                      // Not needed in Node 19
+                      secondaryServer.closeIdleConnections()
+                    /* istanbul ignore next: Cannot test this without Node.js core support */
+                    } else if (typeof secondaryServer.closeAllConnections === 'function' && serverOpts.forceCloseConnections) {
+                      secondaryServer.closeAllConnections()
+                    }
+                  } else {
+                    done(null)
+                  }
+                })
               }
 
               if (binded === binding) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -138,10 +138,12 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
                 // pace through the `onClose` hook.
                 // It also allows them to handle possible connections already
                 // attached to them if any.
-                this.onClose((error, done) => {
-                  if (this[kState].listening) {
+                this.onClose((instance, done) => {
+                  if (instance[kState].listening) {
                     // No new TCP connections are accepted
-                    secondaryServer.close(done)
+                    // We swallow any error from the secondary
+                    // server
+                    secondaryServer.close(() => done())
                     /* istanbul ignore next: Cannot test this without Node.js core support */
                     if (serverOpts.forceCloseConnections === 'idle') {
                       // Not needed in Node 19
@@ -151,7 +153,7 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
                       secondaryServer.closeAllConnections()
                     }
                   } else {
-                    done(error)
+                    done()
                   }
                 })
               }

--- a/test/close-pipelining.test.js
+++ b/test/close-pipelining.test.js
@@ -89,11 +89,14 @@ test('Should close the socket abruptly - pipelining - return503OnClosing: false,
   const responses = await Promise.allSettled([
     instance.request({ path: '/', method: 'GET' }),
     instance.request({ path: '/', method: 'GET' }),
+    instance.request({ path: '/', method: 'GET' }),
     instance.request({ path: '/', method: 'GET' })
   ])
+
   t.equal(responses[0].status, 'fulfilled')
-  t.equal(responses[1].status, 'rejected')
+  t.equal(responses[1].status, 'fulfilled')
   t.equal(responses[2].status, 'rejected')
+  t.equal(responses[3].status, 'rejected')
 
   await instance.close()
 })

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -2,8 +2,7 @@
 
 const net = require('net')
 const http = require('http')
-const t = require('tap')
-const test = t.test
+const { test } = require('tap')
 const Fastify = require('..')
 const { Client } = require('undici')
 const semver = require('semver')
@@ -205,7 +204,7 @@ test('Should return error while closing (callback) - injection', t => {
 })
 
 const isV19plus = semver.gte(process.version, '19.0.0')
-t.test('Current opened connection should continue to work after closing and return "connection: close" header - return503OnClosing: false, skip Node >= v19.x', { skip: isV19plus }, t => {
+test('Current opened connection should continue to work after closing and return "connection: close" header - return503OnClosing: false, skip Node >= v19.x', { skip: isV19plus }, t => {
   const fastify = Fastify({
     return503OnClosing: false,
     forceCloseConnections: false
@@ -243,7 +242,7 @@ t.test('Current opened connection should continue to work after closing and retu
   })
 })
 
-t.test('Current opened connection should NOT continue to work after closing and return "connection: close" header - return503OnClosing: false, skip Node < v19.x', { skip: !isV19plus }, t => {
+test('Current opened connection should NOT continue to work after closing and return "connection: close" header - return503OnClosing: false, skip Node < v19.x', { skip: !isV19plus }, t => {
   t.plan(4)
   const fastify = Fastify({
     return503OnClosing: false,
@@ -282,7 +281,7 @@ t.test('Current opened connection should NOT continue to work after closing and 
   })
 })
 
-t.test('Current opened connection should not accept new incoming connections', t => {
+test('Current opened connection should not accept new incoming connections', t => {
   t.plan(3)
   const fastify = Fastify({ forceCloseConnections: false })
   fastify.get('/', (req, reply) => {
@@ -304,7 +303,7 @@ t.test('Current opened connection should not accept new incoming connections', t
   })
 })
 
-t.test('rejected incoming connections should be logged', t => {
+test('rejected incoming connections should be logged', t => {
   t.plan(2)
   const stream = split(JSON.parse)
   const fastify = Fastify({
@@ -446,6 +445,62 @@ test('shutsdown while keep-alive connections are active (non-async, idle, native
         t.equal(client.closed, false)
       })
     })
+  })
+})
+
+test('triggers on-close hook in the right order with multiple bindings', { only: true }, async t => {
+  const expectedPayload = { hello: 'world' }
+  const timeoutTime = 2 * 60 * 1000
+  const expectedOrder = [1, 2]
+  const order = []
+  const fastify = Fastify({ forceCloseConnections: 'idle' })
+
+  fastify.server.setTimeout(timeoutTime)
+  fastify.server.keepAliveTimeout = timeoutTime
+
+  fastify.get('/', async (req, reply) => {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1000)
+    })
+
+    return expectedPayload
+  })
+
+  fastify.addHook('onClose', () => {
+    order.push(1)
+  })
+
+  await fastify.listen({ port: 0 })
+  const addresses = fastify.addresses()
+  const testPlan = (addresses.length * 2) + 1
+
+  t.plan(testPlan)
+
+  for (const addr of addresses) {
+    const { family, address, port } = addr
+    const host = family === 'IPv6' ? `[${address}]` : address
+    const client = new Client(`http://${host}:${port}`, {
+      keepAliveTimeout: 1 * 60 * 1000
+    })
+
+    client.request({ path: '/', method: 'GET' })
+      .then((res) => res.body.json(), err => t.error(err))
+      .then(json => {
+        t.match(json, expectedPayload, 'should payload match')
+        t.notOk(client.closed, 'should client not be closed')
+      }, err => t.error(err))
+  }
+
+  await new Promise((resolve, reject) => {
+    setTimeout(() => {
+      fastify.close(err => {
+        order.push(2)
+        t.match(order, expectedOrder)
+
+        if (err) t.error(err)
+        else resolve()
+      })
+    }, 2000)
   })
 })
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Fixes #4774

The PR attempts to fix an unexpected behaviour when secondary binding servers were not in sync with the lifecycle hooks of the application.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
