### PR TITLE
fix: build problems when `Symbol.asyncDispose` type is not available.

### DIFF
--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -143,6 +143,8 @@ export interface FastifyInstance<
   close(closeListener: () => void): undefined;
 
   /** Alias for {@linkcode FastifyInstance.close()} */
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore - @types/node >=17 or typescript >= 5.2 is required to use this
   [Symbol.asyncDispose](): Promise<undefined>;
 
   // should be able to define something useful with the decorator getter/setter pattern using Generics to enforce the users function returns what they expect it to

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -144,7 +144,7 @@ export interface FastifyInstance<
 
   /** Alias for {@linkcode FastifyInstance.close()} */
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore - @types/node >=17 or typescript >= 5.2 is required to use this
+  // @ts-ignore - type only available for @types/node >=17 or typescript >= 5.2
   [Symbol.asyncDispose](): Promise<undefined>;
 
   // should be able to define something useful with the decorator getter/setter pattern using Generics to enforce the users function returns what they expect it to


### PR DESCRIPTION
This PR "fixes" the type error reported at https://github.com/fastify/fastify/issues/5094. This error happens when the user's `tsconfig` has [`skipLibCheck: false`](https://www.typescriptlang.org/tsconfig#skipLibCheck) and an outdated version of `@types/node` or `typescript`.

Current fix only adds a `@ts-ignore` comment if the type is not available. This error should be harmless as the actual JS will only call `Symbol.asyncDispose` if its available.

I'm not sure how we should test this, as it would require to downgrade our typescript and @types/node versions, which would break other ts features that being used in fastify's types.

However, I downgraded them in my machine and can confirm the error was fixed.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
