### PR TITLE
chore: convert custom parser 1 to node test runner

### DIFF
--- a/test/custom-parser.1.test.js
+++ b/test/custom-parser.1.test.js
@@ -1,15 +1,15 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const sget = require('simple-get').concat
 const Fastify = require('../fastify')
 const jsonParser = require('fast-json-body')
 const { getServerUrl } = require('./helper')
+const { waitForCb } = require('./toolkit')
 
 process.removeAllListeners('warning')
 
-test('Should have typeof body object with no custom parser defined, null body and content type = \'text/plain\'', t => {
+test('Should have typeof body object with no custom parser defined, null body and content type = \'text/plain\'', (t, testDone) => {
   t.plan(4)
   const fastify = Fastify()
 
@@ -18,7 +18,7 @@ test('Should have typeof body object with no custom parser defined, null body an
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -28,15 +28,16 @@ test('Should have typeof body object with no custom parser defined, null body an
         'Content-Type': 'text/plain'
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.equal(typeof body, 'object')
+      t.assert.ifError(err)
+      t.assert.deepEqual(response.statusCode, 200)
+      t.assert.deepEqual(typeof body, 'object')
       fastify.close()
+      testDone()
     })
   })
 })
 
-test('Should have typeof body object with no custom parser defined, undefined body and content type = \'text/plain\'', t => {
+test('Should have typeof body object with no custom parser defined, undefined body and content type = \'text/plain\'', (t, testDone) => {
   t.plan(4)
   const fastify = Fastify()
 
@@ -45,7 +46,7 @@ test('Should have typeof body object with no custom parser defined, undefined bo
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -55,15 +56,16 @@ test('Should have typeof body object with no custom parser defined, undefined bo
         'Content-Type': 'text/plain'
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.equal(typeof body, 'object')
+      t.assert.ifError(err)
+      t.assert.deepEqual(response.statusCode, 200)
+      t.assert.deepEqual(typeof body, 'object')
       fastify.close()
+      testDone()
     })
   })
 })
 
