### PR TITLE
docs(ecosystem): adds fastify-sqlite-typed to the community plugins list

### DIFF
--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -617,7 +617,7 @@ middlewares into Fastify plugins
 - [`fastify-sqlite`](https://github.com/Eomm/fastify-sqlite) connects your
   application to a sqlite3 database.
 - [`fastify-sqlite-typed`](https://github.com/yoav0gal/fastify-sqlite-typed) connects
-  your application to a SQLite database with full typescript support.
+  your application to a SQLite database with full Typescript support.
 - [`fastify-sse`](https://github.com/lolo32/fastify-sse) to provide Server-Sent
   Events with `reply.sse( … )` to Fastify.
 - [`fastify-sse-v2`](https://github.com/nodefactoryio/fastify-sse-v2) to provide

--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -617,7 +617,7 @@ middlewares into Fastify plugins
 - [`fastify-sqlite`](https://github.com/Eomm/fastify-sqlite) connects your
   application to a sqlite3 database.
 - [`fastify-sqlite-typed`](https://github.com/yoav0gal/fastify-sqlite-typed) connects
-  your application to a sqlite database with full typescript support.
+  your application to a SQLite database with full typescript support.
 - [`fastify-sse`](https://github.com/lolo32/fastify-sse) to provide Server-Sent
   Events with `reply.sse( … )` to Fastify.
 - [`fastify-sse-v2`](https://github.com/nodefactoryio/fastify-sse-v2) to provide

--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -616,6 +616,8 @@ middlewares into Fastify plugins
   HTTP part of the request.
 - [`fastify-sqlite`](https://github.com/Eomm/fastify-sqlite) connects your
   application to a sqlite3 database.
+- [`fastify-sqlite-typed`](https://github.com/yoav0gal/fastify-sqlite-typed) connects
+  your application to a sqlite database with full typescript support.
 - [`fastify-sse`](https://github.com/lolo32/fastify-sse) to provide Server-Sent
   Events with `reply.sse( … )` to Fastify.
 - [`fastify-sse-v2`](https://github.com/nodefactoryio/fastify-sse-v2) to provide


### PR DESCRIPTION
 Adds [fastify-sqlite-typed](https://github.com/yoav0gal/fastify-sqlite-typed) to the community plugins list

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
