### PR TITLE
feat: replace diagnostics_channel w/ dc-polyfill

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -519,15 +519,10 @@ function fastify (options) {
   // Delay configuring clientError handler so that it can access fastify state.
   server.on('clientError', options.clientErrorHandler.bind(fastify))
 
-  try {
-    const dc = require('node:diagnostics_channel')
-    const initChannel = dc.channel('fastify.initialization')
-    if (initChannel.hasSubscribers) {
-      initChannel.publish({ fastify })
-    }
-  } catch (e) {
-    // This only happens if `diagnostics_channel` isn't available, i.e. earlier
-    // versions of Node.js. In that event, we don't care, so ignore the error.
+  const dc = require('dc-polyfill')
+  const initChannel = dc.channel('fastify.initialization')
+  if (initChannel.hasSubscribers) {
+    initChannel.publish({ fastify })
   }
 
   return fastify

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "@fastify/fast-json-stringify-compiler": "^4.3.0",
     "abstract-logging": "^2.0.1",
     "avvio": "^8.2.1",
+    "dc-polyfill": "^0.1.2",
     "fast-content-type-parse": "^1.0.0",
     "fast-json-stringify": "^5.7.0",
     "find-my-way": "^7.6.0",

--- a/test/diagnostics-channel.test.js
+++ b/test/diagnostics-channel.test.js
@@ -24,7 +24,7 @@ test('diagnostics_channel when present and subscribers', t => {
   }
 
   const fastify = proxyquire('../fastify', {
-    'node:diagnostics_channel': dc
+    'dc-polyfill': dc
   })()
   t.equal(fastifyInHook, fastify)
 })
@@ -46,16 +46,6 @@ test('diagnostics_channel when present and no subscribers', t => {
   }
 
   proxyquire('../fastify', {
-    'node:diagnostics_channel': dc
+    'dc-polyfill': dc
   })()
-})
-
-test('diagnostics_channel when not present', t => {
-  t.plan(1)
-
-  t.doesNotThrow(() => {
-    proxyquire('../fastify', {
-      'node:diagnostics_channel': null
-    })()
-  })
 })


### PR DESCRIPTION
This change replaces the internal `diagnostics_channel` module with the `dc-polyfill` package, which aims be backport and polyfill newer diagnostics channel features and bugfixes and make them available to older versions of Node.js. Specifically it supports versions as old as Node.js v12.17.

I've removed the try/catch, but if Fastify runs on versions of Node.js older than 12.17 then I can add the try/catch back.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
  - getting (hopefully unrelated) typescript errors
  - benchmark fails, both in `next` and in my branch
    - funny enough the req/sec increased in this branch (119859.2) as compared to the `next` branch (117241.6)
- [x] tests and/or benchmarks are included
  - this reuses the existing diagnostics channel tests
- [ ] documentation is changed or added
  - I don't think it's necessary
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
