### PR TITLE
fix: ReplyTypeConstrainer array type inference

### DIFF
--- a/test/types/reply.test-d.ts
+++ b/test/types/reply.test-d.ts
@@ -53,6 +53,10 @@ interface ReplyPayload {
   };
 }
 
+interface ReplyArrayPayload {
+  Reply: string[]
+}
+
 interface ReplyUnion {
   Reply: {
     success: boolean;
@@ -137,3 +141,6 @@ expectError(server.get<ReplyHttpCodes>('/get-generic-http-codes-send-error-4', a
 expectError(server.get<ReplyHttpCodes>('/get-generic-http-codes-send-error-5', async function handler (request, reply) {
   reply.code(401).send({ foo: 123 })
 }))
+server.get<ReplyArrayPayload>('/get-generic-array-send', async function handler (request, reply) {
+  reply.code(200).send([''])
+})

--- a/test/types/reply.test-d.ts
+++ b/test/types/reply.test-d.ts
@@ -74,6 +74,14 @@ interface ReplyHttpCodes {
   }
 }
 
+interface InvalidReplyHttpCodes {
+  Reply: {
+    '1xx': number,
+    200: string,
+    999: boolean,
+  }
+}
+
 const typedHandler: RouteHandler<ReplyPayload> = async (request, reply) => {
   expectType<((payload?: ReplyPayload['Reply']) => FastifyReply<RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>, ReplyPayload>)>(reply.send)
   expectType<((payload?: ReplyPayload['Reply']) => FastifyReply<RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>, ReplyPayload>)>(reply.code(100).send)
@@ -143,4 +151,14 @@ expectError(server.get<ReplyHttpCodes>('/get-generic-http-codes-send-error-5', a
 }))
 server.get<ReplyArrayPayload>('/get-generic-array-send', async function handler (request, reply) {
   reply.code(200).send([''])
+})
+expectError(server.get<InvalidReplyHttpCodes>('get-invalid-http-codes-reply-error', async function handler (request, reply) {
+  reply.code(200).send('')
+}))
+server.get<InvalidReplyHttpCodes>('get-invalid-http-codes-reply-error', async function handler (request, reply) {
+  reply.code(200).send({
+    '1xx': 0,
+    200: '',
+    999: false
+  })
 })

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -6,16 +6,19 @@ import { FastifyRequest } from './request'
 import { RouteGenericInterface } from './route'
 import { FastifySchema } from './schema'
 import { FastifyReplyType, FastifyTypeProvider, FastifyTypeProviderDefault, ResolveFastifyReplyType } from './type-provider'
-import { CodeToReplyKey, ContextConfigDefault, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RawServerDefault, ReplyDefault, ReplyKeysToCodes } from './utils'
+import { CodeToReplyKey, ContextConfigDefault, HttpKeys, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RawServerDefault, ReplyDefault, ReplyKeysToCodes } from './utils'
 
 export interface ReplyGenericInterface {
   Reply?: ReplyDefault;
 }
 
+type HttpCodesReplyType = Partial<Record<HttpKeys, unknown>>
+
 type ReplyTypeConstrainer<RouteGenericReply, Code extends ReplyKeysToCodes<keyof RouteGenericReply>> =
-  RouteGenericReply extends Record<Code, unknown> ? RouteGenericReply[Code] :
-    RouteGenericReply extends Record<CodeToReplyKey<Code>, unknown> ? RouteGenericReply[CodeToReplyKey<Code>] :
-      RouteGenericReply;
+  RouteGenericReply extends HttpCodesReplyType & Record<Exclude<keyof RouteGenericReply, keyof HttpCodesReplyType>, never> ?
+    Code extends keyof RouteGenericReply ? Required<RouteGenericReply[Code]> :
+      CodeToReplyKey<Code> extends keyof RouteGenericReply ? Required<RouteGenericReply[CodeToReplyKey<Code>]> : unknown :
+    RouteGenericReply;
 
 export type ResolveReplyTypeWithRouteGeneric<RouteGenericReply, Code extends ReplyKeysToCodes<keyof RouteGenericReply>,
   SchemaCompiler extends FastifySchema = FastifySchema,

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -16,8 +16,8 @@ type HttpCodesReplyType = Partial<Record<HttpKeys, unknown>>
 
 type ReplyTypeConstrainer<RouteGenericReply, Code extends ReplyKeysToCodes<keyof RouteGenericReply>> =
   RouteGenericReply extends HttpCodesReplyType & Record<Exclude<keyof RouteGenericReply, keyof HttpCodesReplyType>, never> ?
-    Code extends keyof RouteGenericReply ? Required<RouteGenericReply[Code]> :
-      CodeToReplyKey<Code> extends keyof RouteGenericReply ? Required<RouteGenericReply[CodeToReplyKey<Code>]> : unknown :
+    Code extends keyof RouteGenericReply ? RouteGenericReply[Code] :
+      CodeToReplyKey<Code> extends keyof RouteGenericReply ? RouteGenericReply[CodeToReplyKey<Code>] : unknown :
     RouteGenericReply;
 
 export type ResolveReplyTypeWithRouteGeneric<RouteGenericReply, Code extends ReplyKeysToCodes<keyof RouteGenericReply>,

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -12,11 +12,10 @@ export interface ReplyGenericInterface {
   Reply?: ReplyDefault;
 }
 
-type ReplyTypeConstrainer<RouteGenericReply, Code extends ReplyKeysToCodes<keyof RouteGenericReply>, ReplyKey = CodeToReplyKey<Code>> =
-  Code extends keyof RouteGenericReply ? RouteGenericReply[Code] :
-    [ReplyKey] extends [never] ? unknown :
-      ReplyKey extends keyof RouteGenericReply ? RouteGenericReply[ReplyKey] :
-        RouteGenericReply;
+type ReplyTypeConstrainer<RouteGenericReply, Code extends ReplyKeysToCodes<keyof RouteGenericReply>> =
+  RouteGenericReply extends Record<Code, unknown> ? RouteGenericReply[Code] :
+    RouteGenericReply extends Record<CodeToReplyKey<Code>, unknown> ? RouteGenericReply[CodeToReplyKey<Code>] :
+      RouteGenericReply;
 
 export type ResolveReplyTypeWithRouteGeneric<RouteGenericReply, Code extends ReplyKeysToCodes<keyof RouteGenericReply>,
   SchemaCompiler extends FastifySchema = FastifySchema,


### PR DESCRIPTION
Closes #4883

As @aadito123 mentioned on the issue, there's a pitfall here: if someone wants the Reply type to be an object with keys as http codes like `{ 401: string, 409: string }`, the inference of the return type will be `string`. A possible workaround for this case would be `{ '4xx':  { 401: string, 409: string } }`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
