### PR TITLE
test: migrated listen.1.test.js from tap to node:test

### DIFF
--- a/test/listen.1.test.js
+++ b/test/listen.1.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test, before } = require('tap')
+const { test, before } = require('node:test')
 const Fastify = require('..')
 const helper = require('./helper')
 
@@ -13,69 +13,70 @@ before(async function () {
 
 test('listen works without arguments', async t => {
   const doNotWarn = () => {
-    t.fail('should not be deprecated')
+    t.assert.fail('should not be deprecated')
   }
   process.on('warning', doNotWarn)
 
   const fastify = Fastify()
-  t.teardown(() => {
+  t.after(() => {
     fastify.close()
     process.removeListener('warning', doNotWarn)
   })
   await fastify.listen()
   const address = fastify.server.address()
-  t.equal(address.address, localhost)
-  t.ok(address.port > 0)
+  t.assert.strictEqual(address.address, localhost)
+  t.assert.ok(address.port > 0)
 })
 
 test('Async/await listen with arguments', async t => {
   const doNotWarn = () => {
-    t.fail('should not be deprecated')
+    t.assert.fail('should not be deprecated')
   }
   process.on('warning', doNotWarn)
 
   const fastify = Fastify()
-  t.teardown(() => {
+  t.after(() => {
     fastify.close()
     process.removeListener('warning', doNotWarn)
   })
   const addr = await fastify.listen({ port: 0, host: '0.0.0.0' })
   const address = fastify.server.address()
-  t.equal(addr, `http://127.0.0.1:${address.port}`)
-  t.same(address, {
+  t.assert.strictEqual(addr, `http://127.0.0.1:${address.port}`)
+  t.assert.deepEqual(address, {
     address: '0.0.0.0',
     family: 'IPv4',
     port: address.port
   })
 })
 
-test('listen accepts a callback', t => {
+test('listen accepts a callback', (t, done) => {
   t.plan(2)
   const doNotWarn = () => {
-    t.fail('should not be deprecated')
+    t.assert.fail('should not be deprecated')
   }
   process.on('warning', doNotWarn)
 
   const fastify = Fastify()
-  t.teardown(() => {
+  t.after(() => {
     fastify.close()
     process.removeListener('warning', doNotWarn)
   })
   fastify.listen({ port: 0 }, (err) => {
-    t.equal(fastify.server.address().address, localhost)
-    t.error(err)
+    t.assert.ifError(err)
+    t.assert.strictEqual(fastify.server.address().address, localhost)
+    done()
   })
 })
 
-test('listen accepts options and a callback', t => {
+test('listen accepts options and a callback', (t, done) => {
   t.plan(1)
   const doNotWarn = () => {
-    t.fail('should not be deprecated')
+    t.assert.fail('should not be deprecated')
   }
   process.on('warning', doNotWarn)
 
   const fastify = Fastify()
-  t.teardown(() => {
+  t.after(() => {
     fastify.close()
     process.removeListener('warning', doNotWarn)
   })
@@ -88,40 +89,42 @@ test('listen accepts options and a callback', t => {
     writableAll: false,
     ipv6Only: false
   }, (err) => {
-    t.error(err)
+    t.assert.ifError(err)
+    done()
   })
 })
 
-test('listen after Promise.resolve()', t => {
+test('listen after Promise.resolve()', (t, done) => {
   t.plan(2)
-  const f = Fastify()
-  t.teardown(f.close.bind(f))
+  const fastify = Fastify()
+  t.after(() => fastify.close())
   Promise.resolve()
     .then(() => {
-      f.listen({ port: 0 }, (err, address) => {
-        f.server.unref()
-        t.equal(address, `http://${localhostForURL}:${f.server.address().port}`)
-        t.error(err)
+      fastify.listen({ port: 0 }, (err, address) => {
+        fastify.server.unref()
+        t.assert.strictEqual(address, `http://${localhostForURL}:${fastify.server.address().port}`)
+        t.assert.ifError(err)
+        done()
       })
     })
 })
 
 test('listen works with undefined host', async t => {
   const doNotWarn = () => {
-    t.fail('should not be deprecated')
+    t.assert.fail('should not be deprecated')
   }
   process.on('warning', doNotWarn)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
-  t.teardown(() => {
+  t.after(() => fastify.close())
+  t.after(() => {
     fastify.close()
     process.removeListener('warning', doNotWarn)
   })
   await fastify.listen({ host: undefined, port: 0 })
   const address = fastify.server.address()
-  t.equal(address.address, localhost)
-  t.ok(address.port > 0)
+  t.assert.strictEqual(address.address, localhost)
+  t.assert.ok(address.port > 0)
 })
 
 test('listen works with null host', async t => {
@@ -131,13 +134,13 @@ test('listen works with null host', async t => {
   process.on('warning', doNotWarn)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
-  t.teardown(() => {
+  t.after(() => fastify.close())
+  t.after(() => {
     fastify.close()
     process.removeListener('warning', doNotWarn)
   })
   await fastify.listen({ host: null, port: 0 })
   const address = fastify.server.address()
-  t.equal(address.address, localhost)
-  t.ok(address.port > 0)
+  t.assert.strictEqual(address.address, localhost)
+  t.assert.ok(address.port > 0)
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

Proposal:

  - migrated `listen.1.test.js` from `tap` to `node:test` 🔥