### PR TITLE
chore: remove unused type assertion

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "fast-json-stringify": "^5.8.0",
     "find-my-way": "^7.7.0",
     "light-my-request": "^5.11.0",
-    "pino": "^8.16.0",
+    "pino": "^8.17.0",
     "process-warning": "^2.3.0",
     "proxy-addr": "^2.0.7",
     "rfdc": "^1.3.0",

--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -150,7 +150,7 @@ const customLogger: CustomLoggerInterface = {
   trace: () => { },
   debug: () => { },
   foo: () => { }, // custom severity logger method
-  child: () => customLogger as pino.Logger<never>
+  child: () => customLogger
 }
 
 const serverWithCustomLogger = fastify({ logger: customLogger })


### PR DESCRIPTION
tiny PR to be merged so that https://github.com/pinojs/pino/pull/1858 doesn't break fastify types.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
