### PR TITLE
fix(test): flaky on-listen hook test

### DIFF
--- a/test/hooks.on-listen.test.js
+++ b/test/hooks.on-listen.test.js
@@ -1077,8 +1077,8 @@ test('onListen hooks do not block /1', t => {
     t.error(err)
     t.ok(Date.now() - startDate < 2000)
     listenDone = true
-    clearTimeout(timer)
-    if (doneRef) doneRef()
+    timer && clearTimeout(timer)
+    doneRef && doneRef()
   })
 })
 

--- a/test/hooks.on-listen.test.js
+++ b/test/hooks.on-listen.test.js
@@ -1059,7 +1059,7 @@ test('onListen hooks do not block /1', t => {
   t.teardown(fastify.close.bind(fastify))
 
   fastify.addHook('onListen', function (done) {
-    t.ok(fastify[kState].listening, true)
+    t.equal(fastify[kState].listening, true)
     done()
   })
 
@@ -1078,7 +1078,7 @@ test('onListen hooks do not block /2', async t => {
   t.teardown(fastify.close.bind(fastify))
 
   fastify.addHook('onListen', async function () {
-    t.ok(fastify[kState].listening, true)
+    t.equal(fastify[kState].listening, true)
   })
 
   await fastify.listen({


### PR DESCRIPTION
The onListen hook test, which checks that the hook is non blocking, is flaky and breaking our CI. 
This should fix it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
