### PR TITLE
perf: don't use optional chaining for typeof .then checks

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -197,7 +197,7 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
   } else {
     const result = parser.fn(request, request[kRequestPayloadStream], done)
 
-    if (typeof result?.then === 'function') {
+    if (result && typeof result.then === 'function') {
       result.then(body => done(null, body), done)
     }
   }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -119,7 +119,7 @@ function validateParam (validatorFunction, request, paramName) {
   const isUndefined = request[paramName] === undefined
   const ret = validatorFunction && validatorFunction(isUndefined ? null : request[paramName])
 
-  if (ret?.then) {
+  if (ret && typeof ret.then === 'function') {
     return ret
       .then((res) => { return answer(res) })
       .catch(err => { return err }) // return as simple error (not throw)


### PR DESCRIPTION
@mcollina came to the rescue

Let's not mix `result && typeof result.then === 'function'` and `typeof result?.then === 'function'` in the codebase as the former is still faster