### PR TITLE
refactor: migrate deprecation warnings to actual deprecation warnings

### DIFF
--- a/docs/Guides/Plugins-Guide.md
+++ b/docs/Guides/Plugins-Guide.md
@@ -493,8 +493,8 @@ use case, you can use the
 
 ```js
 const warning = require('process-warning')()
-warning.create('FastifyDeprecation', 'FST_ERROR_CODE', 'message')
-warning.emit('FST_ERROR_CODE')
+warning.create('MyPluginWarning', 'MP_ERROR_CODE', 'message')
+warning.emit('MP_ERROR_CODE')
 ```
 
 ## Let's start!

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -7,35 +7,35 @@ const warning = require('process-warning')()
  *   - FSTDEP005
  */
 
-warning.create('FastifyDeprecation', 'FSTDEP005', 'You are accessing the deprecated "request.connection" property. Use "request.socket" instead.')
+warning.createDeprecation('FSTDEP005', 'You are accessing the deprecated "request.connection" property. Use "request.socket" instead.')
 
-warning.create('FastifyDeprecation', 'FSTDEP006', 'You are decorating Request/Reply with a reference type. This reference is shared amongst all requests. Use onRequest hook instead. Property: %s')
+warning.createDeprecation('FSTDEP006', 'You are decorating Request/Reply with a reference type. This reference is shared amongst all requests. Use onRequest hook instead. Property: %s')
 
-warning.create('FastifyDeprecation', 'FSTDEP007', 'You are trying to set a HEAD route using "exposeHeadRoute" route flag when a sibling route is already set. See documentation for more info.')
+warning.createDeprecation('FSTDEP007', 'You are trying to set a HEAD route using "exposeHeadRoute" route flag when a sibling route is already set. See documentation for more info.')
 
-warning.create('FastifyDeprecation', 'FSTDEP008', 'You are using route constraints via the route { version: "..." } option, use { constraints: { version: "..." } } option instead.')
+warning.createDeprecation('FSTDEP008', 'You are using route constraints via the route { version: "..." } option, use { constraints: { version: "..." } } option instead.')
 
-warning.create('FastifyDeprecation', 'FSTDEP009', 'You are using a custom route versioning strategy via the server { versioning: "..." } option, use { constraints: { version: "..." } } option instead.')
+warning.createDeprecation('FSTDEP009', 'You are using a custom route versioning strategy via the server { versioning: "..." } option, use { constraints: { version: "..." } } option instead.')
 
-warning.create('FastifyDeprecation', 'FSTDEP010', 'Modifying the "reply.sent" property is deprecated. Use the "reply.hijack()" method instead.')
+warning.createDeprecation('FSTDEP010', 'Modifying the "reply.sent" property is deprecated. Use the "reply.hijack()" method instead.')
 
-warning.create('FastifyDeprecation', 'FSTDEP011', 'Variadic listen method is deprecated. Please use ".listen(optionsObject)" instead. The variadic signature will be removed in `fastify@5`.')
+warning.createDeprecation('FSTDEP011', 'Variadic listen method is deprecated. Please use ".listen(optionsObject)" instead. The variadic signature will be removed in `fastify@5`.')
 
-warning.create('FastifyDeprecation', 'FSTDEP012', 'request.context property access is deprecated. Please use "request.routeOptions.config" or "request.routeOptions.schema" instead for accessing Route settings. The "request.context" will be removed in `fastify@5`.')
+warning.createDeprecation('FSTDEP012', 'request.context property access is deprecated. Please use "request.routeOptions.config" or "request.routeOptions.schema" instead for accessing Route settings. The "request.context" will be removed in `fastify@5`.')
 
-warning.create('FastifyDeprecation', 'FSTDEP013', 'Direct return of "trailers" function is deprecated. Please use "callback" or "async-await" for return value. The support of direct return will removed in `fastify@5`.')
+warning.createDeprecation('FSTDEP013', 'Direct return of "trailers" function is deprecated. Please use "callback" or "async-await" for return value. The support of direct return will removed in `fastify@5`.')
 
-warning.create('FastifyDeprecation', 'FSTDEP014', 'You are trying to set/access the default route. This property is deprecated. Please, use setNotFoundHandler if you want to custom a 404 handler or the wildcard (*) to match all routes.')
+warning.createDeprecation('FSTDEP014', 'You are trying to set/access the default route. This property is deprecated. Please, use setNotFoundHandler if you want to custom a 404 handler or the wildcard (*) to match all routes.')
 
-warning.create('FastifyDeprecation', 'FSTDEP015', 'You are accessing the deprecated "request.routeSchema" property. Use "request.routeOptions.schema" instead. Property "req.routeSchema" will be removed in `fastify@5`.')
+warning.createDeprecation('FSTDEP015', 'You are accessing the deprecated "request.routeSchema" property. Use "request.routeOptions.schema" instead. Property "req.routeSchema" will be removed in `fastify@5`.')
 
