### PR TITLE
docs(reference): mimic github notes and warning style

### DIFF
--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -23,7 +23,7 @@ Note that for `GET` and `HEAD` requests, the payload is never parsed. For
 [catch-all](#catch-all) parser is not executed, and the payload is simply not
 parsed.
 
-> ## ⚠ Security Notice
+> ⚠ Warning:
 > When using regular expressions to detect `Content-Type`, it is important to
 > ensure proper detection. For example, to match `application/*`, use
 > `/^application\/([\w-]+);?/` to match the
@@ -152,8 +152,8 @@ fastify.addContentTypeParser('text/xml', function (request, payload, done) {
 })
 ```
 
-**Notice**: `function(req, done)` and `async function(req)` are
-still supported but deprecated.
+> 🛈 Note: `function(req, done)` and `async function(req)` are
+> still supported but deprecated.
 
 #### Body Parser
 The request body can be parsed in two ways. First, add a custom content type

--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -34,9 +34,9 @@ are Request/Reply hooks and application hooks:
 - [Using Hooks to Inject Custom Properties](#using-hooks-to-inject-custom-properties)
 - [Diagnostics Channel Hooks](#diagnostics-channel-hooks)
 
-**Notice:** the `done` callback is not available when using `async`/`await` or
-returning a `Promise`. If you do invoke a `done` callback in this situation
-unexpected behavior may occur, e.g. duplicate invocation of handlers.
+> 🛈 Note: The `done` callback is not available when using `async`/`await` or
+> returning a `Promise`. If you do invoke a `done` callback in this situation
+> unexpected behavior may occur, e.g. duplicate invocation of handlers.
 
 ## Request/Reply Hooks
 
@@ -68,9 +68,9 @@ fastify.addHook('onRequest', async (request, reply) => {
 })
 ```
 
-**Notice:** in the [onRequest](#onrequest) hook, `request.body` will always be
-`undefined`, because the body parsing happens before the
-[preValidation](#prevalidation) hook.
+> 🛈 Note: In the [onRequest](#onrequest) hook, `request.body` will always be
+> `undefined`, because the body parsing happens before the
+> [preValidation](#prevalidation) hook.
 
 ### preParsing
 
@@ -98,17 +98,17 @@ fastify.addHook('preParsing', async (request, reply, payload) => {
 })
 ```
 
-**Notice:** in the [preParsing](#preparsing) hook, `request.body` will always be
-`undefined`, because the body parsing happens before the
-[preValidation](#prevalidation) hook.
+> 🛈 Note: In the [preParsing](#preparsing) hook, `request.body` will always be
+> `undefined`, because the body parsing happens before the
+> [preValidation](#prevalidation) hook.
 
-**Notice:** you should also add a `receivedEncodedLength` property to the
-returned stream. This property is used to correctly match the request payload
-with the `Content-Length` header value. Ideally, this property should be updated
-on each received chunk.
+> 🛈 Note: You should also add a `receivedEncodedLength` property to the
+> returned stream. This property is used to correctly match the request payload
+> with the `Content-Length` header value. Ideally, this property should be updated
+> on each received chunk.
 
-**Notice:** The size of the returned stream is checked to not exceed the limit
-set in [`bodyLimit`](./Server.md#bodylimit) option.
+> 🛈 Note: The size of the returned stream is checked to not exceed the limit
+> set in [`bodyLimit`](./Server.md#bodylimit) option.
 
 ### preValidation
 
@@ -166,8 +166,8 @@ fastify.addHook('preSerialization', async (request, reply, payload) => {
 })
 ```
 
-Note: the hook is NOT called if the payload is a `string`, a `Buffer`, a
-`stream`, or `null`.
+> 🛈 Note: The hook is NOT called if the payload is a `string`, a `Buffer`, a
+> `stream`, or `null`.
 
 ### onError
 ```js
@@ -196,8 +196,8 @@ user
 *(Note that the default error handler always sends the error back to the
 user)*.
 
-**Notice:** unlike the other hooks, passing an error to the `done` function is not
-supported.
+> 🛈 Note: Unlike the other hooks, passing an error to the `done` function is not
+> supported.
 
 ### onSend
 If you are using the `onSend` hook, you can change the payload. For example:
@@ -233,8 +233,8 @@ fastify.addHook('onSend', (request, reply, payload, done) => {
 > to `0`, whereas the `Content-Length` header will not be set if the payload is
 > `null`.
 
-Note: If you change the payload, you may only change it to a `string`, a
-`Buffer`, a `stream`, a `ReadableStream`, a `Response`, or `null`.
+> 🛈 Note: If you change the payload, you may only change it to a `string`, a
+> `Buffer`, a `stream`, a `ReadableStream`, a `Response`, or `null`.
 
 
 ### onResponse
@@ -256,8 +256,8 @@ The `onResponse` hook is executed when a response has been sent, so you will not
 be able to send more data to the client. It can however be useful for sending
 data to external services, for example, to gather statistics.
 
-**Note:** setting `disableRequestLogging` to `true` will disable any error log
-inside the `onResponse` hook. In this case use `try - catch` to log errors.
+> 🛈 Note: Setting `disableRequestLogging` to `true` will disable any error log
+> inside the `onResponse` hook. In this case use `try - catch` to log errors.
 
 ### onTimeout
 
@@ -298,7 +298,8 @@ The `onRequestAbort` hook is executed when a client closes the connection before
 the entire request has been processed. Therefore, you will not be able to send
 data to the client.
 
-**Notice:** client abort detection is not completely reliable. See: [`Detecting-When-Clients-Abort.md`](../Guides/Detecting-When-Clients-Abort.md)
+> 🛈 Note: Client abort detection is not completely reliable.
+> See: [`Detecting-When-Clients-Abort.md`](../Guides/Detecting-When-Clients-Abort.md)
 
 ### Manage Errors from a hook
 If you get an error during the execution of your hook, just pass it to `done()`
@@ -451,8 +452,8 @@ fastify.addHook('onListen', async function () {
 })
 ```
 
-> **Note**
-> This hook will not run when the server is started using `fastify.inject()` or `fastify.ready()`
+> 🛈 Note: This hook will not run when the server is started using
+> fastify.inject()` or `fastify.ready()`.
 
 ### onClose
 <a id="on-close"></a>
@@ -575,8 +576,8 @@ This hook can be useful if you are developing a plugin that needs to know when a
 plugin context is formed, and you want to operate in that specific context, thus
 this hook is encapsulated.
 
-**Note:** This hook will not be called if a plugin is wrapped inside
-[`fastify-plugin`](https://github.com/fastify/fastify-plugin).
+> 🛈 Note: This hook will not be called if a plugin is wrapped inside
+> [`fastify-plugin`](https://github.com/fastify/fastify-plugin).
 ```js
 fastify.decorate('data', [])
 
@@ -773,7 +774,7 @@ fastify.route({
 })
 ```
 
-**Note**: both options also accept an array of functions.
+> 🛈 Note: Both options also accept an array of functions.
 
 ## Using Hooks to Inject Custom Properties
 <a id="using-hooks-to-inject-custom-properties"></a>
@@ -860,7 +861,7 @@ channel.subscribe(function ({ fastify }) {
 })
 ```
 
-> **Note:** The TracingChannel class API is currently experimental and may undergo
+> 🛈 Note: The TracingChannel class API is currently experimental and may undergo
 > breaking changes even in semver-patch releases of Node.js.
 
 Five other events are published on a per-request basis following the

--- a/docs/Reference/Logging.md
+++ b/docs/Reference/Logging.md
@@ -157,11 +157,11 @@ const fastify = require('fastify')({
 });
 ```
 
-**Note**: In some cases, the [`Reply`](./Reply.md) object passed to the `res`
-serializer cannot be fully constructed. When writing a custom `res` serializer,
-check for the existence of any properties on `reply` aside from `statusCode`,
-which is always present. For example, verify the existence of `getHeaders`
-before calling it:
+> 🛈 Note: In some cases, the [`Reply`](./Reply.md) object passed to the `res`
+> serializer cannot be fully constructed. When writing a custom `res`
+> serializer, check for the existence of any properties on `reply` aside from
+> `statusCode`, which is always present. For example, verify the existence of
+> `getHeaders` before calling it:
 
 ```js
 const fastify = require('fastify')({
@@ -184,7 +184,7 @@ const fastify = require('fastify')({
 });
 ```
 
-**Note**: The body cannot be serialized inside a `req` method because the
+> 🛈 Note: The body cannot be serialized inside a `req` method because the
 request is serialized when the child logger is created. At that time, the body
 is not yet parsed.
 
@@ -199,10 +199,10 @@ app.addHook('preHandler', function (req, reply, done) {
 })
 ```
 
-**Note**: Ensure serializers never throw errors, as this can cause the Node
-process to exit. See the
-[Pino documentation](https://getpino.io/#/docs/api?id=opt-serializers) for more
-information.
+> 🛈 Note: Ensure serializers never throw errors, as this can cause the Node
+> process to exit. See the
+> [Pino documentation](https://getpino.io/#/docs/api?id=opt-serializers) for more
+> information.
 
 *Any logger other than Pino will ignore this option.*
 

--- a/docs/Reference/Middleware.md
+++ b/docs/Reference/Middleware.md
@@ -50,8 +50,8 @@ that already has the Fastify [Request](./Request.md#request) and
 To run middleware under certain paths, pass the path as the first parameter to
 `use`.
 
-*Note: This does not support routes with parameters (e.g. `/user/:id/comments`)
-and wildcards are not supported in multiple paths.*
+> 🛈 Note: This does not support routes with parameters
+> (e.g. `/user/:id/comments`) and wildcards are not supported in multiple paths.
 
 ```js
 const path = require('node:path')

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -151,7 +151,7 @@ fastify.get('/', async function (req, rep) {
 Sets a response header. If the value is omitted or undefined, it is coerced to
 `''`.
 
-> Note: the header's value must be properly encoded using
+> 🛈 Note: The header's value must be properly encoded using
 > [`encodeURI`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI)
 > or similar modules such as
 > [`encodeurl`](https://www.npmjs.com/package/encodeurl). Invalid characters
@@ -260,11 +260,11 @@ requires heavy resources to be sent after the `data`, for example,
 `Server-Timing` and `Etag`. It can ensure the client receives the response data
 as soon as possible.
 
-*Note: The header `Transfer-Encoding: chunked` will be added once you use the
-trailer. It is a hard requirement for using trailer in Node.js.*
+> 🛈 Note: The header `Transfer-Encoding: chunked` will be added once you use
+> the trailer. It is a hard requirement for using trailer in Node.js.
 
-*Note: Any error passed to `done` callback will be ignored. If you interested
-in the error, you can turn on `debug` level logging.*
+> 🛈 Note: Any error passed to `done` callback will be ignored. If you interested
+> in the error, you can turn on `debug` level logging.*
 
 ```js
 reply.trailer('server-timing', function() {
@@ -314,7 +314,7 @@ reply.getTrailer('server-timing') // undefined
 Redirects a request to the specified URL, the status code is optional, default
 to `302` (if status code is not already set by calling `code`).
 
-> Note: the input URL must be properly encoded using
+> 🛈 Note: The input URL must be properly encoded using
 > [`encodeURI`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI)
 > or similar modules such as
 > [`encodeurl`](https://www.npmjs.com/package/encodeurl). Invalid URLs will
@@ -823,8 +823,8 @@ automatically create an error structured as the following:
 You can add custom properties to the Error object, such as `headers`, that will
 be used to enhance the HTTP response.
 
-*Note: If you are passing an error to `send` and the statusCode is less than
-400, Fastify will automatically set it at 500.*
+> 🛈 Note: If you are passing an error to `send` and the statusCode is less than
+> 400, Fastify will automatically set it at 500.
 
 Tip: you can simplify errors by using the
 [`http-errors`](https://npm.im/http-errors) module or
@@ -871,7 +871,7 @@ fastify.get('/', {
 If you want to customize error handling, check out
 [`setErrorHandler`](./Server.md#seterrorhandler) API.
 
-*Note: you are responsible for logging when customizing the error handler*
+> 🛈 Note: you are responsible for logging when customizing the error handler.
 
 API:
 

--- a/docs/Reference/Request.md
+++ b/docs/Reference/Request.md
@@ -84,8 +84,8 @@ This operation adds new values to the request headers, accessible via
 For performance reasons, `Symbol('fastify.RequestAcceptVersion')` may be added
 to headers on `not found` routes.
 
-> Note: Schema validation may mutate the `request.headers` and
-`request.raw.headers` objects, causing the headers to become empty.
+> 🛈 Note: Schema validation may mutate the `request.headers` and
+> `request.raw.headers` objects, causing the headers to become empty.
 
 ```js
 fastify.post('/:params', options, function (request, reply) {

--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -376,12 +376,12 @@ fastify.get('/', options, async function (request, reply) {
 })
 ```
 
-**Warning:**
-* When using both `return value` and `reply.send(value)`, the first one takes
-  precedence, the second is discarded, and a *warn* log is emitted.
-* Calling `reply.send()` outside of the promise is possible but requires special
-  attention. See [promise-resolution](#promise-resolution).
-* `undefined` cannot be returned. See [promise-resolution](#promise-resolution).
+> ⚠ Warning:
+> * When using both `return value` and `reply.send(value)`, the first one takes
+>   precedence, the second is discarded, and a *warn* log is emitted.
+> * Calling `reply.send()` outside of the promise is possible but requires special
+>   attention. See [promise-resolution](#promise-resolution).
+> * `undefined` cannot be returned. See [promise-resolution](#promise-resolution).
 
 ### Promise resolution
 <a id="promise-resolution"></a>
@@ -659,7 +659,7 @@ fastify.inject({
 })
 ```
 
-> ## ⚠  Security Notice
+> ⚠ Warning:
 > Set a
 > [`Vary`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary)
 > header in responses with the value used for versioning
@@ -771,7 +771,7 @@ const secret = {
 }
 ```
 
-> ## ⚠  Security Notice
+> ⚠ Warning:
 > When using asynchronous constraints, avoid returning errors inside the
 > callback. If errors are unavoidable, provide a custom `frameworkErrors`
 > handler to manage them. Otherwise, route selection may break or expose

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -166,7 +166,7 @@ When set to `true`, upon [`close`](#close) the server will iterate the current
 persistent connections and [destroy their
 sockets](https://nodejs.org/dist/latest-v16.x/docs/api/net.html#socketdestroyerror).
 
-> **Warning**
+> ⚠ Warning:
 > Connections are not inspected to determine if requests have
 > been completed.
 
@@ -193,7 +193,7 @@ to understand the effect of this option. This option only applies when HTTP/1.1
 is in use. Also, when `serverFactory` option is specified, this option is
 ignored.
 
-> **Note**
+> 🛈 Note:
 >  At the time of writing, only node >= v16.10.0 supports this option.
 
 ### `requestTimeout`
@@ -211,7 +211,7 @@ It must be set to a non-zero value (e.g. 120 seconds) to protect against potenti
 Denial-of-Service attacks in case the server is deployed without a reverse proxy
 in front.
 
-> **Note**
+> 🛈 Note:
 >  At the time of writing, only node >= v14.11.0 supports this option
 
 ### `ignoreTrailingSlash`
@@ -529,7 +529,7 @@ Especially in distributed systems, you may want to override the default ID
 generation behavior as shown below. For generating `UUID`s you may want to check
 out [hyperid](https://github.com/mcollina/hyperid).
 
-> **Note**
+> 🛈 Note:
 > `genReqId` will be not called if the header set in
 > <code>[requestIdHeader](#requestidheader)</code> is available (defaults to
 > 'request-id').
@@ -581,7 +581,7 @@ fastify.get('/', (request, reply) => {
 })
 ```
 
-> **Note**
+> 🛈 Note:
 > If a request contains multiple `x-forwarded-host` or `x-forwarded-proto`
 > headers, it is only the last one that is used to derive `request.hostname`
 > and `request.protocol`.
@@ -735,7 +735,7 @@ Fastify provides default error handlers for the most common use cases. It is
 possible to override one or more of those handlers with custom code using this
 option.
 
-> **Note**
+> 🛈 Note:
 > Only `FST_ERR_BAD_URL` and `FST_ERR_ASYNC_CONSTRAINT` are implemented at present.
 
 ```js
@@ -788,7 +788,7 @@ function defaultClientErrorHandler (err, socket) {
 }
 ```
 
-> **Note**
+> 🛈 Note:
 > `clientErrorHandler` operates with raw sockets. The handler is expected to
 > return a properly formed HTTP response that includes a status line, HTTP headers
 > and a message body. Before attempting to write the socket, the handler should
@@ -877,7 +877,7 @@ fastify.get('/dev', async (request, reply) => {
 [server](https://nodejs.org/api/http.html#http_class_http_server) object as
 returned by the [**`Fastify factory function`**](#factory).
 
-> **Warning**
+> ⚠ Warning:
 > If utilized improperly, certain Fastify features could be disrupted.
 > It is recommended to only use it for attaching listeners.
 
@@ -1219,7 +1219,7 @@ different ways to define a name (in order).
 Newlines are replaced by ` -- `. This will help to identify the root cause when
 you deal with many plugins.
 
-> **Warning**
+> ⚠ Warning:
 > If you have to deal with nested plugins, the name differs with the usage of
 > the [fastify-plugin](https://github.com/fastify/fastify-plugin) because
 > no new scope is created and therefore we have no place to attach contextual
@@ -1355,7 +1355,7 @@ Set the schema error formatter for all routes. See
 Set the schema serializer compiler for all routes. See
 [#schema-serializer](./Validation-and-Serialization.md#schema-serializer).
 
-> **Note**
+> 🛈 Note:
 > [`setReplySerializer`](#set-reply-serializer) has priority if set!
 
 #### validatorCompiler
@@ -1488,7 +1488,7 @@ lifecycle](./Lifecycle.md#lifecycle). *async-await* is supported as well.
 You can also register [`preValidation`](./Hooks.md#route-hooks) and
 [`preHandler`](./Hooks.md#route-hooks) hooks for the 404 handler.
 
-> **Note**
+> 🛈 Note:
 > The `preValidation` hook registered using this method will run for a
 > route that Fastify does not recognize and **not** when a route handler manually
 > calls [`reply.callNotFound`](./Reply.md#call-not-found). In which case, only
@@ -1524,7 +1524,7 @@ plugins are registered. If you would like to augment the behavior of the default
 arguments `fastify.setNotFoundHandler()` within the context of these registered
 plugins.
 
-> **Note**
+> 🛈 Note:
 > Some config properties from the request object will be
 > undefined inside the custom not found handler. E.g.:
 > `request.routerPath`, `routerMethod` and `context.config`.

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -11,7 +11,7 @@ All examples use the
 [JSON Schema Draft 7](https://json-schema.org/specification-links.html#draft-7)
 specification.
 
-> ## ⚠  Security Notice
+> ⚠ Warning:
 > Treat schema definitions as application code. Validation and serialization
 > features use `new Function()`, which is unsafe with user-provided schemas. See
 > [Ajv](https://npm.im/ajv) and
@@ -432,9 +432,9 @@ fastify.setValidatorCompiler(({ schema, method, url, httpPart }) => {
   return ajv.compile(schema)
 })
 ```
-_**Note:** When using a custom validator instance, add schemas to the validator
-instead of Fastify. Fastify's `addSchema` method will not recognize the custom
-validator._
+> 🛈 Note: When using a custom validator instance, add schemas to the validator
+> instead of Fastify. Fastify's `addSchema` method will not recognize the custom
+> validator.
 
 ##### Using other validation libraries
 <a id="using-other-validation-libraries"></a>
@@ -793,7 +793,7 @@ const fastify = Fastify({
   ajv: {
     customOptions: {
       jsonPointers: true,
-      // Warning: Enabling this option may lead to this security issue https://www.cvedetails.com/cve/CVE-2020-8192/
+      // ⚠ Warning: Enabling this option may lead to this security issue https://www.cvedetails.com/cve/CVE-2020-8192/
       allErrors: true
     },
     plugins: [


### PR DESCRIPTION
This PR updates the notes and warnings across the reference documentation to use emojis and block quotes, [mimicking GitHub's note and warning highlighting](https://github.com/orgs/community/discussions/16925).

This should make these parts of the documentation stand out more. You can already see this in action on the [ContentTypeParser page](https://fastify.dev/docs/latest/Reference/ContentTypeParser/#content-type-parser), where this style draws your attention to the warning.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
