### PR TITLE
test: migrated reply-code.test.js from tap to node:test

### DIFF
--- a/test/reply-code.test.js
+++ b/test/reply-code.test.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('node:test')
 const { Readable } = require('stream')
-const test = t.test
 const Fastify = require('..')
 
-test('code should handle null/undefined/float', t => {
+test('code should handle null/undefined/float', (t, done) => {
   t.plan(8)
 
   const fastify = Fastify()
@@ -26,9 +25,9 @@ test('code should handle null/undefined/float', t => {
     method: 'GET',
     url: '/null'
   }, (error, res) => {
-    t.error(error)
-    t.equal(res.statusCode, 500)
-    t.same(res.json(), {
+    t.assert.ifError(error)
+    t.assert.strictEqual(res.statusCode, 500)
+    t.assert.deepStrictEqual(res.json(), {
       statusCode: 500,
       code: 'FST_ERR_BAD_STATUS_CODE',
       error: 'Internal Server Error',
@@ -40,9 +39,9 @@ test('code should handle null/undefined/float', t => {
     method: 'GET',
     url: '/undefined'
   }, (error, res) => {
-    t.error(error)
-    t.equal(res.statusCode, 500)
-    t.same(res.json(), {
+    t.assert.ifError(error)
+    t.assert.strictEqual(res.statusCode, 500)
+    t.assert.deepStrictEqual(res.json(), {
       statusCode: 500,
       code: 'FST_ERR_BAD_STATUS_CODE',
       error: 'Internal Server Error',
@@ -54,12 +53,13 @@ test('code should handle null/undefined/float', t => {
     method: 'GET',
     url: '/404.5'
   }, (error, res) => {
-    t.error(error)
-    t.equal(res.statusCode, 404)
+    t.assert.ifError(error)
+    t.assert.strictEqual(res.statusCode, 404)
+    done()
   })
 })
 
-test('code should handle 204', t => {
+test('code should handle 204', (t, done) => {
   t.plan(13)
 
   const fastify = Fastify()
@@ -80,7 +80,7 @@ test('code should handle 204', t => {
       }
     })
     stream.on('end', () => {
-      t.pass('stream ended')
+      t.assert.ok('stream ended')
     })
     reply.status(204).send(stream)
   })
@@ -89,34 +89,35 @@ test('code should handle 204', t => {
     method: 'GET',
     url: '/204'
   }, (error, res) => {
-    t.error(error)
-    t.equal(res.statusCode, 204)
-    t.equal(res.payload, '')
-    t.equal(res.headers['content-length'], undefined)
+    t.assert.ifError(error)
+    t.assert.strictEqual(res.statusCode, 204)
+    t.assert.strictEqual(res.payload, '')
+    t.assert.strictEqual(res.headers['content-length'], undefined)
   })
 
   fastify.inject({
     method: 'GET',
     url: '/undefined/204'
   }, (error, res) => {
-    t.error(error)
-    t.equal(res.statusCode, 204)
-    t.equal(res.payload, '')
-    t.equal(res.headers['content-length'], undefined)
+    t.assert.ifError(error)
+    t.assert.strictEqual(res.statusCode, 204)
+    t.assert.strictEqual(res.payload, '')
+    t.assert.strictEqual(res.headers['content-length'], undefined)
   })
 
   fastify.inject({
     method: 'GET',
     url: '/stream/204'
   }, (error, res) => {
-    t.error(error)
-    t.equal(res.statusCode, 204)
-    t.equal(res.payload, '')
-    t.equal(res.headers['content-length'], undefined)
+    t.assert.ifError(error)
+    t.assert.strictEqual(res.statusCode, 204)
+    t.assert.strictEqual(res.payload, '')
+    t.assert.strictEqual(res.headers['content-length'], undefined)
+    done()
   })
 })
 
-test('code should handle onSend hook on 204', t => {
+test('code should handle onSend hook on 204', (t, done) => {
   t.plan(5)
 
   const fastify = Fastify()
@@ -137,10 +138,11 @@ test('code should handle onSend hook on 204', t => {
     method: 'GET',
     url: '/204'
   }, (error, res) => {
-    t.error(error)
-    t.equal(res.statusCode, 204)
-    t.equal(res.payload, '')
-    t.equal(res.headers['content-length'], undefined)
-    t.equal(res.headers['content-type'], undefined)
+    t.assert.ifError(error)
+    t.assert.strictEqual(res.statusCode, 204)
+    t.assert.strictEqual(res.payload, '')
+    t.assert.strictEqual(res.headers['content-length'], undefined)
+    t.assert.strictEqual(res.headers['content-type'], undefined)
+    done()
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Proposal:

   - migrated `reply-code.test.js` file from `tap` to `node:test` 🔥