### PR TITLE
feat: add listen async callback warning

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -6,6 +6,7 @@ const dns = require('node:dns')
 const os = require('node:os')
 
 const { kState, kOptions, kServerBindings } = require('./symbols')
+const { FSTWRN003 } = require('./warnings')
 const { onListenHookRunner } = require('./hooks')
 const {
   FST_ERR_HTTP2_INVALID_VERSION,
@@ -29,6 +30,10 @@ function createServer (options, httpHandler) {
     cb = undefined
   ) {
     if (typeof cb === 'function') {
+      if (cb.constructor.name === 'AsyncFunction') {
+        FSTWRN003('listen method')
+      }
+
       listenOptions.cb = cb
     }
     if (listenOptions.signal) {

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -8,6 +8,7 @@ const { createWarning } = require('process-warning')
  *   - FSTSEC001
  *
  * Deprecation Codes FSTDEP001 - FSTDEP021 were used by v4 and MUST NOT not be reused.
+ * Warning Codes FSTWRN001 - FSTWRN002 were used by v4 and MUST NOT not be reused.
  */
 
 const FSTWRN001 = createWarning({
@@ -15,6 +16,13 @@ const FSTWRN001 = createWarning({
   code: 'FSTWRN001',
   message: 'The %s schema for %s: %s is missing. This may indicate the schema is not well specified.',
   unlimited: true
+})
+
+const FSTWRN003 = createWarning({
+  name: 'FastifyWarning',
+  code: 'FSTWRN003',
+  message: 'The %s mixes async and callback styles that may lead to unhandled rejections. Please use only one of them.',
+  unlimited: false
 })
 
 const FSTSEC001 = createWarning({
@@ -26,5 +34,6 @@ const FSTSEC001 = createWarning({
 
 module.exports = {
   FSTWRN001,
+  FSTWRN003,
   FSTSEC001
 }

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -22,7 +22,7 @@ const FSTWRN003 = createWarning({
   name: 'FastifyWarning',
   code: 'FSTWRN003',
   message: 'The %s mixes async and callback styles that may lead to unhandled rejections. Please use only one of them.',
-  unlimited: false
+  unlimited: true
 })
 
 const FSTSEC001 = createWarning({


### PR DESCRIPTION
I'm seeing multiple users that keep mixing async and callback.

This PR adds the generic `FSTWRN003` warning (which accepts the `subject` as input) in order to add more warnings to help the developer to find bad usage.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
