### PR TITLE
chore: remove sponsort

### DIFF
--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -16,7 +16,6 @@ _Be the first!_
 - [Mercedes-Benz Group](https://github.com/mercedes-benz)
 - [Val Town, Inc.](https://opencollective.com/valtown)
 - [Handsontable - JavaScript Data Grid](https://handsontable.com/docs/react-data-grid/?utm_source=Fastify_GH&utm_medium=sponsorship&utm_campaign=library_sponsorship_2024)
-- [Jspreadsheet](https://jspreadsheet.com/)
 - [Lokalise - A Localization and Translation Software Tool](https://lokalise.com/?utm_source=Fastify_GH&utm_medium=sponsorship)
 
 ## Tier 2


### PR DESCRIPTION
Removing the sponsor as the subscription has been cancelled

(the next charge did not happen)

![image](https://github.com/user-attachments/assets/0421c1ab-5359-49b7-8305-f92c8762fad0)