### PR TITLE
chore(sponsor): add handsontable

### DIFF
--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -15,6 +15,7 @@ _Be the first!_
 
 - [Mercedes-Benz Group](https://github.com/mercedes-benz)
 - [Val Town, Inc.](https://opencollective.com/valtown)
+- [Handsontable - JavaScript Data Grid](https://handsontable.com/)
 
 ## Tier 2
 


### PR DESCRIPTION
As titled

- https://opencollective.com/handsontable-javascript-data-grid

<img width="620" alt="image" src="https://github.com/user-attachments/assets/0475385c-56f7-4464-a683-75d67ae9752b">


If someone from Handsontable team would like to submit a better link or a logo to add it to the website, I will be more than happy to deploy it!
