### PR TITLE
[Backport 4.x] fix: hasRoute method comparison with case insensitive

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -168,7 +168,12 @@ function buildRouting (options) {
   }
 
   function hasRoute ({ options }) {
-    return findRoute(options) !== null
+    const normalizedMethod = options.method?.toUpperCase() ?? ''
+    return router.hasRoute(
+      normalizedMethod,
+      options.url || '',
+      options.constraints
+    )
   }
 
   function findRoute (options) {

--- a/test/has-route.test.js
+++ b/test/has-route.test.js
@@ -5,7 +5,7 @@ const test = t.test
 const Fastify = require('../fastify')
 
 test('hasRoute', t => {
-  t.plan(4)
+  t.plan(5)
   const test = t.test
   const fastify = Fastify()
 
@@ -71,7 +71,23 @@ test('hasRoute', t => {
 
     t.equal(fastify.hasRoute({
       method: 'GET',
-      url: '/example/12345.png'
+      url: '/example/:file(^\\d+).png'
+    }), true)
+  })
+
+  test('hasRoute - finds a route even if method is not uppercased', t => {
+    t.plan(1)
+    fastify.route({
+      method: 'GET',
+      url: '/equal',
+      handler: function (req, reply) {
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    t.equal(fastify.hasRoute({
+      method: 'get',
+      url: '/equal'
     }), true)
   })
 })


### PR DESCRIPTION
fix for issue: https://github.com/fastify/fastify/issues/5503
#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
