### PR TITLE
fix: reorder handling of `Response` replies

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -600,14 +600,30 @@ function onSendEnd (reply, payload) {
     reply.header('Trailer', header.trim())
   }
 
-  // since Response contain status code, we need to update before
-  // any action that used statusCode
-  const isResponse = toString.call(payload) === '[object Response]'
-  if (isResponse) {
+  // since Response contain status code, headers and body,
+  // we need to update the status, add the headers and use it's body as payload
+  // before continuing
+  if (toString.call(payload) === '[object Response]') {
     // https://developer.mozilla.org/en-US/docs/Web/API/Response/status
     if (typeof payload.status === 'number') {
       reply.code(payload.status)
     }
+
+    // https://developer.mozilla.org/en-US/docs/Web/API/Response/headers
+    if (typeof payload.headers === 'object' && typeof payload.headers.forEach === 'function') {
+      for (const [headerName, headerValue] of payload.headers) {
+        reply.header(headerName, headerValue)
+      }
+    }
+
+    // https://developer.mozilla.org/en-US/docs/Web/API/Response/body
+    if (payload.body !== null) {
+      if (payload.bodyUsed) {
+        throw new FST_ERR_REP_RESPONSE_BODY_CONSUMED()
+      }
+    }
+    // Keep going, body is either null or ReadableStream
+    payload = payload.body
   }
   const statusCode = res.statusCode
 
@@ -651,26 +667,6 @@ function onSendEnd (reply, payload) {
   // node:stream/web
   if (typeof payload.getReader === 'function') {
     sendWebStream(payload, res, reply)
-    return
-  }
-
-  // Response
-  if (isResponse) {
-    // https://developer.mozilla.org/en-US/docs/Web/API/Response/headers
-    if (typeof payload.headers === 'object' && typeof payload.headers.forEach === 'function') {
-      for (const [headerName, headerValue] of payload.headers) {
-        reply.header(headerName, headerValue)
-      }
-    }
-
-    // https://developer.mozilla.org/en-US/docs/Web/API/Response/body
-    if (payload.body != null) {
-      if (payload.bodyUsed) {
-        throw new FST_ERR_REP_RESPONSE_BODY_CONSUMED()
-      }
-      // Response.body always a ReadableStream
-      sendWebStream(payload.body, res, reply)
-    }
     return
   }
 

--- a/test/web-api.test.js
+++ b/test/web-api.test.js
@@ -56,6 +56,81 @@ test('should response with a Response', async (t) => {
   t.equal(headers.hello, 'world')
 })
 
+test('should response with a Response 204', async (t) => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  fastify.get('/', function (request, reply) {
+    reply.send(new Response(null, {
+      status: 204,
+      headers: {
+        hello: 'world'
+      }
+    }))
+  })
+
+  const {
+    statusCode,
+    headers,
+    body
+  } = await fastify.inject({ method: 'GET', path: '/' })
+
+  t.equal(statusCode, 204)
+  t.equal(body, '')
+  t.equal(headers.hello, 'world')
+})
+
+test('should response with a Response 304', async (t) => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  fastify.get('/', function (request, reply) {
+    reply.send(new Response(null, {
+      status: 304,
+      headers: {
+        hello: 'world'
+      }
+    }))
+  })
+
+  const {
+    statusCode,
+    headers,
+    body
+  } = await fastify.inject({ method: 'GET', path: '/' })
+
+  t.equal(statusCode, 304)
+  t.equal(body, '')
+  t.equal(headers.hello, 'world')
+})
+
+test('should response with a Response without body', async (t) => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  fastify.get('/', function (request, reply) {
+    reply.send(new Response(null, {
+      status: 200,
+      headers: {
+        hello: 'world'
+      }
+    }))
+  })
+
+  const {
+    statusCode,
+    headers,
+    body
+  } = await fastify.inject({ method: 'GET', path: '/' })
+
+  t.equal(statusCode, 200)
+  t.equal(body, '')
+  t.equal(headers.hello, 'world')
+})
+
 test('able to use in onSend hook - ReadableStream', async (t) => {
   t.plan(4)
 


### PR DESCRIPTION
We must add `Response.headers` before proceeding, otherwise early returns (ie: `204`) will miss them.

We can also remove special handling of `ReadableStream`: since the `Response` usage is fully finished, we can continue with `Response.body` as the payload and the possible types `null` or `ReadableStream` will be handled by existing cases.

Last but not least, we should add `304` handling to the same early return handling `204`, including the removal of `content-*` headers.

> **NOTE:** this should be back ported to other branches, at least v4 suffers from the same issue.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] ~documentation is changed or added~ (not needed)
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
