### PR TITLE
fix: make content-type case-insensitive

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -169,7 +169,7 @@ ContentTypeParser.prototype.remove = function (contentType) {
 }
 
 ContentTypeParser.prototype.run = function (contentType, handler, request, reply) {
-  const parser = this.getParser(contentType)
+  const parser = this.getParser(contentType.toLowerCase())
 
   if (parser === undefined) {
     if (request.is404) {

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -109,16 +109,20 @@ ContentTypeParser.prototype.existingParser = function (contentType) {
 ContentTypeParser.prototype.getParser = function (contentType) {
   let parser = this.customParsers.get(contentType)
   if (parser !== undefined) return parser
-
   parser = this.cache.get(contentType)
   if (parser !== undefined) return parser
 
+  const caseInsensitiveContentType = contentType.toLowerCase()
   // eslint-disable-next-line no-var
   for (var i = 0; i !== this.parserList.length; ++i) {
     const parserListItem = this.parserList[i]
     if (
-      contentType.slice(0, parserListItem.length) === parserListItem &&
-      (contentType.length === parserListItem.length || contentType.charCodeAt(parserListItem.length) === 59 /* `;` */ || contentType.charCodeAt(parserListItem.length) === 32 /* ` ` */)
+      caseInsensitiveContentType.slice(0, parserListItem.length) === parserListItem &&
+      (
+        caseInsensitiveContentType.length === parserListItem.length ||
+        caseInsensitiveContentType.charCodeAt(parserListItem.length) === 59 /* `;` */ ||
+        caseInsensitiveContentType.charCodeAt(parserListItem.length) === 32 /* ` ` */
+      )
     ) {
       parser = this.customParsers.get(parserListItem)
       this.cache.set(contentType, parser)
@@ -169,7 +173,7 @@ ContentTypeParser.prototype.remove = function (contentType) {
 }
 
 ContentTypeParser.prototype.run = function (contentType, handler, request, reply) {
-  const parser = this.getParser(contentType.toLowerCase())
+  const parser = this.getParser(contentType)
 
   if (parser === undefined) {
     if (request.is404) {

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -252,6 +252,54 @@ test('add', t => {
   t.end()
 })
 
+test('run', t => {
+  test('should be case-insensitive', t => {
+    t.plan(6)
+
+    const fastify = Fastify()
+
+    fastify.addContentTypeParser('text/html', (req, payload, done) => {
+      done(null, payload)
+    })
+
+    fastify.post('/', (req, reply) => {
+      reply.send(req.body)
+    })
+
+    fastify.inject({
+      method: 'POST',
+      url: '/',
+      headers: { 'Content-Type': 'text/html' },
+      payload: 'hello world'
+    }, (err, res) => {
+      t.error(err)
+      t.same(res.payload, 'hello world')
+    })
+
+    fastify.inject({
+      method: 'POST',
+      url: '/',
+      headers: { 'Content-Type': 'TEXT/HTML' },
+      payload: 'hello world'
+    }, (err, res) => {
+      t.error(err)
+      t.same(res.payload, 'hello world')
+    })
+
+    fastify.inject({
+      method: 'POST',
+      url: '/',
+      headers: { 'Content-Type': 'TEXT/HTML; charset=utf-8' },
+      payload: 'hello world'
+    }, (err, res) => {
+      t.error(err)
+      t.same(res.payload, 'hello world')
+    })
+  })
+
+  t.end()
+})
+
 test('non-Error thrown from content parser is properly handled', t => {
   t.plan(3)
 

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -79,6 +79,23 @@ test('getParser', t => {
   })
 
   test('should return matching parser with caching /2', t => {
+    t.plan(8)
+
+    const fastify = Fastify()
+
+    fastify.addContentTypeParser('text/html', first)
+
+    t.equal(fastify[keys.kContentTypeParser].getParser('text/html').fn, first)
+    t.equal(fastify[keys.kContentTypeParser].cache.size, 0)
+    t.equal(fastify[keys.kContentTypeParser].getParser('text/HTML').fn, first)
+    t.equal(fastify[keys.kContentTypeParser].cache.size, 1)
+    t.equal(fastify[keys.kContentTypeParser].getParser('TEXT/html').fn, first)
+    t.equal(fastify[keys.kContentTypeParser].cache.size, 2)
+    t.equal(fastify[keys.kContentTypeParser].getParser('TEXT/html').fn, first)
+    t.equal(fastify[keys.kContentTypeParser].cache.size, 2)
+  })
+
+  test('should return matching parser with caching /3', t => {
     t.plan(6)
 
     const fastify = Fastify()
@@ -247,54 +264,6 @@ test('add', t => {
     } catch (err) {
       t.same(err.message, FST_ERR_CTP_ALREADY_PRESENT('text/html').message)
     }
-  })
-
-  t.end()
-})
-
-test('run', t => {
-  test('should be case-insensitive', t => {
-    t.plan(6)
-
-    const fastify = Fastify()
-
-    fastify.addContentTypeParser('text/html', (req, payload, done) => {
-      done(null, payload)
-    })
-
-    fastify.post('/', (req, reply) => {
-      reply.send(req.body)
-    })
-
-    fastify.inject({
-      method: 'POST',
-      url: '/',
-      headers: { 'Content-Type': 'text/html' },
-      payload: 'hello world'
-    }, (err, res) => {
-      t.error(err)
-      t.same(res.payload, 'hello world')
-    })
-
-    fastify.inject({
-      method: 'POST',
-      url: '/',
-      headers: { 'Content-Type': 'TEXT/HTML' },
-      payload: 'hello world'
-    }, (err, res) => {
-      t.error(err)
-      t.same(res.payload, 'hello world')
-    })
-
-    fastify.inject({
-      method: 'POST',
-      url: '/',
-      headers: { 'Content-Type': 'TEXT/HTML; charset=utf-8' },
-      payload: 'hello world'
-    }, (err, res) => {
-      t.error(err)
-      t.same(res.payload, 'hello world')
-    })
   })
 
   t.end()


### PR DESCRIPTION
so this actually correctly fixes #5740

[standards](https://httpwg.org/specs/rfc9110.html#media.type) say `Content-Type` is case insensitive, which is why we prevent the registration of `text/html` and `text/HTML` at the same time, but currently don't treat text/html and text/HTML as the same