### PR TITLE
chore: implicitly infer SchemaCompiler as readonly

### DIFF
--- a/docs/Reference/Type-Providers.md
+++ b/docs/Reference/Type-Providers.md
@@ -47,7 +47,7 @@ server.get('/route', {
             },
             required: ['foo', 'bar']
         }
-    } as const // don't forget to use const !
+    }
 
 }, (request, reply) => {
 
@@ -141,7 +141,7 @@ function pluginWithJsonSchema(fastify: FastifyInstance, _opts, done): void {
             y: { type: 'number' },
             z: { type: 'boolean' }
           },
-        } as const
+        }
       }
     }, (req) => {
       const { x, y, z } = req.body // type safe

--- a/test/types/type-provider.test-d.ts
+++ b/test/types/type-provider.test-d.ts
@@ -105,6 +105,67 @@ expectAssignable<FastifyInstance>(server.withTypeProvider<TypeBoxProvider>())
 
 interface JsonSchemaToTsProvider extends FastifyTypeProvider { output: this['input'] extends JSONSchema ? FromSchema<this['input']> : unknown }
 
+// explicitly setting schema `as const`
+
+expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
+  '/',
+  {
+    schema: {
+      body: {
+        type: 'object',
+        properties: {
+          x: { type: 'number' },
+          y: { type: 'string' },
+          z: { type: 'boolean' }
+        }
+      } as const
+    },
+    errorHandler: (error, request, reply) => {
+      expectType<FastifyError>(error)
+      expectAssignable<FastifyRequest>(request)
+      expectType<number | undefined>(request.body.x)
+      expectType<string | undefined>(request.body.y)
+      expectType<boolean | undefined>(request.body.z)
+      expectAssignable<FastifyReply>(reply)
+    }
+  },
+  (req) => {
+    expectType<number | undefined>(req.body.x)
+    expectType<string | undefined>(req.body.y)
+    expectType<boolean | undefined>(req.body.z)
+  }
+))
+
+expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().route({
+  url: '/',
+  method: 'POST',
+  schema: {
+    body: {
+      type: 'object',
+      properties: {
+        x: { type: 'number' },
+        y: { type: 'string' },
+        z: { type: 'boolean' }
+      }
+    }
+  } as const,
+  errorHandler: (error, request, reply) => {
+    expectType<FastifyError>(error)
+    expectAssignable<FastifyRequest>(request)
+    expectType<number | undefined>(request.body.x)
+    expectType<string | undefined>(request.body.y)
+    expectType<boolean | undefined>(request.body.z)
+    expectAssignable<FastifyReply>(reply)
+  },
+  handler: (req) => {
+    expectType<number | undefined>(req.body.x)
+    expectType<string | undefined>(req.body.y)
+    expectType<boolean | undefined>(req.body.z)
+  }
+}))
+
+// infering schema `as const`
+
 expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
   '/',
   {

--- a/test/types/type-provider.test-d.ts
+++ b/test/types/type-provider.test-d.ts
@@ -116,7 +116,7 @@ expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
           y: { type: 'string' },
           z: { type: 'boolean' }
         }
-      } as const
+      }
     },
     errorHandler: (error, request, reply) => {
       expectType<FastifyError>(error)
@@ -133,6 +133,34 @@ expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get(
     expectType<boolean | undefined>(req.body.z)
   }
 ))
+
+expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().route({
+  url: '/',
+  method: 'POST',
+  schema: {
+    body: {
+      type: 'object',
+      properties: {
+        x: { type: 'number' },
+        y: { type: 'string' },
+        z: { type: 'boolean' }
+      }
+    }
+  },
+  errorHandler: (error, request, reply) => {
+    expectType<FastifyError>(error)
+    expectAssignable<FastifyRequest>(request)
+    expectType<number | undefined>(request.body.x)
+    expectType<string | undefined>(request.body.y)
+    expectType<boolean | undefined>(request.body.z)
+    expectAssignable<FastifyReply>(reply)
+  },
+  handler: (req) => {
+    expectType<number | undefined>(req.body.x)
+    expectType<string | undefined>(req.body.y)
+    expectType<boolean | undefined>(req.body.z)
+  }
+}))
 
 expectAssignable<FastifyInstance>(server.withTypeProvider<JsonSchemaToTsProvider>())
 

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -196,7 +196,7 @@ export interface FastifyInstance<
   route<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
     ContextConfig = ContextConfigDefault,
-    SchemaCompiler extends FastifySchema = FastifySchema,
+    const SchemaCompiler extends FastifySchema = FastifySchema,
   >(opts: RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
 
   get: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider>;

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -121,16 +121,16 @@ export interface RouteShorthandMethod<
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
 > {
-  <RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault, SchemaCompiler extends FastifySchema = FastifySchema, Logger extends FastifyBaseLogger = FastifyBaseLogger>(
+  <RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault, const SchemaCompiler extends FastifySchema = FastifySchema, Logger extends FastifyBaseLogger = FastifyBaseLogger>(
     path: string,
     opts: RouteShorthandOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>,
     handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
-  <RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault, SchemaCompiler extends FastifySchema = FastifySchema, Logger extends FastifyBaseLogger = FastifyBaseLogger>(
+  <RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault, const SchemaCompiler extends FastifySchema = FastifySchema, Logger extends FastifyBaseLogger = FastifyBaseLogger>(
     path: string,
     handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
-  <RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault, SchemaCompiler extends FastifySchema = FastifySchema, Logger extends FastifyBaseLogger = FastifyBaseLogger>(
+  <RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault, const SchemaCompiler extends FastifySchema = FastifySchema, Logger extends FastifyBaseLogger = FastifyBaseLogger>(
     path: string,
     opts: RouteShorthandOptionsWithHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Skip explicitly providing as const when defining a schema with `json-schema-to-ts` as a type provider.

Now we can go from this:
```ts
const server = fastify().withTypeProvider<JsonSchemaToTsProvider>()

server.get('/route', {
    schema: {
        querystring: {
            type: 'object',
            properties: {
                foo: { type: 'number' },
                bar: { type: 'string' },
            },
            required: ['foo', 'bar']
        }
    } as const // <----- You had to specify it as const to get the literal types
}, (request, reply) => {
    const { foo, bar } = request.query // type safe!
})
```
To this:
```ts
const server = fastify().withTypeProvider<JsonSchemaToTsProvider>()

server.get('/route', {
    schema: {
        querystring: {
            type: 'object',
            properties: {
                foo: { type: 'number' },
                bar: { type: 'string' },
            },
            required: ['foo', 'bar']
        }
    } // <--- We can now skip as const because the compiler knows that object is both readonly and literal type
}, (request, reply) => {
    const { foo, bar } = request.query // type safe!
})
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)