### PR TITLE
feat: handle synchronous errors in errorHandler

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -65,13 +65,17 @@ function handleError (reply, error, cb) {
     return
   }
 
-  const result = func(error, reply.request, reply)
-  if (result !== undefined) {
-    if (result !== null && typeof result.then === 'function') {
-      wrapThenable(result, reply)
-    } else {
-      reply.send(result)
+  try {
+    const result = func(error, reply.request, reply)
+    if (result !== undefined) {
+      if (result !== null && typeof result.then === 'function') {
+        wrapThenable(result, reply)
+      } else {
+        reply.send(result)
+      }
     }
+  } catch (err) {
+    reply.send(err)
   }
 }
 

--- a/lib/wrapThenable.js
+++ b/lib/wrapThenable.js
@@ -39,6 +39,8 @@ function wrapThenable (thenable, reply) {
     // try-catch allow to re-throw error in error handler for async handler
     try {
       reply.send(err)
+      // The following should not happen
+      /* c8 ignore next 3 */
     } catch (err) {
       reply.send(err)
     }


### PR DESCRIPTION

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
