### PR TITLE
feat: added custom logging keys for req, res, err

### DIFF
--- a/lib/logger-custom-transport.js
+++ b/lib/logger-custom-transport.js
@@ -24,11 +24,7 @@ module.exports = async function (opts) {
         delete obj.err
       }
       // Write the transformed log message to the destination (e.g., to stdout)
-      const toDrain = !destination.write(JSON.stringify(obj) + '\n')
-      // This block will handle backpressure
-      if (toDrain) {
-        await once(destination, 'drain')
-      }
+      destination.write(JSON.stringify(obj) + '\n')
     }
   }, {
     async close (_err) {

--- a/lib/logger-custom-transport.js
+++ b/lib/logger-custom-transport.js
@@ -1,0 +1,42 @@
+const build = require('pino-abstract-transport')
+const SonicBoom = require('sonic-boom')
+const { once } = require('events')
+
+module.exports = async function (opts) {
+  // SonicBoom is necessary to avoid loops with the main thread.
+  // It is the same as pino.destination().
+  const destination = new SonicBoom({ dest: opts.destination || 1, sync: false })
+  const customKeys = opts.customAttributeKeys
+  await once(destination, 'ready')
+
+  return build(async function (source) {
+    for await (const obj of source) {
+      if (customKeys.req && obj.req) {
+        obj[customKeys.req] = obj.req
+        delete obj.req
+      }
+      if (customKeys.res && obj.res) {
+        obj[customKeys.res] = obj.res
+        delete obj.res
+      }
+      if (customKeys.err && obj.err) {
+        obj[customKeys.err] = obj.err
+        delete obj.err
+      }
+      // Write the transformed log message to the destination (e.g., to stdout)
+      const toDrain = !destination.write(JSON.stringify(obj) + '\n')
+      // This block will handle backpressure
+      if (toDrain) {
+        await once(destination, 'drain')
+      }
+    }
+  }, {
+    async close (err) {
+      if (err) {
+        console.error('Transport close error:', err.message)
+      }
+      destination.end()
+      await once(destination, 'close')
+    }
+  })
+}

--- a/lib/logger-custom-transport.js
+++ b/lib/logger-custom-transport.js
@@ -31,10 +31,7 @@ module.exports = async function (opts) {
       }
     }
   }, {
-    async close (err) {
-      if (err) {
-        console.error('Transport close error:', err.message)
-      }
+    async close (_err) {
       destination.end()
       await once(destination, 'close')
     }

--- a/lib/logger-pino.js
+++ b/lib/logger-pino.js
@@ -18,7 +18,6 @@ function createPinoLogger (opts) {
   } else if (opts.file) {
     // we do not have stream
     opts.stream = pino.destination(opts.file)
-    delete opts.file
   }
 
   const prevLogger = opts.logger
@@ -37,8 +36,21 @@ function createPinoLogger (opts) {
     opts.logger = prevLogger
     opts.genReqId = prevGenReqId
   } else {
-    logger = pino(opts, opts.stream)
+    if (opts.customAttributeKeys) {
+      const transport = pino.transport({
+        target: './logger-custom-transport.js',
+        options: {
+          destination: opts.file,
+          customAttributeKeys: opts.customAttributeKeys,
+        }
+      })
+      logger = pino(opts, transport)
+    } else {
+      logger = pino(opts, opts.stream)
+    }
   }
+
+  delete opts.file
 
   return logger
 }

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -78,6 +78,13 @@ export interface FastifyLoggerOptions<
   file?: string;
   genReqId?: (req: RawRequest) => string;
   stream?: FastifyLoggerStreamDestination;
+  customAttributeKeys?: CustomAttributeKeys;
+}
+
+export interface CustomAttributeKeys {
+  req?: string;
+  res?: string;
+  err?: string;
 }
 
 export interface FastifyChildLoggerFactory<


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
Addressed issue #4413

`req`, `res`, `err` can now be changed in the log entry. Keys are changed via a Pino custom transporter. Example usage:
> ```ts
> const fastify = Fastify({
>         logger: {
>             customAttributeKeys: {
>                 req: 'customReq',
>                 res: 'customRes',
>                 err: 'customErr',
>             },
>        }
> })
> ```

`customAttributeKeys` is not currently working with `stream` as the custom transporter replaces the original stream. However, it is working fine with `file`.

#### Checklist
- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation needs to be added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