-warning.create('FastifyDeprecation', 'FSTDEP016', 'You are accessing the deprecated "request.routeConfig" property. Use "request.routeOptions.config" instead. Property "req.routeConfig" will be removed in `fastify@5`.')
+warning.createDeprecation('FSTDEP016', 'You are accessing the deprecated "request.routeConfig" property. Use "request.routeOptions.config" instead. Property "req.routeConfig" will be removed in `fastify@5`.')
 
-warning.create('FastifyDeprecation', 'FSTDEP017', 'You are accessing the deprecated "request.routerPath" property. Use "request.routeOptions.url" instead. Property "req.routerPath" will be removed in `fastify@5`.')
+warning.createDeprecation('FSTDEP017', 'You are accessing the deprecated "request.routerPath" property. Use "request.routeOptions.url" instead. Property "req.routerPath" will be removed in `fastify@5`.')
 
-warning.create('FastifyDeprecation', 'FSTDEP018', 'You are accessing the deprecated "request.routerMethod" property. Use "request.routeOptions.method" instead. Property "req.routerMethod" will be removed in `fastify@5`.')
+warning.createDeprecation('FSTDEP018', 'You are accessing the deprecated "request.routerMethod" property. Use "request.routeOptions.method" instead. Property "req.routerMethod" will be removed in `fastify@5`.')
 
-warning.create('FastifyDeprecation', 'FSTDEP019', 'reply.context property access is deprecated. Please use "reply.routeOptions.config" or "reply.routeOptions.schema" instead for accessing Route settings. The "reply.context" will be removed in `fastify@5`.')
+warning.createDeprecation('FSTDEP019', 'reply.context property access is deprecated. Please use "reply.routeOptions.config" or "reply.routeOptions.schema" instead for accessing Route settings. The "reply.context" will be removed in `fastify@5`.')
 
 warning.create('FastifyWarning', 'FSTWRN001', 'The %s schema for %s: %s is missing. This may indicate the schema is not well specified.', { unlimited: true })
 

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "find-my-way": "^7.7.0",
     "light-my-request": "^5.11.0",
     "pino": "^8.16.0",
-    "process-warning": "^2.2.0",
+    "process-warning": "^2.3.0",
     "proxy-addr": "^2.0.7",
     "rfdc": "^1.3.0",
     "secure-json-parse": "^2.7.0",

--- a/test/default-route.test.js
+++ b/test/default-route.test.js
@@ -18,7 +18,7 @@ test('setDefaultRoute should emit a deprecation warning', t => {
 
   process.on('warning', onWarning)
   function onWarning (warning) {
-    t.equal(warning.name, 'FastifyDeprecation')
+    t.equal(warning.name, 'DeprecationWarning')
     t.equal(warning.code, 'FSTDEP014')
   }
 
@@ -37,7 +37,7 @@ test('getDefaultRoute should emit a deprecation warning', t => {
 
   process.on('warning', onWarning)
   function onWarning (warning) {
-    t.equal(warning.name, 'FastifyDeprecation')
+    t.equal(warning.name, 'DeprecationWarning')
     t.equal(warning.code, 'FSTDEP014')
   }
 

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -1472,7 +1472,7 @@ test('should emit deprecation warning when trying to modify the reply.sent prope
   process.removeAllListeners('warning')
   process.on('warning', onWarning)
   function onWarning (warning) {
-    t.equal(warning.name, 'FastifyDeprecation')
+    t.equal(warning.name, 'DeprecationWarning')
     t.equal(warning.code, deprecationCode)
   }
 
@@ -1500,7 +1500,7 @@ test('should emit deprecation warning when trying to use the reply.context.confi
   process.removeAllListeners('warning')
   process.on('warning', onWarning)
   function onWarning (warning) {
-    t.equal(warning.name, 'FastifyDeprecation')
+    t.equal(warning.name, 'DeprecationWarning')
     t.equal(warning.code, deprecationCode)
   }
 

--- a/test/reply-trailers.test.js
+++ b/test/reply-trailers.test.js
@@ -200,7 +200,7 @@ test('should emit deprecation warning when using direct return', t => {
 
   process.on('warning', onWarning)
   function onWarning (warning) {
-    t.equal(warning.name, 'FastifyDeprecation')
+    t.equal(warning.name, 'DeprecationWarning')
     t.equal(warning.code, 'FSTDEP013')
   }
   t.teardown(() => process.removeListener('warning', onWarning))


### PR DESCRIPTION
This PR changes the deprecation warnings to be actual Node.js recognizable deprecation warnings. Whereas the errors we were emitting prior to this PR were plain warnings with "FastifyDeprecation" as the name, these are:

1. Emitted with "DeprecationWarning" as the name
2. Are recognized as deprecation warnings by Node.js

The benefit of doing this is that deprecations can be traced with `--trace-deprecation`, silenced with `--no-deprecation`, and caused to abort the process with `--throw-deprecation`.

This is made possible through https://github.com/fastify/process-warning/pull/87.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
