### PR TITLE
fix: errorCodes import using ESM

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -893,8 +893,6 @@ function fastify (options) {
   }
 }
 
-fastify.errorCodes = errorCodes
-
 function validateSchemaErrorFormatter (schemaErrorFormatter) {
   if (typeof schemaErrorFormatter !== 'function') {
     throw new FST_ERR_SCHEMA_ERROR_FORMATTER_NOT_FN(typeof schemaErrorFormatter)
@@ -915,5 +913,6 @@ function validateSchemaErrorFormatter (schemaErrorFormatter) {
  * - `import fastify, { TSC_definition } from 'fastify'`
  */
 module.exports = fastify
+module.exports.errorCodes = errorCodes
 module.exports.fastify = fastify
 module.exports.default = fastify

--- a/test/esm/errorCodes.test.mjs
+++ b/test/esm/errorCodes.test.mjs
@@ -1,0 +1,10 @@
+import { errorCodes } from '../../fastify.js'
+import t from 'tap'
+
+t.test('errorCodes in ESM', async t => {
+  // test a custom fastify error using errorCodes with ESM
+  const customError = errorCodes.FST_ERR_VALIDATION('custom error message')
+  t.ok(typeof customError !== 'undefined')
+  t.ok(customError instanceof errorCodes.FST_ERR_VALIDATION)
+  t.equal(customError.message, 'custom error message')
+})


### PR DESCRIPTION
- [x] Fixing errorCodes import using ESM. 
- [x] Adding an unit-test
- [x] Extend `.taprc` configuration to run `test.mjs` files as well
- [ ] Rename other mjs files to `.test.mjs` filename?

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

In favor of: https://github.com/fastify/fastify/pull/5388