### PR TITLE
docs: Update informal contributing guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,7 +142,7 @@ pnpm-lock.yaml
 yarn.lock
 
 # editor files
-.vscode
+# .vscode
 .idea
 
 # tap files

--- a/.gitignore
+++ b/.gitignore
@@ -142,7 +142,7 @@ pnpm-lock.yaml
 yarn.lock
 
 # editor files
-# .vscode
+.vscode
 .idea
 
 # tap files

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+  "recommendations": ["dbaeumer.vscode-eslint"]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "[javascript]": {
+      "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+      "editor.codeActionsOnSave": {
+          "source.fixAll": "explicit"
+      }
+  },
+
+  "workbench.colorCustomizations": {
+      "statusBar.background": "#178bb9"
+  }
+}

--- a/docs/Guides/Contributing.md
+++ b/docs/Guides/Contributing.md
@@ -166,7 +166,7 @@ baseline settings that should be set before VSCode is ready.
 Press `cmd+shift+p` to bring up the VSCode command input prompt. Type `open
 settings (json)`. Three [VSCode Setting](https://code.visualstudio.com/docs/getstarted/settings)
 options will appear in the dropdown: Workspace, Default,
-and User settings. We recommend selecting Default. This will open a document
+and User settings. Choose Workspace or User (Default is not editable by default). This will open a document
 that is the settings for the editor. Paste the following JSON into this
 document, overwriting any text already present, and save it:
 
@@ -175,7 +175,7 @@ document, overwriting any text already present, and save it:
     "[javascript]": {
         "editor.defaultFormatter": "dbaeumer.vscode-eslint",
         "editor.codeActionsOnSave": {
-            "source.fixAll": true
+            "source.fixAll": "explicit"
         }
     },
 

--- a/docs/Guides/Contributing.md
+++ b/docs/Guides/Contributing.md
@@ -14,13 +14,12 @@ us.
 ## Table Of Contents
 <a id="contributing-toc"></a>
 
-- [Table Of Contents](#table-of-contents)
-- [Types Of Contributions We're Looking
-  For](#types-of-contributions-were-looking-for)
-- [Ground Rules & Expectations](#ground-rules--expectations)
-- [How To Contribute](#how-to-contribute)
-- [Setting Up Your Environment](#setting-up-your-environment)
-  - [Using Visual Studio Code](#using-visual-studio-code)
+- [Contributing To Fastify](#contributing-to-fastify)
+  - [Table Of Contents](#table-of-contents)
+  - [Types Of Contributions We're Looking For](#types-of-contributions-were-looking-for)
+  - [Ground Rules \& Expectations](#ground-rules--expectations)
+  - [How To Contribute](#how-to-contribute)
+  - [Setting Up Your Environment](#setting-up-your-environment)
 
 ## Types Of Contributions We're Looking For
 <a id="contribution-types"></a>
@@ -80,114 +79,6 @@ https://github.com/github/opensource.guide/blob/2868efbf0c14aec821909c19e210c360
 Please adhere to the project's code and documentation style. Some popular tools
 that automatically "correct" code and documentation do not follow a style that
 conforms to the styles this project uses. Notably, this project uses
-[StandardJS](https://standardjs.com) for code formatting.
+[Neostandard](https://github.com/neostandard/neostandard) for code formatting.
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/fastify/fastify)
-
-### Using Visual Studio Code
-<a id="contributing-vscode"></a>
-
-What follows is how to use [Visual Studio Code (VSCode)
-portable](https://code.visualstudio.com/docs/editor/portable) to create a
-Fastify specific environment. This guide is written as if you are setting up the
-environment on macOS, but the principles are the same across all platforms. See
-the previously linked VSCode portable guide for help with other platforms.
-
-First, [download VSCode](https://code.visualstudio.com/download) and unpackage
-it to `/Applications/VSCodeFastify/`. Upon doing so, the following should output
-"found" when run in a terminal:
-
-```sh
-[ -d /Applications/VSCodeFastify/Visual\ Studio\ Code.app ] && echo "found"
-```
-
-As mentioned in the VSCode portable guide, we need to unsandbox the application
-for the portable mode to work correctly. So issue the following in a terminal:
-
-```sh
-xattr -dr com.apple.quarantine /Applications/VSCodeFastify/Visual\ Studio\ Code.app
-```
-
-Next, create the required data directories for VSCode:
-
-```sh
-mkdir -p /Applications/VSCodeFastify/code-portable-data/{user-data,extensions}
-```
-
-Before continuing, we need to add the `code` command to your terminal's `PATH`.
-To do so, we will [manually add VSCode to the
-`PATH`](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line).
-As outlined in that document, the instructions vary depending on your default
-shell, so you should follow the instructions in that guide as relates to your
-preferred shell. However, we will tweak them slightly by defining an alias
-instead of a direct reference to the `code` tool. This is so we do not conflict
-with any other installation of VSCode you may have, and to keep this guide
-specific to Fastify. So, ultimately, we want the following:
-
-```sh
-alias code-fastify="/Applications/VSCodeFastify/Visual\ Studio\ Code.app/Contents/Resources/app/bin/code"
-```
-
-The result should be that `code-fastify --version` results in something like:
-
-```sh
-❯ code-fastify --version
-1.50.0
-93c2f0fbf16c5a4b10e4d5f89737d9c2c25488a3
-x64
-```
-
-Now that VSCode is installed, and we can work with it via the command line, we
-need to install an extension that will aid in keeping any JavaScript you write
-for the project formatted according to the project's style:
-
-```sh
-code-fastify --install-extension dbaeumer.vscode-eslint
-```
-
-Upon successful execution of the previous command, the following command should
-result in "found" being output:
-
-```sh
-[ -d /Applications/VSCodeFastify/code-portable-data/extensions/dbaeumer.vscode-eslint-* ] && echo "found"
-```
-
-Now, from within the directory of your local clone of the Fastify project, we
-can open VSCode:
-
-```sh
-code-fastify .
-```
-
-A new VSCode window should open and you should see the Fastify project files in
-the left sidebar. But wait! We are not quite done yet. There are a few more
-baseline settings that should be set before VSCode is ready.
-
-Press `cmd+shift+p` to bring up the VSCode command input prompt. Type `open
-settings (json)`. Three [VSCode Setting](https://code.visualstudio.com/docs/getstarted/settings)
-options will appear in the dropdown: Workspace, Default,
-and User settings. Choose Workspace or User (Default is not editable by default). This will open a document
-that is the settings for the editor. Paste the following JSON into this
-document, overwriting any text already present, and save it:
-
-```json
-{
-    "[javascript]": {
-        "editor.defaultFormatter": "dbaeumer.vscode-eslint",
-        "editor.codeActionsOnSave": {
-            "source.fixAll": "explicit"
-        }
-    },
-
-    "workbench.colorCustomizations": {
-        "statusBar.background": "#178bb9"
-    }
-}
-```
-
-Finally, from the menu bar, select "Terminal > New Terminal" to open a new terminal
-in the editor. Run `npm i` to install the Fastify dependencies.
-
-At this point, you are all setup with a custom VSCode instance that can be used
-to work on Fastify contributions. As you edit and save JavaScript files, the
-editor will autocorrect any style issues.


### PR DESCRIPTION
Hi!
I want to start contributing to the project, so I've been following the [informal contributing guide](https://github.com/fastify/fastify/blob/main/docs/Guides/Contributing.md), and I've found it's outdated.

Changes proposed in this PR:

- Add `.vscode/settings.json`, including the recommended settings
- Add `.vscode/extensions.json`, including `dbaeumer.vscode-eslint` in the "recommendations" array
- Get rid of the "Using Visual Studio Code" section
- Updated reference to Neostandard, instead of StandardJS

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
