### PR TITLE
fix: restrict findRoute exposed property

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -173,11 +173,23 @@ function buildRouting (options) {
   }
 
   function findRoute (options) {
-    return router.find(
+    const route = router.find(
       options.method,
       options.url || '',
       options.constraints
     )
+    if (route) {
+      // we must reduce the expose surface, otherwise
+      // we provide the ability for the user to modify
+      // all the route and server information in runtime
+      return {
+        handler: route.handler,
+        params: route.params,
+        searchParams: route.searchParams
+      }
+    } else {
+      return null
+    }
   }
 
   /**

--- a/test/findRoute.test.js
+++ b/test/findRoute.test.js
@@ -67,7 +67,7 @@ test('findRoute should return null when route cannot be found due to a different
 })
 
 test('findRoute should return the route when found', t => {
-  t.plan(2)
+  t.plan(1)
   const fastify = Fastify()
 
   const handler = (req, reply) => reply.send(typeof req.params.artistId)
@@ -85,7 +85,6 @@ test('findRoute should return the route when found', t => {
   })
 
   t.same(route.params, { artistId: ':artistId' })
-  t.same(route.store.schema, { params: { artistId: { type: 'integer' } } })
 })
 
 test('findRoute should work correctly when used within plugins', t => {
@@ -115,4 +114,22 @@ test('findRoute should work correctly when used within plugins', t => {
   fastify.ready(() => {
     t.equal(fastify.validateRoutes.validateParams(), true)
   })
+})
+
+test('findRoute should not expose store', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  fastify.get('/artists/:artistId', {
+    schema: {
+      params: { artistId: { type: 'integer' } }
+    },
+    handler: (req, reply) => reply.send(typeof req.params.artistId)
+  })
+
+  const route = fastify.findRoute({
+    method: 'GET',
+    url: '/artists/:artistId'
+  })
+  t.equal(route.store, undefined)
 })

--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -3,9 +3,8 @@ import * as http from 'http'
 import { expectAssignable, expectError, expectType } from 'tsd'
 import fastify, { FastifyInstance, FastifyReply, FastifyRequest, RouteHandlerMethod } from '../../fastify'
 import { RequestPayload } from '../../types/hooks'
-import { HTTPMethods, RawServerBase, RawServerDefault } from '../../types/utils'
-import { FindResult, HTTPVersion } from 'find-my-way'
-import { FindMyWayFindResult, FindMyWayVersion } from '../../types/instance'
+import { FindMyWayFindResult } from '../../types/instance'
+import { HTTPMethods, RawServerDefault } from '../../types/utils'
 
 /*
  * Testing Fastify HTTP Routes and Route Shorthands.
@@ -455,12 +454,18 @@ expectType<boolean>(fastify().hasRoute({
   }
 }))
 
-expectType<FindMyWayFindResult<RawServerDefault>>(
+expectType<Omit<FindMyWayFindResult<RawServerDefault>, 'store'>>(
   fastify().findRoute({
     url: '/',
     method: 'get'
   })
 )
+
+// we should not expose store
+expectError(fastify().findRoute({
+  url: '/',
+  method: 'get'
+}).store)
 
 expectType<FastifyInstance>(fastify().route({
   url: '/',

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -1,14 +1,15 @@
 import { FastifyError } from '@fastify/error'
 import { ConstraintStrategy, FindResult, HTTPVersion } from 'find-my-way'
 import * as http from 'http'
-import { CallbackFunc as LightMyRequestCallback, Chain as LightMyRequestChain, InjectOptions, Response as LightMyRequestResponse } from 'light-my-request'
-import { AddContentTypeParser, ConstructorAction, FastifyBodyParser, getDefaultJsonParser, hasContentTypeParser, ProtoAction, removeAllContentTypeParsers, removeContentTypeParser } from './content-type-parser'
-import { onCloseAsyncHookHandler, onCloseHookHandler, onErrorAsyncHookHandler, onErrorHookHandler, onReadyAsyncHookHandler, onReadyHookHandler, onListenAsyncHookHandler, onListenHookHandler, onRegisterHookHandler, onRequestAsyncHookHandler, onRequestHookHandler, onRequestAbortAsyncHookHandler, onRequestAbortHookHandler, onResponseAsyncHookHandler, onResponseHookHandler, onRouteHookHandler, onSendAsyncHookHandler, onSendHookHandler, onTimeoutAsyncHookHandler, onTimeoutHookHandler, preHandlerAsyncHookHandler, preHandlerHookHandler, preParsingAsyncHookHandler, preParsingHookHandler, preSerializationAsyncHookHandler, preSerializationHookHandler, preValidationAsyncHookHandler, preValidationHookHandler, preCloseHookHandler, preCloseAsyncHookHandler, LifecycleHook, ApplicationHook, HookAsyncLookup, HookLookup } from './hooks'
+import { InjectOptions, CallbackFunc as LightMyRequestCallback, Chain as LightMyRequestChain, Response as LightMyRequestResponse } from 'light-my-request'
+import { AddressInfo } from 'net'
+import { AddContentTypeParser, ConstructorAction, FastifyBodyParser, ProtoAction, getDefaultJsonParser, hasContentTypeParser, removeAllContentTypeParsers, removeContentTypeParser } from './content-type-parser'
+import { ApplicationHook, HookAsyncLookup, HookLookup, LifecycleHook, onCloseAsyncHookHandler, onCloseHookHandler, onErrorAsyncHookHandler, onErrorHookHandler, onListenAsyncHookHandler, onListenHookHandler, onReadyAsyncHookHandler, onReadyHookHandler, onRegisterHookHandler, onRequestAbortAsyncHookHandler, onRequestAbortHookHandler, onRequestAsyncHookHandler, onRequestHookHandler, onResponseAsyncHookHandler, onResponseHookHandler, onRouteHookHandler, onSendAsyncHookHandler, onSendHookHandler, onTimeoutAsyncHookHandler, onTimeoutHookHandler, preCloseAsyncHookHandler, preCloseHookHandler, preHandlerAsyncHookHandler, preHandlerHookHandler, preParsingAsyncHookHandler, preParsingHookHandler, preSerializationAsyncHookHandler, preSerializationHookHandler, preValidationAsyncHookHandler, preValidationHookHandler } from './hooks'
 import { FastifyBaseLogger, FastifyChildLoggerFactory } from './logger'
 import { FastifyRegister } from './register'
 import { FastifyReply } from './reply'
 import { FastifyRequest } from './request'
-import { DefaultRoute, RouteGenericInterface, RouteOptions, RouteShorthandMethod, RouteHandlerMethod } from './route'
+import { DefaultRoute, RouteGenericInterface, RouteHandlerMethod, RouteOptions, RouteShorthandMethod } from './route'
 import {
   FastifySchema,
   FastifySchemaCompiler,
@@ -20,8 +21,7 @@ import {
   FastifyTypeProvider,
   FastifyTypeProviderDefault
 } from './type-provider'
-import { HTTPMethods, ContextConfigDefault, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RawServerDefault } from './utils'
-import { AddressInfo } from 'net'
+import { ContextConfigDefault, HTTPMethods, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RawServerDefault } from './utils'
 
 export interface PrintRoutesOptions {
   method?: HTTPMethods;
@@ -224,7 +224,7 @@ export interface FastifyInstance<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
     ContextConfig = ContextConfigDefault,
     SchemaCompiler extends FastifySchema = FastifySchema,
-  >(opts: Pick<RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>, 'method' | 'url' | 'constraints'>): FindMyWayFindResult<RawServer>;
+  >(opts: Pick<RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>, 'method' | 'url' | 'constraints'>): Omit<FindMyWayFindResult<RawServer>, 'store'>;
 
   // addHook: overloads
 


### PR DESCRIPTION
Follow Up #5230 

In the above mentioned PR, it expose the whole store within `find-my-way` which contains not even the schema but the whole `fastify` context which should not be able to modify or see.
We need to decide what should be exposed and minimize it.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
