### PR TITLE
fix: do not double send the response if the request is destroyed but not aborted

### DIFF
--- a/lib/wrapThenable.js
+++ b/lib/wrapThenable.js
@@ -18,7 +18,10 @@ function wrapThenable (thenable, reply) {
     // the request may be terminated during the reply. in this situation,
     // it require an extra checking of request.aborted to see whether
     // the request is killed by client.
-    if (payload !== undefined || (reply.sent === false && reply.raw.headersSent === false && reply.request.raw.aborted === false)) {
+    // Most of the times aborted will be true when destroyed is true,
+    // however there is a race condition where the request is not
+    // aborted but only destroyed.
+    if (payload !== undefined || (reply.sent === false && reply.raw.headersSent === false && reply.request.raw.aborted === false && reply.request.raw.destroyed === false)) {
       // we use a try-catch internally to avoid adding a catch to another
       // promise, increase promise perf by 10%
       try {

--- a/test/wrapThenable.test.js
+++ b/test/wrapThenable.test.js
@@ -27,3 +27,25 @@ test('should reject immediately when reply[kReplyHijacked] is true', t => {
   const thenable = Promise.reject(new Error('Reply sent already'))
   wrapThenable(thenable, reply)
 })
+
+test('should not send the payload if the raw socket was destroyed but not aborted', async t => {
+  const reply = {
+    sent: false,
+    raw: {
+      headersSent: false
+    },
+    request: {
+      raw: {
+        aborted: false,
+        destroyed: true
+      }
+    },
+    send () {
+      t.fail('should not send')
+    }
+  }
+  const thenable = Promise.resolve()
+  wrapThenable(thenable, reply)
+
+  await thenable
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Fixes #4959 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
