### PR TITLE
test: fix flaky

### DIFF
--- a/test/toolkit.js
+++ b/test/toolkit.js
@@ -1,0 +1,32 @@
+'use strict'
+
+exports.waitForCb = function (options) {
+  let count = null
+  let done = false
+  let iResolve
+  let iReject
+
+  function stepIn () {
+    if (done) {
+      iReject(new Error('Unexpected done call'))
+      return
+    }
+
+    if (--count) {
+      return
+    }
+
+    done = true
+    iResolve()
+  }
+
+  const patience = new Promise((resolve, reject) => {
+    iResolve = resolve
+    iReject = reject
+  })
+
+  count = options.steps || 1
+  done = false
+
+  return { stepIn, patience }
+}


### PR DESCRIPTION
Our `main` tests are not stable:

<img width="987" alt="image" src="https://github.com/user-attachments/assets/989fe322-d1c6-479c-a9cc-03ed118b5a56" />

This PR clean up a bit the flaky test and adds a small utility to avoid the `pending` stuff to wait for multiple async functions

Unblock #6013 