### PR TITLE
fix: server.listen listener is not cleanup properly

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -203,6 +203,7 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
 function listenCallback (server, listenOptions) {
   const wrap = (err) => {
     server.removeListener('error', wrap)
+    server.removeListener('listening', wrap)
     if (!err) {
       const address = logServerAddress.call(this, server, listenOptions.listenTextResolver || defaultResolveServerListeningText)
       listenOptions.cb(null, address)
@@ -223,7 +224,8 @@ function listenCallback (server, listenOptions) {
 
     server.once('error', wrap)
     if (!this[kState].closing) {
-      server.listen(listenOptions, wrap)
+      server.once('listening', wrap)
+      server.listen(listenOptions)
       this[kState].listening = true
     }
   }
@@ -238,25 +240,33 @@ function listenPromise (server, listenOptions) {
 
   return this.ready().then(() => {
     let errEventHandler
+    let listeningEventHandler
+    function cleanup () {
+      server.removeListener('error', errEventHandler)
+      server.removeListener('listening', listeningEventHandler)
+    }
     const errEvent = new Promise((resolve, reject) => {
       errEventHandler = (err) => {
+        cleanup()
         this[kState].listening = false
         reject(err)
       }
       server.once('error', errEventHandler)
     })
-    const listen = new Promise((resolve, reject) => {
-      server.listen(listenOptions, () => {
-        server.removeListener('error', errEventHandler)
+    const listeningEvent = new Promise((resolve, reject) => {
+      listeningEventHandler = () => {
+        cleanup()
+        this[kState].listening = true
         resolve(logServerAddress.call(this, server, listenOptions.listenTextResolver || defaultResolveServerListeningText))
-      })
-      // we set it afterwards because listen can throw
-      this[kState].listening = true
+      }
+      server.once('listening', listeningEventHandler)
     })
+
+    server.listen(listenOptions)
 
     return Promise.race([
       errEvent, // e.g invalid port range error is always emitted before the server listening
-      listen
+      listeningEvent
     ])
   })
 }

--- a/test/listen.5.test.js
+++ b/test/listen.5.test.js
@@ -1,0 +1,88 @@
+'use strict'
+
+const { test } = require('tap')
+const net = require('node:net')
+const Fastify = require('../fastify')
+const { once } = require('node:events')
+
+test('same port conflict and success should not fire callback multiple times - callback', async (t) => {
+  t.plan(7)
+  const server = net.createServer()
+  server.listen({ port: 0, host: '127.0.0.1' })
+  await once(server, 'listening')
+  const option = { port: server.address().port, host: server.address().address }
+  let count = 0
+  const fastify = Fastify()
+  function callback (err) {
+    switch (count) {
+      case 6: {
+        // success in here
+        t.error(err)
+        fastify.close((err) => {
+          t.error(err)
+        })
+        break
+      }
+      case 5: {
+        server.close()
+        setTimeout(() => {
+          fastify.listen(option, callback)
+        }, 100)
+        break
+      }
+      default: {
+        // expect error
+        t.equal(err.code, 'EADDRINUSE')
+        setTimeout(() => {
+          fastify.listen(option, callback)
+        }, 100)
+      }
+    }
+    count++
+  }
+  fastify.listen(option, callback)
+})
+
+test('same port conflict and success should not fire callback multiple times - promise', async (t) => {
+  t.plan(5)
+  const server = net.createServer()
+  server.listen({ port: 0, host: '127.0.0.1' })
+  await once(server, 'listening')
+  const option = { port: server.address().port, host: server.address().address }
+  const fastify = Fastify()
+
+  try {
+    await fastify.listen(option)
+  } catch (err) {
+    t.equal(err.code, 'EADDRINUSE')
+  }
+  try {
+    await fastify.listen(option)
+  } catch (err) {
+    t.equal(err.code, 'EADDRINUSE')
+  }
+  try {
+    await fastify.listen(option)
+  } catch (err) {
+    t.equal(err.code, 'EADDRINUSE')
+  }
+  try {
+    await fastify.listen(option)
+  } catch (err) {
+    t.equal(err.code, 'EADDRINUSE')
+  }
+  try {
+    await fastify.listen(option)
+  } catch (err) {
+    t.equal(err.code, 'EADDRINUSE')
+  }
+
+  server.close()
+
+  await once(server, 'close')
+
+  // when ever we can listen, and close properly
+  // which means there is no problem on the callback
+  await fastify.listen()
+  await fastify.close()
+})


### PR DESCRIPTION
I don't think we should permit multiple calls to `.listen`, but we should also properly cleanup the listener if `node` currently doesn't.

Fixes #5519 

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
