### PR TITLE
docs(client-aborted): remove deprecated function

### DIFF
--- a/docs/Guides/Detecting-When-Clients-Abort.md
+++ b/docs/Guides/Detecting-When-Clients-Abort.md
@@ -55,7 +55,7 @@ const app = Fastify({
 
 app.addHook('onRequest', async (request, reply) => {
   request.raw.on('close', () => {
-    if (request.raw.aborted) {
+    if (request.raw.destroyed) {
       app.log.info('request closed')
     }
   })
@@ -85,7 +85,7 @@ functionality:
 of `{ ok: true }`.
 - An onRequest hook that triggers when every request is received.
 - Logic that triggers in the hook when the request is closed.
-- Logging that occurs when the closed request property `aborted` is true.
+- Logging that occurs when the closed request property `destroyed` is true.
 
 In the request close event, you should examine the diff between a successful 
 request and one aborted by the client to determine the best property for your 
@@ -97,7 +97,7 @@ You can also perform this logic outside of a hook, directly in a specific route.
 ```js
 app.get('/', async (request, reply) => {
   request.raw.on('close', () => {
-    if (request.raw.aborted) {
+    if (request.raw.destroyed) {
       app.log.info('request closed')
     }
   })
@@ -112,7 +112,7 @@ aborted and perform alternative actions.
 ```js
 app.get('/', async (request, reply) => {
   await sleep(3000)
-  if (request.raw.aborted) {
+  if (request.raw.destroyed) {
     // do something here
   }
   await sleep(3000)


### PR DESCRIPTION
[request.aborted](https://nodejs.org/docs/latest-v16.x/api/http.html#requestaborted) has been deprecated since node 16.
It seems like [request.destroyed](https://nodejs.org/docs/latest-v16.x/api/http.html#requestdestroyed) should be used instead

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
