### PR TITLE
docs(reference/contenttypeparser): make more concise

### DIFF
--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -1,38 +1,32 @@
 <h1 align="center">Fastify</h1>
 
 ## `Content-Type` Parser
-Natively, Fastify only supports `'application/json'` and `'text/plain'` content
-types. If the content type is not one of these, an
-`FST_ERR_CTP_INVALID_MEDIA_TYPE` error will be thrown.
-Other common content types are supported through the use of
-[plugins](https://fastify.dev/ecosystem/).
+Fastify natively supports `'application/json'` and `'text/plain'` content types
+with a default charset of `utf-8`. These default parsers can be changed or
+removed.
 
-The default charset is `utf-8`. If you need to support different content types,
-you can use the `addContentTypeParser` API. *The default JSON and/or plain text
-parser can be changed or removed.*
+Unsupported content types will throw an `FST_ERR_CTP_INVALID_MEDIA_TYPE` error.
 
-*Note: If you decide to specify your own content type with the `Content-Type`
-header, UTF-8 will not be the default. Be sure to include UTF-8 like this
-`text/html; charset=utf-8`.*
+To support other content types, use the `addContentTypeParser` API or an
+existing [plugin](https://fastify.dev/ecosystem/).
 
-As with the other APIs, `addContentTypeParser` is encapsulated in the scope in
-which it is declared. This means that if you declare it in the root scope it
-will be available everywhere, while if you declare it inside a plugin it will be
-available only in that scope and its children.
+As with other APIs, `addContentTypeParser` is encapsulated in the scope in which
+it is declared. If declared in the root scope, it is available everywhere; if
+declared in a plugin, it is available only in that scope and its children.
 
 Fastify automatically adds the parsed request payload to the [Fastify
-request](./Request.md) object which you can access with `request.body`.
+request](./Request.md) object, accessible via `request.body`.
 
-Note that for `GET` and `HEAD` requests the payload is never parsed. For
-`OPTIONS` and `DELETE` requests the payload is only parsed if the content type
-is given in the content-type header. If it is not given, the
-[catch-all](#catch-all) parser is not executed as with `POST`, `PUT` and
-`PATCH`, but the payload is simply not parsed.
+Note that for `GET` and `HEAD` requests, the payload is never parsed. For
+`OPTIONS` and `DELETE` requests, the payload is parsed only if a valid
+`content-type` header is provided. Unlike `POST`, `PUT`, and `PATCH`, the
+[catch-all](#catch-all) parser is not executed, and the payload is simply not
+parsed.
 
-> ## ⚠  Security Notice
-> When using with RegExp to detect `Content-Type`, you should beware of
-> how to properly detect the `Content-Type`. For example, if you need
-> `application/*`, you should use `/^application\/([\w-]+);?/` to match the
+> ## ⚠ Security Notice
+> When using regular expressions to detect `Content-Type`, it is important to
+> ensure proper detection. For example, to match `application/*`, use
+> `/^application\/([\w-]+);?/` to match the
 > [essence MIME type](https://mimesniff.spec.whatwg.org/#mime-type-miscellaneous)
 > only.
 
@@ -70,11 +64,10 @@ fastify.addContentTypeParser('text/json', { parseAs: 'string' }, fastify.getDefa
 ```
 
 Fastify first tries to match a content-type parser with a `string` value before
-trying to find a matching `RegExp`. If you provide overlapping content types,
-Fastify tries to find a matching content type by starting with the last one
-passed and ending with the first one. So if you want to specify a general
-content type more precisely, first specify the general content type and then the
-more specific one, like in the example below.
+trying to find a matching `RegExp`. For overlapping content types, it starts
+with the last one passed and ends with the first. To specify a general content
+type more precisely, first specify the general type, then the specific one, as
+shown below.
 
 ```js
 // Here only the second content type parser is called because its value also matches the first one
@@ -88,10 +81,9 @@ fastify.addContentTypeParser('application/vnd.custom+xml', (request, body, done)
 ```
 
 ### Using addContentTypeParser with fastify.register
-When using `addContentTypeParser` in combination with `fastify.register`,
-`await` should not be used when registering routes. Using `await` causes
-the route registration to be asynchronous and can lead to routes being registered
-before the addContentTypeParser has been set.
+When using `addContentTypeParser` with `fastify.register`, avoid `await`
+when registering routes. Using `await` makes route registration asynchronous, 
+potentially registering routes before `addContentTypeParser` is set.
 
 #### Correct Usage
 ```js
@@ -109,14 +101,13 @@ fastify.register((fastify, opts) => {
 });
 ```
 
-Besides the `addContentTypeParser` API there are further APIs that can be used.
-These are `hasContentTypeParser`, `removeContentTypeParser` and
-`removeAllContentTypeParsers`.
+In addition to `addContentTypeParser`, the `hasContentTypeParser`,
+`removeContentTypeParser`, and `removeAllContentTypeParsers` APIs are available.
 
 #### hasContentTypeParser
 
-You can use the `hasContentTypeParser` API to find if a specific content type
-parser already exists.
+Use the `hasContentTypeParser` API to check if a specific content type parser
+exists.
 
 ```js
 if (!fastify.hasContentTypeParser('application/jsoff')){
@@ -130,8 +121,8 @@ if (!fastify.hasContentTypeParser('application/jsoff')){
 
 #### removeContentTypeParser
 
-With `removeContentTypeParser` a single or an array of content types can be
-removed. The method supports `string` and `RegExp` content types.
+`removeContentTypeParser` can remove a single content type or an array of
+content types, supporting both `string` and `RegExp`.
 
 ```js
 fastify.addContentTypeParser('text/xml', function (request, payload, done) {
@@ -145,16 +136,10 @@ fastify.removeContentTypeParser(['application/json', 'text/plain'])
 ```
 
 #### removeAllContentTypeParsers
-
-In the example from just above, it is noticeable that we need to specify each
-content type that we want to remove. To solve this problem Fastify provides the
-`removeAllContentTypeParsers` API. This can be used to remove all currently
-existing content type parsers. In the example below we achieve the same as in
-the example above except that we do not need to specify each content type to
-delete. Just like `removeContentTypeParser`, this API supports encapsulation.
-The API is especially useful if you want to register a [catch-all content type
-parser](#catch-all) that should be executed for every content type and the
-built-in parsers should be ignored as well.
+The `removeAllContentTypeParsers` API removes all existing content type parsers
+eliminating the need to specify each one individually. This API support encapsulation
+and is useful for registering a [catch-all content type parser](#catch-all) that
+should be executed for every content type, ignoring built-in parsers.
 
 ```js
 fastify.removeAllContentTypeParsers()
@@ -166,18 +151,16 @@ fastify.addContentTypeParser('text/xml', function (request, payload, done) {
 })
 ```
 
-**Notice**: The old syntaxes `function(req, done)` and `async function(req)` for
-the parser are still supported but they are deprecated.
+**Notice**: The old syntaxes `function(req, done)` and `async function(req)` are
+still supported but deprecated.
 
 #### Body Parser
-You can parse the body of a request in two ways. The first one is shown above:
-you add a custom content type parser and handle the request stream. In the
-second one, you should pass a `parseAs` option to the `addContentTypeParser`
-API, where you declare how you want to get the body. It could be of type
-`'string'` or `'buffer'`. If you use the `parseAs` option, Fastify will
-internally handle the stream and perform some checks, such as the [maximum
-size](./Server.md#factory-body-limit) of the body and the content length. If the
-limit is exceeded the custom parser will not be invoked.
+The request body can be parsed in two ways. First, add a custom content type
+parser and handle the request stream. Or second, use the `parseAs` option in the
+`addContentTypeParser` API, specifying `'string'` or `'buffer'`. Fastify will
+handle the stream, check the [maximum size](./Server.md#factory-body-limit) of
+the body, and the content length. If the limit is exceeded, the custom parser
+will not be invoked.
 ```js
 fastify.addContentTypeParser('application/json', { parseAs: 'string' }, function (req, body, done) {
   try {
@@ -195,15 +178,14 @@ See
 for an example.
 
 ##### Custom Parser Options
-+ `parseAs` (string): Either `'string'` or `'buffer'` to designate how the
-  incoming data should be collected. Default: `'buffer'`.
++ `parseAs` (string): `'string'` or `'buffer'` to designate how the incoming
+  data should be collected. Default: `'buffer'`.
 + `bodyLimit` (number): The maximum payload size, in bytes, that the custom
   parser will accept. Defaults to the global body limit passed to the [`Fastify
   factory function`](./Server.md#bodylimit).
 
 #### Catch-All
-There are some cases where you need to catch all requests regardless of their
-content type. With Fastify, you can just use the `'*'` content type.
+To catch all requests regardless of content type, use the `'*'` content type:
 ```js
 fastify.addContentTypeParser('*', function (request, payload, done) {
   let data = ''
@@ -213,9 +195,8 @@ fastify.addContentTypeParser('*', function (request, payload, done) {
   })
 })
 ```
-
-Using this, all requests that do not have a corresponding content type parser
-will be handled by the specified function.
+All requests without a corresponding content type parser will be handled by
+this function.
 
 This is also useful for piping the request stream. You can define a content
 parser like:
@@ -226,7 +207,7 @@ fastify.addContentTypeParser('*', function (request, payload, done) {
 })
 ```
 
-and then access the core HTTP request directly for piping it where you want:
+And then access the core HTTP request directly for piping it where you want:
 
 ```js
 app.post('/hello', (request, reply) => {
@@ -254,12 +235,11 @@ fastify.route({
 })
  ```
 
-For piping file uploads you may want to check out [this
-plugin](https://github.com/fastify/fastify-multipart).
+For piping file uploads, check out
+[`@fastify/multipart`](https://github.com/fastify/fastify-multipart).
 
-If you want the content type parser to be executed on all content types and not
-only on those that don't have a specific one, you should call the
-`removeAllContentTypeParsers` method first.
+To execute the content type parser on all content types, call
+`removeAllContentTypeParsers` first.
 
 ```js
 // Without this call, the request body with the content type application/json would be processed by the built-in JSON parser

--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -65,7 +65,7 @@ fastify.addContentTypeParser('text/json', { parseAs: 'string' }, fastify.getDefa
 
 Fastify first tries to match a content-type parser with a `string` value before
 trying to find a matching `RegExp`. For overlapping content types, it starts
-with the last one passed and ends with the first. To specify a general content
+with the last one configured and ends with the first (last in, first out). To specify a general content
 type more precisely, first specify the general type, then the specific one, as
 shown below.
 

--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -151,7 +151,7 @@ fastify.addContentTypeParser('text/xml', function (request, payload, done) {
 })
 ```
 
-**Notice**: The old syntaxes `function(req, done)` and `async function(req)` are
+**Notice**: `function(req, done)` and `async function(req)` are
 still supported but deprecated.
 
 #### Body Parser

--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -65,9 +65,9 @@ fastify.addContentTypeParser('text/json', { parseAs: 'string' }, fastify.getDefa
 
 Fastify first tries to match a content-type parser with a `string` value before
 trying to find a matching `RegExp`. For overlapping content types, it starts
-with the last one configured and ends with the first (last in, first out). To specify a general content
-type more precisely, first specify the general type, then the specific one, as
-shown below.
+with the last one configured and ends with the first (last in, first out).
+To specify a general content type more precisely, first specify the general
+type, then the specific one, as shown below.
 
 ```js
 // Here only the second content type parser is called because its value also matches the first one
@@ -137,9 +137,10 @@ fastify.removeContentTypeParser(['application/json', 'text/plain'])
 
 #### removeAllContentTypeParsers
 The `removeAllContentTypeParsers` API removes all existing content type parsers
-eliminating the need to specify each one individually. This API supports encapsulation
-and is useful for registering a [catch-all content type parser](#catch-all) that
-should be executed for every content type, ignoring built-in parsers.
+eliminating the need to specify each one individually. This API supports
+encapsulation and is useful for registering a
+[catch-all content type parser](#catch-all) that should be executed for every
+content type, ignoring built-in parsers.
 
 ```js
 fastify.removeAllContentTypeParsers()

--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -137,7 +137,7 @@ fastify.removeContentTypeParser(['application/json', 'text/plain'])
 
 #### removeAllContentTypeParsers
 The `removeAllContentTypeParsers` API removes all existing content type parsers
-eliminating the need to specify each one individually. This API support encapsulation
+eliminating the need to specify each one individually. This API supports encapsulation
 and is useful for registering a [catch-all content type parser](#catch-all) that
 should be executed for every content type, ignoring built-in parsers.
 

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -362,7 +362,8 @@ Sets the content type for the response. This is a shortcut for
 reply.type('text/html')
 ```
 If the `Content-Type` has a JSON subtype, and the charset parameter is not set,
-`utf-8` will be used as the charset by default.
+`utf-8` will be used as the charset by default. For other content types, the
+charset must be set explicitly.
 
 ### .getSerializationFunction(schema | httpStatus, [contentType])
 <a id="getserializationfunction"></a>


### PR DESCRIPTION
This PR:
- Improves clarity and conciseness
- Moves an [unrelated sentence](https://github.com/fastify/fastify/pull/3159#discussion_r659017947) to the `reply` reference doc

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
