### PR TITLE
test: migrated request-id.test.js from tap to node:test

### DIFF
--- a/test/request-id.test.js
+++ b/test/request-id.test.js
@@ -53,6 +53,8 @@ test('The request id header key can be customized', (t, done) => {
     reply.send({ id: req.id })
   })
 
+  t.after(() => fastify.close())
+
   fastify.listen({ port: 0 }, (err, address) => {
     t.assert.ifError(err)
 
@@ -65,7 +67,6 @@ test('The request id header key can be customized', (t, done) => {
     }, (err, response, body) => {
       t.assert.ifError(err)
       t.assert.strictEqual(body.toString(), `{"id":"${REQUEST_ID}"}`)
-      fastify.close()
       done()
     })
   })
@@ -84,6 +85,8 @@ test('The request id header key can be customized', (t, done) => {
     reply.send({ id: req.id })
   })
 
+  t.after(() => fastify.close())
+
   fastify.listen({ port: 0 }, (err, address) => {
     t.assert.ifError(err)
 
@@ -96,7 +99,6 @@ test('The request id header key can be customized', (t, done) => {
     }, (err, response, body) => {
       t.assert.ifError(err)
       t.assert.strictEqual(body.toString(), `{"id":"${REQUEST_ID}"}`)
-      fastify.close()
       done()
     })
   })

--- a/test/request-id.test.js
+++ b/test/request-id.test.js
@@ -115,6 +115,8 @@ test('The request id header key can be customized', (t, done) => {
     reply.send({ id: req.id })
   })
 
+  t.after(() => fastify.close())
+
   fastify.listen({ port: 0 }, (err, address) => {
     t.assert.ifError(err)
 
@@ -127,7 +129,6 @@ test('The request id header key can be customized', (t, done) => {
     }, (err, response, body) => {
       t.assert.ifError(err)
       t.assert.strictEqual(body.toString(), `{"id":"${REQUEST_ID}"}`)
-      fastify.close()
       done()
     })
   })

--- a/test/request-id.test.js
+++ b/test/request-id.test.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('node:test')
 const Fastify = require('..')
 const sget = require('simple-get').concat
 
-t.test('The request id header key can be customized', async (t) => {
+test('The request id header key can be customized', async (t) => {
   t.plan(2)
   const REQUEST_ID = '42'
 
@@ -13,16 +13,16 @@ t.test('The request id header key can be customized', async (t) => {
   })
 
   fastify.get('/', (req, reply) => {
-    t.equal(req.id, REQUEST_ID)
+    t.assert.strictEqual(req.id, REQUEST_ID)
     reply.send({ id: req.id })
   })
 
   const response = await fastify.inject({ method: 'GET', url: '/', headers: { 'my-custom-request-id': REQUEST_ID } })
   const body = await response.json()
-  t.equal(body.id, REQUEST_ID)
+  t.assert.strictEqual(body.id, REQUEST_ID)
 })
 
-t.test('The request id header key can be customized', async (t) => {
+test('The request id header key can be customized', async (t) => {
   t.plan(2)
   const REQUEST_ID = '42'
 
@@ -31,16 +31,16 @@ t.test('The request id header key can be customized', async (t) => {
   })
 
   fastify.get('/', (req, reply) => {
-    t.equal(req.id, REQUEST_ID)
+    t.assert.strictEqual(req.id, REQUEST_ID)
     reply.send({ id: req.id })
   })
 
   const response = await fastify.inject({ method: 'GET', url: '/', headers: { 'MY-CUSTOM-REQUEST-ID': REQUEST_ID } })
   const body = await response.json()
-  t.equal(body.id, REQUEST_ID)
+  t.assert.strictEqual(body.id, REQUEST_ID)
 })
 
-t.test('The request id header key can be customized', (t) => {
+test('The request id header key can be customized', (t, done) => {
   t.plan(4)
   const REQUEST_ID = '42'
 
@@ -49,13 +49,12 @@ t.test('The request id header key can be customized', (t) => {
   })
 
   fastify.get('/', (req, reply) => {
-    t.equal(req.id, REQUEST_ID)
+    t.assert.strictEqual(req.id, REQUEST_ID)
     reply.send({ id: req.id })
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
-    t.teardown(() => fastify.close())
+    t.assert.ifError(err)
 
     sget({
       method: 'GET',
@@ -64,13 +63,15 @@ t.test('The request id header key can be customized', (t) => {
         'my-custom-request-id': REQUEST_ID
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(body.toString(), `{"id":"${REQUEST_ID}"}`)
+      t.assert.ifError(err)
+      t.assert.strictEqual(body.toString(), `{"id":"${REQUEST_ID}"}`)
+      fastify.close()
+      done()
     })
   })
 })
 
-t.test('The request id header key can be customized', (t) => {
+test('The request id header key can be customized', (t, done) => {
   t.plan(4)
   const REQUEST_ID = '42'
 
@@ -79,13 +80,12 @@ t.test('The request id header key can be customized', (t) => {
   })
 
   fastify.get('/', (req, reply) => {
-    t.equal(req.id, REQUEST_ID)
+    t.assert.strictEqual(req.id, REQUEST_ID)
     reply.send({ id: req.id })
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
-    t.teardown(() => fastify.close())
+    t.assert.ifError(err)
 
     sget({
       method: 'GET',
@@ -94,13 +94,15 @@ t.test('The request id header key can be customized', (t) => {
         'MY-CUSTOM-REQUEST-ID': REQUEST_ID
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(body.toString(), `{"id":"${REQUEST_ID}"}`)
+      t.assert.ifError(err)
+      t.assert.strictEqual(body.toString(), `{"id":"${REQUEST_ID}"}`)
+      fastify.close()
+      done()
     })
   })
 })
 
-t.test('The request id header key can be customized', (t) => {
+test('The request id header key can be customized', (t, done) => {
   t.plan(4)
   const REQUEST_ID = '42'
 
@@ -109,13 +111,12 @@ t.test('The request id header key can be customized', (t) => {
   })
 
   fastify.get('/', (req, reply) => {
-    t.equal(req.id, REQUEST_ID)
+    t.assert.strictEqual(req.id, REQUEST_ID)
     reply.send({ id: req.id })
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
-    t.teardown(() => fastify.close())
+    t.assert.ifError(err)
 
     sget({
       method: 'GET',
@@ -124,8 +125,10 @@ t.test('The request id header key can be customized', (t) => {
         'MY-CUSTOM-REQUEST-ID': REQUEST_ID
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(body.toString(), `{"id":"${REQUEST_ID}"}`)
+      t.assert.ifError(err)
+      t.assert.strictEqual(body.toString(), `{"id":"${REQUEST_ID}"}`)
+      fastify.close()
+      done()
     })
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


Proposal:

  - migrated `request-id.test.js` from `tap` to `node:test` 🔥
