### PR TITLE
docs: remove --node-arg prefix

### DIFF
--- a/docs/Guides/Testing.md
+++ b/docs/Guides/Testing.md
@@ -340,10 +340,10 @@ test('should ...', {only: true}, t => ...)
 ```
 2. Run `node --test`
 ```bash
-> node --test --test-only --node-arg=--inspect-brk test/<test-file.test.js>
+> node --test --test-only --inspect-brk test/<test-file.test.js>
 ```
 - `--test-only` specifies to run tests with the `only` option enabled
-- `--node-arg=--inspect-brk` will launch the node debugger
+- `--inspect-brk` will launch the node debugger
 3. In VS Code, create and launch a `Node.js: Attach` debug configuration. No
    modification should be necessary.
 


### PR DESCRIPTION
#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

Replace `--node-arg=--inspect-brk` by `--inspect-brk`.

The `--node-arg` is a [NODE TAP](https://node-tap.org/cli/#--node-arg%3D%3Carg%3E) and this package is not used anymore.