### PR TITLE
docs: add @scalar/fastify-api-reference to community plugins list

### DIFF
--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -195,6 +195,8 @@ section.
   Fast sodium-based crypto for @mgcrea/fastify-session
 - [`@mgcrea/pino-pretty-compact`](https://github.com/mgcrea/pino-pretty-compact)
   A custom compact pino-base prettifier
+- [`@scalar/fastify-api-reference`](https://github.com/scalar/scalar/tree/main/packages/fastify-api-reference)
+  Beautiful OpenAPI/Swagger API references for Fastify
 - [`@trubavuong/fastify-seaweedfs`](https://github.com/trubavuong/fastify-seaweedfs)
   SeaweedFS for Fastify
 - [`apollo-server-fastify`](https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-fastify)


### PR DESCRIPTION
This PR adds `@scalar/fastify-api-reference` to the list of community plugins. This plugin renders modern OpenAPI/Swagger docs based on `@fastify/swagger`.

Read more about the Scalar API References here: https://github.com/scalar/scalar
And about the Fastify plugin here: https://github.com/scalar/scalar/tree/main/packages/fastify-api-reference

#### Usage of the plugin

```ts
await fastify.register(require('@scalar/fastify-api-reference'), {
  routePrefix: '/docs',
})
```

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
