### PR TITLE
fix: clear `[kState].readyPromise` for garbage collection

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -639,7 +639,7 @@ function fastify (options) {
       resolveReady(fastify)
       fastify[kState].booting = false
       fastify[kState].ready = true
-      fastify[kState].promise = null
+      fastify[kState].readyPromise = null
     }
   }
 

--- a/test/fastify-instance.test.js
+++ b/test/fastify-instance.test.js
@@ -7,7 +7,8 @@ const os = require('node:os')
 const {
   kOptions,
   kErrorHandler,
-  kChildLoggerFactory
+  kChildLoggerFactory,
+  kState
 } = require('../lib/symbols')
 
 test('root fastify instance is an object', t => {
@@ -287,4 +288,11 @@ test('fastify instance should contains listeningOrigin property (IPv6)', async t
   await fastify.listen({ port, host })
   t.assert.deepStrictEqual(fastify.listeningOrigin, `http://[::1]:${port}`)
   await fastify.close()
+})
+
+test('fastify instance should ensure ready promise cleanup on ready', async t => {
+  t.plan(1)
+  const fastify = Fastify()
+  await fastify.ready()
+  t.assert.strictEqual(fastify[kState].readyPromise, null)
 })


### PR DESCRIPTION
Disclaimer: this is committed with `--no-verify` because penultimate test fails locally with `EAFNOSUPPORT`.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

Once support of Node.js older than v22.x is dropped, this should probably be rewritten using `Promise.withResolvers()`.

Without the patch, `assert.strictEqual` might hang and timeout instead of failing immediately. Didn't look into it closely, i guess combination of resolved promise and circular references might trigger a bug in `strictEqual()`?