### PR TITLE
test: migrated route.8.test.js from tap to node:test

### DIFF
--- a/test/route.8.test.js
+++ b/test/route.8.test.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const sget = require('simple-get').concat
-const Fastify = require('../fastify')
+const Fastify = require('..')
 const {
   FST_ERR_INVALID_URL
 } = require('../lib/errors')
@@ -24,9 +23,9 @@ test('Request and Reply share the route options', async t => {
     url: '/',
     config,
     handler: (req, reply) => {
-      t.same(req.routeOptions, reply.routeOptions)
-      t.same(req.routeOptions.config, reply.routeOptions.config)
-      t.match(req.routeOptions.config, config, 'there are url and method additional properties')
+      t.assert.deepStrictEqual(req.routeOptions, reply.routeOptions)
+      t.assert.deepStrictEqual(req.routeOptions.config, reply.routeOptions.config)
+      t.assert.match(req.routeOptions.config, config, 'there are url and method additional properties')
 
       reply.send({ hello: 'world' })
     }
@@ -62,10 +61,10 @@ test('Will not try to re-createprefixed HEAD route if it already exists and expo
 
   await fastify.ready()
 
-  t.ok(true)
+  t.assert.ok(true)
 })
 
-test('route with non-english characters', t => {
+test('route with non-english characters', (t, done) => {
   t.plan(4)
 
   const fastify = Fastify()
@@ -75,16 +74,17 @@ test('route with non-english characters', t => {
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
-    t.teardown(() => { fastify.close() })
+    t.assert.ifError(err)
 
     sget({
       method: 'GET',
       url: getServerUrl(fastify) + encodeURI('/föö')
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.equal(body.toString(), 'here /föö')
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 200)
+      t.assert.strictEqual(body.toString(), 'here /föö')
+      fastify.close()
+      done()
     })
   })
 })
@@ -96,7 +96,7 @@ test('invalid url attribute - non string URL', t => {
   try {
     fastify.get(/^\/(donations|skills|blogs)/, () => { })
   } catch (error) {
-    t.equal(error.code, FST_ERR_INVALID_URL().code)
+    t.assert.strictEqual(error.code, FST_ERR_INVALID_URL().code)
   }
 })
 
@@ -117,7 +117,7 @@ test('exposeHeadRoute should not reuse the same route option', async t => {
   })
 
   fastify.addHook('onRoute', function (routeOption) {
-    t.equal(routeOption.onRequest.length, 1)
+    t.assert.strictEqual(routeOption.onRequest.length, 1)
   })
 
   fastify.route({
@@ -140,7 +140,7 @@ test('using fastify.all when a catchall is defined does not degrade performance'
     fastify.all(`/${i}`, async (_, reply) => reply.json({ ok: true }))
   }
 
-  t.pass()
+  t.assert.ok("fastify.all doesn't degrade performance")
 })
 
 test('Adding manually HEAD route after GET with the same path throws Fastify duplicated route instance error', t => {
@@ -164,9 +164,9 @@ test('Adding manually HEAD route after GET with the same path throws Fastify dup
         reply.send({ hello: 'world' })
       }
     })
-    t.fail('Should throw fastify duplicated route declaration')
+    t.assert.fail('Should throw fastify duplicated route declaration')
   } catch (error) {
-    t.equal(error.code, 'FST_ERR_DUPLICATED_ROUTE')
+    t.assert.strictEqual(error.code, 'FST_ERR_DUPLICATED_ROUTE')
   }
 })
 
@@ -198,7 +198,7 @@ test('Will pass onSend hook to HEAD method if exposeHeadRoutes is true /1', asyn
     method: 'HEAD'
   })
 
-  t.equal(result.headers['x-content-type'], 'application/fastify')
+  t.assert.strictEqual(result.headers['x-content-type'], 'application/fastify')
 })
 
 test('Will pass onSend hook to HEAD method if exposeHeadRoutes is true /2', async (t) => {
@@ -229,5 +229,5 @@ test('Will pass onSend hook to HEAD method if exposeHeadRoutes is true /2', asyn
     method: 'HEAD'
   })
 
-  t.equal(result.headers['x-content-type'], 'application/fastify')
+  t.assert.strictEqual(result.headers['x-content-type'], 'application/fastify')
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Proposal:

 - migrated `router.8.test.js` from `tap` to `node:test` 🔥
