### PR TITLE
test: Fix flaky tests in versioned-routes.test.js

### DIFF
--- a/test/versioned-routes.test.js
+++ b/test/versioned-routes.test.js
@@ -15,7 +15,7 @@ before(async function () {
   [localhost] = await helper.getLoopbackHost()
 })
 
-test('Should register a versioned route', (t, done) => {
+test('Should register a versioned route (inject)', (t, done) => {
   t.plan(11)
   const fastify = Fastify()
 
@@ -233,7 +233,7 @@ test('Versioned route but not version header should return a 404', (t, done) => 
   })
 })
 
-test('Should register a versioned route', (t, done) => {
+test('Should register a versioned route (server)', (t, done) => {
   t.plan(6)
   const fastify = Fastify()
 
@@ -260,18 +260,18 @@ test('Should register a versioned route', (t, done) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 200)
       t.assert.deepStrictEqual(JSON.parse(body), { hello: 'world' })
-    })
 
-    sget({
-      method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port,
-      headers: {
-        'Accept-Version': '2.x'
-      }
-    }, (err, response, body) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 404)
-      done()
+      sget({
+        method: 'GET',
+        url: 'http://localhost:' + fastify.server.address().port,
+        headers: {
+          'Accept-Version': '2.x'
+        }
+      }, (err, response, body) => {
+        t.assert.ifError(err)
+        t.assert.strictEqual(response.statusCode, 404)
+        done()
+      })
     })
   })
 })
@@ -428,18 +428,18 @@ test('Bad accept version (server)', (t, done) => {
     }, (err, response, body) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 404)
-    })
 
-    sget({
-      method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port,
-      headers: {
-        'Accept-Version': 12
-      }
-    }, (err, response, body) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 404)
-      done()
+      sget({
+        method: 'GET',
+        url: 'http://localhost:' + fastify.server.address().port,
+        headers: {
+          'Accept-Version': 12
+        }
+      }, (err, response, body) => {
+        t.assert.ifError(err)
+        t.assert.strictEqual(response.statusCode, 404)
+        done()
+      })
     })
   })
 })


### PR DESCRIPTION
The server tests in `test/versioned-routes.test.js` use sget and thus callback notation. This causes a race condition where the second callback (containing the `done()` call) runs before the first callback.

To fix, the second request was moved into the callback of the first request.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
