### PR TITLE
chore: remove node 18 from CI

### DIFF
--- a/.github/workflows/benchmark-parser.yml
+++ b/.github/workflows/benchmark-parser.yml
@@ -11,15 +11,13 @@ jobs:
     permissions:
       contents: read
     outputs:
-      PR-BENCH-18: ${{ steps.benchmark-pr.outputs.BENCH_RESULT18 }}
       PR-BENCH-20: ${{ steps.benchmark-pr.outputs.BENCH_RESULT20 }}
       PR-BENCH-22: ${{ steps.benchmark-pr.outputs.BENCH_RESULT22 }}
-      MAIN-BENCH-18: ${{ steps.benchmark-main.outputs.BENCH_RESULT18 }}
       MAIN-BENCH-20: ${{ steps.benchmark-main.outputs.BENCH_RESULT20 }}
       MAIN-BENCH-22: ${{ steps.benchmark-main.outputs.BENCH_RESULT22 }}
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -75,12 +73,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: |
-            **Node**: 18
-            **PR**: ${{ needs.benchmark.outputs.PR-BENCH-18 }}
-            **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-18 }}
-            
-            ---
-            
             **Node**: 20
             **PR**: ${{ needs.benchmark.outputs.PR-BENCH-20 }}
             **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-20 }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,15 +11,13 @@ jobs:
     permissions:
       contents: read
     outputs:
-      PR-BENCH-18: ${{ steps.benchmark-pr.outputs.BENCH_RESULT18 }}
       PR-BENCH-20: ${{ steps.benchmark-pr.outputs.BENCH_RESULT20 }}
       PR-BENCH-22: ${{ steps.benchmark-pr.outputs.BENCH_RESULT22 }}
-      MAIN-BENCH-18: ${{ steps.benchmark-main.outputs.BENCH_RESULT18 }}
       MAIN-BENCH-20: ${{ steps.benchmark-main.outputs.BENCH_RESULT20 }}
       MAIN-BENCH-22: ${{ steps.benchmark-main.outputs.BENCH_RESULT22 }}
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -75,12 +73,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: |
-            **Node**: 18
-            **PR**: ${{ needs.benchmark.outputs.PR-BENCH-18 }}
-            **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-18 }}
-            
-            ---
-            
             **Node**: 20
             **PR**: ${{ needs.benchmark.outputs.PR-BENCH-20 }}
             **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-20 }}

--- a/.github/workflows/ci-alternative-runtime.yml
+++ b/.github/workflows/ci-alternative-runtime.yml
@@ -26,12 +26,9 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [20]
         os: [macos-latest, ubuntu-latest, windows-latest]
         include:
-          - runtime: nsolid
-            node-version: 18
-            nsolid-version: 5
           - runtime: nsolid
             node-version: 20
             nsolid-version: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,11 +111,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22]
         os: [macos-latest, ubuntu-latest, windows-latest]
-        exclude:
-          - os: macos-latest
-            node-version: 16
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration-alternative-runtimes.yml
+++ b/.github/workflows/integration-alternative-runtimes.yml
@@ -25,12 +25,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         runtime: [nsolid]
-        node-version: [18, 20]
+        node-version: [20]
         pnpm-version: [8]
         include:
-          - nsolid-version: 5
-            node-version: 18
-            runtime: nsolid
           - nsolid-version: 5
             node-version: 20
             runtime: nsolid

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22]
         os: [ubuntu-latest]
         pnpm-version: [8]
 

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # Maintenance and active LTS
-        node-version: [18, 20, 22]
+        node-version: [20, 22]
         os: [ubuntu-latest]
         pnpm-version: [8]
 
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         # Maintenance and active LTS
-        node-version: [18, 20, 22]
+        node-version: [20, 22]
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
The main reason is to remove node 18 from the alternative runtimes CI, which [keeps failing for PRs where normal node 18 passes](https://github.com/fastify/fastify/pull/5480); [but as @mcollina suggested](https://github.com/fastify/fastify/issues/5460), we can just remove node 18 support from v5 since it's already pretty divergent from v20+