### PR TITLE
perf: use FifoMap to check contentType

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { AsyncResource } = require('node:async_hooks')
-const { Fifo } = require('toad-cache')
+const { FifoMap: Fifo } = require('toad-cache')
 const { safeParse: safeParseContentType, defaultContentType } = require('fast-content-type-parse')
 const secureJson = require('secure-json-parse')
 const {


### PR DESCRIPTION
For the same reason as https://github.com/fastify/fastify-rate-limit/pull/353

There is a 50%+ improvement in the lookup performance of non-numeric keys when a map is used instead of an object — contentType is a string