### PR TITLE
fix: don't check for payload type in default json parser

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -304,7 +304,7 @@ function getDefaultJsonParser (onProtoPoisoning, onConstructorPoisoning) {
   return defaultJsonParser
 
   function defaultJsonParser (req, body, done) {
-    if (body == null || body.length === 0) {
+    if (body.length === 0) {
       return done(new FST_ERR_CTP_EMPTY_JSON_BODY(), undefined)
     }
     try {

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -2,7 +2,7 @@
 
 const { AsyncResource } = require('node:async_hooks')
 const { FifoMap: Fifo } = require('toad-cache')
-const secureJson = require('secure-json-parse')
+const { parse: secureJsonParse } = require('secure-json-parse')
 const {
   kDefaultJsonParse,
   kContentTypeParser,
@@ -304,17 +304,15 @@ function getDefaultJsonParser (onProtoPoisoning, onConstructorPoisoning) {
   return defaultJsonParser
 
   function defaultJsonParser (req, body, done) {
-    if (body === '' || body == null || (Buffer.isBuffer(body) && body.length === 0)) {
+    if (body == null || body.length === 0) {
       return done(new FST_ERR_CTP_EMPTY_JSON_BODY(), undefined)
     }
-    let json
     try {
-      json = secureJson.parse(body, { protoAction: onProtoPoisoning, constructorAction: onConstructorPoisoning })
+      done(null, secureJsonParse(body, { protoAction: onProtoPoisoning, constructorAction: onConstructorPoisoning }))
     } catch (err) {
       err.statusCode = 400
       return done(err, undefined)
     }
-    done(null, json)
   }
 }
 

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -311,7 +311,7 @@ function getDefaultJsonParser (onProtoPoisoning, onConstructorPoisoning) {
       done(null, secureJsonParse(body, { protoAction: onProtoPoisoning, constructorAction: onConstructorPoisoning }))
     } catch (err) {
       err.statusCode = 400
-      return done(err, undefined)
+      done(err, undefined)
     }
   }
 }


### PR DESCRIPTION
While looking at https://github.com/fastify/fastify/pull/5925, I realized we might be doing more payload validation than necessary

We set the default parsers with [`asString = true`](https://github.com/fastify/fastify/blob/36c38bc5ae250a52c8aa953c38919f599db4683b/lib/contentTypeParser.js#L35-L36), so the `body` will already be a string once it reaches the default json parser and we don't need the `== null`, `Buffer.isBuffer`, etc.