### PR TITLE
fix: contentType match should not include invalid strings that start with the matched type

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -80,7 +80,7 @@ ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
 }
 
 ContentTypeParser.prototype.hasParser = function (contentType) {
-  return this.customParsers.has(typeof contentType === 'string' ? contentType : contentType.toString())
+  return this.customParsers.has(typeof contentType === 'string' ? contentType.trim().toLowerCase() : contentType.toString())
 }
 
 ContentTypeParser.prototype.existingParser = function (contentType) {

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -45,9 +45,13 @@ ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
   if (contentTypeIsString) {
     contentType = contentType.trim().toLowerCase()
     if (contentType.length === 0) throw new FST_ERR_CTP_EMPTY_TYPE()
+  } else if (!(contentType instanceof RegExp)) {
+    throw new FST_ERR_CTP_INVALID_TYPE()
   }
-  if (!contentTypeIsString && !(contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()
-  if (typeof parserFn !== 'function') throw new FST_ERR_CTP_INVALID_HANDLER()
+
+  if (typeof parserFn !== 'function') {
+    throw new FST_ERR_CTP_INVALID_HANDLER()
+  }
 
   if (this.existingParser(contentType)) {
     throw new FST_ERR_CTP_ALREADY_PRESENT(contentType)

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -39,6 +39,21 @@ function ContentTypeParser (bodyLimit, onProtoPoisoning, onConstructorPoisoning)
   this.cache = new Fifo(100)
 }
 
+ContentTypeParser.prototype.existingParser = function (contentType) {
+  if (contentType === 'application/json' && this.customParsers.has(contentType)) {
+    return this.customParsers.get(contentType).fn !== this[kDefaultJsonParse]
+  }
+  if (contentType === 'text/plain' && this.customParsers.has(contentType)) {
+    return this.customParsers.get(contentType).fn !== defaultPlainTextParser
+  }
+
+  return this.hasParser(contentType)
+}
+
+ContentTypeParser.prototype.hasParser = function (contentType) {
+  return this.customParsers.has(typeof contentType === 'string' ? contentType.trim().toLowerCase() : contentType.toString())
+}
+
 ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
   const contentTypeIsString = typeof contentType === 'string'
 
@@ -79,19 +94,34 @@ ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
   }
 }
 
-ContentTypeParser.prototype.hasParser = function (contentType) {
-  return this.customParsers.has(typeof contentType === 'string' ? contentType.trim().toLowerCase() : contentType.toString())
+ContentTypeParser.prototype.remove = function (contentType) {
+  const contentTypeIsString = typeof contentType === 'string'
+  let parsers
+
+  if (contentTypeIsString) {
+    contentType = contentType.trim().toLowerCase()
+    parsers = this.parserList
+  } else {
+    if (!(contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()
+    contentType = contentType.toString()
+    parsers = this.parserRegExpList
+  }
+
+  const removed = this.customParsers.delete(contentType)
+  const idx = parsers.findIndex(ct => ct.toString() === contentType)
+
+  if (idx > -1) {
+    parsers.splice(idx, 1)
+  }
+
+  return removed || idx > -1
 }
 
-ContentTypeParser.prototype.existingParser = function (contentType) {
-  if (contentType === 'application/json' && this.customParsers.has(contentType)) {
-    return this.customParsers.get(contentType).fn !== this[kDefaultJsonParse]
-  }
-  if (contentType === 'text/plain' && this.customParsers.has(contentType)) {
-    return this.customParsers.get(contentType).fn !== defaultPlainTextParser
-  }
-
-  return this.hasParser(contentType)
+ContentTypeParser.prototype.removeAll = function () {
+  this.customParsers = new Map()
+  this.parserRegExpList = []
+  this.parserList = []
+  this.cache = new Fifo(100)
 }
 
 ContentTypeParser.prototype.getParser = function (contentType) {
@@ -122,36 +152,6 @@ ContentTypeParser.prototype.getParser = function (contentType) {
   }
 
   return this.customParsers.get('')
-}
-
-ContentTypeParser.prototype.removeAll = function () {
-  this.customParsers = new Map()
-  this.parserRegExpList = []
-  this.parserList = []
-  this.cache = new Fifo(100)
-}
-
-ContentTypeParser.prototype.remove = function (contentType) {
-  const contentTypeIsString = typeof contentType === 'string'
-  let parsers
-
-  if (contentTypeIsString) {
-    contentType = contentType.trim().toLowerCase()
-    parsers = this.parserList
-  } else {
-    if (!(contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()
-    contentType = contentType.toString()
-    parsers = this.parserRegExpList
-  }
-
-  const removed = this.customParsers.delete(contentType)
-  const idx = parsers.findIndex(ct => ct.toString() === contentType)
-
-  if (idx > -1) {
-    parsers.splice(idx, 1)
-  }
-
-  return removed || idx > -1
 }
 
 ContentTypeParser.prototype.run = function (contentType, handler, request, reply) {

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -95,7 +95,7 @@ ContentTypeParser.prototype.existingParser = function (contentType) {
 }
 
 ContentTypeParser.prototype.getParser = function (contentType) {
-  contentType = contentType.trim()
+  contentType = contentType.trimStart()
 
   if (this.hasParser(contentType)) {
     return this.customParsers.get(contentType)

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -95,19 +95,18 @@ ContentTypeParser.prototype.existingParser = function (contentType) {
 }
 
 ContentTypeParser.prototype.getParser = function (contentType) {
-  contentType = contentType.trim()
-
-  if (this.hasParser(contentType)) {
-    return this.customParsers.get(contentType)
-  }
-
-  const parser = this.cache.get(contentType)
+  let parser = this.customParsers.get(contentType)
   if (parser !== undefined) return parser
+
+  parser = this.cache.get(contentType)
+  if (parser !== undefined) return parser
+
+  const trimmedContentType = contentType.trimStart()
 
   // eslint-disable-next-line no-var
   for (var i = 0; i !== this.parserList.length; ++i) {
     const parserListItem = this.parserList[i]
-    if (contentType.indexOf(parserListItem) === 0) {
+    if (trimmedContentType.indexOf(parserListItem) === 0) {
       const parser = this.customParsers.get(parserListItem)
       this.cache.set(contentType, parser)
       return parser

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -107,7 +107,7 @@ ContentTypeParser.prototype.getParser = function (contentType) {
   for (var i = 0; i !== this.parserList.length; ++i) {
     const parserListItem = this.parserList[i]
     if (trimmedContentType.indexOf(parserListItem) === 0) {
-      const parser = this.customParsers.get(parserListItem)
+      parser = this.customParsers.get(parserListItem)
       this.cache.set(contentType, parser)
       return parser
     }
@@ -117,7 +117,7 @@ ContentTypeParser.prototype.getParser = function (contentType) {
   for (var j = 0; j !== this.parserRegExpList.length; ++j) {
     const parserRegExp = this.parserRegExpList[j]
     if (parserRegExp.test(contentType)) {
-      const parser = this.customParsers.get(parserRegExp.toString())
+      parser = this.customParsers.get(parserRegExp.toString())
       this.cache.set(contentType, parser)
       return parser
     }

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -101,12 +101,10 @@ ContentTypeParser.prototype.getParser = function (contentType) {
   parser = this.cache.get(contentType)
   if (parser !== undefined) return parser
 
-  const trimmedContentType = contentType.trimStart()
-
   // eslint-disable-next-line no-var
   for (var i = 0; i !== this.parserList.length; ++i) {
     const parserListItem = this.parserList[i]
-    if (trimmedContentType.indexOf(parserListItem) === 0) {
+    if (contentType.indexOf(parserListItem) === 0) {
       parser = this.customParsers.get(parserListItem)
       this.cache.set(contentType, parser)
       return parser

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -109,7 +109,7 @@ ContentTypeParser.prototype.getParser = function (contentType) {
   // eslint-disable-next-line no-var
   for (var i = 0; i !== this.parserList.length; ++i) {
     const parserListItem = this.parserList[i]
-    if (contentType.indexOf(parserListItem) === 0) {
+    if (contentType.indexOf(parserListItem) === 0 && (contentType.length === parserListItem.length || contentType.charCodeAt(parserListItem.length) === 59 /* `;` */)) {
       parser = this.customParsers.get(parserListItem)
       this.cache.set(contentType, parser)
       return parser

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -136,10 +136,9 @@ ContentTypeParser.prototype.removeAll = function () {
 }
 
 ContentTypeParser.prototype.remove = function (contentType) {
-  const contentTypeIsString = typeof contentType === 'string'
   let parsers
 
-  if (contentTypeIsString) {
+  if (typeof contentType === 'string') {
     contentType = contentType.trim().toLowerCase()
     parsers = this.parserList
   } else {

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -109,7 +109,10 @@ ContentTypeParser.prototype.getParser = function (contentType) {
   // eslint-disable-next-line no-var
   for (var i = 0; i !== this.parserList.length; ++i) {
     const parserListItem = this.parserList[i]
-    if (contentType.indexOf(parserListItem) === 0 && (contentType.length === parserListItem.length || contentType.charCodeAt(parserListItem.length) === 59 /* `;` */)) {
+    if (
+      contentType.indexOf(parserListItem) === 0 &&
+      (contentType.length === parserListItem.length || contentType.charCodeAt(parserListItem.length) === 59 /* `;` */ || contentType.charCodeAt(parserListItem.length) === 32 /* ` ` */)
+    ) {
       parser = this.customParsers.get(parserListItem)
       this.cache.set(contentType, parser)
       return parser

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -42,12 +42,12 @@ function ContentTypeParser (bodyLimit, onProtoPoisoning, onConstructorPoisoning)
 ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
   const contentTypeIsString = typeof contentType === 'string'
 
-  if (typeof parserFn !== 'function') throw new FST_ERR_CTP_INVALID_HANDLER()
-  if (!contentTypeIsString && !(contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()
   if (contentTypeIsString) {
     contentType = contentType.trim().toLowerCase()
     if (contentType.length === 0) throw new FST_ERR_CTP_EMPTY_TYPE()
   }
+  if (!contentTypeIsString && !(contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()
+  if (typeof parserFn !== 'function') throw new FST_ERR_CTP_INVALID_HANDLER()
 
   if (this.existingParser(contentType)) {
     throw new FST_ERR_CTP_ALREADY_PRESENT(contentType)
@@ -66,7 +66,7 @@ ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
     parserFn
   )
 
-  if (contentTypeIsString && contentType === '*') {
+  if (contentType === '*') {
     this.customParsers.set('', parser)
   } else {
     if (contentTypeIsString) {
@@ -95,6 +95,8 @@ ContentTypeParser.prototype.existingParser = function (contentType) {
 }
 
 ContentTypeParser.prototype.getParser = function (contentType) {
+  contentType = contentType.trim()
+
   if (this.hasParser(contentType)) {
     return this.customParsers.get(contentType)
   }
@@ -133,13 +135,20 @@ ContentTypeParser.prototype.removeAll = function () {
 }
 
 ContentTypeParser.prototype.remove = function (contentType) {
-  if (!(typeof contentType === 'string' || contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()
+  const contentTypeIsString = typeof contentType === 'string'
+  let parsers
 
-  const removed = this.customParsers.delete(contentType.toString())
+  if (contentTypeIsString) {
+    contentType = contentType.trim().toLowerCase()
+    parsers = this.parserList
+  } else {
+    if (!(contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()
+    contentType = contentType.toString()
+    parsers = this.parserRegExpList
+  }
 
-  const parsers = typeof contentType === 'string' ? this.parserList : this.parserRegExpList
-
-  const idx = parsers.findIndex(ct => ct.toString() === contentType.toString())
+  const removed = this.customParsers.delete(contentType)
+  const idx = parsers.findIndex(ct => ct.toString() === contentType)
 
   if (idx > -1) {
     parsers.splice(idx, 1)
@@ -175,7 +184,7 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
   } else {
     const result = parser.fn(request, request[kRequestPayloadStream], done)
 
-    if (result && typeof result.then === 'function') {
+    if (typeof result?.then === 'function') {
       result.then(body => done(null, body), done)
     }
   }
@@ -198,9 +207,7 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
 function rawBody (request, reply, options, parser, done) {
   const asString = parser.asString
   const limit = options.limit === null ? parser.bodyLimit : options.limit
-  const contentLength = request.headers['content-length'] === undefined
-    ? NaN
-    : Number(request.headers['content-length'])
+  const contentLength = Number(request.headers['content-length'])
 
   if (contentLength > limit) {
     // We must close the connection as the client is going

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -39,21 +39,6 @@ function ContentTypeParser (bodyLimit, onProtoPoisoning, onConstructorPoisoning)
   this.cache = new Fifo(100)
 }
 
-ContentTypeParser.prototype.existingParser = function (contentType) {
-  if (contentType === 'application/json' && this.customParsers.has(contentType)) {
-    return this.customParsers.get(contentType).fn !== this[kDefaultJsonParse]
-  }
-  if (contentType === 'text/plain' && this.customParsers.has(contentType)) {
-    return this.customParsers.get(contentType).fn !== defaultPlainTextParser
-  }
-
-  return this.hasParser(contentType)
-}
-
-ContentTypeParser.prototype.hasParser = function (contentType) {
-  return this.customParsers.has(typeof contentType === 'string' ? contentType.trim().toLowerCase() : contentType.toString())
-}
-
 ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
   const contentTypeIsString = typeof contentType === 'string'
 
@@ -94,34 +79,19 @@ ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
   }
 }
 
-ContentTypeParser.prototype.remove = function (contentType) {
-  const contentTypeIsString = typeof contentType === 'string'
-  let parsers
-
-  if (contentTypeIsString) {
-    contentType = contentType.trim().toLowerCase()
-    parsers = this.parserList
-  } else {
-    if (!(contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()
-    contentType = contentType.toString()
-    parsers = this.parserRegExpList
-  }
-
-  const removed = this.customParsers.delete(contentType)
-  const idx = parsers.findIndex(ct => ct.toString() === contentType)
-
-  if (idx > -1) {
-    parsers.splice(idx, 1)
-  }
-
-  return removed || idx > -1
+ContentTypeParser.prototype.hasParser = function (contentType) {
+  return this.customParsers.has(typeof contentType === 'string' ? contentType.trim().toLowerCase() : contentType.toString())
 }
 
-ContentTypeParser.prototype.removeAll = function () {
-  this.customParsers = new Map()
-  this.parserRegExpList = []
-  this.parserList = []
-  this.cache = new Fifo(100)
+ContentTypeParser.prototype.existingParser = function (contentType) {
+  if (contentType === 'application/json' && this.customParsers.has(contentType)) {
+    return this.customParsers.get(contentType).fn !== this[kDefaultJsonParse]
+  }
+  if (contentType === 'text/plain' && this.customParsers.has(contentType)) {
+    return this.customParsers.get(contentType).fn !== defaultPlainTextParser
+  }
+
+  return this.hasParser(contentType)
 }
 
 ContentTypeParser.prototype.getParser = function (contentType) {
@@ -152,6 +122,36 @@ ContentTypeParser.prototype.getParser = function (contentType) {
   }
 
   return this.customParsers.get('')
+}
+
+ContentTypeParser.prototype.removeAll = function () {
+  this.customParsers = new Map()
+  this.parserRegExpList = []
+  this.parserList = []
+  this.cache = new Fifo(100)
+}
+
+ContentTypeParser.prototype.remove = function (contentType) {
+  const contentTypeIsString = typeof contentType === 'string'
+  let parsers
+
+  if (contentTypeIsString) {
+    contentType = contentType.trim().toLowerCase()
+    parsers = this.parserList
+  } else {
+    if (!(contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()
+    contentType = contentType.toString()
+    parsers = this.parserRegExpList
+  }
+
+  const removed = this.customParsers.delete(contentType)
+  const idx = parsers.findIndex(ct => ct.toString() === contentType)
+
+  if (idx > -1) {
+    parsers.splice(idx, 1)
+  }
+
+  return removed || idx > -1
 }
 
 ContentTypeParser.prototype.run = function (contentType, handler, request, reply) {

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -75,11 +75,12 @@ ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
   } else {
     if (contentTypeIsString) {
       this.parserList.unshift(contentType)
+      this.customParsers.set(contentType, parser)
     } else {
       validateRegExp(contentType)
       this.parserRegExpList.unshift(contentType)
+      this.customParsers.set(contentType.toString(), parser)
     }
-    this.customParsers.set(contentType.toString(), parser)
   }
 }
 

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -95,7 +95,7 @@ ContentTypeParser.prototype.existingParser = function (contentType) {
 }
 
 ContentTypeParser.prototype.getParser = function (contentType) {
-  contentType = contentType.trimStart()
+  contentType = contentType.trim()
 
   if (this.hasParser(contentType)) {
     return this.customParsers.get(contentType)

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -46,7 +46,7 @@ test('hasContentTypeParser', t => {
 
 test('getParser', t => {
   test('should return matching parser', t => {
-    t.plan(5)
+    t.plan(6)
 
     const fastify = Fastify()
 
@@ -58,6 +58,7 @@ test('getParser', t => {
     t.equal(fastify[keys.kContentTypeParser].getParser('image/png').fn, first)
     t.equal(fastify[keys.kContentTypeParser].getParser('text/html').fn, third)
     t.equal(fastify[keys.kContentTypeParser].getParser('text/html; charset=utf-8').fn, third)
+    t.equal(fastify[keys.kContentTypeParser].getParser('text/html ; charset=utf-8').fn, third)
     t.equal(fastify[keys.kContentTypeParser].getParser('text/htmlINVALID')?.fn, undefined)
   })
 

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -46,7 +46,7 @@ test('hasContentTypeParser', t => {
 
 test('getParser', t => {
   test('should return matching parser', t => {
-    t.plan(3)
+    t.plan(5)
 
     const fastify = Fastify()
 
@@ -57,6 +57,8 @@ test('getParser', t => {
     t.equal(fastify[keys.kContentTypeParser].getParser('application/t+xml').fn, second)
     t.equal(fastify[keys.kContentTypeParser].getParser('image/png').fn, first)
     t.equal(fastify[keys.kContentTypeParser].getParser('text/html').fn, third)
+    t.equal(fastify[keys.kContentTypeParser].getParser('text/html; charset=utf-8').fn, third)
+    t.equal(fastify[keys.kContentTypeParser].getParser('text/htmlINVALID')?.fn, undefined)
   })
 
   test('should return matching parser with caching /1', t => {

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -54,13 +54,13 @@ test('getParser', t => {
     fastify.addContentTypeParser('text/html', third)
 
     t.equal(fastify[keys.kContentTypeParser].getParser('application/t+xml').fn, second)
-    t.equal(fastify[keys.kContentTypeParser].getParser('  application/t+xml   ').fn, second)
     t.equal(fastify[keys.kContentTypeParser].getParser('image/png').fn, first)
+    t.equal(fastify[keys.kContentTypeParser].getParser('  text/html  ').fn, third)
     t.equal(fastify[keys.kContentTypeParser].getParser('text/html').fn, third)
   })
 
   test('should return matching parser with caching /1', t => {
-    t.plan(6)
+    t.plan(10)
 
     const fastify = Fastify()
 
@@ -72,6 +72,10 @@ test('getParser', t => {
     t.equal(fastify[keys.kContentTypeParser].cache.size, 1)
     t.equal(fastify[keys.kContentTypeParser].getParser('text/html;charset=utf-8').fn, first)
     t.equal(fastify[keys.kContentTypeParser].cache.size, 1)
+    t.equal(fastify[keys.kContentTypeParser].getParser('   text/html;charset=utf-8  ').fn, first)
+    t.equal(fastify[keys.kContentTypeParser].cache.size, 2)
+    t.equal(fastify[keys.kContentTypeParser].getParser('   text/html;charset=utf-8  ').fn, first)
+    t.equal(fastify[keys.kContentTypeParser].cache.size, 2)
   })
 
   test('should return matching parser with caching /2', t => {

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -45,7 +45,7 @@ test('hasContentTypeParser', t => {
 
 test('getParser', t => {
   test('should return matching parser', t => {
-    t.plan(4)
+    t.plan(3)
 
     const fastify = Fastify()
 
@@ -55,12 +55,11 @@ test('getParser', t => {
 
     t.equal(fastify[keys.kContentTypeParser].getParser('application/t+xml').fn, second)
     t.equal(fastify[keys.kContentTypeParser].getParser('image/png').fn, first)
-    t.equal(fastify[keys.kContentTypeParser].getParser('  text/html  ').fn, third)
     t.equal(fastify[keys.kContentTypeParser].getParser('text/html').fn, third)
   })
 
   test('should return matching parser with caching /1', t => {
-    t.plan(10)
+    t.plan(6)
 
     const fastify = Fastify()
 
@@ -72,10 +71,6 @@ test('getParser', t => {
     t.equal(fastify[keys.kContentTypeParser].cache.size, 1)
     t.equal(fastify[keys.kContentTypeParser].getParser('text/html;charset=utf-8').fn, first)
     t.equal(fastify[keys.kContentTypeParser].cache.size, 1)
-    t.equal(fastify[keys.kContentTypeParser].getParser('   text/html;charset=utf-8  ').fn, first)
-    t.equal(fastify[keys.kContentTypeParser].cache.size, 2)
-    t.equal(fastify[keys.kContentTypeParser].getParser('   text/html;charset=utf-8  ').fn, first)
-    t.equal(fastify[keys.kContentTypeParser].cache.size, 2)
   })
 
   test('should return matching parser with caching /2', t => {

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -215,37 +215,37 @@ test('add', t => {
     t.equal(contentTypeParser.customParsers.get('').fn, first)
   })
 
+  test('should lowercase contentTypeParser name', async t => {
+    t.plan(1)
+    const fastify = Fastify()
+    fastify.addContentTypeParser('text/html', function (req, done) {
+      done()
+    })
+    try {
+      fastify.addContentTypeParser('TEXT/html', function (req, done) {
+        done()
+      })
+    } catch (err) {
+      t.same(err.message, FST_ERR_CTP_ALREADY_PRESENT('text/html').message)
+    }
+  })
+
+  test('should trim contentTypeParser name', async t => {
+    t.plan(1)
+    const fastify = Fastify()
+    fastify.addContentTypeParser('text/html', function (req, done) {
+      done()
+    })
+    try {
+      fastify.addContentTypeParser('    text/html', function (req, done) {
+        done()
+      })
+    } catch (err) {
+      t.same(err.message, FST_ERR_CTP_ALREADY_PRESENT('text/html').message)
+    }
+  })
+
   t.end()
-})
-
-test('add, should lowercase contentTypeParser names', async t => {
-  t.plan(1)
-  const fastify = Fastify()
-  fastify.addContentTypeParser('text/html', function (req, done) {
-    done()
-  })
-  try {
-    fastify.addContentTypeParser('TEXT/html', function (req, done) {
-      done()
-    })
-  } catch (err) {
-    t.same(err.message, FST_ERR_CTP_ALREADY_PRESENT('text/html').message)
-  }
-})
-
-test('add, should trim contentTypeParser names', async t => {
-  t.plan(1)
-  const fastify = Fastify()
-  fastify.addContentTypeParser('text/html', function (req, done) {
-    done()
-  })
-  try {
-    fastify.addContentTypeParser('    text/html', function (req, done) {
-      done()
-    })
-  } catch (err) {
-    t.same(err.message, FST_ERR_CTP_ALREADY_PRESENT('text/html').message)
-  }
 })
 
 test('non-Error thrown from content parser is properly handled', t => {
@@ -302,7 +302,7 @@ test('Error thrown 415 from content type is null and make post request to server
 
 test('remove', t => {
   test('should remove default parser', t => {
-    t.plan(3)
+    t.plan(6)
 
     const fastify = Fastify()
     const contentTypeParser = fastify[keys.kContentTypeParser]
@@ -310,19 +310,9 @@ test('remove', t => {
     t.ok(contentTypeParser.remove('application/json'))
     t.notOk(contentTypeParser.customParsers['application/json'])
     t.notOk(contentTypeParser.parserList.find(parser => parser === 'application/json'))
-  })
-
-  test('should remove string parser', t => {
-    t.plan(3)
-
-    const fastify = Fastify()
-    fastify.addContentTypeParser('text/html', first)
-
-    const contentTypeParser = fastify[keys.kContentTypeParser]
-
-    t.ok(contentTypeParser.remove('text/html  '))
-    t.notOk(contentTypeParser.customParsers['text/html'])
-    t.notOk(contentTypeParser.parserList.includes('text/html'))
+    t.ok(contentTypeParser.remove('  text/plain  '))
+    t.notOk(contentTypeParser.customParsers['text/plain'])
+    t.notOk(contentTypeParser.parserList.find(parser => parser === 'text/plain'))
   })
 
   test('should remove RegExp parser', t => {

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -68,9 +68,9 @@ test('getParser', t => {
 
     t.equal(fastify[keys.kContentTypeParser].getParser('text/html').fn, first)
     t.equal(fastify[keys.kContentTypeParser].cache.size, 0)
-    t.equal(fastify[keys.kContentTypeParser].getParser('text/html;charset=utf-8').fn, first)
+    t.equal(fastify[keys.kContentTypeParser].getParser('text/html ').fn, first)
     t.equal(fastify[keys.kContentTypeParser].cache.size, 1)
-    t.equal(fastify[keys.kContentTypeParser].getParser('text/html;charset=utf-8').fn, first)
+    t.equal(fastify[keys.kContentTypeParser].getParser('text/html ').fn, first)
     t.equal(fastify[keys.kContentTypeParser].cache.size, 1)
   })
 

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -12,13 +12,14 @@ const third = function (req, payload, done) {}
 
 test('hasContentTypeParser', t => {
   test('should know about internal parsers', t => {
-    t.plan(4)
+    t.plan(5)
 
     const fastify = Fastify()
     fastify.ready(err => {
       t.error(err)
       t.ok(fastify.hasContentTypeParser('application/json'))
       t.ok(fastify.hasContentTypeParser('text/plain'))
+      t.ok(fastify.hasContentTypeParser('  text/plain  '))
       t.notOk(fastify.hasContentTypeParser('application/jsoff'))
     })
   })

--- a/test/content-type.test.js
+++ b/test/content-type.test.js
@@ -3,39 +3,6 @@
 const t = require('tap')
 const test = t.test
 const Fastify = require('..')
-const {
-  FST_ERR_CTP_ALREADY_PRESENT
-} = require('../lib/errors')
-
-test('should lowercase contentTypeParser names', async t => {
-  t.plan(1)
-  const fastify = Fastify()
-  fastify.addContentTypeParser('text/html', function (req, done) {
-    done()
-  })
-  try {
-    fastify.addContentTypeParser('TEXT/html', function (req, done) {
-      done()
-    })
-  } catch (err) {
-    t.same(err.message, FST_ERR_CTP_ALREADY_PRESENT('text/html').message)
-  }
-})
-
-test('should trim contentTypeParser names', async t => {
-  t.plan(1)
-  const fastify = Fastify()
-  fastify.addContentTypeParser('text/html', function (req, done) {
-    done()
-  })
-  try {
-    fastify.addContentTypeParser('    text/html', function (req, done) {
-      done()
-    })
-  } catch (err) {
-    t.same(err.message, FST_ERR_CTP_ALREADY_PRESENT('text/html').message)
-  }
-})
 
 test('should remove content-type for setErrorHandler', async t => {
   t.plan(8)

--- a/test/custom-parser.1.test.js
+++ b/test/custom-parser.1.test.js
@@ -63,7 +63,7 @@ test('Should have typeof body object with no custom parser defined, undefined bo
   })
 })
 
-test('Should get the body as string', t => {
+test('Should get the body as string /1', t => {
   t.plan(6)
   const fastify = Fastify()
 
@@ -92,6 +92,45 @@ test('Should get the body as string', t => {
       body: 'hello world',
       headers: {
         'Content-Type': 'text/plain'
+      }
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(body.toString(), 'hello world')
+      fastify.close()
+    })
+  })
+})
+
+test('Should get the body as string /2', t => {
+  t.plan(6)
+  const fastify = Fastify()
+
+  fastify.post('/', (req, reply) => {
+    reply.send(req.body)
+  })
+
+  fastify.addContentTypeParser('text/plain/test', { parseAs: 'string' }, function (req, body, done) {
+    t.ok('called')
+    t.ok(typeof body === 'string')
+    try {
+      const plainText = body
+      done(null, plainText)
+    } catch (err) {
+      err.statusCode = 400
+      done(err, undefined)
+    }
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    sget({
+      method: 'POST',
+      url: getServerUrl(fastify),
+      body: 'hello world',
+      headers: {
+        'Content-Type': '   text/plain/test  '
       }
     }, (err, response, body) => {
       t.error(err)


### PR DESCRIPTION
Relevant change: https://github.com/fastify/fastify/compare/448ef7b40e734b2f46fe0dcccb3810dcdb39ed0f...657070dda96b14939ef0fbdcf481183853fa8324
Depends on: https://github.com/fastify/fastify/pull/5345

Currently, we match `text/htmlINVALID` with `text/html`, we shouldn't