### PR TITLE
fix: treat space as a delimiter in content-type parsing

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -261,7 +261,7 @@ function wrapValidationError (result, dataVar, schemaErrorFormatter) {
  */
 function getEssenceMediaType (header) {
   if (!header) return ''
-  return header.split(/[ ;]/)[0].trim().toLowerCase()
+  return header.split(/[ ;]/, 1)[0].trim().toLowerCase()
 }
 
 module.exports = {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -261,7 +261,7 @@ function wrapValidationError (result, dataVar, schemaErrorFormatter) {
  */
 function getEssenceMediaType (header) {
   if (!header) return ''
-  return header.split(';', 1)[0].trim().toLowerCase()
+  return header.split(/[ ;]/)[0].trim().toLowerCase()
 }
 
 module.exports = {


### PR DESCRIPTION
Follow-up from https://github.com/fastify/fastify/security/advisories/GHSA-mg2h-6x62-wpwc