### PR TITLE
fix: do not lowercase content-type parameter values

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -43,7 +43,7 @@ ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
   const contentTypeIsString = typeof contentType === 'string'
 
   if (contentTypeIsString) {
-    contentType = contentType.trim().toLowerCase()
+    contentType = contentType.trim()
     if (contentType.length === 0) throw new FST_ERR_CTP_EMPTY_TYPE()
   } else if (!(contentType instanceof RegExp)) {
     throw new FST_ERR_CTP_INVALID_TYPE()

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -219,21 +219,6 @@ test('add', t => {
     t.equal(contentTypeParser.customParsers.get('').fn, first)
   })
 
-  test('should lowercase contentTypeParser name', async t => {
-    t.plan(1)
-    const fastify = Fastify()
-    fastify.addContentTypeParser('text/html', function (req, done) {
-      done()
-    })
-    try {
-      fastify.addContentTypeParser('TEXT/html', function (req, done) {
-        done()
-      })
-    } catch (err) {
-      t.same(err.message, FST_ERR_CTP_ALREADY_PRESENT('text/html').message)
-    }
-  })
-
   test('should trim contentTypeParser name', async t => {
     t.plan(1)
     const fastify = Fastify()


### PR DESCRIPTION
Closes #5740

@Fdawgs is right, my PR that tidied up this part of the API also added lowercasing to the `Content-Type` parsers but it is actually spec-compliant to have case-insensitive parameter values, so it prevents valid use cases

This can trivially be released as a bugfix in the v5 line as it only relaxes the `addContentType` method