### PR TITLE
migrated content-length.test.js from tap to node:test

### DIFF
--- a/test/content-length.test.js
+++ b/test/content-length.test.js
@@ -1,49 +1,48 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test, after } = require('node:test')
+const assert = require('node:assert/strict')
 const Fastify = require('..')
 
-test('default 413 with bodyLimit option', t => {
-  t.plan(4)
-
+test('default 413 with bodyLimit option', async (t) => {
   const fastify = Fastify({
     bodyLimit: 10
   })
+
+  after(() => fastify.close())
 
   fastify.post('/', function (req, reply) {
     reply.send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'POST',
     url: '/',
     body: {
       text: '12345678901234567890123456789012345678901234567890'
     }
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 413)
-    t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-    t.same(JSON.parse(res.payload), {
-      error: 'Payload Too Large',
-      code: 'FST_ERR_CTP_BODY_TOO_LARGE',
-      message: 'Request body is too large',
-      statusCode: 413
-    })
+  })
+
+  assert.strictEqual(res.statusCode, 413)
+  assert.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+  assert.deepStrictEqual(JSON.parse(res.payload), {
+    error: 'Payload Too Large',
+    code: 'FST_ERR_CTP_BODY_TOO_LARGE',
+    message: 'Request body is too large',
+    statusCode: 413
   })
 })
 
-test('default 400 with wrong content-length', t => {
-  t.plan(4)
-
+test('default 400 with wrong content-length', async (t) => {
   const fastify = Fastify()
 
   fastify.post('/', function (req, reply) {
     reply.send({ hello: 'world' })
   })
 
-  fastify.inject({
+  after(() => fastify.close())
+
+  const res = await fastify.inject({
     method: 'POST',
     url: '/',
     headers: {
@@ -52,25 +51,24 @@ test('default 400 with wrong content-length', t => {
     body: {
       text: '12345678901234567890123456789012345678901234567890'
     }
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 400)
-    t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-    t.same(JSON.parse(res.payload), {
-      error: 'Bad Request',
-      code: 'FST_ERR_CTP_INVALID_CONTENT_LENGTH',
-      message: 'Request body size did not match Content-Length',
-      statusCode: 400
-    })
+  })
+
+  assert.strictEqual(res.statusCode, 400)
+  assert.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+  assert.deepStrictEqual(JSON.parse(res.payload), {
+    error: 'Bad Request',
+    code: 'FST_ERR_CTP_INVALID_CONTENT_LENGTH',
+    message: 'Request body size did not match Content-Length',
+    statusCode: 400
   })
 })
 
-test('custom 413 with bodyLimit option', t => {
-  t.plan(4)
-
+test('custom 413 with bodyLimit option', async (t) => {
   const fastify = Fastify({
     bodyLimit: 10
   })
+
+  after(() => fastify.close())
 
   fastify.post('/', function (req, reply) {
     reply.send({ hello: 'world' })
@@ -83,29 +81,28 @@ test('custom 413 with bodyLimit option', t => {
       .send(err)
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'POST',
     url: '/',
     body: {
       text: '12345678901234567890123456789012345678901234567890'
     }
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 413)
-    t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-    t.same(JSON.parse(res.payload), {
-      error: 'Payload Too Large',
-      code: 'FST_ERR_CTP_BODY_TOO_LARGE',
-      message: 'Request body is too large',
-      statusCode: 413
-    })
+  })
+
+  assert.strictEqual(res.statusCode, 413)
+  assert.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+  assert.deepStrictEqual(JSON.parse(res.payload), {
+    error: 'Payload Too Large',
+    code: 'FST_ERR_CTP_BODY_TOO_LARGE',
+    message: 'Request body is too large',
+    statusCode: 413
   })
 })
 
-test('custom 400 with wrong content-length', t => {
-  t.plan(4)
-
+test('custom 400 with wrong content-length', async (t) => {
   const fastify = Fastify()
+
+  after(() => fastify.close())
 
   fastify.post('/', function (req, reply) {
     reply.send({ hello: 'world' })
@@ -118,7 +115,7 @@ test('custom 400 with wrong content-length', t => {
       .send(err)
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'POST',
     url: '/',
     headers: {
@@ -127,21 +124,21 @@ test('custom 400 with wrong content-length', t => {
     body: {
       text: '12345678901234567890123456789012345678901234567890'
     }
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 400)
-    t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-    t.same(JSON.parse(res.payload), {
-      error: 'Bad Request',
-      code: 'FST_ERR_CTP_INVALID_CONTENT_LENGTH',
-      message: 'Request body size did not match Content-Length',
-      statusCode: 400
-    })
+  })
+  assert.strictEqual(res.statusCode, 400)
+  assert.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+  assert.deepStrictEqual(JSON.parse(res.payload), {
+    error: 'Bad Request',
+    code: 'FST_ERR_CTP_INVALID_CONTENT_LENGTH',
+    message: 'Request body size did not match Content-Length',
+    statusCode: 400
   })
 })
 
-test('#2214 - wrong content-length', t => {
+test('#2214 - wrong content-length', async (t) => {
   const fastify = Fastify()
+
+  after(() => fastify.close())
 
   fastify.get('/', async () => {
     const error = new Error('MY_ERROR_MESSAGE')
@@ -151,18 +148,17 @@ test('#2214 - wrong content-length', t => {
     throw error
   })
 
-  fastify.inject({
+  const response = await fastify.inject({
     method: 'GET',
     path: '/'
   })
-    .then(response => {
-      t.equal(response.headers['content-length'], '' + response.rawPayload.length)
-      t.end()
-    })
+  assert.strictEqual(response.headers['content-length'], '' + response.rawPayload.length)
 })
 
-test('#2543 - wrong content-length with errorHandler', t => {
+test('#2543 - wrong content-length with errorHandler', async (t) => {
   const fastify = Fastify()
+
+  after(() => fastify.close())
 
   fastify.setErrorHandler((_error, _request, reply) => {
     reply.code(500).send({ message: 'longer than 2 bytes' })
@@ -176,14 +172,12 @@ test('#2543 - wrong content-length with errorHandler', t => {
     throw error
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     path: '/'
   })
-    .then(res => {
-      t.equal(res.statusCode, 500)
-      t.equal(res.headers['content-length'], '' + res.rawPayload.length)
-      t.same(JSON.parse(res.payload), { message: 'longer than 2 bytes' })
-      t.end()
-    })
+
+  assert.strictEqual(res.statusCode, 500)
+  assert.strictEqual(res.headers['content-length'], '' + res.rawPayload.length)
+  assert.deepStrictEqual(JSON.parse(res.payload), { message: 'longer than 2 bytes' })
 })


### PR DESCRIPTION
<!--
By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This PR removes tap and uses node:test for content-length.test.js

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
