### PR TITLE
feat(backport 4.x): add body parsing on copy move mkcol methods

### DIFF
--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -43,7 +43,8 @@ fastify.route(options)
   [here](./Validation-and-Serialization.md) for more info.
 
   * `body`: validates the body of the request if it is a POST, PUT, PATCH,
-    TRACE, SEARCH, PROPFIND, PROPPATCH, COPY, MOVE, REPORT, MKCALENDAR or LOCK method.
+    TRACE, SEARCH, PROPFIND, PROPPATCH, COPY, MOVE, MKCOL, REPORT, MKCALENDAR
+    or LOCK method.
   * `querystring` or `query`: validates the querystring. This can be a complete
     JSON Schema object, with the property `type` of `object` and `properties`
     object of parameters, or simply the values of what would be contained in the

--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -43,7 +43,7 @@ fastify.route(options)
   [here](./Validation-and-Serialization.md) for more info.
 
   * `body`: validates the body of the request if it is a POST, PUT, PATCH,
-    TRACE, SEARCH, PROPFIND, PROPPATCH or LOCK method.
+    TRACE, SEARCH, PROPFIND, PROPPATCH, COPY, MOVE, REPORT, MKCALENDAR or LOCK method.
   * `querystring` or `query`: validates the querystring. This can be a complete
     JSON Schema object, with the property `type` of `object` and `properties`
     object of parameters, or simply the values of what would be contained in the

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -28,7 +28,8 @@ function handleRequest (err, request, reply) {
   const contentType = headers['content-type']
 
   if (method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'TRACE' || method === 'SEARCH' ||
-    method === 'PROPFIND' || method === 'PROPPATCH' || method === 'LOCK' || method === 'REPORT' || method === 'MKCALENDAR') {
+    method === 'PROPFIND' || method === 'PROPPATCH' || method === 'LOCK' || method === 'COPY' || method === 'MOVE' ||
+    method === 'REPORT' || method === 'MKCALENDAR') {
     if (contentType === undefined) {
       if (
         headers['transfer-encoding'] === undefined &&

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -29,7 +29,7 @@ function handleRequest (err, request, reply) {
 
   if (method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'TRACE' || method === 'SEARCH' ||
     method === 'PROPFIND' || method === 'PROPPATCH' || method === 'LOCK' || method === 'COPY' || method === 'MOVE' ||
-    method === 'REPORT' || method === 'MKCALENDAR') {
+    method === 'MKCOL' || method === 'REPORT' || method === 'MKCALENDAR') {
     if (contentType === undefined) {
       if (
         headers['transfer-encoding'] === undefined &&

--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -12,7 +12,10 @@ test('can be created - copy', t => {
       method: 'COPY',
       url: '*',
       handler: function (req, reply) {
-        reply.code(204).send()
+        reply.code(204)
+          .header('location', req.headers.destination)
+          .header('body', req.body.toString())
+          .send()
       }
     })
     t.pass()
@@ -26,15 +29,19 @@ fastify.listen({ port: 0 }, err => {
   t.teardown(() => { fastify.close() })
 
   test('request - copy', t => {
-    t.plan(2)
+    t.plan(4)
     sget({
       url: `http://localhost:${fastify.server.address().port}/test.txt`,
       method: 'COPY',
       headers: {
-        Destination: '/test2.txt'
-      }
-    }, (err, response, body) => {
+        destination: '/test2.txt',
+        'Content-Type': 'text/plain'
+      },
+      body: '/test3.txt'
+    }, (err, response) => {
       t.error(err)
+      t.equal(response.headers.location, '/test2.txt')
+      t.equal(response.headers.body, '/test3.txt')
       t.equal(response.statusCode, 204)
     })
   })

--- a/test/mkcol.test.js
+++ b/test/mkcol.test.js
@@ -12,7 +12,7 @@ test('can be created - mkcol', t => {
       method: 'MKCOL',
       url: '*',
       handler: function (req, reply) {
-        reply.code(201).send()
+        reply.code(201).header('body', req.body.toString()).send()
       }
     })
     t.pass()
@@ -26,12 +26,15 @@ fastify.listen({ port: 0 }, err => {
   t.teardown(() => { fastify.close() })
 
   test('request - mkcol', t => {
-    t.plan(2)
+    t.plan(3)
     sget({
       url: `http://localhost:${fastify.server.address().port}/test/`,
-      method: 'MKCOL'
-    }, (err, response, body) => {
+      method: 'MKCOL',
+      headers: { 'Content-Type': 'text/plain' },
+      body: '/test.txt'
+    }, (err, response) => {
       t.error(err)
+      t.equal(response.headers.body, '/test.txt')
       t.equal(response.statusCode, 201)
     })
   })

--- a/test/move.test.js
+++ b/test/move.test.js
@@ -12,9 +12,9 @@ test('shorthand - move', t => {
       method: 'MOVE',
       url: '*',
       handler: function (req, reply) {
-        const destination = req.headers.destination
         reply.code(201)
-          .header('location', destination)
+          .header('location', req.headers.destination)
+          .header('body', req.body.toString())
           .send()
       }
     })
@@ -29,17 +29,20 @@ fastify.listen({ port: 0 }, err => {
   t.teardown(() => { fastify.close() })
 
   test('request - move', t => {
-    t.plan(3)
+    t.plan(4)
     sget({
       url: `http://localhost:${fastify.server.address().port}/test.txt`,
       method: 'MOVE',
       headers: {
-        Destination: '/test2.txt'
-      }
-    }, (err, response, body) => {
+        destination: '/test2.txt',
+        'Content-Type': 'text/plain'
+      },
+      body: '/test3.txt'
+    }, (err, response) => {
       t.error(err)
       t.equal(response.statusCode, 201)
       t.equal(response.headers.location, '/test2.txt')
+      t.equal(response.headers.body, '/test3.txt')
     })
   })
 })


### PR DESCRIPTION
- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Already done in version 5, but not available in version 4 (and it's very useful !)