### PR TITLE
Docs: Add Deprecation Guide

### DIFF
--- a/docs/Guides/Deprecations.md
+++ b/docs/Guides/Deprecations.md
@@ -2,10 +2,13 @@
 
 # Deprecations
 
-It is suggested that if you are deprecating features, you can send a deprecation warning: [example](https://github.com/fastify/process-warning/blob/master/examples/example.js)
+It is suggested that if you are deprecating features, 
+you can send a deprecation warning: 
+[example](https://github.com/fastify/process-warning/blob/master/examples/example.js)
 ## Suppressing warnings
 
-It is possible to suppress warnings by utilizing one of node's built-in warning suppression mechanisms (on their own risk).
+It is possible to suppress warnings by utilizing one of node's built-in 
+warning suppression mechanisms (on their own risk).
 
 Warnings can be suppressed:
 
@@ -13,7 +16,8 @@ Warnings can be suppressed:
 - by passing the `--no-warnings` flag to the node process
 - by setting 'no-warnings' in the `NODE_OPTIONS` environment variable
 
-For more information see [node's documentation](https://nodejs.org/api/cli.html).
+For more information see 
+[node's documentation](https://nodejs.org/api/cli.html).
 
 ## Fastify Deprecations in Migration Guides
 
@@ -22,9 +26,14 @@ For more information see [node's documentation](https://nodejs.org/api/cli.html)
 
 
 ### V3 Deprecations ([Migration-Guide-V3](Migration-Guide-V3.md))
- - `preParsing` hook behavior - [#2286](https://github.com/fastify/fastify/pull/2286) - The old syntax of Fastify v2 without payload is supported but it is deprecated. [Notes](Migration-Guide-V3.md#changed-preparsing-hook-behavior-2286)
- - [Content Type Parser](../Reference/ContentTypeParser.md) - The old signatures `fn(req, [done])` or `fn(req, payload, [done])` (where `req`
-is `IncomingMessage`) are still supported but are deprecated. [Notes](Migration-Guide-V3.md#changed-content-type-parser-syntax-2286)
+ - `preParsing` hook behavior - 
+ [#2286](https://github.com/fastify/fastify/pull/2286) - The old syntax
+of Fastify v2 without payload is supported but it is deprecated.
+[Notes](Migration-Guide-V3.md#changed-preparsing-hook-behavior-2286)
+ - [Content Type Parser](../Reference/ContentTypeParser.md) - The old
+ signatures `fn(req, [done])` or `fn(req, payload, [done])` (where `req`
+ is `IncomingMessage`) are still supported but are deprecated. 
+ [Notes](Migration-Guide-V3.md#changed-content-type-parser-syntax-2286)
 - Deprecated `request.req` and `reply.res` for
   [`request.raw`](../Reference/Request.md) and
   [`reply.raw`](../Reference/Reply.md)

--- a/docs/Guides/Deprecations.md
+++ b/docs/Guides/Deprecations.md
@@ -1,0 +1,32 @@
+<h1 align="center">Fastify</h1>
+
+# Deprecations
+
+It is suggested that if you are deprecating features, you can send a deprecation warning: [example](https://github.com/fastify/process-warning/blob/master/examples/example.js)
+## Suppressing warnings
+
+It is possible to suppress warnings by utilizing one of node's built-in warning suppression mechanisms (on their own risk).
+
+Warnings can be suppressed:
+
+- by setting the `NODE_NO_WARNINGS` environment variable to `1`
+- by passing the `--no-warnings` flag to the node process
+- by setting 'no-warnings' in the `NODE_OPTIONS` environment variable
+
+For more information see [node's documentation](https://nodejs.org/api/cli.html).
+
+## Fastify Deprecations in Migration Guides
+
+### V4 Deprecations ([Migration-Guide-V4](Migration-Guide-V34.md))
+ - Deprecation of variadic `.listen()` signature [Notes](Migration-Guide-V4.md#deprecation-of-variadic-listen-signature)
+
+
+### V3 Deprecations ([Migration-Guide-V3](Migration-Guide-V3.md))
+ - `preParsing` hook behavior - [#2286](https://github.com/fastify/fastify/pull/2286) - The old syntax of Fastify v2 without payload is supported but it is deprecated. [Notes](Migration-Guide-V3.md#changed-preparsing-hook-behavior-2286)
+ - [Content Type Parser](../Reference/ContentTypeParser.md) - The old signatures `fn(req, [done])` or `fn(req, payload, [done])` (where `req`
+is `IncomingMessage`) are still supported but are deprecated. [Notes](Migration-Guide-V3.md#changed-content-type-parser-syntax-2286)
+- Deprecated `request.req` and `reply.res` for
+  [`request.raw`](../Reference/Request.md) and
+  [`reply.raw`](../Reference/Reply.md)
+- Removed `modifyCoreObjects` option
+  ([#2015](https://github.com/fastify/fastify/pull/2015))

--- a/docs/Guides/Deprecations.md
+++ b/docs/Guides/Deprecations.md
@@ -21,7 +21,7 @@ For more information see
 
 ## Fastify Deprecations in Migration Guides
 
-### V4 Deprecations ([Migration-Guide-V4](Migration-Guide-V34.md))
+### V4 Deprecations ([Migration-Guide-V4](Migration-Guide-V4.md))
  - Deprecation of variadic `.listen()` signature [Notes](Migration-Guide-V4.md#deprecation-of-variadic-listen-signature)
 
 

--- a/docs/Guides/Index.md
+++ b/docs/Guides/Index.md
@@ -15,7 +15,7 @@ This table of contents is in alphabetical order.
   met in your application. This guide focuses on solving the problem using
   [`Hooks`](../Reference/Hooks.md), [`Decorators`](../Reference/Decorators.md),
   and [`Plugins`](../Reference/Plugins.md).
-+ [Depreciations](./Depreciations.md): A guide on depreciations
++ [Depreciations](./Deprecations.md): A guide on depreciations
 + [Detecting When Clients Abort](./Detecting-When-Clients-Abort.md): A 
   practical guide on detecting if and when a client aborts a request.
 + [Ecosystem](./Ecosystem.md): Lists all core plugins and many known community

--- a/docs/Guides/Index.md
+++ b/docs/Guides/Index.md
@@ -15,6 +15,7 @@ This table of contents is in alphabetical order.
   met in your application. This guide focuses on solving the problem using
   [`Hooks`](../Reference/Hooks.md), [`Decorators`](../Reference/Decorators.md),
   and [`Plugins`](../Reference/Plugins.md).
++ [Depreciations](./Depreciations.md): A guide on depreciations
 + [Detecting When Clients Abort](./Detecting-When-Clients-Abort.md): A 
   practical guide on detecting if and when a client aborts a request.
 + [Ecosystem](./Ecosystem.md): Lists all core plugins and many known community


### PR DESCRIPTION
This was in regards to issue #5040

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
