### PR TITLE
fix: `remove-label` job uses the wrong repo

### DIFF
--- a/.github/workflows/benchmark-parser.yml
+++ b/.github/workflows/benchmark-parser.yml
@@ -64,7 +64,8 @@ jobs:
           echo 'EOF' >> $GITHUB_OUTPUT
 
   output-benchmark:
-    needs: [benchmark]
+    needs:
+      - benchmark
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -101,9 +101,8 @@ jobs:
         uses: octokit/request-action@v2.x
         id: remove-label
         with:
-          route: DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}
-          owner: fastify
-          repo: fastify
+          route: DELETE /repos/{repo}/issues/{issue_number}/labels/{name}
+          repo: ${{ github.repository }}
           issue_number: ${{ github.event.pull_request.number }}
           name: benchmark
         env:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -101,8 +101,9 @@ jobs:
         uses: octokit/request-action@v2.x
         id: remove-label
         with:
-          route: DELETE /repos/{repo}/issues/{issue_number}/labels/{name}
-          repo: ${{ github.event.pull_request.head.repo.full_name }}
+          route: DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}
+          owner: fastify
+          repo: fastify
           issue_number: ${{ github.event.pull_request.number }}
           name: benchmark
         env:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -96,6 +96,8 @@ jobs:
       - benchmark
       - output-benchmark
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Remove benchmark label
         uses: octokit/request-action@v2.x

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -64,7 +64,8 @@ jobs:
           echo 'EOF' >> $GITHUB_OUTPUT
 
   output-benchmark:
-    needs: [benchmark]
+    needs:
+      - benchmark
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,13 +87,15 @@ jobs:
           npm run lint
 
   coverage-nix:
-    needs: lint
+    needs:
+      - lint
     permissions:
       contents: read
     uses: ./.github/workflows/coverage-nix.yml
 
   coverage-win:
-    needs: lint
+    needs:
+      - lint
     permissions:
       contents: read
     uses: ./.github/workflows/coverage-win.yml

--- a/.github/workflows/citgm.yml
+++ b/.github/workflows/citgm.yml
@@ -95,8 +95,9 @@ jobs:
         uses: octokit/request-action@v2.x
         id: remove-label
         with:
-          route: DELETE /repos/{repo}/issues/{issue_number}/labels/{name}
-          repo: ${{ github.event.pull_request.head.repo.full_name }}
+          route: DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}
+          owner: fastify
+          repo: fastify
           issue_number: ${{ github.event.pull_request.number }}
           name: citgm-core-plugins
         env:

--- a/.github/workflows/citgm.yml
+++ b/.github/workflows/citgm.yml
@@ -95,9 +95,8 @@ jobs:
         uses: octokit/request-action@v2.x
         id: remove-label
         with:
-          route: DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}
-          owner: fastify
-          repo: fastify
+          route: DELETE /repos/{repo}/issues/{issue_number}/labels/{name}
+          repo: ${{ github.repository }}
           issue_number: ${{ github.event.pull_request.number }}
           name: citgm-core-plugins
         env:

--- a/.github/workflows/citgm.yml
+++ b/.github/workflows/citgm.yml
@@ -90,6 +90,8 @@ jobs:
       - core-plugins
     continue-on-error: true
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Remove citgm-core-plugins label
         uses: octokit/request-action@v2.x


### PR DESCRIPTION
Another issue discovered in the CI, `remove-label` jobs are failing due wrong information being sent to the REST API:

https://github.com/fastify/fastify/actions/runs/8772362238/job/24071203586?pr=5413#step:2:13
https://github.com/fastify/fastify/actions/runs/8772362236/job/24071226346?pr=5413#step:2:13

I believe it's choosing the wrong repo, it should be the base repo instead of the owner of the PR's repo

Reference: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context