### PR TITLE
docs: Add blank line before onclose hook heading

### DIFF
--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -445,6 +445,7 @@ fastify.addHook('onListen', async function () {
 
 > **Note**  
 > This hook will not run when the server is started using `fastify.inject()` or `fastify.ready()`
+
 ### onClose
 <a id="on-close"></a>
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

As shown in the attached image, the onClose hook heading is included in the quotation.

<img width="478" alt="image" src="https://github.com/fastify/fastify/assets/18162391/1190d76d-b9f4-4839-8b27-b526cc3cfffe">

https://fastify.dev/docs/latest/Reference/Hooks/#onclose

To fix this, I have added a blank line before the onClose hook heading.

<img width="478" alt="image" src="https://github.com/fastify/fastify/assets/18162391/7aacfda1-c3bd-4cc9-9345-1a3db5e8a9a4">


#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
