### PR TITLE
chore: test deprecation cleanup

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const proxyAddr = require('proxy-addr')
-const semver = require('semver')
 const {
   FSTDEP005,
   FSTDEP012,
@@ -239,10 +238,7 @@ Object.defineProperties(Request.prototype, {
   },
   connection: {
     get () {
-      /* istanbul ignore next */
-      if (semver.gte(process.versions.node, '13.0.0')) {
-        FSTDEP005()
-      }
+      FSTDEP005()
       return this.raw.connection
     }
   },

--- a/package.json
+++ b/package.json
@@ -178,7 +178,6 @@
     "fast-json-body": "^1.1.0",
     "fastify-plugin": "^4.5.1",
     "fluent-json-schema": "^4.2.1",
-    "form-data": "^4.0.0",
     "h2url": "^0.2.0",
     "http-errors": "^2.0.0",
     "joi": "^17.12.3",

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -6,7 +6,6 @@ const fp = require('fastify-plugin')
 const sget = require('simple-get').concat
 const errors = require('http-errors')
 const split = require('split2')
-const FormData = require('form-data')
 const Fastify = require('..')
 const { getServerUrl } = require('./helper')
 
@@ -68,21 +67,18 @@ test('default 404', t => {
       })
     })
 
-    test('using post method and multipart/formdata', t => {
+    test('using post method and multipart/formdata', async t => {
       t.plan(3)
-      const form = FormData()
-      form.append('test-field', 'just some field')
+      const form = new FormData()
+      form.set('test-field', 'just some field')
 
-      sget({
+      const response = await fetch(getServerUrl(fastify) + '/notSupported', {
         method: 'POST',
-        url: getServerUrl(fastify) + '/notSupported',
-        body: form,
-        json: false
-      }, (err, response, body) => {
-        t.error(err)
-        t.equal(response.statusCode, 404)
-        t.equal(response.headers['content-type'], 'application/json; charset=utf-8')
+        body: form
       })
+      t.equal(response.status, 404)
+      t.equal(response.statusText, 'Not Found')
+      t.equal(response.headers.get('content-type'), 'application/json; charset=utf-8')
     })
   })
 })

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* eslint no-prototype-builtins: 0 */
-
 const t = require('tap')
 const test = t.test
 const Fastify = require('..')

--- a/test/esm/index.test.js
+++ b/test/esm/index.test.js
@@ -1,18 +1,8 @@
 'use strict'
 
