### PR TITLE
fix: `npm run test:watch`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:report": "npm run lint && npm run unit:report && npm run test:typescript",
     "test:validator:integrity": "npm run build:validation && git diff --quiet --ignore-all-space --ignore-blank-lines --ignore-cr-at-eol lib/error-serializer.js && git diff --quiet --ignore-all-space --ignore-blank-lines --ignore-cr-at-eol lib/configValidator.js",
     "test:typescript": "tsc test/types/import.ts && tsd",
-    "test:watch": "npm run unit -- -w --no-coverage-report -R terse",
+    "test:watch": "npm run unit -- --watch --cov --no-coverage-report --reporter=terse",
     "unit": "c8 tap",
     "unit:junit": "tap-mocha-reporter xunit < out.tap > test/junit-testresults.xml",
     "unit:report": "tap --cov --coverage-report=html --coverage-report=cobertura | tee out.tap",


### PR DESCRIPTION
This was previously failing with the error: `Error: --watch requires coverage to be enabled`

I've also made the arguments use long parameter notation, to better match the other commands and support readability

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
