### PR TITLE
Don't require AJV when using custom validators/serializers

### DIFF
--- a/lib/schema-controller.js
+++ b/lib/schema-controller.js
@@ -1,8 +1,24 @@
 'use strict'
 
 const { buildSchemas } = require('./schemas')
-const SerializerSelector = require('@fastify/fast-json-stringify-compiler')
-const ValidatorSelector = require('@fastify/ajv-compiler')
+
+/**
+ * Inline require to avoid hard dependency on ajv when a custom validator is used
+ */
+function buildDefaultValidator () {
+  const ValidatorSelector = require('@fastify/ajv-compiler')
+
+  return ValidatorSelector()
+}
+
+/**
+ * Inline require to avoid hard dependency on fast-json-stringify when a custom serializer is used
+ */
+function buildDefaultSerializer () {
+  const SerializerSelector = require('@fastify/fast-json-stringify-compiler')
+
+  return SerializerSelector()
+}
 
 /**
  * Called at every fastify context that is being created.
@@ -21,10 +37,10 @@ function buildSchemaController (parentSchemaCtrl, opts) {
   }, opts?.compilersFactory)
 
   if (!compilersFactory.buildValidator) {
-    compilersFactory.buildValidator = ValidatorSelector()
+    compilersFactory.buildValidator = buildDefaultValidator()
   }
   if (!compilersFactory.buildSerializer) {
-    compilersFactory.buildSerializer = SerializerSelector()
+    compilersFactory.buildSerializer = buildDefaultSerializer()
   }
 
   const option = {


### PR DESCRIPTION
When using a custom validator or serializer for content, the AJV and fast-json-stringify libraries are still required by default. This makes excluding them via a build process (like `esbuild`) error out.

This PR moves the require() call into a function that only gets used as a fallback.

See https://github.com/fastify/fastify/issues/5507

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
