### PR TITLE
Next: Disallow `decorate('name', null)` in the types

### DIFF
--- a/docs/Guides/Delay-Accepting-Requests.md
+++ b/docs/Guides/Delay-Accepting-Requests.md
@@ -103,7 +103,7 @@ server.get('/v1*', async function (request, reply) {
   }
 })
 
-server.decorate('magicKey', null)
+server.decorate('magicKey')
 
 server.listen({ port: '1234' }, () => {
   provider.thirdPartyMagicKeyGenerator(USUAL_WAIT_TIME_MS)
@@ -303,7 +303,7 @@ async function setup(fastify) {
   fastify.server.on('listening', doMagic)
 
   // Set up the placeholder for the magicKey
-  fastify.decorate('magicKey', null)
+  fastify.decorate('magicKey')
 
   // Our magic -- important to make sure errors are handled. Beware of async
   // functions outside `try/catch` blocks
@@ -406,7 +406,7 @@ https://nodejs.org/api/net.html#event-listening). We use that to reach out to
 our provider as soon as possible, with the `doMagic` function.
 
 ```js
-  fastify.decorate('magicKey', null)
+  fastify.decorate('magicKey')
 ```
 
 The `magicKey` decoration is also part of the plugin now. We initialize it with

--- a/docs/Reference/Decorators.md
+++ b/docs/Reference/Decorators.md
@@ -193,7 +193,7 @@ hook](./Hooks.md#onrequest). Example:
 const fp = require('fastify-plugin')
 
 async function myPlugin (app) {
-  app.decorateRequest('foo', null)
+  app.decorateRequest('foo')
   app.addHook('onRequest', async (req, reply) => {
     req.foo = { bar: 42 }
   })
@@ -236,7 +236,7 @@ incoming request in the [`'onRequest'` hook](./Hooks.md#onrequest). Example:
 const fp = require('fastify-plugin')
 
 async function myPlugin (app) {
-  app.decorateRequest('foo', null)
+  app.decorateRequest('foo')
   app.addHook('onRequest', async (req, reply) => {
     req.foo = { bar: 42 }
   })

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -386,7 +386,7 @@ server.decorate('typedTestProperty', {
 })
 server.decorate('typedTestProperty')
 server.decorate('typedTestProperty', null, ['foo'])
-server.decorate('typedTestProperty', null)
+expectError(server.decorate('typedTestProperty', null))
 expectError(server.decorate('typedTestProperty', 'foo'))
 expectError(server.decorate('typedTestProperty', {
   getter () {
@@ -426,7 +426,7 @@ server.decorateRequest('typedTestRequestProperty', {
 })
 server.decorateRequest('typedTestRequestProperty')
 server.decorateRequest('typedTestRequestProperty', null, ['foo'])
-server.decorateRequest('typedTestRequestProperty', null)
+expectError(server.decorateRequest('typedTestRequestProperty', null))
 expectError(server.decorateRequest('typedTestRequestProperty', 'foo'))
 expectError(server.decorateRequest('typedTestRequestProperty', {
   getter () {
@@ -466,7 +466,7 @@ server.decorateReply('typedTestReplyProperty', {
 })
 server.decorateReply('typedTestReplyProperty')
 server.decorateReply('typedTestReplyProperty', null, ['foo'])
-server.decorateReply('typedTestReplyProperty', null)
+expectError(server.decorateReply('typedTestReplyProperty', null))
 expectError(server.decorateReply('typedTestReplyProperty', 'foo'))
 expectError(server.decorateReply('typedTestReplyProperty', {
   getter () {

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -106,8 +106,6 @@ type DecorationMethod<This, Return = This> = {
 
   (property: string | symbol): Return;
 
-  (property: string | symbol, value: null): Return;
-
   (property: string | symbol, value: null|undefined, dependencies: string[]): Return;
 }
 


### PR DESCRIPTION
Follow up to #4874

Preferred to use `decorate('name')` , `decorateRequest('name')`, `decorateReply('name')` variants instead

Deprecation prior to dropping is not feasible because of https://github.com/microsoft/TypeScript/issues/54872

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [x] documentation is changed
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
