### PR TITLE
style: add "no comma-dangle" rule to eslint config and remove trailing commas

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,11 +1,19 @@
 'use strict'
+const neostandard = require('neostandard')
 
-module.exports = require('neostandard')({
-  ignores: [
-    'lib/configValidator.js',
-    'lib/error-serializer.js',
-    'test/same-shape.test.js',
-    'test/types/import.js'
-  ],
-  ts: true
-})
+module.exports = [
+  ...neostandard({
+    ignores: [
+      'lib/configValidator.js',
+      'lib/error-serializer.js',
+      'test/same-shape.test.js',
+      'test/types/import.js'
+    ],
+    ts: true
+  }),
+  {
+    rules: {
+      'comma-dangle': ['error', 'never']
+    }
+  }
+]

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -4,7 +4,7 @@ const {
   kReply,
   kRequest,
   kState,
-  kHasBeenDecorated,
+  kHasBeenDecorated
 } = require('./symbols.js')
 
 const {
@@ -13,7 +13,7 @@ const {
   FST_ERR_DEC_AFTER_START,
   FST_ERR_DEC_REFERENCE_TYPE,
   FST_ERR_DEC_DEPENDENCY_INVALID_TYPE,
-  FST_ERR_DEC_UNDECLARED,
+  FST_ERR_DEC_UNDECLARED
 } = require('./errors')
 
 function decorate (instance, name, fn, dependencies) {

--- a/lib/logger-factory.js
+++ b/lib/logger-factory.js
@@ -132,5 +132,5 @@ module.exports = {
   defaultChildLoggerFactory,
   createLogger,
   validateLogger,
-  now,
+  now
 }

--- a/lib/logger-pino.js
+++ b/lib/logger-pino.js
@@ -9,7 +9,7 @@
 const pino = require('pino')
 const { serializersSym } = pino.symbols
 const {
-  FST_ERR_LOG_INVALID_DESTINATION,
+  FST_ERR_LOG_INVALID_DESTINATION
 } = require('./errors')
 
 function createPinoLogger (opts) {
@@ -64,5 +64,5 @@ const serializers = {
 
 module.exports = {
   serializers,
-  createPinoLogger,
+  createPinoLogger
 }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -22,7 +22,7 @@ const {
   kReplyCacheSerializeFns,
   kSchemaController,
   kOptions,
-  kRouteContext,
+  kRouteContext
 } = require('./symbols.js')
 const {
   onSendHookRunner,
@@ -53,7 +53,7 @@ const {
   FST_ERR_BAD_TRAILER_VALUE,
   FST_ERR_MISSING_SERIALIZATION_FN,
   FST_ERR_MISSING_CONTENTTYPE_SERIALIZATION_FN,
-  FST_ERR_DEC_UNDECLARED,
+  FST_ERR_DEC_UNDECLARED
 } = require('./errors')
 const decorators = require('./decorate')
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -11,7 +11,7 @@ const {
   kOptions,
   kRequestCacheValidateFns,
   kRouteContext,
-  kRequestOriginalUrl,
+  kRequestOriginalUrl
 } = require('./symbols')
 const { FST_ERR_REQ_INVALID_VALIDATION_INVOCATION, FST_ERR_DEC_UNDECLARED } = require('./errors')
 const decorators = require('./decorate')

--- a/test/issue-4959.test.js
+++ b/test/issue-4959.test.js
@@ -17,7 +17,7 @@ function runBadClientCall (reqOptions, payload) {
     ...reqOptions,
     headers: {
       'Content-Type': 'application/json',
-      'Content-Length': Buffer.byteLength(postData),
+      'Content-Length': Buffer.byteLength(postData)
     }
   }, () => {
     innerReject(new Error('Request should have failed'))
@@ -78,7 +78,7 @@ test('should handle a soket error', async (t) => {
     hostname: 'localhost',
     port: fastify.server.address().port,
     path: '/',
-    method: 'PUT',
+    method: 'PUT'
   }, { test: 'me' })
   t.assert.equal(err.code, 'ECONNRESET')
 })

--- a/test/types/plugin.test-d.ts
+++ b/test/types/plugin.test-d.ts
@@ -12,7 +12,7 @@ interface TestOptions extends FastifyPluginOptions {
 }
 const testOptions: TestOptions = {
   option1: 'a',
-  option2: false,
+  option2: false
 }
 const testPluginOpts: FastifyPluginCallback<TestOptions> = function (instance, opts, done) {
   expectType<TestOptions>(opts)

--- a/test/types/register.test-d.ts
+++ b/test/types/register.test-d.ts
@@ -50,7 +50,7 @@ const testPluginWithHttp2WithType = (instance: ServerWithHttp2, opts: FastifyPlu
 const testPluginWithHttp2WithTypeAsync = async (instance: ServerWithHttp2, opts: FastifyPluginOptions) => { }
 const testOptions: TestOptions = {
   option1: 'a',
-  option2: false,
+  option2: false
 }
 expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginCallback))
 expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginAsync))

--- a/test/use-semicolon-delimiter.test.js
+++ b/test/use-semicolon-delimiter.test.js
@@ -13,7 +13,7 @@ test('use semicolon delimiter default false', (t, done) => {
     reply.send(req.query)
   })
 
-  fastify.listen({ port: 0, }, err => {
+  fastify.listen({ port: 0 }, err => {
     t.assert.ifError(err)
     sget({
       method: 'GET',


### PR DESCRIPTION
- Added "no `comma-dangle`" rule on eslint config file
- Ran `npm run lint:fix`  to remove remaining trailing commas

I get an error from coverage threshold on tests for `lib/server.js`  but, since it is happening on `main` branch too, I ignored the pre-commit hook. I can open a PR to add the missing test if needed.

Fixes: #6029 


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
