### PR TITLE
feat: emit diagnostics_channel events upon routing request

### DIFF
--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -829,18 +829,17 @@ consider creating a custom [Plugin](./Plugins.md) instead.
 ## Diagnostics Channel Hooks
 
 > **Note:** The `diagnostics_channel` is currently experimental on Node.js, so
-> its API is subject to change even in semver-patch releases of Node.js. For
-> versions of Node.js supported by Fastify where `diagnostics_channel` is
-> unavailable, the hook will use the
-> [polyfill](https://www.npmjs.com/package/diagnostics_channel) if it is
-> available. Otherwise, this feature will not be present.
+> its API is subject to change even in semver-patch releases of Node.js. As some
+> versions of Node.js are supported by Fastify where `diagnostics_channel` is
+> unavailable, or with an incomplete feature set, the hook uses the
+> [dc-polyfill](https://www.npmjs.com/package/dc-polyfill) package to provide a
+> polyfill.
 
-Currently, one
-[`diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html) publish
-event, `'fastify.initialization'`, happens at initialization time. The Fastify
-instance is passed into the hook as a property of the object passed in. At this
-point, the instance can be interacted with to add hooks, plugins, routes, or any
-other sort of modification.
+One [`diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html)
+publish event, `'fastify.initialization'`, happens at initialization time. The
+Fastify instance is passed into the hook as a property of the object passed in.
+At this point, the instance can be interacted with to add hooks, plugins,
+routes, or any other sort of modification.
 
 For example, a tracing package might do something like the following (which is,
 of course, a simplification). This would be in a file loaded in the
@@ -849,13 +848,13 @@ tools first" fashion.
 
 ```js
 const tracer = /* retrieved from elsewhere in the package */
-const dc = require('node:diagnostics_channel')
+const dc = require('node:diagnostics_channel') // or require('dc-polyfill')
 const channel = dc.channel('fastify.initialization')
 const spans = new WeakMap()
 
 channel.subscribe(function ({ fastify }) {
   fastify.addHook('onRequest', (request, reply, done) => {
-    const span = tracer.startSpan('fastify.request')
+    const span = tracer.startSpan('fastify.request.handler')
     spans.set(request, span)
     done()
   })
@@ -865,5 +864,40 @@ channel.subscribe(function ({ fastify }) {
     span.finish()
     done()
   })
+})
+```
+
+Five other events are published on a per-request basis following the
+[Tracing Channel](https://nodejs.org/api/diagnostics_channel.html#class-tracingchannel)
+nomenclature. The list of the channel names and the event they receive is:
+
+- `tracing:fastify.request.handler:start`: Always fires
+  - `{ request: Request, reply: Reply, route: { url, method } }`
+- `tracing:fastify.request.handler:end`: Always fires
+  - `{ request: Request, reply: Reply, route: { url, method }, async: Bool }`
+- `tracing:fastify.request.handler:asyncStart`: Fires for promise/async handlers
+  - `{ request: Request, reply: Reply, route: { url, method } }`
+- `tracing:fastify.request.handler:asyncEnd`: Fires for promise/async handlers
+  - `{ request: Request, reply: Reply, route: { url, method } }`
+- `tracing:fastify.request.handler:error`: Fires when an error occurs
+  - `{ request: Request, reply: Reply, route: { url, method }, error: Error }`
+
+The object instance remains the same for all events associated with a given
+request. All payloads include a `request` and `reply` property which are an
+instance of Fastify's `Request` and `Reply` instances. They also include a
+`route` property which is an object with the matched `url` pattern (e.g.
+`/collection/:id`) and the `method` HTTP method (e.g. `GET`). The `:start` and
+`:end` events always fire for requests. If a request handler is an `async`
+function or one that returns a `Promise` then the `:asyncStart` and `:asyncEnd`
+events also fire. Finally, the `:error` event contains an `error` property
+associated with the request's failure.
+
+These events can be received like so:
+
+```js
+const dc = require('node:diagnostics_channel') // or require('dc-polyfill')
+const channel = dc.channel('tracing:fastify.request.handler:start')
+channel.subscribe((msg) => {
+  console.log(msg.request, msg.reply)
 })
 ```

--- a/fastify.js
+++ b/fastify.js
@@ -4,6 +4,7 @@ const VERSION = '5.0.0-alpha.1'
 
 const Avvio = require('avvio')
 const http = require('node:http')
+const diagnostics = require('dc-polyfill')
 let lightMyRequest
 
 const {
@@ -76,6 +77,8 @@ const {
 } = errorCodes
 
 const { buildErrorHandler } = require('./lib/error-handler.js')
+
+const initChannel = diagnostics.channel('fastify.initialization')
 
 function defaultBuildPrettyMeta (route) {
   // return a shallow copy of route's sanitized context
@@ -540,15 +543,8 @@ function fastify (options) {
   // Delay configuring clientError handler so that it can access fastify state.
   server.on('clientError', options.clientErrorHandler.bind(fastify))
 
-  try {
-    const dc = require('node:diagnostics_channel')
-    const initChannel = dc.channel('fastify.initialization')
-    if (initChannel.hasSubscribers) {
-      initChannel.publish({ fastify })
-    }
-  } catch (e) {
-    // This only happens if `diagnostics_channel` isn't available, i.e. earlier
-    // versions of Node.js. In that event, we don't care, so ignore the error.
+  if (initChannel.hasSubscribers) {
+    initChannel.publish({ fastify })
   }
 
   // Older nodejs versions may not have asyncDispose

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -125,7 +125,7 @@ function preHandlerCallback (err, request, reply) {
 
   const context = request[kRouteContext]
 
-  if (!tcHasSubscribers() || context[kFourOhFourContext] === null) {
+  if (!channels.hasSubscribers || context[kFourOhFourContext] === null) {
     preHandlerCallbackInner(err, request, reply)
   } else {
     const store = {
@@ -180,14 +180,6 @@ function preHandlerCallbackInner (err, request, reply, store) {
   } finally {
     if (store) channels.end.publish(store)
   }
-}
-
-function tcHasSubscribers () {
-  return channels.start.hasSubscribers ||
-    channels.end.hasSubscribers ||
-    channels.asyncStart.hasSubscribers ||
-    channels.asyncEnd.hasSubscribers ||
-    channels.error.hasSubscribers
 }
 
 module.exports = handleRequest

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -1,13 +1,17 @@
 'use strict'
 
 const { bodylessMethods, bodyMethods } = require('./httpMethods')
+const diagnostics = require('dc-polyfill')
 const { validate: validateSchema } = require('./validation')
 const { preValidationHookRunner, preHandlerHookRunner } = require('./hooks')
 const wrapThenable = require('./wrapThenable')
 const {
   kReplyIsError,
-  kRouteContext
+  kRouteContext,
+  kFourOhFourContext
 } = require('./symbols')
+
+const channels = diagnostics.tracingChannel('fastify.request.handler')
 
 function handleRequest (err, request, reply) {
   if (reply.sent === true) return
@@ -119,29 +123,71 @@ function validationCompleted (request, reply, validationErr) {
 function preHandlerCallback (err, request, reply) {
   if (reply.sent) return
 
-  if (err != null) {
-    reply[kReplyIsError] = true
-    reply.send(err)
-    return
-  }
+  const context = request[kRouteContext]
 
-  let result
+  if (!tcHasSubscribers() || context[kFourOhFourContext] === null) {
+    preHandlerCallbackInner(err, request, reply)
+  } else {
+    const store = {
+      request,
+      reply,
+      async: false,
+      route: {
+        url: context.config.url,
+        method: context.config.method
+      }
+    }
+    channels.start.runStores(store, preHandlerCallbackInner, undefined, err, request, reply, store)
+  }
+}
+
+function preHandlerCallbackInner (err, request, reply, store) {
+  const context = request[kRouteContext]
 
   try {
-    result = request[kRouteContext].handler(request, reply)
-  } catch (err) {
-    reply[kReplyIsError] = true
-    reply.send(err)
-    return
-  }
-
-  if (result !== undefined) {
-    if (result !== null && typeof result.then === 'function') {
-      wrapThenable(result, reply)
-    } else {
-      reply.send(result)
+    if (err != null) {
+      reply[kReplyIsError] = true
+      reply.send(err)
+      if (store) {
+        store.error = err
+        channels.error.publish(store)
+      }
+      return
     }
+
+    let result
+
+    try {
+      result = context.handler(request, reply)
+    } catch (err) {
+      if (store) {
+        store.error = err
+        channels.error.publish(store)
+      }
+
+      reply[kReplyIsError] = true
+      reply.send(err)
+      return
+    }
+
+    if (result !== undefined) {
+      if (result !== null && typeof result.then === 'function') {
+        wrapThenable(result, reply, store)
+      } else {
+        reply.send(result)
+      }
+    }
+  } finally {
+    if (store) channels.end.publish(store)
   }
+}
+
+function tcHasSubscribers () {
+  return channels.start.hasSubscribers ||
+    channels.end.hasSubscribers ||
+    channels.asyncStart.hasSubscribers ||
+    channels.asyncEnd.hasSubscribers ||
+    channels.error.hasSubscribers
 }
 
 module.exports = handleRequest

--- a/lib/wrapThenable.js
+++ b/lib/wrapThenable.js
@@ -5,44 +5,68 @@ const {
   kReplyHijacked
 } = require('./symbols')
 
-function wrapThenable (thenable, reply) {
+const diagnostics = require('dc-polyfill')
+const channels = diagnostics.tracingChannel('fastify.request.handler')
+
+function wrapThenable (thenable, reply, store) {
+  if (store) store.async = true
   thenable.then(function (payload) {
     if (reply[kReplyHijacked] === true) {
       return
     }
 
-    // this is for async functions that are using reply.send directly
-    //
-    // since wrap-thenable will be called when using reply.send directly
-    // without actual return. the response can be sent already or
-    // the request may be terminated during the reply. in this situation,
-    // it require an extra checking of request.aborted to see whether
-    // the request is killed by client.
-    if (payload !== undefined || (reply.sent === false && reply.raw.headersSent === false && reply.request.raw.aborted === false)) {
-      // we use a try-catch internally to avoid adding a catch to another
-      // promise, increase promise perf by 10%
-      try {
-        reply.send(payload)
-      } catch (err) {
-        reply[kReplyIsError] = true
-        reply.send(err)
+    if (store) {
+      channels.asyncStart.publish(store)
+    }
+
+    try {
+      // this is for async functions that are using reply.send directly
+      //
+      // since wrap-thenable will be called when using reply.send directly
+      // without actual return. the response can be sent already or
+      // the request may be terminated during the reply. in this situation,
+      // it require an extra checking of request.aborted to see whether
+      // the request is killed by client.
+      if (payload !== undefined || (reply.sent === false && reply.raw.headersSent === false && reply.request.raw.aborted === false)) {
+        // we use a try-catch internally to avoid adding a catch to another
+        // promise, increase promise perf by 10%
+        try {
+          reply.send(payload)
+        } catch (err) {
+          reply[kReplyIsError] = true
+          reply.send(err)
+        }
+      }
+    } finally {
+      if (store) {
+        channels.asyncEnd.publish(store)
       }
     }
   }, function (err) {
-    if (reply.sent === true) {
-      reply.log.error({ err }, 'Promise errored, but reply.sent = true was set')
-      return
+    if (store) {
+      store.error = err
+      channels.error.publish(store) // note that error happens before asyncStart
+      channels.asyncStart.publish(store)
     }
 
-    reply[kReplyIsError] = true
-
-    // try-catch allow to re-throw error in error handler for async handler
     try {
+      if (reply.sent === true) {
+        reply.log.error({ err }, 'Promise errored, but reply.sent = true was set')
+        return
+      }
+
+      reply[kReplyIsError] = true
+
       reply.send(err)
       // The following should not happen
       /* c8 ignore next 3 */
     } catch (err) {
+      // try-catch allow to re-throw error in error handler for async handler
       reply.send(err)
+    } finally {
+      if (store) {
+        channels.asyncEnd.publish(store)
+      }
     }
   })
 }

--- a/package.json
+++ b/package.json
@@ -206,6 +206,7 @@
     "@fastify/fast-json-stringify-compiler": "^4.3.0",
     "abstract-logging": "^2.0.1",
     "avvio": "^8.3.0",
+    "dc-polyfill": "^0.1.5",
     "fast-json-stringify": "^5.14.1",
     "find-my-way": "^8.1.0",
     "light-my-request": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
     "@fastify/fast-json-stringify-compiler": "^4.3.0",
     "abstract-logging": "^2.0.1",
     "avvio": "^8.3.0",
-    "dc-polyfill": "^0.1.5",
+    "dc-polyfill": "^0.1.6",
     "fast-json-stringify": "^5.14.1",
     "find-my-way": "^8.1.0",
     "light-my-request": "^5.13.0",

--- a/test/diagnostics-channel/404.test.js
+++ b/test/diagnostics-channel/404.test.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const t = require('tap')
+const diagnostics = require('dc-polyfill')
+const test = t.test
+const sget = require('simple-get').concat
+const Fastify = require('../..')
+const { getServerUrl } = require('../helper')
+const Request = require('../../lib/request')
+const Reply = require('../../lib/reply')
+
+test('diagnostics channel sync events fire in expected order', t => {
+  t.plan(9)
+  let callOrder = 0
+  let firstEncounteredMessage
+
+  diagnostics.subscribe('tracing:fastify.request.handler:start', (msg) => {
+    t.equal(callOrder++, 0)
+    firstEncounteredMessage = msg
+    t.ok(msg.request instanceof Request)
+    t.ok(msg.reply instanceof Reply)
+  })
+
+  diagnostics.subscribe('tracing:fastify.request.handler:end', (msg) => {
+    t.ok(msg.request instanceof Request)
+    t.ok(msg.reply instanceof Reply)
+    t.equal(callOrder++, 1)
+    t.equal(msg, firstEncounteredMessage)
+  })
+
+  diagnostics.subscribe('tracing:fastify.request.handler:error', (msg) => {
+    t.fail('should not trigger error channel')
+  })
+
+  const fastify = Fastify()
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    handler: function (req, reply) {
+      reply.callNotFound()
+    }
+  })
+
+  fastify.listen({ port: 0 }, function (err) {
+    if (err) t.error(err)
+
+    t.teardown(() => { fastify.close() })
+
+    sget({
+      method: 'GET',
+      url: getServerUrl(fastify) + '/'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 404)
+    })
+  })
+})

--- a/test/diagnostics-channel/async-delay-request.test.js
+++ b/test/diagnostics-channel/async-delay-request.test.js
@@ -1,0 +1,74 @@
+'use strict'
+
+const t = require('tap')
+const diagnostics = require('dc-polyfill')
+const test = t.test
+const sget = require('simple-get').concat
+const Fastify = require('../..')
+const { getServerUrl } = require('../helper')
+const Request = require('../../lib/request')
+const Reply = require('../../lib/reply')
+
+test('diagnostics channel async events fire in expected order', t => {
+  t.plan(19)
+  let callOrder = 0
+  let firstEncounteredMessage
+
+  diagnostics.subscribe('tracing:fastify.request.handler:start', (msg) => {
+    t.equal(callOrder++, 0)
+    firstEncounteredMessage = msg
+    t.ok(msg.request instanceof Request)
+    t.ok(msg.reply instanceof Reply)
+  })
+
+  diagnostics.subscribe('tracing:fastify.request.handler:end', (msg) => {
+    t.equal(callOrder++, 1)
+    t.ok(msg.request instanceof Request)
+    t.ok(msg.reply instanceof Reply)
+    t.equal(msg, firstEncounteredMessage)
+    t.equal(msg.async, true)
+  })
+
+  diagnostics.subscribe('tracing:fastify.request.handler:asyncStart', (msg) => {
+    t.equal(callOrder++, 2)
+    t.ok(msg.request instanceof Request)
+    t.ok(msg.reply instanceof Reply)
+    t.equal(msg, firstEncounteredMessage)
+  })
+
+  diagnostics.subscribe('tracing:fastify.request.handler:asyncEnd', (msg) => {
+    t.equal(callOrder++, 3)
+    t.ok(msg.request instanceof Request)
+    t.ok(msg.reply instanceof Reply)
+    t.equal(msg, firstEncounteredMessage)
+  })
+
+  diagnostics.subscribe('tracing:fastify.request.handler:error', (msg) => {
+    t.fail('should not trigger error channel')
+  })
+
+  const fastify = Fastify()
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    handler: async function (req, reply) {
+      setImmediate(() => reply.send({ hello: 'world' }))
+      return reply
+    }
+  })
+
+  fastify.listen({ port: 0 }, function (err) {
+    if (err) t.error(err)
+
+    t.teardown(() => { fastify.close() })
+
+    sget({
+      method: 'GET',
+      url: getServerUrl(fastify) + '/'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.same(JSON.parse(body), { hello: 'world' })
+    })
+  })
+})

--- a/test/diagnostics-channel/async-request.test.js
+++ b/test/diagnostics-channel/async-request.test.js
@@ -1,0 +1,72 @@
+'use strict'
+
+const t = require('tap')
+const diagnostics = require('dc-polyfill')
+const test = t.test
+const sget = require('simple-get').concat
+const Fastify = require('../..')
+const { getServerUrl } = require('../helper')
+const Request = require('../../lib/request')
+const Reply = require('../../lib/reply')
+
+test('diagnostics channel async events fire in expected order', t => {
+  t.plan(18)
+  let callOrder = 0
+  let firstEncounteredMessage
+
+  diagnostics.subscribe('tracing:fastify.request.handler:start', (msg) => {
+    t.equal(callOrder++, 0)
+    firstEncounteredMessage = msg
+    t.ok(msg.request instanceof Request)
+    t.ok(msg.reply instanceof Reply)
+  })
+
+  diagnostics.subscribe('tracing:fastify.request.handler:end', (msg) => {
+    t.equal(callOrder++, 1)
+    t.ok(msg.request instanceof Request)
+    t.ok(msg.reply instanceof Reply)
+    t.equal(msg, firstEncounteredMessage)
+  })
+
+  diagnostics.subscribe('tracing:fastify.request.handler:asyncStart', (msg) => {
+    t.equal(callOrder++, 2)
+    t.ok(msg.request instanceof Request)
+    t.ok(msg.reply instanceof Reply)
+    t.equal(msg, firstEncounteredMessage)
+  })
+
+  diagnostics.subscribe('tracing:fastify.request.handler:asyncEnd', (msg) => {
+    t.equal(callOrder++, 3)
+    t.ok(msg.request instanceof Request)
+    t.ok(msg.reply instanceof Reply)
+    t.equal(msg, firstEncounteredMessage)
+  })
+
+  diagnostics.subscribe('tracing:fastify.request.handler:error', (msg) => {
+    t.fail('should not trigger error channel')
+  })
+
+  const fastify = Fastify()
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    handler: async function (req, reply) {
+      return { hello: 'world' }
+    }
+  })
+
+  fastify.listen({ port: 0 }, function (err) {
+    if (err) t.error(err)
+
+    t.teardown(() => { fastify.close() })
+
+    sget({
+      method: 'GET',
+      url: getServerUrl(fastify) + '/'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.same(JSON.parse(body), { hello: 'world' })
+    })
+  })
+})

--- a/test/diagnostics-channel/error-before-handler.test.js
+++ b/test/diagnostics-channel/error-before-handler.test.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const t = require('tap')
+const diagnostics = require('dc-polyfill')
+const test = t.test
+require('../../lib/hooks').onSendHookRunner = function Stub () {}
+const Request = require('../../lib/request')
+const Reply = require('../../lib/reply')
+const symbols = require('../../lib/symbols.js')
+const { preHandlerCallback } = require('../../lib/handleRequest')[Symbol.for('internals')]
+
+test('diagnostics channel handles an error before calling context handler', t => {
+  t.plan(3)
+  let callOrder = 0
+
+  diagnostics.subscribe('tracing:fastify.request.handler:start', (msg) => {
+    t.equal(callOrder++, 0)
+  })
+
+  diagnostics.subscribe('tracing:fastify.request.handler:error', (msg) => {
+    t.equal(callOrder++, 1)
+    t.equal(msg.error.message, 'oh no')
+  })
+
+  const error = new Error('oh no')
+  const request = new Request()
+  const reply = new Reply({}, request)
+  request[symbols.kRouteContext] = {
+    config: {
+      url: '/foo',
+      method: 'GET'
+    }
+  }
+
+  preHandlerCallback(error, request, reply)
+})

--- a/test/diagnostics-channel/error-request.test.js
+++ b/test/diagnostics-channel/error-request.test.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const t = require('tap')
+const diagnostics = require('dc-polyfill')
+const test = t.test
+const sget = require('simple-get').concat
+const Fastify = require('../..')
+const { getServerUrl } = require('../helper')
+const Request = require('../../lib/request')
+const Reply = require('../../lib/reply')
+
+test('diagnostics channel events report on errors', t => {
+  t.plan(14)
+  let callOrder = 0
+  let firstEncounteredMessage
+
+  diagnostics.subscribe('tracing:fastify.request.handler:start', (msg) => {
+    t.equal(callOrder++, 0)
+    firstEncounteredMessage = msg
+    t.ok(msg.request instanceof Request)
+    t.ok(msg.reply instanceof Reply)
+  })
+
+  diagnostics.subscribe('tracing:fastify.request.handler:end', (msg) => {
+    t.ok(msg.request instanceof Request)
+    t.ok(msg.reply instanceof Reply)
+    t.equal(callOrder++, 2)
+    t.equal(msg, firstEncounteredMessage)
+  })
+
+  diagnostics.subscribe('tracing:fastify.request.handler:error', (msg) => {
+    t.ok(msg.request instanceof Request)
+    t.ok(msg.reply instanceof Reply)
+    t.ok(msg.error instanceof Error)
+    t.equal(callOrder++, 1)
+    t.equal(msg.error.message, 'borked')
+  })
+
+  const fastify = Fastify()
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    handler: function (req, reply) {
+      throw new Error('borked')
+    }
+  })
+
+  fastify.listen({ port: 0 }, function (err) {
+    if (err) t.error(err)
+
+    t.teardown(() => { fastify.close() })
+
+    sget({
+      method: 'GET',
+      url: getServerUrl(fastify) + '/'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 500)
+    })
+  })
+})

--- a/test/diagnostics-channel/error-status.test.js
+++ b/test/diagnostics-channel/error-status.test.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('../..')
+const statusCodes = require('node:http').STATUS_CODES
+const diagnostics = require('dc-polyfill')
+
+test('Error.status property support', t => {
+  t.plan(4)
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+  const err = new Error('winter is coming')
+  err.status = 418
+
+  diagnostics.subscribe('tracing:fastify.request.handler:error', (msg) => {
+    t.equal(msg.error.message, 'winter is coming')
+  })
+
+  fastify.get('/', () => {
+    return Promise.reject(err)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (error, res) => {
+    t.error(error)
+    t.equal(res.statusCode, 418)
+    t.same(
+      {
+        error: statusCodes['418'],
+        message: err.message,
+        statusCode: 418
+      },
+      JSON.parse(res.payload)
+    )
+  })
+})

--- a/test/diagnostics-channel/init.test.js
+++ b/test/diagnostics-channel/init.test.js
@@ -9,7 +9,7 @@ test('diagnostics_channel when present and subscribers', t => {
 
   let fastifyInHook
 
-  const dc = {
+  const diagnostics = {
     channel (name) {
       t.equal(name, 'fastify.initialization')
       return {
@@ -23,8 +23,8 @@ test('diagnostics_channel when present and subscribers', t => {
     '@noCallThru': true
   }
 
-  const fastify = proxyquire('../fastify', {
-    'node:diagnostics_channel': dc
+  const fastify = proxyquire('../../fastify', {
+    'dc-polyfill': diagnostics
   })()
   t.equal(fastifyInHook, fastify)
 })
@@ -32,7 +32,7 @@ test('diagnostics_channel when present and subscribers', t => {
 test('diagnostics_channel when present and no subscribers', t => {
   t.plan(1)
 
-  const dc = {
+  const diagnostics = {
     channel (name) {
       t.equal(name, 'fastify.initialization')
       return {
@@ -45,17 +45,7 @@ test('diagnostics_channel when present and no subscribers', t => {
     '@noCallThru': true
   }
 
-  proxyquire('../fastify', {
-    'node:diagnostics_channel': dc
+  proxyquire('../../fastify', {
+    'dc-polyfill': diagnostics
   })()
-})
-
-test('diagnostics_channel when not present', t => {
-  t.plan(1)
-
-  t.doesNotThrow(() => {
-    proxyquire('../fastify', {
-      'node:diagnostics_channel': null
-    })()
-  })
 })

--- a/test/diagnostics-channel/sync-delay-request.test.js
+++ b/test/diagnostics-channel/sync-delay-request.test.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const t = require('tap')
+const diagnostics = require('dc-polyfill')
+const test = t.test
+const sget = require('simple-get').concat
+const Fastify = require('../..')
+const { getServerUrl } = require('../helper')
+const Request = require('../../lib/request')
+const Reply = require('../../lib/reply')
+
+test('diagnostics channel sync events fire in expected order', t => {
+  t.plan(10)
+  let callOrder = 0
+  let firstEncounteredMessage
+
+  diagnostics.subscribe('tracing:fastify.request.handler:start', (msg) => {
+    t.equal(callOrder++, 0)
+    firstEncounteredMessage = msg
+    t.ok(msg.request instanceof Request)
+    t.ok(msg.reply instanceof Reply)
+  })
+
+  diagnostics.subscribe('tracing:fastify.request.handler:end', (msg) => {
+    t.ok(msg.request instanceof Request)
+    t.ok(msg.reply instanceof Reply)
+    t.equal(callOrder++, 1)
+    t.equal(msg, firstEncounteredMessage)
+  })
+
+  diagnostics.subscribe('tracing:fastify.request.handler:error', (msg) => {
+    t.fail('should not trigger error channel')
+  })
+
+  const fastify = Fastify()
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    handler: function (req, reply) {
+      setImmediate(() => reply.send({ hello: 'world' }))
+    }
+  })
+
+  fastify.listen({ port: 0 }, function (err) {
+    if (err) t.error(err)
+
+    t.teardown(() => { fastify.close() })
+
+    sget({
+      method: 'GET',
+      url: getServerUrl(fastify) + '/'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.same(JSON.parse(body), { hello: 'world' })
+    })
+  })
+})

--- a/test/diagnostics-channel/sync-request-reply.test.js
+++ b/test/diagnostics-channel/sync-request-reply.test.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const t = require('tap')
+const diagnostics = require('dc-polyfill')
+const test = t.test
+const sget = require('simple-get').concat
+const Fastify = require('../..')
+const { getServerUrl } = require('../helper')
+const Request = require('../../lib/request')
+const Reply = require('../../lib/reply')
+
+test('diagnostics channel sync events fire in expected order', t => {
+  t.plan(10)
+  let callOrder = 0
+  let firstEncounteredMessage
+
+  diagnostics.subscribe('tracing:fastify.request.handler:start', (msg) => {
+    t.equal(callOrder++, 0)
+    firstEncounteredMessage = msg
+    t.ok(msg.request instanceof Request)
+    t.ok(msg.reply instanceof Reply)
+  })
+
+  diagnostics.subscribe('tracing:fastify.request.handler:end', (msg) => {
+    t.ok(msg.request instanceof Request)
+    t.ok(msg.reply instanceof Reply)
+    t.equal(callOrder++, 1)
+    t.equal(msg, firstEncounteredMessage)
+  })
+
+  diagnostics.subscribe('tracing:fastify.request.handler:error', (msg) => {
+    t.fail('should not trigger error channel')
+  })
+
+  const fastify = Fastify()
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    handler: function (req, reply) {
+      reply.send({ hello: 'world' })
+    }
+  })
+
+  fastify.listen({ port: 0 }, function (err) {
+    if (err) t.error(err)
+
+    t.teardown(() => { fastify.close() })
+
+    sget({
+      method: 'GET',
+      url: getServerUrl(fastify) + '/'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.same(JSON.parse(body), { hello: 'world' })
+    })
+  })
+})

--- a/test/diagnostics-channel/sync-request.test.js
+++ b/test/diagnostics-channel/sync-request.test.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const t = require('tap')
+const diagnostics = require('dc-polyfill')
+const test = t.test
+const sget = require('simple-get').concat
+const Fastify = require('../..')
+const { getServerUrl } = require('../helper')
+const Request = require('../../lib/request')
+const Reply = require('../../lib/reply')
+
+test('diagnostics channel sync events fire in expected order', t => {
+  t.plan(13)
+  let callOrder = 0
+  let firstEncounteredMessage
+
+  diagnostics.subscribe('tracing:fastify.request.handler:start', (msg) => {
+    t.equal(callOrder++, 0)
+    firstEncounteredMessage = msg
+    t.ok(msg.request instanceof Request)
+    t.ok(msg.reply instanceof Reply)
+    t.ok(msg.route)
+    t.equal(msg.route.url, '/:id')
+    t.equal(msg.route.method, 'GET')
+  })
+
+  diagnostics.subscribe('tracing:fastify.request.handler:end', (msg) => {
+    t.ok(msg.request instanceof Request)
+    t.ok(msg.reply instanceof Reply)
+    t.equal(callOrder++, 1)
+    t.equal(msg, firstEncounteredMessage)
+  })
+
+  diagnostics.subscribe('tracing:fastify.request.handler:error', (msg) => {
+    t.fail('should not trigger error channel')
+  })
+
+  const fastify = Fastify()
+  fastify.route({
+    method: 'GET',
+    url: '/:id',
+    handler: function (req, reply) {
+      return { hello: 'world' }
+    }
+  })
+
+  fastify.listen({ port: 0 }, function (err) {
+    if (err) t.error(err)
+
+    t.teardown(() => { fastify.close() })
+
+    sget({
+      method: 'GET',
+      url: getServerUrl(fastify) + '/7'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.same(JSON.parse(body), { hello: 'world' })
+    })
+  })
+})

--- a/test/internals/handleRequest.test.js
+++ b/test/internals/handleRequest.test.js
@@ -94,7 +94,11 @@ test('handler function - reply', t => {
     preValidation: [],
     preHandler: [],
     onSend: [],
-    onError: []
+    onError: [],
+    config: {
+      url: '',
+      method: ''
+    }
   }
   buildSchema(context, schemaValidator)
   internals.handler({ [kRouteContext]: context }, new Reply(res, { [kRouteContext]: context }))


### PR DESCRIPTION
This adds support for emitting [diagnostics channel](https://nodejs.org/api/diagnostics_channel.html#class-tracingchannel) events for a request. It's an extension of #5105. 

The `dc-polyfill` package provides a polyfill of the `diagnostics_channel` module for older versions of Node.js. This is why the existing diagnostics channel call has been removed from a conditional in `fastify.js`. Note that `dc-polyfill` falls back to the existing diagnostics channel if present. That's why the tests are requiring diagnostics channel directly instead of the polyfill to show that it works as expected.

Here's some things I'm wondering about:

- [x] extracting payload from `reply.send()`
- [x] rebased on main
- [x] tests
- [x] docs

#### Benchmark results

**main**

```
┌─────────┬──────┬──────┬───────┬───────┬────────┬─────────┬────────┐
│ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%   │ Avg    │ Stdev   │ Max    │
├─────────┼──────┼──────┼───────┼───────┼────────┼─────────┼────────┤
│ Latency │ 4 ms │ 9 ms │ 13 ms │ 13 ms │ 8.3 ms │ 4.19 ms │ 365 ms │
└─────────┴──────┴──────┴───────┴───────┴────────┴─────────┴────────┘
┌───────────┬─────────┬─────────┬─────────┬─────────┬────────────┬──────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg        │ Stdev    │ Min     │
├───────────┼─────────┼─────────┼─────────┼─────────┼────────────┼──────────┼─────────┤
│ Req/Sec   │ 104,639 │ 104,639 │ 114,495 │ 116,735 │ 113,796.27 │ 2,451.61 │ 104,582 │
├───────────┼─────────┼─────────┼─────────┼─────────┼────────────┼──────────┼─────────┤
│ Bytes/Sec │ 19.7 MB │ 19.7 MB │ 21.5 MB │ 22 MB   │ 21.4 MB    │ 461 kB   │ 19.7 MB │
└───────────┴─────────┴─────────┴─────────┴─────────┴────────────┴──────────┴─────────┘
```

**this change**

```
┌─────────┬──────┬──────┬───────┬───────┬─────────┬─────────┬────────┐
│ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%   │ Avg     │ Stdev   │ Max    │
├─────────┼──────┼──────┼───────┼───────┼─────────┼─────────┼────────┤
│ Latency │ 4 ms │ 9 ms │ 13 ms │ 13 ms │ 8.21 ms │ 4.23 ms │ 364 ms │
└─────────┴──────┴──────┴───────┴───────┴─────────┴─────────┴────────┘
┌───────────┬─────────┬─────────┬─────────┬─────────┬───────────┬──────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg       │ Stdev    │ Min     │
├───────────┼─────────┼─────────┼─────────┼─────────┼───────────┼──────────┼─────────┤
│ Req/Sec   │ 107,455 │ 107,455 │ 115,455 │ 117,503 │ 114,822.4 │ 2,261.46 │ 107,414 │
├───────────┼─────────┼─────────┼─────────┼─────────┼───────────┼──────────┼─────────┤
│ Bytes/Sec │ 20.2 MB │ 20.2 MB │ 21.7 MB │ 22.1 MB │ 21.6 MB   │ 426 kB   │ 20.2 MB │
└───────────┴─────────┴─────────┴─────────┴─────────┴───────────┴──────────┴─────────┘
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
