### PR TITLE
docs: Include req.hostname change in upgrade guide

### DIFF
--- a/docs/Guides/Migration-Guide-V5.md
+++ b/docs/Guides/Migration-Guide-V5.md
@@ -528,7 +528,7 @@ fastify.register(function (instance, opts, done) {
 
 In Fastify v4, `req.hostname` would include both the hostname and the
 server’s port, so locally it might have the value `localhost:1234`.
-With v5, we are aligned to the Node.js URL object and include `host`, `hostname`,
+With v5, we aligned to the Node.js URL object and now include `host`, `hostname`,
 and `port` properties. `req.host` has the same value as `req.hostname` did in v4,
 while `req.hostname` includes the hostname _without_ a port if a port is present,
 and `req.port` contains just the port number.

--- a/docs/Guides/Migration-Guide-V5.md
+++ b/docs/Guides/Migration-Guide-V5.md
@@ -526,7 +526,7 @@ fastify.register(function (instance, opts, done) {
 
 ### Requests now have `host`, `hostname`, and `port`, and `hostname` no longer includes the port number
 
-In Fastify 4, `req.hostname` would include both the hostname and the
+In Fastify v4, `req.hostname` would include both the hostname and the
 server’s port, so locally it might have the value `localhost:1234`.
 With v5, we are aligned to the Node.js URL object and include `host`, `hostname`,
 and `port` properties. `req.host` has the same value as `req.hostname` did in v4,

--- a/docs/Guides/Migration-Guide-V5.md
+++ b/docs/Guides/Migration-Guide-V5.md
@@ -524,6 +524,17 @@ fastify.register(function (instance, opts, done) {
 });
 ```
 
+### Requests now have `host`, `hostname`, and `port`, and `hostname` no longer includes the port number
+
+In Fastify 4, `req.hostname` would include both the hostname and the
+server’s port, so locally it might have the value `localhost:1234`.
+With v5, we are aligned to the Node.js URL object and include `host`, `hostname`,
+and `port` properties. `req.host` has the same value as `req.hostname` did in v4,
+while `req.hostname` includes the hostname _without_ a port if a port is present,
+and `req.port` contains just the port number.
+See [#4766](https://github.com/fastify/fastify/pull/4766)
+and [#4682](https://github.com/fastify/fastify/issues/4682) for more information.
+
 ### Removes `getDefaultRoute` and `setDefaultRoute` methods
 
 The `getDefaultRoute` and `setDefaultRoute` methods have been removed in v5.


### PR DESCRIPTION
This wasn't included in the guide, but is a fairly important breaking change for applications that were using `req. hostname`.


#### Checklist

- ~~run `npm run test` and `npm run benchmark`~~
- ~~tests and/or benchmarks are included~~
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
