### PR TITLE
chore: support pre and alpha tags

### DIFF
--- a/lib/pluginUtils.js
+++ b/lib/pluginUtils.js
@@ -106,11 +106,11 @@ function _checkDecorators (that, instance, decorators, name) {
 
 function checkVersion (fn) {
   const meta = getMeta(fn)
-  if (!meta) return
+  if (meta == null || meta?.fastify == null) return
 
   const requiredVersion = meta.fastify
 
-  const fastifyRc = /-rc.+$/.test(this.version)
+  const fastifyRc = /-(rc|pre|alpha).+$/.test(this.version)
   if (fastifyRc === true && semver.gt(this.version, semver.coerce(requiredVersion)) === true) {
     // A Fastify release candidate phase is taking place. In order to reduce
     // the effort needed to test plugins with the RC, we allow plugins targeting

--- a/test/plugin.4.test.js
+++ b/test/plugin.4.test.js
@@ -132,6 +132,9 @@ test('plugin metadata - version not matching requirement', t => {
 test('plugin metadata - version not matching requirement 2', t => {
   t.plan(2)
   const fastify = Fastify()
+  Object.defineProperty(fastify, 'version', {
+    value: '99.0.0'
+  })
 
   plugin[Symbol.for('skip-override')] = true
   plugin[Symbol.for('plugin-meta')] = {
@@ -197,36 +200,75 @@ test('plugin metadata - release candidate', t => {
   }
 })
 
-test('fastify-rc loads prior version plugins', t => {
-  t.plan(2)
-  const fastify = Fastify()
-  Object.defineProperty(fastify, 'version', {
-    value: '99.0.0-rc.1'
+test('fastify-rc loads prior version plugins', async t => {
+  t.test('baseline (rc)', t => {
+    t.plan(2)
+
+    const fastify = Fastify()
+    Object.defineProperty(fastify, 'version', {
+      value: '99.0.0-rc.1'
+    })
+
+    plugin[Symbol.for('plugin-meta')] = {
+      name: 'plugin',
+      fastify: '^98.1.0'
+    }
+    plugin2[Symbol.for('plugin-meta')] = {
+      name: 'plugin2',
+      fastify: '98.x'
+    }
+
+    fastify.register(plugin)
+
+    fastify.ready((err) => {
+      t.error(err)
+      t.pass('everything right')
+    })
+
+    function plugin (instance, opts, done) {
+      done()
+    }
+
+    function plugin2 (instance, opts, done) {
+      done()
+    }
   })
 
-  plugin[Symbol.for('plugin-meta')] = {
-    name: 'plugin',
-    fastify: '^98.1.0'
-  }
-  plugin2[Symbol.for('plugin-meta')] = {
-    name: 'plugin2',
-    fastify: '98.x'
-  }
+  t.test('pre', t => {
+    t.plan(2)
 
-  fastify.register(plugin)
+    const fastify = Fastify()
+    Object.defineProperty(fastify, 'version', { value: '99.0.0-pre.1' })
 
-  fastify.ready((err) => {
-    t.error(err)
-    t.pass('everything right')
+    plugin[Symbol.for('plugin-meta')] = { name: 'plugin', fastify: '^98.x' }
+
+    fastify.register(plugin)
+
+    fastify.ready((err) => {
+      t.error(err)
+      t.pass()
+    })
+
+    function plugin (instance, opts, done) { done() }
   })
 
-  function plugin (instance, opts, done) {
-    done()
-  }
+  t.test('alpha', t => {
+    t.plan(2)
 
-  function plugin2 (instance, opts, done) {
-    done()
-  }
+    const fastify = Fastify()
+    Object.defineProperty(fastify, 'version', { value: '99.0.0-pre.1' })
+
+    plugin[Symbol.for('plugin-meta')] = { name: 'plugin', fastify: '^98.x' }
+
+    fastify.register(plugin)
+
+    fastify.ready((err) => {
+      t.error(err)
+      t.pass()
+    })
+
+    function plugin (instance, opts, done) { done() }
+  })
 })
 
 test('hasPlugin method exists as a function', t => {


### PR DESCRIPTION
The checks against versions in all of our modules relies on this code. I need this plus a new alpha release.