-const t = require('tap')
-const semver = require('semver')
-
-if (semver.lt(process.versions.node, '14.13.0')) {
-  t.skip('Skip named exports because Node version < 14.13.0')
-} else {
-  // Node v8 throw a `SyntaxError: Unexpected token import`
-  // even if this branch is never touch in the code,
-  // by using `eval` we can avoid this issue.
-  // eslint-disable-next-line
-  new Function('module', 'return import(module)')('./named-exports.mjs').catch((err) => {
+import('./named-exports.mjs')
+  .catch(err => {
     process.nextTick(() => {
       throw err
     })
   })
-}

--- a/test/inject.test.js
+++ b/test/inject.test.js
@@ -5,7 +5,6 @@ const test = t.test
 const Stream = require('node:stream')
 const util = require('node:util')
 const Fastify = require('..')
-const FormData = require('form-data')
 const { Readable } = require('node:stream')
 
 test('inject should exist', t => {
@@ -343,7 +342,7 @@ test('inject a multipart request using form-body', t => {
   })
 
   const form = new FormData()
-  form.append('my_field', 'my value')
+  form.set('my_field', 'my value')
 
   fastify.inject({
     method: 'POST',

--- a/test/maxRequestsPerSocket.test.js
+++ b/test/maxRequestsPerSocket.test.js
@@ -2,12 +2,9 @@
 
 const net = require('node:net')
 const { test } = require('tap')
-const semver = require('semver')
 const Fastify = require('../fastify')
 
-const skip = semver.lt(process.versions.node, '16.10.0')
-
-test('maxRequestsPerSocket on node version >= 16.10.0', { skip }, t => {
+test('maxRequestsPerSocket', t => {
   t.plan(8)
 
   const fastify = Fastify({ maxRequestsPerSocket: 2 })
@@ -48,7 +45,7 @@ test('maxRequestsPerSocket on node version >= 16.10.0', { skip }, t => {
   })
 })
 
-test('maxRequestsPerSocket zero should behave same as null', { skip }, t => {
+test('maxRequestsPerSocket zero should behave same as null', t => {
   t.plan(10)
 
   const fastify = Fastify({ maxRequestsPerSocket: 0 })

--- a/test/plugin.1.test.js
+++ b/test/plugin.1.test.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* eslint no-prototype-builtins: 0 */
-
 const t = require('tap')
 const test = t.test
 const Fastify = require('../fastify')
@@ -117,8 +115,8 @@ test('fastify.register with fastify-plugin should provide access to external fas
 
     instance.register((i, o, n) => n(), p => {
       t.notOk(p === instance || p === fastify)
-      t.ok(instance.isPrototypeOf(p))
-      t.ok(fastify.isPrototypeOf(p))
+      t.ok(Object.prototype.isPrototypeOf.call(instance, p))
+      t.ok(Object.prototype.isPrototypeOf.call(fastify, p))
       t.ok(p.global)
     })
 

--- a/test/plugin.2.test.js
+++ b/test/plugin.2.test.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* eslint no-prototype-builtins: 0 */
-
 const t = require('tap')
 const test = t.test
 const Fastify = require('../fastify')

--- a/test/plugin.3.test.js
+++ b/test/plugin.3.test.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* eslint no-prototype-builtins: 0 */
-
 const t = require('tap')
 const test = t.test
 const Fastify = require('../fastify')

--- a/test/plugin.4.test.js
+++ b/test/plugin.4.test.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* eslint no-prototype-builtins: 0 */
-
 const t = require('tap')
 const test = t.test
 const Fastify = require('../fastify')

--- a/test/register.test.js
+++ b/test/register.test.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* eslint no-prototype-builtins: 0 */
-
 const t = require('tap')
 const test = t.test
 const sget = require('simple-get').concat
@@ -14,7 +12,7 @@ test('register', t => {
 
   fastify.register(function (instance, opts, done) {
     t.not(instance, fastify)
-    t.ok(fastify.isPrototypeOf(instance))
+    t.ok(Object.prototype.isPrototypeOf.call(fastify, instance))
 
     t.equal(typeof opts, 'object')
     t.equal(typeof done, 'function')
@@ -27,7 +25,7 @@ test('register', t => {
 
   fastify.register(function (instance, opts, done) {
     t.not(instance, fastify)
-    t.ok(fastify.isPrototypeOf(instance))
+    t.ok(Object.prototype.isPrototypeOf.call(fastify, instance))
 
     t.equal(typeof opts, 'object')
     t.equal(typeof done, 'function')

--- a/test/schema-special-usage.test.js
+++ b/test/schema-special-usage.test.js
@@ -704,7 +704,7 @@ test('Custom schema object should not trigger FST_ERR_SCH_DUPLICATE', async t =>
 })
 
 test('The default schema compilers should not be called when overwritten by the user', async t => {
-  const Fastify = t.mock('../', {
+  const Fastify = t.mockRequire('../', {
     '@fastify/ajv-compiler': () => {
       t.fail('The default validator compiler should not be called')
     },

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -4,7 +4,6 @@ const t = require('tap')
 const test = t.test
 const Fastify = require('..')
 const sget = require('simple-get').concat
-const semver = require('semver')
 const undici = require('undici')
 
 test('listen should accept null port', t => {
@@ -88,7 +87,7 @@ test('Test for hostname and port', t => {
   })
 })
 
-test('abort signal', { skip: semver.lt(process.version, '16.0.0') }, t => {
+test('abort signal', t => {
   t.test('listen should not start server', t => {
     t.plan(2)
     function onClose (instance, done) {

--- a/test/web-api.test.js
+++ b/test/web-api.test.js
@@ -4,14 +4,8 @@ const t = require('tap')
 const test = t.test
 const Fastify = require('../fastify')
 const fs = require('node:fs')
-const semver = require('semver')
 const { Readable } = require('node:stream')
 const { fetch: undiciFetch } = require('undici')
-
-if (semver.lt(process.versions.node, '18.0.0')) {
-  t.skip('Response or ReadableStream not available, skipping test')
-  process.exit(0)
-}
 
 test('should response with a ReadableStream', async (t) => {
   t.plan(2)


### PR DESCRIPTION
(sans FSTDEP)

 - Removed `form-data` package (were throwing util.isArray deprecation warn). Swapped out for native FormData since we now are >= v20
 - Removed semver checks for unsupported versions of node
 - Removed tests not applicable for Node >=v20
 - t.mock (deprecated) -> t.mockRequire
 - Removed `eslint no-prototype-builtins: 0`, and fixed when necessary
 - Removed `new Function('module', 'return import(module)')` 'hack'

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
