### PR TITLE
bodyLimit must be applied on fully decoded body

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -226,8 +226,11 @@ function rawBody (request, reply, options, parser, done) {
 
   function onData (chunk) {
     receivedLength += chunk.length
-
-    if ((payload.receivedEncodedLength || receivedLength) > limit) {
+    const { receivedEncodedLength = 0 } = payload
+    // first of all - resulting body length must not exceed bodyLimit (see "zip bomb")
+    // the case when encoded length is larger than received length is rather theoretical,
+    // unless, of course, preParsing stream is broken and returns wrong value
+    if (receivedLength > limit || receivedEncodedLength > limit) {
       payload.removeListener('data', onData)
       payload.removeListener('end', onEnd)
       payload.removeListener('error', onEnd)

--- a/test/bodyLimit.test.js
+++ b/test/bodyLimit.test.js
@@ -2,6 +2,7 @@
 
 const Fastify = require('..')
 const sget = require('simple-get').concat
+const zlib = require('zlib')
 const t = require('tap')
 const test = t.test
 
@@ -42,6 +43,74 @@ test('bodyLimit', t => {
       t.error(err)
       t.equal(response.statusCode, 413)
     })
+  })
+})
+
+test('bodyLimit is applied to decoded content', t => {
+  t.plan(9)
+
+  const body = { x: 'x'.repeat(30000) }
+  const json = JSON.stringify(body)
+  const encoded = zlib.gzipSync(json)
+
+  const fastify = Fastify()
+
+  fastify.addHook('preParsing', async (req, reply, payload) => {
+    t.equal(req.headers['content-length'], `${encoded.length}`)
+    const unzip = zlib.createGunzip()
+    Object.defineProperty(unzip, 'receivedEncodedLength', {
+      get () {
+        return unzip.bytesWritten
+      }
+    })
+    payload.pipe(unzip)
+    return unzip
+  })
+
+  fastify.post('/body-limit-40k', {
+    bodyLimit: 40000,
+    onError: async (req, res, err) => {
+      t.fail('should not be called')
+    }
+  }, (request, reply) => {
+    reply.send({ x: request.body.x })
+  })
+
+  fastify.post('/body-limit-20k', {
+    bodyLimit: 20000,
+    onError: async (req, res, err) => {
+      t.equal(err.code, 'FST_ERR_CTP_BODY_TOO_LARGE')
+      t.equal(err.statusCode, 413)
+    }
+  }, (request, reply) => {
+    reply.send({ x: 'handler should not be called' })
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/body-limit-40k',
+    headers: {
+      'content-encoding': 'gzip',
+      'content-type': 'application/json'
+    },
+    payload: encoded
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.same(res.json(), body)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/body-limit-20k',
+    headers: {
+      'content-encoding': 'gzip',
+      'content-type': 'application/json'
+    },
+    payload: encoded
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 413)
   })
 })
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This change ensures that `bodyLimit` is applied to `receivedLength`, i.e. the actual length of the body, which is going to be parsed. Current code compares `receivedEncodedLength` instead, if it is available and non-zero. This is correct behaviour for comparing against "content-length" header, but not for maximum allowed body size. 

Without this change default Fastify instance with simple decompressing handler is vulnerable to some sort of "zip bomb" - it is possible to POST huge body, which exceeds `bodyLimit`. Provided new test case shows the problem and fails without changes in `contentTypeParser.js`. 