### PR TITLE
fix: accessing req.routeConfig in frameworkErrors handler throws TypeError

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -172,7 +172,7 @@ Object.defineProperties(Request.prototype, {
   },
   routerPath: {
     get () {
-      return this[kRouteContext].config.url
+      return this[kRouteContext].config?.url
     }
   },
   routeOptions: {
@@ -182,8 +182,8 @@ Object.defineProperties(Request.prototype, {
       const serverLimit = context.server.initialConfig.bodyLimit
       const version = context.server.hasConstraintStrategy('version') ? this.raw.headers['accept-version'] : undefined
       const options = {
-        method: context.config.method,
-        url: context.config.url,
+        method: context.config?.method,
+        url: context.config?.url,
         bodyLimit: (routeLimit || serverLimit),
         attachValidation: context.attachValidation,
         logLevel: context.logLevel,
@@ -196,12 +196,12 @@ Object.defineProperties(Request.prototype, {
   },
   routerMethod: {
     get () {
-      return this[kRouteContext].config.method
+      return this[kRouteContext].config?.method
     }
   },
   routeConfig: {
     get () {
-      return this[kRouteContext][kPublicRouteContext].config
+      return this[kRouteContext][kPublicRouteContext]?.config
     }
   },
   routeSchema: {
@@ -211,7 +211,7 @@ Object.defineProperties(Request.prototype, {
   },
   is404: {
     get () {
-      return this[kRouteContext].config.url === undefined
+      return this[kRouteContext].config?.url === undefined
     }
   },
   connection: {

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -301,7 +301,7 @@ test('within an instance', t => {
       })
     })
 
-    test('auto status code shoud be 200', t => {
+    test('auto status code should be 200', t => {
       t.plan(3)
       sget({
         method: 'GET',
@@ -313,7 +313,7 @@ test('within an instance', t => {
       })
     })
 
-    test('auto type shoud be text/plain', t => {
+    test('auto type should be text/plain', t => {
       t.plan(3)
       sget({
         method: 'GET',

--- a/test/internals/request.test.js
+++ b/test/internals/request.test.js
@@ -75,6 +75,65 @@ test('Regular request', t => {
   t.end()
 })
 
+test('Request with undefined config', t => {
+  const headers = {
+    host: 'hostname'
+  }
+  const req = {
+    method: 'GET',
+    url: '/',
+    socket: { remoteAddress: 'ip' },
+    headers
+  }
+  const context = new Context({
+    schema: {
+      body: {
+        type: 'object',
+        required: ['hello'],
+        properties: {
+          hello: { type: 'string' }
+        }
+      }
+    },
+    server: {
+      [kReply]: {},
+      [kRequest]: Request
+    }
+  })
+  req.connection = req.socket
+  const request = new Request('id', 'params', req, 'query', 'log', context)
+  t.type(request, Request)
+  t.type(request.validateInput, Function)
+  t.type(request.getValidationFunction, Function)
+  t.type(request.compileValidationSchema, Function)
+  t.equal(request.id, 'id')
+  t.equal(request.params, 'params')
+  t.equal(request.raw, req)
+  t.equal(request.query, 'query')
+  t.equal(request.headers, headers)
+  t.equal(request.log, 'log')
+  t.equal(request.ip, 'ip')
+  t.equal(request.ips, undefined)
+  t.equal(request.hostname, 'hostname')
+  t.equal(request.body, undefined)
+  t.equal(request.method, 'GET')
+  t.equal(request.url, '/')
+  t.equal(request.originalUrl, '/')
+  t.equal(request.socket, req.socket)
+  t.equal(request.protocol, 'http')
+  t.equal(request.routeSchema, context[kPublicRouteContext].schema)
+  t.equal(request.routerPath, undefined)
+  t.equal(request.routerMethod, undefined)
+  t.equal(request.routeConfig, undefined)
+
+  // Aim to not bad property keys (including Symbols)
+  t.notOk('undefined' in request)
+
+  // This will be removed, it's deprecated
+  t.equal(request.connection, req.connection)
+  t.end()
+})
+
 test('Regular request - hostname from authority', t => {
   t.plan(2)
   const headers = {


### PR DESCRIPTION
Closes #4807 

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
