### PR TITLE
docs(ecosystem): adds fastify-hana to the community plugins list

### DIFF
--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -386,6 +386,8 @@ section.
   Providers.
 - [`fastify-guard`](https://github.com/hsynlms/fastify-guard) A Fastify plugin
   that protects endpoints by checking authenticated user roles and/or scopes.
+- [`fastify-hana`](hhttps://github.com/yoav0gal/fastify-hana) connects your
+  application to [`SAP-HANA`](https://help.sap.com/docs/SAP_HANA_CLIENT).
 - [`fastify-hashids`](https://github.com/andersonjoseph/fastify-hashids) A Fastify
   plugin to encode/decode IDs using [hashids](https://github.com/niieani/hashids.js).
 - [`fastify-hasura`](https://github.com/ManUtopiK/fastify-hasura) A Fastify
@@ -539,8 +541,6 @@ middlewares into Fastify plugins
   a Fastify project.
 - [`fastify-postgres-dot-js`](https://github.com/kylerush/fastify-postgresjs) Fastify
   PostgreSQL connection plugin that uses [Postgres.js](https://github.com/porsager/postgres).
-- [`fastify-hana`](hhttps://github.com/yoav0gal/fastify-hana) connects your
-  application to [`SAP-HANA`](https://help.sap.com/docs/SAP_HANA_CLIENT).
 - [`fastify-prettier`](https://github.com/hsynlms/fastify-prettier) A Fastify
   plugin that uses [prettier](https://github.com/prettier/prettier) under the
   hood to beautify outgoing responses and/or other things in the Fastify server.

--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -386,7 +386,7 @@ section.
   Providers.
 - [`fastify-guard`](https://github.com/hsynlms/fastify-guard) A Fastify plugin
   that protects endpoints by checking authenticated user roles and/or scopes.
-- [`fastify-hana`](hhttps://github.com/yoav0gal/fastify-hana) connects your
+- [`fastify-hana`](https://github.com/yoav0gal/fastify-hana) connects your
   application to [`SAP-HANA`](https://help.sap.com/docs/SAP_HANA_CLIENT).
 - [`fastify-hashids`](https://github.com/andersonjoseph/fastify-hashids) A Fastify
   plugin to encode/decode IDs using [hashids](https://github.com/niieani/hashids.js).

--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -539,6 +539,8 @@ middlewares into Fastify plugins
   a Fastify project.
 - [`fastify-postgres-dot-js`](https://github.com/kylerush/fastify-postgresjs) Fastify
   PostgreSQL connection plugin that uses [Postgres.js](https://github.com/porsager/postgres).
+- [`fastify-hana`](hhttps://github.com/yoav0gal/fastify-hana) connects your
+  application to [`SAP-HANA`](https://help.sap.com/docs/SAP_HANA_CLIENT).
 - [`fastify-prettier`](https://github.com/hsynlms/fastify-prettier) A Fastify
   plugin that uses [prettier](https://github.com/prettier/prettier) under the
   hood to beautify outgoing responses and/or other things in the Fastify server.


### PR DESCRIPTION
Adds [fastify-hana](https://github.com/yoav0gal/fastify-hana) to the community plugins list

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
