### PR TITLE
chore: fix ci bench

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -91,7 +91,7 @@ jobs:
             **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-20 }}
             
   remove-label:
-    if: "always()"
+    if: ${{ github.event.label.name == 'benchmark' }}
     needs: 
       - benchmark
       - output-benchmark


### PR DESCRIPTION
It fails everytime you add a new label:

```
Warning: Unexpected input(s) 'repo', 'issue_number', 'name', valid inputs are ['route', 'mediaType']
Run octokit/request-action@v[2](https://github.com/fastify/fastify/actions/runs/5922752207/job/16057202744?pr=4982#step:2:2).x
  with:
    route: DELETE /repos/{repo}/issues/{issue_number}/labels/{name}
    repo: fastify/fastify
    issue_number: 4982
    name: benchmark
    mediaType: {}
  env:
    GITHUB_TOKEN: ***
DELETE /repos/{repo}/issues/{issue_number}/labels/{name}
> repo: fastify/fastify
> issue_number: 4982
> name: benchmark
> mediaType: [object Object]
< 404 [3](https://github.com/fastify/fastify/actions/runs/5922752207/job/16057202744?pr=4982#step:2:3)[4](https://github.com/fastify/fastify/actions/runs/5922752207/job/16057202744?pr=4982#step:2:4)2ms
```

https://github.com/fastify/fastify/actions/runs/5922752207/job/16057202744?pr=4982

reading the warning it seems we should fix some parameters too

cc @Uzlopak 