### PR TITLE
docs: Add GitHub links to Type Providers + mention Zod

### DIFF
--- a/docs/Reference/Type-Providers.md
+++ b/docs/Reference/Type-Providers.md
@@ -25,8 +25,8 @@ See also the Type Provider wrapper packages for each of the packages respectivel
 
 - [`@fastify/type-provider-json-schema-to-ts`](https://github.com/fastify/fastify-type-provider-json-schema-to-ts)
 - [`@fastify/type-provider-typebox`](https://github.com/fastify/fastify-type-provider-typebox)
-- [`fastify-type-provider-zod`](https://github.com/turkerdev/fastify-type-provider-zod) 
-(3rd party)
+- [`fastify-type-provider-zod`](https://github.com/turkerdev/fastify-type-provider-zod)
+ (3rd party)
 
 ### Json Schema to Ts
 

--- a/docs/Reference/Type-Providers.md
+++ b/docs/Reference/Type-Providers.md
@@ -17,10 +17,15 @@ convention, and there are several community ones available as well.
 
 The following inference packages are supported:
 
-- `json-schema-to-ts` -
-  [github](https://github.com/ThomasAribart/json-schema-to-ts)
-- `typebox` - [github](https://github.com/sinclairzx81/typebox)
-- `zod` - [github](https://github.com/colinhacks/zod)
+- [`json-schema-to-ts`](https://github.com/ThomasAribart/json-schema-to-ts)
+- [`typebox`](https://github.com/sinclairzx81/typebox)
+- [`zod`](https://github.com/colinhacks/zod)
+
+See also the Type Provider wrapper packages for each of the packages respectively:
+
+- [`@fastify/type-provider-json-schema-to-ts`](https://github.com/fastify/fastify-type-provider-json-schema-to-ts)
+- [`@fastify/type-provider-typebox`](https://github.com/fastify/fastify-type-provider-typebox)
+- [`fastify-type-provider-zod`](https://github.com/turkerdev/fastify-type-provider-zod)
 
 ### Json Schema to Ts
 

--- a/docs/Reference/Type-Providers.md
+++ b/docs/Reference/Type-Providers.md
@@ -19,13 +19,13 @@ The following inference packages are supported:
 
 - [`json-schema-to-ts`](https://github.com/ThomasAribart/json-schema-to-ts)
 - [`typebox`](https://github.com/sinclairzx81/typebox)
-- [`zod`](https://github.com/colinhacks/zod) (3rd party package)
+- [`zod`](https://github.com/colinhacks/zod)
 
 See also the Type Provider wrapper packages for each of the packages respectively:
 
 - [`@fastify/type-provider-json-schema-to-ts`](https://github.com/fastify/fastify-type-provider-json-schema-to-ts)
 - [`@fastify/type-provider-typebox`](https://github.com/fastify/fastify-type-provider-typebox)
-- [`fastify-type-provider-zod`](https://github.com/turkerdev/fastify-type-provider-zod)
+- [`fastify-type-provider-zod`](https://github.com/turkerdev/fastify-type-provider-zod) (3rd party package)
 
 ### Json Schema to Ts
 

--- a/docs/Reference/Type-Providers.md
+++ b/docs/Reference/Type-Providers.md
@@ -25,7 +25,8 @@ See also the Type Provider wrapper packages for each of the packages respectivel
 
 - [`@fastify/type-provider-json-schema-to-ts`](https://github.com/fastify/fastify-type-provider-json-schema-to-ts)
 - [`@fastify/type-provider-typebox`](https://github.com/fastify/fastify-type-provider-typebox)
-- [`fastify-type-provider-zod`](https://github.com/turkerdev/fastify-type-provider-zod) (3rd party package)
+- [`fastify-type-provider-zod`](https://github.com/turkerdev/fastify-type-provider-zod) 
+(3rd party)
 
 ### Json Schema to Ts
 

--- a/docs/Reference/Type-Providers.md
+++ b/docs/Reference/Type-Providers.md
@@ -19,7 +19,7 @@ The following inference packages are supported:
 
 - [`json-schema-to-ts`](https://github.com/ThomasAribart/json-schema-to-ts)
 - [`typebox`](https://github.com/sinclairzx81/typebox)
-- [`zod`](https://github.com/colinhacks/zod)
+- [`zod`](https://github.com/colinhacks/zod) (3rd party package)
 
 See also the Type Provider wrapper packages for each of the packages respectively:
 

--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -218,12 +218,12 @@ Providers](./Type-Providers.md) page.
 Below is how to setup schema validation using _vanilla_ `typebox` and
 `json-schema-to-ts` packages.
 
-#### typebox
+#### TypeBox
 
 A useful library for building types and a schema at once is
-[typebox](https://www.npmjs.com/package/@sinclair/typebox) along with 
+[TypeBox](https://www.npmjs.com/package/@sinclair/typebox) along with 
 [fastify-type-provider-typebox](https://github.com/fastify/fastify-type-provider-typebox).
-With typebox you define your schema within your code and use them
+With TypeBox you define your schema within your code and use them
 directly as types or schemas as you need them.
 
 When you want to use it for validation of some payload in a fastify route you
@@ -275,7 +275,6 @@ can do it as follows:
       }
     )
     ```
-
 
 #### Schemas in JSON Files
 

--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -205,7 +205,7 @@ Fastify offers two packages wrapping `json-schema-to-ts` and `typebox`:
 - [`@fastify/type-provider-json-schema-to-ts`](https://github.com/fastify/fastify-type-provider-json-schema-to-ts)
 - [`@fastify/type-provider-typebox`](https://github.com/fastify/fastify-type-provider-typebox)
 
-And a `zod` wrapper by a third party called: [`fastify-type-provider-zod`](https://github.com/turkerdev/fastify-type-provider-zod)
+And a `zod` wrapper by a third party called [`fastify-type-provider-zod`](https://github.com/turkerdev/fastify-type-provider-zod)
 
 They simplify schema validation setup and you can read more about them in [Type
 Providers](./Type-Providers.md) page.

--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -202,10 +202,10 @@ Here are some options on how to achieve this.
 
 Fastify offers two packages wrapping `json-schema-to-ts` and `typebox`:
 
-- `@fastify/type-provider-json-schema-to-ts` - [GitHub](https://github.com/fastify/fastify-type-provider-json-schema-to-ts)
-- `@fastify/type-provider-typebox` - [GitHub](https://github.com/fastify/fastify-type-provider-typebox)
+- [`@fastify/type-provider-json-schema-to-ts`](https://github.com/fastify/fastify-type-provider-json-schema-to-ts)
+- [`@fastify/type-provider-typebox`](https://github.com/fastify/fastify-type-provider-typebox)
 
-And a `zod` wrapper by a third party called: `fastify-type-provider-zod` - [GitHub](https://github.com/turkerdev/fastify-type-provider-zod)
+And a `zod` wrapper by a third party called: [`fastify-type-provider-zod`](https://github.com/turkerdev/fastify-type-provider-zod)
 
 They simplify schema validation setup and you can read more about them in [Type
 Providers](./Type-Providers.md) page.

--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -207,13 +207,15 @@ Here are some options on how to achieve this.
 
 Fastify offers two packages wrapping `json-schema-to-ts` and `typebox`:
 
-- `@fastify/type-provider-json-schema-to-ts`
-- `@fastify/type-provider-typebox`
+- `@fastify/type-provider-json-schema-to-ts` - [GitHub](https://github.com/fastify/fastify-type-provider-json-schema-to-ts)
+- `@fastify/type-provider-typebox` - [GitHub](https://github.com/fastify/fastify-type-provider-typebox)
+
+And a `zod` wrapper by a third party called: `fastify-type-provider-zod` - [GitHub](https://github.com/turkerdev/fastify-type-provider-zod)
 
 They simplify schema validation setup and you can read more about them in [Type
 Providers](./Type-Providers.md) page.
 
-Below is how to setup schema validation using vanilla `typebox` and
+Below is how to setup schema validation using _vanilla_ `typebox` and
 `json-schema-to-ts` packages.
 
 #### typebox


### PR DESCRIPTION
- Add links behind each package name, so people can easily find and look-up the corresponding READMEs
- Add Zod to the TypeScript list as 3rd party
- Add Type Provider wrapper packages to the Type Provider page
- Make all links consistency, not using "GitHub" anymore

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
