### PR TITLE
Fixed type inference on .code().send()

### DIFF
--- a/test/types/reply.test-d.ts
+++ b/test/types/reply.test-d.ts
@@ -72,6 +72,7 @@ interface ReplyHttpCodes {
 
 const typedHandler: RouteHandler<ReplyPayload> = async (request, reply) => {
   expectType<((payload?: ReplyPayload['Reply']) => FastifyReply<RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>, ReplyPayload>)>(reply.send)
+  expectType<((payload?: ReplyPayload['Reply']) => FastifyReply<RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>, ReplyPayload>)>(reply.code(100).send)
 }
 
 const server = fastify()

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -16,7 +16,7 @@ type ReplyTypeConstrainer<RouteGenericReply, Code extends ReplyKeysToCodes<keyof
   Code extends keyof RouteGenericReply ? RouteGenericReply[Code] :
     [ReplyKey] extends [never] ? unknown :
       ReplyKey extends keyof RouteGenericReply ? RouteGenericReply[ReplyKey] :
-        unknown;
+        RouteGenericReply;
 
 export type ResolveReplyTypeWithRouteGeneric<RouteGenericReply, Code extends ReplyKeysToCodes<keyof RouteGenericReply>,
   SchemaCompiler extends FastifySchema = FastifySchema,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

An instance where the Reply generic was defined without HttpCodes as keys, would break type inference when .code().send were being chained. For example:
```typescript
fastify.get<{ Reply: string }>('/path', (req, reply) => {
  reply.code(123).send(23); // <-- this was not showing an error, when it should've
})
```
Fixed and added a test.
