### PR TITLE
docs(plugins): note side-effect when using `await` in `fastify.register()`

### DIFF
--- a/docs/Reference/Plugins.md
+++ b/docs/Reference/Plugins.md
@@ -145,6 +145,10 @@ await fastify.ready()
 
 await fastify.listen({ port: 3000 })
 ```
+*Note: Using await when registering a plugin finalizes the encapsulation 
+process, so any mutations to the instance after the plugin has been awaited will
+not be reflected in the parent instance. 
+See: [Issue #3863](https://github.com/fastify/fastify/issues/3863#issuecomment-1114132490)*
 
 #### ESM support
 <a id="esm-support"></a>

--- a/docs/Reference/Plugins.md
+++ b/docs/Reference/Plugins.md
@@ -145,10 +145,10 @@ await fastify.ready()
 
 await fastify.listen({ port: 3000 })
 ```
-*Note: Using await when registering a plugin finalizes the encapsulation 
-process, so any mutations to the instance after the plugin has been awaited will
-not be reflected in the parent instance. 
-See: [Issue #3863](https://github.com/fastify/fastify/issues/3863#issuecomment-1114132490)*
+*Note: Using `await` when registering a plugin loads the plugin
+and the underlying dependency tree, "finalizing" the encapsulation process.
+Any mutations to the plugin after it and its dependencies have been
+loaded will not be reflected in the parent instance.*
 
 #### ESM support
 <a id="esm-support"></a>


### PR DESCRIPTION
This PR adds documentation for a side effect of using `await` when registering a plugin in Fastify (#3863)

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)