### PR TITLE
test: add a test case for a string const response

### DIFF
--- a/test/schema-validation.test.js
+++ b/test/schema-validation.test.js
@@ -1040,3 +1040,29 @@ test('Custom validator compiler should not mutate schema', async t => {
 
   await fastify.ready()
 })
+test('Validates string response', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.get('/', {
+    handler (req, reply) { return req.query.test },
+    schema: {
+      response: {
+        200: {
+          type: 'string',
+          const: 'known'
+        }
+      }
+    }
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    query: { test: 'unknown' }
+  }, (err, res) => {
+    t.error(err)
+    t.notEqual(res.body, 'unknown')
+    t.equal(res.statusCode, 400)
+  })
+})

--- a/test/schema-validation.test.js
+++ b/test/schema-validation.test.js
@@ -1040,8 +1040,9 @@ test('Custom validator compiler should not mutate schema', async t => {
 
   await fastify.ready()
 })
+
 test('Validates string response', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
 
   fastify.get('/', {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Hi @mcollina, I am still determining if this is correct behavior, but Fastify doesn't validate the response schema for a const/enum string. I've added a corresponding unit test and will happily fix it if needed or at least find the root reason.

```js
  fastify.get('/', {
    handler (req, reply) { return req.query.test },
    schema: {
      response: {
        200: {
          type: 'string',
          const: 'known'
        }
      }
    }
  })

```
<img width="588" alt="image" src="https://github.com/fastify/fastify/assets/2446638/2e88a17b-0aaa-4ecd-84d6-fe4eaa195192">


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
