### PR TITLE
docs: remove mixing ES6 and commomjs in the example

### DIFF
--- a/docs/Guides/Getting-Started.md
+++ b/docs/Guides/Getting-Started.md
@@ -277,7 +277,7 @@ async function dbConnector (fastify, options) {
 
 // Wrapping a plugin function with fastify-plugin exposes the decorators
 // and hooks, declared inside the plugin to the parent scope.
-module.exports = fastifyPlugin(dbConnector)
+export default fastifyPlugin(dbConnector)
 
 ```
 


### PR DESCRIPTION
Removed the mixing ESM and commom from the documentation example in our-db-connector.js

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
