### PR TITLE
test: migrated custom-parser.4.test.js and custom-parser.5.test.js fr…

### DIFF
--- a/test/custom-parser.5.test.js
+++ b/test/custom-parser.5.test.js
@@ -141,7 +141,7 @@ test('should be able to add a custom content type parser after removeAllContentT
     }, (err, response, body) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 200)
-      t.assert.deepEqual(body.toString(), JSON.stringify({ hello: 'world' }))
+      t.assert.deepStrictEqual(body.toString(), JSON.stringify({ hello: 'world' }))
       fastify.close()
       done()
     })

--- a/test/custom-parser.5.test.js
+++ b/test/custom-parser.5.test.js
@@ -121,7 +121,6 @@ test('should be able to add a custom content type parser after removeAllContentT
   })
 
   fastify.removeAllContentTypeParsers()
-
   fastify.addContentTypeParser('application/jsoff', function (req, payload, done) {
     t.ok('called')
     jsonParser(payload, function (err, body) {

--- a/test/custom-parser.5.test.js
+++ b/test/custom-parser.5.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const sget = require('simple-get').concat
 const Fastify = require('../fastify')
 const jsonParser = require('fast-json-body')
@@ -9,35 +8,33 @@ const { getServerUrl, plainTextParser } = require('./helper')
 
 process.removeAllListeners('warning')
 
-test('cannot remove all content type parsers after binding', t => {
+test('cannot remove all content type parsers after binding', (t, done) => {
   t.plan(2)
 
   const fastify = Fastify()
 
-  t.teardown(fastify.close.bind(fastify))
-
   fastify.listen({ port: 0 }, function (err) {
-    t.error(err)
-
-    t.throws(() => fastify.removeAllContentTypeParsers())
+    t.assert.ifError(err)
+    t.assert.throws(() => fastify.removeAllContentTypeParsers())
+    fastify.close()
+    done()
   })
 })
 
-test('cannot remove content type parsers after binding', t => {
+test('cannot remove content type parsers after binding', (t, done) => {
   t.plan(2)
 
   const fastify = Fastify()
 
-  t.teardown(fastify.close.bind(fastify))
-
   fastify.listen({ port: 0 }, function (err) {
-    t.error(err)
-
-    t.throws(() => fastify.removeContentTypeParser('application/json'))
+    t.assert.ifError(err)
+    t.assert.throws(() => fastify.removeContentTypeParser('application/json'))
+    fastify.close()
+    done()
   })
 })
 
-test('should be able to override the default json parser after removeAllContentTypeParsers', t => {
+test('should be able to override the default json parser after removeAllContentTypeParsers', (t, done) => {
   t.plan(5)
 
   const fastify = Fastify()
@@ -49,14 +46,14 @@ test('should be able to override the default json parser after removeAllContentT
   fastify.removeAllContentTypeParsers()
 
   fastify.addContentTypeParser('application/json', function (req, payload, done) {
-    t.ok('called')
+    t.assert.ok('called')
     jsonParser(payload, function (err, body) {
       done(err, body)
     })
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -66,15 +63,16 @@ test('should be able to override the default json parser after removeAllContentT
         'Content-Type': 'application/json'
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.same(body.toString(), JSON.stringify({ hello: 'world' }))
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 200)
+      t.assert.deepStrictEqual(body.toString(), JSON.stringify({ hello: 'world' }))
       fastify.close()
+      done()
     })
   })
 })
 
-test('should be able to override the default plain text parser after removeAllContentTypeParsers', t => {
+test('should be able to override the default plain text parser after removeAllContentTypeParsers', (t, done) => {
   t.plan(5)
 
   const fastify = Fastify()
@@ -86,14 +84,14 @@ test('should be able to override the default plain text parser after removeAllCo
   fastify.removeAllContentTypeParsers()
 
   fastify.addContentTypeParser('text/plain', function (req, payload, done) {
-    t.ok('called')
+    t.assert.ok('called')
     plainTextParser(payload, function (err, body) {
       done(err, body)
     })
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -103,15 +101,16 @@ test('should be able to override the default plain text parser after removeAllCo
         'Content-Type': 'text/plain'
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.equal(body.toString(), 'hello world')
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 200)
+      t.assert.strictEqual(body.toString(), 'hello world')
       fastify.close()
+      done()
     })
   })
 })
 
-test('should be able to add a custom content type parser after removeAllContentTypeParsers', t => {
+test('should be able to add a custom content type parser after removeAllContentTypeParsers', (t, done) => {
   t.plan(5)
 
   const fastify = Fastify()
@@ -122,14 +121,14 @@ test('should be able to add a custom content type parser after removeAllContentT
 
   fastify.removeAllContentTypeParsers()
   fastify.addContentTypeParser('application/jsoff', function (req, payload, done) {
-    t.ok('called')
+    t.assert.ok('called')
     jsonParser(payload, function (err, body) {
       done(err, body)
     })
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -139,10 +138,11 @@ test('should be able to add a custom content type parser after removeAllContentT
         'Content-Type': 'application/jsoff'
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.same(body.toString(), JSON.stringify({ hello: 'world' }))
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 200)
+      t.assert.deepEqual(body.toString(), JSON.stringify({ hello: 'world' }))
       fastify.close()
+      done()
     })
   })
 })

--- a/test/custom-parser.5.test.js
+++ b/test/custom-parser.5.test.js
@@ -26,10 +26,11 @@ test('cannot remove content type parsers after binding', (t, done) => {
 
   const fastify = Fastify()
 
+  t.after(() => fastify.close())
+
   fastify.listen({ port: 0 }, function (err) {
     t.assert.ifError(err)
     t.assert.throws(() => fastify.removeContentTypeParser('application/json'))
-    fastify.close()
     done()
   })
 })


### PR DESCRIPTION
…om tap to node:test

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Proposals:

  - migrated `custom-parser.4.test.js` from `tap` to `node:test` 🔥( see commit here: [7f00b8f](https://github.com/fastify/fastify/pull/5837/commits/7f00b8f33c1d30c4f58b22a09b38b3416be0647b))
  - migrated `custom-parser.5.test.js` from `tap` to `node:test` 🔥 ( see commit here:  [10c01d4](https://github.com/fastify/fastify/pull/5837/commits/10c01d467eeae0751cd1742542d163283a0d7cae))
