### PR TITLE
fix: Try to fix parser benchmark workflow

### DIFF
--- a/.github/workflows/benchmark-parser.yml
+++ b/.github/workflows/benchmark-parser.yml
@@ -1,4 +1,4 @@
-name: Benchmark-parser
+name: Benchmark Parser
 
 on:
   pull_request_target:
@@ -11,15 +11,15 @@ jobs:
     permissions:
       contents: read
     outputs:
-      PR-BENCH-14: ${{ steps.benchmark-pr.outputs.BENCH_RESULT14 }}
       PR-BENCH-16: ${{ steps.benchmark-pr.outputs.BENCH_RESULT16 }}
       PR-BENCH-18: ${{ steps.benchmark-pr.outputs.BENCH_RESULT18 }}
-      MAIN-BENCH-14: ${{ steps.benchmark-main.outputs.BENCH_RESULT14 }}
+      PR-BENCH-20: ${{ steps.benchmark-pr.outputs.BENCH_RESULT20 }}
       MAIN-BENCH-16: ${{ steps.benchmark-main.outputs.BENCH_RESULT16 }}
       MAIN-BENCH-18: ${{ steps.benchmark-main.outputs.BENCH_RESULT18 }}
+      MAIN-BENCH-20: ${{ steps.benchmark-main.outputs.BENCH_RESULT20 }}
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [16, 18, 20]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -74,39 +74,18 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: |
-            **Node**: 14
-            **Type**: Parser
-            **PR**: ${{ needs.benchmark.outputs.PR-BENCH-14 }}
-            **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-14 }}
-            
-            ---
-            
             **Node**: 16
-            **Type**: Parser
             **PR**: ${{ needs.benchmark.outputs.PR-BENCH-16 }}
             **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-16 }}
             
             ---
             
             **Node**: 18
-            **Type**: Parser
             **PR**: ${{ needs.benchmark.outputs.PR-BENCH-18 }}
             **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-18 }}
-
-  remove-label:
-    if: "always()"
-    needs: 
-      - benchmark
-      - output-benchmark
-    runs-on: ubuntu-latest
-    steps:
-      - name: Remove benchmark label
-        uses: octokit/request-action@v2.x
-        id: remove-label
-        with:
-          route: DELETE /repos/{repo}/issues/{issue_number}/labels/{name}
-          repo: ${{ github.event.pull_request.head.repo.full_name }}
-          issue_number: ${{ github.event.pull_request.number }}
-          name: benchmark
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            
+            ---
+            
+            **Node**: 20
+            **PR**: ${{ needs.benchmark.outputs.PR-BENCH-20 }}
+            **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-20 }}


### PR DESCRIPTION
Impossible to test it properly without merging, unfortunately, as workflow depends on definition in main, but now it's 100% consistent with the benchmark that is passing, so fingers crossed.

Invoking benchmark script itself inside GA is passing on my fork.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
