### PR TITLE
chore: replace mention of fastify `.io` domain with `.dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center"> <a href="https://fastify.io/">
+<div align="center"> <a href="https://fastify.dev/">
     <img
       src="https://github.com/fastify/graphics/raw/HEAD/fastify-landscape-outlined.svg"
       width="650"

--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -125,11 +125,11 @@ section.
   throttling the download speed of a request.
 - [`@fastify/type-provider-json-schema-to-ts`](https://github.com/fastify/fastify-type-provider-json-schema-to-ts)
   Fastify
-  [type provider](https://www.fastify.io/docs/latest/Reference/Type-Providers/)
+  [type provider](https://www.fastify.dev/docs/latest/Reference/Type-Providers/)
   for [json-schema-to-ts](https://github.com/ThomasAribart/json-schema-to-ts).
 - [`@fastify/type-provider-typebox`](https://github.com/fastify/fastify-type-provider-typebox)
   Fastify
-  [type provider](https://www.fastify.io/docs/latest/Reference/Type-Providers/)
+  [type provider](https://www.fastify.dev/docs/latest/Reference/Type-Providers/)
   for [Typebox](https://github.com/sinclairzx81/typebox).
 - [`@fastify/under-pressure`](https://github.com/fastify/under-pressure) Measure
   process load with automatic handling of _"Service Unavailable"_ plugin for
@@ -618,11 +618,11 @@ middlewares into Fastify plugins
   Useful functions for Twitch Extension Backend Services (EBS).
 - [`fastify-type-provider-effect-schema`](https://github.com/daotl/fastify-type-provider-effect-schema)
   Fastify
-  [type provider](https://www.fastify.io/docs/latest/Reference/Type-Providers/)
+  [type provider](https://www.fastify.dev/docs/latest/Reference/Type-Providers/)
   for [@effect/schema](https://github.com/effect-ts/schema).
 - [`fastify-type-provider-zod`](https://github.com/turkerdev/fastify-type-provider-zod)
   Fastify
-  [type provider](https://www.fastify.io/docs/latest/Reference/Type-Providers/)
+  [type provider](https://www.fastify.dev/docs/latest/Reference/Type-Providers/)
   for [zod](https://github.com/colinhacks/zod).
 - [`fastify-typeorm-plugin`](https://github.com/inthepocket/fastify-typeorm-plugin)
   Fastify plugin to work with TypeORM.

--- a/docs/Guides/Getting-Started.md
+++ b/docs/Guides/Getting-Started.md
@@ -178,7 +178,7 @@ fastify.listen({ port: 3000 }, function (err, address) {
 /**
  * Encapsulates the routes
  * @param {FastifyInstance} fastify  Encapsulated Fastify Instance
- * @param {Object} options plugin options, refer to https://www.fastify.io/docs/latest/Reference/Plugins/#plugin-options
+ * @param {Object} options plugin options, refer to https://www.fastify.dev/docs/latest/Reference/Plugins/#plugin-options
  */
 async function routes (fastify, options) {
   fastify.get('/', async (request, reply) => {
@@ -293,7 +293,7 @@ const fastifyPlugin = require('fastify-plugin')
 /**
  * Connects to a MongoDB database
  * @param {FastifyInstance} fastify Encapsulated Fastify Instance
- * @param {Object} options plugin options, refer to https://www.fastify.io/docs/latest/Reference/Plugins/#plugin-options
+ * @param {Object} options plugin options, refer to https://www.fastify.dev/docs/latest/Reference/Plugins/#plugin-options
  */
 async function dbConnector (fastify, options) {
   fastify.register(require('@fastify/mongodb'), {
@@ -312,7 +312,7 @@ module.exports = fastifyPlugin(dbConnector)
 /**
  * A plugin that provide encapsulated routes
  * @param {FastifyInstance} fastify encapsulated fastify instance
- * @param {Object} options plugin options, refer to https://www.fastify.io/docs/latest/Reference/Plugins/#plugin-options
+ * @param {Object} options plugin options, refer to https://www.fastify.dev/docs/latest/Reference/Plugins/#plugin-options
  */
 async function routes (fastify, options) {
   const collection = fastify.mongo.db.collection('test_collection')

--- a/docs/Guides/Style-Guide.md
+++ b/docs/Guides/Style-Guide.md
@@ -13,7 +13,7 @@ This guide is for anyone who loves to build with Fastify or wants to contribute
 to our documentation. You do not need to be an expert in writing technical
 documentation. This guide is here to help you.
 
-Visit the [contribute](https://www.fastify.io/contribute) page on our website or
+Visit the [contribute](https://www.fastify.dev/contribute) page on our website or
 read the
 [CONTRIBUTING.md](https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md)
 file on GitHub to join our Open Source folks.
@@ -70,12 +70,12 @@ markdown.
 **Example**
 
 ```
