### PR TITLE
fix(types): correct FastifyValidationResult error return type

### DIFF
--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -20,6 +20,7 @@ import { FastifyReply } from '../../types/reply'
 import { FastifyRequest, RequestRouteOptions } from '../../types/request'
 import { FastifyRouteConfig, RouteGenericInterface } from '../../types/route'
 import { RequestHeadersDefault, RequestParamsDefault, RequestQuerystringDefault } from '../../types/utils'
+import { FastifySchemaValidationError } from '../../types/schema'
 
 interface RequestBody {
   content: string;
@@ -86,7 +87,7 @@ const getHandler: RouteHandler = function (request, _reply) {
   expectType<string>(request.id)
   expectType<FastifyLoggerInstance>(request.log)
   expectType<RawRequestDefaultExpression['socket']>(request.socket)
-  expectType<Error & { validation: any; validationContext: string } | undefined>(request.validationError)
+  expectType<Error & { validation?: FastifySchemaValidationError[]; validationContext: string } | undefined>(request.validationError)
   expectType<FastifyInstance>(request.server)
   expectAssignable<(httpPart: HTTPRequestPart) => ExpectedGetValidationFunction>(request.getValidationFunction)
   expectAssignable<(schema: { [key: string]: unknown }) => ExpectedGetValidationFunction>(request.getValidationFunction)

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -3,7 +3,7 @@ import { FastifyContextConfig } from './context'
 import { FastifyInstance } from './instance'
 import { FastifyBaseLogger } from './logger'
 import { FastifyRouteConfig, RouteGenericInterface, RouteHandlerMethod } from './route'
-import { FastifySchema } from './schema'
+import { FastifySchema, FastifySchemaValidationError } from './schema'
 import { FastifyRequestType, FastifyTypeProvider, FastifyTypeProviderDefault, ResolveFastifyRequestType } from './type-provider'
 import { ContextConfigDefault, HTTPMethods, RawRequestDefaultExpression, RawServerBase, RawServerDefault, RequestBodyDefault, RequestHeadersDefault, RequestParamsDefault, RequestQuerystringDefault } from './utils'
 
@@ -63,7 +63,7 @@ export interface FastifyRequest<RouteGeneric extends RouteGenericInterface = Rou
   body: RequestType['body'];
 
   /** in order for this to be used the user should ensure they have set the attachValidation option. */
-  validationError?: Error & { validation: any; validationContext: string };
+  validationError?: Error & { validation?: FastifySchemaValidationError[]; validationContext: string };
 
   /**
    * @deprecated Use `raw` property

--- a/types/schema.d.ts
+++ b/types/schema.d.ts
@@ -33,7 +33,7 @@ export interface FastifySchemaValidationError {
 }
 
 export interface FastifyValidationResult {
-  (data: any): boolean | SafePromiseLike<any> | { error?: Error, value?: any }
+  (data: any): boolean | SafePromiseLike<any> | { error?: Error | FastifySchemaValidationError[], value?: any }
   errors?: FastifySchemaValidationError[] | null;
 }
 


### PR DESCRIPTION
This type should take both `Error` and `FastifySchemaValidationError[]` as well as `validation` should be typed as an optional `FastifySchemaValidationError[]` based on the following code:

https://github.com/fastify/fastify/blob/728b07ef4f14fa57762fe7dd4ffb6046a407b3a8/lib/validation.js#L241-L256

https://github.com/fastify/fastify/blob/2ee97ffa57f80be390414585ca8c07ecdaf250bc/types/schema.d.ts#L61

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


