### PR TITLE
docs: the no floating promise guide is not needed anymore

### DIFF
--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -659,23 +659,6 @@ However, there are a couple of suggestions to help improve this experience:
 - Make sure the `no-unused-vars` rule is enabled in
   [ESLint](https://eslint.org/docs/rules/no-unused-vars) and any imported plugin
   are actually being loaded.
-- In case you've the `@typescript-eslint/no-floating-promises` enabled,
-please double-check that your ESLint configuration includes a `allowForKnownSafePromises`
-property as described on the [`typescript-eslint no-floating-promises allowForKnownSafePromises
-documentation`](https://typescript-eslint.io/rules/no-floating-promises/#allowforknownsafepromises):
-```
-{
-  "rules": {
-    "@typescript-eslint/no-floating-promises": ["error", {
-      "allowForKnownSafePromises": [
-        { "from": "package", "name": "FastifyInstance", "package": "fastify" },
-        { "from": "package", "name": "FastifyReply", "package": "fastify" },
-        { "from": "package", "name": "SafePromiseLike", "package": "fastify" },
-      ]
-    }]
-  }
-}
-```
 - Use a module such as [depcheck](https://www.npmjs.com/package/depcheck) or
   [npm-check](https://www.npmjs.com/package/npm-check) to verify plugin
   dependencies are being used somewhere in your project.


### PR DESCRIPTION
Since typescript-eslint v8, no special care is needed when dealing with `no-floating-promise` rule, everything just works by default.