### PR TITLE
ci: ignore node-14 on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,10 @@ jobs:
       matrix:
         node-version: [14, 16, 18, 19]
         os: [macos-latest, ubuntu-latest, windows-latest]
+        exclude:
+          # excludes node 14 on Windows
+          - os: windows-latest
+            node-version: 14
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
target: get the pipeline green again due this error:

```
Run npm install --ignore-scripts
npm WARN deprecated readdir-scoped-modules@1.1.0: This functionality has been moved to @npmcli/fs
npm WARN notsup Unsupported engine for json-schema-to-ts@2.9.1: wanted: {"node":">=16"} (current: {"node":"1[4](https://github.com/fastify/fastify/actions/runs/5205483502/jobs/9391059215?pr=4799#step:5:5).21.3","npm":"[6](https://github.com/fastify/fastify/actions/runs/5205483502/jobs/9391059215?pr=4799#step:5:7).14.18"})
npm WARN notsup Not compatible with your version of node/npm: json-schema-to-ts@2.9.1
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.2 (node_modules\chokidar\node_modules\fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"win32","arch":"x64"})

npm ERR! code EPERM
npm ERR! syscall rename
npm ERR! path D:\a\fastify\fastify\node_modules\tap\node_modules\@jridgewell\.trace-mapping.DELETE\node_modules\@jridgewell
npm ERR! dest D:\a\fastify\fastify\node_modules\tap\node_modules\@jridgewell\trace-mapping\node_modules\@jridgewell
npm ERR! errno -404[8](https://github.com/fastify/fastify/actions/runs/5205483502/jobs/9391059215?pr=4799#step:5:9)
npm ERR! Error: EPERM: operation not permitted, rename 'D:\a\fastify\fastify\node_modules\tap\node_modules\@jridgewell\.trace-mapping.DELETE\node_modules\@jridgewell' -> 'D:\a\fastify\fastify\node_modules\tap\node_modules\@jridgewell\trace-mapping\node_modules\@jridgewell'
npm ERR!  [OperationalError: EPERM: operation not permitted, rename '
```

I extracted this piece of code from #4691 

I looked around here to understand if this error has been triggered by a windows image update, but did not find any evidence:

https://github.com/actions/runner-images/commits/main/images/win/Windows2022-Readme.md

