### PR TITLE
feat: contentTypeParser cache, prefer lru to fifo

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { AsyncResource } = require('node:async_hooks')
-const { FifoMap: Fifo } = require('toad-cache')
+const { LruMap: Lru } = require('toad-cache')
 const { safeParse: safeParseContentType, defaultContentType } = require('fast-content-type-parse')
 const secureJson = require('secure-json-parse')
 const {
@@ -36,7 +36,7 @@ function ContentTypeParser (bodyLimit, onProtoPoisoning, onConstructorPoisoning)
   this.customParsers.set('text/plain', new Parser(true, false, bodyLimit, defaultPlainTextParser))
   this.parserList = [new ParserListItem('application/json'), new ParserListItem('text/plain')]
   this.parserRegExpList = []
-  this.cache = new Fifo(100)
+  this.cache = new Lru(100)
 }
 
 ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
@@ -136,7 +136,7 @@ ContentTypeParser.prototype.removeAll = function () {
   this.customParsers = new Map()
   this.parserRegExpList = []
   this.parserList = []
-  this.cache = new Fifo(100)
+  this.cache = new Lru(100)
 }
 
 ContentTypeParser.prototype.remove = function (contentType) {


### PR DESCRIPTION
Why Fifo?

If there is a cache match, we should make that entry fresh again as chances of it being used again is now higher