### PR TITLE
fix(typescript): route config should not pass url and method

### DIFF
--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -1,9 +1,9 @@
-import fastify, { FastifyInstance, FastifyRequest, FastifyReply, RouteHandlerMethod } from '../../fastify'
-import { expectType, expectError, expectAssignable, printType } from 'tsd'
-import { HTTPMethods } from '../../types/utils'
-import * as http from 'http'
-import { RequestPayload } from '../../types/hooks'
 import { FastifyError } from '@fastify/error'
+import * as http from 'http'
+import { expectAssignable, expectError, expectType } from 'tsd'
+import fastify, { FastifyInstance, FastifyReply, FastifyRequest, RouteHandlerMethod } from '../../fastify'
+import { RequestPayload } from '../../types/hooks'
+import { HTTPMethods } from '../../types/utils'
 
 /*
  * Testing Fastify HTTP Routes and Route Shorthands.
@@ -74,7 +74,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
     Headers: HeadersInterface;
   }
 
-  fastify()[lowerCaseMethod]<RouteGeneric, RouteSpecificContextConfigType>('/', { config: { foo: 'bar', bar: 100, extra: true, url: '/', method: lowerCaseMethod } }, (req, res) => {
+  fastify()[lowerCaseMethod]<RouteGeneric, RouteSpecificContextConfigType>('/', { config: { foo: 'bar', bar: 100, extra: true } }, (req, res) => {
     expectType<BodyInterface>(req.body)
     expectType<QuerystringInterface>(req.query)
     expectType<ParamsInterface>(req.params)
@@ -94,7 +94,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
   fastify().route<RouteGeneric>({
     url: '/',
     method: method as HTTPMethods,
-    config: { foo: 'bar', bar: 100, url: '/', method: method as HTTPMethods },
+    config: { foo: 'bar', bar: 100 },
     prefixTrailingSlash: 'slash',
     onRequest: (req, res, done) => { // these handlers are tested in `hooks.test-d.ts`
       expectType<BodyInterface>(req.body)
@@ -231,7 +231,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
   fastify().route<RouteGeneric>({
     url: '/',
     method: method as HTTPMethods,
-    config: { foo: 'bar', bar: 100, url: '/', method: method as HTTPMethods },
+    config: { foo: 'bar', bar: 100 },
     prefixTrailingSlash: 'slash',
     onRequest: async (req, res, done) => { // these handlers are tested in `hooks.test-d.ts`
       expectType<BodyInterface>(req.body)

--- a/types/context.d.ts
+++ b/types/context.d.ts
@@ -1,8 +1,7 @@
 import { ContextConfigDefault } from './utils'
-import { FastifyRouteConfig } from './route'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface FastifyContextConfig extends FastifyRouteConfig {
+export interface FastifyContextConfig {
 }
 
 /**

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -1,12 +1,12 @@
 import { Buffer } from 'buffer'
-import { FastifyContext } from './context'
+import { FastifyContext, FastifyContextConfig } from './context'
 import { FastifyInstance } from './instance'
 import { FastifyBaseLogger } from './logger'
 import { FastifyRequest } from './request'
-import { RouteGenericInterface } from './route'
+import { FastifyRouteConfig, RouteGenericInterface } from './route'
 import { FastifySchema } from './schema'
 import { FastifyReplyType, FastifyTypeProvider, FastifyTypeProviderDefault, ResolveFastifyReplyType } from './type-provider'
-import { CodeToReplyKey, ContextConfigDefault, ReplyKeysToCodes, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RawServerDefault, ReplyDefault } from './utils'
+import { CodeToReplyKey, ContextConfigDefault, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RawServerDefault, ReplyDefault, ReplyKeysToCodes } from './utils'
 
 export interface ReplyGenericInterface {
   Reply?: ReplyDefault;
@@ -32,7 +32,7 @@ export interface FastifyReply<
   ReplyType extends FastifyReplyType = ResolveFastifyReplyType<TypeProvider, SchemaCompiler, RouteGeneric>
 > {
   raw: RawReply;
-  context: FastifyContext<ContextConfig>;
+  context: Omit<FastifyContext<ContextConfig>, 'config'> & { config: FastifyContextConfig & ContextConfig & FastifyRouteConfig };
   log: FastifyBaseLogger;
   request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>;
   server: FastifyInstance;

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -1,11 +1,11 @@
 import { ErrorObject } from '@fastify/ajv-compiler'
-import { FastifyBaseLogger } from './logger'
-import { ContextConfigDefault, RawServerBase, RawServerDefault, RawRequestDefaultExpression, RequestBodyDefault, RequestQuerystringDefault, RequestParamsDefault, RequestHeadersDefault } from './utils'
-import { RouteGenericInterface } from './route'
-import { FastifyInstance } from './instance'
-import { FastifyTypeProvider, FastifyTypeProviderDefault, FastifyRequestType, ResolveFastifyRequestType } from './type-provider'
-import { FastifySchema } from './schema'
 import { FastifyContext, FastifyContextConfig } from './context'
+import { FastifyInstance } from './instance'
+import { FastifyBaseLogger } from './logger'
+import { FastifyRouteConfig, RouteGenericInterface } from './route'
+import { FastifySchema } from './schema'
+import { FastifyRequestType, FastifyTypeProvider, FastifyTypeProviderDefault, ResolveFastifyRequestType } from './type-provider'
+import { ContextConfigDefault, RawRequestDefaultExpression, RawServerBase, RawServerDefault, RequestBodyDefault, RequestHeadersDefault, RequestParamsDefault, RequestQuerystringDefault } from './utils'
 
 type HTTPRequestPart = 'body' | 'query' | 'querystring' | 'params' | 'headers'
 export interface RequestGenericInterface {
@@ -58,8 +58,8 @@ export interface FastifyRequest<RouteGeneric extends RouteGenericInterface = Rou
   log: Logger;
   server: FastifyInstance;
   body: RequestType['body'];
-  context: FastifyContext<ContextConfig>;
-  routeConfig: FastifyContextConfig & ContextConfig;
+  context: Omit<FastifyContext<ContextConfig>, 'config'> & { config: FastifyContextConfig & ContextConfig & FastifyRouteConfig };
+  routeConfig: FastifyContextConfig & ContextConfig & FastifyRouteConfig;
   routeSchema: FastifySchema
 
   /** in order for this to be used the user should ensure they have set the attachValidation option. */


### PR DESCRIPTION
#4850 is actually forcing people to define `url` and `method` in `config` which shouldn't.
This PR fixes the behavior and still provide correct types for `request.context.config` and `request.routeConfig`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
