### PR TITLE
adding missing type definition in FastifyContextConfig

### DIFF
--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -1,4 +1,4 @@
-import fastify, { FastifyInstance, FastifyRequest, FastifyReply, RouteHandlerMethod, FastifyContextConfig } from '../../fastify'
+import fastify, { FastifyInstance, FastifyRequest, FastifyReply, RouteHandlerMethod } from '../../fastify'
 import { expectType, expectError, expectAssignable, printType } from 'tsd'
 import { HTTPMethods } from '../../types/utils'
 import * as http from 'http'
@@ -74,7 +74,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
     Headers: HeadersInterface;
   }
 
-  fastify()[lowerCaseMethod]<RouteGeneric, RouteSpecificContextConfigType>('/', { config: { url: 'localhost', foo: 'bar', bar: 100, extra: true } }, (req, res) => {
+  fastify()[lowerCaseMethod]<RouteGeneric, RouteSpecificContextConfigType>('/', { config: { foo: 'bar', bar: 100, extra: true } }, (req, res) => {
     expectType<BodyInterface>(req.body)
     expectType<QuerystringInterface>(req.query)
     expectType<ParamsInterface>(req.params)
@@ -90,7 +90,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
   fastify().route<RouteGeneric>({
     url: '/',
     method: method as HTTPMethods,
-    config: { foo: 'bar', bar: 100, url: 'localhost' },
+    config: { foo: 'bar', bar: 100 },
     prefixTrailingSlash: 'slash',
     onRequest: (req, res, done) => { // these handlers are tested in `hooks.test-d.ts`
       expectType<BodyInterface>(req.body)
@@ -101,7 +101,6 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
-      expectType<string>(res.context.config.url)
     },
     preParsing: (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -112,7 +111,6 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
-      expectType<string>(res.context.config.url)
       expectType<RequestPayload>(payload)
       expectAssignable<(err?: FastifyError | null, res?: RequestPayload) => void>(done)
       expectAssignable<(err?: NodeJS.ErrnoException) => void>(done)
@@ -126,7 +124,6 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
-      expectType<string>(res.context.config.url)
     },
     preHandler: (req, res, done) => {
       expectType<BodyInterface>(req.body)
@@ -137,7 +134,6 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
-      expectType<string>(res.context.config.url)
     },
     onResponse: (req, res, done) => {
       expectType<BodyInterface>(req.body)
@@ -148,7 +144,6 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
-      expectType<string>(res.context.config.url)
       expectType<number>(res.statusCode)
     },
     onError: (req, res, error, done) => {
@@ -160,7 +155,6 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
-      expectType<string>(res.context.config.url)
     },
     preSerialization: (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -171,7 +165,6 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
-      expectType<string>(res.context.config.url)
     },
     onSend: (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -182,7 +175,6 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
-      expectType<string>(res.context.config.url)
     },
     handler: (req, res) => {
       expectType<BodyInterface>(req.body)
@@ -193,14 +185,13 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
-      expectType<string>(res.context.config.url)
     }
   })
 
   fastify().route<RouteGeneric>({
     url: '/',
     method: method as HTTPMethods,
-    config: { url: 'localhost', foo: 'bar', bar: 100 },
+    config: { foo: 'bar', bar: 100 },
     prefixTrailingSlash: 'slash',
     onRequest: async (req, res, done) => { // these handlers are tested in `hooks.test-d.ts`
       expectType<BodyInterface>(req.body)
@@ -211,7 +202,6 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
-      expectType<string>(res.context.config.url)
     },
     preParsing: async (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -222,7 +212,6 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
-      expectType<string>(res.context.config.url)
       expectType<RequestPayload>(payload)
       expectAssignable<(err?: FastifyError | null, res?: RequestPayload) => void>(done)
       expectAssignable<(err?: NodeJS.ErrnoException) => void>(done)
@@ -236,7 +225,6 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
-      expectType<string>(res.context.config.url)
     },
     preHandler: async (req, res, done) => {
       expectType<BodyInterface>(req.body)
@@ -247,7 +235,6 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
-      expectType<string>(res.context.config.url)
     },
     onResponse: async (req, res, done) => {
       expectType<BodyInterface>(req.body)
@@ -258,7 +245,6 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
-      expectType<string>(res.context.config.url)
       expectType<number>(res.statusCode)
     },
     onError: async (req, res, error, done) => {
@@ -270,7 +256,6 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
-      expectType<string>(res.context.config.url)
     },
     preSerialization: async (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -281,7 +266,6 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
-      expectType<string>(res.context.config.url)
     },
     onSend: async (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -292,7 +276,6 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
-      expectType<string>(res.context.config.url)
     },
     handler: (req, res) => {
       expectType<BodyInterface>(req.body)
@@ -303,7 +286,6 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
-      expectType<string>(res.context.config.url)
     }
   })
 })

--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -74,7 +74,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
     Headers: HeadersInterface;
   }
 
-  fastify()[lowerCaseMethod]<RouteGeneric, RouteSpecificContextConfigType>('/', { config: { foo: 'bar', bar: 100, extra: true } }, (req, res) => {
+  fastify()[lowerCaseMethod]<RouteGeneric, RouteSpecificContextConfigType>('/', { config: { foo: 'bar', bar: 100, extra: true, url: 'localhost' } }, (req, res) => {
     expectType<BodyInterface>(req.body)
     expectType<QuerystringInterface>(req.query)
     expectType<ParamsInterface>(req.params)
@@ -85,12 +85,13 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
     expectType<string>(res.context.config.foo)
     expectType<number>(res.context.config.bar)
     expectType<boolean>(res.context.config.extra)
+    expectType<string>(res.context.config.url)
   })
 
   fastify().route<RouteGeneric>({
     url: '/',
     method: method as HTTPMethods,
-    config: { foo: 'bar', bar: 100 },
+    config: { foo: 'bar', bar: 100, url: 'localhost' },
     prefixTrailingSlash: 'slash',
     onRequest: (req, res, done) => { // these handlers are tested in `hooks.test-d.ts`
       expectType<BodyInterface>(req.body)
@@ -101,6 +102,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     preParsing: (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -111,6 +113,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
       expectType<RequestPayload>(payload)
       expectAssignable<(err?: FastifyError | null, res?: RequestPayload) => void>(done)
       expectAssignable<(err?: NodeJS.ErrnoException) => void>(done)
@@ -124,6 +127,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     preHandler: (req, res, done) => {
       expectType<BodyInterface>(req.body)
@@ -134,6 +138,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     onResponse: (req, res, done) => {
       expectType<BodyInterface>(req.body)
@@ -144,6 +149,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
       expectType<number>(res.statusCode)
     },
     onError: (req, res, error, done) => {
@@ -155,6 +161,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     preSerialization: (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -165,6 +172,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     onSend: (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -175,6 +183,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     handler: (req, res) => {
       expectType<BodyInterface>(req.body)
@@ -185,13 +194,14 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     }
   })
 
   fastify().route<RouteGeneric>({
     url: '/',
     method: method as HTTPMethods,
-    config: { foo: 'bar', bar: 100 },
+    config: { foo: 'bar', bar: 100, url: 'localhost' },
     prefixTrailingSlash: 'slash',
     onRequest: async (req, res, done) => { // these handlers are tested in `hooks.test-d.ts`
       expectType<BodyInterface>(req.body)
@@ -202,6 +212,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     preParsing: async (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -212,6 +223,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
       expectType<RequestPayload>(payload)
       expectAssignable<(err?: FastifyError | null, res?: RequestPayload) => void>(done)
       expectAssignable<(err?: NodeJS.ErrnoException) => void>(done)
@@ -225,6 +237,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     preHandler: async (req, res, done) => {
       expectType<BodyInterface>(req.body)
@@ -235,6 +248,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     onResponse: async (req, res, done) => {
       expectType<BodyInterface>(req.body)
@@ -245,6 +259,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
       expectType<number>(res.statusCode)
     },
     onError: async (req, res, error, done) => {
@@ -256,6 +271,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     preSerialization: async (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -266,6 +282,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     onSend: async (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -276,6 +293,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     handler: (req, res) => {
       expectType<BodyInterface>(req.body)
@@ -286,6 +304,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     }
   })
 })

--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -1,4 +1,4 @@
-import fastify, { FastifyInstance, FastifyRequest, FastifyReply, RouteHandlerMethod } from '../../fastify'
+import fastify, { FastifyInstance, FastifyRequest, FastifyReply, RouteHandlerMethod, FastifyContextConfig } from '../../fastify'
 import { expectType, expectError, expectAssignable, printType } from 'tsd'
 import { HTTPMethods } from '../../types/utils'
 import * as http from 'http'
@@ -74,7 +74,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
     Headers: HeadersInterface;
   }
 
-  fastify()[lowerCaseMethod]<RouteGeneric, RouteSpecificContextConfigType>('/', { config: { foo: 'bar', bar: 100, extra: true } }, (req, res) => {
+  fastify()[lowerCaseMethod]<RouteGeneric, RouteSpecificContextConfigType>('/', { config: { url: 'localhost', foo: 'bar', bar: 100, extra: true } }, (req, res) => {
     expectType<BodyInterface>(req.body)
     expectType<QuerystringInterface>(req.query)
     expectType<ParamsInterface>(req.params)
@@ -90,7 +90,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
   fastify().route<RouteGeneric>({
     url: '/',
     method: method as HTTPMethods,
-    config: { foo: 'bar', bar: 100 },
+    config: { foo: 'bar', bar: 100, url: 'localhost' },
     prefixTrailingSlash: 'slash',
     onRequest: (req, res, done) => { // these handlers are tested in `hooks.test-d.ts`
       expectType<BodyInterface>(req.body)
@@ -101,6 +101,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     preParsing: (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -111,6 +112,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
       expectType<RequestPayload>(payload)
       expectAssignable<(err?: FastifyError | null, res?: RequestPayload) => void>(done)
       expectAssignable<(err?: NodeJS.ErrnoException) => void>(done)
@@ -124,6 +126,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     preHandler: (req, res, done) => {
       expectType<BodyInterface>(req.body)
@@ -134,6 +137,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     onResponse: (req, res, done) => {
       expectType<BodyInterface>(req.body)
@@ -144,6 +148,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
       expectType<number>(res.statusCode)
     },
     onError: (req, res, error, done) => {
@@ -155,6 +160,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     preSerialization: (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -165,6 +171,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     onSend: (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -175,6 +182,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     handler: (req, res) => {
       expectType<BodyInterface>(req.body)
@@ -185,13 +193,14 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     }
   })
 
   fastify().route<RouteGeneric>({
     url: '/',
     method: method as HTTPMethods,
-    config: { foo: 'bar', bar: 100 },
+    config: { url: 'localhost', foo: 'bar', bar: 100 },
     prefixTrailingSlash: 'slash',
     onRequest: async (req, res, done) => { // these handlers are tested in `hooks.test-d.ts`
       expectType<BodyInterface>(req.body)
@@ -202,6 +211,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     preParsing: async (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -212,6 +222,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
       expectType<RequestPayload>(payload)
       expectAssignable<(err?: FastifyError | null, res?: RequestPayload) => void>(done)
       expectAssignable<(err?: NodeJS.ErrnoException) => void>(done)
@@ -225,6 +236,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     preHandler: async (req, res, done) => {
       expectType<BodyInterface>(req.body)
@@ -235,6 +247,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     onResponse: async (req, res, done) => {
       expectType<BodyInterface>(req.body)
@@ -245,6 +258,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
       expectType<number>(res.statusCode)
     },
     onError: async (req, res, error, done) => {
@@ -256,6 +270,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     preSerialization: async (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -266,6 +281,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     onSend: async (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -276,6 +292,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     handler: (req, res) => {
       expectType<BodyInterface>(req.body)
@@ -286,6 +303,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     }
   })
 })

--- a/types/context.d.ts
+++ b/types/context.d.ts
@@ -1,7 +1,7 @@
 import { ContextConfigDefault } from './utils'
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface FastifyContextConfig {
+  url: string;
 }
 
 /**

--- a/types/context.d.ts
+++ b/types/context.d.ts
@@ -1,7 +1,7 @@
 import { ContextConfigDefault } from './utils'
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface FastifyContextConfig {
-  url: string;
 }
 
 /**


### PR DESCRIPTION

- [X] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

fixes [#4788](https://github.com/fastify/fastify/issues/4788) 
