### PR TITLE
fix: routeShortHandOptions type updated

### DIFF
--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -3,7 +3,7 @@ import { FastifyRequest, RequestGenericInterface } from './request'
 import { FastifyReply, ReplyGenericInterface } from './reply'
 import { FastifySchema, FastifySchemaCompiler, FastifySerializerCompiler, SchemaErrorFormatter } from './schema'
 import { HTTPMethods, RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, ContextConfigDefault } from './utils'
-import { preValidationHookHandler, preHandlerHookHandler, preSerializationHookHandler, onRequestHookHandler, preParsingHookHandler, onResponseHookHandler, onSendHookHandler, onErrorHookHandler, onTimeoutHookHandler, onRequestAbortHookHandler } from './hooks'
+import { preValidationHookHandler, preHandlerHookHandler, preSerializationHookHandler, onRequestHookHandler, preParsingHookHandler, onResponseHookHandler, onSendHookHandler, onErrorHookHandler, onTimeoutHookHandler, onRequestAbortHookHandler, onRequestAsyncHookHandler } from './hooks'
 import { FastifyError } from '@fastify/error'
 import { FastifyContext } from './context'
 import {
@@ -50,7 +50,9 @@ export interface RouteShorthandOptions<
 
   // hooks
   onRequest?: onRequestHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  | onRequestHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
+  | onRequestHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[]
+  | onRequestAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+  | onRequestAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
   preParsing?: preParsingHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
   | preParsingHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
   preValidation?: preValidationHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>


### PR DESCRIPTION
#### Changes 
- missing types to routeShortHandOptions added
- added a fix for #4859 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
```
Suites:   ​128 passed​, ​128 of 128 completed​
Asserts:  ​​​6990 passed​, ​4 skip​, ​of 6994​
```
```
| Stat    | 2.5%  | 50% | 97.5% | 99%  | Avg      | Stdev    | Max  |
|---------|-------|-----|-------|------|----------|----------|------|
| Latency | 4 ms  | 9 ms| 12 ms | 14 ms| 7.83 ms  | 2.86 ms  | 62 ms|

| Stat      | 1%     | 2.5%   | 50%    | 97.5%  | Avg       | Stdev    | Min    |
|-----------|--------|--------|--------|--------|-----------|----------|--------|
| Req/Sec   | 104383 | 104383 | 121087 | 125119 | 119889.07 | 4897.82  | 104352 |
| Bytes/Sec | 19.6MB | 19.6MB | 22.8MB | 23.5MB | 22.5MB    | 922kB    | 19.6MB |

```

- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
