### PR TITLE
docs: remove thenable promisesaplus spec references

### DIFF
--- a/docs/Reference/Plugins.md
+++ b/docs/Reference/Plugins.md
@@ -133,7 +133,8 @@ fastify.listen({ port: 3000 }, (err, address) => {
 ### async/await
 <a id="async-await"></a>
 
-*async/await* is supported by `after`, `ready`, and `listen`, as well as fastify being a Thenable.
+*async/await* is supported by `after`, `ready`, and `listen`, as well as
+`fastify` being a Thenable.
 
 ```js
 await fastify.register(require('my-plugin'))

--- a/docs/Reference/Plugins.md
+++ b/docs/Reference/Plugins.md
@@ -133,7 +133,7 @@ fastify.listen({ port: 3000 }, (err, address) => {
 ### async/await
 <a id="async-await"></a>
 
-*async/await* is supported by `after`, `ready`, and `listen`
+*async/await* is supported by `after`, `ready`, and `listen`, as well as fastify being a Thenable.
 
 ```js
 await fastify.register(require('my-plugin'))

--- a/docs/Reference/Plugins.md
+++ b/docs/Reference/Plugins.md
@@ -133,8 +133,7 @@ fastify.listen({ port: 3000 }, (err, address) => {
 ### async/await
 <a id="async-await"></a>
 
-*async/await* is supported by `after`, `ready`, and `listen`, as well as
-`fastify` being a [Thenable](https://promisesaplus.com/).
+*async/await* is supported by `after`, `ready`, and `listen`
 
 ```js
 await fastify.register(require('my-plugin'))

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -892,6 +892,5 @@ For more details, see:
 
 - https://github.com/fastify/fastify/issues/1864 for the discussion about this
   feature
-- https://promisesaplus.com/ for the definition of thenables
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
   for the signature

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -458,7 +458,6 @@ Reply.prototype.getResponseTime = function () {
 // Make reply a thenable, so it could be used with async/await.
 // See
 // - https://github.com/fastify/fastify/issues/1864 for the discussions
-// - https://promisesaplus.com/ for the definition of thenable
 // - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then for the signature
 Reply.prototype.then = function (fulfilled, rejected) {
   if (this.sent) {


### PR DESCRIPTION
#### Checklist

This PR removes references to promisesaplus.com spec defintion for thenable. Discuessed in https://github.com/fastify/fastify/issues/5005

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
