### PR TITLE
test: migrated content-type and context-config tests from tap to node:test

### DIFF
--- a/test/content-type.test.js
+++ b/test/content-type.test.js
@@ -37,6 +37,6 @@ test('should remove content-type for setErrorHandler', async t => {
   })
 
   const { statusCode, body } = await fastify.inject({ method: 'GET', path: '/' })
-  t.assert.equal(statusCode, 400)
+  t.assert.strictEqual(statusCode, 400)
   t.assert.strictEqual(body, JSON.stringify({ foo: 'bar' }))
 })

--- a/test/content-type.test.js
+++ b/test/content-type.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const Fastify = require('..')
 
 test('should remove content-type for setErrorHandler', async t => {
@@ -10,22 +9,22 @@ test('should remove content-type for setErrorHandler', async t => {
 
   const fastify = Fastify()
   fastify.setErrorHandler(function (error, request, reply) {
-    t.same(error.message, 'kaboom')
-    t.same(reply.hasHeader('content-type'), false)
+    t.assert.strictEqual(error.message, 'kaboom')
+    t.assert.strictEqual(reply.hasHeader('content-type'), false)
     reply.code(400).send({ foo: 'bar' })
   })
   fastify.addHook('onSend', async function (request, reply, payload) {
     count++
-    t.same(typeof payload, 'string')
+    t.assert.strictEqual(typeof payload, 'string')
     switch (count) {
       case 1: {
         // should guess the correct content-type based on payload
-        t.same(reply.getHeader('content-type'), 'text/plain; charset=utf-8')
+        t.assert.strictEqual(reply.getHeader('content-type'), 'text/plain; charset=utf-8')
         throw Error('kaboom')
       }
       case 2: {
         // should guess the correct content-type based on payload
-        t.same(reply.getHeader('content-type'), 'application/json; charset=utf-8')
+        t.assert.strictEqual(reply.getHeader('content-type'), 'application/json; charset=utf-8')
         return payload
       }
       default: {
@@ -38,6 +37,6 @@ test('should remove content-type for setErrorHandler', async t => {
   })
 
   const { statusCode, body } = await fastify.inject({ method: 'GET', path: '/' })
-  t.same(statusCode, 400)
-  t.same(body, JSON.stringify({ foo: 'bar' }))
+  t.assert.equal(statusCode, 400)
+  t.assert.strictEqual(body, JSON.stringify({ foo: 'bar' }))
 })

--- a/test/context-config.test.js
+++ b/test/context-config.test.js
@@ -41,38 +41,32 @@ test('config', async t => {
     handler
   })
 
-  {
-    const response = await fastify.inject({
-      method: 'GET',
-      url: '/route'
-    })
+  let response = await fastify.inject({
+    method: 'GET',
+    url: '/route'
+  })
 
-    t.assert.ifError(response.error)
-    t.assert.equal(response.statusCode, 200)
-    t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
-  }
+  t.assert.ifError(response.error)
+  t.assert.equal(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
 
-  {
-    const response = await fastify.inject({
-      method: 'GET',
-      url: '/route'
-    })
+  response = await fastify.inject({
+    method: 'GET',
+    url: '/route'
+  })
 
-    t.assert.ifError(response.error)
-    t.assert.equal(response.statusCode, 200)
-    t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
-  }
+  t.assert.ifError(response.error)
+  t.assert.equal(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
 
-  {
-    const response = await fastify.inject({
-      method: 'GET',
-      url: '/no-config'
-    })
+  response = await fastify.inject({
+    method: 'GET',
+    url: '/no-config'
+  })
 
-    t.assert.ifError(response.error)
-    t.assert.equal(response.statusCode, 200)
-    t.assert.deepStrictEqual(JSON.parse(response.payload), { url: '/no-config', method: 'GET' })
-  }
+  t.assert.ifError(response.error)
+  t.assert.equal(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), { url: '/no-config', method: 'GET' })
 })
 
 test('config with exposeHeadRoutes', async t => {
@@ -99,38 +93,32 @@ test('config with exposeHeadRoutes', async t => {
     handler
   })
 
-  {
-    const response = await fastify.inject({
-      method: 'GET',
-      url: '/get'
-    })
+  let response = await fastify.inject({
+    method: 'GET',
+    url: '/get'
+  })
 
-    t.assert.ifError(response.error)
-    t.assert.equal(response.statusCode, 200)
-    t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/get', method: 'GET' }, schema.config))
-  }
+  t.assert.ifError(response.error)
+  t.assert.equal(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/get', method: 'GET' }, schema.config))
 
-  {
-    const response = await fastify.inject({
-      method: 'GET',
-      url: '/route'
-    })
+  response = await fastify.inject({
+    method: 'GET',
+    url: '/route'
+  })
 
-    t.assert.ifError(response.error)
-    t.assert.equal(response.statusCode, 200)
-    t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
-  }
+  t.assert.ifError(response.error)
+  t.assert.equal(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
 
-  {
-    const response = await fastify.inject({
-      method: 'GET',
-      url: '/no-config'
-    })
+  response = await fastify.inject({
+    method: 'GET',
+    url: '/no-config'
+  })
 
-    t.assert.ifError(response.error)
-    t.assert.equal(response.statusCode, 200)
-    t.assert.deepStrictEqual(JSON.parse(response.payload), { url: '/no-config', method: 'GET' })
-  }
+  t.assert.ifError(response.error)
+  t.assert.equal(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), { url: '/no-config', method: 'GET' })
 })
 
 test('config without exposeHeadRoutes', async t => {
@@ -157,35 +145,29 @@ test('config without exposeHeadRoutes', async t => {
     handler
   })
 
-  {
-    const response = await fastify.inject({
-      method: 'GET',
-      url: '/get'
-    })
+  let response = await fastify.inject({
+    method: 'GET',
+    url: '/get'
+  })
 
-    t.assert.ifError(response.error)
-    t.assert.equal(response.statusCode, 200)
-    t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/get', method: 'GET' }, schema.config))
-  }
+  t.assert.ifError(response.error)
+  t.assert.equal(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/get', method: 'GET' }, schema.config))
 
-  {
-    const response = await fastify.inject({
-      method: 'GET',
-      url: '/route'
-    })
-    t.assert.ifError(response.error)
-    t.assert.equal(response.statusCode, 200)
-    t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
-  }
+  response = await fastify.inject({
+    method: 'GET',
+    url: '/route'
+  })
+  t.assert.ifError(response.error)
+  t.assert.equal(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
 
-  {
-    const response = await fastify.inject({
-      method: 'GET',
-      url: '/no-config'
-    })
+  response = await fastify.inject({
+    method: 'GET',
+    url: '/no-config'
+  })
 
-    t.assert.ifError(response.error)
-    t.assert.equal(response.statusCode, 200)
-    t.assert.deepStrictEqual(JSON.parse(response.payload), { url: '/no-config', method: 'GET' })
-  }
+  t.assert.ifError(response.error)
+  t.assert.equal(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), { url: '/no-config', method: 'GET' })
 })

--- a/test/context-config.test.js
+++ b/test/context-config.test.js
@@ -48,7 +48,7 @@ test('config', async t => {
 
   t.assert.ifError(response.error)
   t.assert.equal(response.statusCode, 200)
-  t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
+  t.assert.deepStrictEqual(response.json(), Object.assign({ url: '/route', method: 'GET' }, schema.config))
 
   response = await fastify.inject({
     method: 'GET',
@@ -57,7 +57,7 @@ test('config', async t => {
 
   t.assert.ifError(response.error)
   t.assert.equal(response.statusCode, 200)
-  t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
+  t.assert.deepStrictEqual(response.json(), Object.assign({ url: '/route', method: 'GET' }, schema.config))
 
   response = await fastify.inject({
     method: 'GET',
@@ -66,7 +66,7 @@ test('config', async t => {
 
   t.assert.ifError(response.error)
   t.assert.equal(response.statusCode, 200)
-  t.assert.deepStrictEqual(JSON.parse(response.payload), { url: '/no-config', method: 'GET' })
+  t.assert.deepStrictEqual(response.json(), { url: '/no-config', method: 'GET' })
 })
 
 test('config with exposeHeadRoutes', async t => {
@@ -100,7 +100,7 @@ test('config with exposeHeadRoutes', async t => {
 
   t.assert.ifError(response.error)
   t.assert.equal(response.statusCode, 200)
-  t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/get', method: 'GET' }, schema.config))
+  t.assert.deepStrictEqual(response.json(), Object.assign({ url: '/get', method: 'GET' }, schema.config))
 
   response = await fastify.inject({
     method: 'GET',
@@ -109,7 +109,7 @@ test('config with exposeHeadRoutes', async t => {
 
   t.assert.ifError(response.error)
   t.assert.equal(response.statusCode, 200)
-  t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
+  t.assert.deepStrictEqual(response.json(), Object.assign({ url: '/route', method: 'GET' }, schema.config))
 
   response = await fastify.inject({
     method: 'GET',
@@ -118,7 +118,7 @@ test('config with exposeHeadRoutes', async t => {
 
   t.assert.ifError(response.error)
   t.assert.equal(response.statusCode, 200)
-  t.assert.deepStrictEqual(JSON.parse(response.payload), { url: '/no-config', method: 'GET' })
+  t.assert.deepStrictEqual(response.json(), { url: '/no-config', method: 'GET' })
 })
 
 test('config without exposeHeadRoutes', async t => {
@@ -152,7 +152,7 @@ test('config without exposeHeadRoutes', async t => {
 
   t.assert.ifError(response.error)
   t.assert.equal(response.statusCode, 200)
-  t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/get', method: 'GET' }, schema.config))
+  t.assert.deepStrictEqual(response.json(), Object.assign({ url: '/get', method: 'GET' }, schema.config))
 
   response = await fastify.inject({
     method: 'GET',
@@ -160,7 +160,7 @@ test('config without exposeHeadRoutes', async t => {
   })
   t.assert.ifError(response.error)
   t.assert.equal(response.statusCode, 200)
-  t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
+  t.assert.deepStrictEqual(response.json(), Object.assign({ url: '/route', method: 'GET' }, schema.config))
 
   response = await fastify.inject({
     method: 'GET',
@@ -169,5 +169,5 @@ test('config without exposeHeadRoutes', async t => {
 
   t.assert.ifError(response.error)
   t.assert.equal(response.statusCode, 200)
-  t.assert.deepStrictEqual(JSON.parse(response.payload), { url: '/no-config', method: 'GET' })
+  t.assert.deepStrictEqual(response.json(), { url: '/no-config', method: 'GET' })
 })

--- a/test/context-config.test.js
+++ b/test/context-config.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
+
 const { kRouteContext } = require('../lib/symbols')
 const Fastify = require('..')
 
@@ -17,7 +17,7 @@ function handler (req, reply) {
   reply.send(reply[kRouteContext].config)
 }
 
-test('config', t => {
+test('config', async t => {
   t.plan(9)
   const fastify = Fastify()
 
@@ -41,35 +41,41 @@ test('config', t => {
     handler
   })
 
-  fastify.inject({
-    method: 'GET',
-    url: '/get'
-  }, (err, response) => {
-    t.error(err)
-    t.equal(response.statusCode, 200)
-    t.same(JSON.parse(response.payload), Object.assign({ url: '/get', method: 'GET' }, schema.config))
-  })
+  {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/route'
+    })
 
-  fastify.inject({
-    method: 'GET',
-    url: '/route'
-  }, (err, response) => {
-    t.error(err)
-    t.equal(response.statusCode, 200)
-    t.same(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
-  })
+    t.assert.ifError(response.error)
+    t.assert.equal(response.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
+  }
 
-  fastify.inject({
-    method: 'GET',
-    url: '/no-config'
-  }, (err, response) => {
-    t.error(err)
-    t.equal(response.statusCode, 200)
-    t.same(JSON.parse(response.payload), { url: '/no-config', method: 'GET' })
-  })
+  {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/route'
+    })
+
+    t.assert.ifError(response.error)
+    t.assert.equal(response.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
+  }
+
+  {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/no-config'
+    })
+
+    t.assert.ifError(response.error)
+    t.assert.equal(response.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(response.payload), { url: '/no-config', method: 'GET' })
+  }
 })
 
-test('config with exposeHeadRoutes', t => {
+test('config with exposeHeadRoutes', async t => {
   t.plan(9)
   const fastify = Fastify({ exposeHeadRoutes: true })
 
@@ -93,35 +99,41 @@ test('config with exposeHeadRoutes', t => {
     handler
   })
 
-  fastify.inject({
-    method: 'GET',
-    url: '/get'
-  }, (err, response) => {
-    t.error(err)
-    t.equal(response.statusCode, 200)
-    t.same(JSON.parse(response.payload), Object.assign({ url: '/get', method: 'GET' }, schema.config))
-  })
+  {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/get'
+    })
 
-  fastify.inject({
-    method: 'GET',
-    url: '/route'
-  }, (err, response) => {
-    t.error(err)
-    t.equal(response.statusCode, 200)
-    t.same(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
-  })
+    t.assert.ifError(response.error)
+    t.assert.equal(response.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/get', method: 'GET' }, schema.config))
+  }
 
-  fastify.inject({
-    method: 'GET',
-    url: '/no-config'
-  }, (err, response) => {
-    t.error(err)
-    t.equal(response.statusCode, 200)
-    t.same(JSON.parse(response.payload), { url: '/no-config', method: 'GET' })
-  })
+  {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/route'
+    })
+
+    t.assert.ifError(response.error)
+    t.assert.equal(response.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
+  }
+
+  {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/no-config'
+    })
+
+    t.assert.ifError(response.error)
+    t.assert.equal(response.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(response.payload), { url: '/no-config', method: 'GET' })
+  }
 })
 
-test('config without exposeHeadRoutes', t => {
+test('config without exposeHeadRoutes', async t => {
   t.plan(9)
   const fastify = Fastify({ exposeHeadRoutes: false })
 
@@ -145,30 +157,35 @@ test('config without exposeHeadRoutes', t => {
     handler
   })
 
-  fastify.inject({
-    method: 'GET',
-    url: '/get'
-  }, (err, response) => {
-    t.error(err)
-    t.equal(response.statusCode, 200)
-    t.same(JSON.parse(response.payload), Object.assign({ url: '/get', method: 'GET' }, schema.config))
-  })
+  {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/get'
+    })
 
-  fastify.inject({
-    method: 'GET',
-    url: '/route'
-  }, (err, response) => {
-    t.error(err)
-    t.equal(response.statusCode, 200)
-    t.same(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
-  })
+    t.assert.ifError(response.error)
+    t.assert.equal(response.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/get', method: 'GET' }, schema.config))
+  }
 
-  fastify.inject({
-    method: 'GET',
-    url: '/no-config'
-  }, (err, response) => {
-    t.error(err)
-    t.equal(response.statusCode, 200)
-    t.same(JSON.parse(response.payload), { url: '/no-config', method: 'GET' })
-  })
+  {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/route'
+    })
+    t.assert.ifError(response.error)
+    t.assert.equal(response.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(response.payload), Object.assign({ url: '/route', method: 'GET' }, schema.config))
+  }
+
+  {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/no-config'
+    })
+
+    t.assert.ifError(response.error)
+    t.assert.equal(response.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(response.payload), { url: '/no-config', method: 'GET' })
+  }
 })

--- a/test/context-config.test.js
+++ b/test/context-config.test.js
@@ -47,7 +47,7 @@ test('config', async t => {
   })
 
   t.assert.ifError(response.error)
-  t.assert.equal(response.statusCode, 200)
+  t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), Object.assign({ url: '/route', method: 'GET' }, schema.config))
 
   response = await fastify.inject({
@@ -56,7 +56,7 @@ test('config', async t => {
   })
 
   t.assert.ifError(response.error)
-  t.assert.equal(response.statusCode, 200)
+  t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), Object.assign({ url: '/route', method: 'GET' }, schema.config))
 
   response = await fastify.inject({
@@ -65,7 +65,7 @@ test('config', async t => {
   })
 
   t.assert.ifError(response.error)
-  t.assert.equal(response.statusCode, 200)
+  t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), { url: '/no-config', method: 'GET' })
 })
 
@@ -99,7 +99,7 @@ test('config with exposeHeadRoutes', async t => {
   })
 
   t.assert.ifError(response.error)
-  t.assert.equal(response.statusCode, 200)
+  t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), Object.assign({ url: '/get', method: 'GET' }, schema.config))
 
   response = await fastify.inject({
@@ -108,7 +108,7 @@ test('config with exposeHeadRoutes', async t => {
   })
 
   t.assert.ifError(response.error)
-  t.assert.equal(response.statusCode, 200)
+  t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), Object.assign({ url: '/route', method: 'GET' }, schema.config))
 
   response = await fastify.inject({
@@ -117,7 +117,7 @@ test('config with exposeHeadRoutes', async t => {
   })
 
   t.assert.ifError(response.error)
-  t.assert.equal(response.statusCode, 200)
+  t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), { url: '/no-config', method: 'GET' })
 })
 
@@ -151,7 +151,7 @@ test('config without exposeHeadRoutes', async t => {
   })
 
   t.assert.ifError(response.error)
-  t.assert.equal(response.statusCode, 200)
+  t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), Object.assign({ url: '/get', method: 'GET' }, schema.config))
 
   response = await fastify.inject({
@@ -159,7 +159,7 @@ test('config without exposeHeadRoutes', async t => {
     url: '/route'
   })
   t.assert.ifError(response.error)
-  t.assert.equal(response.statusCode, 200)
+  t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), Object.assign({ url: '/route', method: 'GET' }, schema.config))
 
   response = await fastify.inject({
@@ -168,6 +168,6 @@ test('config without exposeHeadRoutes', async t => {
   })
 
   t.assert.ifError(response.error)
-  t.assert.equal(response.statusCode, 200)
+  t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), { url: '/no-config', method: 'GET' })
 })

--- a/test/context-config.test.js
+++ b/test/context-config.test.js
@@ -18,7 +18,7 @@ function handler (req, reply) {
 }
 
 test('config', async t => {
-  t.plan(9)
+  t.plan(6)
   const fastify = Fastify()
 
   fastify.get('/get', {
@@ -46,7 +46,6 @@ test('config', async t => {
     url: '/route'
   })
 
-  t.assert.ifError(response.error)
   t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), Object.assign({ url: '/route', method: 'GET' }, schema.config))
 
@@ -55,7 +54,6 @@ test('config', async t => {
     url: '/route'
   })
 
-  t.assert.ifError(response.error)
   t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), Object.assign({ url: '/route', method: 'GET' }, schema.config))
 
@@ -64,13 +62,12 @@ test('config', async t => {
     url: '/no-config'
   })
 
-  t.assert.ifError(response.error)
   t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), { url: '/no-config', method: 'GET' })
 })
 
 test('config with exposeHeadRoutes', async t => {
-  t.plan(9)
+  t.plan(6)
   const fastify = Fastify({ exposeHeadRoutes: true })
 
   fastify.get('/get', {
@@ -98,7 +95,6 @@ test('config with exposeHeadRoutes', async t => {
     url: '/get'
   })
 
-  t.assert.ifError(response.error)
   t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), Object.assign({ url: '/get', method: 'GET' }, schema.config))
 
@@ -107,7 +103,6 @@ test('config with exposeHeadRoutes', async t => {
     url: '/route'
   })
 
-  t.assert.ifError(response.error)
   t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), Object.assign({ url: '/route', method: 'GET' }, schema.config))
 
@@ -116,13 +111,12 @@ test('config with exposeHeadRoutes', async t => {
     url: '/no-config'
   })
 
-  t.assert.ifError(response.error)
   t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), { url: '/no-config', method: 'GET' })
 })
 
 test('config without exposeHeadRoutes', async t => {
-  t.plan(9)
+  t.plan(6)
   const fastify = Fastify({ exposeHeadRoutes: false })
 
   fastify.get('/get', {
@@ -150,7 +144,6 @@ test('config without exposeHeadRoutes', async t => {
     url: '/get'
   })
 
-  t.assert.ifError(response.error)
   t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), Object.assign({ url: '/get', method: 'GET' }, schema.config))
 
@@ -158,7 +151,6 @@ test('config without exposeHeadRoutes', async t => {
     method: 'GET',
     url: '/route'
   })
-  t.assert.ifError(response.error)
   t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), Object.assign({ url: '/route', method: 'GET' }, schema.config))
 
@@ -167,7 +159,6 @@ test('config without exposeHeadRoutes', async t => {
     url: '/no-config'
   })
 
-  t.assert.ifError(response.error)
   t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), { url: '/no-config', method: 'GET' })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Porting of `content-type.test.js` and `context-config.test.js` from `tap` to `node:test`

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
