### PR TITLE
chore: simplify `neostandard` setup

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,28 +1,11 @@
 'use strict'
 
-const neo = require('neostandard')
-
-module.exports = [
-  {
-    ignores: [
-      'lib/configValidator.js',
-      'lib/error-serializer.js',
-      'test/same-shape.test.js',
-      'test/types/import.js'
-    ]
-  },
-  ...neo({
-    ts: true
-  }),
-  {
-    rules: {
-      '@stylistic/comma-dangle': ['error', {
-        arrays: 'never',
-        objects: 'never',
-        imports: 'never',
-        exports: 'never',
-        functions: 'never'
-      }]
-    }
-  }
-]
+module.exports = require('neostandard')({
+  ignores: [
+    'lib/configValidator.js',
+    'lib/error-serializer.js',
+    'test/same-shape.test.js',
+    'test/types/import.js'
+  ],
+  ts: true
+})

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "json-schema-to-ts": "^3.0.1",
     "JSONStream": "^1.3.5",
     "markdownlint-cli2": "^0.13.0",
-    "neostandard": "^0.11.0",
+    "neostandard": "^0.11.3",
     "node-forge": "^1.3.1",
     "proxyquire": "^2.1.3",
     "send": "^0.18.0",


### PR DESCRIPTION
The shortcomings that necessitated the workarounds when `neostandard` was introduced int #5509 have now all been fixed upstream, so a simpler setup can now be used.

(This is a short little simple PR before I get started contributing more substantially here again)

(Disclaimer: I'm the main author of `neostandard` so I wanted to clean up the mess I left behind)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] ~~run `npm run test` and `npm run benchmark`~~ ran `npx eslint` and it passed
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
