### PR TITLE
docs: added not in invalid URLs in setNotFoundHandler

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1479,7 +1479,8 @@ call is encapsulated by prefix, so different plugins can set different not found
 handlers if a different [`prefix` option](./Plugins.md#route-prefixing-option)
 is passed to `fastify.register()`. The handler is treated as a regular route
 handler so requests will go through the full [Fastify
-lifecycle](./Lifecycle.md#lifecycle). *async-await* is supported as well.
+lifecycle](./Lifecycle.md#lifecycle) for valid URLs. Invalid URLs are set directly 
+to the handler.  *async-await* is supported as well.
 
 You can also register [`preValidation`](./Hooks.md#route-hooks) and
 [`preHandler`](./Hooks.md#route-hooks) hooks for the 404 handler.


### PR DESCRIPTION
I was struggling to understand why a bad URL did not go through the _lifecycle_ like the documentation says. Turns out it doesn't as the router returns directly to the `setNotFoundHandler` in the case of a bad URL. 
Adding this small note will save others from having to dig down into the router 😄 

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
