### PR TITLE
docs(ecosystem): update apitally description

### DIFF
--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -218,9 +218,9 @@ section.
   Beautiful OpenAPI/Swagger API references for Fastify
 - [`@trubavuong/fastify-seaweedfs`](https://github.com/trubavuong/fastify-seaweedfs)
   SeaweedFS for Fastify
-- [`apitally`](https://github.com/apitally/nodejs-client) Fastify plugin to
-  integrate with [Apitally](https://apitally.io), a simple API monitoring &
-  API key management solution.
+- [`apitally`](https://github.com/apitally/apitally-js) Fastify plugin to
+  integrate with [Apitally](https://apitally.io/fastify), an API analytics,
+  logging and monitoring tool.
 - [`arecibo`](https://github.com/nucleode/arecibo) Fastify ping responder for
   Kubernetes Liveness and Readiness Probes.
 - [`aws-xray-sdk-fastify`](https://github.com/aws/aws-xray-sdk-node/tree/master/sdk_contrib/fastify)


### PR DESCRIPTION
Updates the description for Apitally, a community plugin listed on the Ecosystem page in the docs. This is to reflect how Apitally has evolved since it was first added.