### PR TITLE
ci: enable caching; split jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,9 @@ jobs:
           NODE_OPTIONS: no-network-family-autoselection
 
   package:
-    needs: test
+    needs:
+      - test-typescript
+      - test-unit
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,13 @@ jobs:
           node-version: 'lts/*'
 
       - uses: actions/cache@v3
-        id: check-cache
+        id: npm-cache
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-lts-${{ hashFiles('**/package.json') }}
 
       - name: Install
+        if: ${{ steps.npm-cache.outputs.cache-hit != 'true' }}
         run: |
           npm install --ignore-scripts
 
@@ -81,12 +82,13 @@ jobs:
           node-version: 'lts/*'
 
       - uses: actions/cache@v3
-        id: check-cache
+        id: npm-cache
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-lts-${{ hashFiles('**/package.json') }}
 
       - name: Install
+        if: ${{ steps.npm-cache.outputs.cache-hit != 'true' }}
         run: |
           npm install --ignore-scripts
 
@@ -135,12 +137,13 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - uses: actions/cache@v3
-        id: check-cache
+        id: npm-cache
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package.json') }}
 
       - name: Install
+        if: ${{ steps.npm-cache.outputs.cache-hit != 'true' }}
         run: |
           npm install --ignore-scripts
 
@@ -155,7 +158,7 @@ jobs:
       - lint
       - coverage-nix
       - coverage-win
-    runs-on: 'ubuntu-latets'
+    runs-on: 'ubuntu-latest'
     permissions:
       contents: read
 
@@ -169,12 +172,13 @@ jobs:
           node-version: '20'
 
       - uses: actions/cache@v3
-        id: check-cache
+        id: npm-cache
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-20-${{ hashFiles('**/package.json') }}
 
       - name: Install
+        if: ${{ steps.npm-cache.outputs.cache-hit != 'true' }}
         run: |
           npm install --ignore-scripts
 
@@ -200,11 +204,12 @@ jobs:
         with:
           node-version: 'lts/*'
       - uses: actions/cache@v3
-        id: check-cache
+        id: npm-cache
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-lts-${{ hashFiles('**/package.json') }}
       - name: install fastify
+        if: ${{ steps.npm-cache.outputs.cache-hit != 'true' }}
         run: |
           npm install --ignore-scripts
       - name: install webpack stack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
           key: ${{ runner.os }}-node-lts-${{ hashFiles('**/package.json') }}
 
       - name: Install
-        if: ${{ steps.npm-cache.outputs.cache-hit != 'true' }}
         run: |
           npm install --ignore-scripts
 
@@ -88,7 +87,6 @@ jobs:
           key: ${{ runner.os }}-node-lts-${{ hashFiles('**/package.json') }}
 
       - name: Install
-        if: ${{ steps.npm-cache.outputs.cache-hit != 'true' }}
         run: |
           npm install --ignore-scripts
 
@@ -143,7 +141,6 @@ jobs:
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package.json') }}
 
       - name: Install
-        if: ${{ steps.npm-cache.outputs.cache-hit != 'true' }}
         run: |
           npm install --ignore-scripts
 
@@ -178,7 +175,6 @@ jobs:
           key: ${{ runner.os }}-node-20-${{ hashFiles('**/package.json') }}
 
       - name: Install
-        if: ${{ steps.npm-cache.outputs.cache-hit != 'true' }}
         run: |
           npm install --ignore-scripts
 
@@ -209,7 +205,6 @@ jobs:
           path: ~/.npm
           key: ${{ runner.os }}-node-lts-${{ hashFiles('**/package.json') }}
       - name: install fastify
-        if: ${{ steps.npm-cache.outputs.cache-hit != 'true' }}
         run: |
           npm install --ignore-scripts
       - name: install webpack stack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
-
-      - uses: actions/cache@v3
-        id: npm-cache
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-lts-${{ hashFiles('**/package.json') }}
+          cache: 'npm'
+          cache-dependency-path: package.json
 
       - name: Install
         run: |
@@ -79,12 +75,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
-
-      - uses: actions/cache@v3
-        id: npm-cache
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-lts-${{ hashFiles('**/package.json') }}
+          cache: 'npm'
+          cache-dependency-path: package.json
 
       - name: Install
         run: |
@@ -133,12 +125,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-
-      - uses: actions/cache@v3
-        id: npm-cache
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package.json') }}
+          cache: 'npm'
+          cache-dependency-path: package.json
 
       - name: Install
         run: |
