### PR TITLE
feat(plugins): mixing async and callback style now returns a warning

### DIFF
--- a/docs/Reference/Warnings.md
+++ b/docs/Reference/Warnings.md
@@ -22,6 +22,7 @@ Only experienced users should consider disabling warnings.
 | Code | Description | How to solve | Discussion |
 | ---- | ----------- | ------------ | ---------- |
 | **FSTWRN001** | The specified schema for a route is missing. This may indicate the schema is not well specified. | Check the schema for the route. | [#4647](https://github.com/fastify/fastify/pull/4647) |
+| **FSTWRN002** | You are trying to register a plugin with mixing async and callback style. This will return error in `fastify@5`. | Do not mix async and callback style. | [TBD]() |
 
 
 ### Fastify Deprecation Codes

--- a/docs/Reference/Warnings.md
+++ b/docs/Reference/Warnings.md
@@ -22,7 +22,7 @@ Only experienced users should consider disabling warnings.
 | Code | Description | How to solve | Discussion |
 | ---- | ----------- | ------------ | ---------- |
 | **FSTWRN001** | The specified schema for a route is missing. This may indicate the schema is not well specified. | Check the schema for the route. | [#4647](https://github.com/fastify/fastify/pull/4647) |
-| **FSTWRN002** | You are trying to register a plugin with mixing async and callback style. This will return error in `fastify@5`. | Do not mix async and callback style. | [TBD]() |
+| **FSTWRN002** | The %s plugin being registered mixes async and callback styles, which will result in an error in `fastify@5`. | Do not mix async and callback style. | [#5139](https://github.com/fastify/fastify/pull/5139) |
 
 
 ### Fastify Deprecation Codes

--- a/lib/pluginUtils.js
+++ b/lib/pluginUtils.js
@@ -129,21 +129,23 @@ function checkVersion (fn) {
 function registerPluginName (fn) {
   const meta = getMeta(fn)
 
-  const name = meta?.name ?? 'anonymous'
+  if (!meta) return
 
+  const name = meta.name
+  if (!name) return
   this[kRegisteredPlugins].push(name)
+  return name
 }
 
-function checkPluginHealthiness (fn) {
+function checkPluginHealthiness (fn, pluginName = 'anonymous') {
   if (fn.constructor.name === 'AsyncFunction' && fn.length === 3) {
-    console.log(this[kRegisteredPlugins])
-    warning.emit('FSTWRN002', this[kRegisteredPlugins][this[kRegisteredPlugins].length - 1])
+    warning.emit('FSTWRN002', pluginName)
   }
 }
 
 function registerPlugin (fn) {
-  registerPluginName.call(this, fn)
-  checkPluginHealthiness.call(this, fn)
+  const pluginName = registerPluginName.call(this, fn)
+  checkPluginHealthiness.call(this, fn, pluginName)
   checkVersion.call(this, fn)
   checkDecorators.call(this, fn)
   checkDependencies.call(this, fn)

--- a/lib/pluginUtils.js
+++ b/lib/pluginUtils.js
@@ -11,6 +11,7 @@ const {
   FST_ERR_PLUGIN_VERSION_MISMATCH,
   FST_ERR_PLUGIN_NOT_PRESENT_IN_INSTANCE
 } = require('./errors')
+const warning = require('./warnings.js')
 
 function getMeta (fn) {
   return fn[Symbol.for('plugin-meta')]
@@ -134,7 +135,14 @@ function registerPluginName (fn) {
   this[kRegisteredPlugins].push(name)
 }
 
+function checkPluginHealthiness (fn) {
+  if (fn.constructor.name === 'AsyncFunction' && fn.length === 3) {
+    warning.emit('FSTWRN002')
+  }
+}
+
 function registerPlugin (fn) {
+  checkPluginHealthiness.call(this, fn)
   registerPluginName.call(this, fn)
   checkVersion.call(this, fn)
   checkDecorators.call(this, fn)

--- a/lib/pluginUtils.js
+++ b/lib/pluginUtils.js
@@ -128,22 +128,22 @@ function checkVersion (fn) {
 
 function registerPluginName (fn) {
   const meta = getMeta(fn)
-  if (!meta) return
 
-  const name = meta.name
-  if (!name) return
+  const name = meta?.name ?? 'anonymous'
+
   this[kRegisteredPlugins].push(name)
 }
 
 function checkPluginHealthiness (fn) {
   if (fn.constructor.name === 'AsyncFunction' && fn.length === 3) {
-    warning.emit('FSTWRN002')
+    console.log(this[kRegisteredPlugins])
+    warning.emit('FSTWRN002', this[kRegisteredPlugins][this[kRegisteredPlugins].length - 1])
   }
 }
 
 function registerPlugin (fn) {
-  checkPluginHealthiness.call(this, fn)
   registerPluginName.call(this, fn)
+  checkPluginHealthiness.call(this, fn)
   checkVersion.call(this, fn)
   checkDecorators.call(this, fn)
   checkDependencies.call(this, fn)

--- a/lib/pluginUtils.js
+++ b/lib/pluginUtils.js
@@ -128,7 +128,6 @@ function checkVersion (fn) {
 
 function registerPluginName (fn) {
   const meta = getMeta(fn)
-
   if (!meta) return
 
   const name = meta.name

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -55,6 +55,6 @@ warning.createDeprecation('FSTDEP019', 'reply.context property access is depreca
 
 warning.create('FastifyWarning', 'FSTWRN001', 'The %s schema for %s: %s is missing. This may indicate the schema is not well specified.', { unlimited: true })
 
-warning.create('FastifyWarning', 'FSTWRN002', 'The %s plugin you are trying to register has mixing async and callback style. This will return error in `fastify@5`', { unlimited: true })
+warning.create('FastifyWarning', 'FSTWRN002', 'The %s plugin being registered mixes async and callback styles, which will result in an error in `fastify@5`', { unlimited: true })
 
 module.exports = warning

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -55,6 +55,6 @@ warning.createDeprecation('FSTDEP019', 'reply.context property access is depreca
 
 warning.create('FastifyWarning', 'FSTWRN001', 'The %s schema for %s: %s is missing. This may indicate the schema is not well specified.', { unlimited: true })
 
-warning.create('FastifyWarning', 'FSTWRN002', 'You are trying to register a plugin with mixing async and callback style. This will return error in `fastify@5`', { unlimited: true })
+warning.create('FastifyWarning', 'FSTWRN002', 'The %s plugin you are trying to register has mixing async and callback style. This will return error in `fastify@5`', { unlimited: true })
 
 module.exports = warning

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -20,6 +20,7 @@ const warning = require('process-warning')()
  *   - FSTDEP018
  *   - FSTDEP019
  *   - FSTWRN001
+ *   - FSTWRN002
  */
 
 warning.createDeprecation('FSTDEP005', 'You are accessing the deprecated "request.connection" property. Use "request.socket" instead.')
@@ -53,5 +54,7 @@ warning.createDeprecation('FSTDEP018', 'You are accessing the deprecated "reques
 warning.createDeprecation('FSTDEP019', 'reply.context property access is deprecated. Please use "reply.routeOptions.config" or "reply.routeOptions.schema" instead for accessing Route settings. The "reply.context" will be removed in `fastify@5`.')
 
 warning.create('FastifyWarning', 'FSTWRN001', 'The %s schema for %s: %s is missing. This may indicate the schema is not well specified.', { unlimited: true })
+
+warning.create('FastifyWarning', 'FSTWRN002', 'You are trying to register a plugin with mixing async and callback style. This will return error in `fastify@5`', { unlimited: true })
 
 module.exports = warning

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -3469,7 +3469,7 @@ test('onRequestAbort should support encapsulation', t => {
     done()
   })
 
-  fastify.register(async function (_child, _, done) {
+  fastify.register(async function (_child, _) {
     child = _child
 
     fastify.addHook('onRequestAbort', async function (req) {
@@ -3488,8 +3488,6 @@ test('onRequestAbort should support encapsulation', t => {
         t.equal(++order, 3, 'called in route')
       }
     })
-
-    done()
   })
 
   fastify.listen({ port: 0 }, err => {

--- a/test/plugin.4.test.js
+++ b/test/plugin.4.test.js
@@ -415,10 +415,8 @@ test('hasPlugin returns true when using encapsulation', async t => {
   await fastify.ready()
 })
 
-test('registering plugin with mixed style should return a warning', async t => {
-  t.plan(2)
-
-  const fastify = Fastify()
+test('registering plugins with mixed style should return a warning', async t => {
+  t.plan(4)
 
   process.on('warning', onWarning)
   function onWarning (warning) {
@@ -426,9 +424,21 @@ test('registering plugin with mixed style should return a warning', async t => {
     t.equal(warning.code, 'FSTWRN002')
   }
 
-  fastify.register(async function plugin (app, opts, done) {
+  const fastify = Fastify()
+
+  const anonymousPlugin = async (app, opts, done) => {
     done()
-  })
+  }
+
+  const pluginName = 'error-plugin'
+  const errorPlugin = async (app, opts, done) => {
+    done()
+  }
+
+  const namedPlugin = fp(errorPlugin, { name: pluginName })
+
+  fastify.register(namedPlugin)
+  fastify.register(anonymousPlugin)
 
   await fastify.ready()
 })

--- a/test/plugin.4.test.js
+++ b/test/plugin.4.test.js
@@ -414,3 +414,21 @@ test('hasPlugin returns true when using encapsulation', async t => {
 
   await fastify.ready()
 })
+
+test('registering plugin with mixed style should return a warning', async t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  process.on('warning', onWarning)
+  function onWarning (warning) {
+    t.equal(warning.name, 'FastifyWarning')
+    t.equal(warning.code, 'FSTWRN002')
+  }
+
+  fastify.register(async function plugin (app, opts, done) {
+    done()
+  })
+
+  await fastify.ready()
+})

--- a/test/register.test.js
+++ b/test/register.test.js
@@ -105,20 +105,20 @@ test('awaitable register and after', async t => {
   let second = false
   let third = false
 
-  await fastify.register(async (instance, opts, done) => {
+  await fastify.register(async (instance, opts) => {
     first = true
   })
 
   t.equal(first, true)
 
-  fastify.register(async (instance, opts, done) => {
+  fastify.register(async (instance, opts) => {
     second = true
   })
 
   await fastify.after()
   t.equal(second, true)
 
-  fastify.register(async (instance, opts, done) => {
+  fastify.register(async (instance, opts) => {
     third = true
   })
 
@@ -145,7 +145,7 @@ test('awaitable register error handling', async t => {
 
   await t.rejects(fastify.after(), e)
 
-  fastify.register(async (instance, opts, done) => {
+  fastify.register(async (instance, opts) => {
     t.fail('should not be executed')
   })
 
@@ -167,7 +167,7 @@ test('awaitable after error handling', async t => {
 
   await t.rejects(fastify.after(), e)
 
-  fastify.register(async (instance, opts, done) => {
+  fastify.register(async (instance, opts) => {
     t.fail('should not be executed')
   })
 


### PR DESCRIPTION
Closes #5112 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)