### PR TITLE
reset listening state for each secondary server

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -127,6 +127,7 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
           cb: (_ignoreErr) => {
             binded++
 
+            /* istanbul ignore next: the else won't be taken unless listening fails */
             if (!_ignoreErr) {
               this[kServerBindings].push(secondaryServer)
             }
@@ -144,6 +145,7 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
         mainServer.on('unref', closeSecondary)
         mainServer.on('close', closeSecondary)
         mainServer.on('error', closeSecondary)
+        this[kState].listening = false
         listenCallback.call(this, secondaryServer, secondaryOpts)()
       }
     }


### PR DESCRIPTION
This is https://github.com/fastify/fastify/pull/4802 targeting the main branch since the v20 branch was merged.

The `listenCallback()` function is called for each secondary address that a server should listen on. However, each call sets the listening state to `true`, so subsequent addresses fail with `FST_ERR_REOPENED_SERVER`. This commit resets the state on each call.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
