### PR TITLE
chore: remove `www.` from `fastify.dev` urls

### DIFF
--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -137,11 +137,11 @@ section.
   throttling the download speed of a request.
 - [`@fastify/type-provider-json-schema-to-ts`](https://github.com/fastify/fastify-type-provider-json-schema-to-ts)
   Fastify
-  [type provider](https://www.fastify.dev/docs/latest/Reference/Type-Providers/)
+  [type provider](https://fastify.dev/docs/latest/Reference/Type-Providers/)
   for [json-schema-to-ts](https://github.com/ThomasAribart/json-schema-to-ts).
 - [`@fastify/type-provider-typebox`](https://github.com/fastify/fastify-type-provider-typebox)
   Fastify
-  [type provider](https://www.fastify.dev/docs/latest/Reference/Type-Providers/)
+  [type provider](https://fastify.dev/docs/latest/Reference/Type-Providers/)
   for [Typebox](https://github.com/sinclairzx81/typebox).
 - [`@fastify/under-pressure`](https://github.com/fastify/under-pressure) Measure
   process load with automatic handling of _"Service Unavailable"_ plugin for
@@ -644,11 +644,11 @@ middlewares into Fastify plugins
   Useful functions for Twitch Extension Backend Services (EBS).
 - [`fastify-type-provider-effect-schema`](https://github.com/daotl/fastify-type-provider-effect-schema)
   Fastify
-  [type provider](https://www.fastify.dev/docs/latest/Reference/Type-Providers/)
+  [type provider](https://fastify.dev/docs/latest/Reference/Type-Providers/)
   for [@effect/schema](https://github.com/effect-ts/schema).
 - [`fastify-type-provider-zod`](https://github.com/turkerdev/fastify-type-provider-zod)
   Fastify
-  [type provider](https://www.fastify.dev/docs/latest/Reference/Type-Providers/)
+  [type provider](https://fastify.dev/docs/latest/Reference/Type-Providers/)
   for [zod](https://github.com/colinhacks/zod).
 - [`fastify-typeorm-plugin`](https://github.com/inthepocket/fastify-typeorm-plugin)
   Fastify plugin to work with TypeORM.

--- a/docs/Guides/Getting-Started.md
+++ b/docs/Guides/Getting-Started.md
@@ -178,7 +178,7 @@ fastify.listen({ port: 3000 }, function (err, address) {
 /**
  * Encapsulates the routes
  * @param {FastifyInstance} fastify  Encapsulated Fastify Instance
- * @param {Object} options plugin options, refer to https://www.fastify.dev/docs/latest/Reference/Plugins/#plugin-options
+ * @param {Object} options plugin options, refer to https://fastify.dev/docs/latest/Reference/Plugins/#plugin-options
  */
 async function routes (fastify, options) {
   fastify.get('/', async (request, reply) => {
@@ -293,7 +293,7 @@ const fastifyPlugin = require('fastify-plugin')
 /**
  * Connects to a MongoDB database
  * @param {FastifyInstance} fastify Encapsulated Fastify Instance
- * @param {Object} options plugin options, refer to https://www.fastify.dev/docs/latest/Reference/Plugins/#plugin-options
+ * @param {Object} options plugin options, refer to https://fastify.dev/docs/latest/Reference/Plugins/#plugin-options
  */
 async function dbConnector (fastify, options) {
   fastify.register(require('@fastify/mongodb'), {
@@ -312,7 +312,7 @@ module.exports = fastifyPlugin(dbConnector)
 /**
  * A plugin that provide encapsulated routes
  * @param {FastifyInstance} fastify encapsulated fastify instance
- * @param {Object} options plugin options, refer to https://www.fastify.dev/docs/latest/Reference/Plugins/#plugin-options
+ * @param {Object} options plugin options, refer to https://fastify.dev/docs/latest/Reference/Plugins/#plugin-options
  */
 async function routes (fastify, options) {
   const collection = fastify.mongo.db.collection('test_collection')

--- a/docs/Guides/Style-Guide.md
+++ b/docs/Guides/Style-Guide.md
@@ -13,7 +13,7 @@ This guide is for anyone who loves to build with Fastify or wants to contribute
 to our documentation. You do not need to be an expert in writing technical
 documentation. This guide is here to help you.
 
-Visit the [contribute](https://www.fastify.dev/contribute) page on our website or
+Visit the [contribute](https://fastify.dev/contribute) page on our website or
 read the
 [CONTRIBUTING.md](https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md)
 file on GitHub to join our Open Source folks.
@@ -70,12 +70,12 @@ markdown.
 **Example**
 
 ```
-To learn more about hooks, see [Fastify hooks](https://www.fastify.dev/docs/latest/Reference/Hooks/).
+To learn more about hooks, see [Fastify hooks](https://fastify.dev/docs/latest/Reference/Hooks/).
 ```
 
 Result:
 >To learn more about hooks, see [Fastify
->hooks](https://www.fastify.dev/docs/latest/Reference/Hooks/).
+>hooks](https://fastify.dev/docs/latest/Reference/Hooks/).
 
 
 
@@ -224,18 +224,18 @@ hyperlink should look:
 <!-- More like this -->
 
 // Add clear & brief description
-[Fastify Plugins] (https://www.fastify.dev/docs/latest/Plugins/)
+[Fastify Plugins] (https://fastify.dev/docs/latest/Plugins/)
 
 <!--Less like this -->
 
 // incomplete description
-[Fastify] (https://www.fastify.dev/docs/latest/Plugins/)
+[Fastify] (https://fastify.dev/docs/latest/Plugins/)
 
 // Adding title in link brackets
-[](https://www.fastify.dev/docs/latest/Plugins/ "fastify plugin")
+[](https://fastify.dev/docs/latest/Plugins/ "fastify plugin")
 
 // Empty title
-[](https://www.fastify.dev/docs/latest/Plugins/)
+[](https://fastify.dev/docs/latest/Plugins/)
 
 // Adding links localhost URLs instead of using code strings (``)
 [http://localhost:3000/](http://localhost:3000/)

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
   "bugs": {
     "url": "https://github.com/fastify/fastify/issues"
   },
-  "homepage": "https://www.fastify.dev/",
+  "homepage": "https://fastify.dev/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/fastify"


### PR DESCRIPTION
Shaves off a few bytes.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
