### PR TITLE
test: migrated genReqId.test.js from tap to node:test

### DIFF
--- a/test/genReqId.test.js
+++ b/test/genReqId.test.js
@@ -1,11 +1,11 @@
 'use strict'
 
 const { Readable } = require('node:stream')
-const { test } = require('tap')
+const { test } = require('node:test')
 const fp = require('fastify-plugin')
 const Fastify = require('..')
 
-test('Should accept a custom genReqId function', t => {
+test('Should accept a custom genReqId function', (t, done) => {
   t.plan(4)
 
   const fastify = Fastify({
@@ -14,62 +14,64 @@ test('Should accept a custom genReqId function', t => {
     }
   })
 
+  t.after(() => fastify.close())
   fastify.get('/', (req, reply) => {
-    t.ok(req.id)
+    t.assert.ok(req.id)
     reply.send({ id: req.id })
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
     fastify.inject({
       method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port
+      url: `http://localhost:${fastify.server.address().port}`
     }, (err, res) => {
-      t.error(err)
+      t.assert.ifError(err)
       const payload = JSON.parse(res.payload)
-      t.equal(payload.id, 'a')
-      fastify.close()
+      t.assert.strictEqual(payload.id, 'a')
+      done()
     })
   })
 })
 
-test('Custom genReqId function gets raw request as argument', t => {
+test('Custom genReqId function gets raw request as argument', (t, done) => {
   t.plan(9)
 
   const REQUEST_ID = 'REQ-1234'
 
   const fastify = Fastify({
     genReqId: function (req) {
-      t.notOk('id' in req)
-      t.notOk('raw' in req)
-      t.ok(req instanceof Readable)
+      t.assert.strictEqual('id' in req, false)
+      t.assert.strictEqual('raw' in req, false)
+      t.assert.ok(req instanceof Readable)
       // http.IncomingMessage does have `rawHeaders` property, but FastifyRequest does not
       const index = req.rawHeaders.indexOf('x-request-id')
       const xReqId = req.rawHeaders[index + 1]
-      t.equal(xReqId, REQUEST_ID)
-      t.equal(req.headers['x-request-id'], REQUEST_ID)
+      t.assert.strictEqual(xReqId, REQUEST_ID)
+      t.assert.strictEqual(req.headers['x-request-id'], REQUEST_ID)
       return xReqId
     }
   })
+  t.after(() => fastify.close())
 
   fastify.get('/', (req, reply) => {
-    t.equal(req.id, REQUEST_ID)
+    t.assert.strictEqual(req.id, REQUEST_ID)
     reply.send({ id: req.id })
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
     fastify.inject({
       method: 'GET',
       headers: {
         'x-request-id': REQUEST_ID
       },
-      url: 'http://localhost:' + fastify.server.address().port
+      url: `http://localhost:${fastify.server.address().port}`
     }, (err, res) => {
-      t.error(err)
+      t.assert.ifError(err)
       const payload = JSON.parse(res.payload)
-      t.equal(payload.id, REQUEST_ID)
-      fastify.close()
+      t.assert.strictEqual(payload.id, REQUEST_ID)
+      done()
     })
   })
 })
@@ -77,13 +79,13 @@ test('Custom genReqId function gets raw request as argument', t => {
 test('Should handle properly requestIdHeader option', t => {
   t.plan(4)
 
-  t.equal(Fastify({ requestIdHeader: '' }).initialConfig.requestIdHeader, false)
-  t.equal(Fastify({ requestIdHeader: false }).initialConfig.requestIdHeader, false)
-  t.equal(Fastify({ requestIdHeader: true }).initialConfig.requestIdHeader, 'request-id')
-  t.equal(Fastify({ requestIdHeader: 'x-request-id' }).initialConfig.requestIdHeader, 'x-request-id')
+  t.assert.strictEqual(Fastify({ requestIdHeader: '' }).initialConfig.requestIdHeader, false)
+  t.assert.strictEqual(Fastify({ requestIdHeader: false }).initialConfig.requestIdHeader, false)
+  t.assert.strictEqual(Fastify({ requestIdHeader: true }).initialConfig.requestIdHeader, 'request-id')
+  t.assert.strictEqual(Fastify({ requestIdHeader: 'x-request-id' }).initialConfig.requestIdHeader, 'x-request-id')
 })
 
-test('Should accept option to set genReqId with setGenReqId option', t => {
+test('Should accept option to set genReqId with setGenReqId option', (t, done) => {
   t.plan(9)
 
   const fastify = Fastify({
@@ -92,12 +94,14 @@ test('Should accept option to set genReqId with setGenReqId option', t => {
     }
   })
 
+  t.after(() => fastify.close())
+
   fastify.register(function (instance, opts, next) {
     instance.setGenReqId(function (req) {
       return 'foo'
     })
     instance.get('/', (req, reply) => {
-      t.ok(req.id)
+      t.assert.ok(req.id)
       reply.send({ id: req.id })
     })
     next()
@@ -108,49 +112,57 @@ test('Should accept option to set genReqId with setGenReqId option', t => {
       return 'bar'
     })
     instance.get('/', (req, reply) => {
-      t.ok(req.id)
+      t.assert.ok(req.id)
       reply.send({ id: req.id })
     })
     next()
   }, { prefix: 'bar' })
 
   fastify.get('/', (req, reply) => {
-    t.ok(req.id)
+    t.assert.ok(req.id)
     reply.send({ id: req.id })
   })
+
+  let pending = 3
+
+  function completed () {
+    if (--pending === 0) {
+      done()
+    }
+  }
 
   fastify.inject({
     method: 'GET',
     url: '/'
   }, (err, res) => {
-    t.error(err)
+    t.assert.ifError(err)
     const payload = JSON.parse(res.payload)
-    t.equal(payload.id, 'base')
-    fastify.close()
+    t.assert.strictEqual(payload.id, 'base')
+    completed()
   })
 
   fastify.inject({
     method: 'GET',
     url: '/foo'
   }, (err, res) => {
-    t.error(err)
+    t.assert.ifError(err)
     const payload = JSON.parse(res.payload)
-    t.equal(payload.id, 'foo')
-    fastify.close()
+    t.assert.strictEqual(payload.id, 'foo')
+    completed()
   })
 
   fastify.inject({
     method: 'GET',
     url: '/bar'
   }, (err, res) => {
-    t.error(err)
+    t.assert.ifError(err)
     const payload = JSON.parse(res.payload)
-    t.equal(payload.id, 'bar')
-    fastify.close()
+    t.assert.strictEqual(payload.id, 'bar')
+    completed()
   })
 })
 
-test('Should encapsulate setGenReqId', t => {
+test('Should encapsulate setGenReqId', (t, done) => {
   t.plan(12)
 
   const fastify = Fastify({
@@ -159,6 +171,7 @@ test('Should encapsulate setGenReqId', t => {
     }
   })
 
+  t.after(() => fastify.close())
   const bazInstance = function (instance, opts, next) {
     instance.register(barInstance, { prefix: 'baz' })
 
@@ -166,7 +179,7 @@ test('Should encapsulate setGenReqId', t => {
       return 'baz'
     })
     instance.get('/', (req, reply) => {
-      t.ok(req.id)
+      t.assert.ok(req.id)
       reply.send({ id: req.id })
     })
     next()
@@ -177,7 +190,7 @@ test('Should encapsulate setGenReqId', t => {
       return 'bar'
     })
     instance.get('/', (req, reply) => {
-      t.ok(req.id)
+      t.assert.ok(req.id)
       reply.send({ id: req.id })
     })
     next()
@@ -192,7 +205,7 @@ test('Should encapsulate setGenReqId', t => {
     })
 
     instance.get('/', (req, reply) => {
-      t.ok(req.id)
+      t.assert.ok(req.id)
       reply.send({ id: req.id })
     })
     next()
@@ -201,159 +214,71 @@ test('Should encapsulate setGenReqId', t => {
   fastify.register(fooInstance, { prefix: 'foo' })
 
   fastify.get('/', (req, reply) => {
-    t.ok(req.id)
+    t.assert.ok(req.id)
     reply.send({ id: req.id })
   })
 
-  fastify.inject({
-    method: 'GET',
-    url: '/'
-  }, (err, res) => {
-    t.error(err)
-    const payload = JSON.parse(res.payload)
-    t.equal(payload.id, 'base')
-    fastify.close()
-  })
+  let pending = 4
 
-  fastify.inject({
-    method: 'GET',
-    url: '/foo'
-  }, (err, res) => {
-    t.error(err)
-    const payload = JSON.parse(res.payload)
-    t.equal(payload.id, 'foo')
-    fastify.close()
-  })
-
-  fastify.inject({
-    method: 'GET',
-    url: '/foo/bar'
-  }, (err, res) => {
-    t.error(err)
-    const payload = JSON.parse(res.payload)
-    t.equal(payload.id, 'bar')
-    fastify.close()
-  })
-
-  fastify.inject({
-    method: 'GET',
-    url: '/foo/baz'
-  }, (err, res) => {
-    t.error(err)
-    const payload = JSON.parse(res.payload)
-    t.equal(payload.id, 'baz')
-    fastify.close()
-  })
-})
-
-test('Should encapsulate setGenReqId', t => {
-  t.plan(12)
-
-  const fastify = Fastify({
-    genReqId: function (req) {
-      return 'base'
+  function completed () {
+    if (--pending === 0) {
+      done()
     }
-  })
-
-  const bazInstance = function (instance, opts, next) {
-    instance.register(barInstance, { prefix: 'baz' })
-
-    instance.setGenReqId(function (req) {
-      return 'baz'
-    })
-    instance.get('/', (req, reply) => {
-      t.ok(req.id)
-      reply.send({ id: req.id })
-    })
-    next()
   }
-
-  const barInstance = function (instance, opts, next) {
-    instance.setGenReqId(function (req) {
-      return 'bar'
-    })
-    instance.get('/', (req, reply) => {
-      t.ok(req.id)
-      reply.send({ id: req.id })
-    })
-    next()
-  }
-
-  const fooInstance = function (instance, opts, next) {
-    instance.register(bazInstance, { prefix: 'baz' })
-    instance.register(barInstance, { prefix: 'bar' })
-
-    instance.setGenReqId(function (req) {
-      return 'foo'
-    })
-
-    instance.get('/', (req, reply) => {
-      t.ok(req.id)
-      reply.send({ id: req.id })
-    })
-    next()
-  }
-
-  fastify.register(fooInstance, { prefix: 'foo' })
-
-  fastify.get('/', (req, reply) => {
-    t.ok(req.id)
-    reply.send({ id: req.id })
-  })
 
   fastify.inject({
     method: 'GET',
     url: '/'
   }, (err, res) => {
-    t.error(err)
+    t.assert.ifError(err)
     const payload = JSON.parse(res.payload)
-    t.equal(payload.id, 'base')
-    fastify.close()
+    t.assert.strictEqual(payload.id, 'base')
+    completed()
   })
 
   fastify.inject({
     method: 'GET',
     url: '/foo'
   }, (err, res) => {
-    t.error(err)
+    t.assert.ifError(err)
     const payload = JSON.parse(res.payload)
-    t.equal(payload.id, 'foo')
-    fastify.close()
+    t.assert.strictEqual(payload.id, 'foo')
+    completed()
   })
 
   fastify.inject({
     method: 'GET',
     url: '/foo/bar'
   }, (err, res) => {
-    t.error(err)
+    t.assert.ifError(err)
     const payload = JSON.parse(res.payload)
-    t.equal(payload.id, 'bar')
-    fastify.close()
+    t.assert.strictEqual(payload.id, 'bar')
+    completed()
   })
 
   fastify.inject({
     method: 'GET',
     url: '/foo/baz'
   }, (err, res) => {
-    t.error(err)
+    t.assert.ifError(err)
     const payload = JSON.parse(res.payload)
-    t.equal(payload.id, 'baz')
-    fastify.close()
+    t.assert.strictEqual(payload.id, 'baz')
+    completed()
   })
 })
 
-test('Should not alter parent of genReqId', t => {
+test('Should not alter parent of genReqId', (t, done) => {
   t.plan(6)
 
   const fastify = Fastify()
-
+  t.after(() => fastify.close())
   const fooInstance = function (instance, opts, next) {
     instance.setGenReqId(function (req) {
       return 'foo'
     })
 
     instance.get('/', (req, reply) => {
-      t.ok(req.id)
+      t.assert.ok(req.id)
       reply.send({ id: req.id })
     })
     next()
@@ -362,32 +287,40 @@ test('Should not alter parent of genReqId', t => {
   fastify.register(fooInstance, { prefix: 'foo' })
 
   fastify.get('/', (req, reply) => {
-    t.ok(req.id)
+    t.assert.ok(req.id)
     reply.send({ id: req.id })
   })
+
+  let pending = 2
+
+  function completed () {
+    if (--pending === 0) {
+      done()
+    }
+  }
 
   fastify.inject({
     method: 'GET',
     url: '/'
   }, (err, res) => {
-    t.error(err)
+    t.assert.ifError(err)
     const payload = JSON.parse(res.payload)
-    t.equal(payload.id, 'req-1')
-    fastify.close()
+    t.assert.strictEqual(payload.id, 'req-1')
+    completed()
   })
 
   fastify.inject({
     method: 'GET',
     url: '/foo'
   }, (err, res) => {
-    t.error(err)
+    t.assert.ifError(err)
     const payload = JSON.parse(res.payload)
-    t.equal(payload.id, 'foo')
-    fastify.close()
+    t.assert.strictEqual(payload.id, 'foo')
+    completed()
   })
 })
 
-test('Should have child instance user parent genReqId', t => {
+test('Should have child instance user parent genReqId', (t, done) => {
   t.plan(6)
 
   const fastify = Fastify({
@@ -395,10 +328,11 @@ test('Should have child instance user parent genReqId', t => {
       return 'foo'
     }
   })
+  t.after(() => fastify.close())
 
   const fooInstance = function (instance, opts, next) {
     instance.get('/', (req, reply) => {
-      t.ok(req.id)
+      t.assert.ok(req.id)
       reply.send({ id: req.id })
     })
     next()
@@ -407,69 +341,86 @@ test('Should have child instance user parent genReqId', t => {
   fastify.register(fooInstance, { prefix: 'foo' })
 
   fastify.get('/', (req, reply) => {
-    t.ok(req.id)
+    t.assert.ok(req.id)
     reply.send({ id: req.id })
   })
+
+  let pending = 2
+
+  function completed () {
+    if (--pending === 0) {
+      done()
+    }
+  }
 
   fastify.inject({
     method: 'GET',
     url: '/'
   }, (err, res) => {
-    t.error(err)
+    t.assert.ifError(err)
     const payload = JSON.parse(res.payload)
-    t.equal(payload.id, 'foo')
-    fastify.close()
+    t.assert.strictEqual(payload.id, 'foo')
+    completed()
   })
 
   fastify.inject({
     method: 'GET',
     url: '/foo'
   }, (err, res) => {
-    t.error(err)
+    t.assert.ifError(err)
     const payload = JSON.parse(res.payload)
-    t.equal(payload.id, 'foo')
-    fastify.close()
+    t.assert.strictEqual(payload.id, 'foo')
+    completed()
   })
 })
 
-test('genReqId set on root scope when using fastify-plugin', t => {
+test('genReqId set on root scope when using fastify-plugin', (t, done) => {
   t.plan(6)
 
   const fastify = Fastify()
+  t.after(() => fastify.close())
 
   fastify.register(fp(function (fastify, options, done) {
     fastify.setGenReqId(function (req) {
       return 'not-encapsulated'
     })
     fastify.get('/not-encapsulated-1', (req, reply) => {
-      t.ok(req.id)
+      t.assert.ok(req.id)
       reply.send({ id: req.id })
     })
     done()
   }))
 
   fastify.get('/not-encapsulated-2', (req, reply) => {
-    t.ok(req.id)
+    t.assert.ok(req.id)
     reply.send({ id: req.id })
   })
+
+  let pending = 2
+
+  function completed () {
+    if (--pending === 0) {
+      done()
+    }
+  }
 
   fastify.inject({
     method: 'GET',
     url: '/not-encapsulated-1'
   }, (err, res) => {
-    t.error(err)
+    t.assert.ifError(err)
     const payload = JSON.parse(res.payload)
-    t.equal(payload.id, 'not-encapsulated')
-    fastify.close()
+    t.assert.strictEqual(payload.id, 'not-encapsulated')
+    completed()
   })
 
   fastify.inject({
     method: 'GET',
     url: '/not-encapsulated-2'
   }, (err, res) => {
-    t.error(err)
+    t.assert.ifError(err)
     const payload = JSON.parse(res.payload)
-    t.equal(payload.id, 'not-encapsulated')
-    fastify.close()
+    t.assert.strictEqual(payload.id, 'not-encapsulated')
+    completed()
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Proposal:
   - migrated `genReqId.test.js` from `tap` to `node:test` 🔥