### PR TITLE
perf: limit search space for contentType

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -117,7 +117,7 @@ ContentTypeParser.prototype.getParser = function (contentType) {
   for (var i = 0; i !== this.parserList.length; ++i) {
     const parserListItem = this.parserList[i]
     if (
-      contentType.indexOf(parserListItem) === 0 &&
+      contentType.slice(0, parserListItem.length) === parserListItem &&
       (contentType.length === parserListItem.length || contentType.charCodeAt(parserListItem.length) === 59 /* `;` */ || contentType.charCodeAt(parserListItem.length) === 32 /* ` ` */)
     ) {
       parser = this.customParsers.get(parserListItem)


### PR DESCRIPTION
@Uzlopak made a good point about how indexOf searches until the end of a string

[node's maxHeader size is 16kb](https://opensource.hcltechsw.com/connections-doc/v8-cr1/admin/install/changing_maximum_allowed_http_header_size.html), so potentially somebody could send malicious requests where contentType won't be found and we'd search ~16kb each time

It's not a huge issue, but this PR will make it more performant in those cases

[Note that slice won't create a new string](https://iliazeus.github.io/articles/js-string-optimizations-en/#sliced), [and when combined with a strict equality check, is as performant as indexOf](https://github.com/nodejs/performance/issues/159#issuecomment-2051717180)