### PR TITLE
fix: only run citgm if citgm-core-plugins label is set

### DIFF
--- a/.github/workflows/citgm.yml
+++ b/.github/workflows/citgm.yml
@@ -85,8 +85,8 @@ jobs:
       node-version: ${{ matrix.node-version }}
 
   remove-label:
-    if: always()
-    needs: 
+    if: ${{ github.event.label.name == 'citgm-core-plugins' }}
+    needs:
       - core-plugins
     continue-on-error: true
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hopefully the last fix...

Last 2 PRs [fixed](https://github.com/fastify/fastify/pull/5413#event-12551166195) the benchmark workflow, but CITGM's `remove-label` job is also [always](https://github.com/fastify/fastify/blob/c47b0330a6c3f546c7fc2535b53d641b20525ab0/.github/workflows/citgm.yml#L88) running whenever a label is set and failing because it can't find the label it's trying to remove — it should only run if `citgm-core-plugins` label is set to remove [that specific label](https://github.com/fastify/fastify/blob/c47b0330a6c3f546c7fc2535b53d641b20525ab0/.github/workflows/citgm.yml#L96-L103)