### PR TITLE
fix: route constraints

### DIFF
--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -444,7 +444,7 @@ expectType<boolean>(fastify().hasRoute({
   url: '/',
   method: 'GET',
   constraints: {
-    // constraints value should accept any value 
+    // constraints value should accept any value
     number: 12,
     date: new Date(),
     boolean: true,

--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -444,19 +444,12 @@ expectType<boolean>(fastify().hasRoute({
   url: '/',
   method: 'GET',
   constraints: {
-    something: {
-      name: 'secret',
-      storage: function () {
-        return {
-          get: (type) => {
-            return null
-          },
-          set: (type, store) => {}
-        }
-      },
-      deriveConstraint: (req, ctx, done) => {},
-      mustMatchWhenDerived: true
-    }
+    // constraints value should accept any value 
+    number: 12,
+    date: new Date(),
+    boolean: true,
+    function: () => {},
+    object: { foo: 'bar' }
   }
 }))
 

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -1,4 +1,5 @@
 import { FastifyError } from '@fastify/error'
+import { ConstraintStrategy } from 'find-my-way'
 import { FastifyRequestContext } from './context'
 import { onErrorMetaHookHandler, onRequestAbortMetaHookHandler, onRequestMetaHookHandler, onResponseMetaHookHandler, onSendMetaHookHandler, onTimeoutMetaHookHandler, preHandlerMetaHookHandler, preParsingMetaHookHandler, preSerializationMetaHookHandler, preValidationMetaHookHandler } from './hooks'
 import { FastifyInstance } from './instance'
@@ -12,7 +13,6 @@ import {
   ResolveFastifyReplyReturnType
 } from './type-provider'
 import { ContextConfigDefault, HTTPMethods, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RawServerDefault } from './utils'
-import { ConstraintStrategy } from 'find-my-way'
 
 export interface FastifyRouteConfig {
   url: string;
@@ -23,6 +23,12 @@ export interface RouteGenericInterface extends RequestGenericInterface, ReplyGen
 
 export type RouteConstraintType = Omit<ConstraintStrategy<any>, 'deriveConstraint'> & {
   deriveConstraint<Context>(req: RawRequestDefaultExpression<RawServerDefault>, ctx?: Context, done?: (err: Error, ...args: any) => any): any,
+}
+
+export interface RouteConstraint {
+  version?: string
+  host?: RegExp | string
+  [name: string]: unknown
 }
 
 /**
@@ -48,7 +54,7 @@ export interface RouteShorthandOptions<
   logLevel?: LogLevel;
   config?: Omit<FastifyRequestContext<ContextConfig>['config'], 'url' | 'method'>;
   version?: string;
-  constraints?: { version: string } | {host: RegExp | string} | {[name: string]: RouteConstraintType },
+  constraints?: RouteConstraint,
   prefixTrailingSlash?: 'slash'|'no-slash'|'both';
   errorHandler?: (
     this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,


### PR DESCRIPTION
In https://github.com/fastify/fastify/pull/5097, it provides a wrong typings of `route.constraints`.
The `constraints` options is a value that passed to a custom constraints which is initialized when the startup of `fastify`.
You cannot create a constraints through the route option.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
