### PR TITLE
docs: improve onError docs by specifying what the error handler is

### DIFF
--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -189,9 +189,10 @@ specific header in case of error.
 It is not intended for changing the error, and calling `reply.send` will throw
 an exception.
 
-This hook will be executed only after the `customErrorHandler` has been
-executed, and only if the `customErrorHandler` sends an error back to the user
-*(Note that the default `customErrorHandler` always sends the error back to the
+This hook will be executed only after
+the [Custom Error Handler set by `setErrorHandler`](./Server.md#seterrorhandler)
+has been executed, and only if the custom error handler sends an error back to the user
+*(Note that the default error handler always sends the error back to the
 user)*.
 
 **Notice:** unlike the other hooks, passing an error to the `done` function is not

--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -191,7 +191,8 @@ an exception.
 
 This hook will be executed only after
 the [Custom Error Handler set by `setErrorHandler`](./Server.md#seterrorhandler)
-has been executed, and only if the custom error handler sends an error back to the user
+has been executed, and only if the custom error handler sends an error back to the
+user
 *(Note that the default error handler always sends the error back to the
 user)*.
 


### PR DESCRIPTION
- Fixes #5353 

The docs refer to `customErrorHandler` but don't say what it is - this links the `setErrorHandler` method.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
