### PR TITLE
test: migrated proto-poisoning.test.js from tap to node:test

### DIFF
--- a/test/proto-poisoning.test.js
+++ b/test/proto-poisoning.test.js
@@ -2,21 +2,19 @@
 
 const Fastify = require('..')
 const sget = require('simple-get').concat
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 
-test('proto-poisoning error', t => {
+test('proto-poisoning error', (t, done) => {
   t.plan(3)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
 
   fastify.post('/', (request, reply) => {
-    t.fail('handler should not be called')
+    t.assert.fail('handler should not be called')
   })
 
   fastify.listen({ port: 0 }, function (err) {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -24,25 +22,26 @@ test('proto-poisoning error', t => {
       headers: { 'Content-Type': 'application/json' },
       body: '{ "__proto__": { "a": 42 } }'
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 400)
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 400)
+      fastify.close()
+      done()
     })
   })
 })
 
-test('proto-poisoning remove', t => {
+test('proto-poisoning remove', (t, done) => {
   t.plan(4)
 
   const fastify = Fastify({ onProtoPoisoning: 'remove' })
-  t.teardown(fastify.close.bind(fastify))
 
   fastify.post('/', (request, reply) => {
-    t.equal(undefined, Object.assign({}, request.body).a)
+    t.assert.strictEqual(undefined, Object.assign({}, request.body).a)
     reply.send({ ok: true })
   })
 
   fastify.listen({ port: 0 }, function (err) {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -50,25 +49,26 @@ test('proto-poisoning remove', t => {
       headers: { 'Content-Type': 'application/json' },
       body: '{ "__proto__": { "a": 42 }, "b": 42 }'
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 200)
+      fastify.close()
+      done()
     })
   })
 })
 
-test('proto-poisoning ignore', t => {
+test('proto-poisoning ignore', (t, done) => {
   t.plan(4)
 
   const fastify = Fastify({ onProtoPoisoning: 'ignore' })
-  t.teardown(fastify.close.bind(fastify))
 
   fastify.post('/', (request, reply) => {
-    t.equal(42, Object.assign({}, request.body).a)
+    t.assert.strictEqual(42, Object.assign({}, request.body).a)
     reply.send({ ok: true })
   })
 
   fastify.listen({ port: 0 }, function (err) {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -76,24 +76,25 @@ test('proto-poisoning ignore', t => {
       headers: { 'Content-Type': 'application/json' },
       body: '{ "__proto__": { "a": 42 }, "b": 42 }'
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 200)
+      fastify.close()
+      done()
     })
   })
 })
 
-test('constructor-poisoning error (default in v3)', t => {
+test('constructor-poisoning error (default in v3)', (t, done) => {
   t.plan(3)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
 
   fastify.post('/', (request, reply) => {
     reply.send('ok')
   })
 
   fastify.listen({ port: 0 }, function (err) {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -101,24 +102,25 @@ test('constructor-poisoning error (default in v3)', t => {
       headers: { 'Content-Type': 'application/json' },
       body: '{ "constructor": { "prototype": { "foo": "bar" } } }'
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 400)
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 400)
+      fastify.close()
+      done()
     })
   })
 })
 
-test('constructor-poisoning error', t => {
+test('constructor-poisoning error', (t, done) => {
   t.plan(3)
 
   const fastify = Fastify({ onConstructorPoisoning: 'error' })
-  t.teardown(fastify.close.bind(fastify))
 
   fastify.post('/', (request, reply) => {
-    t.fail('handler should not be called')
+    t.assert.fail('handler should not be called')
   })
 
   fastify.listen({ port: 0 }, function (err) {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -126,25 +128,26 @@ test('constructor-poisoning error', t => {
       headers: { 'Content-Type': 'application/json' },
       body: '{ "constructor": { "prototype": { "foo": "bar" } } }'
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 400)
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 400)
+      fastify.close()
+      done()
     })
   })
 })
 
-test('constructor-poisoning remove', t => {
+test('constructor-poisoning remove', (t, done) => {
   t.plan(4)
 
   const fastify = Fastify({ onConstructorPoisoning: 'remove' })
-  t.teardown(fastify.close.bind(fastify))
 
   fastify.post('/', (request, reply) => {
-    t.equal(undefined, Object.assign({}, request.body).foo)
+    t.assert.strictEqual(undefined, Object.assign({}, request.body).foo)
     reply.send({ ok: true })
   })
 
   fastify.listen({ port: 0 }, function (err) {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -152,8 +155,10 @@ test('constructor-poisoning remove', t => {
       headers: { 'Content-Type': 'application/json' },
       body: '{ "constructor": { "prototype": { "foo": "bar" } } }'
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 200)
+      fastify.close()
+      done()
     })
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Proposal:

- migrated `proto-poisoning.test.js` from `tap` to `node:test` 🔥