### PR TITLE
test: Migrate http2 test to node:test

### DIFF
--- a/test/http2/constraint.test.js
+++ b/test/http2/constraint.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const Fastify = require('../..')
 const h2url = require('h2url')
 
@@ -9,10 +8,10 @@ const alpha = { res: 'alpha' }
 const beta = { res: 'beta' }
 
 const { buildCertificate } = require('../build-certificate')
-t.before(buildCertificate)
+test.before(buildCertificate)
 
-test('A route supports host constraints under http2 protocol and secure connection', (t) => {
-  t.plan(6)
+test('A route supports host constraints under http2 protocol and secure connection', async (t) => {
+  t.plan(5)
 
   let fastify
   try {
@@ -23,9 +22,9 @@ test('A route supports host constraints under http2 protocol and secure connecti
         cert: global.context.cert
       }
     })
-    t.pass('Key/cert successfully loaded')
+    t.assert.ok(true, 'Key/cert successfully loaded')
   } catch (e) {
-    t.fail('Key/cert loading failed', e)
+    t.assert.fail('Key/cert loading failed')
   }
 
   const constrain = 'fastify.dev'
@@ -53,60 +52,58 @@ test('A route supports host constraints under http2 protocol and secure connecti
       reply.code(200).send({ ...beta, hostname: req.hostname })
     }
   })
+  t.after(() => { fastify.close() })
 
