### PR TITLE
fix: added missing type definition in FastifyContextConfig

### DIFF
--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -74,7 +74,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
     Headers: HeadersInterface;
   }
 
-  fastify()[lowerCaseMethod]<RouteGeneric, RouteSpecificContextConfigType>('/', { config: { foo: 'bar', bar: 100, extra: true } }, (req, res) => {
+  fastify()[lowerCaseMethod]<RouteGeneric, RouteSpecificContextConfigType>('/', { config: { foo: 'bar', bar: 100, extra: true, url: 'localhost' } }, (req, res) => {
     expectType<BodyInterface>(req.body)
     expectType<QuerystringInterface>(req.query)
     expectType<ParamsInterface>(req.params)
@@ -85,12 +85,13 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
     expectType<string>(res.context.config.foo)
     expectType<number>(res.context.config.bar)
     expectType<boolean>(res.context.config.extra)
+    expectType<string>(res.context.config.url)
   })
 
   fastify().route<RouteGeneric>({
     url: '/',
     method: method as HTTPMethods,
-    config: { foo: 'bar', bar: 100 },
+    config: { foo: 'bar', bar: 100, url: 'localhost' },
     prefixTrailingSlash: 'slash',
     onRequest: (req, res, done) => { // these handlers are tested in `hooks.test-d.ts`
       expectType<BodyInterface>(req.body)
@@ -101,6 +102,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     preParsing: (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -111,6 +113,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
       expectType<RequestPayload>(payload)
       expectAssignable<(err?: FastifyError | null, res?: RequestPayload) => void>(done)
       expectAssignable<(err?: NodeJS.ErrnoException) => void>(done)
@@ -124,6 +127,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     preHandler: (req, res, done) => {
       expectType<BodyInterface>(req.body)
@@ -134,6 +138,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     onResponse: (req, res, done) => {
       expectType<BodyInterface>(req.body)
@@ -144,6 +149,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
       expectType<number>(res.statusCode)
     },
     onError: (req, res, error, done) => {
@@ -155,6 +161,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     preSerialization: (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -165,6 +172,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     onSend: (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -175,6 +183,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     handler: (req, res) => {
       expectType<BodyInterface>(req.body)
@@ -185,13 +194,14 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     }
   })
 
   fastify().route<RouteGeneric>({
     url: '/',
     method: method as HTTPMethods,
-    config: { foo: 'bar', bar: 100 },
+    config: { foo: 'bar', bar: 100, url: 'localhost' },
     prefixTrailingSlash: 'slash',
     onRequest: async (req, res, done) => { // these handlers are tested in `hooks.test-d.ts`
       expectType<BodyInterface>(req.body)
@@ -202,6 +212,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     preParsing: async (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -212,6 +223,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
       expectType<RequestPayload>(payload)
       expectAssignable<(err?: FastifyError | null, res?: RequestPayload) => void>(done)
       expectAssignable<(err?: NodeJS.ErrnoException) => void>(done)
@@ -225,6 +237,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     preHandler: async (req, res, done) => {
       expectType<BodyInterface>(req.body)
@@ -235,6 +248,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     onResponse: async (req, res, done) => {
       expectType<BodyInterface>(req.body)
@@ -245,6 +259,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
       expectType<number>(res.statusCode)
     },
     onError: async (req, res, error, done) => {
@@ -256,6 +271,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     preSerialization: async (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -266,6 +282,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     onSend: async (req, res, payload, done) => {
       expectType<BodyInterface>(req.body)
@@ -276,6 +293,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     },
     handler: (req, res) => {
       expectType<BodyInterface>(req.body)
@@ -286,6 +304,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<number>(req.context.config.bar)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(res.context.config.url)
     }
   })
 })

--- a/types/context.d.ts
+++ b/types/context.d.ts
@@ -1,7 +1,7 @@
 import { ContextConfigDefault } from './utils'
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface FastifyContextConfig {
+  url: string;
 }
 
 /**


### PR DESCRIPTION
#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Fixes [4788](https://github.com/fastify/fastify/issues/4788)