### PR TITLE
fix: always consume stream payloads when responding to 204 with no body

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -605,6 +605,10 @@ function onSendEnd (reply, payload) {
     reply.removeHeader('content-length')
     safeWriteHead(reply, statusCode)
     sendTrailer(undefined, res, reply)
+    if (typeof payload.resume === 'function') {
+      payload.on('error', noop)
+      payload.resume()
+    }
     return
   }
 


### PR DESCRIPTION
Fixes https://github.com/fastify/fastify-reply-from/issues/338.

This is quite a bad regression.