### PR TITLE
feat: add use semicolon delimter config, default = true

### DIFF
--- a/build/build-validation.js
+++ b/build/build-validation.js
@@ -41,7 +41,8 @@ const defaultInitOptions = {
   requestIdHeader: 'request-id',
   requestIdLogLabel: 'reqId',
   http2SessionTimeout: 72000, // 72 seconds
-  exposeHeadRoutes: true
+  exposeHeadRoutes: true,
+  useSemicolonDelimiter: true
 }
 
 const schema = {
@@ -101,6 +102,7 @@ const schema = {
     requestIdLogLabel: { type: 'string', default: defaultInitOptions.requestIdLogLabel },
     http2SessionTimeout: { type: 'integer', default: defaultInitOptions.http2SessionTimeout },
     exposeHeadRoutes: { type: 'boolean', default: defaultInitOptions.exposeHeadRoutes },
+    useSemicolonDelimiter: { type: 'boolean', default: defaultInitOptions.useSemicolonDelimiter },
     // deprecated style of passing the versioning constraint
     versioning: {
       type: 'object',

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -866,7 +866,7 @@ function rewriteUrl (req) {
 + Default `true`
 
 Enabled by default. Fastify uses [find-my-way](https://github.com/delvedor/find-my-way)
-to separates path and query string with ? character. According to
+to separates path and query string with `;` character. According to
 [RFC3986](https://www.rfc-editor.org/rfc/rfc3986#section-3.4), To disable, set
 `useSemicolonDelimiter` to `false`.
 

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -44,6 +44,7 @@ describes the properties available in that options object.
   - [`frameworkErrors`](#frameworkerrors)
   - [`clientErrorHandler`](#clienterrorhandler)
   - [`rewriteUrl`](#rewriteurl)
+  - [`useSemicolonDelimiter`](#usesemicolondelimiter)
 - [Instance](#instance)
   - [Server Methods](#server-methods)
     - [server](#server)
@@ -858,6 +859,16 @@ function rewriteUrl (req) {
   }
 }
 ```
+
+### `useSemicolonDelimiter`
+<a id="use-semicolon-delimiter"></a>
+
++ Default `true`
+
+Enabled by default. Fastify uses [find-my-way](https://github.com/delvedor/find-my-way)
+to separates path and query string with ? character. According to
+[RFC3986](https://www.rfc-editor.org/rfc/rfc3986#section-3.4), To disable, set
+`useSemicolonDelimiter` to `false`.
 
 ## Instance
 
@@ -1920,6 +1931,7 @@ The properties that can currently be exposed are:
 - requestIdHeader
 - requestIdLogLabel
 - http2SessionTimeout
+- useSemicolonDelimiter 
 
 ```js
 const { readFileSync } = require('node:fs')

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -865,10 +865,25 @@ function rewriteUrl (req) {
 
 + Default `true`
 
-Enabled by default. Fastify uses [find-my-way](https://github.com/delvedor/find-my-way)
-to separates path and query string with `;` character. According to
-[RFC3986](https://www.rfc-editor.org/rfc/rfc3986#section-3.4), To disable, set
-`useSemicolonDelimiter` to `false`.
+Fastify uses [find-my-way](https://github.com/delvedor/find-my-way) which supports,
+separating the path and query string with a `;` character (code 59), e.g. `/dev;foo=bar`.
+This decision originated from [delvedor/find-my-way#76]
+(https://github.com/delvedor/find-my-way/issues/76). Thus, this option will support
+backwards compatiblilty for the need to split on `;`. To disable support for splitting
+on `;` set `useSemicolonDelimiter` to `false`.
+
+```js
+const fastify = require('fastify')({
+  useSemicolonDelimiter: true
+})
+
+fastify.get('/dev', async (request, reply) => {
+  // An example request such as `/dev;foo=bar`
+  // Will produce the following query params result `{ foo = 'bar' }`
+  return request.query
+})
+```
+
 
 ## Instance
 

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -109,6 +109,7 @@ declare namespace fastify {
     allowUnsafeRegex?: boolean,
     requestIdHeader?: string | false,
     requestIdLogLabel?: string;
+    useSemicolonDelimiter?: boolean,
     jsonShorthand?: boolean;
     genReqId?: (req: RawRequestDefaultExpression<RawServer>) => string,
     trustProxy?: boolean | string | string[] | number | TrustProxyFunction,

--- a/fastify.js
+++ b/fastify.js
@@ -182,7 +182,7 @@ function fastify (options) {
       allowUnsafeRegex: options.allowUnsafeRegex || defaultInitOptions.allowUnsafeRegex,
       buildPrettyMeta: defaultBuildPrettyMeta,
       querystringParser: options.querystringParser,
-      useSemicolonDelimiter: typeof options.useSemicolonDelimiter === 'boolean' ? options.useSemicolonDelimiter : defaultInitOptions.useSemicolonDelimiter
+      useSemicolonDelimiter: options.useSemicolonDelimiter ?? defaultInitOptions.useSemicolonDelimiter
     }
   })
 

--- a/fastify.js
+++ b/fastify.js
@@ -144,6 +144,7 @@ function fastify (options) {
   options.disableRequestLogging = disableRequestLogging
   options.ajv = ajvOptions
   options.clientErrorHandler = options.clientErrorHandler || defaultClientErrorHandler
+  options.useSemicolonDelimiter = options.useSemicolonDelimiter || defaultInitOptions.useSemicolonDelimiter
 
   const initialConfig = getSecuredInitialConfig(options)
 
@@ -181,7 +182,8 @@ function fastify (options) {
       caseSensitive: options.caseSensitive,
       allowUnsafeRegex: options.allowUnsafeRegex || defaultInitOptions.allowUnsafeRegex,
       buildPrettyMeta: defaultBuildPrettyMeta,
-      querystringParser: options.querystringParser
+      querystringParser: options.querystringParser,
+      useSemicolonDelimiter: options.useSemicolonDelimiter || defaultInitOptions.useSemicolonDelimiter
     }
   })
 

--- a/fastify.js
+++ b/fastify.js
@@ -144,7 +144,6 @@ function fastify (options) {
   options.disableRequestLogging = disableRequestLogging
   options.ajv = ajvOptions
   options.clientErrorHandler = options.clientErrorHandler || defaultClientErrorHandler
-  options.useSemicolonDelimiter = options.useSemicolonDelimiter || defaultInitOptions.useSemicolonDelimiter
 
   const initialConfig = getSecuredInitialConfig(options)
 
@@ -183,7 +182,7 @@ function fastify (options) {
       allowUnsafeRegex: options.allowUnsafeRegex || defaultInitOptions.allowUnsafeRegex,
       buildPrettyMeta: defaultBuildPrettyMeta,
       querystringParser: options.querystringParser,
-      useSemicolonDelimiter: options.useSemicolonDelimiter || defaultInitOptions.useSemicolonDelimiter
+      useSemicolonDelimiter: typeof options.useSemicolonDelimiter === 'boolean' ? options.useSemicolonDelimiter : defaultInitOptions.useSemicolonDelimiter
     }
   })
 

--- a/lib/configValidator.js
+++ b/lib/configValidator.js
@@ -3,7 +3,7 @@
 "use strict";
 module.exports = validate10;
 module.exports.default = validate10;
-const schema11 = {"type":"object","additionalProperties":false,"properties":{"connectionTimeout":{"type":"integer","default":0},"keepAliveTimeout":{"type":"integer","default":72000},"forceCloseConnections":{"oneOf":[{"type":"string","pattern":"idle"},{"type":"boolean"}]},"maxRequestsPerSocket":{"type":"integer","default":0,"nullable":true},"requestTimeout":{"type":"integer","default":0},"bodyLimit":{"type":"integer","default":1048576},"caseSensitive":{"type":"boolean","default":true},"allowUnsafeRegex":{"type":"boolean","default":false},"http2":{"type":"boolean"},"https":{"if":{"not":{"oneOf":[{"type":"boolean"},{"type":"null"},{"type":"object","additionalProperties":false,"required":["allowHTTP1"],"properties":{"allowHTTP1":{"type":"boolean"}}}]}},"then":{"setDefaultValue":true}},"ignoreTrailingSlash":{"type":"boolean","default":false},"ignoreDuplicateSlashes":{"type":"boolean","default":false},"disableRequestLogging":{"type":"boolean","default":false},"jsonShorthand":{"type":"boolean","default":true},"maxParamLength":{"type":"integer","default":100},"onProtoPoisoning":{"type":"string","default":"error"},"onConstructorPoisoning":{"type":"string","default":"error"},"pluginTimeout":{"type":"integer","default":10000},"requestIdHeader":{"anyOf":[{"enum":[false]},{"type":"string"}],"default":"request-id"},"requestIdLogLabel":{"type":"string","default":"reqId"},"http2SessionTimeout":{"type":"integer","default":72000},"exposeHeadRoutes":{"type":"boolean","default":true},"versioning":{"type":"object","additionalProperties":true,"required":["storage","deriveVersion"],"properties":{"storage":{},"deriveVersion":{}}},"constraints":{"type":"object","additionalProperties":{"type":"object","required":["name","storage","validate","deriveConstraint"],"additionalProperties":true,"properties":{"name":{"type":"string"},"storage":{},"validate":{},"deriveConstraint":{}}}}}};
+const schema11 = {"type":"object","additionalProperties":false,"properties":{"connectionTimeout":{"type":"integer","default":0},"keepAliveTimeout":{"type":"integer","default":72000},"forceCloseConnections":{"oneOf":[{"type":"string","pattern":"idle"},{"type":"boolean"}]},"maxRequestsPerSocket":{"type":"integer","default":0,"nullable":true},"requestTimeout":{"type":"integer","default":0},"bodyLimit":{"type":"integer","default":1048576},"caseSensitive":{"type":"boolean","default":true},"allowUnsafeRegex":{"type":"boolean","default":false},"http2":{"type":"boolean"},"https":{"if":{"not":{"oneOf":[{"type":"boolean"},{"type":"null"},{"type":"object","additionalProperties":false,"required":["allowHTTP1"],"properties":{"allowHTTP1":{"type":"boolean"}}}]}},"then":{"setDefaultValue":true}},"ignoreTrailingSlash":{"type":"boolean","default":false},"ignoreDuplicateSlashes":{"type":"boolean","default":false},"disableRequestLogging":{"type":"boolean","default":false},"jsonShorthand":{"type":"boolean","default":true},"maxParamLength":{"type":"integer","default":100},"onProtoPoisoning":{"type":"string","default":"error"},"onConstructorPoisoning":{"type":"string","default":"error"},"pluginTimeout":{"type":"integer","default":10000},"requestIdHeader":{"anyOf":[{"enum":[false]},{"type":"string"}],"default":"request-id"},"requestIdLogLabel":{"type":"string","default":"reqId"},"http2SessionTimeout":{"type":"integer","default":72000},"exposeHeadRoutes":{"type":"boolean","default":true},"useSemicolonDelimiter":{"type":"boolean","default":true},"versioning":{"type":"object","additionalProperties":true,"required":["storage","deriveVersion"],"properties":{"storage":{},"deriveVersion":{}}},"constraints":{"type":"object","additionalProperties":{"type":"object","required":["name","storage","validate","deriveConstraint"],"additionalProperties":true,"properties":{"name":{"type":"string"},"storage":{},"validate":{},"deriveConstraint":{}}}}}};
 const func2 = Object.prototype.hasOwnProperty;
 const pattern0 = new RegExp("idle", "u");
 
@@ -68,6 +68,9 @@ data.http2SessionTimeout = 72000;
 }
 if(data.exposeHeadRoutes === undefined){
 data.exposeHeadRoutes = true;
+}
+if(data.useSemicolonDelimiter === undefined){
+data.useSemicolonDelimiter = true;
 }
 const _errs1 = errors;
 for(const key0 in data){
@@ -985,13 +988,38 @@ data["exposeHeadRoutes"] = coerced24;
 }
 var valid0 = _errs66 === errors;
 if(valid0){
-if(data.versioning !== undefined){
-let data23 = data.versioning;
+let data23 = data.useSemicolonDelimiter;
 const _errs68 = errors;
-if(errors === _errs68){
-if(data23 && typeof data23 == "object" && !Array.isArray(data23)){
+if(typeof data23 !== "boolean"){
+let coerced25 = undefined;
+if(!(coerced25 !== undefined)){
+if(data23 === "false" || data23 === 0 || data23 === null){
+coerced25 = false;
+}
+else if(data23 === "true" || data23 === 1){
+coerced25 = true;
+}
+else {
+validate10.errors = [{instancePath:instancePath+"/useSemicolonDelimiter",schemaPath:"#/properties/useSemicolonDelimiter/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
+return false;
+}
+}
+if(coerced25 !== undefined){
+data23 = coerced25;
+if(data !== undefined){
+data["useSemicolonDelimiter"] = coerced25;
+}
+}
+}
+var valid0 = _errs68 === errors;
+if(valid0){
+if(data.versioning !== undefined){
+let data24 = data.versioning;
+const _errs70 = errors;
+if(errors === _errs70){
+if(data24 && typeof data24 == "object" && !Array.isArray(data24)){
 let missing1;
-if(((data23.storage === undefined) && (missing1 = "storage")) || ((data23.deriveVersion === undefined) && (missing1 = "deriveVersion"))){
+if(((data24.storage === undefined) && (missing1 = "storage")) || ((data24.deriveVersion === undefined) && (missing1 = "deriveVersion"))){
 validate10.errors = [{instancePath:instancePath+"/versioning",schemaPath:"#/properties/versioning/required",keyword:"required",params:{missingProperty: missing1},message:"must have required property '"+missing1+"'"}];
 return false;
 }
@@ -1001,49 +1029,49 @@ validate10.errors = [{instancePath:instancePath+"/versioning",schemaPath:"#/prop
 return false;
 }
 }
-var valid0 = _errs68 === errors;
+var valid0 = _errs70 === errors;
 }
 else {
 var valid0 = true;
 }
 if(valid0){
 if(data.constraints !== undefined){
-let data24 = data.constraints;
-const _errs71 = errors;
-if(errors === _errs71){
-if(data24 && typeof data24 == "object" && !Array.isArray(data24)){
-for(const key2 in data24){
-let data25 = data24[key2];
-const _errs74 = errors;
-if(errors === _errs74){
+let data25 = data.constraints;
+const _errs73 = errors;
+if(errors === _errs73){
 if(data25 && typeof data25 == "object" && !Array.isArray(data25)){
+for(const key2 in data25){
+let data26 = data25[key2];
+const _errs76 = errors;
+if(errors === _errs76){
+if(data26 && typeof data26 == "object" && !Array.isArray(data26)){
 let missing2;
-if(((((data25.name === undefined) && (missing2 = "name")) || ((data25.storage === undefined) && (missing2 = "storage"))) || ((data25.validate === undefined) && (missing2 = "validate"))) || ((data25.deriveConstraint === undefined) && (missing2 = "deriveConstraint"))){
+if(((((data26.name === undefined) && (missing2 = "name")) || ((data26.storage === undefined) && (missing2 = "storage"))) || ((data26.validate === undefined) && (missing2 = "validate"))) || ((data26.deriveConstraint === undefined) && (missing2 = "deriveConstraint"))){
 validate10.errors = [{instancePath:instancePath+"/constraints/" + key2.replace(/~/g, "~0").replace(/\//g, "~1"),schemaPath:"#/properties/constraints/additionalProperties/required",keyword:"required",params:{missingProperty: missing2},message:"must have required property '"+missing2+"'"}];
 return false;
 }
 else {
-if(data25.name !== undefined){
-let data26 = data25.name;
-if(typeof data26 !== "string"){
-let dataType25 = typeof data26;
-let coerced25 = undefined;
-if(!(coerced25 !== undefined)){
-if(dataType25 == "number" || dataType25 == "boolean"){
-coerced25 = "" + data26;
+if(data26.name !== undefined){
+let data27 = data26.name;
+if(typeof data27 !== "string"){
+let dataType26 = typeof data27;
+let coerced26 = undefined;
+if(!(coerced26 !== undefined)){
+if(dataType26 == "number" || dataType26 == "boolean"){
+coerced26 = "" + data27;
 }
-else if(data26 === null){
-coerced25 = "";
+else if(data27 === null){
+coerced26 = "";
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/constraints/" + key2.replace(/~/g, "~0").replace(/\//g, "~1")+"/name",schemaPath:"#/properties/constraints/additionalProperties/properties/name/type",keyword:"type",params:{type: "string"},message:"must be string"}];
 return false;
 }
 }
-if(coerced25 !== undefined){
-data26 = coerced25;
-if(data25 !== undefined){
-data25["name"] = coerced25;
+if(coerced26 !== undefined){
+data27 = coerced26;
+if(data26 !== undefined){
+data26["name"] = coerced26;
 }
 }
 }
@@ -1055,7 +1083,7 @@ validate10.errors = [{instancePath:instancePath+"/constraints/" + key2.replace(/
 return false;
 }
 }
-var valid7 = _errs74 === errors;
+var valid7 = _errs76 === errors;
 if(!valid7){
 break;
 }
@@ -1066,10 +1094,11 @@ validate10.errors = [{instancePath:instancePath+"/constraints",schemaPath:"#/pro
 return false;
 }
 }
-var valid0 = _errs71 === errors;
+var valid0 = _errs73 === errors;
 }
 else {
 var valid0 = true;
+}
 }
 }
 }
@@ -1106,4 +1135,4 @@ return errors === 0;
 }
 
 
-module.exports.defaultInitOptions = {"connectionTimeout":0,"keepAliveTimeout":72000,"maxRequestsPerSocket":0,"requestTimeout":0,"bodyLimit":1048576,"caseSensitive":true,"allowUnsafeRegex":false,"disableRequestLogging":false,"jsonShorthand":true,"ignoreTrailingSlash":false,"ignoreDuplicateSlashes":false,"maxParamLength":100,"onProtoPoisoning":"error","onConstructorPoisoning":"error","pluginTimeout":10000,"requestIdHeader":"request-id","requestIdLogLabel":"reqId","http2SessionTimeout":72000,"exposeHeadRoutes":true}
+module.exports.defaultInitOptions = {"connectionTimeout":0,"keepAliveTimeout":72000,"maxRequestsPerSocket":0,"requestTimeout":0,"bodyLimit":1048576,"caseSensitive":true,"allowUnsafeRegex":false,"disableRequestLogging":false,"jsonShorthand":true,"ignoreTrailingSlash":false,"ignoreDuplicateSlashes":false,"maxParamLength":100,"onProtoPoisoning":"error","onConstructorPoisoning":"error","pluginTimeout":10000,"requestIdHeader":"request-id","requestIdLogLabel":"reqId","http2SessionTimeout":72000,"exposeHeadRoutes":true,"useSemicolonDelimiter":true}

--- a/lib/route.js
+++ b/lib/route.js
@@ -58,7 +58,6 @@ const { buildErrorHandler } = require('./error-handler')
 const { createChildLogger } = require('./logger')
 
 function buildRouting (options) {
-  options.config.useSemicolonDelimiter = true // To avoid a breaking change
   const router = FindMyWay(options.config)
 
   let avvio

--- a/test/internals/initialConfig.test.js
+++ b/test/internals/initialConfig.test.js
@@ -48,14 +48,15 @@ test('without options passed to Fastify, initialConfig should expose default val
     requestIdHeader: 'request-id',
     requestIdLogLabel: 'reqId',
     http2SessionTimeout: 72000,
-    exposeHeadRoutes: true
+    exposeHeadRoutes: true,
+    useSemicolonDelimiter: true
   }
 
   t.same(Fastify().initialConfig, fastifyDefaultOptions)
 })
 
 test('Fastify.initialConfig should expose all options', t => {
-  t.plan(21)
+  t.plan(22)
 
   const serverFactory = (handler, opts) => {
     const server = http.createServer((req, res) => {
@@ -99,6 +100,7 @@ test('Fastify.initialConfig should expose all options', t => {
     allowUnsafeRegex: false,
     requestIdHeader: 'request-id-alt',
     pluginTimeout: 20000,
+    useSemicolonDelimiter: false,
     querystringParser: str => str,
     genReqId: function (req) {
       return reqId++
@@ -123,6 +125,7 @@ test('Fastify.initialConfig should expose all options', t => {
   t.equal(fastify.initialConfig.bodyLimit, 1049600)
   t.equal(fastify.initialConfig.onProtoPoisoning, 'remove')
   t.equal(fastify.initialConfig.caseSensitive, true)
+  t.equal(fastify.initialConfig.useSemicolonDelimiter, true)
   t.equal(fastify.initialConfig.allowUnsafeRegex, false)
   t.equal(fastify.initialConfig.requestIdHeader, 'request-id-alt')
   t.equal(fastify.initialConfig.pluginTimeout, 20000)
@@ -285,7 +288,8 @@ test('Should not have issues when passing stream options to Pino.js', t => {
       requestIdHeader: 'request-id',
       requestIdLogLabel: 'reqId',
       http2SessionTimeout: 72000,
-      exposeHeadRoutes: true
+      exposeHeadRoutes: true,
+      useSemicolonDelimiter: true
     })
   } catch (error) {
     t.fail()

--- a/test/internals/initialConfig.test.js
+++ b/test/internals/initialConfig.test.js
@@ -125,7 +125,7 @@ test('Fastify.initialConfig should expose all options', t => {
   t.equal(fastify.initialConfig.bodyLimit, 1049600)
   t.equal(fastify.initialConfig.onProtoPoisoning, 'remove')
   t.equal(fastify.initialConfig.caseSensitive, true)
-  t.equal(fastify.initialConfig.useSemicolonDelimiter, true)
+  t.equal(fastify.initialConfig.useSemicolonDelimiter, false)
   t.equal(fastify.initialConfig.allowUnsafeRegex, false)
   t.equal(fastify.initialConfig.requestIdHeader, 'request-id-alt')
   t.equal(fastify.initialConfig.pluginTimeout, 20000)

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -330,7 +330,8 @@ type InitialConfig = Readonly<{
   pluginTimeout?: number,
   requestIdHeader?: string | false,
   requestIdLogLabel?: string,
-  http2SessionTimeout?: number
+  http2SessionTimeout?: number,
+  useSemicolonDelimiter?: boolean
 }>
 
 expectType<InitialConfig>(fastify().initialConfig)

--- a/test/useSemicolonDelimiter.test.js
+++ b/test/useSemicolonDelimiter.test.js
@@ -1,0 +1,113 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('..')
+const sget = require('simple-get').concat
+
+test('use semicolon delimiter default true', t => {
+  t.plan(4)
+
+  const fastify = Fastify({})
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/1234', (req, reply) => {
+    reply.send(req.query)
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    console.log('http://localhost:' + fastify.server.address().port + '/1234;foo=bar')
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port + '/1234;foo=bar'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.same(JSON.parse(body), {
+        foo: 'bar'
+      })
+    })
+  })
+})
+
+test('use semicolon delimiter set to true', t => {
+  t.plan(4)
+
+  const fastify = Fastify({
+    useSemicolonDelimiter: true
+  })
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/1234', (req, reply) => {
+    reply.send(req.query)
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port + '/1234;foo=bar'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.same(JSON.parse(body), {
+        foo: 'bar'
+      })
+    })
+  })
+})
+
+test('use semicolon delimiter set to false', t => {
+  t.plan(4)
+
+  const fastify = Fastify({
+    useSemicolonDelimiter: false
+  })
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/1234;foo=bar', (req, reply) => {
+    reply.send(req.query)
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port + '/1234;foo=bar'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.same(JSON.parse(body), {})
+    })
+  })
+})
+
+test('use semicolon delimiter set to false return 404', t => {
+  t.plan(3)
+
+  const fastify = Fastify({
+    useSemicolonDelimiter: false
+  })
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/1234', (req, reply) => {
+    reply.send(req.query)
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port + '/1234;foo=bar'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 404)
+    })
+  })
+})

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -589,6 +589,7 @@ export interface FastifyInstance<
     pluginTimeout?: number,
     requestIdHeader?: string | false,
     requestIdLogLabel?: string,
-    http2SessionTimeout?: number
+    http2SessionTimeout?: number,
+    useSemicolonDelimiter?: boolean,
   }>
 }


### PR DESCRIPTION
#### Checklist

fixes: https://github.com/fastify/fastify/issues/5237
This PR adds `useSemicolonDefault` with a default option of `true`

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
