### PR TITLE
refactor: migrate test framework in build module

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,11 @@
     {
       "name": "Aras Abbasi",
       "email": "aras.abbasi@gmail.com"
+    },
+    {
+      "name": "Reidner Adnan",
+      "url": "https://github.com/reidn3r",
+      "email": "rdn.adn00@gmail.com"
     }
   ],
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -133,11 +133,6 @@
     {
       "name": "Aras Abbasi",
       "email": "aras.abbasi@gmail.com"
-    },
-    {
-      "name": "Reidner Adnan",
-      "url": "https://github.com/reidn3r",
-      "email": "rdn.adn00@gmail.com"
     }
   ],
   "license": "MIT",

--- a/test/build/error-serializer.test.js
+++ b/test/build/error-serializer.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const fs = require('node:fs')
 const path = require('node:path')
 const { loadESLint } = require('eslint')
@@ -22,7 +21,7 @@ test('check generated code syntax', async (t) => {
 
   // if there are any invalid syntax
   // fatal count will be greater than 0
-  t.equal(result[0].fatalErrorCount, 0)
+  t.assert.strictEqual(result[0].fatalErrorCount, 0)
 })
 
 const isPrepublish = !!process.env.PREPUBLISH
@@ -33,5 +32,5 @@ test('ensure the current error serializer is latest', { skip: !isPrepublish }, a
   const current = await fs.promises.readFile(path.resolve('lib/error-serializer.js'))
 
   // line break should not be a problem depends on system
-  t.equal(unifyLineBreak(current), unifyLineBreak(code))
+  t.assert.strictEqual(unifyLineBreak(current), unifyLineBreak(code))
 })

--- a/test/build/version.test.js
+++ b/test/build/version.test.js
@@ -2,8 +2,7 @@
 
 const fs = require('node:fs')
 const path = require('node:path')
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const fastify = require('../../fastify')()
 
 test('should be the same as package.json', t => {
@@ -11,5 +10,5 @@ test('should be the same as package.json', t => {
 
   const json = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', 'package.json')).toString('utf8'))
 
-  t.equal(fastify.version, json.version)
+  t.assert.strictEqual(fastify.version, json.version)
 })


### PR DESCRIPTION
These change are related to the issue #5555 

- Migrated from tap framework to node:test in fastify build module
- Ran the tests that i changed and confirmed they passed successfully
