### PR TITLE
test: migrated use-semicolon-delimiter.test.js from tap to node:test

### DIFF
--- a/test/use-semicolon-delimiter.test.js
+++ b/test/use-semicolon-delimiter.test.js
@@ -4,7 +4,7 @@ const { test } = require('node:test')
 const Fastify = require('..')
 const sget = require('simple-get').concat
 
-test('use semicolon delimiter default false', t => {
+test('use semicolon delimiter default false', (t, done) => {
   t.plan(4)
 
   const fastify = Fastify({})
@@ -25,11 +25,12 @@ test('use semicolon delimiter default false', t => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 200)
       t.assert.deepStrictEqual(JSON.parse(body), {})
+      done()
     })
   })
 })
 
-test('use semicolon delimiter set to true', t => {
+test('use semicolon delimiter set to true', (t, done) => {
   t.plan(4)
 
   const fastify = Fastify({
@@ -53,11 +54,12 @@ test('use semicolon delimiter set to true', t => {
       t.assert.deepStrictEqual(JSON.parse(body), {
         foo: 'bar'
       })
+      done()
     })
   })
 })
 
-test('use semicolon delimiter set to false', t => {
+test('use semicolon delimiter set to false', (t, done) => {
   t.plan(4)
 
   const fastify = Fastify({
@@ -79,11 +81,12 @@ test('use semicolon delimiter set to false', t => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 200)
       t.assert.deepStrictEqual(JSON.parse(body), {})
+      done()
     })
   })
 })
 
-test('use semicolon delimiter set to false return 404', t => {
+test('use semicolon delimiter set to false return 404', (t, done) => {
   t.plan(3)
 
   const fastify = Fastify({
@@ -104,6 +107,7 @@ test('use semicolon delimiter set to false return 404', t => {
     }, (err, response, body) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 404)
+      done()
     })
   })
 })

--- a/test/use-semicolon-delimiter.test.js
+++ b/test/use-semicolon-delimiter.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const Fastify = require('..')
 const sget = require('simple-get').concat
 
@@ -10,22 +9,22 @@ test('use semicolon delimiter default false', t => {
 
   const fastify = Fastify({})
 
-  t.teardown(fastify.close.bind(fastify))
+  t.after(fastify.close.bind(fastify))
 
   fastify.get('/1234;foo=bar', (req, reply) => {
     reply.send(req.query)
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'GET',
       url: 'http://localhost:' + fastify.server.address().port + '/1234;foo=bar'
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.same(JSON.parse(body), {})
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 200)
+      t.assert.deepStrictEqual(JSON.parse(body), {})
     })
   })
 })
@@ -36,22 +35,22 @@ test('use semicolon delimiter set to true', t => {
   const fastify = Fastify({
     useSemicolonDelimiter: true
   })
-  t.teardown(fastify.close.bind(fastify))
+  t.after(fastify.close.bind(fastify))
 
   fastify.get('/1234', (req, reply) => {
     reply.send(req.query)
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'GET',
       url: 'http://localhost:' + fastify.server.address().port + '/1234;foo=bar'
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.same(JSON.parse(body), {
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 200)
+      t.assert.deepStrictEqual(JSON.parse(body), {
         foo: 'bar'
       })
     })
@@ -64,22 +63,22 @@ test('use semicolon delimiter set to false', t => {
   const fastify = Fastify({
     useSemicolonDelimiter: false
   })
-  t.teardown(fastify.close.bind(fastify))
+  t.after(fastify.close.bind(fastify))
 
   fastify.get('/1234;foo=bar', (req, reply) => {
     reply.send(req.query)
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'GET',
       url: 'http://localhost:' + fastify.server.address().port + '/1234;foo=bar'
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.same(JSON.parse(body), {})
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 200)
+      t.assert.deepStrictEqual(JSON.parse(body), {})
     })
   })
 })
@@ -90,21 +89,21 @@ test('use semicolon delimiter set to false return 404', t => {
   const fastify = Fastify({
     useSemicolonDelimiter: false
   })
-  t.teardown(fastify.close.bind(fastify))
+  t.after(fastify.close.bind(fastify))
 
   fastify.get('/1234', (req, reply) => {
     reply.send(req.query)
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'GET',
       url: 'http://localhost:' + fastify.server.address().port + '/1234;foo=bar'
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 404)
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 404)
     })
   })
 })

