### PR TITLE
test: migrate trust-proxy, type-provider, url-rewriting to node:test

### DIFF
--- a/test/trust-proxy.test.js
+++ b/test/trust-proxy.test.js
@@ -1,12 +1,11 @@
 'use strict'
 
-const t = require('tap')
-const { test, before } = t
+const { test, before } = require('node:test')
 const sget = require('simple-get').concat
 const fastify = require('..')
 const helper = require('./helper')
 
-const sgetForwardedRequest = (app, forHeader, path, protoHeader) => {
+const sgetForwardedRequest = (app, forHeader, path, protoHeader, done) => {
   const headers = {
     'X-Forwarded-For': forHeader,
     'X-Forwarded-Host': 'example.com'
@@ -18,30 +17,35 @@ const sgetForwardedRequest = (app, forHeader, path, protoHeader) => {
     method: 'GET',
     headers,
     url: 'http://localhost:' + app.server.address().port + path
-  }, () => {})
+  }, () => {
+    if (done) {
+      app.close()
+      done()
+    }
+  })
 }
 
 const testRequestValues = (t, req, options) => {
   if (options.ip) {
-    t.ok(req.ip, 'ip is defined')
-    t.equal(req.ip, options.ip, 'gets ip from x-forwarded-for')
+    t.assert.ok(req.ip, 'ip is defined')
+    t.assert.strictEqual(req.ip, options.ip, 'gets ip from x-forwarded-for')
   }
   if (options.host) {
-    t.ok(req.host, 'host is defined')
-    t.equal(req.host, options.host, 'gets host from x-forwarded-host')
-    t.ok(req.hostname)
-    t.equal(req.hostname, options.host, 'gets hostname from x-forwarded-host')
+    t.assert.ok(req.host, 'host is defined')
+    t.assert.strictEqual(req.host, options.host, 'gets host from x-forwarded-host')
+    t.assert.ok(req.hostname)
+    t.assert.strictEqual(req.hostname, options.host, 'gets hostname from x-forwarded-host')
   }
   if (options.ips) {
-    t.same(req.ips, options.ips, 'gets ips from x-forwarded-for')
+    t.assert.deepStrictEqual(req.ips, options.ips, 'gets ips from x-forwarded-for')
   }
   if (options.protocol) {
-    t.ok(req.protocol, 'protocol is defined')
-    t.equal(req.protocol, options.protocol, 'gets protocol from x-forwarded-proto')
+    t.assert.ok(req.protocol, 'protocol is defined')
+    t.assert.strictEqual(req.protocol, options.protocol, 'gets protocol from x-forwarded-proto')
   }
   if (options.port) {
-    t.ok(req.port, 'port is defined')
-    t.equal(req.port, options.port, 'port is taken from x-forwarded-for or host')
+    t.assert.ok(req.port, 'port is defined')
+    t.assert.strictEqual(req.port, options.port, 'port is taken from x-forwarded-for or host')
   }
 }
 
@@ -50,7 +54,7 @@ before(async function () {
   [localhost] = await helper.getLoopbackHost()
 })
 
