### PR TITLE
test: migrated route-shorthand.test.js from tap to node:test

### DIFF
--- a/test/route-shorthand.test.js
+++ b/test/route-shorthand.test.js
@@ -1,62 +1,66 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const sget = require('simple-get').concat
-const Fastify = require('../fastify')
+const Fastify = require('..')
 
-test('route-shorthand', t => {
+test('route-shorthand', async (t) => {
   const methodsReader = new Fastify()
   const supportedMethods = methodsReader.supportedMethods
 
-  t.plan(supportedMethods.length + 1)
-  const test = t.test
-
   for (const method of supportedMethods) {
-    test(`route-shorthand - ${method.toLowerCase()}`, t => {
-      t.plan(3)
+    await t.test(`route-shorthand - ${method.toLowerCase()}`, async (t) => {
+      t.plan(2)
       const fastify = new Fastify()
-      fastify[method.toLowerCase()]('/', function (req, reply) {
-        t.equal(req.method, method)
+      fastify[method.toLowerCase()]('/', (req, reply) => {
+        t.assert.strictEqual(req.method, method)
         reply.send()
       })
-      fastify.listen({ port: 0 }, function (err) {
-        if (err) t.error(err)
-        t.teardown(() => { fastify.close() })
+      await fastify.listen({ port: 0 })
+      t.after(() => fastify.close())
+
+      await new Promise((resolve, reject) => {
         sget({
           method,
-          url: 'http://localhost:' + fastify.server.address().port
+          url: `http://localhost:${fastify.server.address().port}`
         }, (err, response, body) => {
-          t.error(err)
-          t.equal(response.statusCode, 200)
+          if (err) {
+            t.assert.ifError(err)
+            return reject(err)
+          }
+          t.assert.strictEqual(response.statusCode, 200)
+          resolve()
         })
       })
     })
   }
 
-  test('route-shorthand - all', t => {
-    t.plan(3 * supportedMethods.length)
+  await t.test('route-shorthand - all', async (t) => {
+    t.plan(2 * supportedMethods.length)
     const fastify = new Fastify()
     let currentMethod = ''
     fastify.all('/', function (req, reply) {
-      t.equal(req.method, currentMethod)
+      t.assert.strictEqual(req.method, currentMethod)
       reply.send()
     })
-    fastify.listen({ port: 0 }, async function (err) {
-      if (err) t.error(err)
-      t.teardown(() => { fastify.close() })
-      for (const method of supportedMethods) {
-        currentMethod = method
-        await new Promise(resolve => sget({
+    await fastify.listen({ port: 0 })
+    t.after(() => fastify.close())
+
+    for (const method of supportedMethods) {
+      currentMethod = method
+      await new Promise((resolve, reject) => {
+        sget({
           method,
-          url: 'http://localhost:' + fastify.server.address().port
+          url: `http://localhost:${fastify.server.address().port}`
         }, (err, response, body) => {
-          t.error(err)
-          t.equal(response.statusCode, 200)
+          if (err) {
+            t.assert.ifError(err)
+            return reject(err)
+          }
+          t.assert.strictEqual(response.statusCode, 200)
           resolve()
         })
-        )
-      }
-    })
+      })
+    }
   })
 })

--- a/test/route-shorthand.test.js
+++ b/test/route-shorthand.test.js
@@ -1,15 +1,15 @@
 'use strict'
 
-const { test } = require('node:test')
+const { describe, test } = require('node:test')
 const sget = require('simple-get').concat
 const Fastify = require('..')
 
-test('route-shorthand', async (t) => {
+describe('route-shorthand', () => {
   const methodsReader = new Fastify()
   const supportedMethods = methodsReader.supportedMethods
 
   for (const method of supportedMethods) {
-    await t.test(`route-shorthand - ${method.toLowerCase()}`, async (t) => {
+    test(`route-shorthand - ${method.toLowerCase()}`, async (t) => {
       t.plan(2)
       const fastify = new Fastify()
       fastify[method.toLowerCase()]('/', (req, reply) => {
@@ -35,7 +35,7 @@ test('route-shorthand', async (t) => {
     })
   }
 
-  await t.test('route-shorthand - all', async (t) => {
+  test('route-shorthand - all', async (t) => {
     t.plan(2 * supportedMethods.length)
     const fastify = new Fastify()
     let currentMethod = ''


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Proposal:

  - migrated `route-shorthand.test.js` from `tap` to `node:test` 🔥
