### PR TITLE
chore: exclude node 14 and 16 on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,10 @@ jobs:
           # excludes node 14 on Windows
           - os: windows-latest
             node-version: 14
+          - os: macos-latest
+            node-version: 14
+          - os: macos-latest
+            node-version: 16
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Related to https://github.com/fastify/.github/issues/37