### PR TITLE
fix: require.cache is undefined breaks SEA

### DIFF
--- a/lib/pluginUtils.js
+++ b/lib/pluginUtils.js
@@ -25,12 +25,15 @@ function getPluginName (func) {
   // let's see if this is a file, and in that case use that
   // this is common for plugins
   const cache = require.cache
-  const keys = Object.keys(cache)
+  // cache is undefined inside SEA
+  if (cache) {
+    const keys = Object.keys(cache)
 
-  for (let i = 0; i < keys.length; i++) {
-    const key = keys[i]
-    if (cache[key].exports === func) {
-      return key
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i]
+      if (cache[key].exports === func) {
+        return key
+      }
     }
   }
 

--- a/test/internals/plugin.test.js
+++ b/test/internals/plugin.test.js
@@ -29,6 +29,21 @@ test('getPluginName should return plugin name if the file is cached', t => {
   t.equal(pluginName, expectedPluginName)
 })
 
+test('getPluginName should not throw when require.cache is undefined', t => {
+  t.plan(1)
+  function example () {
+    console.log('is just an example')
+  }
+  const cache = require.cache
+  require.cache = undefined
+  t.teardown(() => {
+    require.cache = cache
+  })
+  const pluginName = pluginUtilsPublic.getPluginName(example)
+
+  t.equal(pluginName, 'example')
+})
+
 test("getMeta should return the object stored with the 'plugin-meta' symbol", t => {
   t.plan(1)
 


### PR DESCRIPTION
Refs https://github.com/nodejs/node/issues/49163

I am not sure if it is better to use `const cache = require.cache || {}` or a single if to block. 

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