-test('Should get the body as string /1', t => {
+test('Should get the body as string /1', (t, testDone) => {
   t.plan(6)
   const fastify = Fastify()
 
@@ -72,8 +74,8 @@ test('Should get the body as string /1', t => {
   })
 
   fastify.addContentTypeParser('text/plain', { parseAs: 'string' }, function (req, body, done) {
-    t.ok('called')
-    t.ok(typeof body === 'string')
+    t.assert.ok('called')
+    t.assert.ok(typeof body === 'string')
     try {
       const plainText = body
       done(null, plainText)
@@ -84,7 +86,7 @@ test('Should get the body as string /1', t => {
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -94,15 +96,16 @@ test('Should get the body as string /1', t => {
         'Content-Type': 'text/plain'
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.equal(body.toString(), 'hello world')
+      t.assert.ifError(err)
+      t.assert.deepEqual(response.statusCode, 200)
+      t.assert.deepEqual(body.toString(), 'hello world')
       fastify.close()
+      testDone()
     })
   })
 })
 
-test('Should get the body as string /2', t => {
+test('Should get the body as string /2', (t, testDone) => {
   t.plan(6)
   const fastify = Fastify()
 
@@ -111,8 +114,8 @@ test('Should get the body as string /2', t => {
   })
 
   fastify.addContentTypeParser('text/plain/test', { parseAs: 'string' }, function (req, body, done) {
-    t.ok('called')
-    t.ok(typeof body === 'string')
+    t.assert.ok('called')
+    t.assert.ok(typeof body === 'string')
     try {
       const plainText = body
       done(null, plainText)
@@ -123,7 +126,7 @@ test('Should get the body as string /2', t => {
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -133,15 +136,16 @@ test('Should get the body as string /2', t => {
         'Content-Type': '   text/plain/test  '
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.equal(body.toString(), 'hello world')
+      t.assert.ifError(err)
+      t.assert.deepEqual(response.statusCode, 200)
+      t.assert.deepEqual(body.toString(), 'hello world')
       fastify.close()
+      testDone()
     })
   })
 })
 
-test('Should get the body as buffer', t => {
+test('Should get the body as buffer', (t, testDone) => {
   t.plan(6)
   const fastify = Fastify()
 
@@ -150,8 +154,8 @@ test('Should get the body as buffer', t => {
   })
 
   fastify.addContentTypeParser('application/json', { parseAs: 'buffer' }, function (req, body, done) {
-    t.ok('called')
-    t.ok(body instanceof Buffer)
+    t.assert.ok('called')
+    t.assert.ok(body instanceof Buffer)
     try {
       const json = JSON.parse(body)
       done(null, json)
@@ -162,7 +166,7 @@ test('Should get the body as buffer', t => {
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -172,15 +176,16 @@ test('Should get the body as buffer', t => {
         'Content-Type': 'application/json'
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.equal(body.toString(), '{"hello":"world"}')
+      t.assert.ifError(err)
+      t.assert.deepEqual(response.statusCode, 200)
+      t.assert.deepEqual(body.toString(), '{"hello":"world"}')
       fastify.close()
+      testDone()
     })
   })
 })
 
-test('Should get the body as buffer', t => {
+test('Should get the body as buffer', (t, testDone) => {
   t.plan(6)
   const fastify = Fastify()
 
@@ -189,8 +194,8 @@ test('Should get the body as buffer', t => {
   })
 
   fastify.addContentTypeParser('text/plain', { parseAs: 'buffer' }, function (req, body, done) {
-    t.ok('called')
-    t.ok(body instanceof Buffer)
+    t.assert.ok('called')
+    t.assert.ok(body instanceof Buffer)
     try {
       const plainText = body
       done(null, plainText)
@@ -201,7 +206,7 @@ test('Should get the body as buffer', t => {
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -211,20 +216,21 @@ test('Should get the body as buffer', t => {
         'Content-Type': 'text/plain'
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.equal(body.toString(), 'hello world')
+      t.assert.ifError(err)
+      t.assert.deepEqual(response.statusCode, 200)
+      t.assert.deepEqual(body.toString(), 'hello world')
       fastify.close()
+      testDone()
     })
   })
 })
 
-test('Should parse empty bodies as a string', t => {
+test('Should parse empty bodies as a string', (t) => {
   t.plan(9)
   const fastify = Fastify()
 
   fastify.addContentTypeParser('text/plain', { parseAs: 'string' }, (req, body, done) => {
-    t.equal(body, '')
+    t.assert.deepEqual(body, '')
     done(null, body)
   })
 
@@ -236,9 +242,11 @@ test('Should parse empty bodies as a string', t => {
     }
   })
 
+  const completion = waitForCb({ steps: 2 })
+
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
-    t.teardown(() => { fastify.close() })
+    t.assert.ifError(err)
+    t.after(() => { fastify.close() })
 
     sget({
       method: 'POST',
@@ -248,9 +256,10 @@ test('Should parse empty bodies as a string', t => {
         'Content-Type': 'text/plain'
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.equal(body.toString(), '')
+      t.assert.ifError(err)
+      t.assert.deepEqual(response.statusCode, 200)
+      t.assert.deepEqual(body.toString(), '')
+      completion.stepIn()
     })
 
     sget({
@@ -262,14 +271,17 @@ test('Should parse empty bodies as a string', t => {
         'Content-Length': '0'
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.equal(body.toString(), '')
+      t.assert.ifError(err)
+      t.assert.deepEqual(response.statusCode, 200)
+      t.assert.deepEqual(body.toString(), '')
+      completion.stepIn()
     })
   })
+
+  return completion.patience
 })
 
-test('Should parse empty bodies as a buffer', t => {
+test('Should parse empty bodies as a buffer', (t, testDone) => {
   t.plan(6)
   const fastify = Fastify()
 
@@ -278,13 +290,13 @@ test('Should parse empty bodies as a buffer', t => {
   })
 
   fastify.addContentTypeParser('text/plain', { parseAs: 'buffer' }, function (req, body, done) {
-    t.ok(body instanceof Buffer)
-    t.equal(body.length, 0)
+    t.assert.ok(body instanceof Buffer)
+    t.assert.deepEqual(body.length, 0)
     done(null, body)
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -294,15 +306,16 @@ test('Should parse empty bodies as a buffer', t => {
         'Content-Type': 'text/plain'
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.equal(body.length, 0)
+      t.assert.ifError(err)
+      t.assert.deepEqual(response.statusCode, 200)
+      t.assert.deepEqual(body.length, 0)
       fastify.close()
+      testDone()
     })
   })
 })
 
-test('The charset should not interfere with the content type handling', t => {
+test('The charset should not interfere with the content type handling', (t, testDone) => {
   t.plan(5)
   const fastify = Fastify()
 
@@ -311,14 +324,14 @@ test('The charset should not interfere with the content type handling', t => {
   })
 
   fastify.addContentTypeParser('application/json', function (req, payload, done) {
-    t.ok('called')
+    t.assert.ok('called')
     jsonParser(payload, function (err, body) {
       done(err, body)
     })
   })
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'POST',
@@ -328,10 +341,11 @@ test('The charset should not interfere with the content type handling', t => {
         'Content-Type': 'application/json; charset=utf-8'
       }
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.equal(body.toString(), '{"hello":"world"}')
+      t.assert.ifError(err)
+      t.assert.deepEqual(response.statusCode, 200)
+      t.assert.deepEqual(body.toString(), '{"hello":"world"}')
       fastify.close()
+      testDone()
     })
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
