### PR TITLE
types: Remove variadic listen types

### DIFF
--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -181,48 +181,6 @@ function invalidSchemaErrorFormatter (err: Error) {
 }
 expectError(server.setSchemaErrorFormatter(invalidSchemaErrorFormatter))
 
-// test listen method callback
-expectAssignable<void>(server.listen(3000, '', 0, (err, address) => {
-  expectType<Error | null>(err)
-}))
-expectAssignable<void>(server.listen('3000', '', 0, (err, address) => {
-  expectType<Error | null>(err)
-}))
-expectAssignable<void>(server.listen(3000, '', (err, address) => {
-  expectType<Error | null>(err)
-}))
-expectAssignable<void>(server.listen('3000', '', (err, address) => {
-  expectType<Error | null>(err)
-}))
-expectAssignable<void>(server.listen(3000, (err, address) => {
-  expectType<Error | null>(err)
-}))
-expectAssignable<void>(server.listen('3000', (err, address) => {
-  expectType<Error | null>(err)
-}))
-
-// test listen method callback types
-expectAssignable<void>(server.listen('3000', (err, address) => {
-  expectAssignable<Error|null>(err)
-  expectAssignable<string>(address)
-}))
-
-// test listen method promise
-expectAssignable<PromiseLike<string>>(server.listen(3000))
-expectAssignable<PromiseLike<string>>(server.listen('3000'))
-expectAssignable<PromiseLike<string>>(server.listen(3000, '', 0))
-expectAssignable<PromiseLike<string>>(server.listen('3000', '', 0))
-expectAssignable<PromiseLike<string>>(server.listen(3000, ''))
-expectAssignable<PromiseLike<string>>(server.listen('3000', ''))
-
-// Test variadic listen signatures Typescript deprecation
-expectDeprecated(server.listen(3000))
-expectDeprecated(server.listen('3000'))
-expectDeprecated(server.listen(3000, '', 0))
-expectDeprecated(server.listen('3000', '', 0))
-expectDeprecated(server.listen(3000, ''))
-expectDeprecated(server.listen('3000', ''))
-
 // test listen opts objects
 expectAssignable<PromiseLike<string>>(server.listen())
 expectAssignable<PromiseLike<string>>(server.listen({ port: 3000 }))

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -161,27 +161,6 @@ export interface FastifyInstance<
   listen(opts?: FastifyListenOptions): Promise<string>;
   listen(callback: (err: Error | null, address: string) => void): void;
 
-  /**
-   * @deprecated Variadic listen method is deprecated. Please use `.listen(optionsObject, callback)` instead. The variadic signature will be removed in `fastify@5`
-   * @see https://github.com/fastify/fastify/pull/3712
-   */
-  listen(port: number | string, address: string, backlog: number, callback: (err: Error|null, address: string) => void): void;
-  /**
-   * @deprecated Variadic listen method is deprecated. Please use `.listen(optionsObject, callback)` instead. The variadic signature will be removed in `fastify@5`
-   * @see https://github.com/fastify/fastify/pull/3712
-   */
-  listen(port: number | string, address: string, callback: (err: Error|null, address: string) => void): void;
-  /**
-   * @deprecated Variadic listen method is deprecated. Please use `.listen(optionsObject, callback)` instead. The variadic signature will be removed in `fastify@5`
-   * @see https://github.com/fastify/fastify/pull/3712
-   */
-  listen(port: number | string, callback: (err: Error|null, address: string) => void): void;
-  /**
-   * @deprecated Variadic listen method is deprecated. Please use `.listen(optionsObject)` instead. The variadic signature will be removed in `fastify@5`
-   * @see https://github.com/fastify/fastify/pull/3712
-   */
-  listen(port: number | string, address?: string, backlog?: number): Promise<string>;
-
   ready(): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider> & PromiseLike<undefined>;
   ready(readyListener: (err: Error) => void): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
 


### PR DESCRIPTION
Follow up for #4900 
Removes the types for variadic listen()

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
