### PR TITLE
Revert "docs(client-aborted): remove deprecated function (#4898)"

### DIFF
--- a/docs/Guides/Detecting-When-Clients-Abort.md
+++ b/docs/Guides/Detecting-When-Clients-Abort.md
@@ -55,7 +55,7 @@ const app = Fastify({
 
 app.addHook('onRequest', async (request, reply) => {
   request.raw.on('close', () => {
-    if (request.raw.destroyed) {
+    if (request.raw.aborted) {
       app.log.info('request closed')
     }
   })
@@ -85,7 +85,7 @@ functionality:
 of `{ ok: true }`.
 - An onRequest hook that triggers when every request is received.
 - Logic that triggers in the hook when the request is closed.
-- Logging that occurs when the closed request property `destroyed` is true.
+- Logging that occurs when the closed request property `aborted` is true.
 
 In the request close event, you should examine the diff between a successful 
 request and one aborted by the client to determine the best property for your 
@@ -97,7 +97,7 @@ You can also perform this logic outside of a hook, directly in a specific route.
 ```js
 app.get('/', async (request, reply) => {
   request.raw.on('close', () => {
-    if (request.raw.destroyed) {
+    if (request.raw.aborted) {
       app.log.info('request closed')
     }
   })
@@ -112,7 +112,7 @@ aborted and perform alternative actions.
 ```js
 app.get('/', async (request, reply) => {
   await sleep(3000)
-  if (request.raw.destroyed) {
+  if (request.raw.aborted) {
     // do something here
   }
   await sleep(3000)


### PR DESCRIPTION
This reverts commit cc347d7c0b4266097b61b126158b797878668353.

The author on #4898 do not test if `request.aborted` is really identical to `request.destoryed`. 
Instead, they are two completely different property and the meaning is different.

For `request.destoryed`, Node.js document is telling us to `Check` but not `Use` as replacement.

From the below example, a properly closed connection would also triggered when using `request.destroyed`.
So, it is not meaning request abort.

```js
test('onRequestAbort should not be called when using destroyed', t => {
  const fastify = Fastify()

  t.plan(3)
  t.teardown(() => fastify.close())

  fastify.addHook('onRequestAbort', async function (req) {
    process.nextTick(() => t.fail())
  })

  fastify.route({
    method: 'GET',
    path: '/',
    async handler (request, reply) {
      return { hello: 'world' }
    }
  })

  fastify.listen({ port: 0 }, (err, address) => {
    t.error(err)

    sget({
      method: 'GET',
      url: address
    }, (err, response, body) => {
      t.error(err)
      t.equal(response.statusCode, 200)
    })
  })
})
```

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
