### PR TITLE
ci: set workflow permissions to read-only by default

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,12 +6,14 @@ on:
       - labeled
 
 permissions:
-  pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   backport:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     if: >
       github.event.pull_request.merged
       && (

--- a/.github/workflows/benchmark-parser.yml
+++ b/.github/workflows/benchmark-parser.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [labeled]
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     if: ${{ github.event.label.name == 'benchmark' }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [labeled]
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     if: ${{ github.event.label.name == 'benchmark' }}

--- a/.github/workflows/ci-alternative-runtime.yml
+++ b/.github/workflows/ci-alternative-runtime.yml
@@ -19,6 +19,9 @@ concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-unit:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   dependency-review:
       name: Dependency Review

--- a/.github/workflows/citgm-package.yml
+++ b/.github/workflows/citgm-package.yml
@@ -37,6 +37,10 @@ on:
         required: false
         type: string
         default: 'ubuntu-latest'
+
+permissions:
+  contents: read
+
 jobs:
   core-plugins:
     name: CITGM

--- a/.github/workflows/citgm.yml
+++ b/.github/workflows/citgm.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [labeled]
 
+permissions:
+  contents: read
+
 jobs:
   core-plugins:
     name: CITGM

--- a/.github/workflows/coverage-nix.yml
+++ b/.github/workflows/coverage-nix.yml
@@ -3,6 +3,9 @@ name: Code Coverage (*nix)
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   check-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage-win.yml
+++ b/.github/workflows/coverage-win.yml
@@ -3,6 +3,9 @@ name: Code Coverage (win)
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   check-coverage:
     runs-on: windows-latest

--- a/.github/workflows/integration-alternative-runtimes.yml
+++ b/.github/workflows/integration-alternative-runtimes.yml
@@ -14,6 +14,9 @@ on:
       - 'docs/**'
       - '*.md'
 
+permissions:
+  contents: read
+
 jobs:
   install-production:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,6 +14,9 @@ on:
       - 'docs/**'
       - '*.md'
 
+permissions:
+  contents: read
+
 jobs:
   install-production:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,9 @@
 name: "Pull Request Labeler"
 on: pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   label:
     permissions:

--- a/.github/workflows/links-check.yml
+++ b/.github/workflows/links-check.yml
@@ -6,9 +6,14 @@ on:
       - 'docs/**'
       - '*.md'
 
+permissions:
+  contents: read
+
 jobs:
   linkChecker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out repo
         uses: actions/checkout@v4

--- a/.github/workflows/lint-ecosystem-order.yml
+++ b/.github/workflows/lint-ecosystem-order.yml
@@ -8,12 +8,14 @@ on:
       - "**/Ecosystem.md"
 
 permissions:
-  contents: read # to fetch code (actions/checkout)
+  contents: read
 
 jobs:
   build:
     name: Lint Ecosystem Order
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -6,8 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  issues: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: lock
@@ -15,6 +14,9 @@ concurrency:
 jobs:
   action:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: jsumners/lock-threads@b27edac0ac998d42b2815e122b6c24b32b568321
         with:

--- a/.github/workflows/md-lint.yml
+++ b/.github/workflows/md-lint.yml
@@ -13,12 +13,14 @@ on:
        - "**/*.md"
 
 permissions:
-  contents: read # to fetch code (actions/checkout)
+  contents: read
 
 jobs:
   build:
     name: Lint Markdown
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/missing_types.yml
+++ b/.github/workflows/missing_types.yml
@@ -5,12 +5,14 @@ on:
     types: [closed]
 
 permissions:
-  issues: write
-  pull-requests: read
+  contents: read
 
 jobs:
   create_issue:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
     if: |
       github.event.pull_request.merged &&
       contains(github.event.pull_request.labels.*.name, 'missing-types')

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   pnpm:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
 
     strategy:
       matrix:
@@ -45,6 +47,8 @@ jobs:
 
   yarn:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
 
     strategy:
       matrix:

--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -3,9 +3,14 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   pull-request-title-check:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
     - uses: fastify/action-pr-title@v0
       with:

--- a/.github/workflows/test-compare.yml
+++ b/.github/workflows/test-compare.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
 
+permissions:
+  contents: read
+
 jobs:
   run:
     if: contains(github.event.pull_request.labels.*.name, 'test-compare')


### PR DESCRIPTION
This PR is created by a script. Please check the changes prior to merging.

This PR adds permissions to the workflow and job level, making the workflows read-only by default, and allowing write access only at the job level via granular permissions. This is regularly flagged by CodeQL, Step Security, [OSSF](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions), and other security tools.
This change also allows the org to go read-only everywhere, see https://github.com/fastify/avvio/pull/308#issuecomment-2765300174