### PR TITLE
Fix stub logger setbindings

### DIFF
--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -9,5 +9,5 @@ jobs:
     steps:
     - uses: fastify/action-pr-title@v0
       with:
-        regex: '/^(build|chore|ci|docs|feat|types|fix|perf|refactor|style|test)(?:\([^\):]*\))?:\s/'
+        regex: '/^(build|chore|ci|docs|feat|types|fix|perf|refactor|style|test)(?:\([^\):]*\))?!?:\s/'
         github-token: ${{ github.token }}

--- a/.npmignore
+++ b/.npmignore
@@ -16,3 +16,4 @@ EXPENSE_POLICY.md
 # test certification
 test/https/fastify.cert
 test/https/fastify.key
+.vscode/*

--- a/.npmignore
+++ b/.npmignore
@@ -3,10 +3,13 @@
 .gitignore
 .github
 .nyc_output
+.DS_Store
 coverage/
 tools/
+.tap/
 CODE_OF_CONDUCT.md
 CONTRIBUTING.md
+EXPENSE_POLICY.md
 .clinic
 .gitpod.yml
 

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -14,6 +14,7 @@ _Be the first!_
 ## Tier 3
 
 - [Mercedes-Benz Group](https://github.com/mercedes-benz)
+- [Val Town, Inc.](https://opencollective.com/valtown)
 
 ## Tier 2
 

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -17,7 +17,7 @@
   - [.trailer(key, function)](#trailerkey-function)
   - [.hasTrailer(key)](#hastrailerkey)
   - [.removeTrailer(key)](#removetrailerkey)
-  - [.redirect([code ,] dest)](#redirectcode--dest)
+  - [.redirect(dest, [code ,])](#redirectdest--code)
   - [.callNotFound()](#callnotfound)
   - [.getResponseTime()](#getresponsetime)
   - [.type(contentType)](#typecontenttype)
@@ -62,8 +62,8 @@ since the request was received by Fastify.
 - `.hasTrailer(key)` - Determine if a trailer has been set.
 - `.removeTrailer(key)` - Remove the value of a previously set trailer.
 - `.type(value)` - Sets the header `Content-Type`.
-- `.redirect([code,] dest)` - Redirect to the specified URL, the status code is
-  optional (default to `302`).
+- `.redirect(dest, [code,])` - Redirect to the specified URL, the status code is
+  optional (defaults to `302`).
 - `.callNotFound()` - Invokes the custom not found handler.
 - `.serialize(payload)` - Serializes the specified payload using the default
   JSON serializer or using the custom serializer (if one is set) and returns the
@@ -299,7 +299,7 @@ reply.getTrailer('server-timing') // undefined
 ```
 
 
-### .redirect([code ,] dest)
+### .redirect(dest, [code ,])
 <a id="redirect"></a>
 
 Redirects a request to the specified URL, the status code is optional, default
@@ -320,7 +320,7 @@ reply.redirect('/home')
 Example (no `reply.code()` call) sets status code to `303` and redirects to
 `/home`
 ```js
-reply.redirect(303, '/home')
+reply.redirect('/home', 303)
 ```
 
 Example (`reply.code()` call) sets status code to `303` and redirects to `/home`
@@ -330,7 +330,7 @@ reply.code(303).redirect('/home')
 
 Example (`reply.code()` call) sets status code to `302` and redirects to `/home`
 ```js
-reply.code(303).redirect(302, '/home')
+reply.code(303).redirect('/home', 302)
 ```
 
 ### .callNotFound()

--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -43,7 +43,8 @@ fastify.route(options)
   [here](./Validation-and-Serialization.md) for more info.
 
   * `body`: validates the body of the request if it is a POST, PUT, PATCH,
-    TRACE, SEARCH, PROPFIND, PROPPATCH or LOCK method.
+    TRACE, SEARCH, PROPFIND, PROPPATCH, COPY, MOVE, MKCOL, REPORT, MKCALENDAR
+    or LOCK method.
   * `querystring` or `query`: validates the querystring. This can be a complete
     JSON Schema object, with the property `type` of `object` and `properties`
     object of parameters, or simply the values of what would be contained in the

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -235,6 +235,28 @@ const schema = {
 fastify.post('/the/url', { schema }, handler)
 ```
 
+For `body` schema, it is further possible to differentiate the schema per content
+type by nesting the schemas inside `content` property. The schema validation
+will be applied based on the `Content-Type` header in the request.
+
+```js
+fastify.post('/the/url', {
+  schema: {
+    body: {
+      content: {
+        'application/json': {
+          schema: { type: 'object' }
+        },
+        'text/plain': {
+          schema: { type: 'string' }
+        }
+        // Other content types will not be validated
+      }
+    }
+  }
+}, handler)
+```
+
 *Note that Ajv will try to [coerce](https://ajv.js.org/coercion.html) the values
 to the types specified in your schema `type` keywords, both to pass the
 validation and to use the correctly typed data afterwards.*

--- a/docs/Reference/Warnings.md
+++ b/docs/Reference/Warnings.md
@@ -24,6 +24,7 @@
     - [FSTDEP018](#FSTDEP018)
     - [FSTDEP019](#FSTDEP019)
     - [FSTDEP020](#FSTDEP020)
+    - [FSTDEP021](#FSTDEP021)
 
 
 ## Warnings
@@ -90,3 +91,4 @@ Deprecation codes are further supported by the Node.js CLI options:
 | <a id="FSTDEP018">FSTDEP018</a> | You are accessing the deprecated `request.routerMethod` property. | Use `request.routeOptions.method`. | [#4470](https://github.com/fastify/fastify/pull/4470) |
 | <a id="FSTDEP019">FSTDEP019</a> | You are accessing the deprecated `reply.context` property. | Use `reply.routeOptions.config` or `reply.routeOptions.schema`. | [#5032](https://github.com/fastify/fastify/pull/5032) [#5084](https://github.com/fastify/fastify/pull/5084) |
 | <a id="FSTDEP020">FSTDEP020</a> | You are using the deprecated `reply.getReponseTime()` method. | Use the `reply.elapsedTime` property instead. | [#5263](https://github.com/fastify/fastify/pull/5263) |
+| <a id="FSTDEP021">FSTDEP021</a> | The `reply.redirect()` method has a new signature: `reply.redirect(url: string, code?: number)`. It will be enforced in `fastify@v5`'. | [#5483](https://github.com/fastify/fastify/pull/5483) |

--- a/fastify.js
+++ b/fastify.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const VERSION = '4.28.0'
+const VERSION = '4.28.1'
 
 const Avvio = require('avvio')
 const http = require('node:http')

--- a/fastify.js
+++ b/fastify.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const VERSION = '4.27.0'
+const VERSION = '4.28.0'
 
 const Avvio = require('avvio')
 const http = require('node:http')

--- a/lib/error-serializer.js
+++ b/lib/error-serializer.js
@@ -2,10 +2,8 @@
 /* istanbul ignore file */
 
   'use strict'
