### PR TITLE
test: migrated listen.3.test.js from tap to node:test

### DIFF
--- a/test/listen.3.test.js
+++ b/test/listen.3.test.js
@@ -3,7 +3,7 @@
 const os = require('node:os')
 const path = require('node:path')
 const fs = require('node:fs')
-const { test, before } = require('tap')
+const { test, before } = require('node:test')
 const Fastify = require('..')
 const helper = require('./helper')
 
@@ -15,73 +15,69 @@ before(async function () {
 
 // https://nodejs.org/api/net.html#net_ipc_support
 if (os.platform() !== 'win32') {
-  test('listen on socket', t => {
-    t.plan(3)
+  test('listen on socket', async t => {
+    t.plan(2)
     const fastify = Fastify()
-    t.teardown(fastify.close.bind(fastify))
+    t.after(() => fastify.close())
 
     const sockFile = path.join(os.tmpdir(), `${(Math.random().toString(16) + '0000000').slice(2, 10)}-server.sock`)
     try {
       fs.unlinkSync(sockFile)
     } catch (e) { }
 
-    fastify.listen({ path: sockFile }, (err, address) => {
-      t.error(err)
-      t.strictSame(fastify.addresses(), [sockFile])
-      t.equal(address, sockFile)
-    })
+    await fastify.listen({ path: sockFile })
+    t.assert.deepStrictEqual(fastify.addresses(), [sockFile])
+    t.assert.strictEqual(fastify.server.address(), sockFile)
   })
 } else {
-  test('listen on socket', t => {
-    t.plan(3)
+  test('listen on socket', async t => {
+    t.plan(2)
     const fastify = Fastify()
-    t.teardown(fastify.close.bind(fastify))
+    t.after(() => fastify.close())
 
     const sockFile = `\\\\.\\pipe\\${(Math.random().toString(16) + '0000000').slice(2, 10)}-server-sock`
 
-    fastify.listen({ path: sockFile }, (err, address) => {
-      t.error(err)
-      t.strictSame(fastify.addresses(), [sockFile])
-      t.equal(address, sockFile)
-    })
+    await fastify.listen({ path: sockFile })
+    t.assert.deepStrictEqual(fastify.addresses(), [sockFile])
+    t.assert.strictEqual(fastify.server.address(), sockFile)
   })
 }
 
-test('listen without callback with (address)', t => {
+test('listen without callback with (address)', async t => {
   t.plan(1)
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
-  fastify.listen({ port: 0 })
+  t.after(() => fastify.close())
+  await fastify.listen({ port: 0 })
     .then(address => {
-      t.equal(address, `http://${localhostForURL}:${fastify.server.address().port}`)
+      t.assert.strictEqual(address, `http://${localhostForURL}:${fastify.server.address().port}`)
     })
 })
 
-test('double listen without callback rejects', t => {
+test('double listen without callback rejects', async t => {
   t.plan(1)
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
-  fastify.listen({ port: 0 })
+  t.after(() => fastify.close())
+  await fastify.listen({ port: 0 })
     .then(() => {
       fastify.listen({ port: 0 })
         .catch(err => {
-          t.ok(err)
+          t.assert.ok(err)
         })
     })
-    .catch(err => t.error(err))
+    .catch(err => t.assert.ifError(err))
 })
 
-test('double listen without callback with (address)', t => {
+test('double listen without callback with (address)', async t => {
   t.plan(2)
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
-  fastify.listen({ port: 0 })
+  t.after(() => fastify.close())
+  await fastify.listen({ port: 0 })
     .then(address => {
-      t.equal(address, `http://${localhostForURL}:${fastify.server.address().port}`)
+      t.assert.strictEqual(address, `http://${localhostForURL}:${fastify.server.address().port}`)
       fastify.listen({ port: 0 })
         .catch(err => {
-          t.ok(err)
+          t.assert.ok(err)
         })
     })
-    .catch(err => t.error(err))
+    .catch(err => t.assert.ifError(err))
 })

--- a/test/listen.3.test.js
+++ b/test/listen.3.test.js
@@ -47,36 +47,36 @@ test('listen without callback with (address)', async t => {
   t.plan(1)
   const fastify = Fastify()
   t.after(() => fastify.close())
-  await fastify.listen({ port: 0 })
-    .then(address => {
-      t.assert.strictEqual(address, `http://${localhostForURL}:${fastify.server.address().port}`)
-    })
+  const address = await fastify.listen({ port: 0 })
+  t.assert.strictEqual(address, `http://${localhostForURL}:${fastify.server.address().port}`)
 })
 
-test('double listen without callback rejects', async t => {
+test('double listen without callback rejects', (t, done) => {
   t.plan(1)
   const fastify = Fastify()
   t.after(() => fastify.close())
-  await fastify.listen({ port: 0 })
+  fastify.listen({ port: 0 })
     .then(() => {
       fastify.listen({ port: 0 })
         .catch(err => {
           t.assert.ok(err)
+          done()
         })
     })
     .catch(err => t.assert.ifError(err))
 })
 
-test('double listen without callback with (address)', async t => {
+test('double listen without callback with (address)', (t, done) => {
   t.plan(2)
   const fastify = Fastify()
   t.after(() => fastify.close())
-  await fastify.listen({ port: 0 })
+  fastify.listen({ port: 0 })
     .then(address => {
       t.assert.strictEqual(address, `http://${localhostForURL}:${fastify.server.address().port}`)
       fastify.listen({ port: 0 })
         .catch(err => {
           t.assert.ok(err)
+          done()
         })
     })
     .catch(err => t.assert.ifError(err))


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

Proposal:

   - migrated `listen.3.test.js` from `tap` to `node:test` 🔥