### PR TITLE
ci: pin node version 22.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [20, 22.11]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/coverage-win.yml
+++ b/.github/workflows/coverage-win.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 22.11
           cache: 'npm'
           cache-dependency-path: package.json
           check-latest: true


### PR DESCRIPTION
The current Windows CI is broken because the dns resolves in Windows is returning wrong values.
Refs: https://github.com/nodejs/node/issues/56137

This PR is pinning the `node@22` in `node@22.11` version. So, the revert can be made easily when https://github.com/nodejs/node/pull/56224 is landed in next release.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
