### PR TITLE
chore: rm < node19 support from secondaryServer.close()

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -143,7 +143,6 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
             cb: (_ignoreErr) => {
               bound++
 
-              /* istanbul ignore next: the else won't be taken unless listening fails */
               if (!_ignoreErr) {
                 this[kServerBindings].push(secondaryServer)
               }
@@ -157,18 +156,13 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
 
           const secondaryServer = getServerInstance(serverOpts, httpHandler)
           const closeSecondary = () => {
-            // To avoid fall into situations where the close of the
+            // To avoid falling into situations where the close of the
             // secondary server is triggered before the preClose hook
-            // is done running, we better wait until the main server
-            // is closed.
+            // is done running, we better wait until the main server is closed.
             // No new TCP connections are accepted
-            // We swallow any error from the secondary
-            // server
+            // We swallow any error from the secondary server
             secondaryServer.close(() => {})
-            if (serverOpts.forceCloseConnections === 'idle') {
-              // Not needed in Node 19
-              secondaryServer.closeIdleConnections()
-            } else if (typeof secondaryServer.closeAllConnections === 'function' && serverOpts.forceCloseConnections) {
+            if (typeof secondaryServer.closeAllConnections === 'function' && serverOpts.forceCloseConnections === true) {
               secondaryServer.closeAllConnections()
             }
           }


### PR DESCRIPTION

(Also fixed a typo and removed a Istanbul comment.)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