--- a/test/use-semicolon-delimiter.test.js
+++ b/test/use-semicolon-delimiter.test.js
@@ -7,17 +7,14 @@ const sget = require('simple-get').concat
 test('use semicolon delimiter default false', (t, done) => {
   t.plan(4)
 
-  const fastify = Fastify({})
-
-  t.after(fastify.close())
+  const fastify = Fastify()
 
   fastify.get('/1234;foo=bar', (req, reply) => {
     reply.send(req.query)
   })
 
-  fastify.listen({ port: 0 }, err => {
+  fastify.listen({ port: 0,  }, err => {
     t.assert.ifError(err)
-
     sget({
       method: 'GET',
       url: 'http://localhost:' + fastify.server.address().port + '/1234;foo=bar'
@@ -25,6 +22,7 @@ test('use semicolon delimiter default false', (t, done) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 200)
       t.assert.deepStrictEqual(JSON.parse(body), {})
+      fastify.close()
       done()
     })
   })
@@ -35,7 +33,6 @@ test('use semicolon delimiter set to true', (t, done) => {
   const fastify = Fastify({
     useSemicolonDelimiter: true
   })
-  t.after(fastify.close())
 
   fastify.get('/1234', (req, reply) => {
     reply.send(req.query)
@@ -53,6 +50,7 @@ test('use semicolon delimiter set to true', (t, done) => {
       t.assert.deepStrictEqual(JSON.parse(body), {
         foo: 'bar'
       })
+      fastify.close()
       done()
     })
   })
@@ -64,7 +62,6 @@ test('use semicolon delimiter set to false', (t, done) => {
   const fastify = Fastify({
     useSemicolonDelimiter: false
   })
-  t.after(fastify.close())
 
   fastify.get('/1234;foo=bar', (req, reply) => {
     reply.send(req.query)
@@ -80,6 +77,7 @@ test('use semicolon delimiter set to false', (t, done) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 200)
       t.assert.deepStrictEqual(JSON.parse(body), {})
+      fastify.close()
       done()
     })
   })
@@ -91,7 +89,6 @@ test('use semicolon delimiter set to false return 404', (t, done) => {
   const fastify = Fastify({
     useSemicolonDelimiter: false
   })
-  t.after(fastify.close())
 
   fastify.get('/1234', (req, reply) => {
     reply.send(req.query)
@@ -106,6 +103,7 @@ test('use semicolon delimiter set to false return 404', (t, done) => {
     }, (err, response, body) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 404)
+      fastify.close()
       done()
     })
   })

--- a/test/use-semicolon-delimiter.test.js
+++ b/test/use-semicolon-delimiter.test.js
@@ -4,7 +4,9 @@ const { test } = require('node:test')
 const Fastify = require('..')
 const sget = require('simple-get').concat
 
-test('use semicolon delimiter default false', t => {
+test('use semicolon delimiter default false', (t, done) => {
+  t.plan(4)
+
   const fastify = Fastify({})
 
   t.after(fastify.close())
@@ -23,11 +25,13 @@ test('use semicolon delimiter default false', t => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 200)
       t.assert.deepStrictEqual(JSON.parse(body), {})
+      done()
     })
   })
 })
 
-test('use semicolon delimiter set to true', t => {
+test('use semicolon delimiter set to true', (t, done) => {
+  t.plan(4)
   const fastify = Fastify({
     useSemicolonDelimiter: true
   })
@@ -49,11 +53,12 @@ test('use semicolon delimiter set to true', t => {
       t.assert.deepStrictEqual(JSON.parse(body), {
         foo: 'bar'
       })
+      done()
     })
   })
 })
 
-test('use semicolon delimiter set to false', t => {
+test('use semicolon delimiter set to false', (t, done) => {
   const fastify = Fastify({
     useSemicolonDelimiter: false
   })
@@ -73,11 +78,12 @@ test('use semicolon delimiter set to false', t => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 200)
       t.assert.deepStrictEqual(JSON.parse(body), {})
+      done()
     })
   })
 })
 
-test('use semicolon delimiter set to false return 404', t => {
+test('use semicolon delimiter set to false return 404', (t, done) => {
   const fastify = Fastify({
     useSemicolonDelimiter: false
   })
@@ -96,6 +102,7 @@ test('use semicolon delimiter set to false return 404', t => {
     }, (err, response, body) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 404)
+      done()
     })
   })
 })

