### PR TITLE
Overload `DecorationMethod` to fix #4870

### DIFF
--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -315,6 +315,8 @@ server.decorate<string>('test', {
     expectType<FastifyInstance>(this)
   }
 })
+server.decorate('test')
+server.decorate('test', null, ['foo'])
 
 server.decorateRequest<(x: string, y: number) => void>('test', function (x: string, y: number): void {
   expectType<FastifyRequest>(this)
@@ -365,6 +367,9 @@ server.decorate('typedTestProperty', {
     expectType<FastifyInstance>(this)
   }
 })
+server.decorate('typedTestProperty')
+server.decorate('typedTestProperty', null, ['foo'])
+expectError(server.decorate('typedTestProperty', null))
 expectError(server.decorate('typedTestProperty', 'foo'))
 expectError(server.decorate('typedTestProperty', {
   getter () {

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -103,6 +103,10 @@ type DecorationMethod<This, Return = This> = {
     >,
     dependencies?: string[]
   ): Return;
+
+  (property: string | symbol): Return;
+
+  (property: string | symbol, value: null|undefined, dependencies: string[]): Return;
 }
 
 /**


### PR DESCRIPTION
Overloads `DecorationMethod` to fix #4870.

Adds two overloads:

* Plain `app.decorateRequest('something')` as suggested by @mcollina in https://github.com/fastify/fastify/issues/4870#issuecomment-1617739486
* An `app.decorateRequest('something', null, ['something-else'])` (as confirmed needed in https://github.com/fastify/fastify/issues/4870#issuecomment-1617772218). `undefined` and `null` are both accepted then

Notably is:

* `app.decorateRequest('something', null)` is still not allowed if `something` is typed to not allow `null`

I think this is a good compromise? Thoughts @climba03003, @trim21?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests and/or benchmarks are included
- [x] ~~documentation is changed or added~~
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
