### PR TITLE
fix: add logger.setBindings for mocked logger

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -76,6 +76,7 @@ function createLogger (options) {
   // if no logger is provided, then create a default logger
   if (!options.loggerInstance && !options.logger) {
     const logger = nullLogger
+    logger.setBindings = () => { }
     logger.child = () => logger
     return { logger, hasLogger: false }
   }

--- a/test/logger/options.test.js
+++ b/test/logger/options.test.js
@@ -15,7 +15,7 @@ t.test('logger options', (t) => {
   t.plan(16)
 
   t.test('logger can be silenced', (t) => {
-    t.plan(17)
+    t.plan(19)
     const fastify = Fastify({
       logger: false
     })
@@ -28,6 +28,7 @@ t.test('logger options', (t) => {
     t.equal(typeof fastify.log.info, 'function')
     t.equal(typeof fastify.log.debug, 'function')
     t.equal(typeof fastify.log.trace, 'function')
+    t.equal(fastify.log.setBindings(), undefined)
     t.equal(typeof fastify.log.child, 'function')
 
     const childLog = fastify.log.child()
@@ -39,6 +40,7 @@ t.test('logger options', (t) => {
     t.equal(typeof childLog.info, 'function')
     t.equal(typeof childLog.debug, 'function')
     t.equal(typeof childLog.trace, 'function')
+    t.equal(childLog.setBindings(), undefined)
     t.equal(typeof childLog.child, 'function')
   })
 

--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -45,6 +45,7 @@ class CustomLoggerImpl implements CustomLogger {
   debug (...args: unknown[]) { console.log(args) }
   silent (...args: unknown[]) { }
 
+  setBindings (bindings: P.Bindings) { }
   child (bindings: P.Bindings, options?: P.ChildLoggerOptions): CustomLoggerImpl { return new CustomLoggerImpl() }
 }
 

--- a/test/types/register.test-d.ts
+++ b/test/types/register.test-d.ts
@@ -111,6 +111,7 @@ const customLogger = {
   fatal: () => { },
   trace: () => { },
   debug: () => { },
+  setBindings: () => { },
   child: () => customLogger,
   silent: () => { }
 }

--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -143,6 +143,7 @@ const customLogger: CustomLoggerInterface = {
   trace: () => { },
   debug: () => { },
   foo: () => { }, // custom severity logger method
+  setBindings: () => { },
   child: () => customLogger
 }
 

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -21,6 +21,7 @@ export type Bindings = pino.Bindings
 export type ChildLoggerOptions = pino.ChildLoggerOptions
 
 export interface FastifyBaseLogger extends pino.BaseLogger {
+  setBindings(bindings: Bindings): void
   child(bindings: Bindings, options?: ChildLoggerOptions): FastifyBaseLogger
 }
 


### PR DESCRIPTION
Add the setBindings() to the stub methods for Pino logger when no logger is specified during Fastify instantiation. Allowing that method to be called in components during testing.

Also added an optional type for this method.

Closes https://github.com/fastify/fastify/issues/5605

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
