### PR TITLE
docs: fix archived concurrently link to point to active repo

### DIFF
--- a/docs/Guides/Benchmarking.md
+++ b/docs/Guides/Benchmarking.md
@@ -12,7 +12,7 @@ The modules we will use:
   tool written in node.
 - [Branch-comparer](https://github.com/StarpTech/branch-comparer): Checkout
   multiple git branches, execute scripts, and log the results.
-- [Concurrently](https://github.com/kimmobrunfeldt/concurrently): Run commands
+- [Concurrently](https://github.com/open-cli-tools/concurrently): Run commands
   concurrently.
 - [Npx](https://github.com/npm/npx): NPM package runner used to run scripts
   against different Node.js Versions and execute local binaries. Shipped with


### PR DESCRIPTION
Replaced old GitHub link (kimmobrunfeldt/concurrently) with the new official repo (open-cli-tools/concurrently) since the original has been archived.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
