### PR TITLE
test: migrate tests from tap to node:test and c8

### DIFF
--- a/test/build/error-serializer.test.js
+++ b/test/build/error-serializer.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const fs = require('node:fs')
 const path = require('node:path')
 const { loadESLint } = require('eslint')
@@ -22,7 +21,7 @@ test('check generated code syntax', async (t) => {
 
   // if there are any invalid syntax
   // fatal count will be greater than 0
-  t.equal(result[0].fatalErrorCount, 0)
+  t.assert.strictEqual(result[0].fatalErrorCount, 0)
 })
 
 const isPrepublish = !!process.env.PREPUBLISH
@@ -33,5 +32,5 @@ test('ensure the current error serializer is latest', { skip: !isPrepublish }, a
   const current = await fs.promises.readFile(path.resolve('lib/error-serializer.js'))
 
   // line break should not be a problem depends on system
-  t.equal(unifyLineBreak(current), unifyLineBreak(code))
+  t.assert.strictEqual(unifyLineBreak(current), unifyLineBreak(code))
 })

--- a/test/build/version.test.js
+++ b/test/build/version.test.js
@@ -2,8 +2,7 @@
 
 const fs = require('node:fs')
 const path = require('node:path')
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const fastify = require('../../fastify')()
 
 test('should be the same as package.json', t => {
@@ -11,5 +10,5 @@ test('should be the same as package.json', t => {
 
   const json = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', 'package.json')).toString('utf8'))
 
-  t.equal(fastify.version, json.version)
+  t.assert.strictEqual(fastify.version, json.version)
 })

--- a/test/versioned-routes.test.js
+++ b/test/versioned-routes.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test, before } = require('tap')
+const { test, before } = require('node:test')
 const helper = require('./helper')
 const Fastify = require('..')
 const sget = require('simple-get').concat
@@ -15,7 +15,7 @@ before(async function () {
   [localhost] = await helper.getLoopbackHost()
 })
 
-test('Should register a versioned route', t => {
+test('Should register a versioned route', (t, done) => {
   t.plan(11)
   const fastify = Fastify()
 
@@ -35,9 +35,9 @@ test('Should register a versioned route', t => {
       'Accept-Version': '1.x'
     }
   }, (err, res) => {
-    t.error(err)
-    t.same(JSON.parse(res.payload), { hello: 'world' })
-    t.equal(res.statusCode, 200)
+    t.assert.ifError(err)
+    t.assert.deepStrictEqual(JSON.parse(res.payload), { hello: 'world' })
+    t.assert.strictEqual(res.statusCode, 200)
   })
 
   fastify.inject({
@@ -47,9 +47,9 @@ test('Should register a versioned route', t => {
       'Accept-Version': '1.2.x'
     }
   }, (err, res) => {
-    t.error(err)
-    t.same(JSON.parse(res.payload), { hello: 'world' })
-    t.equal(res.statusCode, 200)
+    t.assert.ifError(err)
+    t.assert.deepStrictEqual(JSON.parse(res.payload), { hello: 'world' })
+    t.assert.strictEqual(res.statusCode, 200)
   })
 
   fastify.inject({
@@ -59,9 +59,9 @@ test('Should register a versioned route', t => {
       'Accept-Version': '1.2.0'
     }
   }, (err, res) => {
-    t.error(err)
-    t.same(JSON.parse(res.payload), { hello: 'world' })
-    t.equal(res.statusCode, 200)
+    t.assert.ifError(err)
+    t.assert.deepStrictEqual(JSON.parse(res.payload), { hello: 'world' })
+    t.assert.strictEqual(res.statusCode, 200)
   })
 
   fastify.inject({
@@ -71,12 +71,13 @@ test('Should register a versioned route', t => {
       'Accept-Version': '1.2.1'
     }
   }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 404)
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 404)
+    done()
   })
 })
 
-test('Should register a versioned route via route constraints', t => {
+test('Should register a versioned route via route constraints', (t, done) => {
   t.plan(6)
   const fastify = Fastify()
 
@@ -96,9 +97,9 @@ test('Should register a versioned route via route constraints', t => {
       'Accept-Version': '1.x'
     }
   }, (err, res) => {
-    t.error(err)
-    t.same(JSON.parse(res.payload), { hello: 'world' })
-    t.equal(res.statusCode, 200)
+    t.assert.ifError(err)
+    t.assert.deepStrictEqual(JSON.parse(res.payload), { hello: 'world' })
+    t.assert.strictEqual(res.statusCode, 200)
   })
 
   fastify.inject({
@@ -108,13 +109,14 @@ test('Should register a versioned route via route constraints', t => {
       'Accept-Version': '1.2.x'
     }
   }, (err, res) => {
-    t.error(err)
-    t.same(JSON.parse(res.payload), { hello: 'world' })
-    t.equal(res.statusCode, 200)
+    t.assert.ifError(err)
+    t.assert.deepStrictEqual(JSON.parse(res.payload), { hello: 'world' })
+    t.assert.strictEqual(res.statusCode, 200)
+    done()
   })
 })
 
-test('Should register the same route with different versions', t => {
+test('Should register the same route with different versions', (t, done) => {
   t.plan(8)
   const fastify = Fastify()
 
@@ -143,9 +145,9 @@ test('Should register the same route with different versions', t => {
       'Accept-Version': '1.x'
     }
   }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.equal(res.payload, '1.3.0')
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.payload, '1.3.0')
   })
 
   fastify.inject({
@@ -155,9 +157,9 @@ test('Should register the same route with different versions', t => {
       'Accept-Version': '1.2.x'
     }
   }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.equal(res.payload, '1.2.0')
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.payload, '1.2.0')
   })
 
   fastify.inject({
@@ -167,12 +169,13 @@ test('Should register the same route with different versions', t => {
       'Accept-Version': '2.x'
     }
   }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 404)
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 404)
+    done()
   })
 })
 
