### PR TITLE
docs(guides/database): correct typo

### DIFF
--- a/docs/Guides/Database.md
+++ b/docs/Guides/Database.md
@@ -245,7 +245,7 @@ for Postgres, MySQL, SQL Server and SQLite. For MongoDB migrations, please check
 #### [Postgrator](https://www.npmjs.com/package/postgrator)
 
 Postgrator is Node.js SQL migration tool that uses a directory of SQL scripts to
-alter the database schema. Each file an migrations folder need to follow the
+alter the database schema. Each file in migrations folder need to follow the
 pattern: ` [version].[action].[optional-description].sql`.
 
 **version:** must be an incrementing number (e.g. `001` or a timestamp).

--- a/docs/Guides/Database.md
+++ b/docs/Guides/Database.md
@@ -245,7 +245,7 @@ for Postgres, MySQL, SQL Server and SQLite. For MongoDB migrations, please check
 #### [Postgrator](https://www.npmjs.com/package/postgrator)
 
 Postgrator is Node.js SQL migration tool that uses a directory of SQL scripts to
-alter the database schema. Each file in migrations folder need to follow the
+alter the database schema. Each file in a migrations folder need to follow the
 pattern: ` [version].[action].[optional-description].sql`.
 
 **version:** must be an incrementing number (e.g. `001` or a timestamp).


### PR DESCRIPTION
From: `Each file an migrations folder need`
To: `Each file in migrations folder need`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
