### PR TITLE
fix(#5180): close secondary bindings after primary is closed

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -163,29 +163,6 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
               /* istanbul ignore next: the else won't be taken unless listening fails */
               if (!_ignoreErr) {
                 this[kServerBindings].push(secondaryServer)
-                // Due to the nature of the feature is not possible to know
-                // ahead of time the number of bindings that will be made.
-                // For instance, each binding is hooked to be closed at their own
-                // pace through the `onClose` hook.
-                // It also allows them to handle possible connections already
-                // attached to them if any.
-                /* c8 ignore next 20 */
-                this.onClose((instance, done) => {
-                  if (instance[kState].listening) {
-                    // No new TCP connections are accepted
-                    // We swallow any error from the secondary
-                    // server
-                    secondaryServer.close(() => done())
-                    if (serverOpts.forceCloseConnections === 'idle') {
-                      // Not needed in Node 19
-                      secondaryServer.closeIdleConnections()
-                    } else if (typeof secondaryServer.closeAllConnections === 'function' && serverOpts.forceCloseConnections) {
-                      secondaryServer.closeAllConnections()
-                    }
-                  } else {
-                    done()
-                  }
-                })
               }
 
               if (bound === binding) {
@@ -196,7 +173,23 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
           })
 
           const secondaryServer = getServerInstance(serverOpts, httpHandler)
-          const closeSecondary = () => { secondaryServer.close(() => { }) }
+          const closeSecondary = () => {
+            // To avoid fall into situations where the close of the
+            // secondary server is triggered before the preClose hook
+            // is done running, we better wait until the main server
+            // is closed.
+            // No new TCP connections are accepted
+            // We swallow any error from the secondary
+            // server
+            secondaryServer.close(() => {})
+            if (serverOpts.forceCloseConnections === 'idle') {
+              // Not needed in Node 19
+              secondaryServer.closeIdleConnections()
+            } else if (typeof secondaryServer.closeAllConnections === 'function' && serverOpts.forceCloseConnections) {
+              secondaryServer.closeAllConnections()
+            }
+          }
+
           secondaryServer.on('upgrade', mainServer.emit.bind(mainServer, 'upgrade'))
           mainServer.on('unref', closeSecondary)
           mainServer.on('close', closeSecondary)

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -151,6 +151,9 @@ t.test('#5180 - preClose should be called before closing secondary server', t =>
     for (const addr of addresses) {
       if (addr.family !== mainServerAddress.family) {
         secondaryAddress = addr
+        secondaryAddress.address = secondaryAddress.family === 'IPv6'
+          ? `[${secondaryAddress.address}]`
+          : secondaryAddress.address
         break
       }
     }

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -4,6 +4,7 @@ const t = require('tap')
 const test = t.test
 const Fastify = require('..')
 const semver = require('semver')
+const undici = require('undici')
 
 test('listen should accept null port', t => {
   t.plan(1)
@@ -122,4 +123,51 @@ test('abort signal', { skip: semver.lt(process.version, '16.0.0') }, t => {
   })
 
   t.end()
+})
+
+t.test('#5180 - preClose should be called before closing secondary server', t => {
+  t.plan(2)
+  const fastify = Fastify({ forceCloseConnections: true })
+  let flag = false
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.addHook('preClose', async () => {
+    flag = true
+  })
+
+  fastify.get('/', async (req, reply) => {
+    await new Promise((resolve) => {
+      setTimeout(() => resolve(1), 1000)
+    })
+
+    return { hello: 'world' }
+  })
+
+  fastify.listen({ port: 0 }, (err) => {
+    t.error(err)
+    const addresses = fastify.addresses()
+    const mainServerAddress = fastify.server.address()
+    let secondaryAddress
+    for (const addr of addresses) {
+      if (addr.family !== mainServerAddress.family) {
+        secondaryAddress = addr
+        break
+      }
+    }
+
+    if (!secondaryAddress) {
+      t.pass('no secondary server')
+      return
+    }
+
+    undici.request(`http://${secondaryAddress.address}:${secondaryAddress.port}/`)
+      .then(
+        () => { t.fail('Request should not succeed') },
+        () => { t.ok(flag) }
+      )
+
+    setTimeout(() => {
+      fastify.close()
+    }, 250)
+  })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Closes #5180

I tried to add a small test to reproduce it, it does covers the case but open to any suggestion to improve it.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
