### PR TITLE
refactor: use `Object.hasOwn`

### DIFF
--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -16,7 +16,7 @@ const {
 } = require('./errors')
 
 function decorate (instance, name, fn, dependencies) {
-  if (Object.prototype.hasOwnProperty.call(instance, name)) {
+  if (Object.hasOwn(instance, name)) {
     throw new FST_ERR_DEC_ALREADY_PRESENT(name)
   }
 
@@ -34,7 +34,7 @@ function decorate (instance, name, fn, dependencies) {
 
 function decorateConstructor (konstructor, name, fn, dependencies) {
   const instance = konstructor.prototype
-  if (Object.prototype.hasOwnProperty.call(instance, name) || hasKey(konstructor, name)) {
+  if (Object.hasOwn(instance, name) || hasKey(konstructor, name)) {
     throw new FST_ERR_DEC_ALREADY_PRESENT(name)
   }
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -87,7 +87,7 @@ function buildRouting (options) {
       disableRequestLogging = options.disableRequestLogging
       ignoreTrailingSlash = options.ignoreTrailingSlash
       ignoreDuplicateSlashes = options.ignoreDuplicateSlashes
-      return503OnClosing = Object.prototype.hasOwnProperty.call(options, 'return503OnClosing') ? options.return503OnClosing : true
+      return503OnClosing = Object.hasOwn(options, 'return503OnClosing') ? options.return503OnClosing : true
       keepAliveConnections = fastifyArgs.keepAliveConnections
     },
     routing: router.lookup.bind(router), // router func to find the right handler to call

--- a/lib/server.js
+++ b/lib/server.js
@@ -55,7 +55,7 @@ function createServer (options, httpHandler) {
     } else {
       host = listenOptions.host
     }
-    if (Object.prototype.hasOwnProperty.call(listenOptions, 'host') === false ||
+    if (!Object.hasOwn(listenOptions, 'host') ||
       listenOptions.host == null) {
       listenOptions.host = host
     }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -82,7 +82,7 @@ function compileSchemasForValidation (context, compile, isCustom) {
       })
     }
     context[headersSchema] = compile({ schema: headersSchemaLowerCase, method, url, httpPart: 'headers' })
-  } else if (Object.prototype.hasOwnProperty.call(schema, 'headers')) {
+  } else if (Object.hasOwn(schema, 'headers')) {
     FSTWRN001('headers', method, url)
   }
 
@@ -98,19 +98,19 @@ function compileSchemasForValidation (context, compile, isCustom) {
     } else {
       context[bodySchema] = compile({ schema: schema.body, method, url, httpPart: 'body' })
     }
-  } else if (Object.prototype.hasOwnProperty.call(schema, 'body')) {
+  } else if (Object.hasOwn(schema, 'body')) {
     FSTWRN001('body', method, url)
   }
 
   if (schema.querystring) {
     context[querystringSchema] = compile({ schema: schema.querystring, method, url, httpPart: 'querystring' })
-  } else if (Object.prototype.hasOwnProperty.call(schema, 'querystring')) {
+  } else if (Object.hasOwn(schema, 'querystring')) {
     FSTWRN001('querystring', method, url)
   }
 
   if (schema.params) {
     context[paramsSchema] = compile({ schema: schema.params, method, url, httpPart: 'params' })
-  } else if (Object.prototype.hasOwnProperty.call(schema, 'params')) {
+  } else if (Object.hasOwn(schema, 'params')) {
     FSTWRN001('params', method, url)
   }
 }

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -639,7 +639,7 @@ test('should register empty values', t => {
 
   fastify.register((instance, opts, done) => {
     instance.decorate('test', null)
-    t.ok(Object.prototype.hasOwnProperty.call(instance, 'test'))
+    t.ok(Object.hasOwn(instance, 'test'))
     done()
   })
 

--- a/test/internals/decorator.test.js
+++ b/test/internals/decorator.test.js
@@ -136,7 +136,7 @@ test('decorate should recognize getter/setter objects', t => {
       this._a = val
     }
   })
-  t.equal(Object.prototype.hasOwnProperty.call(one, 'foo'), true)
+  t.equal(Object.hasOwn(one, 'foo'), true)
   t.equal(one.foo, undefined)
   one.foo = 'a'
   t.equal(one.foo, 'a')
@@ -152,6 +152,6 @@ test('decorate should recognize getter/setter objects', t => {
   decorator.add.call(two, 'foo', {
     getter: () => 'a getter'
   })
-  t.equal(Object.prototype.hasOwnProperty.call(two, 'foo'), true)
+  t.equal(Object.hasOwn(two, 'foo'), true)
   t.equal(two.foo, 'a getter')
 })

--- a/test/internals/request-validate.test.js
+++ b/test/internals/request-validate.test.js
@@ -77,7 +77,7 @@ test('#compileValidationSchema', subtest => {
       const validate = req.compileValidationSchema(defaultSchema)
 
       t.ok(validate({ hello: 'world' }))
-      t.ok(Object.prototype.hasOwnProperty.call(validate, 'errors'))
+      t.ok(Object.hasOwn(validate, 'errors'))
       t.equal(validate.errors, null)
 
       reply.send({ hello: 'world' })
@@ -98,7 +98,7 @@ test('#compileValidationSchema', subtest => {
       const validate = req.compileValidationSchema(defaultSchema)
 
       t.notOk(validate({ world: 'foo' }))
-      t.ok(Object.prototype.hasOwnProperty.call(validate, 'errors'))
+      t.ok(Object.hasOwn(validate, 'errors'))
       t.ok(Array.isArray(validate.errors))
       t.ok(validate.errors.length > 0)
 
@@ -290,7 +290,7 @@ test('#getValidationFunction', subtest => {
       const validate = req.getValidationFunction(defaultSchema)
 
       t.ok(validate({ hello: 'world' }))
-      t.ok(Object.prototype.hasOwnProperty.call(validate, 'errors'))
+      t.ok(Object.hasOwn(validate, 'errors'))
       t.equal(validate.errors, null)
 
       reply.send({ hello: 'world' })
@@ -312,7 +312,7 @@ test('#getValidationFunction', subtest => {
       const validate = req.getValidationFunction(defaultSchema)
 
       t.notOk(validate({ world: 'foo' }))
-      t.ok(Object.prototype.hasOwnProperty.call(validate, 'errors'))
+      t.ok(Object.hasOwn(validate, 'errors'))
       t.ok(Array.isArray(validate.errors))
       t.ok(validate.errors.length > 0)
 


### PR DESCRIPTION
Available since node 16

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
