### PR TITLE
fix: hasPlugin does not track parent plugins

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -241,7 +241,7 @@ function fastify (options) {
     [kReply]: Reply.buildReply(Reply),
     [kRequest]: Request.buildRequest(Request, options.trustProxy),
     [kFourOhFour]: fourOhFour,
-    [pluginUtils.registeredPlugins]: [],
+    [pluginUtils.kRegisteredPlugins]: [],
     [kPluginNameChain]: ['fastify'],
     [kAvvioBoot]: null,
     // routing method
@@ -312,7 +312,7 @@ function fastify (options) {
     close: null,
     printPlugins: null,
     hasPlugin: function (name) {
-      return this[kPluginNameChain].includes(name)
+      return this[pluginUtils.kRegisteredPlugins].includes(name) || this[kPluginNameChain].includes(name)
     },
     // http server
     listen,

--- a/lib/pluginOverride.js
+++ b/lib/pluginOverride.js
@@ -27,9 +27,10 @@ const pluginUtils = require('./pluginUtils')
 module.exports = function override (old, fn, opts) {
   const shouldSkipOverride = pluginUtils.registerPlugin.call(old, fn)
 
+  const fnName = pluginUtils.getPluginName(fn) || pluginUtils.getFuncPreview(fn)
   if (shouldSkipOverride) {
     // after every plugin registration we will enter a new name
-    old[kPluginNameChain].push(pluginUtils.getDisplayName(fn))
+    old[kPluginNameChain].push(fnName)
     return old
   }
 
@@ -48,8 +49,14 @@ module.exports = function override (old, fn, opts) {
   instance[kSchemaController] = SchemaController.buildSchemaController(old[kSchemaController])
   instance.getSchema = instance[kSchemaController].getSchema.bind(instance[kSchemaController])
   instance.getSchemas = instance[kSchemaController].getSchemas.bind(instance[kSchemaController])
-  instance[pluginUtils.registeredPlugins] = Object.create(instance[pluginUtils.registeredPlugins])
-  instance[kPluginNameChain] = [pluginUtils.getPluginName(fn) || pluginUtils.getFuncPreview(fn)]
+
+  // Track the registered and loaded plugins since the root instance.
+  // It does not track the current encapsulated plugin.
+  instance[pluginUtils.kRegisteredPlugins] = Object.create(instance[pluginUtils.kRegisteredPlugins])
+
+  // Track the plugin chain since the root instance.
+  // When an non-encapsulated plugin is added, the chain will be updated.
+  instance[kPluginNameChain] = [fnName]
 
   if (instance[kLogSerializers] || opts.logSerializers) {
     instance[kLogSerializers] = Object.assign(Object.create(instance[kLogSerializers]), opts.logSerializers)

--- a/lib/pluginUtils.js
+++ b/lib/pluginUtils.js
@@ -2,7 +2,7 @@
 
 const semver = require('semver')
 const assert = require('assert')
-const registeredPlugins = Symbol.for('registered-plugin')
+const kRegisteredPlugins = Symbol.for('registered-plugin')
 const {
   kTestInternals
 } = require('./symbols.js')
@@ -65,7 +65,7 @@ function checkDependencies (fn) {
 
   dependencies.forEach(dependency => {
     assert(
-      this[registeredPlugins].indexOf(dependency) > -1,
+      this[kRegisteredPlugins].indexOf(dependency) > -1,
       `The dependency '${dependency}' of plugin '${meta.name}' is not registered`
     )
   })
@@ -128,7 +128,7 @@ function registerPluginName (fn) {
 
   const name = meta.name
   if (!name) return
-  this[registeredPlugins].push(name)
+  this[kRegisteredPlugins].push(name)
 }
 
 function registerPlugin (fn) {
@@ -142,7 +142,7 @@ function registerPlugin (fn) {
 module.exports = {
   getPluginName,
   getFuncPreview,
-  registeredPlugins,
+  kRegisteredPlugins,
   getDisplayName,
   registerPlugin
 }

--- a/test/internals/plugin.test.js
+++ b/test/internals/plugin.test.js
@@ -122,7 +122,7 @@ test('checkDependencies should check if the given dependency is present in the i
   }
 
   function context () {}
-  context[pluginUtilsPublic.registeredPlugins] = ['plugin']
+  context[pluginUtilsPublic.kRegisteredPlugins] = ['plugin']
 
   try {
     pluginUtils.checkDependencies.call(context, fn)
@@ -143,7 +143,7 @@ test('checkDependencies should check if the given dependency is present in the i
   }
 
   function context () {}
-  context[pluginUtilsPublic.registeredPlugins] = []
+  context[pluginUtilsPublic.kRegisteredPlugins] = []
 
   try {
     pluginUtils.checkDependencies.call(context, fn)

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1247,3 +1247,29 @@ test('hasPlugin returns true when using no encapsulation', async t => {
 
   await fastify.ready()
 })
+
+test('hasPlugin returns true when using encapsulation', async t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  const pluginCallback = function (server, options, done) {
+    done()
+  }
+  const pluginName = 'awesome-plugin'
+  const plugin = fp(pluginCallback, { name: pluginName })
+
+  fastify.register(plugin)
+
+  fastify.register(async (server) => {
+    t.ok(server.hasPlugin(pluginName))
+  })
+
+  fastify.register(async function foo (server) {
+    server.register(async function bar (server) {
+      t.ok(server.hasPlugin(pluginName))
+    })
+  })
+
+  await fastify.ready()
+})


### PR DESCRIPTION
closes #4925

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
