### PR TITLE
test: migrated fluent-schema.test.js from tap to node:test

### DIFF
--- a/test/fluent-schema.test.js
+++ b/test/fluent-schema.test.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const Fastify = require('..')
 const S = require('fluent-json-schema')
 
-test('use fluent-json-schema object', t => {
+test('use fluent-json-schema object', (t, done) => {
   t.plan(15)
   const fastify = Fastify()
 
@@ -32,9 +31,9 @@ test('use fluent-json-schema object', t => {
     query: { surname: 'bar' },
     payload: { name: 'foo' }
   }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 400)
-    t.same(res.json(), { statusCode: 400, code: 'FST_ERR_VALIDATION', error: 'Bad Request', message: 'params/id must be >= 42' })
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 400)
+    t.assert.deepStrictEqual(res.json(), { statusCode: 400, code: 'FST_ERR_VALIDATION', error: 'Bad Request', message: 'params/id must be >= 42' })
   })
 
   // check header
@@ -45,9 +44,9 @@ test('use fluent-json-schema object', t => {
     query: { surname: 'bar' },
     payload: { name: 'foo' }
   }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 400)
-    t.same(res.json(), { statusCode: 400, code: 'FST_ERR_VALIDATION', error: 'Bad Request', message: 'headers/x-custom must match format "email"' })
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 400)
+    t.assert.deepStrictEqual(res.json(), { statusCode: 400, code: 'FST_ERR_VALIDATION', error: 'Bad Request', message: 'headers/x-custom must match format "email"' })
   })
 
   // check query
@@ -58,9 +57,9 @@ test('use fluent-json-schema object', t => {
     query: { },
     payload: { name: 'foo' }
   }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 400)
-    t.same(res.json(), { statusCode: 400, code: 'FST_ERR_VALIDATION', error: 'Bad Request', message: 'querystring must have required property \'surname\'' })
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 400)
+    t.assert.deepStrictEqual(res.json(), { statusCode: 400, code: 'FST_ERR_VALIDATION', error: 'Bad Request', message: 'querystring must have required property \'surname\'' })
   })
 
   // check body
@@ -71,9 +70,9 @@ test('use fluent-json-schema object', t => {
     query: { surname: 'bar' },
     payload: { name: [1, 2, 3] }
   }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 400)
-    t.same(res.json(), { statusCode: 400, code: 'FST_ERR_VALIDATION', error: 'Bad Request', message: 'body/name must be string' })
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 400)
+    t.assert.deepStrictEqual(res.json(), { statusCode: 400, code: 'FST_ERR_VALIDATION', error: 'Bad Request', message: 'body/name must be string' })
   })
 
   // check response
@@ -84,13 +83,14 @@ test('use fluent-json-schema object', t => {
     query: { surname: 'bar' },
     payload: { name: 'foo' }
   }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(res.json(), { name: 'a', surname: 'b' })
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.json(), { name: 'a', surname: 'b' })
+    done()
   })
 })
 
