### PR TITLE
fix: benchmark CI

### DIFF
--- a/.github/workflows/benchmark-parser.yml
+++ b/.github/workflows/benchmark-parser.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install
         run: |
-          npm install --only=production --ignore-scripts
+          npm install --ignore-scripts
 
       - name: Run benchmark
         id: benchmark-pr
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install
         run: |
-          npm install --only=production --ignore-scripts
+          npm install --ignore-scripts
 
       - name: Run benchmark
         id: benchmark-main

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install
         run: |
-          npm install --only=production --ignore-scripts
+          npm install --ignore-scripts
 
       - name: Run benchmark
         id: benchmark-pr
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install
         run: |
-          npm install --only=production --ignore-scripts
+          npm install --ignore-scripts
 
       - name: Run benchmark
         id: benchmark-main


### PR DESCRIPTION
We cannot only install production dependencies in these workflows as they depend on devDeps to run:

https://github.com/fastify/fastify/blob/13f9b6eb9083e5f5dcd8de5895adc81101603db4/.github/workflows/benchmark.yml#L36

https://github.com/fastify/fastify/blob/13f9b6eb9083e5f5dcd8de5895adc81101603db4/.github/workflows/benchmark.yml#L41

https://github.com/fastify/fastify/blob/13f9b6eb9083e5f5dcd8de5895adc81101603db4/package.json#L10

https://github.com/fastify/fastify/blob/13f9b6eb9083e5f5dcd8de5895adc81101603db4/package.json#L155-L170