### PR TITLE
test: removed second argument from assert fail method in tests

### DIFF
--- a/test/https/https.test.js
+++ b/test/https/https.test.js
@@ -20,7 +20,7 @@ test('https', async (t) => {
     })
     t.assert.ok('Key/cert successfully loaded')
   } catch (e) {
-    t.assert.fail('Key/cert loading failed', e)
+    t.assert.fail('Key/cert loading failed')
   }
 
   fastify.get('/', function (req, reply) {
@@ -87,7 +87,7 @@ test('https - headers', async (t) => {
     })
     t.assert.ok('Key/cert successfully loaded')
   } catch (e) {
-    t.assert.fail('Key/cert loading failed', e)
+    t.assert.fail('Key/cert loading failed')
   }
 
   fastify.get('/', function (req, reply) {


### PR DESCRIPTION
Hi,

In my previous PR #5714, I accidentally had one file with `assert.fail` receiving two arguments (which is deprecated) instead of one, so I just noticed that and wanted to fix it quickly. I assumed opening a issue for that minor thing is not needed, correct me if I'm wrong.
I made sure that the only place that it happened was `./test/https/https.test.js`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
