### PR TITLE
fix: hasRoute method comparison with case insensitive

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -152,7 +152,7 @@ function buildRouting (options) {
   }
 
   function hasRoute ({ options }) {
-    const normalizedMethod = options.method ? options.method.toUpperCase() : ''
+    const normalizedMethod = options.method?.toUpperCase() ?? ''
     return router.hasRoute(
       normalizedMethod,
       options.url || '',

--- a/lib/route.js
+++ b/lib/route.js
@@ -152,8 +152,9 @@ function buildRouting (options) {
   }
 
   function hasRoute ({ options }) {
+    const normalizeMethod = (options.method ?? '').toUpperCase()
     return router.hasRoute(
-      options.method,
+      normalizeMethod,
       options.url || '',
       options.constraints
     )

--- a/lib/route.js
+++ b/lib/route.js
@@ -152,9 +152,9 @@ function buildRouting (options) {
   }
 
   function hasRoute ({ options }) {
-    const normalizeMethod = (options.method ?? '').toUpperCase()
+    const normalizedMethod = options.method ? options.method.toUpperCase() : ''
     return router.hasRoute(
-      normalizeMethod,
+      normalizedMethod,
       options.url || '',
       options.constraints
     )

--- a/test/has-route.test.js
+++ b/test/has-route.test.js
@@ -75,7 +75,7 @@ test('hasRoute', t => {
     }), true)
   })
 
-  test('hasRoute - with normalize method', t => {
+  test('hasRoute - finds a route even if method is not uppercased', t => {
     t.plan(1)
     fastify.route({
       method: 'GET',

--- a/test/has-route.test.js
+++ b/test/has-route.test.js
@@ -5,7 +5,7 @@ const test = t.test
 const Fastify = require('../fastify')
 
 test('hasRoute', t => {
-  t.plan(4)
+  t.plan(5)
   const test = t.test
   const fastify = Fastify()
 
@@ -72,6 +72,22 @@ test('hasRoute', t => {
     t.equal(fastify.hasRoute({
       method: 'GET',
       url: '/example/:file(^\\d+).png'
+    }), true)
+  })
+
+  test('hasRoute - with normalize method', t => {
+    t.plan(1)
+    fastify.route({
+      method: 'GET',
+      url: '/equal',
+      handler: function (req, reply) {
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    t.equal(fastify.hasRoute({
+      method: 'get',
+      url: '/equal'
     }), true)
   })
 })


### PR DESCRIPTION
fix for issue: #5503 
#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
