### PR TITLE
docs(readme): point ci badge at main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 
 <div align="center">
 
-[![CI](https://github.com/fastify/fastify/actions/workflows/ci.yml/badge.svg)](https://github.com/fastify/fastify/actions/workflows/ci.yml)
-[![Package Manager
-CI](https://github.com/fastify/fastify/workflows/package-manager-ci/badge.svg?branch=main)](https://github.com/fastify/fastify/actions/workflows/package-manager-ci.yml)
+![CI](https://github.com/fastify/fastify/actions/workflows/ci.yml/badge.svg?branch=main)
+![Package Manager
+CI](https://github.com/fastify/fastify/workflows/package-manager-ci/badge.svg?branch=main)
 [![Web
 SIte](https://github.com/fastify/fastify/workflows/website/badge.svg?branch=main)](https://github.com/fastify/fastify/actions/workflows/website.yml)
 [![neostandard javascript style](https://img.shields.io/badge/code_style-neostandard-brightgreen?style=flat)](https://github.com/neostandard/neostandard)


### PR DESCRIPTION
See https://github.com/fastify/fastify-accepts/pull/180

Also swapped out the workflow badge syntax for the [shorter syntax style](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge#using-the-branch-parameter).

#### Checklist

- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
