### PR TITLE
fix: only allow semicolon after Content-Type `type/subtype`

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -118,7 +118,7 @@ ContentTypeParser.prototype.getParser = function (contentType) {
     const parserListItem = this.parserList[i]
     if (
       contentType.slice(0, parserListItem.length) === parserListItem &&
-      (contentType.length === parserListItem.length || contentType.charCodeAt(parserListItem.length) === 59 /* `;` */ || contentType.charCodeAt(parserListItem.length) === 32 /* ` ` */)
+      (contentType.length === parserListItem.length || contentType.charCodeAt(parserListItem.length) === 59 /* `;` */)
     ) {
       parser = this.customParsers.get(parserListItem)
       this.cache.set(contentType, parser)

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -47,7 +47,7 @@ test('hasContentTypeParser', t => {
 
 test('getParser', t => {
   test('should return matching parser', t => {
-    t.plan(6)
+    t.plan(5)
 
     const fastify = Fastify()
 
@@ -59,12 +59,11 @@ test('getParser', t => {
     t.equal(fastify[keys.kContentTypeParser].getParser('image/png').fn, first)
     t.equal(fastify[keys.kContentTypeParser].getParser('text/html').fn, third)
     t.equal(fastify[keys.kContentTypeParser].getParser('text/html; charset=utf-8').fn, third)
-    t.equal(fastify[keys.kContentTypeParser].getParser('text/html ; charset=utf-8').fn, third)
     t.equal(fastify[keys.kContentTypeParser].getParser('text/htmlINVALID')?.fn, undefined)
   })
 
   test('should return matching parser with caching /1', t => {
-    t.plan(6)
+    t.plan(8)
 
     const fastify = Fastify()
 
@@ -72,10 +71,12 @@ test('getParser', t => {
 
     t.equal(fastify[keys.kContentTypeParser].getParser('text/html').fn, first)
     t.equal(fastify[keys.kContentTypeParser].cache.size, 0)
-    t.equal(fastify[keys.kContentTypeParser].getParser('text/html ').fn, first)
+    t.equal(fastify[keys.kContentTypeParser].getParser('text/html; charset=utf-8').fn, first)
     t.equal(fastify[keys.kContentTypeParser].cache.size, 1)
-    t.equal(fastify[keys.kContentTypeParser].getParser('text/html ').fn, first)
-    t.equal(fastify[keys.kContentTypeParser].cache.size, 1)
+    t.equal(fastify[keys.kContentTypeParser].getParser('text/html;charset=utf-8').fn, first)
+    t.equal(fastify[keys.kContentTypeParser].cache.size, 2)
+    t.equal(fastify[keys.kContentTypeParser].getParser('text/html;charset=utf-8').fn, first)
+    t.equal(fastify[keys.kContentTypeParser].cache.size, 2)
   })
 
   test('should return matching parser with caching /2', t => {


### PR DESCRIPTION
[rfc9110](https://httpwg.org/specs/rfc9110.html#media.type):

> The type/subtype MAY be followed by semicolon-delimited parameters ([Section 5.6.6](https://httpwg.org/specs/rfc9110.html#parameter)) in the form of name/value pairs. The presence or absence of a parameter might be significant to the processing of a media type, depending on its definition within the media type registry. Parameter values might or might not be case-sensitive, depending on the semantics of the parameter name.

> For example, the following media types are equivalent in describing HTML text data encoded in the UTF-8 character encoding scheme:

>  text/html;charset=utf-8
>  Text/HTML;Charset="utf-8"
>  text/html; charset="utf-8"
>  text/html;charset=UTF-8

No talk about there being a space between the `type/subtype` and `;`

In other words, it doesn't list something like `text/html   ;charset=UTF-8` as being equivalent to others

I've never seen something like this in the wild either, so I'm thinking it could be a bugfix (and a perf boost)

If this would be a major, we can tag semver major and wait, or I can close this PR and open an issue instead