### PR TITLE
test: migrated max-requests-per-socket.test.js from tap to node:test

### DIFF
--- a/test/max-requests-per-socket.test.js
+++ b/test/max-requests-per-socket.test.js
@@ -1,10 +1,10 @@
 'use strict'
 
 const net = require('node:net')
-const { test } = require('tap')
-const Fastify = require('../fastify')
+const { test } = require('node:test')
+const Fastify = require('..')
 
-test('maxRequestsPerSocket', t => {
+test('maxRequestsPerSocket', (t, done) => {
   t.plan(8)
 
   const fastify = Fastify({ maxRequestsPerSocket: 2 })
@@ -12,32 +12,32 @@ test('maxRequestsPerSocket', t => {
     reply.send({ hello: 'world' })
   })
 
-  t.teardown(fastify.close.bind(fastify))
-
   fastify.listen({ port: 0 }, function (err) {
-    t.error(err)
+    t.assert.ifError(err)
 
     const port = fastify.server.address().port
     const client = net.createConnection({ port }, () => {
       client.write('GET / HTTP/1.1\r\nHost: example.com\r\n\r\n')
 
       client.once('data', data => {
-        t.match(data.toString(), /Connection:\s*keep-alive/i)
-        t.match(data.toString(), /Keep-Alive:\s*timeout=\d+/i)
-        t.match(data.toString(), /200 OK/i)
+        t.assert.match(data.toString(), /Connection:\s*keep-alive/i)
+        t.assert.match(data.toString(), /Keep-Alive:\s*timeout=\d+/i)
+        t.assert.match(data.toString(), /200 OK/i)
 
         client.write('GET / HTTP/1.1\r\nHost: example.com\r\n\r\n')
 
         client.once('data', data => {
-          t.match(data.toString(), /Connection:\s*close/i)
-          t.match(data.toString(), /200 OK/i)
+          t.assert.match(data.toString(), /Connection:\s*close/i)
+          t.assert.match(data.toString(), /200 OK/i)
 
           client.write('GET / HTTP/1.1\r\nHost: example.com\r\n\r\n')
 
           client.once('data', data => {
-            t.match(data.toString(), /Connection:\s*close/i)
-            t.match(data.toString(), /503 Service Unavailable/i)
+            t.assert.match(data.toString(), /Connection:\s*close/i)
+            t.assert.match(data.toString(), /503 Service Unavailable/i)
             client.end()
+            fastify.close()
+            done()
           })
         })
       })
@@ -45,7 +45,7 @@ test('maxRequestsPerSocket', t => {
   })
 })
 
-test('maxRequestsPerSocket zero should behave same as null', t => {
+test('maxRequestsPerSocket zero should behave same as null', (t, done) => {
   t.plan(10)
 
   const fastify = Fastify({ maxRequestsPerSocket: 0 })
@@ -53,34 +53,34 @@ test('maxRequestsPerSocket zero should behave same as null', t => {
     reply.send({ hello: 'world' })
   })
 
-  t.teardown(fastify.close.bind(fastify))
-
   fastify.listen({ port: 0 }, function (err) {
-    t.error(err)
+    t.assert.ifError(err)
 
     const port = fastify.server.address().port
     const client = net.createConnection({ port }, () => {
       client.write('GET / HTTP/1.1\r\nHost: example.com\r\n\r\n')
 
       client.once('data', data => {
-        t.match(data.toString(), /Connection:\s*keep-alive/i)
-        t.match(data.toString(), /Keep-Alive:\s*timeout=\d+/i)
-        t.match(data.toString(), /200 OK/i)
+        t.assert.match(data.toString(), /Connection:\s*keep-alive/i)
+        t.assert.match(data.toString(), /Keep-Alive:\s*timeout=\d+/i)
+        t.assert.match(data.toString(), /200 OK/i)
 
         client.write('GET / HTTP/1.1\r\nHost: example.com\r\n\r\n')
 
         client.once('data', data => {
-          t.match(data.toString(), /Connection:\s*keep-alive/i)
-          t.match(data.toString(), /Keep-Alive:\s*timeout=\d+/i)
-          t.match(data.toString(), /200 OK/i)
+          t.assert.match(data.toString(), /Connection:\s*keep-alive/i)
+          t.assert.match(data.toString(), /Keep-Alive:\s*timeout=\d+/i)
+          t.assert.match(data.toString(), /200 OK/i)
 
           client.write('GET / HTTP/1.1\r\nHost: example.com\r\n\r\n')
 
           client.once('data', data => {
-            t.match(data.toString(), /Connection:\s*keep-alive/i)
-            t.match(data.toString(), /Keep-Alive:\s*timeout=\d+/i)
-            t.match(data.toString(), /200 OK/i)
+            t.assert.match(data.toString(), /Connection:\s*keep-alive/i)
+            t.assert.match(data.toString(), /Keep-Alive:\s*timeout=\d+/i)
+            t.assert.match(data.toString(), /200 OK/i)
             client.end()
+            fastify.close()
+            done()
           })
         })
       })
@@ -92,22 +92,22 @@ test('maxRequestsPerSocket should be set', async (t) => {
   t.plan(1)
 
   const initialConfig = Fastify({ maxRequestsPerSocket: 5 }).initialConfig
-  t.same(initialConfig.maxRequestsPerSocket, 5)
+  t.assert.deepStrictEqual(initialConfig.maxRequestsPerSocket, 5)
 })
 
 test('maxRequestsPerSocket should 0', async (t) => {
   t.plan(1)
 
   const initialConfig = Fastify().initialConfig
-  t.same(initialConfig.maxRequestsPerSocket, 0)
+  t.assert.deepStrictEqual(initialConfig.maxRequestsPerSocket, 0)
 })
 
 test('requestTimeout passed to server', t => {
   t.plan(2)
 
   const httpServer = Fastify({ maxRequestsPerSocket: 5 }).server
-  t.equal(httpServer.maxRequestsPerSocket, 5)
+  t.assert.strictEqual(httpServer.maxRequestsPerSocket, 5)
 
   const httpsServer = Fastify({ maxRequestsPerSocket: 5, https: true }).server
-  t.equal(httpsServer.maxRequestsPerSocket, 5)
+  t.assert.strictEqual(httpsServer.maxRequestsPerSocket, 5)
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Proposal:

- rename file in `kebab-case`
- migrated `max-requests-per-socker.test.js` file from tap to node:test 🔥

