### PR TITLE
chore: remove dc-polyfill

### DIFF
--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -828,13 +828,6 @@ consider creating a custom [Plugin](./Plugins.md) instead.
 
 ## Diagnostics Channel Hooks
 
-> **Note:** The `diagnostics_channel` is currently experimental on Node.js, so
-> its API is subject to change even in semver-patch releases of Node.js. As some
-> versions of Node.js are supported by Fastify where `diagnostics_channel` is
-> unavailable, or with an incomplete feature set, the hook uses the
-> [dc-polyfill](https://www.npmjs.com/package/dc-polyfill) package to provide a
-> polyfill.
-
 One [`diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html)
 publish event, `'fastify.initialization'`, happens at initialization time. The
 Fastify instance is passed into the hook as a property of the object passed in.
@@ -848,7 +841,7 @@ tools first" fashion.
 
 ```js
 const tracer = /* retrieved from elsewhere in the package */
-const dc = require('node:diagnostics_channel') // or require('dc-polyfill')
+const dc = require('node:diagnostics_channel')
 const channel = dc.channel('fastify.initialization')
 const spans = new WeakMap()
 
@@ -866,6 +859,9 @@ channel.subscribe(function ({ fastify }) {
   })
 })
 ```
+
+> **Note:** The TracingChannel class API is currently experimental and may undergo
+> breaking changes even in semver-patch releases of Node.js.
 
 Five other events are published on a per-request basis following the
 [Tracing Channel](https://nodejs.org/api/diagnostics_channel.html#class-tracingchannel)
@@ -895,7 +891,7 @@ associated with the request's failure.
 These events can be received like so:
 
 ```js
-const dc = require('node:diagnostics_channel') // or require('dc-polyfill')
+const dc = require('node:diagnostics_channel')
 const channel = dc.channel('tracing:fastify.request.handler:start')
 channel.subscribe((msg) => {
   console.log(msg.request, msg.reply)

--- a/fastify.js
+++ b/fastify.js
@@ -4,7 +4,7 @@ const VERSION = '5.0.0-alpha.3'
 
 const Avvio = require('avvio')
 const http = require('node:http')
-const diagnostics = require('dc-polyfill')
+const diagnostics = require('node:diagnostics_channel')
 let lightMyRequest
 
 const {

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { bodylessMethods, bodyMethods } = require('./httpMethods')
-const diagnostics = require('dc-polyfill')
+const diagnostics = require('node:diagnostics_channel')
 const { validate: validateSchema } = require('./validation')
 const { preValidationHookRunner, preHandlerHookRunner } = require('./hooks')
 const wrapThenable = require('./wrapThenable')

--- a/lib/wrapThenable.js
+++ b/lib/wrapThenable.js
@@ -5,7 +5,7 @@ const {
   kReplyHijacked
 } = require('./symbols')
 
-const diagnostics = require('dc-polyfill')
+const diagnostics = require('node:diagnostics_channel')
 const channels = diagnostics.tracingChannel('fastify.request.handler')
 
 function wrapThenable (thenable, reply, store) {

--- a/package.json
+++ b/package.json
@@ -195,7 +195,6 @@
     "@fastify/fast-json-stringify-compiler": "^4.3.0",
     "abstract-logging": "^2.0.1",
     "avvio": "^8.3.0",
-    "dc-polyfill": "^0.1.6",
     "fast-json-stringify": "^6.0.0",
     "find-my-way": "^8.1.0",
     "light-my-request": "^5.13.0",

--- a/test/diagnostics-channel/404.test.js
+++ b/test/diagnostics-channel/404.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const t = require('tap')
-const diagnostics = require('dc-polyfill')
+const diagnostics = require('node:diagnostics_channel')
 const test = t.test
 const sget = require('simple-get').concat
 const Fastify = require('../..')

--- a/test/diagnostics-channel/async-delay-request.test.js
+++ b/test/diagnostics-channel/async-delay-request.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const t = require('tap')
-const diagnostics = require('dc-polyfill')
+const diagnostics = require('node:diagnostics_channel')
 const test = t.test
 const sget = require('simple-get').concat
 const Fastify = require('../..')

--- a/test/diagnostics-channel/async-request.test.js
+++ b/test/diagnostics-channel/async-request.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const t = require('tap')
-const diagnostics = require('dc-polyfill')
+const diagnostics = require('node:diagnostics_channel')
 const test = t.test
 const sget = require('simple-get').concat
 const Fastify = require('../..')

--- a/test/diagnostics-channel/error-before-handler.test.js
+++ b/test/diagnostics-channel/error-before-handler.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const t = require('tap')
-const diagnostics = require('dc-polyfill')
+const diagnostics = require('node:diagnostics_channel')
 const test = t.test
 require('../../lib/hooks').onSendHookRunner = function Stub () {}
 const Request = require('../../lib/request')

--- a/test/diagnostics-channel/error-request.test.js
+++ b/test/diagnostics-channel/error-request.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const t = require('tap')
-const diagnostics = require('dc-polyfill')
+const diagnostics = require('node:diagnostics_channel')
 const test = t.test
 const sget = require('simple-get').concat
 const Fastify = require('../..')

--- a/test/diagnostics-channel/error-status.test.js
+++ b/test/diagnostics-channel/error-status.test.js
@@ -4,7 +4,7 @@ const t = require('tap')
 const test = t.test
 const Fastify = require('../..')
 const statusCodes = require('node:http').STATUS_CODES
-const diagnostics = require('dc-polyfill')
+const diagnostics = require('node:diagnostics_channel')
 
 test('Error.status property support', t => {
   t.plan(4)

--- a/test/diagnostics-channel/init.test.js
+++ b/test/diagnostics-channel/init.test.js
@@ -24,7 +24,7 @@ test('diagnostics_channel when present and subscribers', t => {
   }
 
   const fastify = proxyquire('../../fastify', {
-    'dc-polyfill': diagnostics
+    'node:diagnostics_channel': diagnostics
   })()
   t.equal(fastifyInHook, fastify)
 })
@@ -46,6 +46,6 @@ test('diagnostics_channel when present and no subscribers', t => {
   }
 
   proxyquire('../../fastify', {
-    'dc-polyfill': diagnostics
+    'node:diagnostics_channel': diagnostics
   })()
 })

--- a/test/diagnostics-channel/sync-delay-request.test.js
+++ b/test/diagnostics-channel/sync-delay-request.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const t = require('tap')
-const diagnostics = require('dc-polyfill')
+const diagnostics = require('node:diagnostics_channel')
 const test = t.test
 const sget = require('simple-get').concat
 const Fastify = require('../..')

--- a/test/diagnostics-channel/sync-request-reply.test.js
+++ b/test/diagnostics-channel/sync-request-reply.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const t = require('tap')
-const diagnostics = require('dc-polyfill')
+const diagnostics = require('node:diagnostics_channel')
 const test = t.test
 const sget = require('simple-get').concat
 const Fastify = require('../..')

--- a/test/diagnostics-channel/sync-request.test.js
+++ b/test/diagnostics-channel/sync-request.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const t = require('tap')
-const diagnostics = require('dc-polyfill')
+const diagnostics = require('node:diagnostics_channel')
 const test = t.test
 const sget = require('simple-get').concat
 const Fastify = require('../..')


### PR DESCRIPTION
Fastifyv5 engine targets means we no longer need the `dc-polyfill` package.

diagnostics_channel became stable @ v18.13.0.
tracingChannel class api was added in v18.19.0 and is still experimental, however, dc-polyfill uses the internal version if node >=18.19 so it does nothing for us in fastify v5.

(document tweak)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
