### PR TITLE
test: port server.test.js to node:test

### DIFF
--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test, describe } = require('node:test')
+const { test } = require('node:test')
 const Fastify = require('..')
 const sget = require('simple-get').concat
 const undici = require('undici')
@@ -81,8 +81,8 @@ test('Test for hostname and port', (t, end) => {
   })
 })
 
-describe('abort signal', () => {
-  test('listen should not start server', (t, end) => {
+test('abort signal', async t => {
+  await t.test('listen should not start server', (t, end) => {
     t.plan(2)
     function onClose (instance, done) {
       t.assert.equal(instance, fastify)
@@ -100,7 +100,7 @@ describe('abort signal', () => {
     t.assert.strictEqual(fastify.server.listening, false)
   })
 
-  test('listen should not start server if already aborted', (t, end) => {
+  await t.test('listen should not start server if already aborted', (t, end) => {
     t.plan(2)
     function onClose (instance, done) {
       t.assert.equal(instance, fastify)
@@ -118,7 +118,7 @@ describe('abort signal', () => {
     t.assert.strictEqual(fastify.server.listening, false)
   })
 
-  test('listen should throw if received invalid signal', t => {
+  await t.test('listen should throw if received invalid signal', t => {
     t.plan(2)
     const fastify = Fastify()
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,115 +1,111 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test, describe } = require('node:test')
 const Fastify = require('..')
 const sget = require('simple-get').concat
 const undici = require('undici')
 
-test('listen should accept null port', t => {
-  t.plan(1)
-
+test('listen should accept null port', async t => {
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
-  fastify.listen({ port: null }, (err) => {
-    t.error(err)
-  })
+  t.after(() => fastify.close())
+
+  await t.assert.doesNotReject(
+    fastify.listen({ port: null })
+  )
 })
 
-test('listen should accept undefined port', t => {
-  t.plan(1)
-
+test('listen should accept undefined port', async t => {
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
-  fastify.listen({ port: undefined }, (err) => {
-    t.error(err)
-  })
+  t.after(() => fastify.close())
+
+  await t.assert.doesNotReject(
+    fastify.listen({ port: undefined })
+  )
 })
 
-test('listen should accept stringified number port', t => {
-  t.plan(1)
-
+test('listen should accept stringified number port', async t => {
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
-  fastify.listen({ port: '1234' }, (err) => {
-    t.error(err)
-  })
+  t.after(() => fastify.close())
+
+  await t.assert.doesNotReject(
+    fastify.listen({ port: '1234' })
+  )
 })
 
-test('listen should accept log text resolution function', t => {
-  t.plan(3)
-
+test('listen should accept log text resolution function', async t => {
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
-  fastify.listen({
-    host: '127.0.0.1',
-    port: '1234',
-    listenTextResolver: (address) => {
-      t.equal(address, 'http://127.0.0.1:1234')
-      t.pass('executed')
-      return 'hardcoded text'
-    }
-  }, (err) => {
-    t.error(err)
-  })
+  t.after(() => fastify.close())
+
+  await t.assert.doesNotReject(
+    fastify.listen({
+      host: '127.0.0.1',
+      port: '1234',
+      listenTextResolver: (address) => {
+        t.assert.strictEqual(address, 'http://127.0.0.1:1234')
+        return 'hardcoded text'
+      }
+    })
+  )
 })
 
 test('listen should reject string port', async (t) => {
-  t.plan(2)
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   try {
     await fastify.listen({ port: 'hello-world' })
   } catch (error) {
-    t.equal(error.code, 'ERR_SOCKET_BAD_PORT')
+    t.assert.strictEqual(error.code, 'ERR_SOCKET_BAD_PORT')
   }
 
   try {
     await fastify.listen({ port: '1234hello' })
   } catch (error) {
-    t.equal(error.code, 'ERR_SOCKET_BAD_PORT')
+    t.assert.strictEqual(error.code, 'ERR_SOCKET_BAD_PORT')
   }
 })
 
-test('Test for hostname and port', t => {
+test('Test for hostname and port', (t, end) => {
   const app = Fastify()
-  t.teardown(app.close.bind(app))
+  t.after(() => app.close())
   app.get('/host', (req, res) => {
     const host = 'localhost:8000'
-    t.equal(req.host, host)
-    t.equal(req.hostname, req.host.split(':')[0])
-    t.equal(req.port, Number(req.host.split(':')[1]))
+    t.assert.strictEqual(req.host, host)
+    t.assert.strictEqual(req.hostname, req.host.split(':')[0])
+    t.assert.strictEqual(req.port, Number(req.host.split(':')[1]))
     res.send('ok')
   })
+
   app.listen({ port: 8000 }, () => {
-    sget('http://localhost:8000/host', () => { t.end() })
+    sget('http://localhost:8000/host', () => { end() })
   })
 })
 
-test('abort signal', t => {
-  t.test('listen should not start server', t => {
+describe('abort signal', () => {
+  test('listen should not start server', (t, end) => {
     t.plan(2)
     function onClose (instance, done) {
-      t.type(fastify, instance)
+      t.assert.equal(instance, fastify)
       done()
+      end()
     }
     const controller = new AbortController()
 
     const fastify = Fastify()
     fastify.addHook('onClose', onClose)
     fastify.listen({ port: 1234, signal: controller.signal }, (err) => {
-      t.error(err)
+      t.assert.ifError(err)
     })
     controller.abort()
-    t.equal(fastify.server.listening, false)
+    t.assert.strictEqual(fastify.server.listening, false)
   })
 
-  t.test('listen should not start server if already aborted', t => {
+  test('listen should not start server if already aborted', (t, end) => {
     t.plan(2)
     function onClose (instance, done) {
-      t.type(fastify, instance)
+      t.assert.equal(instance, fastify)
       done()
+      end()
     }
 
     const controller = new AbortController()
@@ -117,34 +113,32 @@ test('abort signal', t => {
     const fastify = Fastify()
     fastify.addHook('onClose', onClose)
     fastify.listen({ port: 1234, signal: controller.signal }, (err) => {
-      t.error(err)
+      t.assert.ifError(err)
     })
-    t.equal(fastify.server.listening, false)
+    t.assert.strictEqual(fastify.server.listening, false)
   })
 
-  t.test('listen should throw if received invalid signal', t => {
+  test('listen should throw if received invalid signal', t => {
     t.plan(2)
     const fastify = Fastify()
 
     try {
       fastify.listen({ port: 1234, signal: {} }, (err) => {
-        t.error(err)
+        t.assert.ifError(err)
       })
-      t.fail()
+      t.assert.fail('should throw')
     } catch (e) {
-      t.equal(e.code, 'FST_ERR_LISTEN_OPTIONS_INVALID')
-      t.equal(e.message, 'Invalid listen options: \'Invalid options.signal\'')
+      t.assert.strictEqual(e.code, 'FST_ERR_LISTEN_OPTIONS_INVALID')
+      t.assert.strictEqual(e.message, 'Invalid listen options: \'Invalid options.signal\'')
     }
   })
-
-  t.end()
 })
 
-t.test('#5180 - preClose should be called before closing secondary server', t => {
+test('#5180 - preClose should be called before closing secondary server', (t, end) => {
   t.plan(2)
   const fastify = Fastify({ forceCloseConnections: true })
   let flag = false
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.addHook('preClose', async () => {
     flag = true
@@ -159,7 +153,7 @@ t.test('#5180 - preClose should be called before closing secondary server', t =>
   })
 
   fastify.listen({ port: 0 }, (err) => {
-    t.error(err)
+    t.assert.ifError(err)
     const addresses = fastify.addresses()
     const mainServerAddress = fastify.server.address()
     let secondaryAddress
@@ -174,14 +168,17 @@ t.test('#5180 - preClose should be called before closing secondary server', t =>
     }
 
     if (!secondaryAddress) {
-      t.pass('no secondary server')
+      t.assert.ok(true, 'Secondary address not found')
       return
     }
 
     undici.request(`http://${secondaryAddress.address}:${secondaryAddress.port}/`)
       .then(
-        () => { t.fail('Request should not succeed') },
-        () => { t.ok(flag) }
+        () => { t.assert.fail('Request should not succeed') },
+        () => {
+          t.assert.ok(flag)
+          end()
+        }
       )
 
     setTimeout(() => {


### PR DESCRIPTION
`server.test.js` porting from `tap` to `node:test`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
