### PR TITLE
types: remove nonexistant done parameter from onRegister

### DIFF
--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -3072,13 +3072,14 @@ test('preSerialization hooks should support encapsulation', t => {
 })
 
 test('onRegister hook should be called / 1', t => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
 
-  fastify.addHook('onRegister', (instance, opts) => {
+  fastify.addHook('onRegister', (instance, opts, done) => {
     // duck typing for the win!
     t.ok(instance.addHook)
     t.same(opts, pluginOpts)
+    t.notOk(done)
   })
 
   const pluginOpts = { prefix: 'hello', custom: 'world' }

--- a/test/types/hooks.test-d.ts
+++ b/test/types/hooks.test-d.ts
@@ -131,12 +131,9 @@ server.addHook('onRoute', function (opts) {
   expectType<RouteOptions & { routePath: string; path: string; prefix: string }>(opts)
 })
 
-server.addHook('onRegister', (instance, opts, done) => {
+server.addHook('onRegister', (instance, opts) => {
   expectType<FastifyInstance>(instance)
   expectType<RegisterOptions & FastifyPluginOptions>(opts)
-  expectAssignable<(err?: FastifyError) => void>(done)
-  expectAssignable<(err?: NodeJS.ErrnoException) => void>(done)
-  expectType<void>(done(new Error()))
 })
 
 server.addHook('onReady', function (done) {

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -711,9 +711,8 @@ export interface onRegisterHookHandler<
 > {
   (
     instance: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
-    opts: RegisterOptions & Options,
-    done: HookHandlerDoneFunction
-  ): Promise<unknown> | void; // documentation is missing the `done` method
+    opts: RegisterOptions & Options
+  ): Promise<unknown> | void;
 }
 
 /**


### PR DESCRIPTION
the `done` parameter does not exist in onRegister hooks

https://github.com/fastify/fastify/blob/07bc7cf7600e939b9d3a83338f888cfbe4a52b79/lib/pluginOverride.js#L69