### PR TITLE
Expose all the properties of the route on findRoute method

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -178,14 +178,10 @@ function buildRouting (options) {
       options.constraints
     )
     if (route) {
-      // we must reduce the expose surface, otherwise
+      // we must copy the route properties, otherwise
       // we provide the ability for the user to modify
       // all the route and server information in runtime
-      return {
-        handler: route.handler,
-        params: route.params,
-        searchParams: route.searchParams
-      }
+      return Object.assign({}, route);
     } else {
       return null
     }


### PR DESCRIPTION
With this code, we can expose all the route properties, but creating a clone, so user cannot update the initial route on the runtime.