### PR TITLE
fix: rework FastifyErrors, ensure documentation completeness

### DIFF
--- a/docs/Reference/Errors.md
+++ b/docs/Reference/Errors.md
@@ -168,8 +168,6 @@ ajv.plugins option should be an array.
 
 Version constraint should be a string.
 
-<a name="FST_ERR_CTP_ALREADY_PRESENT"></a>
-
 #### FST_ERR_CTP_ALREADY_PRESENT
 <a id="FST_ERR_CTP_ALREADY_PRESENT"></a>
 
@@ -260,6 +258,11 @@ The hook name must be a string.
 
 The hook callback must be a function.
 
+#### FST_ERR_HOOK_INVALID_ASYNC_HANDLER
+<a id="FST_ERR_HOOK_INVALID_ASYNC_HANDLER"></a>
+
+Async function has too many arguments. Async hooks should not use the `done` argument.
+
 #### FST_ERR_HOOK_NOT_SUPPORTED
 <a id="FST_ERR_HOOK_NOT_SUPPORTED"></a>
 
@@ -271,8 +274,8 @@ The hook is not supported.
 You must register a plugin for handling middlewares,
 visit [`Middleware`](./Middleware.md) for more info.
 
-<a name="FST_ERR_HOOK_TIMEOUT"></a>
 #### FST_ERR_HOOK_TIMEOUT
+<a id="FST_ERR_HOOK_TIMEOUT"></a>
 
 A callback for a hook timed out
 
@@ -327,8 +330,18 @@ Called `reply.trailer` with an invalid header name.
 
 Called `reply.trailer` with an invalid type. Expected a function.
 
+#### FST_ERR_FAILED_ERROR_SERIALIZATION
+<a id="FST_ERR_FAILED_ERROR_SERIALIZATION"></a>
+
+Failed to serialize an error.
+
 #### FST_ERR_MISSING_SERIALIZATION_FN
 <a id="FST_ERR_MISSING_SERIALIZATION_FN"></a>
+
+Missing serialization function.
+
+#### FST_ERR_MISSING_CONTENTTYPE_SERIALIZATION_FN
+<a id="FST_ERR_MISSING_CONTENTTYPE_SERIALIZATION_FN"></a>
 
 Missing serialization function.
 
@@ -347,6 +360,11 @@ The schema provided does not have `$id` property.
 <a id="FST_ERR_SCH_ALREADY_PRESENT"></a>
 
 A schema with the same `$id` already exists.
+
+#### FST_ERR_SCH_CONTENT_MISSING_SCHEMA
+<a id="FST_ERR_SCH_CONTENT_MISSING_SCHEMA"></a>
+
+A schema is missing for the corresponding content type.
 
 #### FST_ERR_SCH_DUPLICATE
 <a id="FST_ERR_SCH_DUPLICATE"></a>
@@ -384,8 +402,8 @@ Invalid initialization options.
 Cannot set forceCloseConnections to `idle` as your HTTP server
 does not support `closeIdleConnections` method.
 
-<a name="FST_ERR_DUPLICATED_ROUTE"></a>
 #### FST_ERR_DUPLICATED_ROUTE
+<a id="FST_ERR_DUPLICATED_ROUTE"></a>
 
 The HTTP method already has a registered controller for that URL
 
@@ -394,7 +412,7 @@ The HTTP method already has a registered controller for that URL
 
 The router received an invalid url.
 
-### FST_ERR_ASYNC_CONSTRAINT
+#### FST_ERR_ASYNC_CONSTRAINT
 <a id="FST_ERR_ASYNC_CONSTRAINT"></a>
 
 The router received an error when using asynchronous constraints.
@@ -469,44 +487,37 @@ Fastify is already listening.
 
 Installed Fastify plugin mismatched expected version.
 
-<a name="FST_ERR_PLUGIN_CALLBACK_NOT_FN"></a>
-
 #### FST_ERR_PLUGIN_CALLBACK_NOT_FN
+<a id="FST_ERR_PLUGIN_CALLBACK_NOT_FN"></a>
 
 Callback for a hook is not a function (mapped directly from `avvio`)
 
-<a name="FST_ERR_PLUGIN_NOT_VALID"></a>
-
 #### FST_ERR_PLUGIN_NOT_VALID
