### PR TITLE
test: migrated custom-parser.2.test.js from tap to node:test

### DIFF
--- a/test/custom-parser.2.test.js
+++ b/test/custom-parser.2.test.js
@@ -2,7 +2,7 @@
 
 const { test } = require('node:test')
 const sget = require('simple-get').concat
-const Fastify = require('../fastify')
+const Fastify = require('..')
 const { getServerUrl } = require('./helper')
 
 process.removeAllListeners('warning')

--- a/test/custom-parser.2.test.js
+++ b/test/custom-parser.2.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const sget = require('simple-get').concat
 const Fastify = require('../fastify')
 const { getServerUrl } = require('./helper')
@@ -14,17 +13,17 @@ test('Wrong parseAs parameter', t => {
 
   try {
     fastify.addContentTypeParser('application/json', { parseAs: 'fireworks' }, () => {})
-    t.fail('should throw')
+    t.assert.fail('should throw')
   } catch (err) {
-    t.equal(err.code, 'FST_ERR_CTP_INVALID_PARSE_TYPE')
-    t.equal(err.message, "The body parser can only parse your data as 'string' or 'buffer', you asked 'fireworks' which is not supported.")
+    t.assert.strictEqual(err.code, 'FST_ERR_CTP_INVALID_PARSE_TYPE')
+    t.assert.strictEqual(err.message, "The body parser can only parse your data as 'string' or 'buffer', you asked 'fireworks' which is not supported.")
   }
 })
 
-test('Should allow defining the bodyLimit per parser', t => {
+test('Should allow defining the bodyLimit per parser', (t, done) => {
   t.plan(3)
   const fastify = Fastify()
-  t.teardown(() => fastify.close())
+  t.after(() => fastify.close())
 
   fastify.post('/', (req, reply) => {
     reply.send(req.body)
@@ -34,13 +33,13 @@ test('Should allow defining the bodyLimit per parser', t => {
     'x/foo',
     { parseAs: 'string', bodyLimit: 5 },
     function (req, body, done) {
-      t.fail('should not be invoked')
+      t.assert.fail('should not be invoked')
       done()
     }
   )
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -50,22 +49,22 @@ test('Should allow defining the bodyLimit per parser', t => {
         'Content-Type': 'x/foo'
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.strictSame(JSON.parse(body.toString()), {
+      t.assert.ifError(err)
+      t.assert.deepStrictEqual(JSON.parse(body.toString()), {
         statusCode: 413,
         code: 'FST_ERR_CTP_BODY_TOO_LARGE',
         error: 'Payload Too Large',
         message: 'Request body is too large'
       })
-      fastify.close()
+      done()
     })
   })
 })
 
-test('route bodyLimit should take precedence over a custom parser bodyLimit', t => {
+test('route bodyLimit should take precedence over a custom parser bodyLimit', (t, done) => {
   t.plan(3)
   const fastify = Fastify()
-  t.teardown(() => fastify.close())
+  t.after(() => fastify.close())
 
   fastify.post('/', { bodyLimit: 5 }, (request, reply) => {
     reply.send(request.body)
@@ -75,13 +74,13 @@ test('route bodyLimit should take precedence over a custom parser bodyLimit', t 
     'x/foo',
     { parseAs: 'string', bodyLimit: 100 },
     function (req, body, done) {
-      t.fail('should not be invoked')
+      t.assert.fail('should not be invoked')
       done()
     }
   )
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -89,14 +88,14 @@ test('route bodyLimit should take precedence over a custom parser bodyLimit', t 
       body: '1234567890',
       headers: { 'Content-Type': 'x/foo' }
     }, (err, response, body) => {
-      t.error(err)
-      t.strictSame(JSON.parse(body.toString()), {
+      t.assert.ifError(err)
+      t.assert.deepStrictEqual(JSON.parse(body.toString()), {
         statusCode: 413,
         code: 'FST_ERR_CTP_BODY_TOO_LARGE',
         error: 'Payload Too Large',
         message: 'Request body is too large'
       })
-      fastify.close()
+      done()
     })
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


Proposal:

 - migrated `custom-parser.2.test.js` from `tap` to `node:test` 🔥
