### PR TITLE
docs: Adding `crudify-mongo` plugin to community list

### DIFF
--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -159,6 +159,8 @@ section.
 
 #### [Community](#community)
 
+- [`@aaroncadillac/crudify-mongo`](https://github.com/aaroncadillac/crudify-mongo)
+  A simple way to add a crud in your fastify proyect.
 - [`@applicazza/fastify-nextjs`](https://github.com/applicazza/fastify-nextjs)
   Alternate Fastify and Next.js integration.
 - [`@blastorg/fastify-aws-dynamodb-cache`](https://github.com/blastorg/fastify-aws-dynamodb-cache)

--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -160,7 +160,7 @@ section.
 #### [Community](#community)
 
 - [`@aaroncadillac/crudify-mongo`](https://github.com/aaroncadillac/crudify-mongo)
-  A simple way to add a crud in your fastify proyect.
+  A simple way to add a crud in your fastify project.
 - [`@applicazza/fastify-nextjs`](https://github.com/applicazza/fastify-nextjs)
   Alternate Fastify and Next.js integration.
 - [`@blastorg/fastify-aws-dynamodb-cache`](https://github.com/blastorg/fastify-aws-dynamodb-cache)


### PR DESCRIPTION
Hi guys, I have this little plugin to add to the community plugins on your ecosystem page, it's very useful for me, so I want to share it with the fastify community.

I have my repository at [https://github.com/aaroncadillac/crudify-mongo](https://github.com/aaroncadillac/crudify-mongo) and it is properly documented and tested, and my plugin is available in npm packages.

Checklist
- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Thanks and happy code 