### PR TITLE
docs(reference/typescript): remove type provider from typebox example

### DIFF
--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -210,24 +210,23 @@ And a `zod` wrapper by a third party called [`fastify-type-provider-zod`](https:
 They simplify schema validation setup and you can read more about them in [Type
 Providers](./Type-Providers.md) page.
 
-Below is how to setup schema validation using _vanilla_ `typebox` and
-`json-schema-to-ts` packages.
+Below is how to setup schema validation using the `typebox`,
+`json-schema-to-typescript`, and `json-schema-to-ts` packages without type
+providers.
 
 #### TypeBox
 
-A useful library for building types and a schema at once is
-[TypeBox](https://www.npmjs.com/package/@sinclair/typebox) along with 
-[fastify-type-provider-typebox](https://github.com/fastify/fastify-type-provider-typebox).
-With TypeBox you define your schema within your code and use them
-directly as types or schemas as you need them.
+A useful library for building types and a schema at once is [TypeBox](https://www.npmjs.com/package/@sinclair/typebox).
+With TypeBox you define your schema within your code and use them directly as
+types or schemas as you need them.
 
 When you want to use it for validation of some payload in a fastify route you
 can do it as follows:
 
-1. Install `typebox` and `fastify-type-provider-typebox` in your project.
+1. Install `typebox` in your project.
 
     ```bash
-    npm i @sinclair/typebox @fastify/type-provider-typebox
+    npm i @sinclair/typebox
     ```
 
 2. Define the schema you need with `Type` and create the respective type  with
@@ -248,10 +247,9 @@ can do it as follows:
 
     ```typescript
     import Fastify from 'fastify'
-    import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox'
     // ...
 
-    const fastify = Fastify().withTypeProvider<TypeBoxTypeProvider>()
+    const fastify = Fastify()
 
     fastify.post<{ Body: UserType, Reply: UserType }>(
       '/',
@@ -271,12 +269,12 @@ can do it as follows:
     )
     ```
 
-#### Schemas in JSON Files
+#### json-schema-to-typescript
 
-In the last example we used interfaces to define the types for the request
-querystring and headers. Many users will already be using JSON Schemas to define
-these properties, and luckily there is a way to transform existing JSON Schemas
-into TypeScript interfaces!
+In the last example we used Typebox to define the types and schemas for our
+route. Many users will already be using JSON Schemas to define these properties,
+and luckily there is a way to transform existing JSON Schemas into TypeScript
+interfaces!
 
 1. If you did not complete the 'Getting Started' example, go back and follow
    steps 1-4 first.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
I made some small adjustments to the Typescript docs:

* I removed the type provider from the Typebox example. The example uses both a type provider and a generic which makes one of them obsolete. Also to my understanding this part of the docs is supposed to show how to use those libraries without type providers. There's a separate documentation of the type providers.
* I rephrased some sentences, just minor things.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
