### PR TITLE
perf: optimize split params

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -406,7 +406,7 @@ function ParserListItem (contentType) {
   // because it would become a match-all handler
   if (this.isEssence === false && parsed.type === '') {
     // handle semicolon or empty string
-    const tmp = contentType.split(';')[0]
+    const tmp = contentType.split(';', 1)[0]
     this.type = tmp === '' ? contentType : tmp
   } else {
     this.type = parsed.type

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -158,7 +158,7 @@ function getSchemaSerializer (context, statusCode, contentType) {
   }
   if (responseSchemaDef[statusCode]) {
     if (responseSchemaDef[statusCode].constructor === Object && contentType) {
-      const mediaName = contentType.split(';')[0]
+      const mediaName = contentType.split(';', 1)[0]
       if (responseSchemaDef[statusCode][mediaName]) {
         return responseSchemaDef[statusCode][mediaName]
       }
@@ -170,7 +170,7 @@ function getSchemaSerializer (context, statusCode, contentType) {
   const fallbackStatusCode = (statusCode + '')[0] + 'xx'
   if (responseSchemaDef[fallbackStatusCode]) {
     if (responseSchemaDef[fallbackStatusCode].constructor === Object && contentType) {
-      const mediaName = contentType.split(';')[0]
+      const mediaName = contentType.split(';', 1)[0]
       if (responseSchemaDef[fallbackStatusCode][mediaName]) {
         return responseSchemaDef[fallbackStatusCode][mediaName]
       }
@@ -182,7 +182,7 @@ function getSchemaSerializer (context, statusCode, contentType) {
   }
   if (responseSchemaDef.default) {
     if (responseSchemaDef.default.constructor === Object && contentType) {
-      const mediaName = contentType.split(';')[0]
+      const mediaName = contentType.split(';', 1)[0]
       if (responseSchemaDef.default[mediaName]) {
         return responseSchemaDef.default[mediaName]
       }


### PR DESCRIPTION
`split` has optional second argument. Since only the first argument of the array is used, you can interrupt parsing the string after the first match.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
