### PR TITLE
fix: wrong reply return type

### DIFF
--- a/test/types/type-provider.test-d.ts
+++ b/test/types/type-provider.test-d.ts
@@ -1010,6 +1010,46 @@ expectAssignable(server.withTypeProvider<JsonSchemaToTsProvider>().get<{ Reply: 
 ))
 
 // -------------------------------------------------------------------
+// RouteGeneric Reply Type Return (Different Status Codes)
+// -------------------------------------------------------------------
+
+expectAssignable(server.get<{
+  Reply: {
+    200: string | { msg: string }
+    400: number
+    '5xx': { error: string }
+  }
+}>(
+  '/',
+  async (_, res) => {
+    const option = 1 as 1 | 2 | 3 | 4
+    switch (option) {
+      case 1: return 'hello'
+      case 2: return { msg: 'hello' }
+      case 3: return 400
+      case 4: return { error: 'error' }
+    }
+  }
+))
+
+// -------------------------------------------------------------------
+// RouteGeneric Reply Type Return: Non Assignable (Different Status Codes)
+// -------------------------------------------------------------------
+
+expectError(server.get<{
+  Reply: {
+    200: string | { msg: string }
+    400: number
+    '5xx': { error: string }
+  }
+}>(
+  '/',
+  async (_, res) => {
+    return true
+  }
+))
+
+// -------------------------------------------------------------------
 // FastifyPlugin: Auxiliary
 // -------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes https://github.com/fastify/fastify/issues/6020

#### Checklist

- [x] run ~~`npm run test`~~ `npm run test:typescript`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
