### PR TITLE
fix(types): missing supportedMethods

### DIFF
--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -36,6 +36,7 @@ expectType<unknown>(server.getSchema('SchemaId'))
 expectType<string>(server.printRoutes())
 expectType<string>(server.printPlugins())
 expectType<string>(server.listeningOrigin)
+expectType<string[]>(server.supportedMethods)
 
 expectAssignable<FastifyInstance>(
   server.setErrorHandler(function (error, request, reply) {

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -549,6 +549,10 @@ export interface FastifyInstance<
    */
   removeAllContentTypeParsers: removeAllContentTypeParsers
   /**
+   * Returns an array of strings containing the list of supported HTTP methods
+   */
+  supportedMethods: string[]
+  /**
    * Add a non-standard HTTP method
    *
    * Methods defined by default include `GET`, `HEAD`, `TRACE`, `DELETE`,


### PR DESCRIPTION
Adds _supportedMethods_ to instance type.

Ref: https://fastify.dev/docs/latest/Guides/Migration-Guide-V5/#removal-of-some-non-standard-http-methods
