### PR TITLE
fix: crash when host header is missing by various of reason

### DIFF
--- a/docs/Reference/Request.md
+++ b/docs/Reference/Request.md
@@ -23,10 +23,13 @@ Request is a core Fastify object containing the following fields:
 - `host` - the host of the incoming request (derived from `X-Forwarded-Host`
   header when the [`trustProxy`](./Server.md#factory-trust-proxy) option is
   enabled). For HTTP/2 compatibility it returns `:authority` if no host header
-  exists. When you use `requireHostHeader = false` in the server options, it
-  will fallback as empty when the host header is missing.
-- `hostname` - the host of the incoming request without the port
-- `port` - the port that the server is listening on
+  exists. The host header may return empty string when using
+  `requireHostHeader = false`, not suppied when connected with `HTTP/1.0` or
+  using schema validation that remove the extra headers.
+- `hostname` - the host of the `host` property, it may refers the incoming
+  request hostname
+- `port` - the port of the `host` property, it may refers the port thats
+  the server is listening on
 - `protocol` - the protocol of the incoming request (`https` or `http`)
 - `method` - the method of the incoming request
 - `url` - the URL of the incoming request
@@ -84,6 +87,9 @@ request's headers with the `request.raw.headers` property.
 
 > Note: For performance reason on `not found` route, you may see that we will
 add an extra property `Symbol('fastify.RequestAcceptVersion')` on the headers.
+
+> Note: When using schema, it may mutate the `request.headers` and
+`request.raw.headers` object. So, you may found the headers becomes empty.
 
 ```js
 fastify.post('/:params', options, function (request, reply) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -117,10 +117,11 @@ function buildRequestWithTrustProxy (R, trustProxy) {
         if (this.ip !== undefined && this.headers['x-forwarded-host']) {
           return getLastEntryInMultiHeaderValue(this.headers['x-forwarded-host'])
         }
-        let host = this.headers.host ?? this.headers[':authority']
-        // support http.requireHostHeader === false
-        if (this.server.server.requireHostHeader === false) host ??= ''
-        return host
+        // the last fallback is used to support the following cases:
+        // 1. support http.requireHostHeader === false
+        // 2. support HTTP/1.0 without Host Header
+        // 3. support headers schema which may remove the Host Header
+        return this.headers.host ?? this.headers[':authority'] ?? ''
       }
     },
     protocol: {
@@ -212,10 +213,11 @@ Object.defineProperties(Request.prototype, {
   },
   host: {
     get () {
-      let host = this.raw.headers.host ?? this.raw.headers[':authority']
-      // support http.requireHostHeader === false
-      if (this.server.server.requireHostHeader === false) host ??= ''
-      return host
+      // the last fallback is used to support the following cases:
+      // 1. support http.requireHostHeader === false
+      // 2. support HTTP/1.0 without Host Header
+      // 3. support headers schema which may remove the Host Header
+      return this.raw.headers.host ?? this.raw.headers[':authority'] ?? ''
     }
   },
   hostname: {
@@ -231,8 +233,7 @@ Object.defineProperties(Request.prototype, {
         return portFromHost
       }
       // now fall back to port from host/:authority header
-      let host = (this.headers.host ?? this.headers[':authority'])
-      if (this.server.server.requireHostHeader === false) host ??= ''
+      const host = (this.headers.host ?? this.headers[':authority'] ?? '')
       const portFromHeader = parseInt(host.split(':').slice(-1)[0])
       if (!isNaN(portFromHeader)) {
         return portFromHeader

--- a/test/request-header-host.test.js
+++ b/test/request-header-host.test.js
@@ -195,3 +195,145 @@ test('Return 200 when Host header is missing and http.requireHostHeader = false 
     })
   })
 })
+
+test('Return 200 when Host header is missing using HTTP/1.0', (t, done) => {
+  t.plan(5)
+  let data = Buffer.alloc(0)
+  const fastify = Fastify({
+    keepAliveTimeout: 10
+  })
+
+  t.after(() => fastify.close())
+
+  fastify.get('/', async function (request) {
+    t.assert.strictEqual(request.host, '')
+    t.assert.strictEqual(request.hostname, '')
+    t.assert.strictEqual(request.port, null)
+    return { ok: true }
+  })
+  fastify.listen({ port: 0 }, err => {
+    t.assert.ifError(err)
+
+    const socket = connect(fastify.server.address().port)
+    socket.write('GET / HTTP/1.0\r\n\r\n')
+    socket.on('data', c => (data = Buffer.concat([data, c])))
+    socket.on('end', () => {
+      t.assert.match(
+        data.toString('utf-8'),
+        /^HTTP\/1.1 200 OK/
+      )
+      done()
+    })
+  })
+})
+
+test('Return 200 when Host header is missing with trust proxy using HTTP/1.0', (t, done) => {
+  t.plan(5)
+  let data = Buffer.alloc(0)
+  const fastify = Fastify({
+    trustProxy: true,
+    keepAliveTimeout: 10
+  })
+
+  t.after(() => fastify.close())
+
+  fastify.get('/', async function (request) {
+    t.assert.strictEqual(request.host, '')
+    t.assert.strictEqual(request.hostname, '')
+    t.assert.strictEqual(request.port, null)
+    return { ok: true }
+  })
+  fastify.listen({ port: 0 }, err => {
+    t.assert.ifError(err)
+
+    const socket = connect(fastify.server.address().port)
+    socket.write('GET / HTTP/1.0\r\n\r\n')
+    socket.on('data', c => (data = Buffer.concat([data, c])))
+    socket.on('end', () => {
+      t.assert.match(
+        data.toString('utf-8'),
+        /^HTTP\/1.1 200 OK/
+      )
+      done()
+    })
+  })
+})
+
+test('Return 200 when Host header is removed by schema', (t, done) => {
+  t.plan(5)
+  let data = Buffer.alloc(0)
+  const fastify = Fastify({
+    keepAliveTimeout: 10
+  })
+
+  t.after(() => fastify.close())
+
+  fastify.get('/', {
+    schema: {
+      headers: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false
+      }
+    }
+  }, async function (request) {
+    t.assert.strictEqual(request.host, '')
+    t.assert.strictEqual(request.hostname, '')
+    t.assert.strictEqual(request.port, null)
+    return { ok: true }
+  })
+  fastify.listen({ port: 0 }, err => {
+    t.assert.ifError(err)
+
+    const socket = connect(fastify.server.address().port)
+    socket.write('GET / HTTP/1.1\r\nHost: localhost\r\n\r\n')
+    socket.on('data', c => (data = Buffer.concat([data, c])))
+    socket.on('end', () => {
+      t.assert.match(
+        data.toString('utf-8'),
+        /^HTTP\/1.1 200 OK/
+      )
+      done()
+    })
+  })
+})
+
+test('Return 200 when Host header is removed by schema with trust proxy', (t, done) => {
+  t.plan(5)
+  let data = Buffer.alloc(0)
+  const fastify = Fastify({
+    trustProxy: true,
+    keepAliveTimeout: 10
+  })
+
+  t.after(() => fastify.close())
+
+  fastify.get('/', {
+    schema: {
+      headers: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false
+      }
+    }
+  }, async function (request) {
+    t.assert.strictEqual(request.host, '')
+    t.assert.strictEqual(request.hostname, '')
+    t.assert.strictEqual(request.port, null)
+    return { ok: true }
+  })
+  fastify.listen({ port: 0 }, err => {
+    t.assert.ifError(err)
+
+    const socket = connect(fastify.server.address().port)
+    socket.write('GET / HTTP/1.1\r\nHost: localhost\r\n\r\n')
+    socket.on('data', c => (data = Buffer.concat([data, c])))
+    socket.on('end', () => {
+      t.assert.match(
+        data.toString('utf-8'),
+        /^HTTP\/1.1 200 OK/
+      )
+      done()
+    })
+  })
+})


### PR DESCRIPTION
Fixes #5841

Since there's so many reason the Host header can be missing.
I would just simplify the logic as always fallback to empty string.

The document is updated to explain `hostname` and `port` is always depends on the `host` property.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
