### PR TITLE
chore: fix flaky test

### DIFF
--- a/.github/workflows/coverage-nix.yml
+++ b/.github/workflows/coverage-nix.yml
@@ -24,18 +24,6 @@ jobs:
         run: |
           npm install --ignore-scripts
 
-      # We do not check coverage requirements here because the goal is to
-      # generate a report to upload as an artifact.
-      - name: Generate coverage report
-        run: |
-          npm run coverage:ci
-
-      - uses: actions/upload-artifact@v4
-        if: ${{ success() }}
-        with:
-          name: coverage-report-nix
-          path: ./.tap/report/
-
       # Here, we verify the coverage thresholds so that this workflow can pass
       # or fail and stop further workflows if this one fails.
       - name: Verify coverage meets thresholds

--- a/.github/workflows/coverage-win.yml
+++ b/.github/workflows/coverage-win.yml
@@ -24,18 +24,6 @@ jobs:
         run: |
           npm install --ignore-scripts
 
-      # We do not check coverage requirements here because the goal is to
-      # generate a report to upload as an artifact.
-      - name: Generate coverage report
-        run: |
-          npm run coverage:ci
-
-      - uses: actions/upload-artifact@v4
-        if: ${{ success() }}
-        with:
-          name: coverage-report-win
-          path: ./.tap/report/
-
       # Here, we verify the coverage thresholds so that this workflow can pass
       # or fail and stop further workflows if this one fails.
       - name: Verify coverage meets thresholds

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "benchmark:parser": "concurrently -k -s first \"node ./examples/benchmark/parser.js\" \"autocannon -c 100 -d 30 -p 10 -i ./examples/benchmark/body.json -H \"content-type:application/jsoff\" -m POST localhost:3000/\"",
     "build:validation": "node build/build-error-serializer.js && node build/build-validation.js",
     "coverage": "c8 --reporter html borp --reporter=./test/test-reporter.mjs --coverage --check-coverage --lines 100 ",
-    "coverage:ci": "c8 --reporter lcov --reporter html borp --reporter=./test/test-reporter.mjs",
     "coverage:ci-check-coverage": "borp --reporter=./test/test-reporter.mjs --coverage --check-coverage --lines 100",
     "lint": "npm run lint:eslint",
     "lint:fix": "eslint --fix",

--- a/test/close-pipelining.test.js
+++ b/test/close-pipelining.test.js
@@ -9,6 +9,7 @@ test('Should return 503 while closing - pipelining', async t => {
     return503OnClosing: true,
     forceCloseConnections: false
   })
