### PR TITLE
test: migrated async-dispose.test.js from tap to node:test

### DIFF
--- a/test/async-dispose.test.js
+++ b/test/async-dispose.test.js
@@ -1,21 +1,21 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('node:test')
 const Fastify = require('../fastify')
 
 // asyncDispose doesn't exist in node <= 16
-t.test('async dispose should close fastify', { skip: !('asyncDispose' in Symbol) }, async t => {
+test('async dispose should close fastify', { skip: !('asyncDispose' in Symbol) }, async t => {
   t.plan(2)
 
   const fastify = Fastify()
 
   await fastify.listen({ port: 0 })
 
-  t.equal(fastify.server.listening, true)
+  t.assert.equal(fastify.server.listening, true)
 
   // the same as syntax sugar for
   // await using app = fastify()
   await fastify[Symbol.asyncDispose]()
 
-  t.equal(fastify.server.listening, false)
+  t.assert.equal(fastify.server.listening, false)
 })

--- a/test/async-dispose.test.js
+++ b/test/async-dispose.test.js
@@ -17,5 +17,5 @@ test('async dispose should close fastify', { skip: !('asyncDispose' in Symbol) }
   // await using app = fastify()
   await fastify[Symbol.asyncDispose]()
 
-  t.assert.equal(fastify.server.listening, false)
+  t.assert.strictEqual(fastify.server.listening, false)
 })

--- a/test/async-dispose.test.js
+++ b/test/async-dispose.test.js
@@ -11,7 +11,7 @@ test('async dispose should close fastify', { skip: !('asyncDispose' in Symbol) }
 
   await fastify.listen({ port: 0 })
 
-  t.assert.equal(fastify.server.listening, true)
+  t.assert.strictEqual(fastify.server.listening, true)
 
   // the same as syntax sugar for
   // await using app = fastify()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Proposal:

   - migrated `async-dispose.test.js` file from `tap` to `node:test` 🔥
