### PR TITLE
fix(package.json): add `engines.node` range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,32 @@ jobs:
         run: |
           npx license-checker --production --summary --onlyAllow="0BSD;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;MIT;"
 
+  check-engines-range:
+    name: Check engines range
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+          cache-dependency-path: package.json
+          check-latest: true
+
+      - name: Install
+        run: |
+          npm install --ignore-scripts
+
+      - name: Check engines range
+        run: |
+          npm run lint:engines-range
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "lint:fix": "eslint --fix",
     "lint:markdown": "markdownlint-cli2",
     "lint:eslint": "eslint",
+    "lint:engines-range": "installed-check --verbose --engine-check",
+    "lint:engines-range:fix": "installed-check --verbose --engine-check --fix",
     "prepublishOnly": "cross-env PREPUBLISH=true tap --allow-incomplete-coverage test/build/**.test.js && npm run test:validator:integrity",
     "test": "npm run lint && npm run unit && npm run test:typescript",
     "test:ci": "npm run unit -- --coverage-report=lcovonly && npm run test:typescript",
@@ -150,6 +152,9 @@
       "url": "https://opencollective.com/fastify"
     }
   ],
+  "engines": {
+    "node": "^20.9.0 || >=22.0.0"
+  },
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
     "@sinclair/typebox": "^0.33.4",
@@ -172,6 +177,7 @@
     "fluent-json-schema": "^5.0.0",
     "h2url": "^0.2.0",
     "http-errors": "^2.0.0",
+    "installed-check": "^9.3.0",
     "joi": "^17.12.3",
     "json-schema-to-ts": "^3.0.1",
     "JSONStream": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "lint:fix": "eslint --fix",
     "lint:markdown": "markdownlint-cli2",
     "lint:eslint": "eslint",
-    "lint:engines-range": "installed-check --verbose --engine-check",
-    "lint:engines-range:fix": "installed-check --verbose --engine-check --fix",
+    "lint:engines-range": "installed-check --verbose --engine-check --ignore-dev",
+    "lint:engines-range:fix": "npm run lint:engines-range -- --fix",
     "prepublishOnly": "cross-env PREPUBLISH=true tap --allow-incomplete-coverage test/build/**.test.js && npm run test:validator:integrity",
     "test": "npm run lint && npm run unit && npm run test:typescript",
     "test:ci": "npm run unit -- --coverage-report=lcovonly && npm run test:typescript",
@@ -153,7 +153,7 @@
     }
   ],
   "engines": {
-    "node": "^20.9.0 || >=22.0.0"
+    "node": ">=20"
   },
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",


### PR DESCRIPTION
Adds `^20.9.0 || >=22.0.0` as the `engines.node` range. In line with https://github.com/fastify/fastify/issues/5460 and added using `npm run lint:engines-range:fix` which in turn runs [`installed-check`](https://github.com/voxpelli/node-installed-check) to validate the engine range

The `^20.9.0 || >=22.0.0` is the widest range that includes the dependency ranges of all dev and non-dev dependencies.

If one instead only includes non-dev dependencies the result will be `>=14.0.0` since most dependencies hasn't specified an engines range:

* @fastify/ajv-compiler: Missing "engines.node"
* @fastify/error: Missing "engines.node"
* @fastify/fast-json-stringify-compiler: Missing "engines.node"
* abstract-logging: Missing "engines.node"
* avvio: Missing "engines.node"
* fast-json-stringify: Missing "engines.node"
* light-my-request: Missing "engines.node"
* pino: Missing "engines.node"
* process-warning: Missing "engines.node"
* rfdc: Missing "engines.node"
* secure-json-parse: Missing "engines.node"

* find-my-way: Narrower "engines.node" is needed: >=14.0.0
* proxy-addr: Narrower "engines.node" is needed: >=0.10.0
* semver: Narrower "engines.node" is needed: >=10.0.0
* toad-cache: Narrower "engines.node" is needed: >=12.0.0

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
