### PR TITLE
fix: removed warning listener from tests

### DIFF
--- a/test/listen.1.test.js
+++ b/test/listen.1.test.js
@@ -12,12 +12,16 @@ before(async function () {
 })
 
 test('listen works without arguments', async t => {
-  process.on('warning', () => {
+  const doNotWarn = () => {
     t.fail('should not be deprecated')
-  })
+  }
+  process.on('warning', doNotWarn)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.teardown(() => {
+    fastify.close()
+    process.removeListener('warning', doNotWarn)
+  })
   await fastify.listen()
   const address = fastify.server.address()
   t.equal(address.address, localhost)
@@ -25,12 +29,16 @@ test('listen works without arguments', async t => {
 })
 
 test('Async/await listen with arguments', async t => {
-  process.on('warning', () => {
+  const doNotWarn = () => {
     t.fail('should not be deprecated')
-  })
+  }
+  process.on('warning', doNotWarn)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.teardown(() => {
+    fastify.close()
+    process.removeListener('warning', doNotWarn)
+  })
   const addr = await fastify.listen({ port: 0, host: '0.0.0.0' })
   const address = fastify.server.address()
   t.equal(addr, `http://127.0.0.1:${address.port}`)
@@ -42,13 +50,17 @@ test('Async/await listen with arguments', async t => {
 })
 
 test('listen accepts a callback', t => {
-  process.on('warning', () => {
-    t.fail('should not be deprecated')
-  })
-
   t.plan(2)
+  const doNotWarn = () => {
+    t.fail('should not be deprecated')
+  }
+  process.on('warning', doNotWarn)
+
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.teardown(() => {
+    fastify.close()
+    process.removeListener('warning', doNotWarn)
+  })
   fastify.listen({ port: 0 }, (err) => {
     t.equal(fastify.server.address().address, localhost)
     t.error(err)
@@ -56,13 +68,17 @@ test('listen accepts a callback', t => {
 })
 
 test('listen accepts options and a callback', t => {
-  process.on('warning', () => {
-    t.fail('should not be deprecated')
-  })
-
   t.plan(1)
+  const doNotWarn = () => {
+    t.fail('should not be deprecated')
+  }
+  process.on('warning', doNotWarn)
+
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.teardown(() => {
+    fastify.close()
+    process.removeListener('warning', doNotWarn)
+  })
   fastify.listen({
     port: 0,
     host: 'localhost',


### PR DESCRIPTION
This PR is for removing the warning listener from the node process in server listen tests ([ref](https://github.com/fastify/fastify/pull/5590#discussion_r1693983872))

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
