### PR TITLE
test: migrated throw.test.js from tap to node:test

### DIFF
--- a/test/throw.test.js
+++ b/test/throw.test.js
@@ -29,7 +29,7 @@ test('Fastify should throw on multiple assignment to the same route', (t) => {
 })
 
 test('Fastify should throw for an invalid schema, printing the error route - headers', async (t) => {
-  t.plan(2)
+  t.plan(1)
 
   const badSchema = {
     type: 'object',
@@ -39,19 +39,18 @@ test('Fastify should throw for an invalid schema, printing the error route - hea
       }
     }
   }
-
   const fastify = Fastify()
   fastify.get('/', { schema: { headers: badSchema } }, () => {})
   fastify.get('/not-loaded', { schema: { headers: badSchema } }, () => {})
 
-  await fastify.ready().catch(err => {
-    t.assert.strictEqual(err.code, 'FST_ERR_SCH_VALIDATION_BUILD')
-    t.assert.match(err.message, /Failed building the validation schema for GET: \//)
+  await t.assert.rejects(fastify.ready(), {
+    code: 'FST_ERR_SCH_VALIDATION_BUILD',
+    message: /Failed building the validation schema for GET: \//
   })
 })
 
 test('Fastify should throw for an invalid schema, printing the error route - body', async (t) => {
-  t.plan(2)
+  t.plan(1)
   const badSchema = {
     type: 'object',
     properties: {
@@ -67,9 +66,9 @@ test('Fastify should throw for an invalid schema, printing the error route - bod
     done()
   }, { prefix: 'hello' })
 
-  await fastify.ready().catch(err => {
-    t.assert.strictEqual(err.code, 'FST_ERR_SCH_VALIDATION_BUILD')
-    t.assert.match(err.message, /Failed building the validation schema for POST: \/hello\/form/)
+  await t.assert.rejects(fastify.ready(), {
+    code: 'FST_ERR_SCH_VALIDATION_BUILD',
+    message: /Failed building the validation schema for POST: \/hello\/form/
   })
 })
 

--- a/test/throw.test.js
+++ b/test/throw.test.js
@@ -1,20 +1,20 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const Fastify = require('..')
 
-test('Fastify should throw on wrong options', t => {
+test('Fastify should throw on wrong options', async (t) => {
   t.plan(2)
   try {
     Fastify('lol')
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.equal(e.message, 'Options must be an object')
-    t.pass()
+    t.assert.strictEqual(e.message, 'Options must be an object')
+    t.assert.ok(true)
   }
 })
 
-test('Fastify should throw on multiple assignment to the same route', t => {
+test('Fastify should throw on multiple assignment to the same route', async (t) => {
   t.plan(1)
   const fastify = Fastify()
 
@@ -22,13 +22,13 @@ test('Fastify should throw on multiple assignment to the same route', t => {
 
   try {
     fastify.get('/', () => {})
-    t.fail('Should throw fastify duplicated route declaration')
+    t.assert.fail('Should throw fastify duplicated route declaration')
   } catch (error) {
-    t.equal(error.code, 'FST_ERR_DUPLICATED_ROUTE')
+    t.assert.strictEqual(error.code, 'FST_ERR_DUPLICATED_ROUTE')
   }
 })
 
-test('Fastify should throw for an invalid schema, printing the error route - headers', t => {
+test('Fastify should throw for an invalid schema, printing the error route - headers', async (t) => {
   t.plan(2)
 
   const badSchema = {
@@ -44,15 +44,14 @@ test('Fastify should throw for an invalid schema, printing the error route - hea
   fastify.get('/', { schema: { headers: badSchema } }, () => {})
   fastify.get('/not-loaded', { schema: { headers: badSchema } }, () => {})
 
-  fastify.ready(err => {
-    t.equal(err.code, 'FST_ERR_SCH_VALIDATION_BUILD')
-    t.match(err.message, /Failed building the validation schema for GET: \//)
+  await fastify.ready().catch(err => {
+    t.assert.strictEqual(err.code, 'FST_ERR_SCH_VALIDATION_BUILD')
+    t.assert.match(err.message, /Failed building the validation schema for GET: \//)
   })
 })
 
-test('Fastify should throw for an invalid schema, printing the error route - body', t => {
+test('Fastify should throw for an invalid schema, printing the error route - body', async (t) => {
   t.plan(2)
-
   const badSchema = {
     type: 'object',
     properties: {
@@ -68,13 +67,13 @@ test('Fastify should throw for an invalid schema, printing the error route - bod
     done()
   }, { prefix: 'hello' })
 
-  fastify.ready(err => {
-    t.equal(err.code, 'FST_ERR_SCH_VALIDATION_BUILD')
-    t.match(err.message, /Failed building the validation schema for POST: \/hello\/form/)
+  await fastify.ready().catch(err => {
+    t.assert.strictEqual(err.code, 'FST_ERR_SCH_VALIDATION_BUILD')
+    t.assert.match(err.message, /Failed building the validation schema for POST: \/hello\/form/)
   })
 })
 
-test('Should throw on unsupported method', t => {
+test('Should throw on unsupported method', async (t) => {
   t.plan(1)
   const fastify = Fastify()
   try {
@@ -84,13 +83,13 @@ test('Should throw on unsupported method', t => {
       schema: {},
       handler: function (req, reply) {}
     })
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 })
 
-test('Should throw on missing handler', t => {
+test('Should throw on missing handler', async (t) => {
   t.plan(1)
   const fastify = Fastify()
   try {
@@ -98,15 +97,15 @@ test('Should throw on missing handler', t => {
       method: 'GET',
       url: '/'
     })
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 })
 
-test('Should throw if one method is unsupported', t => {
-  const fastify = Fastify()
+test('Should throw if one method is unsupported', async (t) => {
   t.plan(1)
+  const fastify = Fastify()
   try {
     fastify.route({
       method: ['GET', 'TROLL'],
@@ -114,28 +113,27 @@ test('Should throw if one method is unsupported', t => {
       schema: {},
       handler: function (req, reply) {}
     })
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 })
 
-test('Should throw on duplicate content type parser', t => {
+test('Should throw on duplicate content type parser', async (t) => {
   t.plan(1)
-
   const fastify = Fastify()
   function customParser (req, payload, done) { done(null, '') }
 
   fastify.addContentTypeParser('application/qq', customParser)
   try {
     fastify.addContentTypeParser('application/qq', customParser)
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 })
 
-test('Should throw on duplicate decorator', t => {
+test('Should throw on duplicate decorator', async (t) => {
   t.plan(1)
 
   const fastify = Fastify()
@@ -144,31 +142,30 @@ test('Should throw on duplicate decorator', t => {
   fastify.decorate('foo', fooObj)
   try {
     fastify.decorate('foo', fooObj)
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 })
 
-test('Should not throw on duplicate decorator encapsulation', t => {
+test('Should not throw on duplicate decorator encapsulation', async (t) => {
   t.plan(1)
-
   const fastify = Fastify()
   const foo2Obj = {}
 
   fastify.decorate('foo2', foo2Obj)
 
   fastify.register(function (fastify, opts, done) {
-    t.doesNotThrow(() => {
+    t.assert.doesNotThrow(() => {
       fastify.decorate('foo2', foo2Obj)
     })
     done()
   })
 
-  fastify.ready()
+  await fastify.ready()
 })
 
-test('Should throw on duplicate request decorator', t => {
+test('Should throw on duplicate request decorator', async (t) => {
   t.plan(2)
 
   const fastify = Fastify()
@@ -176,28 +173,28 @@ test('Should throw on duplicate request decorator', t => {
   fastify.decorateRequest('foo', null)
   try {
     fastify.decorateRequest('foo', null)
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.equal(e.code, 'FST_ERR_DEC_ALREADY_PRESENT')
-    t.equal(e.message, 'The decorator \'foo\' has already been added!')
+    t.assert.strictEqual(e.code, 'FST_ERR_DEC_ALREADY_PRESENT')
+    t.assert.strictEqual(e.message, 'The decorator \'foo\' has already been added!')
   }
 })
 
-test('Should throw if request decorator dependencies are not met', t => {
+test('Should throw if request decorator dependencies are not met', async (t) => {
   t.plan(2)
 
   const fastify = Fastify()
 
   try {
     fastify.decorateRequest('bar', null, ['world'])
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.equal(e.code, 'FST_ERR_DEC_MISSING_DEPENDENCY')
-    t.equal(e.message, 'The decorator is missing dependency \'world\'.')
+    t.assert.strictEqual(e.code, 'FST_ERR_DEC_MISSING_DEPENDENCY')
+    t.assert.strictEqual(e.message, 'The decorator is missing dependency \'world\'.')
   }
 })
 
-test('Should throw on duplicate reply decorator', t => {
+test('Should throw on duplicate reply decorator', async (t) => {
   t.plan(1)
 
   const fastify = Fastify()
@@ -205,149 +202,149 @@ test('Should throw on duplicate reply decorator', t => {
   fastify.decorateReply('foo', null)
   try {
     fastify.decorateReply('foo', null)
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.ok(/has already been added/.test(e.message))
+    t.assert.ok(/has already been added/.test(e.message))
   }
 })
 
-test('Should throw if reply decorator dependencies are not met', t => {
+test('Should throw if reply decorator dependencies are not met', async (t) => {
   t.plan(1)
 
   const fastify = Fastify()
 
   try {
     fastify.decorateReply('bar', null, ['world'])
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.ok(/missing dependency/.test(e.message))
+    t.assert.ok(/missing dependency/.test(e.message))
   }
 })
 
-test('Should throw if handler as the third parameter to the shortcut method is missing and the second parameter is not a function and also not an object', t => {
+test('Should throw if handler as the third parameter to the shortcut method is missing and the second parameter is not a function and also not an object', async (t) => {
   t.plan(5)
 
   const fastify = Fastify()
 
   try {
     fastify.get('/foo/1', '')
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 
   try {
     fastify.get('/foo/2', 1)
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 
   try {
     fastify.get('/foo/3', [])
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 
   try {
     fastify.get('/foo/4', undefined)
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 
   try {
     fastify.get('/foo/5', null)
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 })
 
-test('Should throw if handler as the third parameter to the shortcut method is missing and the second parameter is not a function and also not an object', t => {
+test('Should throw if handler as the third parameter to the shortcut method is missing and the second parameter is not a function and also not an object', async (t) => {
   t.plan(5)
 
   const fastify = Fastify()
 
   try {
     fastify.get('/foo/1', '')
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 
   try {
     fastify.get('/foo/2', 1)
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 
   try {
     fastify.get('/foo/3', [])
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 
   try {
     fastify.get('/foo/4', undefined)
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 
   try {
     fastify.get('/foo/5', null)
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 })
 
-test('Should throw if there is handler function as the third parameter to the shortcut method and options as the second parameter is not an object', t => {
+test('Should throw if there is handler function as the third parameter to the shortcut method and options as the second parameter is not an object', async (t) => {
   t.plan(5)
 
   const fastify = Fastify()
 
   try {
     fastify.get('/foo/1', '', (req, res) => {})
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 
   try {
     fastify.get('/foo/2', 1, (req, res) => {})
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 
   try {
     fastify.get('/foo/3', [], (req, res) => {})
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 
   try {
     fastify.get('/foo/4', undefined, (req, res) => {})
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 
   try {
     fastify.get('/foo/5', null, (req, res) => {})
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 })
 
-test('Should throw if found duplicate handler as the third parameter to the shortcut method and in options', t => {
+test('Should throw if found duplicate handler as the third parameter to the shortcut method and in options', async (t) => {
   t.plan(1)
 
   const fastify = Fastify()
@@ -356,8 +353,8 @@ test('Should throw if found duplicate handler as the third parameter to the shor
     fastify.get('/foo/abc', {
       handler: (req, res) => {}
     }, (req, res) => {})
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.pass()
+    t.assert.ok(true)
   }
 })

--- a/test/throw.test.js
+++ b/test/throw.test.js
@@ -3,7 +3,7 @@
 const { test } = require('node:test')
 const Fastify = require('..')
 
-test('Fastify should throw on wrong options', async (t) => {
+test('Fastify should throw on wrong options', (t) => {
   t.plan(2)
   try {
     Fastify('lol')
@@ -14,7 +14,7 @@ test('Fastify should throw on wrong options', async (t) => {
   }
 })
 
-test('Fastify should throw on multiple assignment to the same route', async (t) => {
+test('Fastify should throw on multiple assignment to the same route', (t) => {
   t.plan(1)
   const fastify = Fastify()
 
@@ -89,7 +89,7 @@ test('Should throw on unsupported method', async (t) => {
   }
 })
 
-test('Should throw on missing handler', async (t) => {
+test('Should throw on missing handler', (t) => {
   t.plan(1)
   const fastify = Fastify()
   try {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

Proposal:

   - migrated `throw.test.js` from `tap` to `node:test` 🔥
 