### PR TITLE
docs: Remove ES module with NodeNext note

### DIFF
--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -61,11 +61,6 @@ in a blank http Fastify server.
 *Note: Set `target` property in `tsconfig.json` to `es2017` or greater to avoid
 [FastifyDeprecation](https://github.com/fastify/fastify/issues/3284) warning.*
 
-*Note 2: Avoid using ```"moduleResolution": "NodeNext"``` in tsconfig.json with 
-```"type": "module"``` in package.json. This combination is currently not 
-supported by fastify typing system.
-[ts(2349)](https://github.com/fastify/fastify/issues/4241) warning.*
-
 4. Create an `index.ts` file - this will contain the server code
 5. Add the following code block to your file:
    ```typescript


### PR DESCRIPTION
https://github.com/fastify/fastify/issues/4241 and https://github.com/smartiniOnGitHub/fastify-healthcheck/issues/20 both seems to be closed. This note can be removed.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
