### PR TITLE
Fix typo in TypeScript docs ("@types/node", not "@node/types")

### DIFF
--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -788,7 +788,7 @@ There are a couple supported import methods with the Fastify type system.
 Many type definitions share the same generic parameters; they are all
 documented, in detail, within this section.
 
-Most definitions depend on `@node/types` modules `http`, `https`, and `http2`
+Most definitions depend on `@types/node` modules `http`, `https`, and `http2`
 
 ##### RawServer
 Underlying Node.js server type


### PR DESCRIPTION
This is a simple typo fix in the TypeScript docs. The name of the package that contains types for Node standard modules is `@types/node`.

See:
- https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
- https://www.npmjs.com/package/@types/node