### PR TITLE
Extend `decorate()` etc to enforce defined values

### DIFF
--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -115,21 +115,36 @@ export interface FastifyInstance<
   close(closeListener: () => void): undefined;
 
   // should be able to define something useful with the decorator getter/setter pattern using Generics to enforce the users function returns what they expect it to
-  decorate<T>(property: string | symbol,
+  decorate<
+    // Need to disable "no-use-before-define" to maintain backwards compatibility, as else decorate<Foo> would suddenly mean something new
+    // eslint-disable-next-line no-use-before-define
+    T extends (P extends keyof FastifyInstance ? FastifyInstance[P] : unknown),
+    P extends string | symbol = string | symbol
+  >(property: P,
     value: T extends (...args: any[]) => any
       ? (this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>, ...args: Parameters<T>) => ReturnType<T>
       : T,
     dependencies?: string[]
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
 
-  decorateRequest<T>(property: string | symbol,
+  decorateRequest<
+    // Need to disable "no-use-before-define" to maintain backwards compatibility, as else decorateRequest<Foo> would suddenly mean something new
+    // eslint-disable-next-line no-use-before-define
+    T extends (P extends keyof FastifyRequest ? FastifyRequest[P] : unknown),
+    P extends string | symbol = string | symbol
+  >(property: P,
     value: T extends (...args: any[]) => any
       ? (this: FastifyRequest, ...args: Parameters<T>) => ReturnType<T>
       : T,
     dependencies?: string[]
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
 
-  decorateReply<T>(property: string | symbol,
+  decorateReply<
+    // Need to disable "no-use-before-define" to maintain backwards compatibility, as else decorateReply<Foo> would suddenly mean something new
+    // eslint-disable-next-line no-use-before-define
+    T extends (P extends keyof FastifyReply ? FastifyReply[P] : unknown),
+    P extends string | symbol = string | symbol
+  >(property: P,
     value: T extends (...args: any[]) => any
       ? (this: FastifyReply, ...args: Parameters<T>) => ReturnType<T>
       : T,


### PR DESCRIPTION
This change is backwards compatible with untyped values like, as requested in #4129 and as such should not exhibit the problems of #4111:

```ts
fastify.decorateRequest('passport', {
  getter() {
    return passport
  },
})
```

#### Explanation of change

```ts
decorate<T>(property: string | symbol,
```

is changed into

```ts
decorate<
  T extends (P extends keyof FastifyInstance ? FastifyInstance[P] : unknown),
  P extends string | symbol = string | symbol
>(property: P,
```

and this is to make this happen:

1. The `property` gets a reference to the generic `P` instead of having the type `string | symbol`
2. `P` is defined as a new optional generic that should be a subset of the type `property` was previous set to, `string | symbol`, and which should default to the same, hence making it optional (import for anyone who has referenced this type before, else they would have to replace `decorate<Foo>` with eg. ~~`decorate<Foo, string | symbol>`~~)
3. `T` is told to check if `P` represents a key of `FastifyInstance` and if `P` does, then `T` should be compatible with the the type in there, `FastifyInstance[P]`. If `P` does not represent a key, eg. when `P` is simply `string | symbol`, then `T` is simply an `unknown` value, just like before.

It would be prettier to define `P` before `T`, but that would make it impossible to make it optional and would make any current `decorate<Foo>` have to be changed into eg. ~~`decorate<string | symbol, Foo>`~~, which would be an unnecessary change. I rather just ignore the [`no-use-before-define`](https://typescript-eslint.io/rules/no-use-before-define/) linting rule here as TypeScript itself has no issues with having `P` follow `T`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
  - Didn't add anything that verified that values are now enforced as unsure whether to extend interface within the `instance.test-d.ts` or not
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
