### PR TITLE
chore: remove unnecessary eslint override

### DIFF
--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* eslint no-prototype-builtins: 0 */
-
 const {
   kReply,
   kRequest,
@@ -101,8 +99,7 @@ function checkDependencies (instance, name, deps) {
     throw new FST_ERR_DEC_DEPENDENCY_INVALID_TYPE(name)
   }
 
-  // eslint-disable-next-line no-var
-  for (var i = 0; i !== deps.length; ++i) {
+  for (let i = 0; i !== deps.length; ++i) {
     if (!checkExistence(instance, deps[i])) {
       throw new FST_ERR_DEC_MISSING_DEPENDENCY(deps[i])
     }

--- a/test/internals/decorator.test.js
+++ b/test/internals/decorator.test.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* eslint no-prototype-builtins: 0 */
-
 const t = require('tap')
 const test = t.test
 const decorator = require('../../lib/decorate')


### PR DESCRIPTION
in decorate.js

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
