### PR TITLE
feat: Improve RouteShorthandOptions['constraints'] type

### DIFF
--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -422,6 +422,44 @@ expectType<boolean>(fastify().hasRoute({
   constraints: { version: '1.2.0' }
 }))
 
+expectType<boolean>(fastify().hasRoute({
+  url: '/',
+  method: 'GET',
+  constraints: { host: 'auth.fastify.io' }
+}))
+
+expectType<boolean>(fastify().hasRoute({
+  url: '/',
+  method: 'GET',
+  constraints: { host: /.*\.fastify\.io/ }
+}))
+
+expectType<boolean>(fastify().hasRoute({
+  url: '/',
+  method: 'GET',
+  constraints: { host: /.*\.fastify\.io/, version: '1.2.3' }
+}))
+
+expectType<boolean>(fastify().hasRoute({
+  url: '/',
+  method: 'GET',
+  constraints: {
+    something: {
+      name: 'secret',
+      storage: function () {
+        return {
+          get: (type) => {
+            return null
+          },
+          set: (type, store) => {}
+        }
+      },
+      deriveConstraint: (req, ctx, done) => {},
+      mustMatchWhenDerived: true
+    }
+  }
+}))
+
 expectType<FastifyInstance>(fastify().route({
   url: '/',
   method: 'get',

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -12,6 +12,7 @@ import {
   ResolveFastifyReplyReturnType
 } from './type-provider'
 import { ContextConfigDefault, HTTPMethods, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RawServerDefault } from './utils'
+import { ConstraintStrategy } from 'find-my-way'
 
 export interface FastifyRouteConfig {
   url: string;
@@ -19,6 +20,10 @@ export interface FastifyRouteConfig {
 }
 
 export interface RouteGenericInterface extends RequestGenericInterface, ReplyGenericInterface {}
+
+export type RouteConstraintType = Omit<ConstraintStrategy<any>, 'deriveConstraint'> & {
+  deriveConstraint<Context>(req: RawRequestDefaultExpression<RawServerDefault>, ctx?: Context, done?: (err: Error, ...args: any) => any): any,
+}
 
 /**
  * Route shorthand options for the various shorthand methods
@@ -43,7 +48,7 @@ export interface RouteShorthandOptions<
   logLevel?: LogLevel;
   config?: Omit<FastifyRequestContext<ContextConfig>['config'], 'url' | 'method'>;
   version?: string;
-  constraints?: Partial<{ version: any, host:any, [name: string]: any }>,
+  constraints?: { version: string } | {host: RegExp | string} | {[name: string]: RouteConstraintType },
   prefixTrailingSlash?: 'slash'|'no-slash'|'both';
   errorHandler?: (
     this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -43,7 +43,7 @@ export interface RouteShorthandOptions<
   logLevel?: LogLevel;
   config?: Omit<FastifyRequestContext<ContextConfig>['config'], 'url' | 'method'>;
   version?: string;
-  constraints?: { [name: string]: any },
+  constraints?: Partial<{ version: any, host:any, [name: string]: any }>,
   prefixTrailingSlash?: 'slash'|'no-slash'|'both';
   errorHandler?: (
     this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

As mentioned in the [the documentation](https://fastify.dev/docs/latest/Reference/Routes/#constraints), routes may have [`version`](https://fastify.dev/docs/latest/Reference/Routes/#version-constraints), [`host`](https://fastify.dev/docs/latest/Reference/Routes/#host-constraints) or other custom constraints. This change only extends `RouteShorthandOptions` type with optional `version` and `host` attributes.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
