### PR TITLE
fix: cb is not a function at fallbackErrorHandler

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -26,23 +26,25 @@ const rootErrorHandler = {
   }
 }
 
+function defaultErrorHandlerCB (reply, payload) {
+  try {
+    reply.raw.writeHead(reply.raw.statusCode, reply[kReplyHeaders])
+  } catch (error) {
+    reply.log.warn(
+      { req: reply.request, res: reply, err: error },
+      error && error.message
+    )
+    reply.raw.writeHead(reply.raw.statusCode)
+  }
+  reply.raw.end(payload)
+}
+
 function handleError (reply, error, cb) {
   reply[kReplyIsRunningOnErrorHook] = false
 
   const context = reply[kRouteContext]
   if (reply[kReplyNextErrorHandler] === false) {
-    fallbackErrorHandler(error, reply, function (reply, payload) {
-      try {
-        reply.raw.writeHead(reply.raw.statusCode, reply[kReplyHeaders])
-      } catch (error) {
-        reply.log.warn(
-          { req: reply.request, res: reply, err: error },
-          error && error.message
-        )
-        reply.raw.writeHead(reply.raw.statusCode)
-      }
-      reply.raw.end(payload)
-    })
+    fallbackErrorHandler(error, reply, defaultErrorHandlerCB)
     return
   }
   const errorHandler = reply[kReplyNextErrorHandler] || context.errorHandler
@@ -123,6 +125,11 @@ function fallbackErrorHandler (error, reply, cb) {
   }
 
   reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)
+  
+  if (typeof cb !== 'function') {
+    defaultErrorHandlerCB(reply, payload)
+    return
+  }
 
   cb(reply, payload)
 }

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -125,7 +125,7 @@ function fallbackErrorHandler (error, reply, cb) {
   }
 
   reply[kReplyHeaders]['content-length'] = '' + Buffer.byteLength(payload)
-  
+
   if (typeof cb !== 'function') {
     defaultErrorHandlerCB(reply, payload)
     return


### PR DESCRIPTION
This fixes error if cb is not a function at fallbackErrorHandler:
![image](https://github.com/fastify/fastify/assets/5627754/bb6cca15-31c7-469a-afcb-e3361f1f7018)

Tests:
![image](https://github.com/fastify/fastify/assets/5627754/4b904a3f-b0c7-4e01-93d5-7be1d27d8589)

Benchmarks:
![image](https://github.com/fastify/fastify/assets/5627754/98ab1a71-64ad-4435-82d3-3e05cce5bcf2)


**Cheklist**:
- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](

