### PR TITLE
test: migrated handler-context.test.js from tap to node:test

### DIFF
--- a/test/handler-context.test.js
+++ b/test/handler-context.test.js
@@ -1,7 +1,7 @@
 'use strict'
-const test = require('tap').test
+const { test } = require('node:test')
 const { kRouteContext } = require('../lib/symbols')
-const fastify = require('../')
+const fastify = require('..')
 
 test('handlers receive correct `this` context', async (t) => {
   t.plan(4)
@@ -17,15 +17,15 @@ test('handlers receive correct `this` context', async (t) => {
   instance.register(plugin)
 
   instance.get('/', function (req, reply) {
-    t.ok(this.foo)
-    t.equal(this.foo, 'foo')
+    t.assert.ok(this.foo)
+    t.assert.strictEqual(this.foo, 'foo')
     reply.send()
   })
 
   await instance.inject('/')
 
-  t.ok(instance.foo)
-  t.equal(instance.foo, 'foo')
+  t.assert.ok(instance.foo)
+  t.assert.strictEqual(instance.foo, 'foo')
 })
 
 test('handlers have access to the internal context', async (t) => {
@@ -33,11 +33,11 @@ test('handlers have access to the internal context', async (t) => {
 
   const instance = fastify()
   instance.get('/', { config: { foo: 'bar' } }, function (req, reply) {
-    t.ok(reply[kRouteContext])
-    t.ok(reply[kRouteContext].config)
-    t.type(reply[kRouteContext].config, Object)
-    t.ok(reply[kRouteContext].config.foo)
-    t.equal(reply[kRouteContext].config.foo, 'bar')
+    t.assert.ok(reply[kRouteContext])
+    t.assert.ok(reply[kRouteContext].config)
+    t.assert.ok(typeof reply[kRouteContext].config, Object)
+    t.assert.ok(reply[kRouteContext].config.foo)
+    t.assert.strictEqual(reply[kRouteContext].config.foo, 'bar')
     reply.send()
   })
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Proposal:

-  migrated `handler-context.test.js` file from `tap` to `node:test` 🔥