+<a id="FST_ERR_PLUGIN_NOT_VALID"></a>
 
 Plugin must be a function or a promise.
 
-<a name="FST_ERR_ROOT_PLG_BOOTED"></a>
-
 #### FST_ERR_ROOT_PLG_BOOTED
+<a id="FST_ERR_ROOT_PLG_BOOTED"></a>
 
 Root plugin has already booted (mapped directly from `avvio`)
 
-<a name="FST_ERR_PARENT_PLUGIN_BOOTED"></a>
-
 #### FST_ERR_PARENT_PLUGIN_BOOTED
+<a id="FST_ERR_PARENT_PLUGIN_BOOTED"></a>
 
 Impossible to load plugin because the parent (mapped directly from `avvio`)
 
-<a name="FST_ERR_PLUGIN_TIMEOUT"></a>
-
 #### FST_ERR_PLUGIN_TIMEOUT
+<a id="FST_ERR_PLUGIN_TIMEOUT"></a>
 
 Plugin did not start in time. Default timeout (in millis): `10000`
 
-<a name="FST_ERR_PLUGIN_NOT_PRESENT_IN_INSTANCE"></a>
-
 #### FST_ERR_PLUGIN_NOT_PRESENT_IN_INSTANCE
+<a id="FST_ERR_PLUGIN_NOT_PRESENT_IN_INSTANCE"></a>
 
 The decorator is not present in the instance.
 
-<a name="FST_ERR_VALIDATION"></a>
-
 #### FST_ERR_VALIDATION
