### PR TITLE
test: migrated post-empty-body.test.js from tap to node:test

### DIFF
--- a/test/post-empty-body.test.js
+++ b/test/post-empty-body.test.js
@@ -11,7 +11,7 @@ setGlobalDispatcher(new Agent({
 
 test('post empty body', async t => {
   const fastify = Fastify()
-  t.after(fastify.close(fastify))
+  t.after(fastify.close.bind(fastify))
 
   fastify.post('/bug', async (request, reply) => {})
 

--- a/test/post-empty-body.test.js
+++ b/test/post-empty-body.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const { test } = require('tap')
-const fastify = require('../')
+const { test } = require('node:test')
+const Fastify = require('..')
 const { request, setGlobalDispatcher, Agent } = require('undici')
 
 setGlobalDispatcher(new Agent({
@@ -10,15 +10,14 @@ setGlobalDispatcher(new Agent({
 }))
 
 test('post empty body', async t => {
-  const app = fastify()
-  t.teardown(app.close.bind(app))
+  const fastify = Fastify()
+  t.after(fastify.close(fastify))
 
-  app.post('/bug', async (request, reply) => {
-  })
+  fastify.post('/bug', async (request, reply) => {})
 
-  await app.listen({ port: 0 })
+  await fastify.listen({ port: 0 })
 
-  const res = await request(`http://127.0.0.1:${app.server.address().port}/bug`, {
+  const res = await request(`http://127.0.0.1:${fastify.server.address().port}/bug`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
@@ -26,6 +25,6 @@ test('post empty body', async t => {
     body: JSON.stringify({ foo: 'bar' })
   })
 
-  t.equal(res.statusCode, 200)
-  t.equal(await res.body.text(), '')
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(await res.body.text(), '')
 })

--- a/test/post-empty-body.test.js
+++ b/test/post-empty-body.test.js
@@ -11,7 +11,12 @@ setGlobalDispatcher(new Agent({
 
 test('post empty body', async t => {
   const fastify = Fastify()
-  t.after(fastify.close.bind(fastify))
+  const abortController = new AbortController()
+  const { signal } = abortController
+  t.after(() => {
+    fastify.close()
+    abortController.abort()
+  })
 
   fastify.post('/bug', async (request, reply) => {})
 
@@ -22,7 +27,8 @@ test('post empty body', async t => {
     headers: {
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({ foo: 'bar' })
+    body: JSON.stringify({ foo: 'bar' }),
+    signal
   })
 
   t.assert.strictEqual(res.statusCode, 200)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


Proposal:

 - migrated `post-empty-body.js` file from `tap` to `node:test` 🔥