### PR TITLE
chore: don't return the `done` function

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -305,7 +305,8 @@ function getDefaultJsonParser (onProtoPoisoning, onConstructorPoisoning) {
 
   function defaultJsonParser (req, body, done) {
     if (body.length === 0) {
-      return done(new FST_ERR_CTP_EMPTY_JSON_BODY(), undefined)
+      done(new FST_ERR_CTP_EMPTY_JSON_BODY(), undefined)
+      return
     }
     try {
       done(null, secureJsonParse(body, { protoAction: onProtoPoisoning, constructorAction: onConstructorPoisoning }))

--- a/lib/headRoute.js
+++ b/lib/headRoute.js
@@ -3,7 +3,8 @@ function headRouteOnSendHandler (req, reply, payload, done) {
   // If payload is undefined
   if (payload === undefined) {
     reply.header('content-length', '0')
-    return done(null, null)
+    done(null, null)
+    return
   }
 
   if (typeof payload.resume === 'function') {
@@ -11,7 +12,8 @@ function headRouteOnSendHandler (req, reply, payload, done) {
       reply.log.error({ err }, 'Error on Stream found for HEAD route')
     })
     payload.resume()
-    return done(null, null)
+    done(null, null)
+    return
   }
 
   const size = '' + Buffer.byteLength(payload)

--- a/lib/pluginUtils.js
+++ b/lib/pluginUtils.js
@@ -106,7 +106,7 @@ function _checkDecorators (that, instance, decorators, name) {
 
 function checkVersion (fn) {
   const meta = getMeta(fn)
-  if (meta == null || meta?.fastify == null) return
+  if (meta?.fastify == null) return
 
   const requiredVersion = meta.fastify
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -119,7 +119,7 @@ function validateParam (validatorFunction, request, paramName) {
   const isUndefined = request[paramName] === undefined
   const ret = validatorFunction && validatorFunction(isUndefined ? null : request[paramName])
 
-  if (ret?.then) {
+  if (typeof ret?.then === 'function') {
     return ret
       .then((res) => { return answer(res) })
       .catch(err => { return err }) // return as simple error (not throw)

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -119,7 +119,7 @@ function validateParam (validatorFunction, request, paramName) {
   const isUndefined = request[paramName] === undefined
   const ret = validatorFunction && validatorFunction(isUndefined ? null : request[paramName])
 
-  if (typeof ret?.then === 'function') {
+  if (ret?.then) {
     return ret
       .then((res) => { return answer(res) })
       .catch(err => { return err }) // return as simple error (not throw)


### PR DESCRIPTION
It's a small thing but we're never interested in what `done` returns and in most of the codebase we use:

```js
done()
return
```

For brevity, I've updated the remaining parts to also return directly and not return `done`