+<a id="FST_ERR_VALIDATION"></a>
 
 The Request failed the payload validation.

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -20,32 +20,38 @@ const codes = {
   FST_ERR_QSP_NOT_FN: createError(
     'FST_ERR_QSP_NOT_FN',
     "querystringParser option should be a function, instead got '%s'",
-    500
+    500,
+    TypeError
   ),
   FST_ERR_SCHEMA_CONTROLLER_BUCKET_OPT_NOT_FN: createError(
     'FST_ERR_SCHEMA_CONTROLLER_BUCKET_OPT_NOT_FN',
     "schemaController.bucket option should be a function, instead got '%s'",
-    500
+    500,
+    TypeError
   ),
   FST_ERR_SCHEMA_ERROR_FORMATTER_NOT_FN: createError(
     'FST_ERR_SCHEMA_ERROR_FORMATTER_NOT_FN',
     "schemaErrorFormatter option should be a non async function. Instead got '%s'.",
-    500
+    500,
+    TypeError
   ),
   FST_ERR_AJV_CUSTOM_OPTIONS_OPT_NOT_OBJ: createError(
     'FST_ERR_AJV_CUSTOM_OPTIONS_OPT_NOT_OBJ',
-    "sajv.customOptions option should be an object, instead got '%s'",
-    500
+    "ajv.customOptions option should be an object, instead got '%s'",
+    500,
+    TypeError
   ),
   FST_ERR_AJV_CUSTOM_OPTIONS_OPT_NOT_ARR: createError(
     'FST_ERR_AJV_CUSTOM_OPTIONS_OPT_NOT_ARR',
-    "sajv.plugins option should be an array, instead got '%s'",
-    500
+    "ajv.plugins option should be an array, instead got '%s'",
+    500,
+    TypeError
   ),
   FST_ERR_VERSION_CONSTRAINT_NOT_STR: createError(
     'FST_ERR_VERSION_CONSTRAINT_NOT_STR',
     'Version constraint should be a string.',
-    500
+    500,
+    TypeError
   ),
   FST_ERR_VALIDATION: createError(
     'FST_ERR_VALIDATION',
@@ -121,7 +127,9 @@ const codes = {
   ),
   FST_ERR_DEC_DEPENDENCY_INVALID_TYPE: createError(
     'FST_ERR_DEC_DEPENDENCY_INVALID_TYPE',
-    "The dependencies of decorator '%s' must be of type Array."
+    "The dependencies of decorator '%s' must be of type Array.",
+    500,
+    TypeError
   ),
   FST_ERR_DEC_MISSING_DEPENDENCY: createError(
     'FST_ERR_DEC_MISSING_DEPENDENCY',
@@ -184,7 +192,9 @@ const codes = {
 
   FST_ERR_LOG_INVALID_LOGGER: createError(
     'FST_ERR_LOG_INVALID_LOGGER',
-    "Invalid logger object provided. The logger instance should have these functions(s): '%s'."
+    "Invalid logger object provided. The logger instance should have these functions(s): '%s'.",
+    500,
+    TypeError
   ),
 
   /**
@@ -202,7 +212,9 @@ const codes = {
   ),
   FST_ERR_REP_SENT_VALUE: createError(
     'FST_ERR_REP_SENT_VALUE',
-    'The only possible value for reply.sent is true.'
+    'The only possible value for reply.sent is true.',
+    500,
+    TypeError
   ),
   FST_ERR_SEND_INSIDE_ONERR: createError(
     'FST_ERR_SEND_INSIDE_ONERR',
@@ -303,7 +315,8 @@ const codes = {
   FST_ERR_BAD_URL: createError(
     'FST_ERR_BAD_URL',
     "'%s' is not a valid url component",
-    400
+    400,
+    URIError
   ),
   FST_ERR_ASYNC_CONSTRAINT: createError(
     'FST_ERR_ASYNC_CONSTRAINT',
@@ -319,12 +332,14 @@ const codes = {
   FST_ERR_INVALID_URL: createError(
     'FST_ERR_INVALID_URL',
     "URL must be a string. Received '%s'",
-    400
+    500,
+    TypeError
   ),
   FST_ERR_ROUTE_OPTIONS_NOT_OBJ: createError(
     'FST_ERR_ROUTE_OPTIONS_NOT_OBJ',
     'Options for "%s:%s" route must be an object',
-    500
+    500,
+    TypeError
   ),
   FST_ERR_ROUTE_DUPLICATED_HANDLER: createError(
     'FST_ERR_ROUTE_DUPLICATED_HANDLER',
@@ -334,7 +349,8 @@ const codes = {
   FST_ERR_ROUTE_HANDLER_NOT_FN: createError(
     'FST_ERR_ROUTE_HANDLER_NOT_FN',
     'Error Handler for %s:%s route, if defined, must be a function',
-    500
+    500,
+    TypeError
   ),
   FST_ERR_ROUTE_MISSING_HANDLER: createError(
     'FST_ERR_ROUTE_MISSING_HANDLER',
@@ -344,7 +360,8 @@ const codes = {
   FST_ERR_ROUTE_METHOD_INVALID: createError(
     'FST_ERR_ROUTE_METHOD_INVALID',
     'Provided method is invalid!',
-    500
+    500,
+    TypeError
   ),
   FST_ERR_ROUTE_METHOD_NOT_SUPPORTED: createError(
     'FST_ERR_ROUTE_METHOD_NOT_SUPPORTED',
@@ -365,7 +382,8 @@ const codes = {
   FST_ERR_ROUTE_REWRITE_NOT_STR: createError(
     'FST_ERR_ROUTE_REWRITE_NOT_STR',
     'Rewrite url for "%s" needs to be of type "string" but received "%s"',
-    500
+    500,
+    TypeError
   ),
 
   /**
@@ -401,7 +419,9 @@ const codes = {
    */
   FST_ERR_PLUGIN_CALLBACK_NOT_FN: createError(
     'FST_ERR_PLUGIN_CALLBACK_NOT_FN',
-    'fastify-plugin: %s'
+    'fastify-plugin: %s',
+    500,
+    TypeError
   ),
   FST_ERR_PLUGIN_NOT_VALID: createError(
     'FST_ERR_PLUGIN_NOT_VALID',

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -332,7 +332,7 @@ const codes = {
   FST_ERR_INVALID_URL: createError(
     'FST_ERR_INVALID_URL',
     "URL must be a string. Received '%s'",
-    500,
+    400,
     TypeError
   ),
   FST_ERR_ROUTE_OPTIONS_NOT_OBJ: createError(

--- a/test/internals/errors.test.js
+++ b/test/internals/errors.test.js
@@ -593,7 +593,7 @@ test('FST_ERR_INVALID_URL', t => {
   t.equal(error.name, 'FastifyError')
   t.equal(error.code, 'FST_ERR_INVALID_URL')
   t.equal(error.message, "URL must be a string. Received '%s'")
-  t.equal(error.statusCode, 500)
+  t.equal(error.statusCode, 400)
   t.ok(error instanceof TypeError)
 })
 

--- a/test/internals/errors.test.js
+++ b/test/internals/errors.test.js
@@ -2,6 +2,8 @@
 
 const { test } = require('tap')
 const errors = require('../../lib/errors')
+const { readFileSync } = require('fs')
+const { resolve } = require('path')
 
 test('should expose 77 errors', t => {
   t.plan(1)
@@ -52,7 +54,7 @@ test('FST_ERR_QSP_NOT_FN', t => {
   t.equal(error.code, 'FST_ERR_QSP_NOT_FN')
   t.equal(error.message, "querystringParser option should be a function, instead got '%s'")
   t.equal(error.statusCode, 500)
-  t.ok(error instanceof Error)
+  t.ok(error instanceof TypeError)
 })
 
 test('FST_ERR_SCHEMA_CONTROLLER_BUCKET_OPT_NOT_FN', t => {
@@ -62,7 +64,7 @@ test('FST_ERR_SCHEMA_CONTROLLER_BUCKET_OPT_NOT_FN', t => {
   t.equal(error.code, 'FST_ERR_SCHEMA_CONTROLLER_BUCKET_OPT_NOT_FN')
   t.equal(error.message, "schemaController.bucket option should be a function, instead got '%s'")
   t.equal(error.statusCode, 500)
-  t.ok(error instanceof Error)
+  t.ok(error instanceof TypeError)
 })
 
 test('FST_ERR_SCHEMA_ERROR_FORMATTER_NOT_FN', t => {
@@ -72,7 +74,7 @@ test('FST_ERR_SCHEMA_ERROR_FORMATTER_NOT_FN', t => {
   t.equal(error.code, 'FST_ERR_SCHEMA_ERROR_FORMATTER_NOT_FN')
   t.equal(error.message, "schemaErrorFormatter option should be a non async function. Instead got '%s'.")
   t.equal(error.statusCode, 500)
-  t.ok(error instanceof Error)
+  t.ok(error instanceof TypeError)
 })
 
 test('FST_ERR_AJV_CUSTOM_OPTIONS_OPT_NOT_OBJ', t => {
@@ -80,9 +82,9 @@ test('FST_ERR_AJV_CUSTOM_OPTIONS_OPT_NOT_OBJ', t => {
   const error = new errors.FST_ERR_AJV_CUSTOM_OPTIONS_OPT_NOT_OBJ()
   t.equal(error.name, 'FastifyError')
   t.equal(error.code, 'FST_ERR_AJV_CUSTOM_OPTIONS_OPT_NOT_OBJ')
-  t.equal(error.message, "sajv.customOptions option should be an object, instead got '%s'")
+  t.equal(error.message, "ajv.customOptions option should be an object, instead got '%s'")
   t.equal(error.statusCode, 500)
-  t.ok(error instanceof Error)
+  t.ok(error instanceof TypeError)
 })
 
 test('FST_ERR_AJV_CUSTOM_OPTIONS_OPT_NOT_ARR', t => {
@@ -90,9 +92,9 @@ test('FST_ERR_AJV_CUSTOM_OPTIONS_OPT_NOT_ARR', t => {
   const error = new errors.FST_ERR_AJV_CUSTOM_OPTIONS_OPT_NOT_ARR()
   t.equal(error.name, 'FastifyError')
   t.equal(error.code, 'FST_ERR_AJV_CUSTOM_OPTIONS_OPT_NOT_ARR')
-  t.equal(error.message, "sajv.plugins option should be an array, instead got '%s'")
+  t.equal(error.message, "ajv.plugins option should be an array, instead got '%s'")
   t.equal(error.statusCode, 500)
-  t.ok(error instanceof Error)
+  t.ok(error instanceof TypeError)
 })
 
 test('FST_ERR_VERSION_CONSTRAINT_NOT_STR', t => {
@@ -102,7 +104,7 @@ test('FST_ERR_VERSION_CONSTRAINT_NOT_STR', t => {
   t.equal(error.code, 'FST_ERR_VERSION_CONSTRAINT_NOT_STR')
   t.equal(error.message, 'Version constraint should be a string.')
   t.equal(error.statusCode, 500)
-  t.ok(error instanceof Error)
+  t.ok(error instanceof TypeError)
 })
 
 test('FST_ERR_CTP_ALREADY_PRESENT', t => {
@@ -162,7 +164,7 @@ test('FST_ERR_CTP_BODY_TOO_LARGE', t => {
   t.equal(error.code, 'FST_ERR_CTP_BODY_TOO_LARGE')
   t.equal(error.message, 'Request body is too large')
   t.equal(error.statusCode, 413)
-  t.ok(error instanceof Error)
+  t.ok(error instanceof RangeError)
 })
 
 test('FST_ERR_CTP_INVALID_MEDIA_TYPE', t => {
@@ -182,7 +184,7 @@ test('FST_ERR_CTP_INVALID_CONTENT_LENGTH', t => {
   t.equal(error.code, 'FST_ERR_CTP_INVALID_CONTENT_LENGTH')
   t.equal(error.message, 'Request body size did not match Content-Length')
   t.equal(error.statusCode, 400)
-  t.ok(error instanceof Error)
+  t.ok(error instanceof RangeError)
 })
 
 test('FST_ERR_CTP_EMPTY_JSON_BODY', t => {
@@ -222,7 +224,7 @@ test('FST_ERR_DEC_DEPENDENCY_INVALID_TYPE', t => {
   t.equal(error.code, 'FST_ERR_DEC_DEPENDENCY_INVALID_TYPE')
   t.equal(error.message, "The dependencies of decorator '%s' must be of type Array.")
   t.equal(error.statusCode, 500)
-  t.ok(error instanceof Error)
+  t.ok(error instanceof TypeError)
 })
 
 test('FST_ERR_DEC_MISSING_DEPENDENCY', t => {
@@ -322,7 +324,7 @@ test('FST_ERR_LOG_INVALID_LOGGER', t => {
   t.equal(error.code, 'FST_ERR_LOG_INVALID_LOGGER')
   t.equal(error.message, "Invalid logger object provided. The logger instance should have these functions(s): '%s'.")
   t.equal(error.statusCode, 500)
-  t.ok(error instanceof Error)
+  t.ok(error instanceof TypeError)
 })
 
 test('FST_ERR_REP_INVALID_PAYLOAD_TYPE', t => {
@@ -352,7 +354,7 @@ test('FST_ERR_REP_SENT_VALUE', t => {
   t.equal(error.code, 'FST_ERR_REP_SENT_VALUE')
   t.equal(error.message, 'The only possible value for reply.sent is true.')
   t.equal(error.statusCode, 500)
-  t.ok(error instanceof Error)
+  t.ok(error instanceof TypeError)
 })
 
 test('FST_ERR_SEND_INSIDE_ONERR', t => {
@@ -591,8 +593,8 @@ test('FST_ERR_INVALID_URL', t => {
   t.equal(error.name, 'FastifyError')
   t.equal(error.code, 'FST_ERR_INVALID_URL')
   t.equal(error.message, "URL must be a string. Received '%s'")
-  t.equal(error.statusCode, 400)
-  t.ok(error instanceof Error)
+  t.equal(error.statusCode, 500)
+  t.ok(error instanceof TypeError)
 })
 
 test('FST_ERR_ROUTE_OPTIONS_NOT_OBJ', t => {
@@ -602,7 +604,7 @@ test('FST_ERR_ROUTE_OPTIONS_NOT_OBJ', t => {
   t.equal(error.code, 'FST_ERR_ROUTE_OPTIONS_NOT_OBJ')
   t.equal(error.message, 'Options for "%s:%s" route must be an object')
   t.equal(error.statusCode, 500)
-  t.ok(error instanceof Error)
+  t.ok(error instanceof TypeError)
 })
 
 test('FST_ERR_ROUTE_DUPLICATED_HANDLER', t => {
@@ -622,7 +624,7 @@ test('FST_ERR_ROUTE_HANDLER_NOT_FN', t => {
   t.equal(error.code, 'FST_ERR_ROUTE_HANDLER_NOT_FN')
   t.equal(error.message, 'Error Handler for %s:%s route, if defined, must be a function')
   t.equal(error.statusCode, 500)
-  t.ok(error instanceof Error)
+  t.ok(error instanceof TypeError)
 })
 
 test('FST_ERR_ROUTE_MISSING_HANDLER', t => {
@@ -642,7 +644,7 @@ test('FST_ERR_ROUTE_METHOD_INVALID', t => {
   t.equal(error.code, 'FST_ERR_ROUTE_METHOD_INVALID')
   t.equal(error.message, 'Provided method is invalid!')
   t.equal(error.statusCode, 500)
-  t.ok(error instanceof Error)
+  t.ok(error instanceof TypeError)
 })
 
 test('FST_ERR_ROUTE_METHOD_NOT_SUPPORTED', t => {
@@ -682,7 +684,7 @@ test('FST_ERR_ROUTE_BODY_LIMIT_OPTION_NOT_INT', t => {
   t.equal(error.code, 'FST_ERR_ROUTE_BODY_LIMIT_OPTION_NOT_INT')
   t.equal(error.message, "'bodyLimit' option must be an integer > 0. Got '%s'")
   t.equal(error.statusCode, 500)
-  t.ok(error instanceof Error)
+  t.ok(error instanceof TypeError)
 })
 
 test('FST_ERR_ROUTE_REWRITE_NOT_STR', t => {
@@ -692,7 +694,7 @@ test('FST_ERR_ROUTE_REWRITE_NOT_STR', t => {
   t.equal(error.code, 'FST_ERR_ROUTE_REWRITE_NOT_STR')
   t.equal(error.message, 'Rewrite url for "%s" needs to be of type "string" but received "%s"')
   t.equal(error.statusCode, 500)
-  t.ok(error instanceof Error)
+  t.ok(error instanceof TypeError)
 })
 
 test('FST_ERR_REOPENED_CLOSE_SERVER', t => {
@@ -752,7 +754,7 @@ test('FST_ERR_PLUGIN_CALLBACK_NOT_FN', t => {
   t.equal(error.code, 'FST_ERR_PLUGIN_CALLBACK_NOT_FN')
   t.equal(error.message, 'fastify-plugin: %s')
   t.equal(error.statusCode, 500)
-  t.ok(error instanceof Error)
+  t.ok(error instanceof TypeError)
 })
 
 test('FST_ERR_PLUGIN_NOT_VALID', t => {
@@ -803,4 +805,29 @@ test('FST_ERR_VALIDATION', t => {
   t.equal(error.message, '%s')
   t.equal(error.statusCode, 400)
   t.ok(error instanceof Error)
+})
+
+test('Ensure that all errors are in Errors.md documented', t => {
+  t.plan(77)
+  const errorsMd = readFileSync(resolve(__dirname, '../../docs/Reference/Errors.md'), 'utf8')
+
+  const exportedKeys = Object.keys(errors)
+  for (const key of exportedKeys) {
+    if (errors[key].name === 'FastifyError') {
+      t.ok(errorsMd.includes(`#### ${key}\n`), key)
+    }
+  }
+})
+
+test('Ensure that non-existing errors are not in Errors.md documented', t => {
+  t.plan(77)
+  const errorsMd = readFileSync(resolve(__dirname, '../../docs/Reference/Errors.md'), 'utf8')
+
+  const matchRE = /#### ([0-9a-zA-Z_]+)\n/g
+  const matches = errorsMd.matchAll(matchRE)
+  const exportedKeys = Object.keys(errors)
+
+  for (const match of matches) {
+    t.ok(exportedKeys.indexOf(match[1]) !== -1, match[1])
+  }
 })


### PR DESCRIPTION
I saw first some issues on the Errors documentation on fastify.dev, like so:
![image](https://github.com/fastify/fastify/assets/5059100/9429785e-722b-48fb-a21c-00863ce32815)

So I started fixing them manually. But then I realized, that I am a lazy guy. So I wrote unit tests, to ensure that the documentation is regarding Errors complete. 

Then I realized, that some of those Errors should be TypeErrors, so I also fixed that. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
