### PR TITLE
ci: continue-on-error on alternative runtime

### DIFF
--- a/.github/workflows/ci-alternative-runtime.yml
+++ b/.github/workflows/ci-alternative-runtime.yml
@@ -48,6 +48,7 @@ jobs:
           npm install --ignore-scripts
 
       - name: Run tests
+        continue-on-error: true
         run: |
           npm run unit
 


### PR DESCRIPTION
We added this CI workflow in https://github.com/fastify/fastify/pull/5332

As suggested: https://github.com/fastify/fastify/pull/5332#pullrequestreview-1906365087, I'm marking this run as "optional" because it is flaky.

Lately I need to run it at least twice to get a green:

<img width="318" alt="image" src="https://github.com/user-attachments/assets/7a4e9d20-0159-41ed-94b3-55d818d9010a" />


- https://github.com/fastify/fastify/actions/runs/14129794841
- https://github.com/fastify/fastify/actions/runs/14041898978
- https://github.com/fastify/fastify/actions/runs/14042618758

TBH, I would evaluate to remove it because it seems to me that the prerequisites are not meet anymore: https://github.com/fastify/fastify/pull/5332#issuecomment-1967933779

NSOLID should just run the pipeline when a new commit is performed on this repo.

cc @RafaelGSS @riosje 