### PR TITLE
feat: make contentTypeParser's existingParser check more strict

### DIFF
--- a/docs/Guides/Serverless.md
+++ b/docs/Guides/Serverless.md
@@ -26,6 +26,7 @@ snippet of code.
 
 - [AWS](#aws)
 - [Google Cloud Functions](#google-cloud-functions)
+- [Google Firebase Functions](#google-firebase-functions)
 - [Google Cloud Run](#google-cloud-run)
 - [Netlify Lambda](#netlify-lambda)
 - [Platformatic Cloud](#platformatic-cloud)
@@ -259,6 +260,115 @@ curl -X POST https://$GOOGLE_REGION-$GOOGLE_PROJECT.cloudfunctions.net/me \
 ### References
 - [Google Cloud Functions - Node.js Quickstart
   ](https://cloud.google.com/functions/docs/quickstart-nodejs)
+
+## Google Firebase Functions
+
+Follow this guide if you want to use Fastify as the HTTP framework for 
+Firebase Functions instead of the vanilla JavaScript router provided with
+`onRequest(async (req, res) => {}`.
+
+### The onRequest() handler
+
+We use the `onRequest` function to wrap our Fastify application instance.
+
+As such, we'll begin with importing it to the code:
+
+```js
+const { onRequest } = require("firebase-functions/v2/https")
+```
+
+### Creation of Fastify instance
+
+Create the Fastify instance and encapsulate the returned application instance
+in a function which will register routes, await the server's processing of 
+plugins, hooks and other settings. As follows:
+
+```js
+const fastify = require("fastify")({
+  logger: true,
+})
+
+const fastifyApp = async (request, reply) => {
+  await registerRoutes(fastify)
+  await fastify.ready()
+  fastify.server.emit("request", request, reply)
+}
+```
+
+### Add Custom `contentTypeParser` to Fastify instance and define endpoints
+
+Firebase Function's HTTP layer already parses the request
+and makes a JSON payload available. It also provides access
+to the raw body, unparsed, which is useful in order to calculate
+request signatures to validate HTTP webhooks.
+
+Add as follows to the `registerRoutes()` function:
+
+```js
+async function registerRoutes (fastify) {
+  fastify.addContentTypeParser("application/json", {}, (req, payload, done) => {
+    // useful to include the request's raw body on the `req` object that will
+    // later be available in your other routes so you can calculate the HMAC
+    // if needed
+    req.rawBody = payload.rawBody
+
+    // payload.body is already the parsed JSON so we just fire the done callback
+    // with it
+    done(null, payload.body)
+  })
+
+  // define your endpoints here...
+  fastify.post("/some-route-here", async (request, reply) => {}
+
+  fastify.get('/', async (request, reply) => {
+    reply.send({message: 'Hello World!'})
+  })
+}
+```
+
+### Export the function using Firebase onRequest
+
+Final step is to export the Fastify app instance to Firebase's own
+`onRequest()` function so it can pass the request and reply objects to it:
+
+```js
+exports.app = onRequest(fastifyApp)
+```
+
+### Local test
+
+Install the Firebase tools functions so you can use the CLI:
+
+```bash
+npm i -g firebase-tools
+```
+
+Then you can run your function locally with:
+
+```bash
+firebase emulators:start --only functions
+```
+
+### Deploy
+
+Deploy your Firebase Functions with:
+
+```bash
+firebase deploy --only functions
+```
+
+#### Read logs
+
+Use the Firebase tools CLI:
+
+```bash
+firebase functions:log
+```
+
+### References
+- [Fastify on Firebase Functions](https://github.com/lirantal/lemon-squeezy-firebase-webhook-fastify/blob/main/package.json)
+- [An article about HTTP webhooks on Firebase Functions and Fastify: A Practical Case Study with Lemon Squeezy](https://lirantal.com/blog/http-webhooks-firebase-functions-fastify-practical-case-study-lemon-squeezy)
+
 
 ## Google Cloud Run
 

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -45,8 +45,8 @@ ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
   if (typeof parserFn !== 'function') throw new FST_ERR_CTP_INVALID_HANDLER()
   if (!contentTypeIsString && !(contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()
   if (contentTypeIsString) {
-    if (contentType.length === 0) throw new FST_ERR_CTP_EMPTY_TYPE()
     contentType = contentType.trim().toLowerCase()
+    if (contentType.length === 0) throw new FST_ERR_CTP_EMPTY_TYPE()
   }
 
   if (this.existingParser(contentType)) {

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -46,7 +46,7 @@ ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
   if (!contentTypeIsString && !(contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()
   if (contentTypeIsString) {
     if (contentType.length === 0) throw new FST_ERR_CTP_EMPTY_TYPE()
-    contentType = contentType.toLowerCase().trim()
+    contentType = contentType.trim().toLowerCase()
   }
 
   if (this.existingParser(contentType)) {

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -42,9 +42,12 @@ function ContentTypeParser (bodyLimit, onProtoPoisoning, onConstructorPoisoning)
 ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
   const contentTypeIsString = typeof contentType === 'string'
 
-  if (!contentTypeIsString && !(contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()
-  if (contentTypeIsString && contentType.length === 0) throw new FST_ERR_CTP_EMPTY_TYPE()
   if (typeof parserFn !== 'function') throw new FST_ERR_CTP_INVALID_HANDLER()
+  if (!contentTypeIsString && !(contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()
+  if (contentTypeIsString) {
+    if (contentType.length === 0) throw new FST_ERR_CTP_EMPTY_TYPE()
+    contentType = contentType.toLowerCase().trim()
+  }
 
   if (this.existingParser(contentType)) {
     throw new FST_ERR_CTP_ALREADY_PRESENT(contentType)

--- a/test/content-type.test.js
+++ b/test/content-type.test.js
@@ -3,6 +3,24 @@
 const t = require('tap')
 const test = t.test
 const Fastify = require('..')
+const {
+  FST_ERR_CTP_ALREADY_PRESENT
+} = require('../lib/errors')
+
+test('should trim contentTypeParser names', async t => {
+  t.plan(1)
+  const fastify = Fastify()
+  fastify.addContentTypeParser('text/html', function (req, done) {
+    done()
+  })
+  try {
+    fastify.addContentTypeParser('    text/html', function (req, done) {
+      done()
+    })
+  } catch (err) {
+    t.same(err.message, FST_ERR_CTP_ALREADY_PRESENT('text/html').message)
+  }
+})
 
 test('should remove content-type for setErrorHandler', async t => {
   t.plan(8)

--- a/test/content-type.test.js
+++ b/test/content-type.test.js
@@ -7,6 +7,21 @@ const {
   FST_ERR_CTP_ALREADY_PRESENT
 } = require('../lib/errors')
 
+test('should lowercase contentTypeParser names', async t => {
+  t.plan(1)
+  const fastify = Fastify()
+  fastify.addContentTypeParser('text/html', function (req, done) {
+    done()
+  })
+  try {
+    fastify.addContentTypeParser('TEXT/html', function (req, done) {
+      done()
+    })
+  } catch (err) {
+    t.same(err.message, FST_ERR_CTP_ALREADY_PRESENT('text/html').message)
+  }
+})
+
 test('should trim contentTypeParser names', async t => {
   t.plan(1)
   const fastify = Fastify()


### PR DESCRIPTION
From https://github.com/fastify/fastify/pull/4477#issuecomment-1378545312

We should not be allowing this in my opinion. Nothing good can come out of it:

```js
fastify.addContentTypeParser('   application/json   ', function (request, body, done) {
  done(null, body)
})
fastify.addContentTypeParser('application/json   ', function (request, body, done) {
  done(null, body)
})
fastify.addContentTypeParser('   application/json', function (request, body, done) {
  done(null, body)
})
fastify.addContentTypeParser('application/JSON', function (request, body, done) {
  done(null, body)
})
```

The Content-Type header is completely case insensitive for the MIME part, and whitespace insensitive when it comes to spaces around the whole value, we should take these facts into account when registering a parser

We can also throw instead of trimming silently, even though I think this is fine... In any case, we should look into changing the current behavior before `v5`