-  fastify.listen({ port: 0 }, err => {
-    t.error(err)
-    t.teardown(() => { fastify.close() })
+  await fastify.listen({ port: 0 })
 
-    t.test('https get request - no constrain', async (t) => {
-      t.plan(3)
+  await t.test('https get request - no constrain', async (t) => {
+    t.plan(3)
 
-      const url = `https://localhost:${fastify.server.address().port}`
-      const res = await h2url.concat({ url })
+    const url = `https://localhost:${fastify.server.address().port}`
+    const res = await h2url.concat({ url })
 
-      t.equal(res.headers[':status'], 200)
-      t.equal(res.headers['content-length'], '' + JSON.stringify(alpha).length)
-      t.same(JSON.parse(res.body), alpha)
+    t.assert.strictEqual(res.headers[':status'], 200)
+    t.assert.strictEqual(res.headers['content-length'], '' + JSON.stringify(alpha).length)
+    t.assert.deepStrictEqual(JSON.parse(res.body), alpha)
+  })
+
+  await t.test('https get request - constrain', async (t) => {
+    t.plan(3)
+
+    const url = `https://localhost:${fastify.server.address().port}/beta`
+    const res = await h2url.concat({
+      url,
+      headers: {
+        ':authority': constrain
+      }
     })
 
-    t.test('https get request - constrain', async (t) => {
-      t.plan(3)
+    t.assert.strictEqual(res.headers[':status'], 200)
+    t.assert.strictEqual(res.headers['content-length'], '' + JSON.stringify(beta).length)
+    t.assert.deepStrictEqual(JSON.parse(res.body), beta)
+  })
 
-      const url = `https://localhost:${fastify.server.address().port}/beta`
-      const res = await h2url.concat({
-        url,
-        headers: {
-          ':authority': constrain
-        }
-      })
+  await t.test('https get request - constrain - not found', async (t) => {
+    t.plan(1)
 
-      t.equal(res.headers[':status'], 200)
-      t.equal(res.headers['content-length'], '' + JSON.stringify(beta).length)
-      t.same(JSON.parse(res.body), beta)
+    const url = `https://localhost:${fastify.server.address().port}/beta`
+    const res = await h2url.concat({
+      url
     })
 
-    t.test('https get request - constrain - not found', async (t) => {
-      t.plan(1)
+    t.assert.strictEqual(res.headers[':status'], 404)
+  })
+  await t.test('https get request - constrain - verify hostname and port from request', async (t) => {
+    t.plan(1)
 
-      const url = `https://localhost:${fastify.server.address().port}/beta`
-      const res = await h2url.concat({
-        url
-      })
-
-      t.equal(res.headers[':status'], 404)
+    const url = `https://localhost:${fastify.server.address().port}/hostname_port`
+    const res = await h2url.concat({
+      url,
+      headers: {
+        ':authority': constrain
+      }
     })
-    t.test('https get request - constrain - verify hostname and port from request', async (t) => {
-      t.plan(1)
-
-      const url = `https://localhost:${fastify.server.address().port}/hostname_port`
-      const res = await h2url.concat({
-        url,
-        headers: {
-          ':authority': constrain
-        }
-      })
-      const body = JSON.parse(res.body)
-      t.equal(body.hostname, constrain)
-    })
+    const body = JSON.parse(res.body)
+    t.assert.strictEqual(body.hostname, constrain)
   })
 })

--- a/test/http2/head.test.js
+++ b/test/http2/head.test.js
@@ -1,35 +1,34 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const Fastify = require('../..')
 const h2url = require('h2url')
 const msg = { hello: 'world' }
 
-let fastify
-try {
-  fastify = Fastify({
-    http2: true
+test('http2 HEAD test', async (t) => {
+  let fastify
+  try {
+    fastify = Fastify({
+      http2: true
+    })
+    t.assert.ok(true, 'http2 successfully loaded')
+  } catch (e) {
+    t.assert.fail('http2 loading failed')
+  }
+
+  fastify.all('/', function (req, reply) {
+    reply.code(200).send(msg)
   })
-  t.pass('http2 successfully loaded')
-} catch (e) {
-  t.fail('http2 loading failed', e)
-}
+  t.after(() => { fastify.close() })
 
-fastify.all('/', function (req, reply) {
-  reply.code(200).send(msg)
-})
+  await fastify.listen({ port: 0 })
 
-fastify.listen({ port: 0 }, err => {
-  t.error(err)
-  t.teardown(() => { fastify.close() })
-
-  test('http HEAD request', async (t) => {
+  await t.test('http HEAD request', async (t) => {
     t.plan(1)
 
     const url = `http://localhost:${fastify.server.address().port}`
     const res = await h2url.concat({ url, method: 'HEAD' })
 
-    t.equal(res.headers[':status'], 200)
+    t.assert.strictEqual(res.headers[':status'], 200)
   })
 })

--- a/test/http2/missing-http2-module.test.js
+++ b/test/http2/missing-http2-module.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const proxyquire = require('proxyquire')
 const server = proxyquire('../../lib/server', { 'node:http2': null })
 const Fastify = proxyquire('../..', { './lib/server.js': server })
@@ -10,9 +9,9 @@ test('should throw when http2 module cannot be found', t => {
   t.plan(2)
   try {
     Fastify({ http2: true })
-    t.fail('fastify did not throw expected error')
+    t.assert.fail('fastify did not throw expected error')
   } catch (err) {
-    t.equal(err.code, 'FST_ERR_HTTP2_INVALID_VERSION')
-    t.equal(err.message, 'HTTP2 is available only from node >= 8.8.1')
+    t.assert.strictEqual(err.code, 'FST_ERR_HTTP2_INVALID_VERSION')
+    t.assert.strictEqual(err.message, 'HTTP2 is available only from node >= 8.8.1')
   }
 })

--- a/test/http2/plain.test.js
+++ b/test/http2/plain.test.js
@@ -1,50 +1,50 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const Fastify = require('../..')
 const h2url = require('h2url')
 const msg = { hello: 'world' }
 
-let fastify
-try {
-  fastify = Fastify({
-    http2: true
+test('http2 plain test', async t => {
+  let fastify
+  try {
+    fastify = Fastify({
+      http2: true
+    })
+    t.assert.ok(true, 'http2 successfully loaded')
+  } catch (e) {
+    t.assert.fail('http2 loading failed')
+  }
+
+  fastify.get('/', function (req, reply) {
+    reply.code(200).send(msg)
   })
-  t.pass('http2 successfully loaded')
-} catch (e) {
-  t.fail('http2 loading failed', e)
-}
 
-fastify.get('/', function (req, reply) {
-  reply.code(200).send(msg)
-})
+  fastify.get('/host', function (req, reply) {
+    reply.code(200).send(req.host)
+  })
 
-fastify.get('/host', function (req, reply) {
-  reply.code(200).send(req.host)
-})
+  fastify.get('/hostname_port', function (req, reply) {
+    reply.code(200).send({ hostname: req.hostname, port: req.port })
+  })
 
-fastify.get('/hostname_port', function (req, reply) {
-  reply.code(200).send({ hostname: req.hostname, port: req.port })
-})
+  t.after(() => { fastify.close() })
 
-fastify.listen({ port: 0 }, err => {
-  t.error(err)
-  t.teardown(() => { fastify.close() })
+  await fastify.listen({ port: 0 })
 
-  test('http get request', async (t) => {
+  await t.test('http get request', async (t) => {
     t.plan(3)
 
     const url = `http://localhost:${fastify.server.address().port}`
     const res = await h2url.concat({ url })
 
-    t.equal(res.headers[':status'], 200)
-    t.equal(res.headers['content-length'], '' + JSON.stringify(msg).length)
+    t.assert.strictEqual(res.headers[':status'], 200)
+    t.assert.strictEqual(res.headers['content-length'], '' + JSON.stringify(msg).length)
 
-    t.same(JSON.parse(res.body), msg)
+    t.assert.deepStrictEqual(JSON.parse(res.body), msg)
   })
 
-  test('http host', async (t) => {
+  await t.test('http host', async (t) => {
     t.plan(1)
 
     const host = `localhost:${fastify.server.address().port}`
@@ -52,9 +52,9 @@ fastify.listen({ port: 0 }, err => {
     const url = `http://${host}/host`
     const res = await h2url.concat({ url })
 
-    t.equal(res.body, host)
+    t.assert.strictEqual(res.body, host)
   })
-  test('http hostname and port', async (t) => {
+  await t.test('http hostname and port', async (t) => {
     t.plan(2)
 
     const host = `localhost:${fastify.server.address().port}`
@@ -62,7 +62,7 @@ fastify.listen({ port: 0 }, err => {
     const url = `http://${host}/hostname_port`
     const res = await h2url.concat({ url })
 
-    t.equal(JSON.parse(res.body).hostname, host.split(':')[0])
-    t.equal(JSON.parse(res.body).port, parseInt(host.split(':')[1]))
+    t.assert.strictEqual(JSON.parse(res.body).hostname, host.split(':')[0])
+    t.assert.strictEqual(JSON.parse(res.body).port, parseInt(host.split(':')[1]))
   })
 })

--- a/test/http2/secure-with-fallback.test.js
+++ b/test/http2/secure-with-fallback.test.js
@@ -1,17 +1,16 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const Fastify = require('../..')
 const h2url = require('h2url')
 const sget = require('simple-get').concat
 const msg = { hello: 'world' }
 
 const { buildCertificate } = require('../build-certificate')
-t.before(buildCertificate)
+test.before(buildCertificate)
 
-test('secure with fallback', (t) => {
-  t.plan(7)
+test('secure with fallback', async (t) => {
+  t.plan(6)
 
   let fastify
   try {
@@ -23,9 +22,9 @@ test('secure with fallback', (t) => {
         cert: global.context.cert
       }
     })
-    t.pass('Key/cert successfully loaded')
+    t.assert.ok(true, 'Key/cert successfully loaded')
   } catch (e) {
-    t.fail('Key/cert loading failed', e)
+    t.assert.fail('Key/cert loading failed')
   }
 
   fastify.get('/', function (req, reply) {
@@ -40,71 +39,72 @@ test('secure with fallback', (t) => {
     throw new Error('kaboom')
   })
 
-  fastify.listen({ port: 0 }, err => {
-    t.error(err)
-    t.teardown(() => { fastify.close() })
+  t.after(() => { fastify.close() })
 
-    t.test('https get error', async (t) => {
-      t.plan(1)
+  await fastify.listen({ port: 0 })
 
-      const url = `https://localhost:${fastify.server.address().port}/error`
-      const res = await h2url.concat({ url })
+  await t.test('https get error', async (t) => {
+    t.plan(1)
 
-      t.equal(res.headers[':status'], 500)
+    const url = `https://localhost:${fastify.server.address().port}/error`
+    const res = await h2url.concat({ url })
+
+    t.assert.strictEqual(res.headers[':status'], 500)
+  })
+
+  await t.test('https post', async (t) => {
+    t.plan(2)
+
+    const url = `https://localhost:${fastify.server.address().port}`
+    const res = await h2url.concat({
+      url,
+      method: 'POST',
+      body: JSON.stringify({ hello: 'http2' }),
+      headers: {
+        'content-type': 'application/json'
+      }
     })
 
-    t.test('https post', async (t) => {
-      t.plan(2)
+    t.assert.strictEqual(res.headers[':status'], 200)
+    t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'http2' })
+  })
 
-      const url = `https://localhost:${fastify.server.address().port}`
-      const res = await h2url.concat({
-        url,
-        method: 'POST',
-        body: JSON.stringify({ hello: 'http2' }),
-        headers: {
-          'content-type': 'application/json'
-        }
-      })
+  await t.test('https get request', async (t) => {
+    t.plan(3)
 
-      t.equal(res.headers[':status'], 200)
-      t.same(JSON.parse(res.body), { hello: 'http2' })
+    const url = `https://localhost:${fastify.server.address().port}`
+    const res = await h2url.concat({ url })
+
+    t.assert.strictEqual(res.headers[':status'], 200)
+    t.assert.strictEqual(res.headers['content-length'], '' + JSON.stringify(msg).length)
+    t.assert.deepStrictEqual(JSON.parse(res.body), msg)
+  })
+
+  await t.test('http1 get request', (t, done) => {
+    t.plan(4)
+    sget({
+      method: 'GET',
+      url: 'https://localhost:' + fastify.server.address().port,
+      rejectUnauthorized: false
+    }, (err, response, body) => {
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 200)
+      t.assert.strictEqual(response.headers['content-length'], '' + body.length)
+      t.assert.deepStrictEqual(JSON.parse(body), { hello: 'world' })
+      done()
     })
+  })
 
-    t.test('https get request', async (t) => {
-      t.plan(3)
-
-      const url = `https://localhost:${fastify.server.address().port}`
-      const res = await h2url.concat({ url })
-
-      t.equal(res.headers[':status'], 200)
-      t.equal(res.headers['content-length'], '' + JSON.stringify(msg).length)
-      t.same(JSON.parse(res.body), msg)
-    })
-
-    t.test('http1 get request', t => {
-      t.plan(4)
-      sget({
-        method: 'GET',
-        url: 'https://localhost:' + fastify.server.address().port,
-        rejectUnauthorized: false
-      }, (err, response, body) => {
-        t.error(err)
-        t.equal(response.statusCode, 200)
-        t.equal(response.headers['content-length'], '' + body.length)
-        t.same(JSON.parse(body), { hello: 'world' })
-      })
-    })
-
-    t.test('http1 get error', (t) => {
-      t.plan(2)
-      sget({
-        method: 'GET',
-        url: 'https://localhost:' + fastify.server.address().port + '/error',
-        rejectUnauthorized: false
-      }, (err, response, body) => {
-        t.error(err)
-        t.equal(response.statusCode, 500)
-      })
+  await t.test('http1 get error', (t, done) => {
+    t.plan(2)
+    sget({
+      method: 'GET',
+      url: 'https://localhost:' + fastify.server.address().port + '/error',
+      rejectUnauthorized: false
+    }, (err, response, body) => {
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 500)
+      done()
     })
   })
 })

--- a/test/http2/secure.test.js
+++ b/test/http2/secure.test.js
@@ -1,16 +1,15 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const Fastify = require('../..')
 const h2url = require('h2url')
 const msg = { hello: 'world' }
 
 const { buildCertificate } = require('../build-certificate')
-t.before(buildCertificate)
+test.before(buildCertificate)
 
-test('secure', (t) => {
-  t.plan(5)
+test('secure', async (t) => {
+  t.plan(4)
 
   let fastify
   try {
@@ -21,9 +20,9 @@ test('secure', (t) => {
         cert: global.context.cert
       }
     })
-    t.pass('Key/cert successfully loaded')
+    t.assert.ok(true, 'Key/cert successfully loaded')
   } catch (e) {
-    t.fail('Key/cert loading failed', e)
+    t.assert.fail('Key/cert loading failed')
   }
 
   fastify.get('/', function (req, reply) {
@@ -36,35 +35,33 @@ test('secure', (t) => {
     reply.code(200).send({ hostname: req.hostname, port: req.port })
   })
 
-  fastify.listen({ port: 0 }, err => {
-    t.error(err)
-    t.teardown(() => { fastify.close() })
+  t.after(() => { fastify.close() })
+  await fastify.listen({ port: 0 })
 
-    t.test('https get request', async (t) => {
-      t.plan(3)
+  await t.test('https get request', async (t) => {
+    t.plan(3)
 
-      const url = `https://localhost:${fastify.server.address().port}`
-      const res = await h2url.concat({ url })
+    const url = `https://localhost:${fastify.server.address().port}`
+    const res = await h2url.concat({ url })
 
-      t.equal(res.headers[':status'], 200)
-      t.equal(res.headers['content-length'], '' + JSON.stringify(msg).length)
-      t.same(JSON.parse(res.body), msg)
-    })
+    t.assert.strictEqual(res.headers[':status'], 200)
+    t.assert.strictEqual(res.headers['content-length'], '' + JSON.stringify(msg).length)
+    t.assert.deepStrictEqual(JSON.parse(res.body), msg)
+  })
 
-    t.test('https get request without trust proxy - protocol', async (t) => {
-      t.plan(2)
+  await t.test('https get request without trust proxy - protocol', async (t) => {
+    t.plan(2)
 
-      const url = `https://localhost:${fastify.server.address().port}/proto`
-      t.same(JSON.parse((await h2url.concat({ url })).body), { proto: 'https' })
-      t.same(JSON.parse((await h2url.concat({ url, headers: { 'X-Forwarded-Proto': 'lorem' } })).body), { proto: 'https' })
-    })
-    t.test('https get request - test hostname and port', async (t) => {
-      t.plan(2)
+    const url = `https://localhost:${fastify.server.address().port}/proto`
+    t.assert.deepStrictEqual(JSON.parse((await h2url.concat({ url })).body), { proto: 'https' })
+    t.assert.deepStrictEqual(JSON.parse((await h2url.concat({ url, headers: { 'X-Forwarded-Proto': 'lorem' } })).body), { proto: 'https' })
+  })
+  await t.test('https get request - test hostname and port', async (t) => {
+    t.plan(2)
 
-      const url = `https://localhost:${fastify.server.address().port}/hostname_port`
-      const parsedbody = JSON.parse((await h2url.concat({ url })).body)
-      t.equal(parsedbody.hostname, 'localhost')
-      t.equal(parsedbody.port, fastify.server.address().port)
-    })
+    const url = `https://localhost:${fastify.server.address().port}/hostname_port`
+    const parsedbody = JSON.parse((await h2url.concat({ url })).body)
+    t.assert.strictEqual(parsedbody.hostname, 'localhost')
+    t.assert.strictEqual(parsedbody.port, fastify.server.address().port)
   })
 })

--- a/test/http2/unknown-http-method.test.js
+++ b/test/http2/unknown-http-method.test.js
@@ -1,31 +1,30 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const Fastify = require('../..')
 const h2url = require('h2url')
 const msg = { hello: 'world' }
 
-const fastify = Fastify({
-  http2: true
-})
+test('http2 unknown http method', async t => {
+  const fastify = Fastify({
+    http2: true
+  })
 
-fastify.get('/', function (req, reply) {
-  reply.code(200).send(msg)
-})
+  fastify.get('/', function (req, reply) {
+    reply.code(200).send(msg)
+  })
 
-fastify.listen({ port: 0 }, err => {
-  t.error(err)
-  t.teardown(() => { fastify.close() })
+  t.after(() => { fastify.close() })
+  await fastify.listen({ port: 0 })
 
-  test('http UNKNOWN_METHOD request', async (t) => {
+  await t.test('http UNKNOWN_METHOD request', async (t) => {
     t.plan(2)
 
     const url = `http://localhost:${fastify.server.address().port}`
     const res = await h2url.concat({ url, method: 'UNKNOWN_METHOD' })
 
-    t.equal(res.headers[':status'], 404)
-    t.same(JSON.parse(res.body), {
+    t.assert.strictEqual(res.headers[':status'], 404)
+    t.assert.deepStrictEqual(JSON.parse(res.body), {
       statusCode: 404,
       code: 'FST_ERR_NOT_FOUND',
       error: 'Not Found',


### PR DESCRIPTION
Hi, 

These changes are related to the issue https://github.com/fastify/fastify/issues/5555
Changed `/test/http2` tests to use `node:test` instead of `tap`.
Basically, followed the same guidelines as my previous PR #5714.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
