### PR TITLE
fix: point this to parent at onRegister

### DIFF
--- a/lib/pluginOverride.js
+++ b/lib/pluginOverride.js
@@ -66,7 +66,7 @@ module.exports = function override (old, fn, opts) {
     instance[kFourOhFour].arrange404(instance)
   }
 
-  for (const hook of instance[kHooks].onRegister) hook.call(this, instance, opts)
+  for (const hook of instance[kHooks].onRegister) hook.call(old, instance, opts)
 
   return instance
 }

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -3072,7 +3072,7 @@ test('preSerialization hooks should support encapsulation', t => {
 })
 
 test('onRegister hook should be called / 1', t => {
-  t.plan(4)
+  t.plan(5)
   const fastify = Fastify()
 
   fastify.addHook('onRegister', function (instance, opts, done) {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -3072,11 +3072,11 @@ test('preSerialization hooks should support encapsulation', t => {
 })
 
 test('onRegister hook should be called / 1', t => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
 
-  fastify.addHook('onRegister', (instance, opts) => {
-    // duck typing for the win!
+  fastify.addHook('onRegister', function (instance, opts) {
+    t.ok(this.addHook)
     t.ok(instance.addHook)
     t.same(opts, pluginOpts)
   })
@@ -3090,11 +3090,11 @@ test('onRegister hook should be called / 1', t => {
 })
 
 test('onRegister hook should be called / 2', t => {
-  t.plan(4)
+  t.plan(7)
   const fastify = Fastify()
 
-  fastify.addHook('onRegister', instance => {
-    // duck typing for the win!
+  fastify.addHook('onRegister', function (instance) {
+    t.ok(this.addHook)
     t.ok(instance.addHook)
   })
 

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -3075,7 +3075,7 @@ test('onRegister hook should be called / 1', t => {
   t.plan(4)
   const fastify = Fastify()
 
-  fastify.addHook('onRegister', function (instance, opts) {
+  fastify.addHook('onRegister', function (instance, opts, done) {
     t.ok(this.addHook)
     t.ok(instance.addHook)
     t.same(opts, pluginOpts)

--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -131,7 +131,8 @@ server.addHook('onRoute', function (opts) {
   expectType<RouteOptions & { routePath: string; path: string; prefix: string }>(opts)
 })
 
-server.addHook('onRegister', (instance, opts, done) => {
+server.addHook('onRegister', function (instance, opts, done) {
+  expectType<FastifyInstance>(this)
   expectType<FastifyInstance>(instance)
   expectType<RegisterOptions & FastifyPluginOptions>(opts)
   expectAssignable<(err?: FastifyError) => void>(done)

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -710,6 +710,7 @@ export interface onRegisterHookHandler<
   Options extends FastifyPluginOptions = FastifyPluginOptions
 > {
   (
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
     instance: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
     opts: RegisterOptions & Options,
     done: HookHandlerDoneFunction


### PR DESCRIPTION
For #4967

To onRegister hooks we pass `this` and the instance, however there are 2 problems:

1) what `this` points to is documented neither in types nor the docs
2) the goal was probably to pass the parent, as the other passed parameter, `instance`, is the new fastify instance, but `this` actually points to the avvio instance as can be seen from here:

https://github.com/fastify/fastify/blob/501be899761e60dfc713ac0a415b518ba6595034/fastify.js#L446

This PR passes the parent as `this`

For more info, see: https://github.com/fastify/fastify/pull/5670#discussion_r1748862579