### PR TITLE
feat: (types) add shorthand types for MKCALENDAR and REPORT

### DIFF
--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -38,10 +38,10 @@ const routeHandlerWithReturnValue: RouteHandlerMethod = function (request, reply
 
 type LowerCaseHTTPMethods = 'delete' | 'get' | 'head' | 'patch' | 'post' | 'put' |
 'options' | 'propfind' | 'proppatch' | 'mkcol' | 'copy' | 'move' | 'lock' |
-'unlock' | 'trace' | 'search'
+'unlock' | 'trace' | 'search' | 'mkcalendar' | 'report'
 
 ;['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS', 'PROPFIND',
-  'PROPPATCH', 'MKCOL', 'COPY', 'MOVE', 'LOCK', 'UNLOCK', 'TRACE', 'SEARCH'
+  'PROPPATCH', 'MKCOL', 'COPY', 'MOVE', 'LOCK', 'UNLOCK', 'TRACE', 'SEARCH', 'MKCALENDAR', 'REPORT'
 ].forEach(method => {
   // route method
   expectType<FastifyInstance>(fastify().route({

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -189,12 +189,14 @@ export interface FastifyInstance<
   options: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
   propfind: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
   proppatch: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
+  mkcalendar: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
   mkcol: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
   copy: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
   move: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
   lock: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
   unlock: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
   trace: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
+  report: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
   search: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
   all: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
 


### PR DESCRIPTION
Carries over the work of https://github.com/fastify/fastify/pull/5444