### PR TITLE
fix: `config` type in RouteShorthandOptions

### DIFF
--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -19,6 +19,13 @@ declare module '../../fastify' {
   interface FastifyContextConfig {
     foo: string;
     bar: number;
+    includeMessage?: boolean;
+  }
+
+  interface FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig, Logger, RequestType> {
+    message: ContextConfig extends { includeMessage: true }
+      ? string
+      : null;
   }
 }
 
@@ -35,6 +42,22 @@ const routeHandlerWithReturnValue: RouteHandlerMethod = function (request, reply
 
   return reply.send()
 }
+
+fastify().get(
+  '/',
+  { config: { foo: 'bar', bar: 100, includeMessage: true } },
+  (req) => {
+    expectType<string>(req.message)
+  }
+)
+
+fastify().get(
+  '/',
+  { config: { foo: 'bar', bar: 100, includeMessage: false } },
+  (req) => {
+    expectType<null>(req.message)
+  }
+)
 
 type LowerCaseHTTPMethods = 'delete' | 'get' | 'head' | 'patch' | 'post' | 'put' |
 'options' | 'propfind' | 'proppatch' | 'mkcol' | 'copy' | 'move' | 'lock' |

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -1,6 +1,6 @@
 import { FastifyError } from '@fastify/error'
 import { ConstraintStrategy } from 'find-my-way'
-import { FastifyRequestContext } from './context'
+import { FastifyContextConfig } from './context'
 import { onErrorMetaHookHandler, onRequestAbortMetaHookHandler, onRequestMetaHookHandler, onResponseMetaHookHandler, onSendMetaHookHandler, onTimeoutMetaHookHandler, preHandlerMetaHookHandler, preParsingMetaHookHandler, preSerializationMetaHookHandler, preValidationMetaHookHandler } from './hooks'
 import { FastifyInstance } from './instance'
 import { FastifyBaseLogger, FastifyChildLoggerFactory, LogLevel } from './logger'
@@ -52,7 +52,7 @@ export interface RouteShorthandOptions<
   serializerCompiler?: FastifySerializerCompiler<SchemaCompiler>;
   bodyLimit?: number;
   logLevel?: LogLevel;
-  config?: Omit<FastifyRequestContext<ContextConfig>['config'], 'url' | 'method'>;
+  config?: FastifyContextConfig & ContextConfig;
   version?: string;
   constraints?: RouteConstraint,
   prefixTrailingSlash?: 'slash'|'no-slash'|'both';


### PR DESCRIPTION
Hello! This PR fixes #5322.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
