### PR TITLE
Bumped light-my-request to v6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "fast-content-type-parse": "^1.1.0",
     "fast-json-stringify": "^5.8.0",
     "find-my-way": "^8.0.0",
-    "light-my-request": "^5.11.0",
+    "light-my-request": "^6.1.0",
     "pino": "^9.0.0",
     "process-warning": "^3.0.0",
     "proxy-addr": "^2.0.7",


### PR DESCRIPTION
### Bump `light-my-request` to Version 6.1.0 to Address Cookie Vulnerability

In this PR, I am bumping the `light-my-request` version from `6.0.0` to `6.1.0` to address a [vulnerability](https://github.com/advisories/GHSA-pxg6-pf52-xh8x) in the `cookie` package. Version `6.1.0` of `light-my-request` has already fixed this issue by upgrading `cookie` to version `0.7.0`, as seen in [PR #302](https://github.com/fastify/light-my-request/pull/302) by @mcollina.

The vulnerability is a concern because the `@nestjs/platform-fastify` package is currently depending on `fastify` version `4.28.1`, which still uses `light-my-request` version `5.11.0`.

### Request to Maintain Fastify v4 Branch

I kindly request that the Fastify maintainers release an update to version `4.28.2` as soon as possible to address this issue.

---
**Checklist**
- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