-test('The versioned route should take precedence', t => {
+test('The versioned route should take precedence', (t, done) => {
   t.plan(3)
   const fastify = Fastify()
 
@@ -200,13 +203,14 @@ test('The versioned route should take precedence', t => {
       'Accept-Version': '1.x'
     }
   }, (err, res) => {
-    t.error(err)
-    t.same(JSON.parse(res.payload), { hello: 'world' })
-    t.equal(res.statusCode, 200)
+    t.assert.ifError(err)
+    t.assert.deepStrictEqual(JSON.parse(res.payload), { hello: 'world' })
+    t.assert.strictEqual(res.statusCode, 200)
+    done()
   })
 })
 
-test('Versioned route but not version header should return a 404', t => {
+test('Versioned route but not version header should return a 404', (t, done) => {
   t.plan(2)
   const fastify = Fastify()
 
@@ -223,12 +227,13 @@ test('Versioned route but not version header should return a 404', t => {
     method: 'GET',
     url: '/'
   }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 404)
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 404)
+    done()
   })
 })
 
-test('Should register a versioned route', t => {
+test('Should register a versioned route', (t, done) => {
   t.plan(6)
   const fastify = Fastify()
 
@@ -242,8 +247,8 @@ test('Should register a versioned route', t => {
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
-    t.teardown(() => { fastify.close() })
+    t.assert.ifError(err)
+    t.after(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -252,9 +257,9 @@ test('Should register a versioned route', t => {
         'Accept-Version': '1.x'
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.same(JSON.parse(body), { hello: 'world' })
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 200)
+      t.assert.deepStrictEqual(JSON.parse(body), { hello: 'world' })
     })
 
     sget({
@@ -264,13 +269,14 @@ test('Should register a versioned route', t => {
         'Accept-Version': '2.x'
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 404)
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 404)
+      done()
     })
   })
 })
 
-test('Shorthand route declaration', t => {
+test('Shorthand route declaration', (t, done) => {
   t.plan(5)
   const fastify = Fastify()
 
@@ -285,9 +291,9 @@ test('Shorthand route declaration', t => {
       'Accept-Version': '1.x'
     }
   }, (err, res) => {
-    t.error(err)
-    t.same(JSON.parse(res.payload), { hello: 'world' })
-    t.equal(res.statusCode, 200)
+    t.assert.ifError(err)
+    t.assert.deepStrictEqual(JSON.parse(res.payload), { hello: 'world' })
+    t.assert.strictEqual(res.statusCode, 200)
   })
 
   fastify.inject({
@@ -297,27 +303,28 @@ test('Shorthand route declaration', t => {
       'Accept-Version': '1.2.1'
     }
   }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 404)
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 404)
+    done()
   })
 })
 
-test('The not found handler should not erase the Accept-Version header', t => {
+test('The not found handler should not erase the Accept-Version header', (t, done) => {
   t.plan(13)
   const fastify = Fastify()
 
   fastify.addHook('onRequest', function (req, reply, done) {
-    t.same(req.headers['accept-version'], '2.x')
+    t.assert.deepStrictEqual(req.headers['accept-version'], '2.x')
     done()
   })
 
   fastify.addHook('preValidation', function (req, reply, done) {
-    t.same(req.headers['accept-version'], '2.x')
+    t.assert.deepStrictEqual(req.headers['accept-version'], '2.x')
     done()
   })
 
   fastify.addHook('preHandler', function (req, reply, done) {
-    t.same(req.headers['accept-version'], '2.x')
+    t.assert.deepStrictEqual(req.headers['accept-version'], '2.x')
     done()
   })
 
@@ -331,14 +338,14 @@ test('The not found handler should not erase the Accept-Version header', t => {
   })
 
   fastify.setNotFoundHandler(function (req, reply) {
-    t.same(req.headers['accept-version'], '2.x')
+    t.assert.deepStrictEqual(req.headers['accept-version'], '2.x')
     // we check if the symbol is exposed on key or not
     for (const key in req.headers) {
-      t.same(typeof key, 'string')
+      t.assert.deepStrictEqual(typeof key, 'string')
     }
 
     for (const key of Object.keys(req.headers)) {
-      t.same(typeof key, 'string')
+      t.assert.deepStrictEqual(typeof key, 'string')
     }
 
     reply.code(404).send('not found handler')
@@ -351,13 +358,14 @@ test('The not found handler should not erase the Accept-Version header', t => {
       'Accept-Version': '2.x'
     }
   }, (err, res) => {
-    t.error(err)
-    t.same(res.payload, 'not found handler')
-    t.equal(res.statusCode, 404)
+    t.assert.ifError(err)
+    t.assert.deepStrictEqual(res.payload, 'not found handler')
+    t.assert.strictEqual(res.statusCode, 404)
+    done()
   })
 })
 
-test('Bad accept version (inject)', t => {
+test('Bad accept version (inject)', (t, done) => {
   t.plan(4)
   const fastify = Fastify()
 
@@ -377,8 +385,8 @@ test('Bad accept version (inject)', t => {
       'Accept-Version': 'a.b.c'
     }
   }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 404)
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 404)
   })
 
   fastify.inject({
@@ -388,12 +396,13 @@ test('Bad accept version (inject)', t => {
       'Accept-Version': 12
     }
   }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 404)
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 404)
+    done()
   })
 })
 
