### PR TITLE
fix: allow uppercase requestdHeader

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -109,7 +109,7 @@ function fastify (options) {
 
   validateBodyLimitOption(options.bodyLimit)
 
-  const requestIdHeader = (options.requestIdHeader === false) ? false : (options.requestIdHeader || defaultInitOptions.requestIdHeader)
+  const requestIdHeader = (options.requestIdHeader === false) ? false : (options.requestIdHeader || defaultInitOptions.requestIdHeader).toLowerCase()
   const genReqId = reqIdGenFactory(requestIdHeader, options.genReqId)
   const requestIdLogLabel = options.requestIdLogLabel || 'reqId'
   const bodyLimit = options.bodyLimit || defaultInitOptions.bodyLimit

--- a/test/request-id.test.js
+++ b/test/request-id.test.js
@@ -1,0 +1,131 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('..')
+const sget = require('simple-get').concat
+
+t.test('The request id header key can be customized', async (t) => {
+  t.plan(2)
+  const REQUEST_ID = '42'
+
+  const fastify = Fastify({
+    requestIdHeader: 'my-custom-request-id'
+  })
+
+  fastify.get('/', (req, reply) => {
+    t.equal(req.id, REQUEST_ID)
+    reply.send({ id: req.id })
+  })
+
+  const response = await fastify.inject({ method: 'GET', url: '/', headers: { 'my-custom-request-id': REQUEST_ID } })
+  const body = await response.json()
+  t.equal(body.id, REQUEST_ID)
+})
+
+t.test('The request id header key can be customized', async (t) => {
+  t.plan(2)
+  const REQUEST_ID = '42'
+
+  const fastify = Fastify({
+    requestIdHeader: 'my-custom-request-id'
+  })
+
+  fastify.get('/', (req, reply) => {
+    t.equal(req.id, REQUEST_ID)
+    reply.send({ id: req.id })
+  })
+
+  const response = await fastify.inject({ method: 'GET', url: '/', headers: { 'MY-CUSTOM-REQUEST-ID': REQUEST_ID } })
+  const body = await response.json()
+  t.equal(body.id, REQUEST_ID)
+})
+
+t.test('The request id header key can be customized', (t) => {
+  t.plan(4)
+  const REQUEST_ID = '42'
+
+  const fastify = Fastify({
+    requestIdHeader: 'my-custom-request-id'
+  })
+
+  fastify.get('/', (req, reply) => {
+    t.equal(req.id, REQUEST_ID)
+    reply.send({ id: req.id })
+  })
+
+  fastify.listen({ port: 0 }, (err, address) => {
+    t.error(err)
+    t.teardown(() => fastify.close())
+
+    sget({
+      method: 'GET',
+      url: address,
+      headers: {
+        'my-custom-request-id': REQUEST_ID
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(body.toString(), `{"id":"${REQUEST_ID}"}`)
+    })
+  })
+})
+
+t.test('The request id header key can be customized', (t) => {
+  t.plan(4)
+  const REQUEST_ID = '42'
+
+  const fastify = Fastify({
+    requestIdHeader: 'my-custom-request-id'
+  })
+
+  fastify.get('/', (req, reply) => {
+    t.equal(req.id, REQUEST_ID)
+    reply.send({ id: req.id })
+  })
+
+  fastify.listen({ port: 0 }, (err, address) => {
+    t.error(err)
+    t.teardown(() => fastify.close())
+
+    sget({
+      method: 'GET',
+      url: address,
+      headers: {
+        'MY-CUSTOM-REQUEST-ID': REQUEST_ID
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(body.toString(), `{"id":"${REQUEST_ID}"}`)
+    })
+  })
+})
+
+t.test('The request id header key can be customized', (t) => {
+  t.plan(4)
+  const REQUEST_ID = '42'
+
+  const fastify = Fastify({
+    requestIdHeader: 'MY-CUSTOM-REQUEST-ID'
+  })
+
+  fastify.get('/', (req, reply) => {
+    t.equal(req.id, REQUEST_ID)
+    reply.send({ id: req.id })
+  })
+
+  fastify.listen({ port: 0 }, (err, address) => {
+    t.error(err)
+    t.teardown(() => fastify.close())
+
+    sget({
+      method: 'GET',
+      url: address,
+      headers: {
+        'MY-CUSTOM-REQUEST-ID': REQUEST_ID
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(body.toString(), `{"id":"${REQUEST_ID}"}`)
+    })
+  })
+})


### PR DESCRIPTION
converts the requestIdHeader configuration value to lowercase at server initializiation

Case in discord, where dev passed the cloudflares `CF-RAY` headername to fastify, but didnt work. The dev needed to lowercase the headername to `cf-ray` to get it working. This PR ensures a better DX.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