-test('use complex fluent-json-schema object', t => {
+test('use complex fluent-json-schema object', (t, done) => {
   t.plan(1)
   const fastify = Fastify()
 
@@ -113,10 +113,13 @@ test('use complex fluent-json-schema object', t => {
     .prop('office', S.ref('https://fastify/demo#/definitions/addressSchema')).required()
 
   fastify.post('/the/url', { schema: { body: bodyJsonSchema } }, () => { })
-  fastify.ready(err => t.error(err))
+  fastify.ready(err => {
+    t.assert.ifError(err)
+    done()
+  })
 })
 
-test('use fluent schema and plain JSON schema', t => {
+test('use fluent schema and plain JSON schema', (t, done) => {
   t.plan(1)
 
   const fastify = Fastify()
@@ -154,10 +157,13 @@ test('use fluent schema and plain JSON schema', t => {
     .prop('office', S.ref('https://fastify/demo#/definitions/addressSchema')).required()
 
   fastify.post('/the/url', { schema: { body: bodyJsonSchema } }, () => { })
-  fastify.ready(err => t.error(err))
+  fastify.ready(err => {
+    t.assert.ifError(err)
+    done()
+  })
 })
 
-test('Should call valueOf internally', t => {
+test('Should call valueOf internally', (t, done) => {
   t.plan(1)
 
   const fastify = new Fastify()
@@ -208,5 +214,8 @@ test('Should call valueOf internally', t => {
     }
   })
 
-  fastify.ready(t.error)
+  fastify.ready(err => {
+    t.assert.ifError(err)
+    done()
+  })
 })

--- a/test/fluent-schema.test.js
+++ b/test/fluent-schema.test.js
@@ -4,8 +4,8 @@ const { test } = require('node:test')
 const Fastify = require('..')
 const S = require('fluent-json-schema')
 
-test('use fluent-json-schema object', (t, done) => {
-  t.plan(15)
+test('use fluent-json-schema object', async (t) => {
+  t.plan(10)
   const fastify = Fastify()
 
   fastify.post('/:id', {
@@ -23,71 +23,59 @@ test('use fluent-json-schema object', (t, done) => {
     }
   })
 
-  // check params
-  fastify.inject({
+  const res1 = await fastify.inject({
     method: 'POST',
     url: '/1',
     headers: { 'x-custom': 'me@me.me' },
     query: { surname: 'bar' },
     payload: { name: 'foo' }
-  }, (err, res) => {
-    t.assert.ifError(err)
-    t.assert.strictEqual(res.statusCode, 400)
-    t.assert.deepStrictEqual(res.json(), { statusCode: 400, code: 'FST_ERR_VALIDATION', error: 'Bad Request', message: 'params/id must be >= 42' })
   })
+  t.assert.strictEqual(res1.statusCode, 400)
+  t.assert.deepStrictEqual(res1.json(), { statusCode: 400, code: 'FST_ERR_VALIDATION', error: 'Bad Request', message: 'params/id must be >= 42' })
 
   // check header
-  fastify.inject({
+  const res2 = await fastify.inject({
     method: 'POST',
     url: '/42',
     headers: { 'x-custom': 'invalid' },
     query: { surname: 'bar' },
     payload: { name: 'foo' }
-  }, (err, res) => {
-    t.assert.ifError(err)
-    t.assert.strictEqual(res.statusCode, 400)
-    t.assert.deepStrictEqual(res.json(), { statusCode: 400, code: 'FST_ERR_VALIDATION', error: 'Bad Request', message: 'headers/x-custom must match format "email"' })
   })
+  t.assert.strictEqual(res2.statusCode, 400)
+  t.assert.deepStrictEqual(res2.json(), { statusCode: 400, code: 'FST_ERR_VALIDATION', error: 'Bad Request', message: 'headers/x-custom must match format "email"' })
 
   // check query
-  fastify.inject({
+  const res3 = await fastify.inject({
     method: 'POST',
     url: '/42',
     headers: { 'x-custom': 'me@me.me' },
     query: { },
     payload: { name: 'foo' }
-  }, (err, res) => {
-    t.assert.ifError(err)
-    t.assert.strictEqual(res.statusCode, 400)
-    t.assert.deepStrictEqual(res.json(), { statusCode: 400, code: 'FST_ERR_VALIDATION', error: 'Bad Request', message: 'querystring must have required property \'surname\'' })
   })
+  t.assert.strictEqual(res3.statusCode, 400)
+  t.assert.deepStrictEqual(res3.json(), { statusCode: 400, code: 'FST_ERR_VALIDATION', error: 'Bad Request', message: 'querystring must have required property \'surname\'' })
 
   // check body
-  fastify.inject({
+  const res4 = await fastify.inject({
     method: 'POST',
     url: '/42',
     headers: { 'x-custom': 'me@me.me' },
     query: { surname: 'bar' },
     payload: { name: [1, 2, 3] }
-  }, (err, res) => {
-    t.assert.ifError(err)
-    t.assert.strictEqual(res.statusCode, 400)
-    t.assert.deepStrictEqual(res.json(), { statusCode: 400, code: 'FST_ERR_VALIDATION', error: 'Bad Request', message: 'body/name must be string' })
   })
+  t.assert.strictEqual(res4.statusCode, 400)
+  t.assert.deepStrictEqual(res4.json(), { statusCode: 400, code: 'FST_ERR_VALIDATION', error: 'Bad Request', message: 'body/name must be string' })
 
   // check response
-  fastify.inject({
+  const res5 = await fastify.inject({
     method: 'POST',
     url: '/42',
     headers: { 'x-custom': 'me@me.me' },
     query: { surname: 'bar' },
     payload: { name: 'foo' }
-  }, (err, res) => {
-    t.assert.ifError(err)
-    t.assert.strictEqual(res.statusCode, 200)
-    t.assert.deepStrictEqual(res.json(), { name: 'a', surname: 'b' })
-    done()
   })
+  t.assert.strictEqual(res5.statusCode, 200)
+  t.assert.deepStrictEqual(res5.json(), { name: 'a', surname: 'b' })
 })
 
 test('use complex fluent-json-schema object', (t, done) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Proposal:

   - migrated `fluent-schema.test.js`  from `tap` to `node:test` 🔥
