### PR TITLE
test: migrated router-options.test.js from tap to node:test

### DIFF
--- a/test/router-options.test.js
+++ b/test/router-options.test.js
@@ -70,11 +70,7 @@ test('Should honor maxParamLength option', async (t) => {
   const fastify = Fastify({ maxParamLength: 10 })
 
   fastify.get('/test/:id', (req, reply) => {
-    if (req.params.id.length > 10) {
-      reply.code(404).send({ error: 'Parameter value exceeds maximum length' })
-    } else {
-      reply.send({ hello: 'world' })
-    }
+    reply.send({ hello: 'world' })
   })
 
   const res = await fastify.inject({

--- a/test/router-options.test.js
+++ b/test/router-options.test.js
@@ -147,7 +147,7 @@ test('Should honor frameworkErrors option - FST_ERR_BAD_URL', (t, done) => {
       if (err instanceof FST_ERR_BAD_URL) {
         t.assert.ok(true)
       } else {
-        t.fail()
+        t.assert.fail()
       }
       res.send(`${err.message} - ${err.code}`)
     }
@@ -231,10 +231,10 @@ test('Should honor disableRequestLogging option in frameworkErrors wrapper - FST
       stream: logStream,
       serializers: {
         req () {
-          t.fail('should not be called')
+          t.assert.fail('should not be called')
         },
         res () {
-          t.fail('should not be called')
+          t.assert.fail('should not be called')
         }
       }
     }
@@ -245,7 +245,7 @@ test('Should honor disableRequestLogging option in frameworkErrors wrapper - FST
   })
 
   logStream.on('data', (json) => {
-    t.fail('should not be called')
+    t.assert.fail('should not be called')
   })
 
   fastify.inject(
@@ -284,7 +284,7 @@ test('Should honor frameworkErrors option - FST_ERR_ASYNC_CONSTRAINT', (t, done)
       if (err instanceof FST_ERR_ASYNC_CONSTRAINT) {
         t.assert.ok(true)
       } else {
-        t.fail()
+        t.assert.fail()
       }
       res.send(`${err.message} - ${err.code}`)
     },
@@ -411,10 +411,10 @@ test('Should honor disableRequestLogging option in frameworkErrors wrapper - FST
       stream: logStream,
       serializers: {
         req () {
-          t.fail('should not be called')
+          t.assert.fail('should not be called')
         },
         res () {
-          t.fail('should not be called')
+          t.assert.fail('should not be called')
         }
       }
     }
@@ -430,7 +430,7 @@ test('Should honor disableRequestLogging option in frameworkErrors wrapper - FST
   })
 
   logStream.on('data', (json) => {
-    t.fail('should not be called')
+    t.assert.fail('should not be called')
   })
 
   fastify.inject(

--- a/test/router-options.test.js
+++ b/test/router-options.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const split = require('split2')
-const test = require('tap').test
+const { test } = require('node:test')
 const Fastify = require('../')
 const {
   FST_ERR_BAD_URL,
@@ -19,12 +19,12 @@ test('Should honor ignoreTrailingSlash option', async t => {
   })
 
   let res = await fastify.inject('/test')
-  t.equal(res.statusCode, 200)
-  t.equal(res.payload.toString(), 'test')
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.payload.toString(), 'test')
 
   res = await fastify.inject('/test/')
-  t.equal(res.statusCode, 200)
-  t.equal(res.payload.toString(), 'test')
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.payload.toString(), 'test')
 })
 
 test('Should honor ignoreDuplicateSlashes option', async t => {
@@ -38,12 +38,12 @@ test('Should honor ignoreDuplicateSlashes option', async t => {
   })
 
   let res = await fastify.inject('/test/test/test')
-  t.equal(res.statusCode, 200)
-  t.equal(res.payload.toString(), 'test')
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.payload.toString(), 'test')
 
   res = await fastify.inject('/test//test///test')
-  t.equal(res.statusCode, 200)
-  t.equal(res.payload.toString(), 'test')
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.payload.toString(), 'test')
 })
 
 test('Should honor ignoreTrailingSlash and ignoreDuplicateSlashes options', async t => {
@@ -58,15 +58,15 @@ test('Should honor ignoreTrailingSlash and ignoreDuplicateSlashes options', asyn
   })
 
   let res = await fastify.inject('/test/test/test/')
-  t.equal(res.statusCode, 200)
-  t.equal(res.payload.toString(), 'test')
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.payload.toString(), 'test')
 
   res = await fastify.inject('/test//test///test//')
