### PR TITLE
fix: Always call resource.emitDestroy()

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -184,7 +184,7 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
   function done (error, body) {
     // We cannot use resource.bind() because it is broken in node v12 and v14
     resource.runInAsyncScope(() => {
-      process.nextTick(emitDestroy, resource)
+      resource.emitDestroy()
       if (error) {
         reply[kReplyIsError] = true
         reply.send(error)
@@ -194,10 +194,6 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
       }
     })
   }
-}
-
-function emitDestroy (resource) {
-  resource.emitDestroy()
 }
 
 function rawBody (request, reply, options, parser, done) {

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -184,6 +184,7 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
   function done (error, body) {
     // We cannot use resource.bind() because it is broken in node v12 and v14
     resource.runInAsyncScope(() => {
+      process.nextTick(emitDestroy, resource)
       if (error) {
         reply[kReplyIsError] = true
         reply.send(error)
@@ -193,6 +194,10 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
       }
     })
   }
+}
+
+function emitDestroy (resource) {
+  resource.emitDestroy()
 }
 
 function rawBody (request, reply, options, parser, done) {

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -157,7 +157,6 @@ ContentTypeParser.prototype.remove = function (contentType) {
 
 ContentTypeParser.prototype.run = function (contentType, handler, request, reply) {
   const parser = this.getParser(contentType)
-  const resource = new AsyncResource('content-type-parser:run', request)
 
   if (parser === undefined) {
     if (request.is404) {
@@ -165,7 +164,14 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
     } else {
       reply.send(new FST_ERR_CTP_INVALID_MEDIA_TYPE(contentType || undefined))
     }
-  } else if (parser.asString === true || parser.asBuffer === true) {
+
+    // Early return to avoid allocating an AsyncResource if it's not needed
+    return
+  }
+
+  const resource = new AsyncResource('content-type-parser:run', request)
+
+  if (parser.asString === true || parser.asBuffer === true) {
     rawBody(
       request,
       reply,

--- a/test/async_hooks.test.js
+++ b/test/async_hooks.test.js
@@ -1,0 +1,69 @@
+'use strict'
+
+const { createHook } = require('node:async_hooks')
+const t = require('tap')
+const Fastify = require('..')
+const sget = require('simple-get').concat
+
+const remainingIds = new Set()
+
+createHook({
+  init (asyncId, type, triggerAsyncId, resource) {
+    if (type === 'content-type-parser:run') {
+      remainingIds.add(asyncId)
+    }
+  },
+  destroy (asyncId) {
+    remainingIds.delete(asyncId)
+  }
+})
+
+const app = Fastify({ logger: false })
+
+app.get('/', function (request, reply) {
+  reply.send({ id: 42 })
+})
+
+app.post('/', function (request, reply) {
+  reply.send({ id: 42 })
+})
+
+app.listen({ port: 0 }, function (err, address) {
+  t.error(err)
+
+  sget({
+    method: 'POST',
+    url: 'http://localhost:' + app.server.address().port,
+    body: {
+      hello: 'world'
+    },
+    json: true
+  }, (err, response, body) => {
+    t.error(err)
+    t.equal(response.statusCode, 200)
+
+    sget({
+      method: 'POST',
+      url: 'http://localhost:' + app.server.address().port,
+      body: {
+        hello: 'world'
+      },
+      json: true
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+
+      sget({
+        method: 'GET',
+        url: 'http://localhost:' + app.server.address().port,
+        json: true
+      }, (err, response, body) => {
+        t.error(err)
+        t.equal(response.statusCode, 200)
+        app.close()
+        t.equal(remainingIds.size, 0)
+        t.end()
+      })
+    })
+  })
+})


### PR DESCRIPTION
The lack of an `.emitDestroy()` might causes a potential memory leak when used with odd implementations of `async_hooks` (including a false positive in why-is-node-running).