### PR TITLE
remove buildHooks fn

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -35,20 +35,38 @@ const {
   kHooks
 } = require('./symbols')
 
-function Hooks () {
-  this.onRequest = []
-  this.preParsing = []
-  this.preValidation = []
-  this.preSerialization = []
-  this.preHandler = []
-  this.onResponse = []
-  this.onSend = []
-  this.onError = []
-  this.onRoute = []
-  this.onRegister = []
+function Hooks (hooks) {
+  if (hooks) {
+    this.onRoute = hooks.onRoute.slice()
+    this.onRegister = hooks.onRegister.slice()
+
+    this.onTimeout = hooks.onTimeout.slice()
+    this.onRequest = hooks.onRequest.slice()
+    this.preParsing = hooks.preParsing.slice()
+    this.preValidation = hooks.preValidation.slice()
+    this.preSerialization = hooks.preSerialization.slice()
+    this.preHandler = hooks.preHandler.slice()
+    this.onSend = hooks.onSend.slice()
+    this.onResponse = hooks.onResponse.slice()
+    this.onError = hooks.onError.slice()
+    this.onRequestAbort = hooks.onRequestAbort.slice()
+  } else {
+    this.onRoute = []
+    this.onRegister = []
+
+    this.onTimeout = []
+    this.onRequest = []
+    this.preParsing = []
+    this.preValidation = []
+    this.preSerialization = []
+    this.preHandler = []
+    this.onSend = []
+    this.onResponse = []
+    this.onError = []
+    this.onRequestAbort = []
+  }
+
   this.onReady = []
-  this.onTimeout = []
-  this.onRequestAbort = []
   this.preClose = []
 }
 
@@ -63,25 +81,6 @@ Hooks.prototype.validate = function (hook, fn) {
 Hooks.prototype.add = function (hook, fn) {
   this.validate(hook, fn)
   this[hook].push(fn)
-}
-
-function buildHooks (h) {
-  const hooks = new Hooks()
-  hooks.onRequest = h.onRequest.slice()
-  hooks.preParsing = h.preParsing.slice()
-  hooks.preValidation = h.preValidation.slice()
-  hooks.preSerialization = h.preSerialization.slice()
-  hooks.preHandler = h.preHandler.slice()
-  hooks.onSend = h.onSend.slice()
-  hooks.onResponse = h.onResponse.slice()
-  hooks.onError = h.onError.slice()
-  hooks.onRoute = h.onRoute.slice()
-  hooks.onRegister = h.onRegister.slice()
-  hooks.onTimeout = h.onTimeout.slice()
-  hooks.onRequestAbort = h.onRequestAbort.slice()
-  hooks.onReady = []
-  hooks.preClose = []
-  return hooks
 }
 
 function hookRunnerApplication (hookName, boot, server, cb) {
@@ -295,7 +294,6 @@ function hookIterator (fn, request, reply, next) {
 
 module.exports = {
   Hooks,
-  buildHooks,
   hookRunner,
   onSendHookRunner,
   onRequestAbortHookRunner,

--- a/lib/pluginOverride.js
+++ b/lib/pluginOverride.js
@@ -19,7 +19,7 @@ const Reply = require('./reply')
 const Request = require('./request')
 const SchemaController = require('./schema-controller')
 const ContentTypeParser = require('./contentTypeParser')
-const { buildHooks } = require('./hooks')
+const { Hooks } = require('./hooks')
 const pluginUtils = require('./pluginUtils')
 
 // Function that runs the encapsulation magic.
@@ -42,7 +42,7 @@ module.exports = function override (old, fn, opts) {
   instance[kRequest] = Request.buildRequest(instance[kRequest])
 
   instance[kContentTypeParser] = ContentTypeParser.helpers.buildContentTypeParser(instance[kContentTypeParser])
-  instance[kHooks] = buildHooks(instance[kHooks])
+  instance[kHooks] = new Hooks(instance[kHooks])
   instance[kRoutePrefix] = buildRoutePrefix(instance[kRoutePrefix], opts.prefix)
   instance[kLogLevel] = opts.logLevel || instance[kLogLevel]
   instance[kSchemaController] = SchemaController.buildSchemaController(old[kSchemaController])


### PR DESCRIPTION
opinionated change. the buildHooks fn should be actually part of the hook constructor. 
if we need to expose the hook functionality this reduces the amount of potentially to be exposed functions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
