### PR TITLE
fix: lowercase type-providers headers types

### DIFF
--- a/test/types/type-provider.test-d.ts
+++ b/test/types/type-provider.test-d.ts
@@ -279,6 +279,62 @@ expectAssignable(server.withTypeProvider<TypeBoxProvider>().get(
 ))
 
 // -------------------------------------------------------------------
+// Request headers
+// -------------------------------------------------------------------
+
+// JsonSchemaToTsProvider
+expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
+  '/',
+  {
+    schema: {
+      headers: {
+        type: 'object',
+        properties: {
+          lowercase: { type: 'string' },
+          UPPERCASE: { type: 'number' },
+          camelCase: { type: 'boolean' },
+          'KEBAB-case': { type: 'boolean' },
+          PRESERVE_OPTIONAL: { type: 'number' }
+        },
+        required: ['lowercase', 'UPPERCASE', 'camelCase', 'KEBAB-case']
+      } as const
+    }
+  },
+  (req) => {
+    expectType<string>(req.headers.lowercase)
+    expectType<string | string[] | undefined>(req.headers.UPPERCASE)
+    expectType<number>(req.headers.uppercase)
+    expectType<boolean>(req.headers.camelcase)
+    expectType<boolean>(req.headers['kebab-case'])
+    expectType<number | undefined>(req.headers.preserve_optional)
+  }
+))
+
+// TypeBoxProvider
+expectAssignable(server.withTypeProvider<TypeBoxProvider>().get(
+  '/',
+  {
+    schema: {
+      headers: Type.Object({
+        lowercase: Type.String(),
+        UPPERCASE: Type.Number(),
+        camelCase: Type.Boolean(),
+        'KEBAB-case': Type.Boolean(),
+        PRESERVE_OPTIONAL: Type.Optional(Type.Number())
+      })
+    }
+  },
+  (req) => {
+    expectType<string>(req.headers.lowercase)
+    expectType<string | string[] | undefined>(req.headers.UPPERCASE)
+    expectType<number>(req.headers.uppercase)
+    expectType<boolean>(req.headers.camelcase)
+    expectType<boolean>(req.headers['kebab-case'])
+    expectType<number | undefined>(req.headers.preserve_optional)
+  }
+))
+
+// -------------------------------------------------------------------
 // TypeBox Reply Type
 // -------------------------------------------------------------------
 

--- a/types/type-provider.d.ts
+++ b/types/type-provider.d.ts
@@ -1,5 +1,6 @@
 import { RouteGenericInterface } from './route'
 import { FastifySchema } from './schema'
+import { RecordKeysToLowercase } from './utils'
 
 // -----------------------------------------------------------------------------------------------
 // TypeProvider
@@ -51,7 +52,7 @@ export interface FastifyRequestType<Params = unknown, Querystring = unknown, Hea
 export interface ResolveFastifyRequestType<TypeProvider extends FastifyTypeProvider, SchemaCompiler extends FastifySchema, RouteGeneric extends RouteGenericInterface> extends FastifyRequestType {
   params: ResolveRequestParams<TypeProvider, SchemaCompiler, RouteGeneric>,
   query: ResolveRequestQuerystring<TypeProvider, SchemaCompiler, RouteGeneric>,
-  headers: ResolveRequestHeaders<TypeProvider, SchemaCompiler, RouteGeneric>,
+  headers: RecordKeysToLowercase<ResolveRequestHeaders<TypeProvider, SchemaCompiler, RouteGeneric>>,
   body: ResolveRequestBody<TypeProvider, SchemaCompiler, RouteGeneric>
 }
 

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -69,3 +69,12 @@ export type ReplyKeysToCodes<Key> = [Key] extends [never] ? number :
 export type CodeToReplyKey<Code extends number> = `${Code}` extends `${infer FirstDigit extends CodeClasses}${number}`
   ? `${FirstDigit}xx`
   : never;
+
+export type RecordKeysToLowercase<Input> = Input extends Record<string, unknown>
+  ? {
+    [Key in keyof Input as Key extends string
+      ? Lowercase<Key>
+      : Key
+    ]: Input[Key];
+  }
+  : Input;


### PR DESCRIPTION
As far as I understand, Fastify converts [request headers to lowercase](https://github.com/fastify/help/issues/71), while **Fastify type provider** seems to pass down to the type provider libraries the headers with the same casing provided in the route handler schemas.

Here is an example:

```ts
fastify.get(
  "/",
  {
    schema: {
      headers: {
        type: "object",
        properties: {
          lowercase: { type: "string" },
          UPPERCASE: { type: "number" },
        },
        required: ["lowercase", "UPPERCASE"],
      } as const,
    },
  },
  (req) => {
    req.headers.lowercase; // Correct types and runtime value
    req.headers.UPPERCASE; // Gets schema types but it's actually undefined and type should be, too
    req.headers.uppercase; // Gets generic headers types but it actually holds the actual request header value
  }
);
```

This PR is an attempt to align Fastify type provider types with the actual Fastify implementation. Where:
```ts
  (req) => {
    req.headers.lowercase; // Correct types and runtime value
    req.headers.UPPERCASE; // Gets schema generic headers types
    req.headers.uppercase; // Gets schema-defined types
  }
```
Technically speaking we might maybe considering typing the original uppercase version of the header as `undefined` but it would be probably too much :)

The case conversion happens on the types returned by the type provider libraries, therefore it should be transparent to them.

## Open points
- [ ] Is there any exception worth considering in Fastify headers lowercase conversion?
- [x] Where I'm supposed to add tests for this type change (couldn't find relevant type tests)
- [ ] Should we consider this a fix or a breaking change?

Happy to review this PR based on your suggestions!
Thank you!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
