### PR TITLE
chore: at-large project

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,10 +377,10 @@ to join this group by Lead Maintainers.
 
 [<img
 src="https://github.com/openjs-foundation/artwork/blob/main/openjs_foundation/openjs_foundation-logo-horizontal-color.png?raw=true"
-width="250px;"/>](https://openjsf.org/projects/#growth)
+width="250px;"/>](https://openjsf.org/projects)
 
-We are a [Growth
-Project](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/PROJECT_PROGRESSION.md#growth-stage)
+We are a [At-Large
+Project](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/PROJECT_PROGRESSION.md#at-large-projects)
 in the [OpenJS Foundation](https://openjsf.org/).
 
 ## Acknowledgements


### PR DESCRIPTION
I missed that we are `at-large` now since 2021

- https://github.com/openjs-foundation/project-status/issues/35

![image](https://github.com/fastify/fastify/assets/11404065/fb88d35d-d45e-46cd-887e-f0cf7f1ec2ea)




