### PR TITLE
refactor: remove FSTDEP007

### DIFF
--- a/docs/Reference/Warnings.md
+++ b/docs/Reference/Warnings.md
@@ -8,7 +8,6 @@
     - [FSTWRN001](#FSTWRN001)
     - [FSTWRN002](#FSTWRN002)
   - [Fastify Deprecation Codes](#fastify-deprecation-codes)
-    - [FSTDEP007](#FSTDEP007)
     - [FSTDEP008](#FSTDEP008)
     - [FSTDEP009](#FSTDEP009)
     - [FSTDEP010](#FSTDEP010)
@@ -70,7 +69,6 @@ Deprecation codes are further supported by the Node.js CLI options:
 
 | Code | Description | How to solve | Discussion |
 | ---- | ----------- | ------------ | ---------- |
-| <a id="FSTDEP007">FSTDEP007</a> | You are trying to set a HEAD route using `exposeHeadRoute` route flag when a sibling route is already set. | Remove `exposeHeadRoutes` or explicitly set `exposeHeadRoutes` to `false` | [#2700](https://github.com/fastify/fastify/pull/2700) |
 | <a id="FSTDEP008">FSTDEP008</a> | You are using route constraints via the route `{version: "..."}` option.  |  Use `{constraints: {version: "..."}}` option.  | [#2682](https://github.com/fastify/fastify/pull/2682) |
 | <a id="FSTDEP009">FSTDEP009</a> | You are using a custom route versioning strategy via the server `{versioning: "..."}` option. |  Use `{constraints: {version: "..."}}` option.  | [#2682](https://github.com/fastify/fastify/pull/2682) |
 | <a id="FSTDEP010">FSTDEP010</a> | Modifying the `reply.sent` property is deprecated. | Use the `reply.hijack()` method. | [#3140](https://github.com/fastify/fastify/pull/3140) |

--- a/lib/route.js
+++ b/lib/route.js
@@ -7,7 +7,6 @@ const { onRequestAbortHookRunner, lifecycleHooks, preParsingHookRunner, onTimeou
 const { normalizeSchema } = require('./schemas')
 const { parseHeadOnSendHandlers } = require('./headRoute')
 const {
-  FSTDEP007,
   FSTDEP008
 } = require('./warnings')
 
@@ -340,11 +339,6 @@ function buildRouting (options) {
       const headHandler = router.findRoute('HEAD', opts.url, constraints)
       const hasHEADHandler = headHandler !== null
 
-      // remove the head route created by fastify
-      if (isHeadRoute && hasHEADHandler && !context[kRouteByFastify] && headHandler.store[kRouteByFastify]) {
-        router.off('HEAD', opts.url, constraints)
-      }
-
       try {
         router.on(opts.method, opts.url, { constraints }, routeHandler, context)
       } catch (error) {
@@ -425,8 +419,6 @@ function buildRouting (options) {
       if (shouldExposeHead && isGetRoute && !isHeadRoute && !hasHEADHandler) {
         const onSendHandlers = parseHeadOnSendHandlers(headOpts.onSend)
         prepareRoute.call(this, { method: 'HEAD', url: path, options: { ...headOpts, onSend: onSendHandlers }, isFastify: true })
-      } else if (hasHEADHandler && exposeHeadRoute) {
-        FSTDEP007()
       }
     }
   }

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -4,7 +4,6 @@ const { createDeprecation, createWarning } = require('process-warning')
 
 /**
  * Deprecation codes:
- *   - FSTDEP007
  *   - FSTDEP008
  *   - FSTDEP009
  *   - FSTDEP010
@@ -19,11 +18,6 @@ const { createDeprecation, createWarning } = require('process-warning')
  *   - FSTWRN001
  *   - FSTSEC001
  */
-
-const FSTDEP007 = createDeprecation({
-  code: 'FSTDEP007',
-  message: 'You are trying to set a HEAD route using "exposeHeadRoute" route flag when a sibling route is already set. See documentation for more info.'
-})
 
 const FSTDEP008 = createDeprecation({
   code: 'FSTDEP008',
@@ -95,7 +89,6 @@ const FSTSEC001 = createWarning({
 })
 
 module.exports = {
-  FSTDEP007,
   FSTDEP008,
   FSTDEP009,
   FSTDEP010,

--- a/test/http-methods/head.test.js
+++ b/test/http-methods/head.test.js
@@ -59,12 +59,12 @@ test('shorthand - head', t => {
 test('shorthand - custom head', t => {
   t.plan(1)
   try {
-    fastify.get('/proxy/*', function (req, reply) {
+    fastify.head('/proxy/*', function (req, reply) {
+      reply.headers({ 'x-foo': 'bar' })
       reply.code(200).send(null)
     })
 
-    fastify.head('/proxy/*', function (req, reply) {
-      reply.headers({ 'x-foo': 'bar' })
+    fastify.get('/proxy/*', function (req, reply) {
       reply.code(200).send(null)
     })
 
@@ -77,12 +77,12 @@ test('shorthand - custom head', t => {
 test('shorthand - custom head with constraints', t => {
   t.plan(1)
   try {
-    fastify.get('/proxy/*', { constraints: { version: '1.0.0' } }, function (req, reply) {
+    fastify.head('/proxy/*', { constraints: { version: '1.0.0' } }, function (req, reply) {
+      reply.headers({ 'x-foo': 'bar' })
       reply.code(200).send(null)
     })
 
-    fastify.head('/proxy/*', { constraints: { version: '1.0.0' } }, function (req, reply) {
-      reply.headers({ 'x-foo': 'bar' })
+    fastify.get('/proxy/*', { constraints: { version: '1.0.0' } }, function (req, reply) {
       reply.code(200).send(null)
     })
 
@@ -105,62 +105,6 @@ test('shorthand - should not reset a head route', t => {
 
     t.pass()
   } catch (e) {
-    t.fail()
-  }
-})
-
-test('shorthand - should override head route when setting multiple routes', t => {
-  t.plan(1)
-  try {
-    fastify.route({
-      method: 'GET',
-      url: '/query2',
-      handler: function (req, reply) {
-        reply.headers({ 'x-foo': 'bar' })
-        reply.code(200).send(null)
-      }
-    })
-
-    fastify.route({
-      method: ['POST', 'PUT', 'HEAD'],
-      url: '/query2',
-      handler: function (req, reply) {
-        reply.headers({ 'x-foo': 'bar' })
-        reply.code(200).send(null)
-      }
-    })
-
-    t.pass()
-  } catch (e) {
-    console.log(e)
-    t.fail()
-  }
-})
-
-test('shorthand - should override head route when setting multiple routes', t => {
-  t.plan(1)
-  try {
-    fastify.route({
-      method: ['GET'],
-      url: '/query3',
-      handler: function (req, reply) {
-        reply.headers({ 'x-foo': 'bar' })
-        reply.code(200).send(null)
-      }
-    })
-
-    fastify.route({
-      method: ['POST', 'PUT', 'HEAD'],
-      url: '/query3',
-      handler: function (req, reply) {
-        reply.headers({ 'x-foo': 'bar' })
-        reply.code(200).send(null)
-      }
-    })
-
-    t.pass()
-  } catch (e) {
-    console.log(e)
     t.fail()
   }
 })
@@ -326,30 +270,6 @@ fastify.listen({ port: 0 }, err => {
       url: 'http://localhost:' + fastify.server.address().port + '/query1'
     }, (err, response) => {
       t.error(err)
-      t.equal(response.statusCode, 200)
-    })
-  })
-
-  test('shorthand - should override head route when setting multiple routes', t => {
-    t.plan(3)
-    sget({
-      method: 'HEAD',
-      url: 'http://localhost:' + fastify.server.address().port + '/query2'
-    }, (err, response) => {
-      t.error(err)
-      t.equal(response.headers['x-foo'], 'bar')
-      t.equal(response.statusCode, 200)
-    })
-  })
-
-  test('shorthand - should override head route when setting multiple routes', t => {
-    t.plan(3)
-    sget({
-      method: 'HEAD',
-      url: 'http://localhost:' + fastify.server.address().port + '/query3'
-    }, (err, response) => {
-      t.error(err)
-      t.equal(response.headers['x-foo'], 'bar')
       t.equal(response.statusCode, 200)
     })
   })

--- a/test/route.7.test.js
+++ b/test/route.7.test.js
@@ -176,18 +176,9 @@ test('Set a custom HEAD route before GET one without disabling exposeHeadRoutes 
 })
 
 test('Set a custom HEAD route before GET one without disabling exposeHeadRoutes (route)', t => {
-  t.plan(7)
+  t.plan(6)
 
-  function onWarning () {
-    t.pass('warning emitted')
-  }
-
-  const route = proxyquire('../lib/route', {
-    './warnings': {
-      FSTDEP007: onWarning
-    }
-  })
-  const fastify = proxyquire('..', { './lib/route.js': route })()
+  const fastify = Fastify()
 
   const resBuffer = Buffer.from('I am a coffee!')
 

--- a/test/route.7.test.js
+++ b/test/route.7.test.js
@@ -5,7 +5,6 @@ const split = require('split2')
 const t = require('tap')
 const test = t.test
 const Fastify = require('..')
-const proxyquire = require('proxyquire')
 
 test("HEAD route should handle stream.on('error')", t => {
   t.plan(6)


### PR DESCRIPTION
Fixes #5596

`HEAD` route must register before `GET` route if `exposeHeadRoute` is enabled.
It can prevents the route b-tree rebuild.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
