### PR TITLE
test: add tests for TOC of errors.md

### DIFF
--- a/test/internals/errors.test.js
+++ b/test/internals/errors.test.js
@@ -817,6 +817,31 @@ test('FST_ERR_LISTEN_OPTIONS_INVALID', t => {
   t.ok(error instanceof TypeError)
 })
 
+test('Ensure that all errors are in Errors.md TOC', t => {
+  t.plan(78)
+  const errorsMd = readFileSync(resolve(__dirname, '../../docs/Reference/Errors.md'), 'utf8')
+
+  const exportedKeys = Object.keys(errors)
+  for (const key of exportedKeys) {
+    if (errors[key].name === 'FastifyError') {
+      t.ok(errorsMd.includes(`  - [${key.toUpperCase()}](#${key.toLowerCase()})`), key)
+    }
+  }
+})
+
+test('Ensure that non-existing errors are not in Errors.md TOC', t => {
+  t.plan(78)
+  const errorsMd = readFileSync(resolve(__dirname, '../../docs/Reference/Errors.md'), 'utf8')
+
+  const matchRE = / {4}- \[([A-Z0-9_]+)\]\(#[a-z0-9_]+\)/g
+  const matches = errorsMd.matchAll(matchRE)
+  const exportedKeys = Object.keys(errors)
+
+  for (const match of matches) {
+    t.ok(exportedKeys.indexOf(match[1]) !== -1, match[1])
+  }
+})
+
 test('Ensure that all errors are in Errors.md documented', t => {
   t.plan(78)
   const errorsMd = readFileSync(resolve(__dirname, '../../docs/Reference/Errors.md'), 'utf8')


### PR DESCRIPTION
While working on #5193 I think tests for the error.md would be great to avoid merge errors.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
