### PR TITLE
docs: add ESM usage example in Getting Started

### DIFF
--- a/docs/Guides/Getting-Started.md
+++ b/docs/Guides/Getting-Started.md
@@ -55,7 +55,7 @@ fastify.listen({ port: 3000 }, function (err, address) {
 })
 ```
 
-> If you're using ECMAScript Modules (ESM) in your project, ensure to
+> If you are using ECMAScript Modules (ESM) in your project, be sure to
 > include "type": "module" in your package.json.
 >```js
 >{

--- a/docs/Guides/Getting-Started.md
+++ b/docs/Guides/Getting-Started.md
@@ -55,6 +55,13 @@ fastify.listen({ port: 3000 }, function (err, address) {
 })
 ```
 
+>If you're using ECMAScript Modules (ESM) in your project, ensure to include "type": "module" in your package.json.
+>```js
+>{
+>  "type": "module"
+>}
+>```
+
 Do you prefer to use `async/await`? Fastify supports it out-of-the-box.
 
 ```js
@@ -172,6 +179,7 @@ fastify.listen({ port: 3000 }, function (err, address) {
 })
 ```
 
+
 ```js
 // our-first-route.js
 
@@ -186,6 +194,10 @@ async function routes (fastify, options) {
   })
 }
 
+//ESM
+export default routes;
+
+// CommonJs
 module.exports = routes
 ```
 In this example, we used the `register` API, which is the core of the Fastify

--- a/docs/Guides/Getting-Started.md
+++ b/docs/Guides/Getting-Started.md
@@ -55,7 +55,8 @@ fastify.listen({ port: 3000 }, function (err, address) {
 })
 ```
 
->If you're using ECMAScript Modules (ESM) in your project, ensure to include "type": "module" in your package.json.
+>If you're using ECMAScript Modules (ESM) in your project, ensure to
+> include "type": "module" in your package.json.
 >```js
 >{
 >  "type": "module"

--- a/docs/Guides/Getting-Started.md
+++ b/docs/Guides/Getting-Started.md
@@ -55,7 +55,7 @@ fastify.listen({ port: 3000 }, function (err, address) {
 })
 ```
 
->If you're using ECMAScript Modules (ESM) in your project, ensure to
+> If you're using ECMAScript Modules (ESM) in your project, ensure to
 > include "type": "module" in your package.json.
 >```js
 >{


### PR DESCRIPTION
This commit updates the 'Getting Started' guide to include an ESM usage example, specifically demonstrating the export of routes using ESM syntax. A code snippet showing the addition of "type": "module" in a configuration example is also provided to assist users in setting up their projects for ESM.

This addresses the confusion mentioned in issue #5292 regarding ESM configuration in Fastify projects.

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
