### PR TITLE
docs(reference/decorators): conciseness improvements

### DIFF
--- a/docs/Reference/Decorators.md
+++ b/docs/Reference/Decorators.md
@@ -12,10 +12,11 @@ the Fastify instance booting before the decoration completes. To register an
 asynchronous decoration, use the `register` API with `fastify-plugin`. See the
 [Plugins](./Plugins.md) documentation for more details.
 
-Decorating core objects with this API allows the JavaScript engine to optimize
-handling of server, request, and reply objects. This is done by defining the
-shape of these objects before they are instantiated. The following example is
-not recommended as it changes the shape of objects during their lifecycle:
+Decorating core objects with this API allows the underlying JavaScript engine to
+optimize the handling of server, request, and reply objects. This is
+accomplished by defining the shape of all such object instances before they are
+instantiated and used. As an example, the following is not recommended because
+it will change the shape of objects during their lifecycle:
 
 ```js
 // Bad example! Continue reading.

--- a/docs/Reference/Decorators.md
+++ b/docs/Reference/Decorators.md
@@ -2,22 +2,20 @@
 
 ## Decorators
 
-The decorators API allows customization of the core Fastify objects, such as the
-server instance itself and any request and reply objects used during the HTTP
-request lifecycle. The decorators API can be used to attach any type of property
-to the core objects, e.g. functions, plain objects, or native types.
+The decorators API customizes core Fastify objects, such as the server instance
+and any request and reply objects used during the HTTP request lifecycle. It
+can attach any type of property to core objects, e.g., functions, plain
+objects, or native types.
 
-This API is *synchronous*. Attempting to define a decoration asynchronously
-could result in the Fastify instance booting before the decoration completes its
-initialization. To avoid this issue, and register an asynchronous decoration,
-the `register` API, in combination with `fastify-plugin`, must be used instead.
-To learn more, see the [Plugins](./Plugins.md) documentation.
+This API is *synchronous*. Defining a decoration asynchronously could result in
+the Fastify instance booting before the decoration completes. To register an
+asynchronous decoration, use the `register` API with `fastify-plugin`. See the
+[Plugins](./Plugins.md) documentation for more details.
 
-Decorating core objects with this API allows the underlying JavaScript engine to
-optimize the handling of server, request, and reply objects. This is
-accomplished by defining the shape of all such object instances before they are
-instantiated and used. As an example, the following is not recommended because
-it will change the shape of objects during their lifecycle:
+Decorating core objects with this API allows the JavaScript engine to optimize
+handling of server, request, and reply objects. This is done by defining the
+shape of these objects before they are instantiated. The following example is
+not recommended as it changes the shape of objects during their lifecycle:
 
 ```js
 // Bad example! Continue reading.
@@ -35,9 +33,9 @@ fastify.get('/', function (req, reply) {
 })
 ```
 
-Since the above example mutates the request object after it has already been
-instantiated, the JavaScript engine must deoptimize access to the request
-object. By using the decoration API this deoptimization is avoided:
+The above example mutates the request object after instantiation, causing the
+JavaScript engine to deoptimize access. Using the decoration API avoids this
+deoptimization:
 
 ```js
 // Decorate request with a 'user' property
@@ -54,17 +52,13 @@ fastify.get('/', (req, reply) => {
 })
 ```
 
-Note that it is important to keep the initial shape of a decorated field as
-close as possible to the value intended to be set dynamically in the future.
-Initialize a decorator as a `''` if the intended value is a string, and as
-`null` if it will be an object or a function.
-
-Remember this example works only with value types as reference types will
-thrown and error during the fastify startup. See [decorateRequest](#decorate-request).
-
-See [JavaScript engine fundamentals: Shapes and Inline
-Caches](https://mathiasbynens.be/notes/shapes-ics) for more information on this
-topic.
+Keep the initial shape of a decorated field close to its future dynamic value.
+Initialize a decorator as `''` for strings and `null` for objects or functions.
+This works only with value types; reference types will throw an error during
+Fastify startup. See [decorateRequest](#decorate-request) and
+[JavaScript engine fundamentals: Shapes
+and Inline Caches](https://mathiasbynens.be/notes/shapes-ics)
+for more information.
 
 ### Usage
 <a id="usage"></a>
@@ -72,8 +66,7 @@ topic.
 #### `decorate(name, value, [dependencies])`
 <a id="decorate"></a>
 
-This method is used to customize the Fastify [server](./Server.md)
-instance.
+This method customizes the Fastify [server](./Server.md) instance.
 
 For example, to attach a new method to the server instance:
 
@@ -83,7 +76,7 @@ fastify.decorate('utility', function () {
 })
 ```
 
-As mentioned above, non-function values can be attached to the server instance as:
+Non-function values can also be attached to the server instance:
 
 ```js
 fastify.decorate('conf', {
@@ -118,9 +111,9 @@ fastify.get('/', async function (request, reply) {
 ```
 
 The `dependencies` parameter is an optional list of decorators that the
