### PR TITLE
feat: allow to access decorators

### DIFF
--- a/docs/Reference/Errors.md
+++ b/docs/Reference/Errors.md
@@ -34,8 +34,10 @@
     - [FST_ERR_DEC_ALREADY_PRESENT](#fst_err_dec_already_present)
     - [FST_ERR_DEC_DEPENDENCY_INVALID_TYPE](#fst_err_dec_dependency_invalid_type)
     - [FST_ERR_DEC_MISSING_DEPENDENCY](#fst_err_dec_missing_dependency)
-    - [FST_ERR_DEC_AFTER_START](#fst_err_dec_after_start)
+    - [FST_ERR_DEC_GET_ACCESS_AFTER_START](#fst_err_dec_get_access_after_start)
     - [FST_ERR_DEC_REFERENCE_TYPE](#fst_err_dec_reference_type)
+    - [FST_ERR_DEC_AFTER_START](#fst_err_dec_after_start)
+    - [FST_ERR_DEC_UNDECLARED](#fst_err_dec_undeclared)
     - [FST_ERR_HOOK_INVALID_TYPE](#fst_err_hook_invalid_type)
     - [FST_ERR_HOOK_INVALID_HANDLER](#fst_err_hook_invalid_handler)
     - [FST_ERR_HOOK_INVALID_ASYNC_HANDLER](#fst_err_hook_invalid_async_handler)
@@ -308,6 +310,8 @@ Below is a table with all the error codes that Fastify uses.
 | <a id="fst_err_dec_missing_dependency">FST_ERR_DEC_MISSING_DEPENDENCY</a> | The decorator cannot be registered due to a missing dependency. | Register the missing dependency. | [#1168](https://github.com/fastify/fastify/pull/1168) |
 | <a id="fst_err_dec_after_start">FST_ERR_DEC_AFTER_START</a> | The decorator cannot be added after start. | Add the decorator before starting the server. | [#2128](https://github.com/fastify/fastify/pull/2128) |
 | <a id="fst_err_dec_reference_type">FST_ERR_DEC_REFERENCE_TYPE</a> | The decorator cannot be a reference type. | Define the decorator with a getter/setter interface or an empty decorator with a hook. | [#5462](https://github.com/fastify/fastify/pull/5462) |
+| <a id="fst_err_dec_get_access_after_start">FST_ERR_DEC_GET_ACCESS_AFTER_START</a> | Methods getDecorators has been called after the application started. | Call getDecorators when registering your plugins, before starting the application. | [#](https://github.com/fastify/fastify/pull/)
+| <a id="fst_err_dec_undeclared">FST_ERR_DEC_UNDECLARED</a> | An attempt was made to access a decorator that has not been declared. | Declare the decorator before using it. | [#](https://github.com/fastify/fastify/pull/)
 | <a id="fst_err_hook_invalid_type">FST_ERR_HOOK_INVALID_TYPE</a> | The hook name must be a string. | Use a string for the hook name. | [#1168](https://github.com/fastify/fastify/pull/1168) |
 | <a id="fst_err_hook_invalid_handler">FST_ERR_HOOK_INVALID_HANDLER</a> | The hook callback must be a function. | Use a function for the hook callback. | [#1168](https://github.com/fastify/fastify/pull/1168) |
 | <a id="fst_err_hook_invalid_async_handler">FST_ERR_HOOK_INVALID_ASYNC_HANDLER</a> | Async function has too many arguments. Async hooks should not use the `done` argument. | Remove the `done` argument from the async hook. | [#4367](https://github.com/fastify/fastify/pull/4367) |

--- a/fastify.js
+++ b/fastify.js
@@ -342,6 +342,7 @@ function fastify (options) {
     decorateRequest: decorator.decorateRequest,
     hasRequestDecorator: decorator.existRequest,
     hasReplyDecorator: decorator.existReply,
+    getDecorators: decorator.getDecorators,
     addHttpMethod,
     // fake http injection
     inject,

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -12,7 +12,9 @@ const {
   FST_ERR_DEC_MISSING_DEPENDENCY,
   FST_ERR_DEC_AFTER_START,
   FST_ERR_DEC_REFERENCE_TYPE,
-  FST_ERR_DEC_DEPENDENCY_INVALID_TYPE
+  FST_ERR_DEC_DEPENDENCY_INVALID_TYPE,
+  FST_ERR_DEC_UNDECLARED,
+  FST_ERR_DEC_GET_ACCESS_AFTER_START
 } = require('./errors')
 
 function decorate (instance, name, fn, dependencies) {
@@ -30,6 +32,32 @@ function decorate (instance, name, fn, dependencies) {
   } else {
     instance[name] = fn
   }
+}
+
+function getDecorator (instance, name) {
+  if (checkExistence(instance, name)) {
+    return instance[name]
+  }
+
+  const prop = getProp(instance[kRequest], name) ?? getProp(instance[kReply], name)
+  if (!prop) {
+    throw new FST_ERR_DEC_UNDECLARED(name)
+  }
+
+  return prop.value
+}
+
+function getDecorators (names) {
+  if (this[kState].started) {
+    throw new FST_ERR_DEC_GET_ACCESS_AFTER_START()
+  }
+
+  const decorators = []
+  for (const name of names) {
+    decorators.push(getDecorator(this, name))
+  }
+
+  return decorators
 }
 
 function decorateConstructor (konstructor, name, fn, dependencies) {
@@ -78,6 +106,10 @@ function hasKey (fn, name) {
     return fn.props.find(({ key }) => key === name)
   }
   return false
+}
+
+function getProp (fn, name) {
+  return fn.props.find(({ key }) => key === name)
 }
 
 function checkRequestExistence (name) {
@@ -133,5 +165,6 @@ module.exports = {
   existReply: checkReplyExistence,
   dependencies: checkDependencies,
   decorateReply,
-  decorateRequest
+  decorateRequest,
+  getDecorators,
 }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -149,6 +149,14 @@ const codes = {
     'FST_ERR_DEC_REFERENCE_TYPE',
     "The decorator '%s' of type '%s' is a reference type. Use the { getter, setter } interface instead."
   ),
+  FST_ERR_DEC_UNDECLARED: createError(
+    'FST_ERR_DEC_UNDECLARED',
+    "No decorator '%s' has been declared."
+  ),
+  FST_ERR_DEC_GET_ACCESS_AFTER_START: createError(
+    'FST_ERR_DEC_GET_ACCESS_AFTER_START',
+    'Methods getDecorators should be called before the application start.'
+  ),
 
   /**
    * hooks

--- a/test/internals/errors.test.js
+++ b/test/internals/errors.test.js
@@ -5,7 +5,7 @@ const errors = require('../../lib/errors')
 const { readFileSync } = require('node:fs')
 const { resolve } = require('node:path')
 
-test('should expose 83 errors', t => {
+test('should expose 85 errors', t => {
   t.plan(1)
   const exportedKeys = Object.keys(errors)
   let counter = 0
@@ -14,11 +14,12 @@ test('should expose 83 errors', t => {
       counter++
     }
   }
-  t.assert.strictEqual(counter, 83)
+
+  t.assert.strictEqual(counter, 85)
 })
 
 test('ensure name and codes of Errors are identical', t => {
-  t.plan(83)
+  t.plan(85)
   const exportedKeys = Object.keys(errors)
   for (const key of exportedKeys) {
     if (errors[key].name === 'FastifyError') {
@@ -868,7 +869,7 @@ test('FST_ERR_ERROR_HANDLER_NOT_FN', t => {
 })
 
 test('Ensure that all errors are in Errors.md TOC', t => {
-  t.plan(83)
+  t.plan(85)
   const errorsMd = readFileSync(resolve(__dirname, '../../docs/Reference/Errors.md'), 'utf8')
 
   const exportedKeys = Object.keys(errors)
@@ -880,7 +881,7 @@ test('Ensure that all errors are in Errors.md TOC', t => {
 })
 
 test('Ensure that non-existing errors are not in Errors.md TOC', t => {
-  t.plan(83)
+  t.plan(85)
   const errorsMd = readFileSync(resolve(__dirname, '../../docs/Reference/Errors.md'), 'utf8')
 
   const matchRE = / {4}- \[([A-Z0-9_]+)\]\(#[a-z0-9_]+\)/g
@@ -893,7 +894,7 @@ test('Ensure that non-existing errors are not in Errors.md TOC', t => {
 })
 
 test('Ensure that all errors are in Errors.md documented', t => {
-  t.plan(83)
+  t.plan(85)
   const errorsMd = readFileSync(resolve(__dirname, '../../docs/Reference/Errors.md'), 'utf8')
 
   const exportedKeys = Object.keys(errors)
@@ -905,7 +906,7 @@ test('Ensure that all errors are in Errors.md documented', t => {
 })
 
 test('Ensure that non-existing errors are not in Errors.md documented', t => {
-  t.plan(83)
+  t.plan(85)
   const errorsMd = readFileSync(resolve(__dirname, '../../docs/Reference/Errors.md'), 'utf8')
 
   const matchRE = /<a id="[0-9a-zA-Z_]+">([0-9a-zA-Z_]+)<\/a>/g

--- a/test/internals/errors.test.js
+++ b/test/internals/errors.test.js
@@ -248,6 +248,26 @@ test('FST_ERR_DEC_REFERENCE_TYPE', t => {
   t.assert.ok(error instanceof Error)
 })
 
+test('FST_ERR_DEC_UNDECLARED', t => {
+  t.plan(5)
+  const error = new errors.FST_ERR_DEC_UNDECLARED('myDecorator')
+  t.assert.strictEqual(error.name, 'FastifyError')
+  t.assert.strictEqual(error.code, 'FST_ERR_DEC_UNDECLARED')
+  t.assert.strictEqual(error.message, "No decorator 'myDecorator' has been declared.")
+  t.assert.strictEqual(error.statusCode, 500)
+  t.assert.ok(error instanceof Error)
+})
+
+test('FST_ERR_DEC_GET_ACCESS_AFTER_START', t => {
+  t.plan(5)
+  const error = new errors.FST_ERR_DEC_GET_ACCESS_AFTER_START()
+  t.assert.strictEqual(error.name, 'FastifyError')
+  t.assert.strictEqual(error.code, 'FST_ERR_DEC_GET_ACCESS_AFTER_START')
+  t.assert.strictEqual(error.message, 'Methods getDecorators should be called before the application start.')
+  t.assert.strictEqual(error.statusCode, 500)
+  t.assert.ok(error instanceof Error)
+})
+
 test('FST_ERR_HOOK_INVALID_TYPE', t => {
   t.plan(5)
   const error = new errors.FST_ERR_HOOK_INVALID_TYPE()

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -519,6 +519,18 @@ expectError(server.decorateReply('typedTestReplyMethod', async function (x) {
   return 'foo'
 }))
 
+const decoratorsRestParameters = server.getDecorators<[string, number]>('decorator1', 'decorator2')
+expectType<[string, number]>(decoratorsRestParameters)
+
+const decoratorsArray = server.getDecorators<[string, number]>(['decorator1', 'decorator2'])
+expectType<[string, number]>(decoratorsArray)
+
+const decoratorsRestParametersDefault = server.getDecorators('decorator1', 'decorator2')
+expectType<any[]>(decoratorsRestParametersDefault)
+
+const decoratorsDefaultArray = server.getDecorators(['decorator1', 'decorator2'])
+expectType<any[]>(decoratorsDefaultArray)
+
 const versionConstraintStrategy = {
   name: 'version',
   storage: () => ({

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -152,6 +152,9 @@ export interface FastifyInstance<
   decorateRequest: DecorationMethod<FastifyRequest, FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>>;
   decorateReply: DecorationMethod<FastifyReply, FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>>;
 
+  getDecorators<T extends any[]>(...names: string[]): T;
+  getDecorators<T extends any[]>(names: string[]): T;
+
   hasDecorator(decorator: string | symbol): boolean;
   hasRequestDecorator(decorator: string | symbol): boolean;
   hasReplyDecorator(decorator: string | symbol): boolean;


### PR DESCRIPTION
Regarding #5061

I will explain in more details later, I need to think more about it and how this can be used with the existing core plugins without breaking change. This is just the beginning of a POC.

To keep it simple, I would like to offer an alternative to module augmentation and merging declaration more broadly. 

If we could export more types from core plugins instead of just augmenting the global instance and request/reply:
```ts
// Some functions
export interface MyFooDecorator {
  (a: string): void;
  (a: string, b?: string): void;
}

export interface MyBarDecorator {
  (a: boolean): void;
}
```

We could use this feature this way at plugin registration:
```ts
const [foo, bar] = fastify.getDecorators<[MyFooDecorator, MyBarDecorator]>('foo', 'bar')

// These tests should work
expectType<MyFooDecorator>(foo)
expectType<MyBarDecorator>(bar)
```
Well, as I said, I need to think more about it.