--- a/test/use-semicolon-delimiter.test.js
+++ b/test/use-semicolon-delimiter.test.js
@@ -13,7 +13,7 @@ test('use semicolon delimiter default false', (t, done) => {
     reply.send(req.query)
   })
 
-  fastify.listen({ port: 0,  }, err => {
+  fastify.listen({ port: 0, }, err => {
     t.assert.ifError(err)
     sget({
       method: 'GET',

--- a/test/use-semicolon-delimiter.test.js
+++ b/test/use-semicolon-delimiter.test.js
@@ -59,6 +59,8 @@ test('use semicolon delimiter set to true', (t, done) => {
 })
 
 test('use semicolon delimiter set to false', (t, done) => {
+  t.plan(4)
+
   const fastify = Fastify({
     useSemicolonDelimiter: false
   })
@@ -84,6 +86,8 @@ test('use semicolon delimiter set to false', (t, done) => {
 })
 
 test('use semicolon delimiter set to false return 404', (t, done) => {
+  t.plan(3)
+
   const fastify = Fastify({
     useSemicolonDelimiter: false
   })

--- a/test/use-semicolon-delimiter.test.js
+++ b/test/use-semicolon-delimiter.test.js
@@ -4,12 +4,10 @@ const { test } = require('node:test')
 const Fastify = require('..')
 const sget = require('simple-get').concat
 
-test('use semicolon delimiter default false', (t, done) => {
-  t.plan(4)
-
+test('use semicolon delimiter default false', t => {
   const fastify = Fastify({})
 
-  t.after(fastify.close.bind(fastify))
+  t.after(fastify.close())
 
   fastify.get('/1234;foo=bar', (req, reply) => {
     reply.send(req.query)
@@ -25,18 +23,15 @@ test('use semicolon delimiter default false', (t, done) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 200)
       t.assert.deepStrictEqual(JSON.parse(body), {})
-      done()
     })
   })
 })
 
-test('use semicolon delimiter set to true', (t, done) => {
-  t.plan(4)
-
+test('use semicolon delimiter set to true', t => {
   const fastify = Fastify({
     useSemicolonDelimiter: true
   })
-  t.after(fastify.close.bind(fastify))
+  t.after(fastify.close())
 
   fastify.get('/1234', (req, reply) => {
     reply.send(req.query)
@@ -54,18 +49,15 @@ test('use semicolon delimiter set to true', (t, done) => {
       t.assert.deepStrictEqual(JSON.parse(body), {
         foo: 'bar'
       })
-      done()
     })
   })
 })
 
-test('use semicolon delimiter set to false', (t, done) => {
-  t.plan(4)
-
+test('use semicolon delimiter set to false', t => {
   const fastify = Fastify({
     useSemicolonDelimiter: false
   })
-  t.after(fastify.close.bind(fastify))
+  t.after(fastify.close())
 
   fastify.get('/1234;foo=bar', (req, reply) => {
     reply.send(req.query)
@@ -81,18 +73,15 @@ test('use semicolon delimiter set to false', (t, done) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 200)
       t.assert.deepStrictEqual(JSON.parse(body), {})
-      done()
     })
   })
 })
 
-test('use semicolon delimiter set to false return 404', (t, done) => {
-  t.plan(3)
-
+test('use semicolon delimiter set to false return 404', t => {
   const fastify = Fastify({
     useSemicolonDelimiter: false
   })
-  t.after(fastify.close.bind(fastify))
+  t.after(fastify.close())
 
   fastify.get('/1234', (req, reply) => {
     reply.send(req.query)
@@ -107,7 +96,6 @@ test('use semicolon delimiter set to false return 404', (t, done) => {
     }, (err, response, body) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 404)
-      done()
     })
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


Proposal:

  - rename file in `kebab-case`
  - migrated `use-semicolon-delimiter.js` file from `tap` to `node:test` 🔥
