### PR TITLE
test: migrated set-error-handler.test.js and header-overflow.test.js from tap to node:test

### DIFF
--- a/test/header-overflow.test.js
+++ b/test/header-overflow.test.js
@@ -1,13 +1,12 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const Fastify = require('..')
 const sget = require('simple-get').concat
 
 const maxHeaderSize = 1024
 
-test('Should return 431 if request header fields are too large', t => {
+test('Should return 431 if request header fields are too large', (t, done) => {
   t.plan(3)
 
   const fastify = Fastify({ http: { maxHeaderSize } })
@@ -20,7 +19,7 @@ test('Should return 431 if request header fields are too large', t => {
   })
 
   fastify.listen({ port: 0 }, function (err) {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'GET',
@@ -29,15 +28,16 @@ test('Should return 431 if request header fields are too large', t => {
         'Large-Header': 'a'.repeat(maxHeaderSize)
       }
     }, (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 431)
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.statusCode, 431)
+      done()
     })
   })
 
-  t.teardown(() => fastify.close())
+  t.after(() => fastify.close())
 })
 
-test('Should return 431 if URI is too long', t => {
+test('Should return 431 if URI is too long', (t, done) => {
   t.plan(3)
 
   const fastify = Fastify({ http: { maxHeaderSize } })
@@ -50,16 +50,17 @@ test('Should return 431 if URI is too long', t => {
   })
 
   fastify.listen({ port: 0 }, function (err) {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'GET',
       url: 'http://localhost:' + fastify.server.address().port + `/${'a'.repeat(maxHeaderSize)}`
     }, (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 431)
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.statusCode, 431)
+      done()
     })
   })
 
-  t.teardown(() => fastify.close())
+  t.after(() => fastify.close())
 })

--- a/test/noop-set.test.js
+++ b/test/noop-set.test.js
@@ -14,6 +14,6 @@ test('does a lot of nothing', async t => {
   t.assert.strictEqual(aSet.has(item), true)
 
   for (const i of aSet) {
-    t.assert.fail('should not have any items', i)
+    t.assert.fail('should not have any items' + i)
   }
 })

--- a/test/noop-set.test.js
+++ b/test/noop-set.test.js
@@ -14,6 +14,6 @@ test('does a lot of nothing', async t => {
   t.assert.strictEqual(aSet.has(item), true)
 
   for (const i of aSet) {
-    t.assert.fail('should not have any items' + i)
+    t.assert.fail('should not have any items: ' + i)
   }
 })

--- a/test/set-error-handler.test.js
+++ b/test/set-error-handler.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const Fastify = require('..')
 const { FST_ERR_ERROR_HANDLER_NOT_FN } = require('../lib/errors')
 
@@ -9,5 +8,5 @@ test('setErrorHandler should throw an error if the handler is not a function', t
   t.plan(1)
   const fastify = Fastify()
 
-  t.throws(() => fastify.setErrorHandler('not a function'), new FST_ERR_ERROR_HANDLER_NOT_FN())
+  t.assert.throws(() => fastify.setErrorHandler('not a function'), new FST_ERR_ERROR_HANDLER_NOT_FN())
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Proposals:

- migrated `set-error-handler.js` from `tap` to `node:test` 🔥 ( see here: [afe854f](https://github.com/fastify/fastify/pull/5835/commits/afe854fb1a2bf4a6f46090f12be91a0fde8954e0))
- migrated `header-overflow.test.js` from `tap` to `node:test` 🔥 (see here: [20d43cd](https://github.com/fastify/fastify/pull/5835/commits/20d43cdbdf5cb60628fe7d410aff37bf9a62fc62))
- fix method `fail` on `noop-set.test.js`file  ( see here: [652a1fd](https://github.com/fastify/fastify/pull/5835/commits/652a1fd00322edc1863ae8f9799a9b1d82e0fb4a))