### PR TITLE
refactor: remove `FSTDEP013`

### DIFF
--- a/docs/Reference/Warnings.md
+++ b/docs/Reference/Warnings.md
@@ -8,7 +8,6 @@
     - [FSTWRN001](#FSTWRN001)
     - [FSTWRN002](#FSTWRN002)
   - [Fastify Deprecation Codes](#fastify-deprecation-codes)
-    - [FSTDEP013](#FSTDEP013)
 
 
 ## Warnings
@@ -59,4 +58,3 @@ Deprecation codes are further supported by the Node.js CLI options:
 
 | Code | Description | How to solve | Discussion |
 | ---- | ----------- | ------------ | ---------- |
-| <a id="FSTDEP013">FSTDEP013</a> | Direct return of "trailers" function is deprecated. | Use "callback" or "async-await" for return value. | [#4380](https://github.com/fastify/fastify/pull/4380) |

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -53,7 +53,6 @@ const {
   FST_ERR_MISSING_SERIALIZATION_FN,
   FST_ERR_MISSING_CONTENTTYPE_SERIALIZATION_FN
 } = require('./errors')
-const { FSTDEP013 } = require('./warnings')
 
 const toString = Object.prototype.toString
 
@@ -781,10 +780,6 @@ function sendTrailer (payload, res, reply) {
     const result = reply[kReplyTrailers][trailerName](reply, payload, cb)
     if (typeof result === 'object' && typeof result.then === 'function') {
       result.then((v) => cb(null, v), cb)
-    } else if (result !== null && result !== undefined) {
-      // TODO: should be removed in fastify@5
-      FSTDEP013()
-      cb(null, result)
     }
   }
 

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -1,18 +1,13 @@
 'use strict'
 
-const { createDeprecation, createWarning } = require('process-warning')
+const { createWarning } = require('process-warning')
 
 /**
  * Deprecation codes:
- *   - FSTDEP013
  *   - FSTWRN001
  *   - FSTSEC001
  */
 
-const FSTDEP013 = createDeprecation({
-  code: 'FSTDEP013',
-  message: 'Direct return of "trailers" function is deprecated. Please use "callback" or "async-await" for return value. The support of direct return will removed in `fastify@5`.'
-})
 const FSTWRN001 = createWarning({
   name: 'FastifyWarning',
   code: 'FSTWRN001',
@@ -28,7 +23,6 @@ const FSTSEC001 = createWarning({
 })
 
 module.exports = {
-  FSTDEP013,
   FSTWRN001,
   FSTSEC001
 }

--- a/test/reply-trailers.test.js
+++ b/test/reply-trailers.test.js
@@ -186,37 +186,6 @@ test('error in trailers should be ignored', t => {
   })
 })
 
-test('should emit deprecation warning when using direct return', t => {
-  t.plan(7)
-
-  const fastify = Fastify()
-
-  fastify.get('/', function (request, reply) {
-    reply.trailer('ETag', function (reply, payload) {
-      return 'custom-etag'
-    })
-    reply.send('')
-  })
-
-  process.on('warning', onWarning)
-  function onWarning (warning) {
-    t.equal(warning.name, 'DeprecationWarning')
-    t.equal(warning.code, 'FSTDEP013')
-  }
-  t.teardown(() => process.removeListener('warning', onWarning))
-
-  fastify.inject({
-    method: 'GET',
-    url: '/'
-  }, (error, res) => {
-    t.error(error)
-    t.equal(res.statusCode, 200)
-    t.equal(res.headers.trailer, 'etag')
-    t.equal(res.trailers.etag, 'custom-etag')
-    t.notHas(res.headers, 'content-length')
-  })
-})
-
 test('trailer handler counter', t => {
   t.plan(2)
 
@@ -412,7 +381,7 @@ test('throw error when trailer header name is not allowed', t => {
   fastify.get('/', function (request, reply) {
     for (const key of INVALID_TRAILERS) {
       try {
-        reply.trailer(key, () => {})
+        reply.trailer(key, () => { })
       } catch (err) {
         t.equal(err.message, `Called reply.trailer with an invalid header name: ${key}`)
       }


### PR DESCRIPTION
Remove `FSTDEP013` deprecation warning

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