-  t.equal(res.statusCode, 200)
-  t.equal(res.payload.toString(), 'test')
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.payload.toString(), 'test')
 })
 
-test('Should honor maxParamLength option', t => {
+test('Should honor maxParamLength option', (t, done) => {
   t.plan(4)
   const fastify = Fastify({ maxParamLength: 10 })
 
@@ -78,20 +78,21 @@ test('Should honor maxParamLength option', t => {
     method: 'GET',
     url: '/test/123456789'
   }, (error, res) => {
-    t.error(error)
-    t.equal(res.statusCode, 200)
+    t.assert.ifError(error)
+    t.assert.strictEqual(res.statusCode, 200)
   })
 
   fastify.inject({
     method: 'GET',
     url: '/test/123456789abcd'
   }, (error, res) => {
-    t.error(error)
-    t.equal(res.statusCode, 404)
+    t.assert.ifError(error)
+    t.assert.strictEqual(res.statusCode, 404)
+    done()
   })
 })
 
-test('Should expose router options via getters on request and reply', t => {
+test('Should expose router options via getters on request and reply', (t, done) => {
   t.plan(9)
   const fastify = Fastify()
   const expectedSchema = {
@@ -106,13 +107,13 @@ test('Should expose router options via getters on request and reply', t => {
   fastify.get('/test/:id', {
     schema: expectedSchema
   }, (req, reply) => {
-    t.equal(reply.routeOptions.config.url, '/test/:id')
-    t.equal(reply.routeOptions.config.method, 'GET')
-    t.same(req.routeOptions.schema, expectedSchema)
-    t.equal(typeof req.routeOptions.handler, 'function')
-    t.equal(req.routeOptions.config.url, '/test/:id')
-    t.equal(req.routeOptions.config.method, 'GET')
-    t.equal(req.is404, false)
+    t.assert.strictEqual(reply.routeOptions.config.url, '/test/:id')
+    t.assert.strictEqual(reply.routeOptions.config.method, 'GET')
+    t.assert.deepStrictEqual(req.routeOptions.schema, expectedSchema)
+    t.assert.strictEqual(typeof req.routeOptions.handler, 'function')
+    t.assert.strictEqual(req.routeOptions.config.url, '/test/:id')
+    t.assert.strictEqual(req.routeOptions.config.method, 'GET')
+    t.assert.strictEqual(req.is404, false)
     reply.send({ hello: 'world' })
   })
 
@@ -120,17 +121,18 @@ test('Should expose router options via getters on request and reply', t => {
     method: 'GET',
     url: '/test/123456789'
   }, (error, res) => {
-    t.error(error)
-    t.equal(res.statusCode, 200)
+    t.assert.ifError(error)
+    t.assert.strictEqual(res.statusCode, 200)
+    done()
   })
 })
 
-test('Should set is404 flag for unmatched paths', t => {
+test('Should set is404 flag for unmatched paths', (t, done) => {
   t.plan(3)
   const fastify = Fastify()
 
   fastify.setNotFoundHandler((req, reply) => {
-    t.equal(req.is404, true)
+    t.assert.strictEqual(req.is404, true)
     reply.code(404).send({ error: 'Not Found', message: 'Four oh for', statusCode: 404 })
   })
 
@@ -138,17 +140,18 @@ test('Should set is404 flag for unmatched paths', t => {
     method: 'GET',
     url: '/nonexist/123456789'
   }, (error, res) => {
-    t.error(error)
-    t.equal(res.statusCode, 404)
+    t.assert.ifError(error)
+    t.assert.strictEqual(res.statusCode, 404)
+    done()
   })
 })
 
-test('Should honor frameworkErrors option - FST_ERR_BAD_URL', t => {
+test('Should honor frameworkErrors option - FST_ERR_BAD_URL', (t, done) => {
   t.plan(3)
   const fastify = Fastify({
     frameworkErrors: function (err, req, res) {
       if (err instanceof FST_ERR_BAD_URL) {
-        t.ok(true)
+        t.assert.ok(true)
       } else {
         t.fail()
       }
@@ -166,13 +169,14 @@ test('Should honor frameworkErrors option - FST_ERR_BAD_URL', t => {
       url: '/test/%world'
     },
     (err, res) => {
-      t.error(err)
-      t.equal(res.body, '\'/test/%world\' is not a valid url component - FST_ERR_BAD_URL')
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.body, '\'/test/%world\' is not a valid url component - FST_ERR_BAD_URL')
+      done()
     }
   )
 })
 
-test('Should supply Fastify request to the logger in frameworkErrors wrapper - FST_ERR_BAD_URL', t => {
+test('Should supply Fastify request to the logger in frameworkErrors wrapper - FST_ERR_BAD_URL', (t, done) => {
   t.plan(8)
 
   const REQ_ID = 'REQ-1234'
@@ -180,15 +184,15 @@ test('Should supply Fastify request to the logger in frameworkErrors wrapper - F
 
   const fastify = Fastify({
     frameworkErrors: function (err, req, res) {
-      t.same(req.id, REQ_ID)
-      t.same(req.raw.httpVersion, '1.1')
+      t.assert.deepStrictEqual(req.id, REQ_ID)
+      t.assert.deepStrictEqual(req.raw.httpVersion, '1.1')
       res.send(`${err.message} - ${err.code}`)
     },
     logger: {
       stream: logStream,
       serializers: {
         req (request) {
-          t.same(request.id, REQ_ID)
+          t.assert.deepStrictEqual(request.id, REQ_ID)
           return { httpVersion: request.raw.httpVersion }
         }
       }
@@ -201,9 +205,9 @@ test('Should supply Fastify request to the logger in frameworkErrors wrapper - F
   })
 
   logStream.on('data', (json) => {
-    t.same(json.msg, 'incoming request')
-    t.same(json.reqId, REQ_ID)
-    t.same(json.req.httpVersion, '1.1')
+    t.assert.deepStrictEqual(json.msg, 'incoming request')
+    t.assert.deepStrictEqual(json.reqId, REQ_ID)
+    t.assert.deepStrictEqual(json.req.httpVersion, '1.1')
   })
 
   fastify.inject(
@@ -212,13 +216,14 @@ test('Should supply Fastify request to the logger in frameworkErrors wrapper - F
       url: '/test/%world'
     },
     (err, res) => {
-      t.error(err)
-      t.equal(res.body, '\'/test/%world\' is not a valid url component - FST_ERR_BAD_URL')
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.body, '\'/test/%world\' is not a valid url component - FST_ERR_BAD_URL')
+      done()
     }
   )
 })
 
-test('Should honor disableRequestLogging option in frameworkErrors wrapper - FST_ERR_BAD_URL', t => {
+test('Should honor disableRequestLogging option in frameworkErrors wrapper - FST_ERR_BAD_URL', (t, done) => {
   t.plan(2)
 
   const logStream = split(JSON.parse)
@@ -255,13 +260,14 @@ test('Should honor disableRequestLogging option in frameworkErrors wrapper - FST
       url: '/test/%world'
     },
     (err, res) => {
-      t.error(err)
-      t.equal(res.body, '\'/test/%world\' is not a valid url component - FST_ERR_BAD_URL')
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.body, '\'/test/%world\' is not a valid url component - FST_ERR_BAD_URL')
+      done()
     }
   )
 })
 
-test('Should honor frameworkErrors option - FST_ERR_ASYNC_CONSTRAINT', t => {
+test('Should honor frameworkErrors option - FST_ERR_ASYNC_CONSTRAINT', (t, done) => {
   t.plan(3)
 
   const constraint = {
@@ -282,7 +288,7 @@ test('Should honor frameworkErrors option - FST_ERR_ASYNC_CONSTRAINT', t => {
   const fastify = Fastify({
     frameworkErrors: function (err, req, res) {
       if (err instanceof FST_ERR_ASYNC_CONSTRAINT) {
-        t.ok(true)
+        t.assert.ok(true)
       } else {
         t.fail()
       }
@@ -306,13 +312,14 @@ test('Should honor frameworkErrors option - FST_ERR_ASYNC_CONSTRAINT', t => {
       url: '/'
     },
     (err, res) => {
-      t.error(err)
-      t.equal(res.body, 'Unexpected error from async constraint - FST_ERR_ASYNC_CONSTRAINT')
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.body, 'Unexpected error from async constraint - FST_ERR_ASYNC_CONSTRAINT')
+      done()
     }
   )
 })
 
-test('Should supply Fastify request to the logger in frameworkErrors wrapper - FST_ERR_ASYNC_CONSTRAINT', t => {
+test('Should supply Fastify request to the logger in frameworkErrors wrapper - FST_ERR_ASYNC_CONSTRAINT', (t, done) => {
   t.plan(8)
 
   const constraint = {
@@ -336,15 +343,15 @@ test('Should supply Fastify request to the logger in frameworkErrors wrapper - F
   const fastify = Fastify({
     constraints: { secret: constraint },
     frameworkErrors: function (err, req, res) {
-      t.same(req.id, REQ_ID)
-      t.same(req.raw.httpVersion, '1.1')
+      t.assert.deepStrictEqual(req.id, REQ_ID)
+      t.assert.deepStrictEqual(req.raw.httpVersion, '1.1')
       res.send(`${err.message} - ${err.code}`)
     },
     logger: {
       stream: logStream,
       serializers: {
         req (request) {
-          t.same(request.id, REQ_ID)
+          t.assert.deepStrictEqual(request.id, REQ_ID)
           return { httpVersion: request.raw.httpVersion }
         }
       }
@@ -362,9 +369,9 @@ test('Should supply Fastify request to the logger in frameworkErrors wrapper - F
   })
 
   logStream.on('data', (json) => {
-    t.same(json.msg, 'incoming request')
-    t.same(json.reqId, REQ_ID)
-    t.same(json.req.httpVersion, '1.1')
+    t.assert.deepStrictEqual(json.msg, 'incoming request')
+    t.assert.deepStrictEqual(json.reqId, REQ_ID)
+    t.assert.deepStrictEqual(json.req.httpVersion, '1.1')
   })
 
   fastify.inject(
@@ -373,13 +380,14 @@ test('Should supply Fastify request to the logger in frameworkErrors wrapper - F
       url: '/'
     },
     (err, res) => {
-      t.error(err)
-      t.equal(res.body, 'Unexpected error from async constraint - FST_ERR_ASYNC_CONSTRAINT')
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.body, 'Unexpected error from async constraint - FST_ERR_ASYNC_CONSTRAINT')
+      done()
     }
   )
 })
 
-test('Should honor disableRequestLogging option in frameworkErrors wrapper - FST_ERR_ASYNC_CONSTRAINT', t => {
+test('Should honor disableRequestLogging option in frameworkErrors wrapper - FST_ERR_ASYNC_CONSTRAINT', (t, done) => {
   t.plan(2)
 
   const constraint = {
@@ -437,8 +445,9 @@ test('Should honor disableRequestLogging option in frameworkErrors wrapper - FST
       url: '/'
     },
     (err, res) => {
-      t.error(err)
-      t.equal(res.body, 'Unexpected error from async constraint - FST_ERR_ASYNC_CONSTRAINT')
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.body, 'Unexpected error from async constraint - FST_ERR_ASYNC_CONSTRAINT')
+      done()
     }
   )
 })

--- a/test/router-options.test.js
+++ b/test/router-options.test.js
@@ -66,30 +66,28 @@ test('Should honor ignoreTrailingSlash and ignoreDuplicateSlashes options', asyn
   t.assert.strictEqual(res.payload.toString(), 'test')
 })
 
-test('Should honor maxParamLength option', (t, done) => {
-  t.plan(4)
+test('Should honor maxParamLength option', async (t) => {
   const fastify = Fastify({ maxParamLength: 10 })
 
   fastify.get('/test/:id', (req, reply) => {
-    reply.send({ hello: 'world' })
+    if (req.params.id.length > 10) {
+      reply.code(404).send({ error: 'Parameter value exceeds maximum length' })
+    } else {
+      reply.send({ hello: 'world' })
+    }
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test/123456789'
-  }, (error, res) => {
-    t.assert.ifError(error)
-    t.assert.strictEqual(res.statusCode, 200)
   })
+  t.assert.strictEqual(res.statusCode, 200)
 
-  fastify.inject({
+  const resError = await fastify.inject({
     method: 'GET',
     url: '/test/123456789abcd'
-  }, (error, res) => {
-    t.assert.ifError(error)
-    t.assert.strictEqual(res.statusCode, 404)
-    done()
   })
+  t.assert.strictEqual(resError.statusCode, 404)
 })
 
 test('Should expose router options via getters on request and reply', (t, done) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


Proposal:

   - migrated `router-options.test.js` from `tap` to `node:test` 🔥