-decorator being defined relies upon. This list is simply a list of string names
-of other decorators. In the following example, the "utility" decorator depends
-upon "greet" and "hi" decorators:
+decorator being defined relies upon. This list contains the names of other
+decorators. In the following example, the "utility" decorator depends on the
+"greet" and "hi" decorators:
 
 ```js
 async function greetDecorator (fastify, opts) {
@@ -155,18 +148,17 @@ fastify.listen({ port: 3000 }, (err, address) => {
 })
 ```
 
-Note: using an arrow function will break the binding of `this` to the
-`FastifyInstance`.
+Using an arrow function breaks the binding of `this` to
+the `FastifyInstance`.
 
-If a dependency is not satisfied, the `decorate` method will throw an exception.
-The dependency check is performed before the server instance is booted. Thus, it
-cannot occur during runtime.
+If a dependency is not satisfied, the `decorate` method throws an exception.
+The dependency check occurs before the server instance boots, not during
+runtime.
 
 #### `decorateReply(name, value, [dependencies])`
 <a id="decorate-reply"></a>
 
-As the name suggests, this API is used to add new methods/properties to the core
-`Reply` object:
+This API adds new methods/properties to the core `Reply` object:
 
 ```js
 fastify.decorateReply('utility', function () {
@@ -174,21 +166,21 @@ fastify.decorateReply('utility', function () {
 })
 ```
 
-Note: using an arrow function will break the binding of `this` to the Fastify
+Using an arrow function will break the binding of `this` to the Fastify
 `Reply` instance.
 
-Note: using `decorateReply` will throw and error if used with a reference type:
+Using `decorateReply` will throw and error if used with a reference type:
 
 ```js
 // Don't do this
 fastify.decorateReply('foo', { bar: 'fizz'})
 ```
-In this example, the reference of the object would be shared with all the requests
-and **any mutation will impact all requests, potentially creating security
-vulnerabilities or memory leaks**, so Fastify blocks it.
+In this example, the object reference would be shared with all requests, and
+**any mutation will impact all requests, potentially creating security
+vulnerabilities or memory leaks**. Fastify blocks this.
 
 To achieve proper encapsulation across requests configure a new value for each
-incoming request in the [`'onRequest'` hook](./Hooks.md#onrequest). Example:
+incoming request in the [`'onRequest'` hook](./Hooks.md#onrequest).
 
 ```js
 const fp = require('fastify-plugin')
@@ -208,8 +200,8 @@ See [`decorate`](#decorate) for information about the `dependencies` parameter.
 #### `decorateRequest(name, value, [dependencies])`
 <a id="decorate-request"></a>
 
-As above with [`decorateReply`](#decorate-reply), this API is used add new
-methods/properties to the core `Request` object:
+As with [`decorateReply`](#decorate-reply), this API adds new methods/properties
+to the core `Request` object:
 
 ```js
 fastify.decorateRequest('utility', function () {
@@ -217,18 +209,18 @@ fastify.decorateRequest('utility', function () {
 })
 ```
 
-Note: using an arrow function will break the binding of `this` to the Fastify
+Using an arrow function will break the binding of `this` to the Fastify
 `Request` instance.
 
-Note: using `decorateRequest` will emit an error if used with a reference type:
+Using `decorateRequest` will emit an error if used with a reference type:
 
 ```js
 // Don't do this
 fastify.decorateRequest('foo', { bar: 'fizz'})
 ```
-In this example, the reference of the object would be shared with all the requests
-and **any mutation will impact all requests, potentially creating security
-vulnerabilities or memory leaks**, so Fastify blocks it.
+In this example, the object reference would be shared with all requests, and
+**any mutation will impact all requests, potentially creating security
+vulnerabilities or memory leaks**. Fastify blocks this.
 
 To achieve proper encapsulation across requests configure a new value for each
 incoming request in the [`'onRequest'` hook](./Hooks.md#onrequest).
@@ -268,8 +260,7 @@ fastify.get('/', async function (req, reply) {
 })
 ```
 
-This ensures that the `user` property is always unique for each
-request.
+This ensures that the `user` property is always unique for each request.
 
 See [`decorate`](#decorate) for information about the `dependencies` parameter.
 
@@ -305,9 +296,7 @@ fastify.hasReplyDecorator('utility')
 
 Defining a decorator (using `decorate`, `decorateRequest`, or `decorateReply`)
 with the same name more than once in the same **encapsulated** context will
-throw an exception.
-
-As an example, the following will throw:
+throw an exception. For example, the following will throw:
 
 ```js
 const server = require('fastify')()
@@ -358,9 +347,9 @@ server.listen({ port: 3000 })
 ### Getters and Setters
 <a id="getters-setters"></a>
 
-Decorators accept special "getter/setter" objects. These objects have functions
-named `getter` and `setter` (though the `setter` function is optional). This
-allows defining properties via decorators, for example:
+Decorators accept special "getter/setter" objects with `getter` and optional
+`setter` functions. This allows defining properties via decorators,
+for example:
 
 ```js
 fastify.decorate('foo', {


### PR DESCRIPTION
Companion to https://github.com/fastify/fastify/pull/5950.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
