### PR TITLE
chore: Migrate async-local-storage and async-await test to node:test

### DIFF
--- a/test/als.test.js
+++ b/test/als.test.js
@@ -1,50 +1,40 @@
 'use strict'
 
 const { AsyncLocalStorage } = require('node:async_hooks')
-const t = require('tap')
+const { test } = require('node:test')
 const Fastify = require('..')
 const sget = require('simple-get').concat
 
-if (!AsyncLocalStorage) {
-  t.skip('AsyncLocalStorage not available, skipping test')
-  process.exit(0)
-}
+test('Async Local Storage test', (t, done) => {
+  t.plan(13)
+  if (!AsyncLocalStorage) {
+    t.skip('AsyncLocalStorage not available, skipping test')
+    process.exit(0)
+  }
 
-const storage = new AsyncLocalStorage()
-const app = Fastify({ logger: false })
+  const storage = new AsyncLocalStorage()
+  const app = Fastify({ logger: false })
 
-let counter = 0
-app.addHook('onRequest', (req, reply, next) => {
-  const id = counter++
-  storage.run({ id }, next)
-})
+  let counter = 0
+  app.addHook('onRequest', (req, reply, next) => {
+    const id = counter++
+    storage.run({ id }, next)
+  })
 
-app.get('/', function (request, reply) {
-  t.ok(storage.getStore())
-  const id = storage.getStore().id
-  reply.send({ id })
-})
+  app.get('/', function (request, reply) {
+    t.assert.ok(storage.getStore())
+    const id = storage.getStore().id
+    reply.send({ id })
+  })
 
-app.post('/', function (request, reply) {
-  t.ok(storage.getStore())
-  const id = storage.getStore().id
-  reply.send({ id })
-})
+  app.post('/', function (request, reply) {
+    t.assert.ok(storage.getStore())
+    const id = storage.getStore().id
+    reply.send({ id })
+  })
 
-app.listen({ port: 0 }, function (err, address) {
-  t.error(err)
-
-  sget({
-    method: 'POST',
-    url: 'http://localhost:' + app.server.address().port,
-    body: {
-      hello: 'world'
-    },
-    json: true
-  }, (err, response, body) => {
-    t.error(err)
-    t.equal(response.statusCode, 200)
-    t.same(body, { id: 0 })
+  app.listen({ port: 0 }, function (err, address) {
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -54,20 +44,33 @@ app.listen({ port: 0 }, function (err, address) {
       },
       json: true
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.same(body, { id: 1 })
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 200)
+      t.assert.deepStrictEqual(body, { id: 0 })
 
       sget({
-        method: 'GET',
+        method: 'POST',
         url: 'http://localhost:' + app.server.address().port,
+        body: {
+          hello: 'world'
+        },
         json: true
       }, (err, response, body) => {
-        t.error(err)
-        t.equal(response.statusCode, 200)
-        t.same(body, { id: 2 })
-        app.close()
-        t.end()
+        t.assert.ifError(err)
+        t.assert.strictEqual(response.statusCode, 200)
+        t.assert.deepStrictEqual(body, { id: 1 })
+
+        sget({
+          method: 'GET',
+          url: 'http://localhost:' + app.server.address().port,
+          json: true
+        }, (err, response, body) => {
+          t.assert.ifError(err)
+          t.assert.strictEqual(response.statusCode, 200)
+          t.assert.deepStrictEqual(body, { id: 2 })
+          app.close()
+          done()
+        })
       })
     })
   })


### PR DESCRIPTION
These changes are related to the issue https://github.com/fastify/fastify/issues/5555
Changed `als.test.js` and `async-await.test.js` to use `node:test` instead of `tap`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
