### PR TITLE
Add dynamic contributors' avatars to Readme Closes #5225

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,3 +405,11 @@ dependencies:
 - ISC
 - BSD-3-Clause
 - BSD-2-Clause
+
+<h2>🤝 Contributors</h2>
+
+Thanks go to these wonderful people:
+
+<a href="https://github.com/fastify/fastify/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=fastify/fastify" />
+</a>

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ dependencies:
 - BSD-3-Clause
 - BSD-2-Clause
 
-<h2>🤝 Contributors</h2>
+## Contributors
 
 Thanks go to these wonderful people:
 


### PR DESCRIPTION
Integrate a dynamic solution to fetch contributors' avatars from their GitHub profiles and display them in the Readme. This enhancement celebrates the diverse community contributing to the project, adding a personal touch to the documentation. By showcasing the faces behind the code, we aim to strengthen the sense of community and recognition for our invaluable contributors. Let's make our Readme reflect the vibrant and diverse community that drives the success of our open-source endeavor.
