### PR TITLE
fix: test asserts to strict asserts

### DIFF
--- a/test/allow-unsafe-regex.test.js
+++ b/test/allow-unsafe-regex.test.js
@@ -112,7 +112,7 @@ test('allow unsafe regex allow unsafe', (t, done) => {
     }, (err, response, body) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 200)
-      t.assert.deepEqual(JSON.parse(body), {
+      t.assert.deepStrictEqual(JSON.parse(body), {
         foo: '1234'
       })
       done()

--- a/test/buffer.test.js
+++ b/test/buffer.test.js
@@ -25,7 +25,7 @@ test('Buffer test', async t => {
 
     t.assert.ifError(response.error)
     t.assert.strictEqual(response.statusCode, 200)
-    t.assert.deepEqual(response.payload.toString(), '{"hello":"world"}')
+    t.assert.deepStrictEqual(response.payload.toString(), '{"hello":"world"}')
   })
 
   await test('should return 400 if the body is empty', async t => {
@@ -42,7 +42,7 @@ test('Buffer test', async t => {
 
     t.assert.ifError(response.error)
     t.assert.strictEqual(response.statusCode, 400)
-    t.assert.deepEqual(JSON.parse(response.payload.toString()), {
+    t.assert.deepStrictEqual(JSON.parse(response.payload.toString()), {
       error: 'Bad Request',
       code: 'FST_ERR_CTP_EMPTY_JSON_BODY',
       message: 'Body cannot be empty when content-type is set to \'application/json\'',

--- a/test/case-insensitive.test.js
+++ b/test/case-insensitive.test.js
@@ -25,7 +25,7 @@ test('case insensitive', (t, done) => {
     }, (err, response, body) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 200)
-      t.assert.deepEqual(JSON.parse(body), {
+      t.assert.deepStrictEqual(JSON.parse(body), {
         hello: 'world'
       })
       done()
@@ -54,7 +54,7 @@ test('case insensitive inject', (t, done) => {
     }, (err, response) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 200)
-      t.assert.deepEqual(JSON.parse(response.payload), {
+      t.assert.deepStrictEqual(JSON.parse(response.payload), {
         hello: 'world'
       })
       done()
@@ -84,7 +84,7 @@ test('case insensitive (parametric)', (t, done) => {
     }, (err, response, body) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 200)
-      t.assert.deepEqual(JSON.parse(body), {
+      t.assert.deepStrictEqual(JSON.parse(body), {
         hello: 'world'
       })
       done()
@@ -114,7 +114,7 @@ test('case insensitive (wildcard)', (t, done) => {
     }, (err, response, body) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 200)
-      t.assert.deepEqual(JSON.parse(body), {
+      t.assert.deepStrictEqual(JSON.parse(body), {
         hello: 'world'
       })
       done()

--- a/test/check.test.js
+++ b/test/check.test.js
@@ -72,7 +72,6 @@ const options = {
 }
 
 const handler = (request, reply) => {
-  console.log('in handler')
   if (request.body.id === '400') {
     return reply.status(400).send({
       statusCode: 400,
@@ -125,7 +124,7 @@ test('serialize the response for a Bad Request error, as defined on the schema',
     }, (err, response, body) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 400)
-      t.assert.deepEqual(body, {
+      t.assert.deepStrictEqual(body, {
         statusCode: 400,
         error: 'Bad Request',
         message: 'body must be object'

--- a/test/conditional-pino.test.js
+++ b/test/conditional-pino.test.js
@@ -21,7 +21,7 @@ test("pino is require'd if logger is passed", t => {
     logger: true
   })
 
-  t.assert.notEqual(require.cache[require.resolve('pino')], undefined)
+  t.assert.notStrictEqual(require.cache[require.resolve('pino')], undefined)
 })
 
 test("pino is require'd if loggerInstance is passed", t => {
@@ -43,5 +43,5 @@ test("pino is require'd if loggerInstance is passed", t => {
     loggerInstance
   })
 
-  t.assert.notEqual(require.cache[require.resolve('pino')], undefined)
+  t.assert.notStrictEqual(require.cache[require.resolve('pino')], undefined)
 })

--- a/test/http-methods/head.test.js
+++ b/test/http-methods/head.test.js
@@ -122,7 +122,6 @@ test('shorthand - should set get and head route in the same api call', t => {
 
     t.assert.ok(true)
   } catch (e) {
-    console.log(e)
     t.assert.fail()
   }
 })
@@ -147,7 +146,6 @@ test('shorthand - head, querystring schema', t => {
     })
     t.assert.ok(true)
   } catch (e) {
-    console.log(e)
     t.assert.fail()
   }
 })
@@ -160,7 +158,6 @@ test('missing schema - head', t => {
     })
     t.assert.ok(true)
   } catch (e) {
-    console.log(e)
     t.assert.fail()
   }
 })

--- a/test/request-timeout.test.js
+++ b/test/request-timeout.test.js
@@ -42,12 +42,12 @@ test('requestTimeout should be set', async (t) => {
   t.plan(1)
 
   const initialConfig = Fastify({ requestTimeout: 5000 }).initialConfig
-  t.assert.deepEqual(initialConfig.requestTimeout, 5000)
+  t.assert.strictEqual(initialConfig.requestTimeout, 5000)
 })
 
 test('requestTimeout should 0', async (t) => {
   t.plan(1)
 
   const initialConfig = Fastify().initialConfig
-  t.assert.deepEqual(initialConfig.requestTimeout, 0)
+  t.assert.strictEqual(initialConfig.requestTimeout, 0)
 })

--- a/test/route.3.test.js
+++ b/test/route.3.test.js
@@ -5,7 +5,7 @@ const joi = require('joi')
 const Fastify = require('..')
 
 test('does not mutate joi schemas', (t, done) => {
-  t.plan(4)
+  t.plan(5)
 
   const fastify = Fastify()
   function validatorCompiler ({ schema, method, url, httpPart }) {
@@ -31,7 +31,8 @@ test('does not mutate joi schemas', (t, done) => {
       params: { an_id: joi.number() }
     },
     handler (req, res) {
-      t.assert.deepEqual(req.params, { an_id: 42 })
+      t.assert.strictEqual(Object.keys(req.params).length, 1)
+      t.assert.strictEqual(req.params.an_id, '42')
       res.send({ hello: 'world' })
     }
   })


### PR DESCRIPTION
#### Checklist

Convert asserts to strict asserts and remove console.log in tests

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
