### PR TITLE
fix(#5049): Remove duplicated calls to onReady

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -217,7 +217,9 @@ function fastify (options) {
     [kState]: {
       listening: false,
       closing: false,
-      started: false
+      started: false,
+      ready: false,
+      booting: false
     },
     [kKeepAliveConnections]: keepAliveConnections,
     [kOptions]: options,
@@ -578,9 +580,10 @@ function fastify (options) {
     function runHooks () {
       // start loading
       fastify[kAvvioBoot]((err, done) => {
-        if (err || fastify[kState].started) {
+        if (err || fastify[kState].started || fastify[kState].ready || fastify[kState].booting) {
           manageErr(err)
         } else {
+          fastify[kState].booting = true
           hookRunnerApplication('onReady', fastify[kAvvioBoot], fastify, manageErr)
         }
         done()
@@ -606,6 +609,8 @@ function fastify (options) {
           return rejectReady(err)
         }
         resolveReady(fastify)
+        fastify[kState].booting = false
+        fastify[kState].ready = true
       }
     }
   }

--- a/fastify.js
+++ b/fastify.js
@@ -581,14 +581,12 @@ function fastify (options) {
     process.nextTick(runHooks)
 
     if (!cb) {
-      const promise = new Promise(function (resolve, reject) {
+      this[kState].readyPromise = new Promise(function (resolve, reject) {
         resolveReady = resolve
         rejectReady = reject
       })
 
-      this[kState].readyPromise = promise
-
-      return promise
+      return this[kState].readyPromise
     }
 
     function runHooks () {

--- a/test/fastify-instance.test.js
+++ b/test/fastify-instance.test.js
@@ -145,6 +145,41 @@ test('ready should resolve in order when called multiply times (promises only)',
   t.strictSame(result, expectedOrder, 'Should resolve in order')
 })
 
+test('ready should reject in order when called multiply times (promises only)', async (t) => {
+  const app = Fastify()
+  const expectedOrder = [1, 2, 3, 4, 5]
+  const result = []
+
+  app.register((instance, opts, done) => {
+    setTimeout(() => done(new Error('test')), 500)
+  })
+
+  const promises = [1, 2, 3, 4, 5]
+    .map((id) => app.ready().catch(() => result.push(id)))
+
+  await Promise.all(promises)
+
+  t.strictSame(result, expectedOrder, 'Should resolve in order')
+})
+
+test('ready should reject in order when called multiply times (callbacks only)', async (t) => {
+  const app = Fastify()
+  const expectedOrder = [1, 2, 3, 4, 5]
+  const result = []
+
+  app.register((instance, opts, done) => {
+    setTimeout(() => done(new Error('test')), 500)
+  })
+
+  expectedOrder.map((id) => app.ready(() => result.push(id)))
+
+  await app.ready().catch(err => {
+    t.equal(err.message, 'test')
+  })
+
+  t.strictSame(result, expectedOrder, 'Should resolve in order')
+})
+
 test('ready should resolve in order when called multiply times (callbacks only)', async (t) => {
   const app = Fastify()
   const expectedOrder = [1, 2, 3, 4, 5]
@@ -167,6 +202,48 @@ test('ready should resolve in order when called multiply times (mixed)', async (
       app.ready(() => result.push(order))
     } else {
       app.ready().then(() => result.push(order))
+    }
+  }
+
+  await app.ready()
+
+  t.strictSame(result, expectedOrder, 'Should resolve in order')
+})
+
+test('ready should reject in order when called multiply times (mixed)', async (t) => {
+  const app = Fastify()
+  const expectedOrder = [1, 2, 3, 4, 5, 6]
+  const result = []
+
+  app.register((instance, opts, done) => {
+    setTimeout(() => done(new Error('test')), 500)
+  })
+
+  for (const order of expectedOrder) {
+    if (order % 2) {
+      app.ready(() => result.push(order))
+    } else {
+      app.ready().then(null, () => result.push(order))
+    }
+  }
+
+  await app.ready().catch(err => {
+    t.equal(err.message, 'test')
+  })
+
+  t.strictSame(result, expectedOrder, 'Should resolve in order')
+})
+
+test('ready should resolve in order when called multiply times (mixed)', async (t) => {
+  const app = Fastify()
+  const expectedOrder = [1, 2, 3, 4, 5, 6]
+  const result = []
+
+  for (const order of expectedOrder) {
+    if (order % 2) {
+      app.ready().then(() => result.push(order))
+    } else {
+      app.ready(() => result.push(order))
     }
   }
 

--- a/test/fastify-instance.test.js
+++ b/test/fastify-instance.test.js
@@ -132,6 +132,49 @@ test('childLoggerFactory in plugin should be separate from the external one', as
   t.same(fastify.childLoggerFactory, fastify[kChildLoggerFactory])
 })
 
+test('ready should resolve in order when called multiply times (promises only)', async (t) => {
+  const app = Fastify()
+  const expectedOrder = [1, 2, 3, 4, 5]
+  const result = []
+
+  const promises = [1, 2, 3, 4, 5]
+    .map((id) => app.ready().then(() => result.push(id)))
+
+  await Promise.all(promises)
+
+  t.strictSame(result, expectedOrder, 'Should resolve in order')
+})
+
+test('ready should resolve in order when called multiply times (callbacks only)', async (t) => {
+  const app = Fastify()
+  const expectedOrder = [1, 2, 3, 4, 5]
+  const result = []
+
+  expectedOrder.map((id) => app.ready(() => result.push(id)))
+
+  await app.ready()
+
+  t.strictSame(result, expectedOrder, 'Should resolve in order')
+})
+
+test('ready should resolve in order when called multiply times (mixed)', async (t) => {
+  const app = Fastify()
+  const expectedOrder = [1, 2, 3, 4, 5, 6]
+  const result = []
+
+  for (const order of expectedOrder) {
+    if (order % 2) {
+      app.ready(() => result.push(order))
+    } else {
+      app.ready().then(() => result.push(order))
+    }
+  }
+
+  await app.ready()
+
+  t.strictSame(result, expectedOrder, 'Should resolve in order')
+})
+
 test('fastify instance should contains listeningOrigin property (with port and host)', async t => {
   t.plan(1)
   const port = 3000

--- a/test/hooks.on-ready.test.js
+++ b/test/hooks.on-ready.test.js
@@ -43,11 +43,12 @@ t.test('onReady should be called once', async (t) => {
     counter++
   })
 
-  await Promise.race([app.ready(), app.ready(), app.ready(), app.ready()])
+  const promises = [1, 2, 3, 4, 5].map((id) => app.ready().then(() => id))
 
-  await app.ready()
+  const result = await Promise.race(promises)
 
-  t.equal(counter, 1)
+  t.strictSame(result, 1, 'Should resolve in order')
+  t.equal(counter, 1, 'Should call onReady only once')
 })
 
 t.test('async onReady should be called in order', async t => {

--- a/test/hooks.on-ready.test.js
+++ b/test/hooks.on-ready.test.js
@@ -35,6 +35,21 @@ t.test('onReady should be called in order', t => {
   fastify.ready(err => t.error(err))
 })
 
+t.test('onReady should be called once', async (t) => {
+  const app = Fastify()
+  let counter = 0
+
+  app.addHook('onReady', async function () {
+    counter++
+  })
+
+  await Promise.race([app.ready(), app.ready(), app.ready(), app.ready()])
+
+  await app.ready()
+
+  t.equal(counter, 1)
+})
+
 t.test('async onReady should be called in order', async t => {
   t.plan(7)
   const fastify = Fastify()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
This PR closes #5049

It fixes the double run of `onReady` hooks when calling `Fastify#ready` more than once.
It introduces two new states `booting` (used to indicate `onReady` hooks are running) and `ready` (used to indicate `onReady` hooks have finished running).

> These additions can be subject to change, but I believe they are a good starting point.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
