### PR TITLE
test: migrated reply-early-hints.test.js from tap to node:test

### DIFF
--- a/test/reply-early-hints.test.js
+++ b/test/reply-early-hints.test.js
@@ -7,7 +7,9 @@ const http2 = require('http2')
 
 const testResBody = 'Hello, world!'
 
-test('sends early hints', (t) => {
+test('sends early hints', (t, done) => {
+  t.plan(6)
+
   const fastify = Fastify({
     logger: false
   })
@@ -42,13 +44,16 @@ test('sends early hints', (t) => {
 
       res.on('end', () => {
         t.assert.strictEqual(data, testResBody)
-        fastify.close(t.end)
+        fastify.close()
+        done()
       })
     })
   })
 })
 
-test('sends early hints (http2)', (t) => {
+test('sends early hints (http2)', (t, done) => {
+  t.plan(6)
+
   const fastify = Fastify({
     http2: true,
     logger: false
@@ -86,7 +91,8 @@ test('sends early hints (http2)', (t) => {
     req.on('end', () => {
       t.assert.strictEqual(data, testResBody)
       client.close()
-      fastify.close(t.end)
+      fastify.close()
+      done()
     })
 
     req.end()

--- a/test/reply-early-hints.test.js
+++ b/test/reply-early-hints.test.js
@@ -1,15 +1,13 @@
 'use strict'
 
 const Fastify = require('..')
-const { test } = require('tap')
+const { test } = require('node:test')
 const http = require('http')
 const http2 = require('http2')
 
 const testResBody = 'Hello, world!'
 
 test('sends early hints', (t) => {
-  t.plan(6)
-
   const fastify = Fastify({
     logger: false
   })
@@ -18,24 +16,24 @@ test('sends early hints', (t) => {
     reply.writeEarlyHints({
       link: '</styles.css>; rel=preload; as=style'
     }, () => {
-      t.pass('callback called')
+      t.assert.ok('callback called')
     })
 
     return testResBody
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
+    t.assert.ifError(err)
 
     const req = http.get(address)
 
     req.on('information', (res) => {
-      t.equal(res.statusCode, 103)
-      t.equal(res.headers.link, '</styles.css>; rel=preload; as=style')
+      t.assert.strictEqual(res.statusCode, 103)
+      t.assert.strictEqual(res.headers.link, '</styles.css>; rel=preload; as=style')
     })
 
     req.on('response', (res) => {
-      t.equal(res.statusCode, 200)
+      t.assert.strictEqual(res.statusCode, 200)
 
       let data = ''
       res.on('data', (chunk) => {
@@ -43,7 +41,7 @@ test('sends early hints', (t) => {
       })
 
       res.on('end', () => {
-        t.equal(data, testResBody)
+        t.assert.strictEqual(data, testResBody)
         fastify.close(t.end)
       })
     })
@@ -51,8 +49,6 @@ test('sends early hints', (t) => {
 })
 
 test('sends early hints (http2)', (t) => {
-  t.plan(6)
-
   const fastify = Fastify({
     http2: true,
     logger: false
@@ -67,19 +63,19 @@ test('sends early hints (http2)', (t) => {
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
+    t.assert.ifError(err)
 
     const client = http2.connect(address)
     const req = client.request()
 
     req.on('headers', (headers) => {
-      t.not(headers, undefined)
-      t.equal(headers[':status'], 103)
-      t.equal(headers.link, '</styles.css>; rel=preload; as=style')
+      t.assert.notStrictEqual(headers, undefined)
+      t.assert.strictEqual(headers[':status'], 103)
+      t.assert.strictEqual(headers.link, '</styles.css>; rel=preload; as=style')
     })
 
     req.on('response', (headers) => {
-      t.equal(headers[':status'], 200)
+      t.assert.strictEqual(headers[':status'], 200)
     })
 
     let data = ''
@@ -88,7 +84,7 @@ test('sends early hints (http2)', (t) => {
     })
 
     req.on('end', () => {
-      t.equal(data, testResBody)
+      t.assert.strictEqual(data, testResBody)
       client.close()
       fastify.close(t.end)
     })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


Proposal:

  - rename file in `kebab-case`
  - migrated `reply-early-hints.test.js` file from `tap` to `node:test` 🔥

