### PR TITLE
fix: throwing "FST_ERR_DUPLICATED_ROUTE" error instead of raw error

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -337,7 +337,7 @@ function buildRouting (options) {
         // any route insertion error created by fastify can be safely ignore
         // because it only duplicate route for head
         if (!context[kRouteByFastify]) {
-          const isDuplicatedRoute = error.message.includes(`Method '${opts.method}' already declared for route '${opts.url}'`)
+          const isDuplicatedRoute = error.message.includes(`Method '${opts.method}' already declared for route`)
           if (isDuplicatedRoute) {
             throw new FST_ERR_DUPLICATED_ROUTE(opts.method, opts.url)
           }

--- a/test/route.8.test.js
+++ b/test/route.8.test.js
@@ -4,7 +4,10 @@ const t = require('tap')
 const test = t.test
 const sget = require('simple-get').concat
 const Fastify = require('../fastify')
-const { FST_ERR_INVALID_URL } = require('../lib/errors')
+const { 
+  FST_ERR_INVALID_URL,
+  FST_ERR_DUPLICATED_ROUTE
+ } = require('../lib/errors')
 const { getServerUrl } = require('./helper')
 
 test('Request and Reply share the route options', async t => {
@@ -139,4 +142,28 @@ test('using fastify.all when a catchall is defined does not degrade performance'
   }
 
   t.pass()
+})
+
+test('Adding manually HEAD route after GET with the same path throws Fastify duplicated route instance error', t => {
+  t.plan(1)
+
+  const fastify = Fastify()
+
+  fastify.route({
+    method: 'GET',
+    path: '/:param1',
+    handler: (req, reply) => {
+      reply.send({ hello: 'world' })
+    }
+  })
+
+  t.throws(() => {
+    fastify.route({
+      method: 'HEAD',
+      path: '/:param2',
+      handler: (req, reply) => {
+        reply.send({ hello: 'world' })
+      }
+    })
+  }, new FST_ERR_DUPLICATED_ROUTE('HEAD', '/:param2'))
 })

--- a/test/route.8.test.js
+++ b/test/route.8.test.js
@@ -4,10 +4,10 @@ const t = require('tap')
 const test = t.test
 const sget = require('simple-get').concat
 const Fastify = require('../fastify')
-const { 
+const {
   FST_ERR_INVALID_URL,
   FST_ERR_DUPLICATED_ROUTE
- } = require('../lib/errors')
+} = require('../lib/errors')
 const { getServerUrl } = require('./helper')
 
 test('Request and Reply share the route options', async t => {

--- a/test/route.8.test.js
+++ b/test/route.8.test.js
@@ -5,8 +5,7 @@ const test = t.test
 const sget = require('simple-get').concat
 const Fastify = require('../fastify')
 const {
-  FST_ERR_INVALID_URL,
-  FST_ERR_DUPLICATED_ROUTE
+  FST_ERR_INVALID_URL
 } = require('../lib/errors')
 const { getServerUrl } = require('./helper')
 
@@ -157,7 +156,7 @@ test('Adding manually HEAD route after GET with the same path throws Fastify dup
     }
   })
 
-  t.throws(() => {
+  try {
     fastify.route({
       method: 'HEAD',
       path: '/:param2',
@@ -165,5 +164,8 @@ test('Adding manually HEAD route after GET with the same path throws Fastify dup
         reply.send({ hello: 'world' })
       }
     })
-  }, new FST_ERR_DUPLICATED_ROUTE('HEAD', '/:param2'))
+    t.fail('Should throw fastify duplicated route declaration')
+  } catch (error) {
+    t.equal(error.code, 'FST_ERR_DUPLICATED_ROUTE')
+  }
 })

--- a/test/throw.test.js
+++ b/test/throw.test.js
@@ -2,9 +2,6 @@
 
 const { test } = require('tap')
 const Fastify = require('..')
