### PR TITLE
docs(testing): add plugin testing guide

### DIFF
--- a/docs/Guides/Testing.md
+++ b/docs/Guides/Testing.md
@@ -1,11 +1,19 @@
-<h1 align="center">Fastify</h1>
+<h1 style="text-align: center;">Fastify</h1>
 
-## Testing
+# Testing
+<a id="testing"></a>
 
 Testing is one of the most important parts of developing an application. Fastify
 is very flexible when it comes to testing and is compatible with most testing
 frameworks (such as [Tap](https://www.npmjs.com/package/tap), which is used in
 the examples below).
+
+**Table of contents**
+- [Testing](#testing)
+  - [Application](#application)
+  - [Plugins](#plugins)
+
+## Application
 
 Let's `cd` into a fresh directory called 'testing-example' and type `npm init
 -y` in our terminal.
@@ -345,3 +353,140 @@ test('should ...', {only: true}, t => ...)
 
 Now you should be able to step through your test file (and the rest of
 `Fastify`) in your code editor.
+
+
+
+## Plugins
+Let's `cd` into a fresh directory called 'testing-plugin-example' and type `npm init
+-y` in our terminal.
+
+Run `npm i fastify fastify-plugin && npm i tap -D`
+
+To use ESM (`import` statements)
+
+**package.json**:
+```json
+"type": "module"
+```
+
+**plugin/myFirstPlugin.js**:
+
+```js
+import fP from "fastify-plugin"
+
+async function myPlugin(fastify, options) {
+    fastify.decorateRequest("helloRequest", "Hello World")
+    fastify.decorate("helloInstance", "Hello Fastify Instance")
+}
+
+export default fP(myPlugin)
+```
+
+A basic example of a Plugin. See [Plugin Guide](./Plugins-Guide)
+
+**test/myFirstPlugin.test.js**:
+
+```js
+import Fastify from "fastify";
+import tap from "tap";
+import myPlugin from "../plugin/myFirstPlugin.js";
+
+tap.test("Test the Plugin Route", async t => {
+    // Create a mock fastify application to test the plugin
+    const fastify = Fastify()
+
+    fastify.register(myPlugin)
+
+    // Add an endpoint of your choice 
+    fastify.get("/", async (request, reply) => {
+        return ({ message: request.helloRequest })
+    })
+
+    // Use fastify.inject to fake a HTTP Request
+    const fastifyResponse = await fastify.inject({
+        method: "GET",
+        url: "/"
+    })
+    
+  console.log('status code: ', fastifyResponse.statusCode)
+  console.log('body: ', fastifyResponse.body)
+})
+```
+Learn more about [```fastify.inject()```](#benefits-of-using-fastifyinject).
+Run the test file in your terminal `node test/myFirstPlugin.test.js`
+
+```sh
+status code:  200
+body:  {"message":"Hello World"}
+```
+
+Now we can replace our `console.log` calls with actual tests!
+
+In your `package.json` change the "test" script to:
+
+`"test": "tap --reporter=list --watch"`
+
+Create the tap test for the endpoint.
+
+**test/myFirstPlugin.test.js**:
+
+```js
+import Fastify from "fastify";
+import tap from "tap";
+import myPlugin from "../plugin/myFirstPlugin.js";
+
+tap.test("Test the Plugin Route", async t => {
+    // Specifies the number of test
+    t.plan(2)
+
+    const fastify = Fastify()
+
+    fastify.register(myPlugin)
+
+    fastify.get("/", async (request, reply) => {
+        return ({ message: request.helloRequest })
+    })
+
+    const fastifyResponse = await fastify.inject({
+        method: "GET",
+        url: "/"
+    })
+    
+    t.equal(fastifyResponse.statusCode, 200)
+    t.same(JSON.parse(fastifyResponse.body), { message: "Hello World" })
+})
+```
+
+Finally, run `npm test` in the terminal and see your test results!
+
+Test the ```.decorate()``` and ```.decorateRequest()```.
+
+**test/myFirstPlugin.test.js**:
+
+```js
+import Fastify from "fastify";
+import tap from "tap";
+import myPlugin from "../plugin/myFirstPlugin.js";
+
+tap.test("Test the Plugin Route", async t => {
+    t.plan(5)
+    const fastify = Fastify()
+
+    fastify.register(myPlugin)
+
+    fastify.get("/", async (request, reply) => {
+        // Testing the fastify decorators
+        t.not(request.helloRequest, null) 
+        t.ok(request.helloRequest, "Hello World")
+        t.ok(fastify.helloInstance, "Hello Fastify Instance")
+        return ({ message: request.helloRequest })
+    })
+
+    const fastifyResponse = await fastify.inject({
+        method: "GET",
+        url: "/"
+    })
+    t.equal(fastifyResponse.statusCode, 200)
+    t.same(JSON.parse(fastifyResponse.body), { message: "Hello World" })
+})
+```

--- a/docs/Guides/Testing.md
+++ b/docs/Guides/Testing.md
@@ -8,11 +8,6 @@ is very flexible when it comes to testing and is compatible with most testing
 frameworks (such as [Tap](https://www.npmjs.com/package/tap), which is used in
 the examples below).
 
-**Table of contents**
-- [Testing](#testing)
-  - [Application](#application)
-  - [Plugins](#plugins)
-
 ## Application
 
 Let's `cd` into a fresh directory called 'testing-example' and type `npm init
@@ -362,24 +357,17 @@ Let's `cd` into a fresh directory called 'testing-plugin-example' and type `npm 
 
 Run `npm i fastify fastify-plugin && npm i tap -D`
 
-To use ESM (`import` statements)
-
-**package.json**:
-```json
-"type": "module"
-```
-
 **plugin/myFirstPlugin.js**:
 
 ```js
-import fP from "fastify-plugin"
+const fP = require("fastify-plugin")
 
 async function myPlugin(fastify, options) {
     fastify.decorateRequest("helloRequest", "Hello World")
     fastify.decorate("helloInstance", "Hello Fastify Instance")
 }
 
-export default fP(myPlugin)
+module.exports = fP(myPlugin)
 ```
 
 A basic example of a Plugin. See [Plugin Guide](./Plugins-Guide.md)
@@ -387,9 +375,9 @@ A basic example of a Plugin. See [Plugin Guide](./Plugins-Guide.md)
 **test/myFirstPlugin.test.js**:
 
 ```js
-import Fastify from "fastify";
-import tap from "tap";
-import myPlugin from "../plugin/myFirstPlugin.js";
+const Fastify = require("fastify");
+const tap = require("tap");
+const myPlugin = require("../plugin/myFirstPlugin");
 
 tap.test("Test the Plugin Route", async t => {
     // Create a mock fastify application to test the plugin
@@ -431,9 +419,9 @@ Create the tap test for the endpoint.
 **test/myFirstPlugin.test.js**:
 
 ```js
-import Fastify from "fastify";
-import tap from "tap";
-import myPlugin from "../plugin/myFirstPlugin.js";
+const Fastify = require("fastify");
+const tap = require("tap");
+const myPlugin = require("../plugin/myFirstPlugin");
 
 tap.test("Test the Plugin Route", async t => {
     // Specifies the number of test
@@ -464,9 +452,9 @@ Test the ```.decorate()``` and ```.decorateRequest()```.
 **test/myFirstPlugin.test.js**:
 
 ```js
-import Fastify from "fastify";
-import tap from "tap";
-import myPlugin from "../plugin/myFirstPlugin.js";
+const Fastify = require("fastify");
+const tap = require("tap");
+const myPlugin = require("../plugin/myFirstPlugin");
 
 tap.test("Test the Plugin Route", async t => {
     t.plan(5)

--- a/docs/Guides/Testing.md
+++ b/docs/Guides/Testing.md
@@ -382,7 +382,7 @@ async function myPlugin(fastify, options) {
 export default fP(myPlugin)
 ```
 
-A basic example of a Plugin. See [Plugin Guide](./Plugins-Guide)
+A basic example of a Plugin. See [Plugin Guide](./Plugins-Guide.md)
 
 **test/myFirstPlugin.test.js**:
 

--- a/docs/Guides/Write-Plugin.md
+++ b/docs/Guides/Write-Plugin.md
@@ -1,4 +1,4 @@
-<h1 align="center">Fastify</h1>
+<h1 style="text-align: center;">Fastify</h1>
 
 # How to write a good plugin
 First, thank you for deciding to write a plugin for Fastify. Fastify is a
@@ -63,6 +63,8 @@ among different versions of its dependencies.
 We do not enforce any testing library. We use [`tap`](https://www.node-tap.org/)
 since it offers out-of-the-box parallel testing and code coverage, but it is up
 to you to choose your library of preference.
+We highly recommend you read the [Plugin Testing](./Testing.md#plugins) to 
+learn about how to test your plugins.
 
 ## Code Linter
 It is not mandatory, but we highly recommend you use a code linter in your


### PR DESCRIPTION
This PR adds documentation for testing a plugin in Fastify (https://github.com/fastify/fastify/issues/4687)
#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
