### PR TITLE
fix(v4): update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,10 +3,13 @@
 .gitignore
 .github
 .nyc_output
+.DS_Store
 coverage/
 tools/
+.tap/
 CODE_OF_CONDUCT.md
 CONTRIBUTING.md
+EXPENSE_POLICY.md
 .clinic
 .gitpod.yml
 


### PR DESCRIPTION
Fixes: https://github.com/fastify/fastify/issues/5536

I think we should bump a new release, 4 MB are too much