### PR TITLE
docs(reference/errors): conciseness improvements

### DIFF
--- a/docs/Reference/Errors.md
+++ b/docs/Reference/Errors.md
@@ -102,8 +102,8 @@
 <a id="error-handling"></a>
 
 #### Uncaught Errors
-In Node.js, uncaught errors are likely to cause memory leaks, file descriptor
-leaks, and other major production issues.
+In Node.js, uncaught errors can cause memory leaks, file descriptor leaks, and
+other major production issues.
 [Domains](https://nodejs.org/en/docs/guides/domain-postmortem/) were a failed
 attempt to fix this.
 
@@ -112,29 +112,28 @@ way to deal with them is to
 [crash](https://nodejs.org/api/process.html#process_warning_using_uncaughtexception_correctly).
 
 #### Catching Errors In Promises
-If you are using promises, you should attach a `.catch()` handler synchronously.
+When using promises, attach a `.catch()` handler synchronously.
 
 ### Errors In Fastify
-Fastify follows an all-or-nothing approach and aims to be lean and optimal as
-much as possible. The developer is responsible for making sure that the errors
-are handled properly.
+Fastify follows an all-or-nothing approach and aims to be lean and optimal. The
+developer is responsible for ensuring errors are handled properly.
 
 #### Errors In Input Data
-Most errors are a result of unexpected input data, so we recommend [validating
-your input data against a JSON schema](./Validation-and-Serialization.md).
+Most errors result from unexpected input data, so it is recommended to
+[validate input data against a JSON schema](./Validation-and-Serialization.md).
 
 #### Catching Uncaught Errors In Fastify
-Fastify tries to catch as many uncaught errors as it can without hindering
+Fastify tries to catch as many uncaught errors as possible without hindering
 performance. This includes:
 
 1. synchronous routes, e.g. `app.get('/', () => { throw new Error('kaboom') })`
 2. `async` routes, e.g. `app.get('/', async () => { throw new Error('kaboom')
    })`
 
-The error in both cases will be caught safely and routed to Fastify's default
-error handler for a generic `500 Internal Server Error` response.
+In both cases, the error will be caught safely and routed to Fastify's default
+error handler, resulting in a generic `500 Internal Server Error` response.
 
-To customize this behavior you should use
+To customize this behavior, use
 [`setErrorHandler`](./Server.md#seterrorhandler).
 
 ### Errors In Fastify Lifecycle Hooks And A Custom Error Handler
@@ -144,52 +143,50 @@ From the [Hooks documentation](./Hooks.md#manage-errors-from-a-hook):
 > `done()` and Fastify will automatically close the request and send the
 > appropriate error code to the user.
 
-When a custom error handler has been defined through
-[`setErrorHandler`](./Server.md#seterrorhandler), the custom error handler will
-receive the error passed to the `done()` callback (or through other supported
-automatic error handling mechanisms). If `setErrorHandler` has been used
-multiple times to define multiple handlers, the error will be routed to the most
-precedent handler defined within the error [encapsulation
-context](./Encapsulation.md). Error handlers are fully encapsulated, so a
-`setErrorHandler` call within a plugin will limit the error handler to that
-plugin's context.
+When a custom error handler is defined through
+[`setErrorHandler`](./Server.md#seterrorhandler), it will receive the error
+passed to the `done()` callback or through other supported automatic error
+handling mechanisms. If `setErrorHandler` is used multiple times, the error will
+be routed to the most precedent handler within the error
+[encapsulation context](./Encapsulation.md). Error handlers are fully
+encapsulated, so a `setErrorHandler` call within a plugin will limit the error
+handler to that plugin's context.
 
 The root error handler is Fastify's generic error handler. This error handler
 will use the headers and status code in the `Error` object, if they exist. The
 headers and status code will not be automatically set if a custom error handler
 is provided.
 
-Some things to consider in your custom error handler:
+The following should be considered when using a custom error handler:
 
-- you can `reply.send(data)`, which will behave as it would in [regular route
-  handlers](./Reply.md#senddata)
+- `reply.send(data)` behaves as in [regular route handlers](./Reply.md#senddata)
   - objects are serialized, triggering the `preSerialization` lifecycle hook if
-    you have one defined
-  - strings, buffers, and streams are sent to the client, with appropriate
-    headers (no serialization)
+    defined
+  - strings, buffers, and streams are sent to the client with appropriate headers
+    (no serialization)
 
-- You can throw a new error in your custom error handler - errors (new error or
-	the received error parameter re-thrown) - will call the parent `errorHandler`.
-  - `onError` hook will be triggered once only for the first error being thrown.
-  - an error will not be triggered twice from a lifecycle hook - Fastify
-    internally monitors the error invocation to avoid infinite loops for errors
-    thrown in the reply phases of the lifecycle. (those after the route handler)
+- Throwing a new error in a custom error handler will call the parent
+  `errorHandler`.
+  - The `onError` hook will be triggered once for the first error thrown
+  - An error will not be triggered twice from a lifecycle hook. Fastify
+    internally monitors error invocation to avoid infinite loops for errors
+    thrown in the reply phases of the lifecycle (those after the route handler)
 
-When utilizing Fastify's custom error handling through [`setErrorHandler`](./Server.md#seterrorhandler),
-you should be aware of how errors are propagated between custom and default
-error handlers.
+When using Fastify's custom error handling through
+[`setErrorHandler`](./Server.md#seterrorhandler), be aware of how errors are
+propagated between custom and default error handlers.
 
-If a plugin's error handler re-throws an error, and the error is not an
-instance of [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)
-(as seen in the `/bad` route in the following example), it will not propagate
-to the parent context error handler. Instead, it will be caught by the default
-error handler.
+If a plugin's error handler re-throws an error that is not an instance of
+[Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error),
+it will not propagate to the parent context error handler. Instead, it will be
+caught by the default error handler. This can be seen in the `/bad` route of the
+example below.
 
-To ensure consistent error handling, it is recommended to throw instances of
-`Error`. For instance, in the following example, replacing `throw 'foo'` with
-`throw new Error('foo')` in the `/bad` route ensures that errors propagate through
-the custom error handling chain as intended. This practice helps avoid potential
-pitfalls when working with custom error handling in Fastify.
+To ensure consistent error handling, throw instances of `Error`. For example,
+replace `throw 'foo'` with `throw new Error('foo')` in the `/bad` route to
+ensure errors propagate through the custom error handling chain as intended.
+This practice helps avoid potential pitfalls when working with custom error
+handling in Fastify.
 
 For example:
 ```js
@@ -242,7 +239,7 @@ You can access `errorCodes` for mapping:
 // ESM
 import { errorCodes } from 'fastify'
 
-// CommonJs
+// CommonJS
 const errorCodes = require('fastify').errorCodes
 ```
 
@@ -267,7 +264,7 @@ fastify.setErrorHandler(function (error, request, reply) {
     // Send error response
     reply.status(500).send({ ok: false })
   } else {
-    // fastify will use parent error handler to handle this
+    // Fastify will use parent error handler to handle this
     reply.send(error)
   }
 })
@@ -282,7 +279,7 @@ fastify.listen({ port: 3000 }, function (err, address) {
 })
 ```
 
-Below is a table with all the error codes that Fastify uses.
+Below is a table with all the error codes used by Fastify.
 
 | Code | Description | How to solve | Discussion |
 |------|-------------|--------------|------------|


### PR DESCRIPTION
Companion to https://github.com/fastify/fastify/pull/5950.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
