### PR TITLE
perf(lib/request): use `array.at(-1)` over `array[array.length -1]`

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -104,7 +104,7 @@ function buildRequestWithTrustProxy (R, trustProxy) {
     ip: {
       get () {
         const addrs = proxyAddr.all(this.raw, proxyFn)
-        return addrs[addrs.length - 1]
+        return addrs.at(-1)
       }
     },
     ips: {


### PR DESCRIPTION
Now that we no longer support Node < 20, we can swap this out.

With [Node 20, `array.at(-1)` is faster than `array[array.length -1]`](https://github.com/RafaelGSS/nodejs-bench-operations/blob/main/RESULTS-v20.md#get-the-last-item-of-an-array), where [in previous versions it was slower](https://github.com/RafaelGSS/nodejs-bench-operations/blob/main/RESULTS-v18.md#get-the-last-item-of-an-array).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
