### PR TITLE
docs: fix misattributed property parent in deprecation warning: request.elapsedTime

### DIFF
--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -79,7 +79,7 @@ const FSTDEP019 = createDeprecation({
 
 const FSTDEP020 = createDeprecation({
   code: 'FSTDEP020',
-  message: 'You are using the deprecated "reply.getResponseTime()"" method. Use the "request.elapsedTime" property instead. Method "reply.getResponseTime()" will be removed in `fastify@5`.'
+  message: 'You are using the deprecated "reply.getResponseTime()" method. Use the "reply.elapsedTime" property instead. Method "reply.getResponseTime()" will be removed in `fastify@5`.'
 })
 
 const FSTWRN001 = createWarning({


### PR DESCRIPTION
The deprecation read:

`You are using the deprecated "reply.getResponseTime()"" method. Use the "request.elapsedTime" property instead.`

This message reference the incorrect parent object and also had a typo of an extra quotation mark. This revision fixes this the content of this warning.