### PR TITLE
fix: return 431 status code on HTTP header overflow error

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -653,6 +653,11 @@ function fastify (options) {
       errorStatus = http.STATUS_CODES[errorCode]
       body = `{"error":"${errorStatus}","message":"Client Timeout","statusCode":408}`
       errorLabel = 'timeout'
+    } else if (err.code === 'HPE_HEADER_OVERFLOW') {
+      errorCode = '431'
+      errorStatus = http.STATUS_CODES[errorCode]
+      body = `{"error":"${errorStatus}","message":"Exceeded maximum allowed HTTP header size","statusCode":431}`
+      errorLabel = 'header_overflow'
     } else {
       errorCode = '400'
       errorStatus = http.STATUS_CODES[errorCode]

--- a/test/header-overflow.test.js
+++ b/test/header-overflow.test.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('..')
+const sget = require('simple-get').concat
+
+const maxHeaderSize = 1024
+
+test('Should return 431 if request header fields are too large', t => {
+  t.plan(3)
+
+  const fastify = Fastify({ http: { maxHeaderSize } })
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    handler: (_req, reply) => {
+      reply.send({ hello: 'world' })
+    }
+  })
+
+  fastify.listen({ port: 0 }, function (err) {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port,
+      headers: {
+        'Large-Header': 'a'.repeat(maxHeaderSize)
+      }
+    }, (err, res) => {
+      t.error(err)
+      t.equal(res.statusCode, 431)
+    })
+  })
+
+  t.teardown(() => fastify.close())
+})
+
+test('Should return 431 if URI is too long', t => {
+  t.plan(3)
+
+  const fastify = Fastify({ http: { maxHeaderSize } })
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    handler: (_req, reply) => {
+      reply.send({ hello: 'world' })
+    }
+  })
+
+  fastify.listen({ port: 0 }, function (err) {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port + `/${'a'.repeat(maxHeaderSize)}`
+    }, (err, res) => {
+      t.error(err)
+      t.equal(res.statusCode, 431)
+    })
+  })
+
+  t.teardown(() => fastify.close())
+})


### PR DESCRIPTION
~~This PR improves error response if URI is too long. The status code should ideally be 414 to better align response with other http servers and return a more meaningful error message to the client.~~

~~EDIT: Since it is not possible to determine if error was caused by too long URI or too large headers we can't change the status code as it could be rather misleading. This PR now just improves the error message if maximum allowed header size was exceeded.~~

EDIT2: As discussed it might be better to just return a 431 for now in both cases (request header fields are too large and URI is too long) to be more concise about the error (400 is too generic) and to be in line with default Node's default response (https://github.com/nodejs/node/pull/25605).

The error code is set by http parser : [`HPE_HEADER_OVERFLOW`](https://github.com/nodejs/http-parser/blob/ec8b5ee63f0e51191ea43bb0c6eac7bfbff3141d/http_parser.c#L158)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