-To learn more about hooks, see [Fastify hooks](https://www.fastify.io/docs/latest/Reference/Hooks/).
+To learn more about hooks, see [Fastify hooks](https://www.fastify.dev/docs/latest/Reference/Hooks/).
 ```
 
 Result:
 >To learn more about hooks, see [Fastify
->hooks](https://www.fastify.io/docs/latest/Reference/Hooks/).
+>hooks](https://www.fastify.dev/docs/latest/Reference/Hooks/).
 
 
 
@@ -224,18 +224,18 @@ hyperlink should look:
 <!-- More like this -->
 
 // Add clear & brief description
-[Fastify Plugins] (https://www.fastify.io/docs/latest/Plugins/)
+[Fastify Plugins] (https://www.fastify.dev/docs/latest/Plugins/)
 
 <!--Less like this -->
 
 // incomplete description
-[Fastify] (https://www.fastify.io/docs/latest/Plugins/)
+[Fastify] (https://www.fastify.dev/docs/latest/Plugins/)
 
 // Adding title in link brackets
-[](https://www.fastify.io/docs/latest/Plugins/ "fastify plugin")
+[](https://www.fastify.dev/docs/latest/Plugins/ "fastify plugin")
 
 // Empty title
-[](https://www.fastify.io/docs/latest/Plugins/)
+[](https://www.fastify.dev/docs/latest/Plugins/)
 
 // Adding links localhost URLs instead of using code strings (``)
 [http://localhost:3000/](http://localhost:3000/)

--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -715,9 +715,9 @@ arbitrary host matching.
 fastify.route({
   method: 'GET',
   url: '/',
-  constraints: { host: 'auth.fastify.io' },
+  constraints: { host: 'auth.fastify.dev' },
   handler: function (request, reply) {
-    reply.send('hello world from auth.fastify.io')
+    reply.send('hello world from auth.fastify.dev')
   }
 })
 
@@ -735,10 +735,10 @@ fastify.inject({
   method: 'GET',
   url: '/',
   headers: {
-    'Host': 'auth.fastify.io'
+    'Host': 'auth.fastify.dev'
   }
 }, (err, res) => {
-  // => 'hello world from auth.fastify.io'
+  // => 'hello world from auth.fastify.dev'
 })
 ```
 
@@ -749,7 +749,7 @@ matching wildcard subdomains (or any other pattern):
 fastify.route({
   method: 'GET',
   url: '/',
-  constraints: { host: /.*\.fastify\.io/ }, // will match any subdomain of fastify.io
+  constraints: { host: /.*\.fastify\.io/ }, // will match any subdomain of fastify.dev
   handler: function (request, reply) {
     reply.send('hello world from ' + request.headers.host)
   }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -179,7 +179,7 @@ const codes = {
    */
   FST_ERR_MISSING_MIDDLEWARE: createError(
     'FST_ERR_MISSING_MIDDLEWARE',
-    'You must register a plugin for handling middlewares, visit fastify.io/docs/latest/Reference/Middleware/ for more info.',
+    'You must register a plugin for handling middlewares, visit fastify.dev/docs/latest/Reference/Middleware/ for more info.',
     500
   ),
 

--- a/test/constrained-routes.test.js
+++ b/test/constrained-routes.test.js
@@ -11,7 +11,7 @@ test('Should register a host constrained route', t => {
   fastify.route({
     method: 'GET',
     url: '/',
-    constraints: { host: 'fastify.io' },
+    constraints: { host: 'fastify.dev' },
     handler: (req, reply) => {
       reply.send({ hello: 'world' })
     }
@@ -21,7 +21,7 @@ test('Should register a host constrained route', t => {
     method: 'GET',
     url: '/',
     headers: {
-      host: 'fastify.io'
+      host: 'fastify.dev'
     }
   }, (err, res) => {
     t.error(err)
@@ -56,9 +56,9 @@ test('Should register the same route with host constraints', t => {
   fastify.route({
     method: 'GET',
     url: '/',
-    constraints: { host: 'fastify.io' },
+    constraints: { host: 'fastify.dev' },
     handler: (req, reply) => {
-      reply.send('fastify.io')
+      reply.send('fastify.dev')
     }
   })
 
@@ -75,12 +75,12 @@ test('Should register the same route with host constraints', t => {
     method: 'GET',
     url: '/',
     headers: {
-      host: 'fastify.io'
+      host: 'fastify.dev'
     }
   }, (err, res) => {
     t.error(err)
     t.equal(res.statusCode, 200)
-    t.equal(res.payload, 'fastify.io')
+    t.equal(res.payload, 'fastify.dev')
   })
 
   fastify.inject({
@@ -479,7 +479,7 @@ test('The hasConstraintStrategy should return false for default constraints unti
   fastify.route({
     method: 'GET',
     url: '/',
-    constraints: { host: 'fastify.io' },
+    constraints: { host: 'fastify.dev' },
     handler: (req, reply) => {
       reply.send({ hello: 'from any other domain' })
     }
@@ -533,9 +533,9 @@ test('Should allow registering an unconstrained route after a constrained route'
   fastify.route({
     method: 'GET',
     url: '/',
-    constraints: { host: 'fastify.io' },
+    constraints: { host: 'fastify.dev' },
     handler: (req, reply) => {
-      reply.send({ hello: 'from fastify.io' })
+      reply.send({ hello: 'from fastify.dev' })
     }
   })
 
@@ -551,11 +551,11 @@ test('Should allow registering an unconstrained route after a constrained route'
     method: 'GET',
     url: '/',
     headers: {
-      host: 'fastify.io'
+      host: 'fastify.dev'
     }
   }, (err, res) => {
     t.error(err)
-    t.same(JSON.parse(res.payload), { hello: 'from fastify.io' })
+    t.same(JSON.parse(res.payload), { hello: 'from fastify.dev' })
     t.equal(res.statusCode, 200)
   })
 
@@ -580,7 +580,7 @@ test('Should allow registering constrained routes in a prefixed plugin', t => {
   fastify.register(async (scope, opts) => {
     scope.route({
       method: 'GET',
-      constraints: { host: 'fastify.io' },
+      constraints: { host: 'fastify.dev' },
       path: '/route',
       handler: (req, reply) => {
         reply.send({ ok: true })
@@ -592,7 +592,7 @@ test('Should allow registering constrained routes in a prefixed plugin', t => {
     method: 'GET',
     url: '/prefix/route',
     headers: {
-      host: 'fastify.io'
+      host: 'fastify.dev'
     }
   }, (err, res) => {
     t.error(err)
@@ -608,7 +608,7 @@ test('Should allow registering a constrained GET route after a constrained HEAD 
   fastify.route({
     method: 'HEAD',
     url: '/',
-    constraints: { host: 'fastify.io' },
+    constraints: { host: 'fastify.dev' },
     handler: (req, reply) => {
       reply.header('content-type', 'text/plain')
       reply.send('custom HEAD response')
@@ -618,7 +618,7 @@ test('Should allow registering a constrained GET route after a constrained HEAD 
   fastify.route({
     method: 'GET',
     url: '/',
-    constraints: { host: 'fastify.io' },
+    constraints: { host: 'fastify.dev' },
     handler: (req, reply) => {
       reply.send({ hello: 'from any other domain' })
     }
@@ -628,7 +628,7 @@ test('Should allow registering a constrained GET route after a constrained HEAD 
     method: 'HEAD',
     url: '/',
     headers: {
-      host: 'fastify.io'
+      host: 'fastify.dev'
     }
   }, (err, res) => {
     t.error(err)
@@ -653,7 +653,7 @@ test('Should allow registering a constrained GET route after an unconstrained HE
   fastify.route({
     method: 'GET',
     url: '/',
-    constraints: { host: 'fastify.io' },
+    constraints: { host: 'fastify.dev' },
     handler: (req, reply) => {
       reply.header('content-type', 'text/plain')
       reply.send('Hello from constrains: length is about 41')
@@ -664,7 +664,7 @@ test('Should allow registering a constrained GET route after an unconstrained HE
     method: 'HEAD',
     url: '/',
     headers: {
-      host: 'fastify.io'
+      host: 'fastify.dev'
     }
   }, (err, res) => {
     t.error(err)
@@ -682,7 +682,7 @@ test('Will not try to re-createprefixed HEAD route if it already exists and expo
     scope.route({
       method: 'HEAD',
       path: '/route',
-      constraints: { host: 'fastify.io' },
+      constraints: { host: 'fastify.dev' },
       handler: (req, reply) => {
         reply.header('content-type', 'text/plain')
         reply.send('custom HEAD response')
@@ -691,7 +691,7 @@ test('Will not try to re-createprefixed HEAD route if it already exists and expo
     scope.route({
       method: 'GET',
       path: '/route',
-      constraints: { host: 'fastify.io' },
+      constraints: { host: 'fastify.dev' },
       handler: (req, reply) => {
         reply.send({ ok: true })
       }
@@ -723,7 +723,7 @@ test('allows separate constrained and unconstrained HEAD routes', async (t) => {
     scope.route({
       method: 'HEAD',
       path: '/route',
-      constraints: { host: 'fastify.io' },
+      constraints: { host: 'fastify.dev' },
       handler: (req, reply) => {
         reply.header('content-type', 'text/plain')
         reply.send('constrained HEAD response')
@@ -733,7 +733,7 @@ test('allows separate constrained and unconstrained HEAD routes', async (t) => {
     scope.route({
       method: 'GET',
       path: '/route',
-      constraints: { host: 'fastify.io' },
+      constraints: { host: 'fastify.dev' },
       handler: (req, reply) => {
         reply.send({ ok: true })
       }
@@ -869,7 +869,7 @@ test('Allow regex constraints in routes', t => {
   fastify.route({
     method: 'GET',
     url: '/',
-    constraints: { host: /.*\.fastify\.io/ },
+    constraints: { host: /.*\.fastify\.dev$/ },
     handler: (req, reply) => {
       reply.send({ hello: 'from fastify dev domain' })
     }
@@ -879,7 +879,7 @@ test('Allow regex constraints in routes', t => {
     method: 'GET',
     url: '/',
     headers: {
-      host: 'dev.fastify.io'
+      host: 'dev.fastify.dev'
     }
   }, (err, res) => {
     t.error(err)

--- a/test/http2/constraint.test.js
+++ b/test/http2/constraint.test.js
@@ -28,7 +28,7 @@ test('A route supports host constraints under http2 protocol and secure connecti
     t.fail('Key/cert loading failed', e)
   }
 
-  const constrain = 'fastify.io'
+  const constrain = 'fastify.dev'
 
   fastify.route({
     method: 'GET',

--- a/test/internals/errors.test.js
+++ b/test/internals/errors.test.js
@@ -292,7 +292,7 @@ test('FST_ERR_MISSING_MIDDLEWARE', t => {
   const error = new errors.FST_ERR_MISSING_MIDDLEWARE()
   t.equal(error.name, 'FastifyError')
   t.equal(error.code, 'FST_ERR_MISSING_MIDDLEWARE')
-  t.equal(error.message, 'You must register a plugin for handling middlewares, visit fastify.io/docs/latest/Reference/Middleware/ for more info.')
+  t.equal(error.message, 'You must register a plugin for handling middlewares, visit fastify.dev/docs/latest/Reference/Middleware/ for more info.')
   t.equal(error.statusCode, 500)
   t.ok(error instanceof Error)
 })

--- a/test/schema-examples.test.js
+++ b/test/schema-examples.test.js
@@ -540,7 +540,7 @@ test('should be able to handle formats of ajv-formats when added by plugins opti
     method: 'POST',
     payload: {
       id: '254381a5-888c-4b41-8116-e3b1a54980bd',
-      email: 'info@fastify.io'
+      email: 'info@fastify.dev'
     },
     url: '/'
   }, (_err, res) => {
@@ -552,7 +552,7 @@ test('should be able to handle formats of ajv-formats when added by plugins opti
     method: 'POST',
     payload: {
       id: 'invalid',
-      email: 'info@fastify.io'
+      email: 'info@fastify.dev'
     },
     url: '/'
   }, (_err, res) => {

--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -425,19 +425,19 @@ expectType<boolean>(fastify().hasRoute({
 expectType<boolean>(fastify().hasRoute({
   url: '/',
   method: 'GET',
-  constraints: { host: 'auth.fastify.io' }
+  constraints: { host: 'auth.fastify.dev' }
 }))
 
 expectType<boolean>(fastify().hasRoute({
   url: '/',
   method: 'GET',
-  constraints: { host: /.*\.fastify\.io/ }
+  constraints: { host: /.*\.fastify\.dev$/ }
 }))
 
 expectType<boolean>(fastify().hasRoute({
   url: '/',
   method: 'GET',
-  constraints: { host: /.*\.fastify\.io/, version: '1.2.3' }
+  constraints: { host: /.*\.fastify\.dev$/, version: '1.2.3' }
 }))
 
 expectType<boolean>(fastify().hasRoute({


### PR DESCRIPTION
Also fixes https://github.com/fastify/fastify/security/code-scanning/3, https://github.com/fastify/fastify/security/code-scanning/5, and https://github.com/fastify/fastify/security/code-scanning/6

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
