### PR TITLE
docs: addContentTypeParser with fastify.register

### DIFF
--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -36,6 +36,9 @@ is given in the content-type header. If it is not given, the
 > [essence MIME type](https://mimesniff.spec.whatwg.org/#mime-type-miscellaneous)
 > only.
 
+## Important: Using addContentTypeParser with fastify.register
+When using `addContentTypeParser` in combination with `fastify.register`, you should not use `await` when registering routes. Using `await` causes the route registration to be asynchronous and can lead to routes being registered before the addContentTypeParser has been set.
+
 ### Usage
 ```js
 fastify.addContentTypeParser('application/jsoff', function (request, payload, done) {

--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -89,7 +89,7 @@ fastify.addContentTypeParser('application/vnd.custom+xml', (request, body, done)
 
 ### Important: Using addContentTypeParser with fastify.register
 When using `addContentTypeParser` in combination with `fastify.register`,
-you should not use `await` when registering routes. Using `await` causes
+`await` should not be used when registering routes. Using `await` causes
 the route registration to be asynchronous and can lead to routes being registered
 before the addContentTypeParser has been set.
 
@@ -108,22 +108,6 @@ fastify.register((fastify, opts) => {
   fastify.get('/hello', async (req, res) => {});
 });
 ```
-
-#### Incorrect Usage
-```js
-const fastify = require('fastify')();
-
-await fastify.register((fastify, opts) => {
-  fastify.get('/hello', async (req, res) => {});
-});
-
-fastify.addContentTypeParser('application/json', function (request, payload, done) {
-  jsonParser(payload, function (err, body) {
-    done(err, body)
-  })
-})
-```
-
 
 Besides the `addContentTypeParser` API there are further APIs that can be used.
 These are `hasContentTypeParser`, `removeContentTypeParser` and

--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -87,7 +87,7 @@ fastify.addContentTypeParser('application/vnd.custom', (request, body, done) => 
 fastify.addContentTypeParser('application/vnd.custom+xml', (request, body, done) => {} )
 ```
 
-### Important: Using addContentTypeParser with fastify.register
+### Using addContentTypeParser with fastify.register
 When using `addContentTypeParser` in combination with `fastify.register`,
 `await` should not be used when registering routes. Using `await` causes
 the route registration to be asynchronous and can lead to routes being registered


### PR DESCRIPTION

for discussion in [5401](https://github.com/fastify/fastify/issues/5401) 

This PR includes an update to the documentation for addContentTypeParser

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
