### PR TITLE
Allow async preHandler hooks on RouteShorthandOptions

### DIFF
--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -58,29 +58,41 @@ fastify.route(options)
   validation error, instead of sending the error to the error handler. The
   default [error format](https://ajv.js.org/api.html#error-objects) is the Ajv
   one.
-* `onRequest(request, reply, done)`: a [function](./Hooks.md#onrequest) called
-  as soon as a request is received, it could also be an array of functions.
-* `preParsing(request, reply, done)`: a [function](./Hooks.md#preparsing) called
-  before parsing the request, it could also be an array of functions.
-* `preValidation(request, reply, done)`: a [function](./Hooks.md#prevalidation)
+* `onRequest(request, reply, done)` or `async onRequest(request, reply)`: a
+  [function](./Hooks.md#onrequest) called as soon as a request is received, it
+  could also be an array of functions.
+* `preParsing(request, reply, done)` or `async preParsing(request, reply)`: a
+  [function](./Hooks.md#preparsing) called before parsing the request, it could
+  also be an array of functions.
+* `preValidation(request, reply, done)` or
+  `async preValidation(request, reply)`: a [function](./Hooks.md#prevalidation)
   called after the shared `preValidation` hooks, useful if you need to perform
   authentication at route level for example, it could also be an array of
   functions.
-* `preHandler(request, reply, done)`: a [function](./Hooks.md#prehandler) called
-  just before the request handler, it could also be an array of functions.
-* `preSerialization(request, reply, payload, done)`: a
+* `preHandler(request, reply, done)` or `async preHandler(request, reply)`: a
+  [function](./Hooks.md#prehandler) called just before the request handler, it
+  could also be an array of functions.
+* `preSerialization(request, reply, payload, done)` or
+  `async preSerialization(request, reply, payload)`: a
   [function](./Hooks.md#preserialization) called just before the serialization,
   it could also be an array of functions.
-* `onSend(request, reply, payload, done)`: a [function](./Hooks.md#route-hooks)
-  called right before a response is sent, it could also be an array of
-  functions.
-* `onResponse(request, reply, done)`: a [function](./Hooks.md#onresponse) called
-  when a response has been sent, so you will not be able to send more data to
-  the client. It could also be an array of functions.
-* `onTimeout(request, reply, done)`: a [function](./Hooks.md#ontimeout) called
-  when a request is timed out and the HTTP socket has been hung up.
-* `onError(request, reply, error, done)`: a [function](./Hooks.md#onerror)
+* `onSend(request, reply, payload, done)`
+  or `async onSend(request, reply, payload)`: a
+  [function](./Hooks.md#route-hooks) called right before a response is sent, it
+  could also be an array of functions.
+* `onResponse(request, reply, done)` or `async onResponse(request, reply)`: a
+  [function](./Hooks.md#onresponse) called when a response has been sent, so
+  you will not be able to send more data to the client. It could also be an
+  array of functions.
+* `onTimeout(request, reply, done)` or `async onTimeout(request, reply)`: a
+  [function](./Hooks.md#ontimeout) called when a request is timed out and the
+  HTTP socket has been hung up.
+* `onError(request, reply, error, done)` or
+  `async onError(request, reply, error)`: a [function](./Hooks.md#onerror)
   called when an Error is thrown or sent to the client by the route handler.
+* `onRequestAbort(request, done)` or `async onRequestAbort(request)`: a
+  [function](./Hooks.md#onrequestabort) called when a client closes the
+  connection before the entire request has been processed.
 * `handler(request, reply)`: the function that will handle this request. The
   [Fastify server](./Server.md) will be bound to `this` when the handler is
   called. Note: using an arrow function will break the binding of `this`.

--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -236,7 +236,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
     method: method as HTTPMethods,
     config: { foo: 'bar', bar: 100 },
     prefixTrailingSlash: 'slash',
-    onRequest: async (req, res, done) => { // these handlers are tested in `hooks.test-d.ts`
+    onRequest: async (req, res) => { // these handlers are tested in `hooks.test-d.ts`
       expectType<BodyInterface>(req.body)
       expectType<QuerystringInterface>(req.query)
       expectType<ParamsInterface>(req.params)
@@ -250,7 +250,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<string>(req.routeConfig.url)
       expectType<HTTPMethods | HTTPMethods[]>(req.routeConfig.method)
     },
-    preParsing: async (req, res, payload, done) => {
+    preParsing: async (req, res, payload) => {
       expectType<BodyInterface>(req.body)
       expectType<QuerystringInterface>(req.query)
       expectType<ParamsInterface>(req.params)
@@ -264,10 +264,8 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<string>(req.routeConfig.url)
       expectType<HTTPMethods | HTTPMethods[]>(req.routeConfig.method)
       expectType<RequestPayload>(payload)
-      expectAssignable<(err?: FastifyError | null, res?: RequestPayload) => void>(done)
-      expectAssignable<(err?: NodeJS.ErrnoException) => void>(done)
     },
-    preValidation: async (req, res, done) => {
+    preValidation: async (req, res) => {
       expectType<BodyInterface>(req.body)
       expectType<QuerystringInterface>(req.query)
       expectType<ParamsInterface>(req.params)
@@ -281,7 +279,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<string>(req.routeConfig.url)
       expectType<HTTPMethods | HTTPMethods[]>(req.routeConfig.method)
     },
-    preHandler: async (req, res, done) => {
+    preHandler: async (req, res) => {
       expectType<BodyInterface>(req.body)
       expectType<QuerystringInterface>(req.query)
       expectType<ParamsInterface>(req.params)
@@ -295,7 +293,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<string>(req.routeConfig.url)
       expectType<HTTPMethods | HTTPMethods[]>(req.routeConfig.method)
     },
-    onResponse: async (req, res, done) => {
+    onResponse: async (req, res) => {
       expectType<BodyInterface>(req.body)
       expectType<QuerystringInterface>(req.query)
       expectType<ParamsInterface>(req.params)
@@ -310,7 +308,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<HTTPMethods | HTTPMethods[]>(req.routeConfig.method)
       expectType<number>(res.statusCode)
     },
-    onError: async (req, res, error, done) => {
+    onError: async (req, res, error) => {
       expectType<BodyInterface>(req.body)
       expectType<QuerystringInterface>(req.query)
       expectType<ParamsInterface>(req.params)
@@ -324,7 +322,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<string>(req.routeConfig.url)
       expectType<HTTPMethods | HTTPMethods[]>(req.routeConfig.method)
     },
-    preSerialization: async (req, res, payload, done) => {
+    preSerialization: async (req, res, payload) => {
       expectType<BodyInterface>(req.body)
       expectType<QuerystringInterface>(req.query)
       expectType<ParamsInterface>(req.params)
@@ -338,7 +336,7 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<string>(req.routeConfig.url)
       expectType<HTTPMethods | HTTPMethods[]>(req.routeConfig.method)
     },
-    onSend: async (req, res, payload, done) => {
+    onSend: async (req, res, payload) => {
       expectType<BodyInterface>(req.body)
       expectType<QuerystringInterface>(req.query)
       expectType<ParamsInterface>(req.params)
@@ -349,6 +347,32 @@ type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete'
       expectType<HTTPMethods | HTTPMethods[]>(req.context.config.method)
       expectType<string>(res.context.config.foo)
       expectType<number>(res.context.config.bar)
+      expectType<string>(req.routeConfig.url)
+      expectType<HTTPMethods | HTTPMethods[]>(req.routeConfig.method)
+    },
+    onTimeout: async (req, res) => {
+      expectType<BodyInterface>(req.body)
+      expectType<QuerystringInterface>(req.query)
+      expectType<ParamsInterface>(req.params)
+      expectType<http.IncomingHttpHeaders & HeadersInterface>(req.headers)
+      expectType<string>(req.context.config.foo)
+      expectType<number>(req.context.config.bar)
+      expectType<string>(req.context.config.url)
+      expectType<HTTPMethods | HTTPMethods[]>(req.context.config.method)
+      expectType<string>(res.context.config.foo)
+      expectType<number>(res.context.config.bar)
+      expectType<string>(req.routeConfig.url)
+      expectType<HTTPMethods | HTTPMethods[]>(req.routeConfig.method)
+    },
+    onRequestAbort: async (req) => {
+      expectType<BodyInterface>(req.body)
+      expectType<QuerystringInterface>(req.query)
+      expectType<ParamsInterface>(req.params)
+      expectType<http.IncomingHttpHeaders & HeadersInterface>(req.headers)
+      expectType<string>(req.context.config.foo)
+      expectType<number>(req.context.config.bar)
+      expectType<string>(req.context.config.url)
+      expectType<HTTPMethods | HTTPMethods[]>(req.context.config.method)
       expectType<string>(req.routeConfig.url)
       expectType<HTTPMethods | HTTPMethods[]>(req.routeConfig.method)
     },

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -1,6 +1,6 @@
 import { FastifyError } from '@fastify/error'
 import { FastifyRequestContext } from './context'
-import { onErrorHookHandler, onRequestAbortHookHandler, onRequestHookHandler, onResponseHookHandler, onSendHookHandler, onTimeoutHookHandler, preHandlerHookHandler, preParsingHookHandler, preSerializationHookHandler, preValidationHookHandler } from './hooks'
+import { onErrorAsyncHookHandler, onErrorHookHandler, onRequestAbortAsyncHookHandler, onRequestAbortHookHandler, onRequestAsyncHookHandler, onRequestHookHandler, onResponseAsyncHookHandler, onResponseHookHandler, onSendAsyncHookHandler, onSendHookHandler, onTimeoutAsyncHookHandler, onTimeoutHookHandler, preHandlerAsyncHookHandler, preHandlerHookHandler, preParsingAsyncHookHandler, preParsingHookHandler, preSerializationAsyncHookHandler, preSerializationHookHandler, preValidationAsyncHookHandler, preValidationHookHandler } from './hooks'
 import { FastifyInstance } from './instance'
 import { FastifyBaseLogger, FastifyChildLoggerFactory, LogLevel } from './logger'
 import { FastifyReply, ReplyGenericInterface } from './reply'
@@ -61,25 +61,45 @@ export interface RouteShorthandOptions<
 
   // hooks
   onRequest?: onRequestHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  | onRequestHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
+  | onRequestAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+  | onRequestHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[]
+  | onRequestAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
   preParsing?: preParsingHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  | preParsingHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
+  | preParsingAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+  | preParsingHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[]
+  | preParsingAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
   preValidation?: preValidationHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  | preValidationHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
+  | preValidationAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+  | preValidationHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[]
+  | preValidationAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
   preHandler?: preHandlerHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  | preHandlerHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
+  | preHandlerAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+  | preHandlerHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[]
+  | preHandlerAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
   preSerialization?: preSerializationHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  | preSerializationHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
+  | preSerializationAsyncHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+  | preSerializationHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[]
+  | preSerializationAsyncHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
   onSend?: onSendHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  | onSendHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
+  | onSendAsyncHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+  | onSendHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[]
+  | onSendAsyncHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
   onResponse?: onResponseHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  | onResponseHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
+  | onResponseAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+  | onResponseHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[]
+  | onResponseAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
   onTimeout?: onTimeoutHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  | onTimeoutHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
+  | onTimeoutAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+  | onTimeoutHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[]
+  | onTimeoutAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
   onError?: onErrorHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, FastifyError, SchemaCompiler, TypeProvider, Logger>
-  | onErrorHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, FastifyError, SchemaCompiler, TypeProvider, Logger>[];
+  | onErrorAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, FastifyError, SchemaCompiler, TypeProvider, Logger>
+  | onErrorHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, FastifyError, SchemaCompiler, TypeProvider, Logger>[]
+  | onErrorAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, FastifyError, SchemaCompiler, TypeProvider, Logger>[];
   onRequestAbort?: onRequestAbortHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  | onRequestAbortHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
+  | onRequestAbortAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+  | onRequestAbortHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[]
+  | onRequestAbortAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
 }
 
 /**


### PR DESCRIPTION
#### Description

In response to issue #5086, where I mentioned that the `hookRunner` function can handle async `preHandler` hooks, I added types to route.d.ts to allow async `preHandler` hooks. This change makes it clear that you want either a callback-based hook that returns void or an async hook that returns a Promise -- using an async hook with a callback is problematic and not handled properly by `hookRunner`. This change can probably be applied to the other hooks in `RouteShorthandOptions`, but I scoped it just to the `preHandler` hook, which I tested locally. In fact, there are already tests in route.test-d.ts that validate async hooks.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