-test('trust proxy, not add properties to node req', (t) => {
+test('trust proxy, not add properties to node req', (t, done) => {
   t.plan(14)
   const app = fastify({
     trustProxy: true
@@ -65,17 +69,15 @@ test('trust proxy, not add properties to node req', (t) => {
     reply.code(200).send({ ip: req.ip, host: req.host })
   })
 
-  t.teardown(app.close.bind(app))
-
   app.listen({ port: 0 }, (err) => {
     app.server.unref()
-    t.error(err)
+    t.assert.ifError(err)
     sgetForwardedRequest(app, '1.1.1.1', '/trustproxy')
-    sgetForwardedRequest(app, '2.2.2.2, 1.1.1.1', '/trustproxychain')
+    sgetForwardedRequest(app, '2.2.2.2, 1.1.1.1', '/trustproxychain', undefined, done)
   })
 })
 
-test('trust proxy chain', (t) => {
+test('trust proxy chain', (t, done) => {
   t.plan(9)
   const app = fastify({
     trustProxy: [localhost, '192.168.1.1']
@@ -86,16 +88,14 @@ test('trust proxy chain', (t) => {
     reply.code(200).send({ ip: req.ip, host: req.host })
   })
 
-  t.teardown(app.close.bind(app))
-
   app.listen({ port: 0 }, (err) => {
     app.server.unref()
-    t.error(err)
-    sgetForwardedRequest(app, '192.168.1.1, 1.1.1.1', '/trustproxychain')
+    t.assert.ifError(err)
+    sgetForwardedRequest(app, '192.168.1.1, 1.1.1.1', '/trustproxychain', undefined, done)
   })
 })
 
-test('trust proxy function', (t) => {
+test('trust proxy function', (t, done) => {
   t.plan(9)
   const app = fastify({
     trustProxy: (address) => address === localhost
@@ -105,16 +105,14 @@ test('trust proxy function', (t) => {
     reply.code(200).send({ ip: req.ip, host: req.host })
   })
 
-  t.teardown(app.close.bind(app))
-
   app.listen({ port: 0 }, (err) => {
     app.server.unref()
-    t.error(err)
-    sgetForwardedRequest(app, '1.1.1.1', '/trustproxyfunc')
+    t.assert.ifError(err)
+    sgetForwardedRequest(app, '1.1.1.1', '/trustproxyfunc', undefined, done)
   })
 })
 
-test('trust proxy number', (t) => {
+test('trust proxy number', (t, done) => {
   t.plan(10)
   const app = fastify({
     trustProxy: 1
@@ -124,16 +122,14 @@ test('trust proxy number', (t) => {
     reply.code(200).send({ ip: req.ip, host: req.host })
   })
 
-  t.teardown(app.close.bind(app))
-
   app.listen({ port: 0 }, (err) => {
     app.server.unref()
-    t.error(err)
-    sgetForwardedRequest(app, '2.2.2.2, 1.1.1.1', '/trustproxynumber')
+    t.assert.ifError(err)
+    sgetForwardedRequest(app, '2.2.2.2, 1.1.1.1', '/trustproxynumber', undefined, done)
   })
 })
 
-test('trust proxy IP addresses', (t) => {
+test('trust proxy IP addresses', (t, done) => {
   t.plan(10)
   const app = fastify({
     trustProxy: `${localhost}, 2.2.2.2`
@@ -143,16 +139,14 @@ test('trust proxy IP addresses', (t) => {
     reply.code(200).send({ ip: req.ip, host: req.host })
   })
 
-  t.teardown(app.close.bind(app))
-
   app.listen({ port: 0 }, (err) => {
     app.server.unref()
-    t.error(err)
-    sgetForwardedRequest(app, '3.3.3.3, 2.2.2.2, 1.1.1.1', '/trustproxyipaddrs')
+    t.assert.ifError(err)
+    sgetForwardedRequest(app, '3.3.3.3, 2.2.2.2, 1.1.1.1', '/trustproxyipaddrs', undefined, done)
   })
 })
 
-test('trust proxy protocol', (t) => {
+test('trust proxy protocol', (t, done) => {
   t.plan(31)
   const app = fastify({
     trustProxy: true
@@ -170,13 +164,12 @@ test('trust proxy protocol', (t) => {
     reply.code(200).send({ ip: req.ip, host: req.host })
   })
 
-  t.teardown(app.close.bind(app))
-
   app.listen({ port: 0 }, (err) => {
     app.server.unref()
-    t.error(err)
+    t.assert.ifError(err)
     sgetForwardedRequest(app, '1.1.1.1', '/trustproxyprotocol', 'lorem')
     sgetForwardedRequest(app, '1.1.1.1', '/trustproxynoprotocol')
-    sgetForwardedRequest(app, '1.1.1.1', '/trustproxyprotocols', 'ipsum, dolor')
+    // Allow for sgetForwardedRequest requests above to finish
+    setTimeout(() => sgetForwardedRequest(app, '1.1.1.1', '/trustproxyprotocols', 'ipsum, dolor', done))
   })
 })

--- a/test/type-provider.test.js
+++ b/test/type-provider.test.js
@@ -1,20 +1,22 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const Fastify = require('..')
 
-test('Should export withTypeProvider function', t => {
+test('Should export withTypeProvider function', (t, done) => {
   t.plan(1)
   try {
     Fastify().withTypeProvider()
-    t.pass()
+    t.assert.ok('pass')
+    done()
   } catch (e) {
-    t.fail()
+    t.assert.fail(e)
   }
 })
 
-test('Should return same instance', t => {
+test('Should return same instance', (t, done) => {
   t.plan(1)
   const fastify = Fastify()
-  t.equal(fastify, fastify.withTypeProvider())
+  t.assert.strictEqual(fastify, fastify.withTypeProvider())
+  done()
 })

--- a/test/url-rewriting.test.js
+++ b/test/url-rewriting.test.js
@@ -25,6 +25,7 @@ test('Should rewrite url', (t, done) => {
   fastify.listen({ port: 0 }, function (err) {
     t.assert.ifError(err)
 
+    t.after(() => fastify.close())
     sget({
       method: 'GET',
       url: 'http://localhost:' + fastify.server.address().port + '/this-would-404-without-url-rewrite'
@@ -32,7 +33,6 @@ test('Should rewrite url', (t, done) => {
       t.assert.ifError(err)
       t.assert.deepStrictEqual(JSON.parse(body), { hello: 'world' })
       t.assert.strictEqual(response.statusCode, 200)
-      fastify.close()
       done()
     })
   })
@@ -58,14 +58,13 @@ test('Should not rewrite if the url is the same', (t, done) => {
 
   fastify.listen({ port: 0 }, function (err) {
     t.assert.ifError(err)
-
+    t.after(() => fastify.close())
     sget({
       method: 'GET',
       url: 'http://localhost:' + fastify.server.address().port + '/this-would-404-without-url-rewrite'
     }, (err, response, body) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 404)
-      fastify.close()
       done()
     })
   })
@@ -91,7 +90,7 @@ test('Should throw an error', (t, done) => {
 
   fastify.listen({ port: 0 }, function (err) {
     t.assert.ifError(err)
-
+    t.after(() => fastify.close())
     sget({
       method: 'GET',
       url: 'http://localhost:' + fastify.server.address().port + '/this-would-404-without-url-rewrite'
@@ -99,7 +98,6 @@ test('Should throw an error', (t, done) => {
       t.assert.strictEqual(err.code, 'ECONNRESET')
       t.assert.strictEqual(response, undefined)
       t.assert.strictEqual(body, undefined)
-      fastify.close()
       done()
     })
   })
@@ -126,7 +124,7 @@ test('Should rewrite url but keep originalUrl unchanged', (t, done) => {
 
   fastify.listen({ port: 0 }, function (err) {
     t.assert.ifError(err)
-
+    t.after(() => fastify.close())
     sget({
       method: 'GET',
       url: 'http://localhost:' + fastify.server.address().port + '/this-would-404-without-url-rewrite'
@@ -135,7 +133,6 @@ test('Should rewrite url but keep originalUrl unchanged', (t, done) => {
       const parsedBody = JSON.parse(body)
       t.assert.deepStrictEqual(parsedBody, { hello: 'world', hostname: 'localhost', port: fastify.server.address().port })
       t.assert.strictEqual(response.statusCode, 200)
-      fastify.close()
       done()
     })
   })

--- a/test/url-rewriting.test.js
+++ b/test/url-rewriting.test.js
@@ -1,15 +1,14 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const Fastify = require('..')
 const sget = require('simple-get').concat
 
-test('Should rewrite url', t => {
+test('Should rewrite url', (t, done) => {
   t.plan(5)
   const fastify = Fastify({
     rewriteUrl (req) {
-      t.equal(req.url, '/this-would-404-without-url-rewrite')
+      t.assert.strictEqual(req.url, '/this-would-404-without-url-rewrite')
       this.log.info('rewriting url')
       return '/'
     }
@@ -24,26 +23,26 @@ test('Should rewrite url', t => {
   })
 
   fastify.listen({ port: 0 }, function (err) {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'GET',
       url: 'http://localhost:' + fastify.server.address().port + '/this-would-404-without-url-rewrite'
     }, (err, response, body) => {
-      t.error(err)
-      t.same(JSON.parse(body), { hello: 'world' })
-      t.equal(response.statusCode, 200)
+      t.assert.ifError(err)
+      t.assert.deepStrictEqual(JSON.parse(body), { hello: 'world' })
+      t.assert.strictEqual(response.statusCode, 200)
+      fastify.close()
+      done()
     })
   })
-
-  t.teardown(() => fastify.close())
 })
 
-test('Should not rewrite if the url is the same', t => {
+test('Should not rewrite if the url is the same', (t, done) => {
   t.plan(4)
   const fastify = Fastify({
     rewriteUrl (req) {
-      t.equal(req.url, '/this-would-404-without-url-rewrite')
+      t.assert.strictEqual(req.url, '/this-would-404-without-url-rewrite')
       this.log.info('rewriting url')
       return req.url
     }
@@ -58,24 +57,25 @@ test('Should not rewrite if the url is the same', t => {
   })
 
   fastify.listen({ port: 0 }, function (err) {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'GET',
       url: 'http://localhost:' + fastify.server.address().port + '/this-would-404-without-url-rewrite'
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 404)
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 404)
+      fastify.close()
+      done()
     })
   })
-
-  t.teardown(() => fastify.close())
 })
-test('Should throw an error', t => {
+
+test('Should throw an error', (t, done) => {
   t.plan(5)
   const fastify = Fastify({
     rewriteUrl (req) {
-      t.equal(req.url, '/this-would-404-without-url-rewrite')
+      t.assert.strictEqual(req.url, '/this-would-404-without-url-rewrite')
       this.log.info('rewriting url')
       return undefined
     }
@@ -90,27 +90,27 @@ test('Should throw an error', t => {
   })
 
   fastify.listen({ port: 0 }, function (err) {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'GET',
       url: 'http://localhost:' + fastify.server.address().port + '/this-would-404-without-url-rewrite'
     }, (err, response, body) => {
-      t.equal(err.code, 'ECONNRESET')
-      t.equal(response, undefined)
-      t.equal(body, undefined)
+      t.assert.strictEqual(err.code, 'ECONNRESET')
+      t.assert.strictEqual(response, undefined)
+      t.assert.strictEqual(body, undefined)
+      fastify.close()
+      done()
     })
   })
-
-  t.teardown(() => fastify.close())
 })
 
-test('Should rewrite url but keep originalUrl unchanged', t => {
+test('Should rewrite url but keep originalUrl unchanged', (t, done) => {
   t.plan(7)
   const fastify = Fastify({
     rewriteUrl (req) {
-      t.equal(req.url, '/this-would-404-without-url-rewrite')
-      t.equal(req.originalUrl, '/this-would-404-without-url-rewrite')
+      t.assert.strictEqual(req.url, '/this-would-404-without-url-rewrite')
+      t.assert.strictEqual(req.originalUrl, '/this-would-404-without-url-rewrite')
       return '/'
     }
   })
@@ -120,23 +120,23 @@ test('Should rewrite url but keep originalUrl unchanged', t => {
     url: '/',
     handler: (req, reply) => {
       reply.send({ hello: 'world', hostname: req.hostname, port: req.port })
-      t.equal(req.originalUrl, '/this-would-404-without-url-rewrite')
+      t.assert.strictEqual(req.originalUrl, '/this-would-404-without-url-rewrite')
     }
   })
 
   fastify.listen({ port: 0 }, function (err) {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'GET',
       url: 'http://localhost:' + fastify.server.address().port + '/this-would-404-without-url-rewrite'
     }, (err, response, body) => {
-      t.error(err)
+      t.assert.ifError(err)
       const parsedBody = JSON.parse(body)
-      t.same(parsedBody, { hello: 'world', hostname: 'localhost', port: fastify.server.address().port })
-      t.equal(response.statusCode, 200)
+      t.assert.deepStrictEqual(parsedBody, { hello: 'world', hostname: 'localhost', port: fastify.server.address().port })
+      t.assert.strictEqual(response.statusCode, 200)
+      fastify.close()
+      done()
     })
   })
-
-  t.teardown(() => fastify.close())
 })


### PR DESCRIPTION
#### Checklist

Mirgate tests from tap to node:test
- trust-proxy.test.js
- type-provider.test.js
- url-rewriting.test.js

<hr>

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
