### PR TITLE
ci: fix broken ci by skipping tests if node v > 18.19.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14, 16, '18.18.2', 20]
+        node-version: [14, 16, 18, 20]
         os: [macos-latest, ubuntu-latest, windows-latest]
         exclude:
           # excludes node 14 on Windows

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,7 +23,7 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [16, '18.18.2', 20]
+        node-version: [16, 18, 20]
         os: [ubuntu-latest]
         pnpm-version: [8]
         # pnpm@8 does not support Node.js 14 so include it separately

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # Maintenance and active LTS
-        node-version: [16, '18.18.2', 20]
+        node-version: [16, 18, 20]
         os: [ubuntu-latest]
         pnpm-version: [8]
         # pnpm@8 does not support Node.js 14 so include it separately
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         # Maintenance and active LTS
-        node-version: [14, 16, '18.18.2', 20]
+        node-version: [14, 16, 18, 20]
         os: [ubuntu-latest]
 
     steps:

--- a/test/close-pipelining.test.js
+++ b/test/close-pipelining.test.js
@@ -36,8 +36,8 @@ test('Should return 503 while closing - pipelining', async t => {
   await instance.close()
 })
 
-const isVgte19 = semver.gte(process.version, '19.0.0')
-test('Should not return 503 while closing - pipelining - return503OnClosing: false, skip Node >= v19.x', { skip: isVgte19 }, async t => {
+const isNodeVersionGte1819 = semver.gte(process.version, '18.19.0')
+test('Should not return 503 while closing - pipelining - return503OnClosing: false, skip Node >= v18.19.x', { skip: isNodeVersionGte1819 }, async t => {
   const fastify = Fastify({
     return503OnClosing: false,
     forceCloseConnections: false
@@ -67,8 +67,8 @@ test('Should not return 503 while closing - pipelining - return503OnClosing: fal
   await instance.close()
 })
 
-test('Should close the socket abruptly - pipelining - return503OnClosing: false, skip Node < v19.x', { skip: !isVgte19 }, async t => {
-  // Since Node v19, we will always invoke server.closeIdleConnections()
+test('Should close the socket abruptly - pipelining - return503OnClosing: false, skip Node < v18.19.x', { skip: !isNodeVersionGte1819 }, async t => {
+  // Since Node v18, we will always invoke server.closeIdleConnections()
   // therefore our socket will be closed
   const fastify = Fastify({
     return503OnClosing: false,

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -204,8 +204,8 @@ test('Should return error while closing (callback) - injection', t => {
   })
 })
 
-const isV19plus = semver.gte(process.version, '19.0.0')
-test('Current opened connection should continue to work after closing and return "connection: close" header - return503OnClosing: false, skip Node >= v19.x', { skip: isV19plus }, t => {
+const isNodeVersionGte1819 = semver.gte(process.version, '18.19.0')
+test('Current opened connection should continue to work after closing and return "connection: close" header - return503OnClosing: false, skip Node >= v18.19.x', { skip: isNodeVersionGte1819 }, t => {
   const fastify = Fastify({
     return503OnClosing: false,
     forceCloseConnections: false
@@ -243,7 +243,7 @@ test('Current opened connection should continue to work after closing and return
   })
 })
 
-test('Current opened connection should NOT continue to work after closing and return "connection: close" header - return503OnClosing: false, skip Node < v19.x', { skip: !isV19plus }, t => {
+test('Current opened connection should NOT continue to work after closing and return "connection: close" header - return503OnClosing: false, skip Node < v18.19.x', { skip: !isNodeVersionGte1819 }, t => {
   t.plan(4)
   const fastify = Fastify({
     return503OnClosing: false,


### PR DESCRIPTION
I guess in 18.19.0 the PR which has something to do with closeIdleConnections got backported and thus breaking our CI. 


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
