### PR TITLE
body reader to use statusCode from stream error, if available (#4785)

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -248,7 +248,9 @@ function rawBody (request, reply, options, parser, done) {
     payload.removeListener('error', onEnd)
 
     if (err !== undefined) {
-      err.statusCode = 400
+      if (!(typeof err.statusCode === 'number' && err.statusCode >= 400)) {
+        err.statusCode = 400
+      }
       reply[kReplyIsError] = true
       reply.code(err.statusCode).send(err)
       return

--- a/test/hooks-async.test.js
+++ b/test/hooks-async.test.js
@@ -194,6 +194,121 @@ test('preParsing hooks should be able to modify the payload', t => {
   })
 })
 
+test('preParsing hooks should be able to supply statusCode', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.addHook('preParsing', async (req, reply, payload) => {
+    const stream = new Readable({
+      read () {
+        const error = new Error('kaboom')
+        error.statusCode = 408
+        this.destroy(error)
+      }
+    })
+    stream.receivedEncodedLength = 20
+    return stream
+  })
+
+  fastify.addHook('onError', async (req, res, err) => {
+    t.equal(err.statusCode, 408)
+  })
+
+  fastify.post('/', function (request, reply) {
+    t.fail('should not be called')
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: { hello: 'world' }
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 408)
+    t.same(JSON.parse(res.payload), {
+      statusCode: 408,
+      error: 'Request Timeout',
+      message: 'kaboom'
+    })
+  })
+})
+
+test('preParsing hooks should ignore statusCode 200 in stream error', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.addHook('preParsing', async (req, reply, payload) => {
+    const stream = new Readable({
+      read () {
+        const error = new Error('kaboom')
+        error.statusCode = 200
+        this.destroy(error)
+      }
+    })
+    stream.receivedEncodedLength = 20
+    return stream
+  })
+
+  fastify.addHook('onError', async (req, res, err) => {
+    t.equal(err.statusCode, 400)
+  })
+
+  fastify.post('/', function (request, reply) {
+    t.fail('should not be called')
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: { hello: 'world' }
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 400)
+    t.same(JSON.parse(res.payload), {
+      statusCode: 400,
+      error: 'Bad Request',
+      message: 'kaboom'
+    })
+  })
+})
+
+test('preParsing hooks should default to statusCode 400 if stream error', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.addHook('preParsing', async (req, reply, payload) => {
+    const stream = new Readable({
+      read () {
+        this.destroy(new Error('kaboom'))
+      }
+    })
+    stream.receivedEncodedLength = 20
+    return stream
+  })
+
+  fastify.addHook('onError', async (req, res, err) => {
+    t.equal(err.statusCode, 400)
+  })
+
+  fastify.post('/', function (request, reply) {
+    t.fail('should not be called')
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: { hello: 'world' }
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 400)
+    t.same(JSON.parse(res.payload), {
+      statusCode: 400,
+      error: 'Bad Request',
+      message: 'kaboom'
+    })
+  })
+})
+
 test('preParsing hooks should handle errors', t => {
   t.plan(3)
   const fastify = Fastify()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
