### PR TITLE
chore: use group dependencies in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,18 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      # Production dependencies without breaking changes
+      dependencies:
+        dependency-type: "production"
+        update-types:
+        - "minor"
+        - "patch"
+      # Production dependencies with breaking changes
+      dependencies-major:
+        dependency-type: "production"
+        update-types:
+        - "major"
+      # Development dependencies
+      dev-dependencies:
+        dependency-type: "development"


### PR DESCRIPTION
I would like to see if `groups dependencies` reduce the amounts of noise.
Maybe we can change to daily check for one or two weeks to see if it feasible.

More on https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
