### PR TITLE
fix(plugins): mixing async and callback style now returns an error

### DIFF
--- a/docs/Reference/Errors.md
+++ b/docs/Reference/Errors.md
@@ -529,6 +529,11 @@ Plugin did not start in time. Default timeout (in milliseconds): `10000`
 
 The decorator is not present in the instance.
 
+#### FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER
+<a id="FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER"></a>
+
+A plugin has been registered with mixing async and callback style.
+
 #### FST_ERR_VALIDATION
 <a id="FST_ERR_VALIDATION"></a>
 

--- a/docs/Reference/Errors.md
+++ b/docs/Reference/Errors.md
@@ -532,7 +532,7 @@ The decorator is not present in the instance.
 #### FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER
 <a id="FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER"></a>
 
-A plugin has been registered with mixing async and callback style.
+The plugin being registered mixes async and callback styles.
 
 #### FST_ERR_VALIDATION
 <a id="FST_ERR_VALIDATION"></a>

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -436,7 +436,7 @@ const codes = {
   ),
   FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER: createError(
     'FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER',
-    'Async function has too many arguments. Async plugin should not use the \'done\' argument.',
+    'The %s plugin being registered mixes async and callback styles. Async plugin should not mix async and callback style.',
     500,
     TypeError
   ),

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -434,6 +434,12 @@ const codes = {
     'FST_ERR_PLUGIN_NOT_PRESENT_IN_INSTANCE',
     "The decorator '%s'%s is not present in %s"
   ),
+  FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER: createError(
+    'FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER',
+    'Async function has too many arguments. Async plugin should not use the \'done\' argument.',
+    500,
+    TypeError
+  ),
 
   /**
    *  Avvio Errors

--- a/lib/pluginUtils.js
+++ b/lib/pluginUtils.js
@@ -12,7 +12,6 @@ const {
   FST_ERR_PLUGIN_NOT_PRESENT_IN_INSTANCE,
   FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER
 } = require('./errors')
-const warning = require('./warnings.js')
 
 function getMeta (fn) {
   return fn[Symbol.for('plugin-meta')]

--- a/lib/pluginUtils.js
+++ b/lib/pluginUtils.js
@@ -137,9 +137,9 @@ function registerPluginName (fn) {
   return name
 }
 
-function checkPluginHealthiness (fn) {
+function checkPluginHealthiness (fn, pluginName = 'anonymous') {
   if (fn.constructor.name === 'AsyncFunction' && fn.length === 3) {
-    throw new FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER()
+    throw new FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER(pluginName)
   }
 }
 

--- a/lib/pluginUtils.js
+++ b/lib/pluginUtils.js
@@ -9,7 +9,8 @@ const {
 const { exist, existReply, existRequest } = require('./decorate')
 const {
   FST_ERR_PLUGIN_VERSION_MISMATCH,
-  FST_ERR_PLUGIN_NOT_PRESENT_IN_INSTANCE
+  FST_ERR_PLUGIN_NOT_PRESENT_IN_INSTANCE,
+  FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER
 } = require('./errors')
 const warning = require('./warnings.js')
 
@@ -136,9 +137,9 @@ function registerPluginName (fn) {
   return name
 }
 
-function checkPluginHealthiness (fn, pluginName = 'anonymous') {
+function checkPluginHealthiness (fn) {
   if (fn.constructor.name === 'AsyncFunction' && fn.length === 3) {
-    warning.emit('FSTWRN002', pluginName)
+    throw new FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER()
   }
 }
 

--- a/test/internals/errors.test.js
+++ b/test/internals/errors.test.js
@@ -5,7 +5,7 @@ const errors = require('../../lib/errors')
 const { readFileSync } = require('node:fs')
 const { resolve } = require('node:path')
 
-test('should expose 80 errors', t => {
+test('should expose 81 errors', t => {
   t.plan(1)
   const exportedKeys = Object.keys(errors)
   let counter = 0
@@ -14,11 +14,11 @@ test('should expose 80 errors', t => {
       counter++
     }
   }
-  t.equal(counter, 80)
+  t.equal(counter, 81)
 })
 
 test('ensure name and codes of Errors are identical', t => {
-  t.plan(80)
+  t.plan(81)
   const exportedKeys = Object.keys(errors)
   for (const key of exportedKeys) {
     if (errors[key].name === 'FastifyError') {
@@ -767,6 +767,16 @@ test('FST_ERR_PLUGIN_NOT_PRESENT_IN_INSTANCE', t => {
   t.ok(error instanceof Error)
 })
 
+test('FST_ERR_PLUGIN_NOT_PRESENT_IN_INSTANCE', t => {
+  t.plan(5)
+  const error = new errors.FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER()
+  t.equal(error.name, 'FastifyError')
+  t.equal(error.code, 'FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER')
+  t.equal(error.message, 'Async function has too many arguments. Async plugin should not use the \'done\' argument.')
+  t.equal(error.statusCode, 500)
+  t.ok(error instanceof Error)
+})
+
 test('FST_ERR_PLUGIN_CALLBACK_NOT_FN', t => {
   t.plan(5)
   const error = new errors.FST_ERR_PLUGIN_CALLBACK_NOT_FN()
@@ -838,7 +848,7 @@ test('FST_ERR_LISTEN_OPTIONS_INVALID', t => {
 })
 
 test('Ensure that all errors are in Errors.md documented', t => {
-  t.plan(80)
+  t.plan(81)
   const errorsMd = readFileSync(resolve(__dirname, '../../docs/Reference/Errors.md'), 'utf8')
 
   const exportedKeys = Object.keys(errors)
@@ -850,7 +860,7 @@ test('Ensure that all errors are in Errors.md documented', t => {
 })
 
 test('Ensure that non-existing errors are not in Errors.md documented', t => {
-  t.plan(80)
+  t.plan(81)
   const errorsMd = readFileSync(resolve(__dirname, '../../docs/Reference/Errors.md'), 'utf8')
 
   const matchRE = /#### ([0-9a-zA-Z_]+)\n/g

--- a/test/internals/errors.test.js
+++ b/test/internals/errors.test.js
@@ -767,14 +767,14 @@ test('FST_ERR_PLUGIN_NOT_PRESENT_IN_INSTANCE', t => {
   t.ok(error instanceof Error)
 })
 
-test('FST_ERR_PLUGIN_NOT_PRESENT_IN_INSTANCE', t => {
+test('FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER', t => {
   t.plan(5)
-  const error = new errors.FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER()
+  const error = new errors.FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER('easter-egg')
   t.equal(error.name, 'FastifyError')
   t.equal(error.code, 'FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER')
-  t.equal(error.message, 'Async function has too many arguments. Async plugin should not use the \'done\' argument.')
+  t.equal(error.message, 'The easter-egg plugin being registered mixes async and callback styles. Async plugin should not mix async and callback style.')
   t.equal(error.statusCode, 500)
-  t.ok(error instanceof Error)
+  t.ok(error instanceof TypeError)
 })
 
 test('FST_ERR_PLUGIN_CALLBACK_NOT_FN', t => {


### PR DESCRIPTION
Closes #5112, opened as discussed in #5139

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
