### PR TITLE
feat: adds webdav methods that require body & content type parsing

### DIFF
--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -42,7 +42,7 @@ fastify.route(options)
   [here](./Validation-and-Serialization.md) for more info.
 
   * `body`: validates the body of the request if it is a POST, PUT, PATCH,
-    TRACE, or SEARCH method.
+    TRACE, SEARCH, PROPFIND, PROPPATCH, LOCK or UNLOCK method.
   * `querystring` or `query`: validates the querystring. This can be a complete
     JSON Schema object, with the property `type` of `object` and `properties`
     object of parameters, or simply the values of what would be contained in the

--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -42,7 +42,7 @@ fastify.route(options)
   [here](./Validation-and-Serialization.md) for more info.
 
   * `body`: validates the body of the request if it is a POST, PUT, PATCH,
-    TRACE, SEARCH, PROPFIND, PROPPATCH, LOCK or UNLOCK method.
+    TRACE, SEARCH, PROPFIND, PROPPATCH or LOCK method.
   * `querystring` or `query`: validates the querystring. This can be a complete
     JSON Schema object, with the property `type` of `object` and `properties`
     object of parameters, or simply the values of what would be contained in the

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -27,7 +27,8 @@ function handleRequest (err, request, reply) {
 
   const contentType = headers['content-type']
 
-  if (method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'TRACE' || method === 'SEARCH') {
+  if (method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'TRACE' || method === 'SEARCH'
+    || method === 'PROPFIND' || method === 'PROPPATCH' || method === 'LOCK' || method === 'UNLOCK') {
     if (contentType === undefined) {
       if (
         headers['transfer-encoding'] === undefined &&

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -27,8 +27,8 @@ function handleRequest (err, request, reply) {
 
   const contentType = headers['content-type']
 
-  if (method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'TRACE' || method === 'SEARCH'
-    || method === 'PROPFIND' || method === 'PROPPATCH' || method === 'LOCK' || method === 'UNLOCK') {
+  if (method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'TRACE' || method === 'SEARCH' ||
+    method === 'PROPFIND' || method === 'PROPPATCH' || method === 'LOCK' || method === 'UNLOCK') {
     if (contentType === undefined) {
       if (
         headers['transfer-encoding'] === undefined &&

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -28,7 +28,7 @@ function handleRequest (err, request, reply) {
   const contentType = headers['content-type']
 
   if (method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'TRACE' || method === 'SEARCH' ||
-    method === 'PROPFIND' || method === 'PROPPATCH' || method === 'LOCK' || method === 'UNLOCK') {
+    method === 'PROPFIND' || method === 'PROPPATCH' || method === 'LOCK') {
     if (contentType === undefined) {
       if (
         headers['transfer-encoding'] === undefined &&

--- a/test/lock.test.js
+++ b/test/lock.test.js
@@ -5,6 +5,15 @@ const test = t.test
 const sget = require('simple-get').concat
 const fastify = require('..')()
 
+const bodySample = `<?xml version="1.0" encoding="utf-8" ?>
+        <D:lockinfo xmlns:D='DAV:'>
+          <D:lockscope> <D:exclusive/> </D:lockscope>
+          <D:locktype> <D:write/> </D:locktype>
+          <D:owner>
+            <D:href>http://example.org/~ejw/contact.html</D:href>
+          </D:owner>
+        </D:lockinfo> `
+
 test('can be created - lock', t => {
   t.plan(1)
   try {
@@ -49,23 +58,44 @@ test('can be created - lock', t => {
 
 fastify.listen({ port: 0 }, err => {
   t.error(err)
-  t.teardown(() => { fastify.close() })
+  t.teardown(() => {
+    fastify.close()
+  })
 
   // the body test uses a text/plain content type instead of application/xml because it requires
   // a specific content type parser
-  test('request - lock', t => {
+  test('request with body - lock', t => {
     t.plan(3)
     sget({
       url: `http://localhost:${fastify.server.address().port}/test/a.txt`,
       headers: { 'content-type': 'text/plain' },
-      body: `<?xml version="1.0" encoding="utf-8" ?>
-        <D:lockinfo xmlns:D='DAV:'>
-          <D:lockscope> <D:exclusive/> </D:lockscope>
-          <D:locktype> <D:write/> </D:locktype>
-          <D:owner>
-            <D:href>http://example.org/~ejw/contact.html</D:href>
-          </D:owner>
-        </D:lockinfo> `,
+      body: bodySample,
+      method: 'LOCK'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers['content-length'], '' + body.length)
+    })
+  })
+
+  test('request with body and no content type (415 error) - lock', t => {
+    t.plan(3)
+    sget({
+      url: `http://localhost:${fastify.server.address().port}/test/a.txt`,
+      body: bodySample,
+      method: 'LOCK'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 415)
+      t.equal(response.headers['content-length'], '' + body.length)
+    })
+  })
+
+  test('request without body - lock', t => {
+    t.plan(3)
+    sget({
+      url: `http://localhost:${fastify.server.address().port}/test/a.txt`,
+      headers: { 'content-type': 'text/plain' },
       method: 'LOCK'
     }, (err, response, body) => {
       t.error(err)

--- a/test/lock.test.js
+++ b/test/lock.test.js
@@ -51,10 +51,13 @@ fastify.listen({ port: 0 }, err => {
   t.error(err)
   t.teardown(() => { fastify.close() })
 
+  // the body test uses a text/plain content type instead of application/xml because it requires
+  // a specific content type parser
   test('request - lock', t => {
     t.plan(3)
     sget({
       url: `http://localhost:${fastify.server.address().port}/test/a.txt`,
+      headers: { 'content-type': 'text/plain' },
       body: `<?xml version="1.0" encoding="utf-8" ?>
         <D:lockinfo xmlns:D='DAV:'>
           <D:lockscope> <D:exclusive/> </D:lockscope>

--- a/test/propfind.test.js
+++ b/test/propfind.test.js
@@ -87,10 +87,13 @@ fastify.listen({ port: 0 }, err => {
     })
   })
 
+  // the body test uses a text/plain content type instead of application/xml because it requires
+  // a specific content type parser
   test('request with body - propfind', t => {
     t.plan(3)
     sget({
       url: `http://localhost:${fastify.server.address().port}/test`,
+      headers: { 'content-type': 'text/plain' },
       body: `<?xml version="1.0" encoding="utf-8" ?>
         <D:propfind xmlns:D="DAV:">
           <D:prop xmlns:R="http://ns.example.com/boxschema/">

--- a/test/propfind.test.js
+++ b/test/propfind.test.js
@@ -5,6 +5,14 @@ const test = t.test
 const sget = require('simple-get').concat
 const fastify = require('..')()
 
+const bodySample = `<?xml version="1.0" encoding="utf-8" ?>
+        <D:propfind xmlns:D="DAV:">
+          <D:prop xmlns:R="http://ns.example.com/boxschema/">
+            <R:bigbox/> <R:author/> <R:DingALing/> <R:Random/>
+          </D:prop>
+        </D:propfind>
+      `
+
 test('can be created - propfind', t => {
   t.plan(1)
   try {
@@ -61,7 +69,9 @@ test('can be created - propfind', t => {
 
 fastify.listen({ port: 0 }, err => {
   t.error(err)
-  t.teardown(() => { fastify.close() })
+  t.teardown(() => {
+    fastify.close()
+  })
 
   test('request - propfind', t => {
     t.plan(3)
@@ -94,13 +104,32 @@ fastify.listen({ port: 0 }, err => {
     sget({
       url: `http://localhost:${fastify.server.address().port}/test`,
       headers: { 'content-type': 'text/plain' },
-      body: `<?xml version="1.0" encoding="utf-8" ?>
-        <D:propfind xmlns:D="DAV:">
-          <D:prop xmlns:R="http://ns.example.com/boxschema/">
-            <R:bigbox/> <R:author/> <R:DingALing/> <R:Random/>
-          </D:prop>
-        </D:propfind>
-      `,
+      body: bodySample,
+      method: 'PROPFIND'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 207)
+      t.equal(response.headers['content-length'], '' + body.length)
+    })
+  })
+
+  test('request with body and no content type (415 error) - propfind', t => {
+    t.plan(3)
+    sget({
+      url: `http://localhost:${fastify.server.address().port}/test`,
+      body: bodySample,
+      method: 'PROPFIND'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 415)
+      t.equal(response.headers['content-length'], '' + body.length)
+    })
+  })
+
+  test('request without body - propfind', t => {
+    t.plan(3)
+    sget({
+      url: `http://localhost:${fastify.server.address().port}/test`,
       method: 'PROPFIND'
     }, (err, response, body) => {
       t.error(err)

--- a/test/proppatch.test.js
+++ b/test/proppatch.test.js
@@ -47,10 +47,13 @@ fastify.listen({ port: 0 }, err => {
   t.error(err)
   t.teardown(() => { fastify.close() })
 
+  // the body test uses a text/plain content type instead of application/xml because it requires
+  // a specific content type parser
   test('request - proppatch', t => {
     t.plan(3)
     sget({
       url: `http://localhost:${fastify.server.address().port}/test/a.txt`,
+      headers: { 'content-type': 'text/plain' },
       body: `<?xml version="1.0" encoding="utf-8" ?>
         <D:propertyupdate xmlns:D="DAV:"
           xmlns:Z="http://ns.example.com/standards/z39.50/">

--- a/test/proppatch.test.js
+++ b/test/proppatch.test.js
@@ -5,6 +5,24 @@ const test = t.test
 const sget = require('simple-get').concat
 const fastify = require('..')()
 
+const bodySample = `<?xml version="1.0" encoding="utf-8" ?>
+        <D:propertyupdate xmlns:D="DAV:"
+          xmlns:Z="http://ns.example.com/standards/z39.50/">
+          <D:set>
+            <D:prop>
+              <Z:Authors>
+                <Z:Author>Jim Whitehead</Z:Author>
+                <Z:Author>Roy Fielding</Z:Author>
+              </Z:Authors>
+            </D:prop>
+          </D:set>
+          <D:remove>
+            <D:prop>
+              <Z:Copyright-Owner/>
+            </D:prop>
+          </D:remove>
+        </D:propertyupdate>`
+
 test('shorthand - proppatch', t => {
   t.plan(1)
   try {
@@ -49,28 +67,37 @@ fastify.listen({ port: 0 }, err => {
 
   // the body test uses a text/plain content type instead of application/xml because it requires
   // a specific content type parser
-  test('request - proppatch', t => {
+  test('request with body - proppatch', t => {
     t.plan(3)
     sget({
       url: `http://localhost:${fastify.server.address().port}/test/a.txt`,
       headers: { 'content-type': 'text/plain' },
-      body: `<?xml version="1.0" encoding="utf-8" ?>
-        <D:propertyupdate xmlns:D="DAV:"
-          xmlns:Z="http://ns.example.com/standards/z39.50/">
-          <D:set>
-            <D:prop>
-              <Z:Authors>
-                <Z:Author>Jim Whitehead</Z:Author>
-                <Z:Author>Roy Fielding</Z:Author>
-              </Z:Authors>
-            </D:prop>
-          </D:set>
-          <D:remove>
-            <D:prop>
-              <Z:Copyright-Owner/>
-            </D:prop>
-          </D:remove>
-        </D:propertyupdate>`,
+      body: bodySample,
+      method: 'PROPPATCH'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 207)
+      t.equal(response.headers['content-length'], '' + body.length)
+    })
+  })
+
+  test('request with body and no content type (415 error) - proppatch', t => {
+    t.plan(3)
+    sget({
+      url: `http://localhost:${fastify.server.address().port}/test/a.txt`,
+      body: bodySample,
+      method: 'PROPPATCH'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 415)
+      t.equal(response.headers['content-length'], '' + body.length)
+    })
+  })
+
+  test('request without body - proppatch', t => {
+    t.plan(3)
+    sget({
+      url: `http://localhost:${fastify.server.address().port}/test/a.txt`,
       method: 'PROPPATCH'
     }, (err, response, body) => {
       t.error(err)


### PR DESCRIPTION
- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Adds webdav methods that require parsing, missing from this PR: https://github.com/fastify/fastify/pull/3836