### PR TITLE
docs(guides/abort):  suggest explicit use of the `aborted` property

### DIFF
--- a/docs/Guides/Detecting-When-Clients-Abort.md
+++ b/docs/Guides/Detecting-When-Clients-Abort.md
@@ -87,10 +87,12 @@ of `{ ok: true }`.
 - Logic that triggers in the hook when the request is closed.
 - Logging that occurs when the closed request property `aborted` is true.
 
-In the request close event, you should examine the diff between a successful 
-request and one aborted by the client to determine the best property for your 
-use case. You can find details about request properties in the 
-[Node.js documentation](https://nodejs.org/api/http.html).
+Whilst the `aborted` property has been deprecated, `destroyed` is not a
+suitable replacement as the
+[Node.js documentation suggests](https://nodejs.org/api/http.html#requestaborted).
+A request can be `destroyed` for various reasons, such as when the server closes
+the connection. The `aborted` property is still the most reliable way to detect
+when a client intentionally aborts a request.
 
 You can also perform this logic outside of a hook, directly in a specific route.
 


### PR DESCRIPTION
Closes https://github.com/fastify/help/issues/999.

The original documentation implied that other request properties may be used to detect an aborted request.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
