### PR TITLE
Fix post async regression

### DIFF
--- a/lib/wrapThenable.js
+++ b/lib/wrapThenable.js
@@ -18,10 +18,7 @@ function wrapThenable (thenable, reply) {
     // the request may be terminated during the reply. in this situation,
     // it require an extra checking of request.aborted to see whether
     // the request is killed by client.
-    // Most of the times aborted will be true when destroyed is true,
-    // however there is a race condition where the request is not
-    // aborted but only destroyed.
-    if (payload !== undefined || (reply.sent === false && reply.raw.headersSent === false && reply.request.raw.aborted === false && reply.request.raw.destroyed === false)) {
+    if (payload !== undefined || (reply.sent === false && reply.raw.headersSent === false && reply.request.raw.aborted === false)) {
       // we use a try-catch internally to avoid adding a catch to another
       // promise, increase promise perf by 10%
       try {

--- a/test/post-empty-body.test.js
+++ b/test/post-empty-body.test.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const { test } = require('tap')
+const fastify = require('../')
+const { request } = require('undici')
+
+test('post empty body', async t => {
+  const app = fastify()
+  t.teardown(app.close.bind(app))
+
+  app.post('/bug', async (request, reply) => {
+  })
+
+  await app.listen({ port: 0 })
+
+  const res = await request(`http://127.0.0.1:${app.server.address().port}/bug`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ foo: 'bar' })
+  })
+
+  t.equal(res.statusCode, 200)
+  t.equal(await res.body.text(), '')
+})

--- a/test/wrapThenable.test.js
+++ b/test/wrapThenable.test.js
@@ -27,25 +27,3 @@ test('should reject immediately when reply[kReplyHijacked] is true', t => {
   const thenable = Promise.reject(new Error('Reply sent already'))
   wrapThenable(thenable, reply)
 })
-
-test('should not send the payload if the raw socket was destroyed but not aborted', async t => {
-  const reply = {
-    sent: false,
-    raw: {
-      headersSent: false
-    },
-    request: {
-      raw: {
-        aborted: false,
-        destroyed: true
-      }
-    },
-    send () {
-      t.fail('should not send')
-    }
-  }
-  const thenable = Promise.resolve()
-  wrapThenable(thenable, reply)
-
-  await thenable
-})


### PR DESCRIPTION
This PR reverts https://github.com/fastify/fastify/pull/4963 and adds a test to prevent such regressions.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
