### PR TITLE
docs: update setErrorHandler to explain not found behaviour

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1532,13 +1532,11 @@ handlers. *async-await* is supported as well.
 If the error `statusCode` is less than 400, Fastify will automatically
 set it to 500 before calling the error handler.
 
-> **Note** 
-> `setErrorHandler` will ***not*** catch any error inside
-> an `onResponse` hook because the response has already been sent to the client.
-
-> **Note** 
-> `setErrorHandler` will ***not*** catch not found (404) errors. See
-> [`setNotFoundHandler`](#set-not-found-handler) instead.
+`setErrorHandler` will ***not*** catch:
+- errors thrown in an `onResponse` hook because the response has already been
+  sent to the client. Use the `onSend` hook instead.
+- not found (404) errors. Use [`setNotFoundHandler`](#set-not-found-handler)
+  instead.
 
 ```js
 fastify.setErrorHandler(function (error, request, reply) {

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1536,6 +1536,10 @@ set it to 500 before calling the error handler.
 > `setErrorHandler` will ***not*** catch any error inside
 > an `onResponse` hook because the response has already been sent to the client.
 
+> **Note** 
+> `setErrorHandler` will ***not*** catch not found (404) errors. See
+> [`setNotFoundHandler`](#set-not-found-handler) instead.
+
 ```js
 fastify.setErrorHandler(function (error, request, reply) {
   // Log error


### PR DESCRIPTION
Coming from other frameworks this is somewhat surprising. This documents the behaviour and explains to catch 404 errors users need to set a not found handler.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
