### PR TITLE
fix: ensure `onListen` hooks are called when they should be

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -181,10 +181,6 @@ function onListenHookRunner (server) {
   const hooks = server[kHooks].onListen
   const hooksLen = hooks.length
 
-  if (hooksLen === 0) {
-    return
-  }
-
   let i = 0
   let c = 0
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -192,7 +192,7 @@ function onListenHookRunner (server) {
     if (
       i === hooksLen
     ) {
-      if (c < server[kChildren].length) {
+      while (c < server[kChildren].length) {
         const child = server[kChildren][c++]
         onListenHookRunner(child)
       }

--- a/test/hooks.on-listen.test.js
+++ b/test/hooks.on-listen.test.js
@@ -304,6 +304,25 @@ test('localhost onListen encapsulation should be called in order', t => {
   })
 })
 
+test('localhost onListen encapsulation with only nested hook', async t => {
+  t.plan(1)
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  await fastify.register(async (child, o) => {
+    await child.register(async (child2, o) => {
+      child2.addHook('onListen', function (done) {
+        t.pass()
+        done()
+      })
+    })
+  })
+  await fastify.listen({
+    host: 'localhost',
+    port: 0
+  })
+})
+
 test('localhost onListen encapsulation should be called in order and should log errors as warnings and continue', t => {
   t.plan(7)
   const stream = split(JSON.parse)


### PR DESCRIPTION
This PR fixes an issue where the `onListen` application hooks don't run in some cases when they should:
1. When there is an `onListen` hook registered in a child encapsulation context, but the parent context does not have one
2. When there are multiple encapsulation contexts that are peers (i.e. at the same level / both children of the same parent), only the first will run

See example code:
```js
const Fastify = require('./fastify.js')

const fastify = Fastify({ logger: true })

fastify.addHook('onListen', (done) => {
  console.log('i am called')
  done()
})

fastify.register((instance, opts, done) => {
  instance.addHook('onListen', (hookDone) => {
    console.log('i am also called')
    hookDone()
  })

  // create an encapsulation, and then create another immediately inside it
  instance.register((instance2, opts, done2) => {
    instance2.register((instance3, opts, done3) => {
      instance3.addHook('onListen', (hookDone) => {
        console.log('i am not called, because my parent does not have an onListen hook')
        hookDone()
      })
      done3()
    })
    done2()
  })
  done()
})

// since there is another context at this level (i.e. peer context), the hook inside this context won't run.
fastify.register((instance, opts, done) => {
  instance.addHook('onListen', (hookDone) => {
    console.log('i am not called because I am a peer context')
    hookDone()
  })
  done()
})

fastify.listen({ port: 3000 })
```

With the current version of fastify, this produces the following log output:
```
{"level":30,"time":1705470523577,"pid":99149,"hostname":"AJs-MacBook-Pro.local","msg":"Server listening at http://[::1]:3000"}
{"level":30,"time":1705470523578,"pid":99149,"hostname":"AJs-MacBook-Pro.local","msg":"Server listening at http://127.0.0.1:3000"}
i am called
i am also called
```

I believe the appropriate output would be:
```
{"level":30,"time":1705470550633,"pid":99225,"hostname":"AJs-MacBook-Pro.local","msg":"Server listening at http://[::1]:3000"}
{"level":30,"time":1705470550634,"pid":99225,"hostname":"AJs-MacBook-Pro.local","msg":"Server listening at http://127.0.0.1:3000"}
i am called
i am also called
i am not called, because my parent does not have an onListen hook
i am not called because I am a peer context
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
