### PR TITLE
build(dependabot): regroup dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,23 @@ updates:
         dependency-type: "production"
         update-types:
         - "major"
+      # ESLint related dependencies
+      dev-dependencies-eslint:
+        patterns:
+          - "eslint"
+          - "neostandard"
+          - "@stylistic/*"
+      # TypeScript related dependencies
+      dev-dependencies-typescript:
+        patterns:
+          - "@types/*"
+          - "tsd"
+          - "typescript"
+      # Ajv related dependencies
+      dev-dependencies-ajv:
+        patterns:
+          - "ajv"
+          - "ajv-*"
     ignore:
         - dependency-name: tap
           update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,9 +29,6 @@ updates:
         dependency-type: "production"
         update-types:
         - "major"
-      # Development dependencies
-      dev-dependencies:
-        dependency-type: "development"
     ignore:
         - dependency-name: tap
           update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Copied from https://github.com/fastify/fastify/pull/5924#issuecomment-2577093391

I don't think we should have grouped unrelated dev dependencies in this repo for Dependabot updates. One breaks and it blocks the rest.

It makes sense to group packages that depend on each other like Eslint with any Eslint plugins, but not this.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist


- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