@@ -167,12 +155,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '20'
-
-      - uses: actions/cache@v3
-        id: npm-cache
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-20-${{ hashFiles('**/package.json') }}
+          cache: 'npm'
+          cache-dependency-path: package.json
 
       - name: Install
         run: |
@@ -199,11 +183,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
-      - uses: actions/cache@v3
-        id: npm-cache
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-lts-${{ hashFiles('**/package.json') }}
+          cache: 'npm'
+          cache-dependency-path: package.json
       - name: install fastify
         run: |
           npm install --ignore-scripts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,8 @@ jobs:
         github.event_name == 'pull_request' &&
         github.event.pull_request.user.login == 'dependabot[bot]'
     needs: 
-      - test
+      - test-typescript
+      - test-unit
       - package
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
           - name: Dependency review
             uses: actions/dependency-review-action@v3
 
-  linter:
+  check-licenses:
+    name: Check licenses
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -50,6 +51,41 @@ jobs:
         with:
           node-version: 'lts/*'
 
+      - uses: actions/cache@v3
+        id: check-cache
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-lts-${{ hashFiles('**/package.json') }}
+
+      - name: Install
+        run: |
+          npm install --ignore-scripts
+
+      - name: Check licenses
+        run: |
+          npm run license-checker
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+
+      - uses: actions/cache@v3
+        id: check-cache
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-lts-${{ hashFiles('**/package.json') }}
+
       - name: Install
         run: |
           npm install --ignore-scripts
@@ -59,18 +95,22 @@ jobs:
           npm run lint
 
   coverage-nix:
-    needs: linter
+    needs: lint
     permissions:
       contents: read
     uses: ./.github/workflows/coverage-nix.yml
+
   coverage-win:
-    needs: linter
+    needs: lint
     permissions:
       contents: read
     uses: ./.github/workflows/coverage-win.yml
 
-  test:
-    needs: [linter, coverage-nix, coverage-win]
+  test-unit:
+    needs: 
+      - lint
+      - coverage-nix
+      - coverage-win
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -99,36 +139,50 @@ jobs:
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-
 
       - name: Install
         run: |
           npm install --ignore-scripts
 
-      - name: Check licenses
-        run: |
-          npm run license-checker
-
       - name: Run tests
         run: |
-          npm run test:ci
+          npm run unit
         env:
           NODE_OPTIONS: no-network-family-autoselection 
 
-  automerge:
-    if: >
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.user.login == 'dependabot[bot]'
-    needs: test
-    runs-on: ubuntu-latest
+  test-typescript:
+    needs: 
+      - lint
+      - coverage-nix
+      - coverage-win
+    runs-on: 'ubuntu-latets'
     permissions:
-      pull-requests: write
-      contents: write
+      contents: read
+
     steps:
-      - uses: fastify/github-action-merge-dependabot@v3
+      - uses: actions/checkout@v3
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - uses: actions/cache@v3
+        id: check-cache
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-20-${{ hashFiles('**/package.json') }}
+
+      - name: Install
+        run: |
+          npm install --ignore-scripts
+
+      - name: Run typescript tests
+        run: |
+          npm run test:typescript
+        env:
+          NODE_OPTIONS: no-network-family-autoselection
 
   package:
     needs: test
@@ -147,9 +201,7 @@ jobs:
         id: check-cache
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          key: ${{ runner.os }}-node-lts-${{ hashFiles('**/package.json') }}
       - name: install fastify
         run: |
           npm install --ignore-scripts
@@ -165,3 +217,19 @@ jobs:
       - name: Test esbuild bundle
         run: |
           cd test/bundler/esbuild && npm run test
+
+  automerge:
+    if: >
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.user.login == 'dependabot[bot]'
+    needs: 
+      - test
+      - package
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coverage-nix.yml
+++ b/.github/workflows/coverage-nix.yml
@@ -16,14 +16,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
-
-      - uses: actions/cache@v3
-        id: check-cache
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: 'npm'
+          cache-dependency-path: package.json
 
       - name: Install
         run: |

--- a/.github/workflows/coverage-win.yml
+++ b/.github/workflows/coverage-win.yml
@@ -16,14 +16,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
-
-      - uses: actions/cache@v3
-        id: check-cache
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: 'npm'
+          cache-dependency-path: package.json
 
       - name: Install
         run: |


### PR DESCRIPTION
Using now caching by setup-node, which is ensuring, that we cache properly. E.g. currently caching on windows machines was not happening, because the npm cache is not on ~/npm on windows. 

Split some jobs like linter and typescript tests, as they only need to run once and it is enough that they run on lts of node. 

automerge is running after package tests succeeded.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
