### PR TITLE
test: skip IPv6 tests if its support is not present

### DIFF
--- a/test/fastify-instance.test.js
+++ b/test/fastify-instance.test.js
@@ -11,6 +11,8 @@ const {
   kState
 } = require('../lib/symbols')
 
+const hasIPv6 = Object.values(os.networkInterfaces()).flat().some(({ family }) => family === 'IPv6')
+
 test('root fastify instance is an object', t => {
   t.plan(1)
   t.assert.strictEqual(typeof Fastify(), 'object')
@@ -280,7 +282,7 @@ test('fastify instance should contains listeningOrigin property (unix socket)', 
   await fastify.close()
 })
 
-test('fastify instance should contains listeningOrigin property (IPv6)', async t => {
+test('fastify instance should contains listeningOrigin property (IPv6)', { skip: !hasIPv6 }, async t => {
   t.plan(1)
   const port = 3000
   const host = '::1'

--- a/test/fastify-instance.test.js
+++ b/test/fastify-instance.test.js
@@ -11,7 +11,7 @@ const {
   kState
 } = require('../lib/symbols')
 
-const hasIPv6 = Object.values(os.networkInterfaces()).flat().some(({ family }) => family === 'IPv6')
+const isIPv6Missing = !Object.values(os.networkInterfaces()).flat().some(({ family }) => family === 'IPv6')
 
 test('root fastify instance is an object', t => {
   t.plan(1)
@@ -282,7 +282,7 @@ test('fastify instance should contains listeningOrigin property (unix socket)', 
   await fastify.close()
 })
 
-test('fastify instance should contains listeningOrigin property (IPv6)', { skip: !hasIPv6 }, async t => {
+test('fastify instance should contains listeningOrigin property (IPv6)', { skip: isIPv6Missing }, async t => {
   t.plan(1)
   const port = 3000
   const host = '::1'

--- a/test/hooks.on-listen.test.js
+++ b/test/hooks.on-listen.test.js
@@ -6,6 +6,9 @@ const fp = require('fastify-plugin')
 const split = require('split2')
 const helper = require('./helper')
 const { kState } = require('../lib/symbols')
+const { networkInterfaces } = require('node:os')
+
+const hasIPv6 = Object.values(networkInterfaces()).flat().some(({ family }) => family === 'IPv6')
 
 let localhost
 before(async function () {
@@ -405,7 +408,7 @@ test('localhost onListen encapsulation should be called in order and should log 
   })
 })
 
-test('non-localhost onListen should be called in order', t => {
+test('non-localhost onListen should be called in order', { skip: !hasIPv6 }, t => {
   t.plan(2)
 
   const fastify = Fastify()
@@ -428,7 +431,7 @@ test('non-localhost onListen should be called in order', t => {
   })
 })
 
-test('non-localhost async onListen should be called in order', async t => {
+test('non-localhost async onListen should be called in order', { skip: !hasIPv6 }, async t => {
   t.plan(2)
   const fastify = Fastify()
   t.teardown(fastify.close.bind(fastify))
@@ -448,7 +451,7 @@ test('non-localhost async onListen should be called in order', async t => {
   })
 })
 
-test('non-localhost sync onListen should log errors as warnings and continue', t => {
+test('non-localhost sync onListen should log errors as warnings and continue', { skip: !hasIPv6 }, t => {
   t.plan(4)
   const stream = split(JSON.parse)
   const fastify = Fastify({
@@ -488,7 +491,7 @@ test('non-localhost sync onListen should log errors as warnings and continue', t
   })
 })
 
-test('non-localhost async onListen should log errors as warnings and continue', async t => {
+test('non-localhost async onListen should log errors as warnings and continue', { skip: !hasIPv6 }, async t => {
   t.plan(6)
   const stream = split(JSON.parse)
   const fastify = Fastify({
@@ -529,7 +532,7 @@ test('non-localhost async onListen should log errors as warnings and continue', 
   })
 })
 
-test('non-localhost Register onListen hook after a plugin inside a plugin', t => {
+test('non-localhost Register onListen hook after a plugin inside a plugin', { skip: !hasIPv6 }, t => {
   t.plan(3)
   const fastify = Fastify()
   t.teardown(fastify.close.bind(fastify))
@@ -562,7 +565,7 @@ test('non-localhost Register onListen hook after a plugin inside a plugin', t =>
   })
 })
 
-test('non-localhost Register onListen hook after a plugin inside a plugin should log errors as warnings and continue', t => {
+test('non-localhost Register onListen hook after a plugin inside a plugin should log errors as warnings and continue', { skip: !hasIPv6 }, t => {
   t.plan(6)
   const stream = split(JSON.parse)
   const fastify = Fastify({
@@ -608,7 +611,7 @@ test('non-localhost Register onListen hook after a plugin inside a plugin should
   })
 })
 
-test('non-localhost onListen encapsulation should be called in order', t => {
+test('non-localhost onListen encapsulation should be called in order', { skip: !hasIPv6 }, t => {
   t.plan(6)
   const fastify = Fastify()
   t.teardown(fastify.close.bind(fastify))
@@ -640,7 +643,7 @@ test('non-localhost onListen encapsulation should be called in order', t => {
   })
 })
 
-test('non-localhost onListen encapsulation should be called in order and should log errors as warnings and continue', t => {
+test('non-localhost onListen encapsulation should be called in order and should log errors as warnings and continue', { skip: !hasIPv6 }, t => {
   t.plan(7)
   const stream = split(JSON.parse)
   const fastify = Fastify({
@@ -874,7 +877,7 @@ test('onListen localhost with callback encapsulation should be called in order',
   })
 })
 
-test('onListen non-localhost should work in order with callback in sync', t => {
+test('onListen non-localhost should work in order with callback in sync', { skip: !hasIPv6 }, t => {
   t.plan(4)
   const fastify = Fastify()
   t.teardown(fastify.close.bind(fastify))
@@ -896,7 +899,7 @@ test('onListen non-localhost should work in order with callback in sync', t => {
   })
 })
 
-test('onListen non-localhost should work in order with callback in async', t => {
+test('onListen non-localhost should work in order with callback in async', { skip: !hasIPv6 }, t => {
   t.plan(4)
   const fastify = Fastify()
   t.teardown(fastify.close.bind(fastify))
@@ -916,7 +919,7 @@ test('onListen non-localhost should work in order with callback in async', t => 
   })
 })
 
-test('onListen non-localhost sync with callback should log errors as warnings and continue', t => {
+test('onListen non-localhost sync with callback should log errors as warnings and continue', { skip: !hasIPv6 }, t => {
   t.plan(8)
 
   const stream = split(JSON.parse)
@@ -960,7 +963,7 @@ test('onListen non-localhost sync with callback should log errors as warnings an
   })
 })
 
-test('onListen non-localhost async with callback should log errors as warnings and continue', t => {
+test('onListen non-localhost async with callback should log errors as warnings and continue', { skip: !hasIPv6 }, t => {
   t.plan(8)
 
   const stream = split(JSON.parse)
@@ -1002,7 +1005,7 @@ test('onListen non-localhost async with callback should log errors as warnings a
   })
 })
 
-test('Register onListen hook non-localhost with callback after a plugin inside a plugin', t => {
+test('Register onListen hook non-localhost with callback after a plugin inside a plugin', { skip: !hasIPv6 }, t => {
   t.plan(5)
   const fastify = Fastify()
   t.teardown(fastify.close.bind(fastify))
@@ -1035,7 +1038,7 @@ test('Register onListen hook non-localhost with callback after a plugin inside a
   })
 })
 
-test('onListen non-localhost with callback encapsulation should be called in order', t => {
+test('onListen non-localhost with callback encapsulation should be called in order', { skip: !hasIPv6 }, t => {
   t.plan(8)
   const fastify = Fastify()
   t.teardown(fastify.close.bind(fastify))

--- a/test/hooks.on-listen.test.js
+++ b/test/hooks.on-listen.test.js
@@ -8,7 +8,7 @@ const helper = require('./helper')
 const { kState } = require('../lib/symbols')
 const { networkInterfaces } = require('node:os')
 
-const hasIPv6 = Object.values(networkInterfaces()).flat().some(({ family }) => family === 'IPv6')
+const isIPv6Missing = !Object.values(networkInterfaces()).flat().some(({ family }) => family === 'IPv6')
 
 let localhost
 before(async function () {
@@ -408,7 +408,7 @@ test('localhost onListen encapsulation should be called in order and should log 
   })
 })
 
-test('non-localhost onListen should be called in order', { skip: !hasIPv6 }, t => {
+test('non-localhost onListen should be called in order', { skip: isIPv6Missing }, t => {
   t.plan(2)
 
   const fastify = Fastify()
@@ -431,7 +431,7 @@ test('non-localhost onListen should be called in order', { skip: !hasIPv6 }, t =
   })
 })
 
-test('non-localhost async onListen should be called in order', { skip: !hasIPv6 }, async t => {
+test('non-localhost async onListen should be called in order', { skip: isIPv6Missing }, async t => {
   t.plan(2)
   const fastify = Fastify()
   t.teardown(fastify.close.bind(fastify))
@@ -451,7 +451,7 @@ test('non-localhost async onListen should be called in order', { skip: !hasIPv6 
   })
 })
 
-test('non-localhost sync onListen should log errors as warnings and continue', { skip: !hasIPv6 }, t => {
+test('non-localhost sync onListen should log errors as warnings and continue', { skip: isIPv6Missing }, t => {
   t.plan(4)
   const stream = split(JSON.parse)
   const fastify = Fastify({
@@ -491,7 +491,7 @@ test('non-localhost sync onListen should log errors as warnings and continue', {
   })
 })
 
-test('non-localhost async onListen should log errors as warnings and continue', { skip: !hasIPv6 }, async t => {
+test('non-localhost async onListen should log errors as warnings and continue', { skip: isIPv6Missing }, async t => {
   t.plan(6)
   const stream = split(JSON.parse)
   const fastify = Fastify({
@@ -532,7 +532,7 @@ test('non-localhost async onListen should log errors as warnings and continue', 
   })
 })
 
-test('non-localhost Register onListen hook after a plugin inside a plugin', { skip: !hasIPv6 }, t => {
+test('non-localhost Register onListen hook after a plugin inside a plugin', { skip: isIPv6Missing }, t => {
   t.plan(3)
   const fastify = Fastify()
   t.teardown(fastify.close.bind(fastify))
@@ -565,7 +565,7 @@ test('non-localhost Register onListen hook after a plugin inside a plugin', { sk
   })
 })
 
-test('non-localhost Register onListen hook after a plugin inside a plugin should log errors as warnings and continue', { skip: !hasIPv6 }, t => {
+test('non-localhost Register onListen hook after a plugin inside a plugin should log errors as warnings and continue', { skip: isIPv6Missing }, t => {
   t.plan(6)
   const stream = split(JSON.parse)
   const fastify = Fastify({
@@ -611,7 +611,7 @@ test('non-localhost Register onListen hook after a plugin inside a plugin should
   })
 })
 
-test('non-localhost onListen encapsulation should be called in order', { skip: !hasIPv6 }, t => {
+test('non-localhost onListen encapsulation should be called in order', { skip: isIPv6Missing }, t => {
   t.plan(6)
   const fastify = Fastify()
   t.teardown(fastify.close.bind(fastify))
@@ -643,7 +643,7 @@ test('non-localhost onListen encapsulation should be called in order', { skip: !
   })
 })
 
-test('non-localhost onListen encapsulation should be called in order and should log errors as warnings and continue', { skip: !hasIPv6 }, t => {
+test('non-localhost onListen encapsulation should be called in order and should log errors as warnings and continue', { skip: isIPv6Missing }, t => {
   t.plan(7)
   const stream = split(JSON.parse)
   const fastify = Fastify({
@@ -877,7 +877,7 @@ test('onListen localhost with callback encapsulation should be called in order',
   })
 })
 
-test('onListen non-localhost should work in order with callback in sync', { skip: !hasIPv6 }, t => {
+test('onListen non-localhost should work in order with callback in sync', { skip: isIPv6Missing }, t => {
   t.plan(4)
   const fastify = Fastify()
   t.teardown(fastify.close.bind(fastify))
@@ -899,7 +899,7 @@ test('onListen non-localhost should work in order with callback in sync', { skip
   })
 })
 
-test('onListen non-localhost should work in order with callback in async', { skip: !hasIPv6 }, t => {
+test('onListen non-localhost should work in order with callback in async', { skip: isIPv6Missing }, t => {
   t.plan(4)
   const fastify = Fastify()
   t.teardown(fastify.close.bind(fastify))
@@ -919,7 +919,7 @@ test('onListen non-localhost should work in order with callback in async', { ski
   })
 })
 
-test('onListen non-localhost sync with callback should log errors as warnings and continue', { skip: !hasIPv6 }, t => {
+test('onListen non-localhost sync with callback should log errors as warnings and continue', { skip: isIPv6Missing }, t => {
   t.plan(8)
 
   const stream = split(JSON.parse)
@@ -963,7 +963,7 @@ test('onListen non-localhost sync with callback should log errors as warnings an
   })
 })
 
-test('onListen non-localhost async with callback should log errors as warnings and continue', { skip: !hasIPv6 }, t => {
+test('onListen non-localhost async with callback should log errors as warnings and continue', { skip: isIPv6Missing }, t => {
   t.plan(8)
 
   const stream = split(JSON.parse)
@@ -1005,7 +1005,7 @@ test('onListen non-localhost async with callback should log errors as warnings a
   })
 })
 
-test('Register onListen hook non-localhost with callback after a plugin inside a plugin', { skip: !hasIPv6 }, t => {
+test('Register onListen hook non-localhost with callback after a plugin inside a plugin', { skip: isIPv6Missing }, t => {
   t.plan(5)
   const fastify = Fastify()
   t.teardown(fastify.close.bind(fastify))
@@ -1038,7 +1038,7 @@ test('Register onListen hook non-localhost with callback after a plugin inside a
   })
 })
 
-test('onListen non-localhost with callback encapsulation should be called in order', { skip: !hasIPv6 }, t => {
+test('onListen non-localhost with callback encapsulation should be called in order', { skip: isIPv6Missing }, t => {
   t.plan(8)
   const fastify = Fastify()
   t.teardown(fastify.close.bind(fastify))

--- a/test/listen.2.test.js
+++ b/test/listen.2.test.js
@@ -5,7 +5,7 @@ const Fastify = require('..')
 const helper = require('./helper')
 const { networkInterfaces } = require('node:os')
 
-const hasIPv6 = Object.values(networkInterfaces()).flat().some(({ family }) => family === 'IPv6')
+const isIPv6Missing = !Object.values(networkInterfaces()).flat().some(({ family }) => family === 'IPv6')
 
 let localhostForURL
 
@@ -62,7 +62,7 @@ test('double listen errors callback with (err, address)', (t, done) => {
   })
 })
 
-test('nonlocalhost double listen errors callback with (err, address)', { skip: !hasIPv6 }, (t, done) => {
+test('nonlocalhost double listen errors callback with (err, address)', { skip: isIPv6Missing }, (t, done) => {
   t.plan(4)
   const fastify = Fastify()
   t.after(() => fastify.close())

--- a/test/listen.2.test.js
+++ b/test/listen.2.test.js
@@ -3,6 +3,9 @@
 const { test, before } = require('node:test')
 const Fastify = require('..')
 const helper = require('./helper')
+const { networkInterfaces } = require('node:os')
+
+const hasIPv6 = Object.values(networkInterfaces()).flat().some(({ family }) => family === 'IPv6')
 
 let localhostForURL
 
@@ -59,7 +62,7 @@ test('double listen errors callback with (err, address)', (t, done) => {
   })
 })
 
-test('nonlocalhost double listen errors callback with (err, address)', (t, done) => {
+test('nonlocalhost double listen errors callback with (err, address)', { skip: !hasIPv6 }, (t, done) => {
   t.plan(4)
   const fastify = Fastify()
   t.after(() => fastify.close())


### PR DESCRIPTION
Avoid `EAFNOSUPPORT` failures on systems without IPv6 support.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
