### PR TITLE
fix: Set `FastifyRequest.id` type as a string

### DIFF
--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -83,7 +83,7 @@ const getHandler: RouteHandler = function (request, _reply) {
   request.headers = {}
 
   expectType<RequestQuerystringDefault>(request.query)
-  expectType<any>(request.id)
+  expectType<string>(request.id)
   expectType<FastifyLoggerInstance>(request.log)
   expectType<RawRequestDefaultExpression['socket']>(request.socket)
   expectType<Error & { validation: any; validationContext: string } | undefined>(request.validationError)

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -50,7 +50,7 @@ export interface FastifyRequest<RouteGeneric extends RouteGenericInterface = Rou
   //   the RequestType (preferred) or swap Logger and RequestType arguments when
   //   creating custom types of FastifyRequest. Related issue #4123
 > {
-  id: any;
+  id: string;
   params: RequestType['params']; // deferred inference
   raw: RawRequest;
   query: RequestType['query'];


### PR DESCRIPTION
Resolves https://github.com/fastify/fastify/issues/4993