### PR TITLE
docs: clarify handling of streams and buffers

### DIFF
--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -721,7 +721,7 @@ fastify.get('/streams', async function (request, reply) {
 #### TypedArrays
 <a id="send-typedarrays"></a>
 
-`send` manages TypedArray like like a Buffer, and sets the `'Content-Type'` 
+`send` manages TypedArray like a Buffer, and sets the `'Content-Type'`
 header to `'application/octet-stream'` if not already set.
 
 As noted above, TypedArray/Buffers are considered to be pre-serialized, so they 

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -665,8 +665,12 @@ fastify.get('/json', options, function (request, reply) {
 #### Streams
 <a id="send-streams"></a>
 
-*send* can also handle streams by setting the `'Content-Type'` header to
-`'application/octet-stream'`.
+If you are sending a stream and you have not set a `'Content-Type'` header,
+*send* will set it to `'application/octet-stream'`.
+
+As noted above, streams are considered to be pre-serialized, so they will be
+sent unmodified without response validation.
+
 ```js
 fastify.get('/streams', function (request, reply) {
   const fs = require('node:fs')
@@ -690,6 +694,10 @@ fastify.get('/streams', async function (request, reply) {
 
 If you are sending a buffer and you have not set a `'Content-Type'` header,
 *send* will set it to `'application/octet-stream'`.
+
+As noted above, Buffers are considered to be pre-serialized, so they will be 
+sent unmodified without response validation.
+
 ```js
 const fs = require('node:fs')
 fastify.get('/streams', function (request, reply) {
@@ -713,8 +721,12 @@ fastify.get('/streams', async function (request, reply) {
 #### TypedArrays
 <a id="send-typedarrays"></a>
 
-`send` manages TypedArray and sets the `'Content-Type'=application/octet-stream'`
-header if not already set.
+`send` manages TypedArray like like a Buffer, and sets the `'Content-Type'` 
+header to `'application/octet-stream'` if not already set.
+
+As noted above, TypedArray/Buffers are considered to be pre-serialized, so they 
+will be sent unmodified without response validation.
+
 ```js
 const fs = require('node:fs')
 fastify.get('/streams', function (request, reply) {


### PR DESCRIPTION
Updates the docs to:
- Reflect the actual behaviour wherein it is no longer mandatory to set `Content-Type=application/octet-stream` to respond with a stream
- Mention within the immediate context that stream and buffer responses are treated as pre-serialized and skip any response serialization or validation