-  const { dependencies } = require('fast-json-stringify/lib/standalone')
 
-  const { Serializer, Validator } = dependencies
-
+  const Serializer = require('fast-json-stringify/lib/serializer')
   const serializerState = {"mode":"standalone"}
   const serializer = Serializer.restoreFromState(serializerState)
 
@@ -15,6 +13,18 @@
   module.exports = function anonymous(validator,serializer
 ) {
 
+    const JSON_STR_BEGIN_OBJECT = '{'
+    const JSON_STR_END_OBJECT = '}'
+    const JSON_STR_BEGIN_ARRAY = '['
+    const JSON_STR_END_ARRAY = ']'
+    const JSON_STR_COMMA = ','
+    const JSON_STR_COLONS = ':'
+    const JSON_STR_QUOTE = '"'
+    const JSON_STR_EMPTY_OBJECT = JSON_STR_BEGIN_OBJECT + JSON_STR_END_OBJECT
+    const JSON_STR_EMPTY_ARRAY = JSON_STR_BEGIN_ARRAY + JSON_STR_END_ARRAY
+    const JSON_STR_EMPTY_STRING = JSON_STR_QUOTE + JSON_STR_QUOTE
+    const JSON_STR_NULL = 'null'
+  
     
   
     // #
@@ -23,36 +33,83 @@
     ? input.toJSON()
     : input
   
-      if (obj === null) return '{}'
+      if (obj === null) return JSON_STR_EMPTY_OBJECT
 
-      let json = '{'
+      let value
+let json = JSON_STR_BEGIN_OBJECT
 let addComma = false
 
-      if (obj["statusCode"] !== undefined) {
-        !addComma && (addComma = true) || (json += ',')
+      value = obj["statusCode"]
+      if (value !== undefined) {
+        !addComma && (addComma = true) || (json += JSON_STR_COMMA)
         json += "\"statusCode\":"
-        json += serializer.asNumber(obj["statusCode"])
+        json += serializer.asNumber(value)
       }
 
-      if (obj["code"] !== undefined) {
-        !addComma && (addComma = true) || (json += ',')
+      value = obj["code"]
+      if (value !== undefined) {
+        !addComma && (addComma = true) || (json += JSON_STR_COMMA)
         json += "\"code\":"
-        json += serializer.asString(obj["code"])
+        
+        if (typeof value !== 'string') {
+          if (value === null) {
+            json += JSON_STR_EMPTY_STRING
+          } else if (value instanceof Date) {
+            json += JSON_STR_QUOTE + value.toISOString() + JSON_STR_QUOTE
+          } else if (value instanceof RegExp) {
+            json += serializer.asString(value.source)
+          } else {
+            json += serializer.asString(value.toString())
+          }
+        } else {
+          json += serializer.asString(value)
+        }
+        
       }
 
-      if (obj["error"] !== undefined) {
-        !addComma && (addComma = true) || (json += ',')
+      value = obj["error"]
+      if (value !== undefined) {
+        !addComma && (addComma = true) || (json += JSON_STR_COMMA)
         json += "\"error\":"
-        json += serializer.asString(obj["error"])
+        
+        if (typeof value !== 'string') {
+          if (value === null) {
+            json += JSON_STR_EMPTY_STRING
+          } else if (value instanceof Date) {
+            json += JSON_STR_QUOTE + value.toISOString() + JSON_STR_QUOTE
+          } else if (value instanceof RegExp) {
+            json += serializer.asString(value.source)
+          } else {
+            json += serializer.asString(value.toString())
+          }
+        } else {
+          json += serializer.asString(value)
+        }
+        
       }
 
-      if (obj["message"] !== undefined) {
-        !addComma && (addComma = true) || (json += ',')
+      value = obj["message"]
+      if (value !== undefined) {
+        !addComma && (addComma = true) || (json += JSON_STR_COMMA)
         json += "\"message\":"
-        json += serializer.asString(obj["message"])
+        
+        if (typeof value !== 'string') {
+          if (value === null) {
+            json += JSON_STR_EMPTY_STRING
+          } else if (value instanceof Date) {
+            json += JSON_STR_QUOTE + value.toISOString() + JSON_STR_QUOTE
+          } else if (value instanceof RegExp) {
+            json += serializer.asString(value.source)
+          } else {
+            json += serializer.asString(value.toString())
+          }
+        } else {
+          json += serializer.asString(value)
+        }
+        
       }
 
-    return json + '}'
+    return json + JSON_STR_END_OBJECT
   
     }
   

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -28,7 +28,8 @@ function handleRequest (err, request, reply) {
   const contentType = headers['content-type']
 
   if (method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'TRACE' || method === 'SEARCH' ||
-    method === 'PROPFIND' || method === 'PROPPATCH' || method === 'LOCK' || method === 'REPORT' || method === 'MKCALENDAR') {
+    method === 'PROPFIND' || method === 'PROPPATCH' || method === 'LOCK' || method === 'COPY' || method === 'MOVE' ||
+    method === 'MKCOL' || method === 'REPORT' || method === 'MKCALENDAR') {
     if (contentType === undefined) {
       if (
         headers['transfer-encoding'] === undefined &&

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -72,6 +72,7 @@ function now () {
 function createLogger (options) {
   if (!options.logger) {
     const logger = nullLogger
+    logger.setBindings = () => {}
     logger.child = () => logger
     return { logger, hasLogger: false }
   }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -726,7 +726,7 @@ function sendStream (payload, res, reply) {
       if (res.headersSent || reply.request.raw.aborted === true) {
         if (!errorLogged) {
           errorLogged = true
-          logStreamError(reply.log, err, res)
+          logStreamError(reply.log, err, reply)
         }
         res.destroy()
       } else {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -55,7 +55,7 @@ const {
   FST_ERR_MISSING_SERIALIZATION_FN,
   FST_ERR_MISSING_CONTENTTYPE_SERIALIZATION_FN
 } = require('./errors')
-const { FSTDEP010, FSTDEP013, FSTDEP019, FSTDEP020 } = require('./warnings')
+const { FSTDEP010, FSTDEP013, FSTDEP019, FSTDEP020, FSTDEP021 } = require('./warnings')
 
 const toString = Object.prototype.toString
 
@@ -457,9 +457,15 @@ Reply.prototype.type = function (type) {
   return this
 }
 
-Reply.prototype.redirect = function (code, url) {
-  if (typeof code === 'string') {
-    url = code
+Reply.prototype.redirect = function (url, code) {
+  if (typeof url === 'number') {
+    FSTDEP021()
+    const temp = code
+    code = url
+    url = temp
+  }
+
+  if (!code) {
     code = this[kReplyHasStatusCode] ? this.raw.statusCode : 302
   }
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -168,7 +168,11 @@ function buildRouting (options) {
   }
 
   function hasRoute ({ options }) {
-    return findRoute(options) !== null
+    const normalizedMethod = options.method?.toUpperCase() ?? ''
+    return findRoute({
+      ...options,
+      method: normalizedMethod
+    }) !== null
   }
 
   function findRoute (options) {

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -73,6 +73,19 @@ function normalizeSchema (routeSchemas, serverOptions) {
   for (const key of SCHEMAS_SOURCE) {
     const schema = routeSchemas[key]
     if (schema && !isCustomSchemaPrototype(schema)) {
+      if (key === 'body' && schema.content) {
+        const contentProperty = schema.content
+        const keys = Object.keys(contentProperty)
+        for (let i = 0; i < keys.length; i++) {
+          const contentType = keys[i]
+          const contentSchema = contentProperty[contentType].schema
+          if (!contentSchema) {
+            throw new FST_ERR_SCH_CONTENT_MISSING_SCHEMA(contentType)
+          }
+          routeSchemas.body.content[contentType].schema = getSchemaAnyway(contentSchema, serverOptions.jsonShorthand)
+        }
+        continue
+      }
       routeSchemas[key] = getSchemaAnyway(schema, serverOptions.jsonShorthand)
     }
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -72,7 +72,8 @@ function createServer (options, httpHandler) {
     } else {
       host = listenOptions.host
     }
-    if (Object.prototype.hasOwnProperty.call(listenOptions, 'host') === false) {
+    if (Object.prototype.hasOwnProperty.call(listenOptions, 'host') === false ||
+      listenOptions.host == null) {
       listenOptions.host = host
     }
     if (host === 'localhost') {

--- a/lib/server.js
+++ b/lib/server.js
@@ -220,6 +220,7 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
 function listenCallback (server, listenOptions) {
   const wrap = (err) => {
     server.removeListener('error', wrap)
+    server.removeListener('listening', wrap)
     if (!err) {
       const address = logServerAddress.call(this, server, listenOptions.listenTextResolver || defaultResolveServerListeningText)
       listenOptions.cb(null, address)
@@ -240,7 +241,8 @@ function listenCallback (server, listenOptions) {
 
     server.once('error', wrap)
     if (!this[kState].closing) {
-      server.listen(listenOptions, wrap)
+      server.once('listening', wrap)
+      server.listen(listenOptions)
       this[kState].listening = true
     }
   }
@@ -255,25 +257,33 @@ function listenPromise (server, listenOptions) {
 
   return this.ready().then(() => {
     let errEventHandler
+    let listeningEventHandler
+    function cleanup () {
+      server.removeListener('error', errEventHandler)
+      server.removeListener('listening', listeningEventHandler)
+    }
     const errEvent = new Promise((resolve, reject) => {
       errEventHandler = (err) => {
+        cleanup()
         this[kState].listening = false
         reject(err)
       }
       server.once('error', errEventHandler)
     })
-    const listen = new Promise((resolve, reject) => {
-      server.listen(listenOptions, () => {
-        server.removeListener('error', errEventHandler)
+    const listeningEvent = new Promise((resolve, reject) => {
+      listeningEventHandler = () => {
+        cleanup()
+        this[kState].listening = true
         resolve(logServerAddress.call(this, server, listenOptions.listenTextResolver || defaultResolveServerListeningText))
-      })
-      // we set it afterwards because listen can throw
-      this[kState].listening = true
+      }
+      server.once('listening', listeningEventHandler)
     })
+
+    server.listen(listenOptions)
 
     return Promise.race([
       errEvent, // e.g invalid port range error is always emitted before the server listening
-      listen
+      listeningEvent
     ])
   })
 }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -87,7 +87,17 @@ function compileSchemasForValidation (context, compile, isCustom) {
   }
 
   if (schema.body) {
-    context[bodySchema] = compile({ schema: schema.body, method, url, httpPart: 'body' })
+    const contentProperty = schema.body.content
+    if (contentProperty) {
+      const contentTypeSchemas = {}
+      for (const contentType of Object.keys(contentProperty)) {
+        const contentSchema = contentProperty[contentType].schema
+        contentTypeSchemas[contentType] = compile({ schema: contentSchema, method, url, httpPart: 'body', contentType })
+      }
+      context[bodySchema] = contentTypeSchemas
+    } else {
+      context[bodySchema] = compile({ schema: schema.body, method, url, httpPart: 'body' })
+    }
   } else if (Object.prototype.hasOwnProperty.call(schema, 'body')) {
     FSTWRN001('body', method, url)
   }
@@ -140,7 +150,18 @@ function validate (context, request, execution) {
   }
 
   if (runExecution || !execution.skipBody) {
-    const body = validateParam(context[bodySchema], request, 'body')
+    let validatorFunction = null
+    if (typeof context[bodySchema] === 'function') {
+      validatorFunction = context[bodySchema]
+    } else if (context[bodySchema]) {
+      // TODO: add request.contentType and reuse it here
+      const contentType = request.headers['content-type']?.split(';', 1)[0]
+      const contentSchema = context[bodySchema][contentType]
+      if (contentSchema) {
+        validatorFunction = contentSchema
+      }
+    }
+    const body = validateParam(validatorFunction, request, 'body')
     if (body) {
       if (typeof body.then !== 'function') {
         return wrapValidationError(body, 'body', context.schemaErrorFormatter)

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -82,6 +82,11 @@ const FSTDEP020 = createDeprecation({
   message: 'You are using the deprecated "reply.getResponseTime()" method. Use the "reply.elapsedTime" property instead. Method "reply.getResponseTime()" will be removed in `fastify@5`.'
 })
 
+const FSTDEP021 = createDeprecation({
+  code: 'FSTDEP021',
+  message: 'The `reply.redirect()` method has a new signature: `reply.redirect(url: string, code?: number)`. It will be enforced in `fastify@v5`'
+})
+
 const FSTWRN001 = createWarning({
   name: 'FastifyWarning',
   code: 'FSTWRN001',
@@ -113,6 +118,7 @@ module.exports = {
   FSTDEP018,
   FSTDEP019,
   FSTDEP020,
+  FSTDEP021,
   FSTWRN001,
   FSTWRN002
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify",
-  "version": "4.27.0",
+  "version": "4.28.0",
   "description": "Fast and low overhead web framework, for Node.js",
   "main": "fastify.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify",
-  "version": "4.28.0",
+  "version": "4.28.1",
   "description": "Fast and low overhead web framework, for Node.js",
   "main": "fastify.js",
   "type": "commonjs",

--- a/test/close-pipelining.test.js
+++ b/test/close-pipelining.test.js
@@ -36,8 +36,15 @@ test('Should return 503 while closing - pipelining', async t => {
   await instance.close()
 })
 
-const isNodeVersionGte1819 = semver.gte(process.version, '18.19.0')
-test('Should not return 503 while closing - pipelining - return503OnClosing: false, skip Node >= v18.19.x', { skip: isNodeVersionGte1819 }, async t => {
+// default enable of idle closing idle connection is accidentally backported to 18.19.0 and fixed in 18.20.3
+// Refs: https://github.com/nodejs/node/releases/tag/v18.20.3
+const isNodeDefaultClosingIdleConnection =
+  (
+    semver.gte(process.version, '18.19.0') &&
+    semver.lt(process.version, '18.20.3')
+  ) ||
+  semver.gte(process.version, '19.0.0')
+test('Should not return 503 while closing - pipelining - return503OnClosing: false, skip when Node default closing idle connection', { skip: isNodeDefaultClosingIdleConnection }, async t => {
   const fastify = Fastify({
     return503OnClosing: false,
     forceCloseConnections: false
@@ -67,8 +74,8 @@ test('Should not return 503 while closing - pipelining - return503OnClosing: fal
   await instance.close()
 })
 
-test('Should close the socket abruptly - pipelining - return503OnClosing: false, skip Node < v18.19.x', { skip: !isNodeVersionGte1819 }, async t => {
-  // Since Node v18, we will always invoke server.closeIdleConnections()
+test('Should close the socket abruptly - pipelining - return503OnClosing: false, skip when Node not default closing idle connection', { skip: !isNodeDefaultClosingIdleConnection }, async t => {
+  // Since Node v19, we will always invoke server.closeIdleConnections()
   // therefore our socket will be closed
   const fastify = Fastify({
     return503OnClosing: false,

--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -12,7 +12,10 @@ test('can be created - copy', t => {
       method: 'COPY',
       url: '*',
       handler: function (req, reply) {
-        reply.code(204).send()
+        reply.code(204)
+          .header('location', req.headers.destination)
+          .header('body', req.body.toString())
+          .send()
       }
     })
     t.pass()
@@ -26,15 +29,19 @@ fastify.listen({ port: 0 }, err => {
   t.teardown(() => { fastify.close() })
 
   test('request - copy', t => {
-    t.plan(2)
+    t.plan(4)
     sget({
       url: `http://localhost:${fastify.server.address().port}/test.txt`,
       method: 'COPY',
       headers: {
-        Destination: '/test2.txt'
-      }
-    }, (err, response, body) => {
+        destination: '/test2.txt',
+        'Content-Type': 'text/plain'
+      },
+      body: '/test3.txt'
+    }, (err, response) => {
       t.error(err)
+      t.equal(response.headers.location, '/test2.txt')
+      t.equal(response.headers.body, '/test3.txt')
       t.equal(response.statusCode, 204)
     })
   })

--- a/test/has-route.test.js
+++ b/test/has-route.test.js
@@ -5,7 +5,7 @@ const test = t.test
 const Fastify = require('../fastify')
 
 test('hasRoute', t => {
-  t.plan(4)
+  t.plan(5)
   const test = t.test
   const fastify = Fastify()
 
@@ -72,6 +72,22 @@ test('hasRoute', t => {
     t.equal(fastify.hasRoute({
       method: 'GET',
       url: '/example/12345.png'
+    }), true)
+  })
+
+  test('hasRoute - finds a route even if method is not uppercased', t => {
+    t.plan(1)
+    fastify.route({
+      method: 'GET',
+      url: '/equal',
+      handler: function (req, reply) {
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    t.equal(fastify.hasRoute({
+      method: 'get',
+      url: '/equal'
     }), true)
   })
 })

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -19,7 +19,7 @@ const {
 } = require('../../lib/symbols')
 const fs = require('node:fs')
 const path = require('node:path')
-const { FSTDEP010, FSTDEP019, FSTDEP020 } = require('../../lib/warnings')
+const { FSTDEP010, FSTDEP019, FSTDEP020, FSTDEP021 } = require('../../lib/warnings')
 
 const agent = new http.Agent({ keepAlive: false })
 
@@ -250,7 +250,7 @@ test('within an instance', t => {
   })
 
   fastify.get('/redirect-code', function (req, reply) {
-    reply.redirect(301, '/')
+    reply.redirect('/', 301)
   })
 
   fastify.get('/redirect-code-before-call', function (req, reply) {
@@ -258,7 +258,7 @@ test('within an instance', t => {
   })
 
   fastify.get('/redirect-code-before-call-overwrite', function (req, reply) {
-    reply.code(307).redirect(302, '/')
+    reply.code(307).redirect('/', 302)
   })
 
   fastify.get('/custom-serializer', function (req, reply) {
@@ -2092,6 +2092,36 @@ test('redirect to an invalid URL should not crash the server', async t => {
   }
 
   await fastify.close()
+})
+
+test('redirect with deprecated signature should warn', t => {
+  t.plan(4)
+
+  process.removeAllListeners('warning')
+  process.on('warning', onWarning)
+  function onWarning (warning) {
+    t.equal(warning.name, 'DeprecationWarning')
+    t.equal(warning.code, FSTDEP021.code)
+  }
+
+  const fastify = Fastify()
+
+  fastify.get('/', (req, reply) => {
+    reply.redirect(302, '/new')
+  })
+
+  fastify.get('/new', (req, reply) => {
+    reply.send('new')
+  })
+
+  fastify.inject({ method: 'GET', url: '/' }, (err, res) => {
+    t.error(err)
+    t.pass()
+
+    process.removeListener('warning', onWarning)
+  })
+
+  FSTDEP021.emitted = false
 })
 
 test('invalid response headers should not crash the server', async t => {

--- a/test/internals/validation.test.js
+++ b/test/internals/validation.test.js
@@ -63,7 +63,7 @@ test('build schema - output schema', t => {
   t.equal(typeof opts[symbols.responseSchema]['201'], 'function')
 })
 
-test('build schema - payload schema', t => {
+test('build schema - body schema', t => {
   t.plan(1)
   const opts = {
     schema: {
@@ -77,6 +77,32 @@ test('build schema - payload schema', t => {
   }
   validation.compileSchemasForValidation(opts, ({ schema, method, url, httpPart }) => ajv.compile(schema))
   t.equal(typeof opts[symbols.bodySchema], 'function')
+})
+
+test('build schema - body with multiple content type schemas', t => {
+  t.plan(2)
+  const opts = {
+    schema: {
+      body: {
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                hello: { type: 'string' }
+              }
+            }
+          },
+          'text/plain': {
+            schema: { type: 'string' }
+          }
+        }
+      }
+    }
+  }
+  validation.compileSchemasForValidation(opts, ({ schema, method, url, httpPart }) => ajv.compile(schema))
+  t.type(opts[symbols.bodySchema]['application/json'], 'function')
+  t.type(opts[symbols.bodySchema]['text/plain'], 'function')
 })
 
 test('build schema - avoid repeated normalize schema', t => {

--- a/test/listen.1.test.js
+++ b/test/listen.1.test.js
@@ -99,3 +99,39 @@ test('listen after Promise.resolve()', t => {
       })
     })
 })
+
+test('listen works with undefined host', async t => {
+  const doNotWarn = () => {
+    t.fail('should not be deprecated')
+  }
+  process.on('warning', doNotWarn)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+  t.teardown(() => {
+    fastify.close()
+    process.removeListener('warning', doNotWarn)
+  })
+  await fastify.listen({ host: undefined, port: 0 })
+  const address = fastify.server.address()
+  t.equal(address.address, localhost)
+  t.ok(address.port > 0)
+})
+
+test('listen works with null host', async t => {
+  const doNotWarn = () => {
+    t.fail('should not be deprecated')
+  }
+  process.on('warning', doNotWarn)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+  t.teardown(() => {
+    fastify.close()
+    process.removeListener('warning', doNotWarn)
+  })
+  await fastify.listen({ host: null, port: 0 })
+  const address = fastify.server.address()
+  t.equal(address.address, localhost)
+  t.ok(address.port > 0)
+})

--- a/test/listen.5.test.js
+++ b/test/listen.5.test.js
@@ -1,0 +1,88 @@
+'use strict'
+
+const { test } = require('tap')
+const net = require('node:net')
+const Fastify = require('../fastify')
+const { once } = require('node:events')
+
+test('same port conflict and success should not fire callback multiple times - callback', async (t) => {
+  t.plan(7)
+  const server = net.createServer()
+  server.listen({ port: 0, host: '127.0.0.1' })
+  await once(server, 'listening')
+  const option = { port: server.address().port, host: server.address().address }
+  let count = 0
+  const fastify = Fastify()
+  function callback (err) {
+    switch (count) {
+      case 6: {
+        // success in here
+        t.error(err)
+        fastify.close((err) => {
+          t.error(err)
+        })
+        break
+      }
+      case 5: {
+        server.close()
+        setTimeout(() => {
+          fastify.listen(option, callback)
+        }, 100)
+        break
+      }
+      default: {
+        // expect error
+        t.equal(err.code, 'EADDRINUSE')
+        setTimeout(() => {
+          fastify.listen(option, callback)
+        }, 100)
+      }
+    }
+    count++
+  }
+  fastify.listen(option, callback)
+})
+
+test('same port conflict and success should not fire callback multiple times - promise', async (t) => {
+  t.plan(5)
+  const server = net.createServer()
+  server.listen({ port: 0, host: '127.0.0.1' })
+  await once(server, 'listening')
+  const option = { port: server.address().port, host: server.address().address }
+  const fastify = Fastify()
+
+  try {
+    await fastify.listen(option)
+  } catch (err) {
+    t.equal(err.code, 'EADDRINUSE')
+  }
+  try {
+    await fastify.listen(option)
+  } catch (err) {
+    t.equal(err.code, 'EADDRINUSE')
+  }
+  try {
+    await fastify.listen(option)
+  } catch (err) {
+    t.equal(err.code, 'EADDRINUSE')
+  }
+  try {
+    await fastify.listen(option)
+  } catch (err) {
+    t.equal(err.code, 'EADDRINUSE')
+  }
+  try {
+    await fastify.listen(option)
+  } catch (err) {
+    t.equal(err.code, 'EADDRINUSE')
+  }
+
+  server.close()
+
+  await once(server, 'close')
+
+  // when ever we can listen, and close properly
+  // which means there is no problem on the callback
+  await fastify.listen()
+  await fastify.close()
+})

--- a/test/mkcol.test.js
+++ b/test/mkcol.test.js
@@ -12,7 +12,7 @@ test('can be created - mkcol', t => {
       method: 'MKCOL',
       url: '*',
       handler: function (req, reply) {
-        reply.code(201).send()
+        reply.code(201).header('body', req.body.toString()).send()
       }
     })
     t.pass()
@@ -26,12 +26,15 @@ fastify.listen({ port: 0 }, err => {
   t.teardown(() => { fastify.close() })
 
   test('request - mkcol', t => {
-    t.plan(2)
+    t.plan(3)
     sget({
       url: `http://localhost:${fastify.server.address().port}/test/`,
-      method: 'MKCOL'
-    }, (err, response, body) => {
+      method: 'MKCOL',
+      headers: { 'Content-Type': 'text/plain' },
+      body: '/test.txt'
+    }, (err, response) => {
       t.error(err)
+      t.equal(response.headers.body, '/test.txt')
       t.equal(response.statusCode, 201)
     })
   })

--- a/test/move.test.js
+++ b/test/move.test.js
@@ -12,9 +12,9 @@ test('shorthand - move', t => {
       method: 'MOVE',
       url: '*',
       handler: function (req, reply) {
-        const destination = req.headers.destination
         reply.code(201)
-          .header('location', destination)
+          .header('location', req.headers.destination)
+          .header('body', req.body.toString())
           .send()
       }
     })
@@ -29,17 +29,20 @@ fastify.listen({ port: 0 }, err => {
   t.teardown(() => { fastify.close() })
 
   test('request - move', t => {
-    t.plan(3)
+    t.plan(4)
     sget({
       url: `http://localhost:${fastify.server.address().port}/test.txt`,
       method: 'MOVE',
       headers: {
-        Destination: '/test2.txt'
-      }
-    }, (err, response, body) => {
+        destination: '/test2.txt',
+        'Content-Type': 'text/plain'
+      },
+      body: '/test3.txt'
+    }, (err, response) => {
       t.error(err)
       t.equal(response.statusCode, 201)
       t.equal(response.headers.location, '/test2.txt')
+      t.equal(response.headers.body, '/test3.txt')
     })
   })
 })

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -190,6 +190,27 @@ test('Should throw of the schema does not exists in input', t => {
   })
 })
 
+test('Should throw if schema is missing for content type', t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  fastify.post('/', {
+    handler: echoBody,
+    schema: {
+      body: {
+        content: {
+          'application/json': {}
+        }
+      }
+    }
+  })
+
+  fastify.ready(err => {
+    t.equal(err.code, 'FST_ERR_SCH_CONTENT_MISSING_SCHEMA')
+    t.equal(err.message, "Schema is missing for the content type 'application/json'")
+  })
+})
+
 test('Should throw of the schema does not exists in output', t => {
   t.plan(2)
   const fastify = Fastify()

--- a/test/stream-serializers.test.js
+++ b/test/stream-serializers.test.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('..')
+const Reply = require('../lib/reply')
+
+test('should serialize reply when response stream is ended', t => {
+  t.plan(3)
+  const stream = require('node:stream')
+  const fastify = Fastify({
+    logger: {
+      serializers: {
+        res (reply) {
+          t.type(reply, Reply)
+          return reply
+        }
+      }
+    }
+  })
+
+  fastify.get('/error', function (req, reply) {
+    const reallyLongStream = new stream.Readable({
+      read: () => { }
+    })
+    reply.code(200).send(reallyLongStream)
+    reply.raw.end(Buffer.from('hello\n'))
+  })
+
+  fastify.inject({
+    url: '/error',
+    method: 'GET'
+  }, (err) => {
+    t.error(err)
+    fastify.close()
+  })
+})

--- a/test/types/reply.test-d.ts
+++ b/test/types/reply.test-d.ts
@@ -29,7 +29,7 @@ const getHandler: RouteHandlerMethod = function (_request, reply) {
   expectAssignable<() => { [key: string]: number | string | string[] | undefined }>(reply.getHeaders)
   expectAssignable<(key: string) => FastifyReply>(reply.removeHeader)
   expectAssignable<(key: string) => boolean>(reply.hasHeader)
-  expectType<{(statusCode: number, url: string): FastifyReply; (url: string): FastifyReply }>(reply.redirect)
+  expectType<{(statusCode: number, url: string): FastifyReply;(url: string, statusCode?: number): FastifyReply;}>(reply.redirect)
   expectType<() => FastifyReply>(reply.hijack)
   expectType<() => void>(reply.callNotFound)
   // Test reply.getResponseTime() deprecation

--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -19,6 +19,13 @@ declare module '../../fastify' {
   interface FastifyContextConfig {
     foo: string;
     bar: number;
+    includeMessage?: boolean;
+  }
+
+  interface FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig, Logger, RequestType> {
+    message: ContextConfig extends { includeMessage: true }
+      ? string
+      : null;
   }
 }
 
@@ -35,6 +42,22 @@ const routeHandlerWithReturnValue: RouteHandlerMethod = function (request, reply
 
   return reply.send()
 }
+
+fastify().get(
+  '/',
+  { config: { foo: 'bar', bar: 100, includeMessage: true } },
+  (req) => {
+    expectType<string>(req.message)
+  }
+)
+
+fastify().get(
+  '/',
+  { config: { foo: 'bar', bar: 100, includeMessage: false } },
+  (req) => {
+    expectType<null>(req.message)
+  }
+)
 
 type LowerCaseHTTPMethods = 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete' | 'options';
 

--- a/test/types/schema.test-d.ts
+++ b/test/types/schema.test-d.ts
@@ -20,6 +20,25 @@ expectAssignable<FastifyInstance>(server.get(
   () => { }
 ))
 
+expectAssignable<FastifyInstance>(server.post(
+  '/multiple-content-schema',
+  {
+    schema: {
+      body: {
+        content: {
+          'application/json': {
+            schema: { type: 'object' }
+          },
+          'text/plain': {
+            schema: { type: 'string' }
+          }
+        }
+      }
+    }
+  },
+  () => { }
+))
+
 expectAssignable<FastifyInstance>(server.get(
   '/empty-schema',
   {

--- a/test/types/type-provider.test-d.ts
+++ b/test/types/type-provider.test-d.ts
@@ -1052,7 +1052,7 @@ expectAssignable(server.withTypeProvider<InlineHandlerProvider>().get(
 // Handlers: Auxiliary
 // -------------------------------------------------------------------
 
-interface AuxiliaryHandlerProvider extends FastifyTypeProvider { output: 'handler-auxiliary' }
+interface AuxiliaryHandlerProvider extends FastifyTypeProvider { output: this['input'] }
 
 // Auxiliary handlers are likely shared for multiple routes and thus should infer as unknown due to potential varying parameters
 function auxiliaryHandler (request: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction): void {
@@ -1063,7 +1063,7 @@ expectAssignable(server.withTypeProvider<AuxiliaryHandlerProvider>().get(
   '/',
   {
     onRequest: auxiliaryHandler,
-    schema: { body: null }
+    schema: { body: 'handler-auxiliary' }
   },
   (req) => {
     expectType<'handler-auxiliary'>(req.body)

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -21,6 +21,7 @@ export type Bindings = pino.Bindings
 export type ChildLoggerOptions = pino.ChildLoggerOptions
 
 export interface FastifyBaseLogger extends pino.BaseLogger {
+  setBindings?(bindings: Bindings): void
   child(bindings: Bindings, options?: ChildLoggerOptions): FastifyBaseLogger
 }
 

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -57,9 +57,11 @@ export interface FastifyReply<
   getHeaders(): Record<HttpHeader, number | string | string[] | undefined>;
   removeHeader(key: HttpHeader): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
   hasHeader(key: HttpHeader): boolean;
-  // Note: should consider refactoring the argument order for redirect. statusCode is optional so it should be after the required url param
+  /**
+   * @deprecated The `reply.redirect()` method has a new signature: `reply.reply.redirect(url: string, code?: number)`. It will be enforced in `fastify@v5`'.
+   */
   redirect(statusCode: number, url: string): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
-  redirect(url: string): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
+  redirect(url: string, statusCode?: number): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
   hijack(): FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>;
   callNotFound(): void;
   /**

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -1,6 +1,6 @@
 import { FastifyError } from '@fastify/error'
 import { ConstraintStrategy } from 'find-my-way'
-import { FastifyRequestContext } from './context'
+import { FastifyContextConfig } from './context'
 import { onErrorMetaHookHandler, onRequestAbortMetaHookHandler, onRequestMetaHookHandler, onResponseMetaHookHandler, onSendMetaHookHandler, onTimeoutMetaHookHandler, preHandlerMetaHookHandler, preParsingMetaHookHandler, preSerializationMetaHookHandler, preValidationMetaHookHandler } from './hooks'
 import { FastifyInstance } from './instance'
 import { FastifyBaseLogger, FastifyChildLoggerFactory, LogLevel } from './logger'
@@ -52,7 +52,7 @@ export interface RouteShorthandOptions<
   serializerCompiler?: FastifySerializerCompiler<NoInferCompat<SchemaCompiler>>;
   bodyLimit?: number;
   logLevel?: LogLevel;
-  config?: Omit<FastifyRequestContext<ContextConfig>['config'], 'url' | 'method'>;
+  config?: FastifyContextConfig & ContextConfig;
   version?: string;
   constraints?: RouteConstraint,
   prefixTrailingSlash?: 'slash'|'no-slash'|'both';

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -12,7 +12,7 @@ import {
   FastifyTypeProviderDefault,
   ResolveFastifyReplyReturnType
 } from './type-provider'
-import { ContextConfigDefault, HTTPMethods, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RawServerDefault } from './utils'
+import { ContextConfigDefault, HTTPMethods, NoInferCompat, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RawServerDefault } from './utils'
 
 export interface FastifyRouteConfig {
   url: string;
@@ -48,8 +48,8 @@ export interface RouteShorthandOptions<
   attachValidation?: boolean;
   exposeHeadRoute?: boolean;
 
-  validatorCompiler?: FastifySchemaCompiler<SchemaCompiler>;
-  serializerCompiler?: FastifySerializerCompiler<SchemaCompiler>;
+  validatorCompiler?: FastifySchemaCompiler<NoInferCompat<SchemaCompiler>>;
+  serializerCompiler?: FastifySerializerCompiler<NoInferCompat<SchemaCompiler>>;
   bodyLimit?: number;
   logLevel?: LogLevel;
   config?: Omit<FastifyRequestContext<ContextConfig>['config'], 'url' | 'method'>;
@@ -59,33 +59,33 @@ export interface RouteShorthandOptions<
   errorHandler?: (
     this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
     error: FastifyError,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig, Logger>,
-    reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, NoInferCompat<SchemaCompiler>, TypeProvider, ContextConfig, Logger>,
+    reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider>
   ) => void;
   childLoggerFactory?: FastifyChildLoggerFactory<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
   schemaErrorFormatter?: SchemaErrorFormatter;
 
   // hooks
-  onRequest?: onRequestMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  | onRequestMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
-  preParsing?: preParsingMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  | preParsingMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
-  preValidation?: preValidationMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  | preValidationMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
-  preHandler?: preHandlerMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  | preHandlerMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
-  preSerialization?: preSerializationMetaHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  | preSerializationMetaHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
-  onSend?: onSendMetaHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  | onSendMetaHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
-  onResponse?: onResponseMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  | onResponseMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
-  onTimeout?: onTimeoutMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  | onTimeoutMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
-  onError?: onErrorMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, FastifyError, SchemaCompiler, TypeProvider, Logger>
-  | onErrorMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, FastifyError, SchemaCompiler, TypeProvider, Logger>[];
-  onRequestAbort?: onRequestAbortMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  | onRequestAbortMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>[];
+  onRequest?: onRequestMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>
+  | onRequestMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>[];
+  preParsing?: preParsingMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>
+  | preParsingMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>[];
+  preValidation?: preValidationMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>
+  | preValidationMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>[];
+  preHandler?: preHandlerMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>
+  | preHandlerMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>[];
+  preSerialization?: preSerializationMetaHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>
+  | preSerializationMetaHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>[];
+  onSend?: onSendMetaHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>
+  | onSendMetaHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>[];
+  onResponse?: onResponseMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>
+  | onResponseMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>[];
+  onTimeout?: onTimeoutMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>
+  | onTimeoutMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>[];
+  onError?: onErrorMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, FastifyError, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>
+  | onErrorMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, FastifyError, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>[];
+  onRequestAbort?: onRequestAbortMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>
+  | onRequestAbortMetaHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>[];
 }
 /**
  * Route handler method declaration.
@@ -162,7 +162,7 @@ export interface RouteOptions<
 > extends RouteShorthandOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> {
   method: HTTPMethods | HTTPMethods[];
   url: string;
-  handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>;
+  handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInferCompat<SchemaCompiler>, TypeProvider, Logger>;
 }
 
 export type RouteHandler<

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -88,3 +88,8 @@ type OmitIndexSignature<T> = {
  * Use this type only for input values, not for output values.
  */
 export type HttpHeader = keyof OmitIndexSignature<http.OutgoingHttpHeaders> | (string & Record<never, never>);
+
+// cheat for similar (same?) behavior as NoInfer but for TS <5.4
+export type NoInferCompat<SC> = {
+  [K in keyof SC]: SC[K]
+};


### PR DESCRIPTION
Add the `setBindings()` to the stub methods for Pino logger when no logger is specified during Fastify instantiation. Allowing that method to be called in components during testing.

Also added an optional type for this method.

Closes https://github.com/fastify/fastify/issues/5605

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
