### PR TITLE
test: migrated request-timeout.test.js from tap to node:test

### DIFF
--- a/test/request-timeout.test.js
+++ b/test/request-timeout.test.js
@@ -1,31 +1,31 @@
 'use strict'
 
 const http = require('node:http')
-const { test } = require('tap')
-const Fastify = require('../fastify')
+const { test } = require('node:test')
+const Fastify = require('..')
 
 test('requestTimeout passed to server', t => {
   t.plan(5)
 
   try {
     Fastify({ requestTimeout: 500.1 })
-    t.fail('option must be an integer')
+    t.assert.fail('option must be an integer')
   } catch (err) {
-    t.ok(err)
+    t.assert.ok(err)
   }
 
   try {
     Fastify({ requestTimeout: [] })
-    t.fail('option must be an integer')
+    t.assert.fail('option must be an integer')
   } catch (err) {
-    t.ok(err)
+    t.assert.ok(err)
   }
 
   const httpServer = Fastify({ requestTimeout: 1000 }).server
-  t.equal(httpServer.requestTimeout, 1000)
+  t.assert.strictEqual(httpServer.requestTimeout, 1000)
 
   const httpsServer = Fastify({ requestTimeout: 1000, https: true }).server
-  t.equal(httpsServer.requestTimeout, 1000)
+  t.assert.strictEqual(httpsServer.requestTimeout, 1000)
 
   const serverFactory = (handler, _) => {
     const server = http.createServer((req, res) => {
@@ -35,19 +35,19 @@ test('requestTimeout passed to server', t => {
     return server
   }
   const customServer = Fastify({ requestTimeout: 4000, serverFactory }).server
-  t.equal(customServer.requestTimeout, 5000)
+  t.assert.strictEqual(customServer.requestTimeout, 5000)
 })
 
 test('requestTimeout should be set', async (t) => {
   t.plan(1)
 
   const initialConfig = Fastify({ requestTimeout: 5000 }).initialConfig
-  t.same(initialConfig.requestTimeout, 5000)
+  t.assert.deepEqual(initialConfig.requestTimeout, 5000)
 })
 
 test('requestTimeout should 0', async (t) => {
   t.plan(1)
 
   const initialConfig = Fastify().initialConfig
-  t.same(initialConfig.requestTimeout, 0)
+  t.assert.deepEqual(initialConfig.requestTimeout, 0)
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Proposal:

- rename file in `kebab-case`
- migrated `request-timeout.test.js` file from `tap` to `node:test` 🔥