### PR TITLE
chore: simplify thenable checks

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -294,7 +294,7 @@ function rawBody (request, reply, options, parser, done) {
     }
 
     const result = parser.fn(request, body, done)
-    if (result && typeof result.then === 'function') {
+    if (typeof result?.then === 'function') {
       result.then(body => done(null, body), done)
     }
   }

--- a/lib/handleRequest.js
+++ b/lib/handleRequest.js
@@ -87,7 +87,7 @@ function preValidationCallback (err, request, reply) {
   }
 
   const validationErr = validateSchema(reply[kRouteContext], request)
-  const isAsync = (validationErr && typeof validationErr.then === 'function') || false
+  const isAsync = typeof validationErr?.then === 'function'
 
   if (isAsync) {
     const cb = validationCompleted.bind(null, request, reply)

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -167,7 +167,7 @@ function hookRunnerApplication (hookName, boot, server, cb) {
 
       try {
         const ret = fn.call(server)
-        if (ret && typeof ret.then === 'function') {
+        if (typeof ret?.then === 'function') {
           ret.then(done, done)
           return
         }
@@ -216,7 +216,7 @@ function onListenHookRunner (server) {
     }
     try {
       const ret = fn.call(server)
-      if (ret && typeof ret.then === 'function') {
+      if (typeof ret?.then === 'function') {
         ret.then(done, done)
         return
       }
@@ -244,7 +244,7 @@ function hookRunnerGenerator (iterator) {
         cb(error, request, reply)
         return
       }
-      if (result && typeof result.then === 'function') {
+      if (typeof result?.then === 'function') {
         result.then(handleResolve, handleReject)
       }
     }
@@ -300,7 +300,7 @@ function onSendHookRunner (functions, request, reply, payload, cb) {
       cb(error, request, reply)
       return
     }
-    if (result && typeof result.then === 'function') {
+    if (typeof result?.then === 'function') {
       result.then(handleResolve, handleReject)
     }
   }
@@ -347,7 +347,7 @@ function preParsingHookRunner (functions, request, reply, cb) {
       return
     }
 
-    if (result && typeof result.then === 'function') {
+    if (typeof result?.then === 'function') {
       result.then(handleResolve, handleReject)
     }
   }
@@ -383,7 +383,7 @@ function onRequestAbortHookRunner (functions, request, cb) {
       cb(error, request)
       return
     }
-    if (result && typeof result.then === 'function') {
+    if (typeof result?.then === 'function') {
       result.then(handleResolve, handleReject)
     }
   }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -777,7 +777,7 @@ function sendTrailer (payload, res, reply) {
     }
 
     const result = reply[kReplyTrailers][trailerName](reply, payload, cb)
-    if (typeof result === 'object' && typeof result.then === 'function') {
+    if (typeof result?.then === 'function') {
       result.then((v) => cb(null, v), cb)
     }
   }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -119,7 +119,7 @@ function validateParam (validatorFunction, request, paramName) {
   const isUndefined = request[paramName] === undefined
   const ret = validatorFunction && validatorFunction(isUndefined ? null : request[paramName])
 
-  if (ret?.then) {
+  if (typeof ret?.then === 'function') {
     return ret
       .then((res) => { return answer(res) })
       .catch(err => { return err }) // return as simple error (not throw)

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -117,7 +117,7 @@ function compileSchemasForValidation (context, compile, isCustom) {
 
 function validateParam (validatorFunction, request, paramName) {
   const isUndefined = request[paramName] === undefined
-  const ret = validatorFunction && validatorFunction(isUndefined ? null : request[paramName])
+  const ret = validatorFunction?.(isUndefined ? null : request[paramName])
 
   if (typeof ret?.then === 'function') {
     return ret


### PR DESCRIPTION
Another small convention inconsistency, the PR simplifies the rest of the thenable checks by always using the optional chaining to check for the existence of `.then` functions