### PR TITLE
feat: add mkcalendar and report methods

### DIFF
--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -34,7 +34,8 @@ fastify.route(options)
 
 * `method`: currently it supports `'DELETE'`, `'GET'`, `'HEAD'`, `'PATCH'`,
   `'POST'`, `'PUT'`, `'OPTIONS'`, `'SEARCH'`, `'TRACE'`, `'PROPFIND'`,
-  `'PROPPATCH'`, `'MKCOL'`, `'COPY'`, `'MOVE'`, `'LOCK'`  and `'UNLOCK'`.
+  `'PROPPATCH'`, `'MKCOL'`, `'COPY'`, `'MOVE'`, `'LOCK'`, `'UNLOCK'`, 
+  `'REPORT'` and `'MKCALENDAR'`.
   It could also be an array of methods.
 * `url`: the path of the URL to match this route (alias: `path`).
 * `schema`: an object containing the schemas for the request and response. They

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -28,7 +28,7 @@ function handleRequest (err, request, reply) {
   const contentType = headers['content-type']
 
   if (method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'TRACE' || method === 'SEARCH' ||
-    method === 'PROPFIND' || method === 'PROPPATCH' || method === 'LOCK') {
+    method === 'PROPFIND' || method === 'PROPPATCH' || method === 'LOCK' || method === 'REPORT' || method === 'MKCALENDAR') {
     if (contentType === undefined) {
       if (
         headers['transfer-encoding'] === undefined &&

--- a/lib/httpMethods.js
+++ b/lib/httpMethods.js
@@ -17,6 +17,8 @@ module.exports = {
     'LOCK',
     'UNLOCK',
     'TRACE',
-    'SEARCH'
+    'SEARCH',
+    'REPORT',
+    'MKCALENDAR'
   ]
 }

--- a/test/mkcalendar.test.js
+++ b/test/mkcalendar.test.js
@@ -1,0 +1,165 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const sget = require('simple-get').concat
+const fastify = require('../fastify')()
+
+const bodySample = `<?xml version="1.0" encoding="UTF-8"?>
+  <B:mkcalendar xmlns:B="urn:ietf:params:xml:ns:caldav">
+    <A:set xmlns:A="DAV:">
+      <A:prop>
+        <B:calendar-free-busy-set>
+          <NO/>
+        </B:calendar-free-busy-set>
+        <E:calendar-order xmlns:E="http://apple.com/ns/ical/">0</E:calendar-order>
+        <B:supported-calendar-component-set>
+          <B:comp name="VEVENT"/>
+        </B:supported-calendar-component-set>
+        <A:displayname>CALENDAR_NAME</A:displayname>
+        <B:calendar-timezone>BEGIN:VCALENDAR&#13;
+          VERSION:2.0&#13;
+        </B:calendar-timezone>
+      </A:prop>
+    </A:set>
+  </B:mkcalendar>
+  `
+
+test('can be created - mkcalendar', (t) => {
+  t.plan(1)
+  try {
+    fastify.route({
+      method: 'MKCALENDAR',
+      url: '*',
+      handler: function (req, reply) {
+        return reply.code(207).send(`<?xml version="1.0" encoding="utf-8"?>
+            <D:multistatus xmlns:D="DAV:">
+              <D:response xmlns:lp1="DAV:">
+                <D:href>/</D:href>
+                <D:propstat>
+                  <D:prop>
+                    <lp1:resourcetype>
+                      <D:collection/>
+                    </lp1:resourcetype>
+                    <lp1:creationdate>2022-04-13T12:35:30Z</lp1:creationdate>
+                    <lp1:getlastmodified>Wed, 13 Apr 2022 12:35:30 GMT</lp1:getlastmodified>
+                    <lp1:getetag>"e0-5dc8869b53ef1"</lp1:getetag>
+                    <D:supportedlock>
+                      <D:lockentry>
+                        <D:lockscope>
+                          <D:exclusive/>
+                        </D:lockscope>
+                        <D:locktype>
+                          <D:write/>
+                        </D:locktype>
+                      </D:lockentry>
+                      <D:lockentry>
+                        <D:lockscope>
+                          <D:shared/>
+                        </D:lockscope>
+                        <D:locktype>
+                          <D:write/>
+                        </D:locktype>
+                      </D:lockentry>
+                    </D:supportedlock>
+                    <D:lockdiscovery/>
+                    <D:getcontenttype>httpd/unix-directory</D:getcontenttype>
+                  </D:prop>
+                  <D:status>HTTP/1.1 200 OK</D:status>
+                </D:propstat>
+              </D:response>
+            </D:multistatus>`)
+      }
+    })
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+})
+
+fastify.listen({ port: 0 }, (err) => {
+  t.error(err)
+  t.teardown(() => {
+    fastify.close()
+  })
+
+  test('request - mkcalendar', (t) => {
+    t.plan(3)
+    sget(
+      {
+        url: `http://localhost:${fastify.server.address().port}/`,
+        method: 'MKCALENDAR'
+      },
+      (err, response, body) => {
+        t.error(err)
+        t.equal(response.statusCode, 207)
+        t.equal(response.headers['content-length'], '' + body.length)
+      }
+    )
+  })
+
+  test('request with other path - mkcalendar', (t) => {
+    t.plan(3)
+    sget(
+      {
+        url: `http://localhost:${fastify.server.address().port}/test`,
+        method: 'MKCALENDAR'
+      },
+      (err, response, body) => {
+        t.error(err)
+        t.equal(response.statusCode, 207)
+        t.equal(response.headers['content-length'], '' + body.length)
+      }
+    )
+  })
+
+  // the body test uses a text/plain content type instead of application/xml because it requires
+  // a specific content type parser
+  test('request with body - mkcalendar', (t) => {
+    t.plan(3)
+    sget(
+      {
+        url: `http://localhost:${fastify.server.address().port}/test`,
+        headers: { 'content-type': 'text/plain' },
+        body: bodySample,
+        method: 'MKCALENDAR'
+      },
+      (err, response, body) => {
+        t.error(err)
+        t.equal(response.statusCode, 207)
+        t.equal(response.headers['content-length'], '' + body.length)
+      }
+    )
+  })
+
+  test('request with body and no content type (415 error) - mkcalendar', (t) => {
+    t.plan(3)
+    sget(
+      {
+        url: `http://localhost:${fastify.server.address().port}/test`,
+        body: bodySample,
+        method: 'MKCALENDAR'
+      },
+      (err, response, body) => {
+        t.error(err)
+        t.equal(response.statusCode, 415)
+        t.equal(response.headers['content-length'], '' + body.length)
+      }
+    )
+  })
+
+  test('request without body - mkcalendar', (t) => {
+    t.plan(3)
+    sget(
+      {
+        url: `http://localhost:${fastify.server.address().port}/test`,
+        method: 'MKCALENDAR'
+      },
+      (err, response, body) => {
+        t.error(err)
+        t.equal(response.statusCode, 207)
+        t.equal(response.headers['content-length'], '' + body.length)
+      }
+    )
+  })
+})

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -1,0 +1,161 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const sget = require('simple-get').concat
+const fastify = require('../fastify')()
+
+const bodySample = `<?xml version="1.0" encoding="UTF-8"?>
+  <B:calendar-query xmlns:B="urn:ietf:params:xml:ns:caldav">
+    <A:prop xmlns:A="DAV:">
+      <A:getetag/>
+      <A:getcontenttype/>
+    </A:prop>
+    <B:filter>
+      <B:comp-filter name="VCALENDAR">
+        <B:comp-filter name="VEVENT">
+          <B:time-range start="20170215T000000Z"/>
+        </B:comp-filter>
+      </B:comp-filter>
+    </B:filter>
+  </B:calendar-query>
+  `
+
+test('can be created - report', (t) => {
+  t.plan(1)
+  try {
+    fastify.route({
+      method: 'REPORT',
+      url: '*',
+      handler: function (req, reply) {
+        return reply.code(207).send(`<?xml version="1.0" encoding="utf-8"?>
+            <D:multistatus xmlns:D="DAV:">
+              <D:response xmlns:lp1="DAV:">
+                <D:href>/</D:href>
+                <D:propstat>
+                  <D:prop>
+                    <lp1:resourcetype>
+                      <D:collection/>
+                    </lp1:resourcetype>
+                    <lp1:creationdate>2022-04-13T12:35:30Z</lp1:creationdate>
+                    <lp1:getlastmodified>Wed, 13 Apr 2022 12:35:30 GMT</lp1:getlastmodified>
+                    <lp1:getetag>"e0-5dc8869b53ef1"</lp1:getetag>
+                    <D:supportedlock>
+                      <D:lockentry>
+                        <D:lockscope>
+                          <D:exclusive/>
+                        </D:lockscope>
+                        <D:locktype>
+                          <D:write/>
+                        </D:locktype>
+                      </D:lockentry>
+                      <D:lockentry>
+                        <D:lockscope>
+                          <D:shared/>
+                        </D:lockscope>
+                        <D:locktype>
+                          <D:write/>
+                        </D:locktype>
+                      </D:lockentry>
+                    </D:supportedlock>
+                    <D:lockdiscovery/>
+                    <D:getcontenttype>httpd/unix-directory</D:getcontenttype>
+                  </D:prop>
+                  <D:status>HTTP/1.1 200 OK</D:status>
+                </D:propstat>
+              </D:response>
+            </D:multistatus>`)
+      }
+    })
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+})
+
+fastify.listen({ port: 0 }, (err) => {
+  t.error(err)
+  t.teardown(() => {
+    fastify.close()
+  })
+
+  test('request - report', (t) => {
+    t.plan(3)
+    sget(
+      {
+        url: `http://localhost:${fastify.server.address().port}/`,
+        method: 'REPORT'
+      },
+      (err, response, body) => {
+        t.error(err)
+        t.equal(response.statusCode, 207)
+        t.equal(response.headers['content-length'], '' + body.length)
+      }
+    )
+  })
+
+  test('request with other path - report', (t) => {
+    t.plan(3)
+    sget(
+      {
+        url: `http://localhost:${fastify.server.address().port}/test`,
+        method: 'REPORT'
+      },
+      (err, response, body) => {
+        t.error(err)
+        t.equal(response.statusCode, 207)
+        t.equal(response.headers['content-length'], '' + body.length)
+      }
+    )
+  })
+
+  // the body test uses a text/plain content type instead of application/xml because it requires
+  // a specific content type parser
+  test('request with body - report', (t) => {
+    t.plan(3)
+    sget(
+      {
+        url: `http://localhost:${fastify.server.address().port}/test`,
+        headers: { 'content-type': 'text/plain' },
+        body: bodySample,
+        method: 'REPORT'
+      },
+      (err, response, body) => {
+        t.error(err)
+        t.equal(response.statusCode, 207)
+        t.equal(response.headers['content-length'], '' + body.length)
+      }
+    )
+  })
+
+  test('request with body and no content type (415 error) - report', (t) => {
+    t.plan(3)
+    sget(
+      {
+        url: `http://localhost:${fastify.server.address().port}/test`,
+        body: bodySample,
+        method: 'REPORT'
+      },
+      (err, response, body) => {
+        t.error(err)
+        t.equal(response.statusCode, 415)
+        t.equal(response.headers['content-length'], '' + body.length)
+      }
+    )
+  })
+
+  test('request without body - report', (t) => {
+    t.plan(3)
+    sget(
+      {
+        url: `http://localhost:${fastify.server.address().port}/test`,
+        method: 'REPORT'
+      },
+      (err, response, body) => {
+        t.error(err)
+        t.equal(response.statusCode, 207)
+        t.equal(response.headers['content-length'], '' + body.length)
+      }
+    )
+  })
+})

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -6,7 +6,7 @@ import * as https from 'https'
  * Standard HTTP method strings
  */
 type _HTTPMethods = 'DELETE' | 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'OPTIONS' |
-'PROPFIND' | 'PROPPATCH' | 'MKCOL' | 'COPY' | 'MOVE' | 'LOCK' | 'UNLOCK' | 'TRACE' | 'SEARCH'
+'PROPFIND' | 'PROPPATCH' | 'MKCOL' | 'COPY' | 'MOVE' | 'LOCK' | 'UNLOCK' | 'TRACE' | 'SEARCH' | 'REPORT' | 'MKCALENDAR'
 
 export type HTTPMethods = Uppercase<_HTTPMethods> | Lowercase<_HTTPMethods>
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Related to [#9](https://github.com/fastify/fastify/issues/9) and [PR #3836](https://github.com/fastify/fastify/pull/3836)

Includes support for `MKCALENDAR` and `REPORT` methods which are both part of the webDAV protocol.

I need to use these methods in a project that deals with contacts and calendars sync (CARDDAV / CALDAV).

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