-const {
-  FST_ERR_DUPLICATED_ROUTE
-} = require('../lib/errors')
 
 test('Fastify should throw on wrong options', t => {
   t.plan(2)
@@ -23,9 +20,12 @@ test('Fastify should throw on multiple assignment to the same route', t => {
 
   fastify.get('/', () => {})
 
-  t.throws(() => {
+  try {
     fastify.get('/', () => {})
-  }, new FST_ERR_DUPLICATED_ROUTE('GET', '/'))
+    t.fail('Should throw fastify duplicated route declaration')
+  } catch (error) {
+    t.equal(error.code, 'FST_ERR_DUPLICATED_ROUTE')
+  }
 })
 
 test('Fastify should throw for an invalid schema, printing the error route - headers', t => {

--- a/test/throw.test.js
+++ b/test/throw.test.js
@@ -2,6 +2,9 @@
 
 const { test } = require('tap')
 const Fastify = require('..')
+const {
+  FST_ERR_DUPLICATED_ROUTE
+} = require('../lib/errors')
 
 test('Fastify should throw on wrong options', t => {
   t.plan(2)
@@ -20,12 +23,9 @@ test('Fastify should throw on multiple assignment to the same route', t => {
 
   fastify.get('/', () => {})
 
-  try {
+  t.throws(() => {
     fastify.get('/', () => {})
-    t.fail('Should throw on duplicated route declaration')
-  } catch (error) {
-    t.equal(error.message, "Method 'GET' already declared for route '/'")
-  }
+  }, new FST_ERR_DUPLICATED_ROUTE('GET', '/'))
 })
 
 test('Fastify should throw for an invalid schema, printing the error route - headers', t => {


### PR DESCRIPTION
Came across this small bug during unit tests in my project.

I have a unit test that catches various errors that lean on Fastify error codes, and I had a case where I expected to get the FST_ERR_DUPLICATED_ROUTE instance, but got raw Error instance:

```
const fastify = require('fastify')({
    logger: true
})

fastify.get('/:param2', (request, reply) => {
    reply.type('application/json').code(200)
    return { hello: 'example' }
})

fastify.head('/:param1',  (request, reply) => {
    reply.type('application/json').code(200)
    return { hello: 'other' }
})

fastify.addHook('onReady', async function hook () {
    console.log(fastify.printRoutes())
})

fastify.listen().then(console.log)
```

In this case, we expect to get `FST_ERR_DUPLICATED_ROUTE` error, because we're adding `HEAD` method of the same route after Fastify added it (after adding the `GET` method on the same route).

instead, we're getting the Error instance:
```
Error: Method 'HEAD' already declared for route '/:' with constraints '{}'
    at Router._on (/Users/toledor/playground/head-issue/node_modules/find-my-way/index.js:287:13)
    at Router.on (/Users/toledor/playground/head-issue/node_modules/find-my-way/index.js:139:10)
    at Object.addNewRoute (/Users/toledor/playground/head-issue/node_modules/fastify/lib/route.js:365:16)
    at Object.route (/Users/toledor/playground/head-issue/node_modules/fastify/lib/route.js:265:19)
    at Object.prepareRoute (/Users/toledor/playground/head-issue/node_modules/fastify/lib/route.js:167:18)
    at Object._head [as head] (/Users/toledor/playground/head-issue/node_modules/fastify/fastify.js:265:34)
    at Object.<anonymous> (/Users/toledor/playground/head-issue/index.js:62:9)
    at Module._compile (node:internal/modules/cjs/loader:1504:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1588:10)
    at Module.load (node:internal/modules/cjs/loader:1282:32)
```

This happens because `find-my-way` throws the error message: `"Method '${opts.method}' already declared for route '<pattern>'"`, and it's been compared to `"Method '${opts.method}' already declared for route '${opts.url}'"`, in our case `opts.url = /:param1`, but the **pattern** equals to `:/`.

Solution: 
Unfortunately, fastify does not possess the pattern, so IMO the best way is to drop the `opts.url`.

After changes we do get the right error:
```
FastifyError [Error]: Method 'HEAD' already declared for route '/:param1'
    at Object.addNewRoute (/Users/toledor/playground/head-issue/node_modules/fastify/lib/route.js:378:19)
    at Object.route (/Users/toledor/playground/head-issue/node_modules/fastify/lib/route.js:265:19)
    at Object.prepareRoute (/Users/toledor/playground/head-issue/node_modules/fastify/lib/route.js:167:18)
    at Object._head [as head] (/Users/toledor/playground/head-issue/node_modules/fastify/fastify.js:265:34)
    at Object.<anonymous> (/Users/toledor/playground/head-issue/index.js:62:9)
    at Module._compile (node:internal/modules/cjs/loader:1504:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1588:10)
    at Module.load (node:internal/modules/cjs/loader:1282:32)
    at Module._load (node:internal/modules/cjs/loader:1098:12)
    at TracingChannel.traceSync (node:diagnostics_channel:315:14) {
  code: 'FST_ERR_DUPLICATED_ROUTE',
  statusCode: 500
}
```



