### PR TITLE
test: migrated listen.2.test.js from tap to node:test

### DIFF
--- a/test/listen.2.test.js
+++ b/test/listen.2.test.js
@@ -24,7 +24,7 @@ test('register after listen using Promise.resolve()', async t => {
       })
       return fastify.ready()
     })
-    .catch((err) => t.assert.ifError(err))
+    .catch((err) => err)
     .then(() => t.assert.ok('resolved'))
 })
 

--- a/test/listen.2.test.js
+++ b/test/listen.2.test.js
@@ -24,7 +24,9 @@ test('register after listen using Promise.resolve()', async t => {
       })
       return fastify.ready()
     })
-    .catch((err) => err)
+    .catch((err) => {
+      t.assert.fail(err.message)
+    })
     .then(() => t.assert.ok('resolved'))
 })
 

--- a/test/listen.2.test.js
+++ b/test/listen.2.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test, before } = require('tap')
+const { test, before } = require('node:test')
 const Fastify = require('..')
 const helper = require('./helper')
 
@@ -10,94 +10,99 @@ before(async function () {
   [, localhostForURL] = await helper.getLoopbackHost()
 })
 
-test('register after listen using Promise.resolve()', t => {
+test('register after listen using Promise.resolve()', async t => {
   t.plan(1)
-  const f = Fastify()
+  const fastify = Fastify()
 
   const handler = (req, res) => res.send({})
-  Promise.resolve()
+  await Promise.resolve()
     .then(() => {
-      f.get('/', handler)
-      f.register((f2, options, done) => {
+      fastify.get('/', handler)
+      fastify.register((f2, options, done) => {
         f2.get('/plugin', handler)
         done()
       })
-      return f.ready()
+      return fastify.ready()
     })
-    .catch(t.error)
-    .then(() => t.pass('resolved'))
+    .catch((err) => t.assert.ifError(err))
+    .then(() => t.assert.ok('resolved'))
 })
 
-test('double listen errors', t => {
+test('double listen errors', (t, done) => {
   t.plan(3)
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
   fastify.listen({ port: 0 }, (err) => {
-    t.error(err)
+    t.assert.ifError(err)
     fastify.listen({ port: fastify.server.address().port }, (err, address) => {
-      t.equal(address, null)
-      t.ok(err)
+      t.assert.strictEqual(address, null)
+      t.assert.ok(err)
+      done()
     })
   })
 })
 
-test('double listen errors callback with (err, address)', t => {
+test('double listen errors callback with (err, address)', (t, done) => {
   t.plan(4)
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
   fastify.listen({ port: 0 }, (err1, address1) => {
-    t.equal(address1, `http://${localhostForURL}:${fastify.server.address().port}`)
-    t.error(err1)
+    t.assert.strictEqual(address1, `http://${localhostForURL}:${fastify.server.address().port}`)
+    t.assert.ifError(err1)
     fastify.listen({ port: fastify.server.address().port }, (err2, address2) => {
-      t.equal(address2, null)
-      t.ok(err2)
+      t.assert.strictEqual(address2, null)
+      t.assert.ok(err2)
+      done()
     })
   })
 })
 
-test('nonlocalhost double listen errors callback with (err, address)', t => {
+test('nonlocalhost double listen errors callback with (err, address)', (t, done) => {
   t.plan(4)
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
   fastify.listen({ host: '::1', port: 0 }, (err, address) => {
-    t.equal(address, `http://${'[::1]'}:${fastify.server.address().port}`)
-    t.error(err)
+    t.assert.strictEqual(address, `http://${'[::1]'}:${fastify.server.address().port}`)
+    t.assert.ifError(err)
     fastify.listen({ host: '::1', port: fastify.server.address().port }, (err2, address2) => {
-      t.equal(address2, null)
-      t.ok(err2)
+      t.assert.strictEqual(address2, null)
+      t.assert.ok(err2)
+      done()
     })
   })
 })
 
-test('listen twice on the same port', t => {
+test('listen twice on the same port', (t, done) => {
   t.plan(4)
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
   fastify.listen({ port: 0 }, (err1, address1) => {
-    t.equal(address1, `http://${localhostForURL}:${fastify.server.address().port}`)
-    t.error(err1)
+    t.assert.strictEqual(address1, `http://${localhostForURL}:${fastify.server.address().port}`)
+    t.assert.ifError(err1)
     const s2 = Fastify()
-    t.teardown(s2.close.bind(s2))
+    t.after(() => fastify.close())
     s2.listen({ port: fastify.server.address().port }, (err2, address2) => {
-      t.equal(address2, null)
-      t.ok(err2)
+      t.assert.strictEqual(address2, null)
+      t.assert.ok(err2)
+      done()
     })
   })
 })
 
-test('listen twice on the same port callback with (err, address)', t => {
+test('listen twice on the same port callback with (err, address)', (t, done) => {
   t.plan(4)
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
   fastify.listen({ port: 0 }, (err1, address1) => {
     const _port = fastify.server.address().port
-    t.equal(address1, `http://${localhostForURL}:${_port}`)
-    t.error(err1)
+    t.assert.strictEqual(address1, `http://${localhostForURL}:${_port}`)
+    t.assert.ifError(err1)
     const s2 = Fastify()
-    t.teardown(s2.close.bind(s2))
+    t.after(() => fastify.close())
     s2.listen({ port: _port }, (err2, address2) => {
-      t.equal(address2, null)
-      t.ok(err2)
+      t.assert.strictEqual(address2, null)
+      t.assert.ok(err2)
+      done()
     })
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Proposal:

  - migrated `listen.2.test.js` from `tap` to `node:test` 🔥