-test('Bad accept version (server)', t => {
+test('Bad accept version (server)', (t, done) => {
   t.plan(5)
   const fastify = Fastify()
 
@@ -407,8 +416,8 @@ test('Bad accept version (server)', t => {
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
-    t.teardown(() => { fastify.close() })
+    t.assert.ifError(err)
+    t.after(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -417,8 +426,8 @@ test('Bad accept version (server)', t => {
         'Accept-Version': 'a.b.c'
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 404)
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 404)
     })
 
     sget({
@@ -428,13 +437,14 @@ test('Bad accept version (server)', t => {
         'Accept-Version': 12
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 404)
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 404)
+      done()
     })
   })
 })
 
-test('test log stream', t => {
+test('test log stream', (t, done) => {
   t.plan(3)
   const stream = split(JSON.parse)
   const fastify = Fastify({
@@ -449,8 +459,8 @@ test('test log stream', t => {
   })
 
   fastify.listen({ port: 0, host: localhost }, err => {
-    t.error(err)
-    t.teardown(() => { fastify.close() })
+    t.assert.ifError(err)
+    t.after(() => { fastify.close() })
 
     http.get({
       host: fastify.server.address().hostname,
@@ -464,16 +474,17 @@ test('test log stream', t => {
 
     stream.once('data', listenAtLogLine => {
       stream.once('data', line => {
-        t.equal(line.req.version, '1.x')
+        t.assert.strictEqual(line.req.version, '1.x')
         stream.once('data', line => {
-          t.equal(line.req.version, '1.x')
+          t.assert.strictEqual(line.req.version, '1.x')
+          done()
         })
       })
     })
   })
 })
 
-test('Should register a versioned route with custom versioning strategy', t => {
+test('Should register a versioned route with custom versioning strategy', (t, done) => {
   t.plan(8)
 
   const customVersioning = {
@@ -523,9 +534,9 @@ test('Should register a versioned route with custom versioning strategy', t => {
       Accept: 'application/vnd.example.api+json;version=2'
     }
   }, (err, res) => {
-    t.error(err)
-    t.same(JSON.parse(res.payload), { hello: 'from route v2' })
-    t.equal(res.statusCode, 200)
+    t.assert.ifError(err)
+    t.assert.deepStrictEqual(JSON.parse(res.payload), { hello: 'from route v2' })
+    t.assert.strictEqual(res.statusCode, 200)
   })
 
   fastify.inject({
@@ -535,9 +546,9 @@ test('Should register a versioned route with custom versioning strategy', t => {
       Accept: 'application/vnd.example.api+json;version=3'
     }
   }, (err, res) => {
-    t.error(err)
-    t.same(JSON.parse(res.payload), { hello: 'from route v3' })
-    t.equal(res.statusCode, 200)
+    t.assert.ifError(err)
+    t.assert.deepStrictEqual(JSON.parse(res.payload), { hello: 'from route v3' })
+    t.assert.strictEqual(res.statusCode, 200)
   })
 
   fastify.inject({
@@ -547,12 +558,13 @@ test('Should register a versioned route with custom versioning strategy', t => {
       Accept: 'application/vnd.example.api+json;version=4'
     }
   }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 404)
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 404)
+    done()
   })
 })
 
-test('Vary header check (for documentation example)', t => {
+test('Vary header check (for documentation example)', (t, done) => {
   t.plan(8)
   const fastify = Fastify()
   fastify.addHook('onSend', async (req, reply) => {
@@ -589,19 +601,20 @@ test('Vary header check (for documentation example)', t => {
       'Accept-Version': '1.x'
     }
   }, (err, res) => {
-    t.error(err)
-    t.same(JSON.parse(res.payload), { hello: 'world' })
-    t.equal(res.statusCode, 200)
-    t.equal(res.headers.vary, 'Accept-Version')
+    t.assert.ifError(err)
+    t.assert.deepStrictEqual(JSON.parse(res.payload), { hello: 'world' })
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.headers.vary, 'Accept-Version')
   })
 
   fastify.inject({
     method: 'GET',
     url: '/'
   }, (err, res) => {
-    t.error(err)
-    t.same(JSON.parse(res.payload), { hello: 'world' })
-    t.equal(res.statusCode, 200)
-    t.equal(res.headers.vary, undefined)
+    t.assert.ifError(err)
+    t.assert.deepStrictEqual(JSON.parse(res.payload), { hello: 'world' })
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.headers.vary, undefined)
+    done()
   })
 })

--- a/test/web-api.test.js
+++ b/test/web-api.test.js
@@ -255,7 +255,6 @@ test('allow to pipe with fetch', async (t) => {
 
   t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), { ok: true })
-  console.log('fjlafjkal')
 })
 
 test('allow to pipe with undici.fetch', async (t) => {

--- a/test/web-api.test.js
+++ b/test/web-api.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const Fastify = require('../fastify')
 const fs = require('node:fs')
 const { Readable } = require('node:stream')
@@ -24,8 +23,8 @@ test('should response with a ReadableStream', async (t) => {
 
   const expected = await fs.promises.readFile(__filename)
 
-  t.equal(statusCode, 200)
-  t.equal(expected.toString(), body.toString())
+  t.assert.strictEqual(statusCode, 200)
+  t.assert.strictEqual(expected.toString(), body.toString())
 })
 
 test('should response with a Response', async (t) => {
@@ -51,9 +50,9 @@ test('should response with a Response', async (t) => {
 
   const expected = await fs.promises.readFile(__filename)
 
-  t.equal(statusCode, 200)
-  t.equal(expected.toString(), body.toString())
-  t.equal(headers.hello, 'world')
+  t.assert.strictEqual(statusCode, 200)
+  t.assert.strictEqual(expected.toString(), body.toString())
+  t.assert.strictEqual(headers.hello, 'world')
 })
 
 test('should response with a Response 204', async (t) => {
@@ -76,9 +75,9 @@ test('should response with a Response 204', async (t) => {
     body
   } = await fastify.inject({ method: 'GET', path: '/' })
 
-  t.equal(statusCode, 204)
-  t.equal(body, '')
-  t.equal(headers.hello, 'world')
+  t.assert.strictEqual(statusCode, 204)
+  t.assert.strictEqual(body, '')
+  t.assert.strictEqual(headers.hello, 'world')
 })
 
 test('should response with a Response 304', async (t) => {
@@ -101,9 +100,9 @@ test('should response with a Response 304', async (t) => {
     body
   } = await fastify.inject({ method: 'GET', path: '/' })
 
-  t.equal(statusCode, 304)
-  t.equal(body, '')
-  t.equal(headers.hello, 'world')
+  t.assert.strictEqual(statusCode, 304)
+  t.assert.strictEqual(body, '')
+  t.assert.strictEqual(headers.hello, 'world')
 })
 
 test('should response with a Response without body', async (t) => {
@@ -126,9 +125,9 @@ test('should response with a Response without body', async (t) => {
     body
   } = await fastify.inject({ method: 'GET', path: '/' })
 
-  t.equal(statusCode, 200)
-  t.equal(body, '')
-  t.equal(headers.hello, 'world')
+  t.assert.strictEqual(statusCode, 200)
+  t.assert.strictEqual(body, '')
+  t.assert.strictEqual(headers.hello, 'world')
 })
 
 test('able to use in onSend hook - ReadableStream', async (t) => {
@@ -142,7 +141,7 @@ test('able to use in onSend hook - ReadableStream', async (t) => {
   })
 
   fastify.addHook('onSend', (request, reply, payload, done) => {
-    t.equal(Object.prototype.toString.call(payload), '[object ReadableStream]')
+    t.assert.strictEqual(Object.prototype.toString.call(payload), '[object ReadableStream]')
     done(null, new Response(payload, {
       status: 200,
       headers: {
@@ -159,9 +158,9 @@ test('able to use in onSend hook - ReadableStream', async (t) => {
 
   const expected = await fs.promises.readFile(__filename)
 
-  t.equal(statusCode, 200)
-  t.equal(expected.toString(), body.toString())
-  t.equal(headers.hello, 'world')
+  t.assert.strictEqual(statusCode, 200)
+  t.assert.strictEqual(expected.toString(), body.toString())
+  t.assert.strictEqual(headers.hello, 'world')
 })
 
 test('able to use in onSend hook - Response', async (t) => {
@@ -180,7 +179,7 @@ test('able to use in onSend hook - Response', async (t) => {
   })
 
   fastify.addHook('onSend', (request, reply, payload, done) => {
-    t.equal(Object.prototype.toString.call(payload), '[object Response]')
+    t.assert.strictEqual(Object.prototype.toString.call(payload), '[object Response]')
     done(null, new Response(payload.body, {
       status: 200,
       headers: payload.headers
@@ -195,9 +194,9 @@ test('able to use in onSend hook - Response', async (t) => {
 
   const expected = await fs.promises.readFile(__filename)
 
-  t.equal(statusCode, 200)
-  t.equal(expected.toString(), body.toString())
-  t.equal(headers.hello, 'world')
+  t.assert.strictEqual(statusCode, 200)
+  t.assert.strictEqual(expected.toString(), body.toString())
+  t.assert.strictEqual(headers.hello, 'world')
 })
 
 test('Error when Response.bodyUsed', async (t) => {
@@ -216,31 +215,37 @@ test('Error when Response.bodyUsed', async (t) => {
       }
     })
     const file = await response.text()
-    t.equal(expected.toString(), file)
-    t.equal(response.bodyUsed, true)
+    t.assert.strictEqual(expected.toString(), file)
+    t.assert.strictEqual(response.bodyUsed, true)
     return reply.send(response)
   })
 
   const response = await fastify.inject({ method: 'GET', path: '/' })
 
-  t.equal(response.statusCode, 500)
+  t.assert.strictEqual(response.statusCode, 500)
   const body = response.json()
-  t.equal(body.code, 'FST_ERR_REP_RESPONSE_BODY_CONSUMED')
+  t.assert.strictEqual(body.code, 'FST_ERR_REP_RESPONSE_BODY_CONSUMED')
 })
 
 test('allow to pipe with fetch', async (t) => {
   t.plan(2)
+  const abortController = new AbortController()
+  const { signal } = abortController
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => {
+    fastify.close()
+    abortController.abort()
+  })
 
   fastify.get('/', function (request, reply) {
     return fetch(`${fastify.listeningOrigin}/fetch`, {
-      method: 'GET'
+      method: 'GET',
+      signal
     })
   })
 
-  fastify.get('/fetch', function (request, reply) {
+  fastify.get('/fetch', function async (request, reply) {
     reply.code(200).send({ ok: true })
   })
 
@@ -248,19 +253,26 @@ test('allow to pipe with fetch', async (t) => {
 
   const response = await fastify.inject({ method: 'GET', path: '/' })
 
-  t.equal(response.statusCode, 200)
-  t.same(response.json(), { ok: true })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(response.json(), { ok: true })
+  console.log('fjlafjkal')
 })
 
 test('allow to pipe with undici.fetch', async (t) => {
   t.plan(2)
+  const abortController = new AbortController()
+  const { signal } = abortController
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => {
+    fastify.close()
+    abortController.abort()
+  })
 
   fastify.get('/', function (request, reply) {
     return undiciFetch(`${fastify.listeningOrigin}/fetch`, {
-      method: 'GET'
+      method: 'GET',
+      signal
     })
   })
 
@@ -272,6 +284,6 @@ test('allow to pipe with undici.fetch', async (t) => {
 
   const response = await fastify.inject({ method: 'GET', path: '/' })
 
-  t.equal(response.statusCode, 200)
-  t.same(response.json(), { ok: true })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(response.json(), { ok: true })
 })

--- a/test/wrapThenable.test.js
+++ b/test/wrapThenable.test.js
@@ -1,17 +1,18 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const { kReplyHijacked } = require('../lib/symbols')
 const wrapThenable = require('../lib/wrapThenable')
 const Reply = require('../lib/reply')
 
-test('should resolve immediately when reply[kReplyHijacked] is true', t => {
-  const reply = {}
-  reply[kReplyHijacked] = true
-  const thenable = Promise.resolve()
-  wrapThenable(thenable, reply)
-  t.end()
+test('should resolve immediately when reply[kReplyHijacked] is true', async t => {
+  await new Promise(resolve => {
+    const reply = {}
+    reply[kReplyHijacked] = true
+    const thenable = Promise.resolve()
+    wrapThenable(thenable, reply)
+    resolve()
+  })
 })
 
 test('should reject immediately when reply[kReplyHijacked] is true', t => {
@@ -20,7 +21,7 @@ test('should reject immediately when reply[kReplyHijacked] is true', t => {
   reply[kReplyHijacked] = true
   reply.log = {
     error: ({ err }) => {
-      t.equal(err.message, 'Reply sent already')
+      t.assert.strictEqual(err.message, 'Reply sent already')
     }
   }
 


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
