### PR TITLE
perf: Optimize resolving X-Forwarded-For addresses

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -115,7 +115,8 @@ function buildRequestWithTrustProxy (R, trustProxy) {
   Object.defineProperties(_Request.prototype, {
     ip: {
       get () {
-        return proxyAddr(this.raw, proxyFn)
+        const addrs = proxyAddr.all(this.raw, proxyFn)
+        return addrs[addrs.length - 1]
       }
     },
     ips: {

--- a/lib/request.js
+++ b/lib/request.js
@@ -50,7 +50,7 @@ function getTrustProxyFn (tp) {
   }
   if (tp === true) {
     // Support plain true/false
-    return function () { return true }
+    return undefined
   }
   if (typeof tp === 'number') {
     // Support trusting hop count

--- a/lib/request.js
+++ b/lib/request.js
@@ -49,7 +49,7 @@ function getTrustProxyFn (tp) {
     return tp
   }
   if (tp === true) {
-    // Support plain true/false
+    // Support trusting everything
     return null
   }
   if (typeof tp === 'number') {

--- a/lib/request.js
+++ b/lib/request.js
@@ -50,7 +50,7 @@ function getTrustProxyFn (tp) {
   }
   if (tp === true) {
     // Support plain true/false
-    return undefined
+    return null
   }
   if (typeof tp === 'number') {
     // Support trusting hop count


### PR DESCRIPTION
Hello, I have a suggestion. When looking up how trustProxy option in Fastify works in detail, I found out that the proxy-addr dependency used by Fastify, specifically the `.all()` function, checks if the trust argument is provided, and if it's not, then it just returns all adresses, skipping the trust checking logic alltogether, which can speed up things greatly, especially if there's a lot of X-Forwarded-For addresses. So, I made this PR, replacing the `return true` function with `undefined`, which has the same effect in the `.ips` property getter of `Request`, but because the proxy-addr default function doesn't support skipping trust argument, I replaced it with proxy-addr `.all()` function in the `.ip` property getter and did the same thing there as the proxy-addr default function does, so everything behaves exactly the same as before. If something needs further explanation please let me know.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
