### PR TITLE
ci: remove automerge from ci alternative runtimes

### DIFF
--- a/.github/workflows/ci-alternative-runtime.yml
+++ b/.github/workflows/ci-alternative-runtime.yml
@@ -105,20 +105,3 @@ jobs:
       - name: Test esbuild bundle
         run: |
           cd test/bundler/esbuild && npm run test
-
-  automerge:
-    if: >
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.user.login == 'dependabot[bot]'
-    needs:
-      - test-typescript
-      - test-unit
-      - package
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
-    steps:
-      - uses: fastify/github-action-merge-dependabot@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We should not provide two track of `automerge` action.
It will leads to race-condition.

See https://github.com/fastify/fastify/pull/5554
Even if the linting failed on the normal track, it merges by the alternative runtime track

Depends on #5558

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
