### PR TITLE
test: migrated custom-http-server from tap to node:test

### DIFF
--- a/test/custom-http-server.test.js
+++ b/test/custom-http-server.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const http = require('node:http')
 const dns = require('node:dns').promises
 const sget = require('simple-get').concat
@@ -16,7 +15,7 @@ async function setup () {
 
     const fastify = Fastify({
       serverFactory: (handler, opts) => {
-        t.ok(opts.serverFactory, 'it is called once for localhost')
+        t.assert.ok(opts.serverFactory, 'it is called once for localhost')
 
         const server = http.createServer((req, res) => {
           req.custom = true
@@ -27,10 +26,9 @@ async function setup () {
       }
     })
 
-    t.teardown(fastify.close.bind(fastify))
-
+    t.after(() => fastify.close())
     fastify.get('/', (req, reply) => {
-      t.ok(req.raw.custom)
+      t.assert.ok(req.raw.custom)
       reply.send({ hello: 'world' })
     })
 
@@ -45,8 +43,8 @@ async function setup () {
         if (err) {
           return reject(err)
         }
-        t.equal(response.statusCode, 200)
-        t.same(JSON.parse(body), { hello: 'world' })
+        t.assert.strictEqual(response.statusCode, 200)
+        t.assert.deepStrictEqual(JSON.parse(body), { hello: 'world' })
         resolve()
       })
     })
@@ -55,7 +53,7 @@ async function setup () {
   test('Should not allow forceCloseConnection=idle if the server does not support closeIdleConnections', t => {
     t.plan(1)
 
-    t.throws(
+    t.assert.throws(
       () => {
         Fastify({
           forceCloseConnections: 'idle',
@@ -75,13 +73,12 @@ async function setup () {
 
   test('Should accept user defined serverFactory and ignore secondary server creation', async t => {
     const server = http.createServer(() => { })
-    t.teardown(() => new Promise(resolve => server.close(resolve)))
-    const app = await Fastify({
+    t.after(() => new Promise(resolve => server.close(resolve)))
+    const app = Fastify({
       serverFactory: () => server
     })
-    t.resolves(async () => {
-      await app.listen({ port: 0 })
-    })
+    t.assert.ok(async () => await app.listen({ port: 0 }))
+    await t.assert.doesNotReject(async () => { await app.listen({ port: 0 }) })
   })
 
   test('Should not call close on the server if it has not created it', async t => {
@@ -107,12 +104,12 @@ async function setup () {
     })
 
     const address = server.address()
-    t.equal(server.listening, true)
+    t.assert.strictEqual(server.listening, true)
     await fastify.close()
 
-    t.equal(server.listening, true)
-    t.same(server.address(), address)
-    t.same(fastify.addresses(), [address])
+    t.assert.strictEqual(server.listening, true)
+    t.assert.deepStrictEqual(server.address(), address)
+    t.assert.deepStrictEqual(fastify.addresses(), [address])
 
     await new Promise((resolve, reject) => {
       server.close((err) => {
@@ -122,8 +119,8 @@ async function setup () {
         resolve()
       })
     })
-    t.equal(server.listening, false)
-    t.same(server.address(), null)
+    t.assert.strictEqual(server.listening, false)
+    t.assert.deepStrictEqual(server.address(), null)
   })
 }
 

--- a/test/custom-http-server.test.js
+++ b/test/custom-http-server.test.js
@@ -77,7 +77,6 @@ async function setup () {
     const app = Fastify({
       serverFactory: () => server
     })
-    t.assert.ok(async () => await app.listen({ port: 0 }))
     await t.assert.doesNotReject(async () => { await app.listen({ port: 0 }) })
   })
 


### PR DESCRIPTION
porting of `custom-http-server.test.js` from tap to node:test

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
