### PR TITLE
fix: add childLoggerFactory option to FastifyHttpOptions type

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -14,7 +14,15 @@ import { FastifyContextConfig, FastifyReplyContext, FastifyRequestContext } from
 import { FastifyErrorCodes } from './types/errors'
 import { DoneFuncWithErrOrRes, HookHandlerDoneFunction, onCloseAsyncHookHandler, onCloseHookHandler, onErrorAsyncHookHandler, onErrorHookHandler, onListenAsyncHookHandler, onListenHookHandler, onReadyAsyncHookHandler, onReadyHookHandler, onRegisterHookHandler, onRequestAbortAsyncHookHandler, onRequestAbortHookHandler, onRequestAsyncHookHandler, onRequestHookHandler, onResponseAsyncHookHandler, onResponseHookHandler, onRouteHookHandler, onSendAsyncHookHandler, onSendHookHandler, onTimeoutAsyncHookHandler, onTimeoutHookHandler, preCloseAsyncHookHandler, preCloseHookHandler, preHandlerAsyncHookHandler, preHandlerHookHandler, preParsingAsyncHookHandler, preParsingHookHandler, preSerializationAsyncHookHandler, preSerializationHookHandler, preValidationAsyncHookHandler, preValidationHookHandler, RequestPayload } from './types/hooks'
 import { FastifyInstance, FastifyListenOptions, PrintRoutesOptions } from './types/instance'
-import { FastifyBaseLogger, FastifyLogFn, FastifyLoggerInstance, FastifyLoggerOptions, LogLevel, PinoLoggerOptions } from './types/logger'
+import {
+  FastifyBaseLogger,
+  FastifyChildLoggerFactory,
+  FastifyLogFn,
+  FastifyLoggerInstance,
+  FastifyLoggerOptions,
+  LogLevel,
+  PinoLoggerOptions
+} from './types/logger'
 import { FastifyPlugin, FastifyPluginAsync, FastifyPluginCallback, FastifyPluginOptions } from './types/plugin'
 import { FastifyRegister, FastifyRegisterOptions, RegisterOptions } from './types/register'
 import { FastifyReply } from './types/reply'
@@ -149,6 +157,7 @@ declare namespace fastify {
      * listener to error events emitted by client connections
      */
     clientErrorHandler?: (error: ConnectionError, socket: Socket) => void,
+    childLoggerFactory?: FastifyChildLoggerFactory
   }
 
   /**

--- a/test/childLoggerFactory.test.js
+++ b/test/childLoggerFactory.test.js
@@ -31,6 +31,35 @@ test('Should accept a custom childLoggerFactory function', t => {
   })
 })
 
+test('Should accept a custom childLoggerFactory function as option', t => {
+  t.plan(2)
+
+  const fastify = Fastify({
+    childLoggerFactory: function (logger, bindings, opts) {
+      t.ok(bindings.reqId)
+      t.ok(opts)
+      this.log.debug(bindings, 'created child logger')
+      return logger.child(bindings, opts)
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    req.log.info('log message')
+    reply.send()
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+    fastify.inject({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, res) => {
+      t.error(err)
+      fastify.close()
+    })
+  })
+})
+
 test('req.log should be the instance returned by the factory', t => {
   t.plan(3)
 

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -21,6 +21,7 @@ import fastify, {
   RouteGenericInterface,
   SafePromiseLike
 } from '../../fastify'
+import { Bindings, ChildLoggerOptions } from '../../types/logger'
 
 // FastifyInstance
 // http server
@@ -216,6 +217,17 @@ expectAssignable<FastifyInstance>(fastify({
   clientErrorHandler: (err, socket) => {
     expectType<ConnectionError>(err)
     expectType<Socket>(socket)
+  }
+}))
+
+expectAssignable<FastifyInstance>(fastify({
+  childLoggerFactory: function (this: FastifyInstance, logger: FastifyBaseLogger, bindings: Bindings, opts: ChildLoggerOptions, req: RawRequestDefaultExpression) {
+    expectType<FastifyBaseLogger>(logger)
+    expectType<Bindings>(bindings)
+    expectType<ChildLoggerOptions>(opts)
+    expectType<RawRequestDefaultExpression>(req)
+    expectAssignable<FastifyInstance>(this)
+    return logger.child(bindings, opts)
   }
 }))
 


### PR DESCRIPTION
- add childLoggerFactory option to FastifyHttpOptions type
- add test for childLoggerFactory option

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

fixes: #5664 
