### PR TITLE
chore: readyListener can be async on server.ready()

### DIFF
--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -237,11 +237,12 @@ expectAssignable<FastifyInstance>(server.ready())
 expectAssignable<FastifyInstance>(server.ready((err) => {
   expectType<Error | null>(err)
 }))
-var readyListener = async (err) => {
+expectAssignable<FastifyInstance>(server.ready(async (err) => {
   expectType<Error | null>(err)
-}
-expectAssignable<FastifyInstance>(server.ready(readyListener))
-expectType<Parameters<typeof server.ready>[0]>(readyListener)
+}))
+expectAssignable<Parameters<typeof server.ready>[0]>(async (err) => {
+  expectType<Error | null>(err)
+})
 
 expectAssignable<void>(server.routing({} as RawRequestDefaultExpression, {} as RawReplyDefaultExpression))
 

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -237,6 +237,11 @@ expectAssignable<FastifyInstance>(server.ready())
 expectAssignable<FastifyInstance>(server.ready((err) => {
   expectType<Error | null>(err)
 }))
+var readyListener = async (err) => {
+  expectType<Error | null>(err)
+}
+expectAssignable<FastifyInstance>(server.ready(readyListener))
+expectType<Parameters<typeof server.ready>[0]>(readyListener)
 
 expectAssignable<void>(server.routing({} as RawRequestDefaultExpression, {} as RawReplyDefaultExpression))
 

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -168,7 +168,7 @@ export interface FastifyInstance<
   listen(callback: (err: Error | null, address: string) => void): void;
 
   ready(): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider> & PromiseLike<undefined>;
-  ready(readyListener: (err: Error | null) => void): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ready(readyListener: (err: Error | null) => void | Promise<void>): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
 
   register: FastifyRegister<FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider> & PromiseLike<undefined>>;
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
