### PR TITLE
docs(reply): cleanup and update to clarify elapsedTime behaviour

### DIFF
--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -19,7 +19,6 @@
   - [.removeTrailer(key)](#removetrailerkey)
   - [.redirect(dest, [code ,])](#redirectdest--code)
   - [.callNotFound()](#callnotfound)
-  - [.getResponseTime()](#getresponsetime)
   - [.type(contentType)](#typecontenttype)
   - [.getSerializationFunction(schema | httpStatus, [contentType])](#getserializationfunctionschema--httpstatus)
   - [.compileSerializationSchema(schema, [httpStatus], [contentType])](#compileserializationschemaschema-httpstatus)
@@ -113,9 +112,6 @@ If not set via `reply.code`, the resulting `statusCode` will be `200`.
 
 Invokes the custom response time getter to calculate the amount of time passed
 since the request was received by Fastify.
-
-Note that unless this function is called in the [`onResponse`
-hook](./Hooks.md#onresponse) it will always return `0`.
 
 ```js
 const milliseconds = reply.elapsedTime


### PR DESCRIPTION
Minor cleanup of Reply docs: Removed incorrect information stating that the elapsedTime getter will return 0 unless called in the onResponse hook, which is not the intended behaviour based on the discussion in #4575 and [existing tests](https://github.com/fastify/fastify/blob/b1b9a75cc08c00c27bae286ef85f71f259892176/test/internals/reply.test.js#L1508). I also removed a link that previously led to the getResponseTime section of the docs before it was removed in v5.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Cheers!