### PR TITLE
fix: typo in module exports

### DIFF
--- a/docs/Guides/Serverless.md
+++ b/docs/Guides/Serverless.md
@@ -203,7 +203,7 @@ const fastifyFunction = async (request, reply) => {
   fastify.server.emit('request', request, reply)
 }
 
-export.fastifyFunction = fastifyFunction;
+exports.fastifyFunction = fastifyFunction;
 ```
 
 ### Local test


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Looks like a typo in the docs for Fastify on GCP.

Somewhat related but I don't want to mix with this PR - I'm using Firebase Functions which I think is *maybe* the same infra under the hood as Google Cloud Functions but I'm not totally sure on that and I've used a different syntax to make things work. Especially with regards to the use of webhooks which requires the raw body *and* JSON for parsing. So, I'm thinking I'll shoot out a new PR to add a new `Google Firebase Functions` section with what I've got that works. Is that ok?

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
