### PR TITLE
docs: Changed var for let and const

### DIFF
--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -53,7 +53,7 @@ fastify.addContentTypeParser(['text/xml', 'application/xml'], function (request,
 
 // Async is also supported in Node versions >= 8.0.0
 fastify.addContentTypeParser('application/jsoff', async function (request, payload) {
-  var res = await jsoffParserAsync(payload)
+  const res = await jsoffParserAsync(payload)
 
   return res
 })
@@ -181,7 +181,7 @@ limit is exceeded the custom parser will not be invoked.
 ```js
 fastify.addContentTypeParser('application/json', { parseAs: 'string' }, function (req, body, done) {
   try {
-    var json = JSON.parse(body)
+    const json = JSON.parse(body)
     done(null, json)
   } catch (err) {
     err.statusCode = 400
@@ -206,7 +206,7 @@ There are some cases where you need to catch all requests regardless of their
 content type. With Fastify, you can just use the `'*'` content type.
 ```js
 fastify.addContentTypeParser('*', function (request, payload, done) {
-  var data = ''
+  let data = ''
   payload.on('data', chunk => { data += chunk })
   payload.on('end', () => {
     done(null, data)
@@ -266,7 +266,7 @@ only on those that don't have a specific one, you should call the
 fastify.removeAllContentTypeParsers()
 
 fastify.addContentTypeParser('*', function (request, payload, done) {
-  var data = ''
+  const data = ''
   payload.on('data', chunk => { data += chunk })
   payload.on('end', () => {
     done(null, data)

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -876,7 +876,7 @@ API:
 ```js
 fastify.setErrorHandler(function (error, request, reply) {
   request.log.warn(error)
-  var statusCode = error.statusCode >= 400 ? error.statusCode : 500
+  const statusCode = error.statusCode >= 400 ? error.statusCode : 500
   reply
     .code(statusCode)
     .type('text/plain')

--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -334,8 +334,8 @@ fastify.post('/name::verb') // will be interpreted as /name:verb
 Are you an `async/await` user? We have you covered!
 ```js
 fastify.get('/', options, async function (request, reply) {
-  var data = await getData()
-  var processed = await processData(data)
+  const data = await getData()
+  const processed = await processData(data)
   return processed
 })
 ```
@@ -349,8 +349,8 @@ handler or you will introduce a race condition in certain situations.
 
 ```js
 fastify.get('/', options, async function (request, reply) {
-  var data = await getData()
-  var processed = await processData(data)
+  const data = await getData()
+  const processed = await processData(data)
   return reply.send(processed)
 })
 ```

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1559,7 +1559,7 @@ is set. It can be accessed using `fastify.errorHandler` and it logs the error
 with respect to its `statusCode`.
 
 ```js
-var statusCode = error.statusCode
+const statusCode = error.statusCode
 if (statusCode >= 500) {
   log.error(error)
 } else if (statusCode >= 400) {


### PR DESCRIPTION
By reading the docs I found out that the `var` keyword is used in some snippets instead of `let` and `const`. As they are the recommended standard I took my time to change it.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
