### PR TITLE
fix: errorHandler callback should utilize TypeProvider

### DIFF
--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -257,9 +257,13 @@ expectNotDeprecated(server.listen({ port: 3000, host: '::/0', ipv6Only: true }, 
 
 expectAssignable<void>(server.routing({} as RawRequestDefaultExpression, {} as RawReplyDefaultExpression))
 
-expectType<FastifyInstance>(fastify().get('/', {
+expectType<FastifyInstance>(fastify().get<RouteGenericInterface, { contextKey: string }>('/', {
   handler: () => {},
   errorHandler: (error, request, reply) => {
+    expectAssignable<FastifyError>(error)
+    expectAssignable<FastifyRequest>(request)
+    expectAssignable<{ contextKey: string }>(request.routeConfig)
+    expectAssignable<FastifyReply>(reply)
     expectAssignable<void>(server.errorHandler(error, request, reply))
   }
 }))

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -6,7 +6,9 @@ import fastify, {
   FastifyInstance,
   RawReplyDefaultExpression,
   RawRequestDefaultExpression,
-  RawServerDefault
+  RawServerDefaultsion,
+  RawServerDefault,
+  RouteGenericInterface
 } from '../../fastify'
 import { HookHandlerDoneFunction } from '../../types/hooks'
 import { FastifyReply } from '../../types/reply'

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -6,7 +6,6 @@ import fastify, {
   FastifyInstance,
   RawReplyDefaultExpression,
   RawRequestDefaultExpression,
-  RawServerDefaultsion,
   RawServerDefault,
   RouteGenericInterface
 } from '../../fastify'

--- a/test/types/type-provider.test-d.ts
+++ b/test/types/type-provider.test-d.ts
@@ -3,7 +3,8 @@ import fastify, {
   HookHandlerDoneFunction,
   FastifyRequest,
   FastifyReply,
-  FastifyInstance
+  FastifyInstance,
+  FastifyError
 } from '../../fastify'
 import { expectAssignable, expectError, expectType } from 'tsd'
 import { IncomingHttpHeaders } from 'http'
@@ -79,6 +80,14 @@ expectAssignable(server.withTypeProvider<TypeBoxProvider>().get(
         y: Type.Number(),
         z: Type.Number()
       })
+    },
+    errorHandler: (error, request, reply) => {
+      expectType<FastifyError>(error)
+      expectAssignable<FastifyRequest>(request)
+      expectType<number>(request.body.x)
+      expectType<number>(request.body.y)
+      expectType<number>(request.body.z)
+      expectAssignable<FastifyReply>(reply)
     }
   },
   (req) => {
@@ -108,6 +117,14 @@ expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
           z: { type: 'boolean' }
         }
       } as const
+    },
+    errorHandler: (error, request, reply) => {
+      expectType<FastifyError>(error)
+      expectAssignable<FastifyRequest>(request)
+      expectType<number | undefined>(request.body.x)
+      expectType<string | undefined>(request.body.y)
+      expectType<boolean | undefined>(request.body.z)
+      expectAssignable<FastifyReply>(reply)
     }
   },
   (req) => {
@@ -135,6 +152,14 @@ expectAssignable(server.withTypeProvider<TypeBoxProvider>().withTypeProvider<Jso
           z: { type: 'boolean' }
         }
       } as const
+    },
+    errorHandler: (error, request, reply) => {
+      expectType<FastifyError>(error)
+      expectAssignable<FastifyRequest>(request)
+      expectType<number | undefined>(request.body.x)
+      expectType<string | undefined>(request.body.y)
+      expectType<boolean | undefined>(request.body.z)
+      expectAssignable<FastifyReply>(reply)
     }
   },
   (req) => {

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -45,7 +45,12 @@ export interface RouteShorthandOptions<
   version?: string;
   constraints?: { [name: string]: any },
   prefixTrailingSlash?: 'slash'|'no-slash'|'both';
-  errorHandler?: (this: FastifyInstance, error: FastifyError, request: FastifyRequest, reply: FastifyReply) => void;
+  errorHandler?: (
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
+    error: FastifyError,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig, Logger>,
+    reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>
+  ) => void;
   childLoggerFactory?: FastifyChildLoggerFactory<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
   schemaErrorFormatter?: SchemaErrorFormatter;
 


### PR DESCRIPTION
While using https://github.com/fastify/fastify-type-provider-json-schema-to-ts I noticed that the `errorHandler` callback request does not have inferred types from TypeProvider, unlike the global `setErrorHandler`.

As far as I can see this being tested else where and I am not entirely sure how to add a test here. I can however add a test to `fastify-type-provider-json-schema-to-ts` though. 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
