### PR TITLE
refactor: deprecate `Reply#getResponseTime()` in favour of `Reply#elapsedTime`

### DIFF
--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -4,6 +4,7 @@
 - [Reply](#reply)
   - [Introduction](#introduction)
   - [.code(statusCode)](#codestatuscode)
+  - [.elapsedTime](#elapsedtime)
   - [.statusCode](#statuscode)
   - [.server](#server)
   - [.header(key, value)](#headerkey-value)
@@ -46,6 +47,8 @@ object that exposes the following functions and properties:
 - `.code(statusCode)` - Sets the status code.
 - `.status(statusCode)` - An alias for `.code(statusCode)`.
 - `.statusCode` - Read and set the HTTP status code.
+- `.elapsedTime` - Returns the amount of time passed
+since the request was received by Fastify.
 - `.server` - A reference to the fastify instance object.
 - `.header(name, value)` - Sets a response header.
 - `.headers(object)` - Sets all the keys of the object as response headers.
@@ -85,6 +88,8 @@ object that exposes the following functions and properties:
   from Node core.
 - `.log` - The logger instance of the incoming request.
 - `.request` - The incoming request.
+- `.getResponseTime()` - Deprecated, returns the amount of time passed
+since the request was received by Fastify.
 - `.context` - Deprecated, access the [Request's context](./Request.md) property.
 
 ```js
@@ -109,6 +114,19 @@ fastify.get('/', {config: {foo: 'bar'}}, function (request, reply) {
 <a id="code"></a>
 
 If not set via `reply.code`, the resulting `statusCode` will be `200`.
+
+### .elapsedTime
+<a id="elapsedTime"></a>
+
+Invokes the custom response time getter to calculate the amount of time passed
+since the request was received by Fastify.
+
+Note that unless this function is called in the [`onResponse`
+hook](./Hooks.md#onresponse) it will always return `0`.
+
+```js
+const milliseconds = reply.elapsedTime
+```
 
 ### .statusCode
 <a id="statusCode"></a>
@@ -327,7 +345,7 @@ reply.callNotFound()
 <a id="getResponseTime"></a>
 
 Invokes the custom response time getter to calculate the amount of time passed
-since the request was started.
+since the request was received by Fastify.
 
 Note that unless this function is called in the [`onResponse`
 hook](./Hooks.md#onresponse) it will always return `0`.
@@ -335,6 +353,9 @@ hook](./Hooks.md#onresponse) it will always return `0`.
 ```js
 const milliseconds = reply.getResponseTime()
 ```
+
+*Note: This method is deprecated and will be removed in `fastify@5`.
+Use the [.elapsedTime](#elapsedtime) property instead.*
 
 ### .type(contentType)
 <a id="type"></a>

--- a/docs/Reference/Warnings.md
+++ b/docs/Reference/Warnings.md
@@ -23,6 +23,7 @@
     - [FSTDEP017](#FSTDEP017)
     - [FSTDEP018](#FSTDEP018)
     - [FSTDEP019](#FSTDEP019)
+    - [FSTDEP020](#FSTDEP020)
 
 
 ## Warnings
@@ -75,3 +76,4 @@ Deprecation codes are further supported by the Node.js CLI options:
 | <a id="FSTDEP017">FSTDEP017</a> | You are accessing the deprecated `request.routerPath` property. | Use `request.routeOptions.url`. | [#4470](https://github.com/fastify/fastify/pull/4470) |
 | <a id="FSTDEP018">FSTDEP018</a> | You are accessing the deprecated `request.routerMethod` property. | Use `request.routeOptions.method`. | [#4470](https://github.com/fastify/fastify/pull/4470) |
 | <a id="FSTDEP019">FSTDEP019</a> | You are accessing the deprecated `reply.context` property. | Use `reply.routeOptions.config` or `reply.routeOptions.schema`. | [#5032](https://github.com/fastify/fastify/pull/5032) [#5084](https://github.com/fastify/fastify/pull/5084) |
+| <a id="FSTDEP020">FSTDEP020</a> | You are using the deprecated `reply.getReponseTime()` method. | Use the `reply.elapsedTime` property instead. | [#5263](https://github.com/fastify/fastify/pull/5263) |

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -86,13 +86,10 @@ Object.defineProperties(Reply.prototype, {
   },
   elapsedTime: {
     get () {
-      let elapsedTime = 0
-
-      if (this[kReplyStartTime] !== undefined) {
-        elapsedTime = (this[kReplyEndTime] || now()) - this[kReplyStartTime]
+      if (this[kReplyStartTime] === undefined) {
+        return 0
       }
-
-      return elapsedTime
+      return (this[kReplyEndTime] || now()) - this[kReplyStartTime]
     }
   },
   server: {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -53,7 +53,7 @@ const {
   FST_ERR_MISSING_SERIALIZATION_FN,
   FST_ERR_MISSING_CONTENTTYPE_SERIALIZATION_FN
 } = require('./errors')
-const { FSTDEP010, FSTDEP013, FSTDEP019 } = require('./warnings')
+const { FSTDEP010, FSTDEP013, FSTDEP019, FSTDEP020 } = require('./warnings')
 
 function Reply (res, request, log) {
   this.raw = res
@@ -82,6 +82,17 @@ Object.defineProperties(Reply.prototype, {
     get () {
       FSTDEP019()
       return this.request[kRouteContext]
+    }
+  },
+  elapsedTime: {
+    get () {
+      let elapsedTime = 0
+
+      if (this[kReplyStartTime] !== undefined) {
+        elapsedTime = (this[kReplyEndTime] || now()) - this[kReplyStartTime]
+      }
+
+      return elapsedTime
     }
   },
   server: {
@@ -452,14 +463,11 @@ Reply.prototype.callNotFound = function () {
   return this
 }
 
+// TODO: should be removed in fastify@5
 Reply.prototype.getResponseTime = function () {
-  let responseTime = 0
+  FSTDEP020()
 
-  if (this[kReplyStartTime] !== undefined) {
-    responseTime = (this[kReplyEndTime] || now()) - this[kReplyStartTime]
-  }
-
-  return responseTime
+  return this.elapsedTime
 }
 
 // Make reply a thenable, so it could be used with async/await.
@@ -813,7 +821,7 @@ function onResponseCallback (err, request, reply) {
     return
   }
 
-  const responseTime = reply.getResponseTime()
+  const responseTime = reply.elapsedTime
 
   if (err != null) {
     reply.log.error({

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -77,6 +77,11 @@ const FSTDEP019 = createDeprecation({
   message: 'reply.context property access is deprecated. Please use "request.routeOptions.config" or "request.routeOptions.schema" instead for accessing Route settings. The "reply.context" will be removed in `fastify@5`.'
 })
 
+const FSTDEP020 = createDeprecation({
+  code: 'FSTDEP020',
+  message: 'You are using the deprecated "reply.getResponseTime()"" method. Use the "request.elapsedTime" property instead. Method "reply.getResponseTime()" will be removed in `fastify@5`.'
+})
+
 const FSTWRN001 = createWarning({
   name: 'FastifyWarning',
   code: 'FSTWRN001',
@@ -107,6 +112,7 @@ module.exports = {
   FSTDEP017,
   FSTDEP018,
   FSTDEP019,
+  FSTDEP020,
   FSTWRN001,
   FSTWRN002
 }

--- a/test/types/reply.test-d.ts
+++ b/test/types/reply.test-d.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'buffer'
-import { expectAssignable, expectError, expectType } from 'tsd'
+import { expectAssignable, expectDeprecated, expectError, expectType } from 'tsd'
 import fastify, { FastifyReplyContext, FastifyReply, FastifyRequest, FastifySchema, FastifySchemaCompiler, FastifyTypeProviderDefault, RawRequestDefaultExpression, RouteHandler, RouteHandlerMethod } from '../../fastify'
 import { FastifyInstance } from '../../types/instance'
 import { FastifyLoggerInstance } from '../../types/logger'
@@ -19,6 +19,7 @@ const getHandler: RouteHandlerMethod = function (_request, reply) {
   expectType<<Code extends number>(statusCode: Code) => DefaultFastifyReplyWithCode<Code>>(reply.code)
   expectType<<Code extends number>(statusCode: Code) => DefaultFastifyReplyWithCode<Code>>(reply.status)
   expectType<(payload?: unknown) => FastifyReply>(reply.code(100 as number).send)
+  expectType<number>(reply.elapsedTime)
   expectType<number>(reply.statusCode)
   expectType<boolean>(reply.sent)
   expectType<((payload?: unknown) => FastifyReply)>(reply.send)
@@ -31,7 +32,8 @@ const getHandler: RouteHandlerMethod = function (_request, reply) {
   expectType<{(statusCode: number, url: string): FastifyReply; (url: string): FastifyReply }>(reply.redirect)
   expectType<() => FastifyReply>(reply.hijack)
   expectType<() => void>(reply.callNotFound)
-  expectType<() => number>(reply.getResponseTime)
+  // Test reply.getResponseTime() deprecation
+  expectDeprecated(reply.getResponseTime)
   expectType<(contentType: string) => FastifyReply>(reply.type)
   expectType<(fn: (payload: any) => string) => FastifyReply>(reply.serializer)
   expectType<(payload: any) => string | ArrayBuffer | Buffer>(reply.serialize)

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -40,6 +40,7 @@ export interface FastifyReply<
 > {
   raw: RawReply;
   context: FastifyReplyContext<ContextConfig>;
+  elapsedTime: number;
   log: FastifyBaseLogger;
   request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>;
   server: FastifyInstance;
@@ -59,6 +60,9 @@ export interface FastifyReply<
   redirect(url: string): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
   hijack(): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
   callNotFound(): void;
+  /**
+   * @deprecated Use the Reply#elapsedTime property instead
+   */
   getResponseTime(): number;
   type(contentType: string): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
   serializer(fn: (payload: any) => string): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist
Fixes #4575 

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