+  t.teardown(() => fastify.close())
 
   fastify.get('/', async (req, reply) => {
     fastify.close()
@@ -30,8 +31,6 @@ test('Should return 503 while closing - pipelining', async t => {
   const actual = responses.map(r => r.statusCode)
 
   t.assert.deepStrictEqual(actual, codes)
-
-  await instance.close()
 })
 
 test('Should close the socket abruptly - pipelining - return503OnClosing: false', async t => {

--- a/test/close-pipelining.test.js
+++ b/test/close-pipelining.test.js
@@ -9,7 +9,6 @@ test('Should return 503 while closing - pipelining', async t => {
     return503OnClosing: true,
     forceCloseConnections: false
   })
-  t.teardown(() => fastify.close())
 
   fastify.get('/', async (req, reply) => {
     fastify.close()
@@ -29,8 +28,9 @@ test('Should return 503 while closing - pipelining', async t => {
     instance.request({ path: '/', method: 'GET' })
   ])
   const actual = responses.map(r => r.statusCode)
-
   t.assert.deepStrictEqual(actual, codes)
+
+  await instance.close()
 })
 
 test('Should close the socket abruptly - pipelining - return503OnClosing: false', async t => {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -212,7 +212,7 @@ test('onRequest hook should support encapsulation / 1', t => {
   })
 })
 
-test('onRequest hook should support encapsulation / 2', (t, done) => {
+test('onRequest hook should support encapsulation / 2', (t) => {
   t.plan(3)
   const fastify = Fastify()
   let pluginInstance
@@ -229,7 +229,6 @@ test('onRequest hook should support encapsulation / 2', (t, done) => {
     t.error(err)
     t.equal(fastify[symbols.kHooks].onRequest.length, 1)
     t.equal(pluginInstance[symbols.kHooks].onRequest.length, 2)
-    done()
   })
 })
 

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -212,7 +212,7 @@ test('onRequest hook should support encapsulation / 1', t => {
   })
 })
 
-test('onRequest hook should support encapsulation / 2', t => {
+test('onRequest hook should support encapsulation / 2', (t, done) => {
   t.plan(3)
   const fastify = Fastify()
   let pluginInstance
@@ -229,6 +229,7 @@ test('onRequest hook should support encapsulation / 2', t => {
     t.error(err)
     t.equal(fastify[symbols.kHooks].onRequest.length, 1)
     t.equal(pluginInstance[symbols.kHooks].onRequest.length, 2)
+    done()
   })
 })
 
@@ -300,6 +301,7 @@ test('onRequest hook should support encapsulation / 3', t => {
 test('preHandler hook should support encapsulation / 5', t => {
   t.plan(17)
   const fastify = Fastify()
+  t.teardown(() => { fastify.close() })
   fastify.decorate('hello', 'world')
 
   fastify.addHook('preHandler', function (req, res, done) {
@@ -334,7 +336,6 @@ test('preHandler hook should support encapsulation / 5', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -729,6 +730,7 @@ test('onRoute hook should able to change the route url', t => {
   t.plan(5)
 
   const fastify = Fastify({ exposeHeadRoutes: false })
+  t.teardown(() => { fastify.close() })
 
   fastify.register((instance, opts, done) => {
     instance.addHook('onRoute', (route) => {
@@ -745,7 +747,6 @@ test('onRoute hook should able to change the route url', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -921,6 +922,7 @@ test('onResponse hook should support encapsulation / 2', t => {
 test('onResponse hook should support encapsulation / 3', t => {
   t.plan(16)
   const fastify = Fastify()
+  t.teardown(() => { fastify.close() })
   fastify.decorate('hello', 'world')
 
   fastify.addHook('onResponse', function (request, reply, done) {
@@ -951,7 +953,6 @@ test('onResponse hook should support encapsulation / 3', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -998,6 +999,7 @@ test('onSend hook should support encapsulation / 1', t => {
 test('onSend hook should support encapsulation / 2', t => {
   t.plan(16)
   const fastify = Fastify()
+  t.teardown(() => { fastify.close() })
   fastify.decorate('hello', 'world')
 
   fastify.addHook('onSend', function (request, reply, thePayload, done) {
@@ -1028,7 +1030,6 @@ test('onSend hook should support encapsulation / 2', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -1272,6 +1273,7 @@ test('onSend hook throws', t => {
     }
   })
   const fastify = Fastify()
+  t.teardown(() => { fastify.close() })
   fastify.addHook('onSend', function (request, reply, payload, done) {
     if (request.raw.method === 'DELETE') {
       done(new Error('some error'))
@@ -1323,7 +1325,6 @@ test('onSend hook throws', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -1446,6 +1447,7 @@ test('Content-Length header should be updated if onSend hook modifies the payloa
 test('cannot add hook after binding', t => {
   t.plan(2)
   const instance = Fastify()
+  t.teardown(() => instance.close())
 
   instance.get('/', function (request, reply) {
     reply.send({ hello: 'world' })
@@ -1453,7 +1455,6 @@ test('cannot add hook after binding', t => {
 
   instance.listen({ port: 0 }, err => {
     t.error(err)
-    t.teardown(instance.server.close.bind(instance.server))
 
     try {
       instance.addHook('onRequest', () => {})
@@ -2423,6 +2424,7 @@ test('preValidation hook should support encapsulation / 2', t => {
 test('preValidation hook should support encapsulation / 3', t => {
   t.plan(20)
   const fastify = Fastify()
+  t.teardown(() => { fastify.close() })
   fastify.decorate('hello', 'world')
 
   fastify.addHook('preValidation', function (req, reply, done) {
@@ -2461,7 +2463,6 @@ test('preValidation hook should support encapsulation / 3', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -2589,6 +2590,7 @@ test('onError hook with setErrorHandler', t => {
 test('preParsing hook should run before parsing and be able to modify the payload', t => {
   t.plan(5)
   const fastify = Fastify()
+  t.teardown(() => { fastify.close() })
 
   fastify.addHook('preParsing', function (req, reply, payload, done) {
     const modified = new stream.Readable()
@@ -2608,7 +2610,6 @@ test('preParsing hook should run before parsing and be able to modify the payloa
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'POST',
@@ -2627,6 +2628,7 @@ test('preParsing hook should run before parsing and be able to modify the payloa
 test('preParsing hooks should run in the order in which they are defined', t => {
   t.plan(5)
   const fastify = Fastify()
+  t.teardown(() => { fastify.close() })
 
   fastify.addHook('preParsing', function (req, reply, payload, done) {
     const modified = new stream.Readable()
@@ -2651,7 +2653,6 @@ test('preParsing hooks should run in the order in which they are defined', t => 
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'POST',
@@ -2670,6 +2671,7 @@ test('preParsing hooks should run in the order in which they are defined', t => 
 test('preParsing hooks should support encapsulation', t => {
   t.plan(9)
   const fastify = Fastify()
+  t.teardown(() => { fastify.close() })
 
   fastify.addHook('preParsing', function (req, reply, payload, done) {
     const modified = new stream.Readable()
@@ -2701,7 +2703,6 @@ test('preParsing hooks should support encapsulation', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'POST',
@@ -2784,6 +2785,7 @@ test('preParsing hook should support encapsulation / 2', t => {
 test('preParsing hook should support encapsulation / 3', t => {
   t.plan(20)
   const fastify = Fastify()
+  t.teardown(() => { fastify.close() })
   fastify.decorate('hello', 'world')
 
   fastify.addHook('preParsing', function (req, reply, payload, done) {
@@ -2822,7 +2824,6 @@ test('preParsing hook should support encapsulation / 3', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -2849,6 +2850,7 @@ test('preParsing hook should support encapsulation / 3', t => {
 test('preSerialization hook should run before serialization and be able to modify the payload', t => {
   t.plan(5)
   const fastify = Fastify()
+  t.teardown(() => { fastify.close() })
 
   fastify.addHook('preSerialization', function (req, reply, payload, done) {
     payload.hello += '1'
@@ -2884,7 +2886,6 @@ test('preSerialization hook should run before serialization and be able to modif
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -2900,6 +2901,7 @@ test('preSerialization hook should run before serialization and be able to modif
 
 test('preSerialization hook should be able to throw errors which are validated against schema response', t => {
   const fastify = Fastify()
+  t.teardown(() => { fastify.close() })
 
   fastify.addHook('preSerialization', function (req, reply, payload, done) {
     done(new Error('preSerialization aborted'))
@@ -2935,7 +2937,6 @@ test('preSerialization hook should be able to throw errors which are validated a
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -2953,6 +2954,7 @@ test('preSerialization hook should be able to throw errors which are validated a
 test('preSerialization hook which returned error should still run onError hooks', t => {
   t.plan(4)
   const fastify = Fastify()
+  t.teardown(() => { fastify.close() })
 
   fastify.addHook('preSerialization', function (req, reply, payload, done) {
     done(new Error('preSerialization aborted'))
@@ -2969,7 +2971,6 @@ test('preSerialization hook which returned error should still run onError hooks'
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -2984,6 +2985,7 @@ test('preSerialization hook which returned error should still run onError hooks'
 test('preSerialization hooks should run in the order in which they are defined', t => {
   t.plan(5)
   const fastify = Fastify()
+  t.teardown(() => { fastify.close() })
 
   fastify.addHook('preSerialization', function (req, reply, payload, done) {
     payload.hello += '2'
@@ -3003,7 +3005,6 @@ test('preSerialization hooks should run in the order in which they are defined',
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -3020,6 +3021,7 @@ test('preSerialization hooks should run in the order in which they are defined',
 test('preSerialization hooks should support encapsulation', t => {
   t.plan(9)
   const fastify = Fastify()
+  t.teardown(() => { fastify.close() })
 
   fastify.addHook('preSerialization', function (req, reply, payload, done) {
     payload.hello += '1'
@@ -3047,7 +3049,6 @@ test('preSerialization hooks should support encapsulation', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    t.teardown(() => { fastify.close() })
 
     sget({
       method: 'GET',
@@ -3273,6 +3274,7 @@ test('reply.send should throw if undefined error is thrown at onSend hook', t =>
 test('onTimeout should be triggered', t => {
   t.plan(6)
   const fastify = Fastify({ connectionTimeout: 500 })
+  t.teardown(() => { fastify.close() })
 
   fastify.addHook('onTimeout', function (req, res, done) {
     t.ok('called', 'onTimeout')
@@ -3289,7 +3291,6 @@ test('onTimeout should be triggered', t => {
 
   fastify.listen({ port: 0 }, (err, address) => {
     t.error(err)
-    t.teardown(() => fastify.close())
 
     sget({
       method: 'GET',
@@ -3311,6 +3312,7 @@ test('onTimeout should be triggered', t => {
 test('onTimeout should be triggered and socket _meta is set', t => {
   t.plan(6)
   const fastify = Fastify({ connectionTimeout: 500 })
+  t.teardown(() => { fastify.close() })
 
   fastify.addHook('onTimeout', function (req, res, done) {
     t.ok('called', 'onTimeout')
@@ -3328,7 +3330,6 @@ test('onTimeout should be triggered and socket _meta is set', t => {
 
   fastify.listen({ port: 0 }, (err, address) => {
     t.error(err)
-    t.teardown(() => fastify.close())
 
     sget({
       method: 'GET',

--- a/test/post-empty-body.test.js
+++ b/test/post-empty-body.test.js
@@ -9,16 +9,18 @@ setGlobalDispatcher(new Agent({
   keepAliveMaxTimeout: 10
 }))
 
-test('post empty body', async t => {
-  const fastify = Fastify()
-  let abortController = new AbortController()
+test('post empty body', { timeout: 3_000 }, async t => {
+  const fastify = Fastify({ forceCloseConnections: true })
+  const abortController = new AbortController()
   const { signal } = abortController
   t.after(() => {
     fastify.close()
-    abortController?.abort()
+    abortController.abort()
   })
 
-  fastify.post('/bug', async (request, reply) => {})
+  fastify.post('/bug', async () => {
+    // This function must be async and return nothing
+  })
 
   await fastify.listen({ port: 0 })
 
@@ -30,7 +32,6 @@ test('post empty body', async t => {
     body: JSON.stringify({ foo: 'bar' }),
     signal
   })
-  abortController = null
 
   t.assert.strictEqual(res.statusCode, 200)
   t.assert.strictEqual(await res.body.text(), '')

--- a/test/post-empty-body.test.js
+++ b/test/post-empty-body.test.js
@@ -11,11 +11,11 @@ setGlobalDispatcher(new Agent({
 
 test('post empty body', async t => {
   const fastify = Fastify()
-  const abortController = new AbortController()
+  let abortController = new AbortController()
   const { signal } = abortController
   t.after(() => {
     fastify.close()
-    abortController.abort()
+    abortController?.abort()
   })
 
   fastify.post('/bug', async (request, reply) => {})
@@ -30,6 +30,7 @@ test('post empty body', async t => {
     body: JSON.stringify({ foo: 'bar' }),
     signal
   })
+  abortController = null
 
   t.assert.strictEqual(res.statusCode, 200)
   t.assert.strictEqual(await res.body.text(), '')

--- a/test/post-empty-body.test.js
+++ b/test/post-empty-body.test.js
@@ -24,7 +24,7 @@ test('post empty body', { timeout: 3_000 }, async t => {
 
   await fastify.listen({ port: 0 })
 
-  const res = await request(`http://127.0.0.1:${fastify.server.address().port}/bug`, {
+  const res = await request(`http://localhost:${fastify.server.address().port}/bug`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'


### PR DESCRIPTION
fixes our win coverage issue:

- https://github.com/fastify/fastify/actions/runs/12182503397/job/33981743111

```
Error: [Error [ERR_TEST_FAILURE]: connect ECONNREFUSED 127.0.0.1:50469] {
  code: 'ERR_TEST_FAILURE',
  failureType: 'testCodeFailure',
  cause: Error: connect ECONNREFUSED 127.0.0.1:50469
      at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1615:16) {
    errno: -4078,
    code: 'ECONNREFUSED',
    syscall: 'connect',
    address: '127.0.0.1',
    port: 50469
  }
}
FAILED: D:\a\fastify\fastify\test\post-empty-body.test.js
```