### PR TITLE
chore: use latest TypeScript version for type testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,6 +215,11 @@
     "semver": "^7.6.0",
     "toad-cache": "^3.7.0"
   },
+  "overrides": {
+    "tsd": {
+      "@tsd/typescript": "~5.8.2"
+    }
+  },
   "tsd": {
     "directory": "test/types"
   }


### PR DESCRIPTION
To draw your attention: currently `tsd` is using `@tsd/typescript@5.4.5` to test types (to verify, run `npm why @tsd/typescript`). This version of TypeScript was published almost a year ago (to be precise: 2024.04.10).

Here is the line in `tsd` repo responsible for this behaviour:  https://github.com/tsdjs/tsd/blob/c46b372130ecad265b1e1e807578e45f912046bf/package.json#L42

It might be this is your intent to test using this particular version. If not, this PR is a workaround to use the latest TypeScript version for type testing.

On surface this might sounds not significant. The fact is that TypeScript behaviour is changing between minor versions. For instance, I was trying to update `@tsd/typescript` version in the `tsd` repo and surprisingly there are four failures in their test suite.

Related: #6033

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)