### PR TITLE
docs: wrong query string parser information

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -601,7 +601,7 @@ controls [avvio](https://www.npmjs.com/package/avvio) 's `timeout` parameter.
 
 The default query string parser that Fastify uses is a more performant fork 
 of Node.js's core `querystring` module called 
-[`fast-query-string`](https://github.com/anonrig/fast-querystring).
+[`fast-querystring`](https://github.com/anonrig/fast-querystring).
 
 You can use this option to use a custom parser, such as
 [`qs`](https://www.npmjs.com/package/qs).

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -599,8 +599,9 @@ controls [avvio](https://www.npmjs.com/package/avvio) 's `timeout` parameter.
 ### `querystringParser`
 <a id="factory-querystring-parser"></a>
 
-The default query string parser that Fastify uses is a more performant fork of Node.js's core
-`querystring` module called [`fast-query-string`](https://github.com/anonrig/fast-querystring).
+The default query string parser that Fastify uses is a more performant fork 
+of Node.js's core `querystring` module called 
+[`fast-query-string`](https://github.com/anonrig/fast-querystring).
 
 You can use this option to use a custom parser, such as
 [`qs`](https://www.npmjs.com/package/qs).

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -599,8 +599,8 @@ controls [avvio](https://www.npmjs.com/package/avvio) 's `timeout` parameter.
 ### `querystringParser`
 <a id="factory-querystring-parser"></a>
 
-The default query string parser that Fastify uses is the Node.js's core
-`querystring` module.
+The default query string parser that Fastify uses is a more performant fork of Node.js's core
+`querystring` module called [`fast-query-string`](https://github.com/anonrig/fast-querystring).
 
 You can use this option to use a custom parser, such as
 [`qs`](https://www.npmjs.com/package/qs).


### PR DESCRIPTION
The current information in the documentation is wrong. Fastify uses https://github.com/delvedor/find-my-way for routing which doesn't use `querystring` for parsing at all but uses [fast-querystring](https://www.npmjs.com/package/fast-querystring) by default.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
