### PR TITLE
fix(linting): fix linting error in error-handler.js

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -110,18 +110,20 @@ function fallbackErrorHandler (error, reply, cb) {
   let payload
   try {
     const serializerFn = getSchemaSerializer(reply[kRouteContext], statusCode, reply[kReplyHeaders]['content-type'])
-    payload = (serializerFn === false)
-      ? serializeError({
-          error: statusCodes[statusCode + ''],
-          code: error.code,
-          message: error.message,
-          statusCode
-        })
-      : serializerFn(Object.create(error, {
-          error: { value: statusCodes[statusCode + ''] },
-          message: { value: error.message },
-          statusCode: { value: statusCode }
-        }))
+    if (serializerFn === false) {
+      payload = serializeError({
+        error: statusCodes[statusCode + ''],
+        code: error.code,
+        message: error.message,
+        statusCode
+      })
+    } else {
+      payload = serializerFn(Object.create(error, {
+        error: { value: statusCodes[statusCode + ''] },
+        message: { value: error.message },
+        statusCode: { value: statusCode }
+      }))
+    }
   } catch (err) {
     if (!reply.log[kDisableRequestLogging]) {
       // error is always FST_ERR_SCH_SERIALIZATION_BUILD because this is called from route/compileSchemasForSerialization


### PR DESCRIPTION
annoyingly linting issues in upstream of neostandard makes our ci fail.

@voxpelli did try to fix this by pinning a dep in #5924 , but this didnt fix it apparantly