### PR TITLE
fix: internal function _addHook failure should be turned into the rejection app.ready is waiting for

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -681,8 +681,12 @@ function fastify (options) {
       this[kHooks].add(name, fn)
     } else {
       this.after((err, done) => {
-        _addHook.call(this, name, fn)
-        done(err)
+        try {
+          _addHook.call(this, name, fn)
+          done(err)
+        } catch (err) {
+          done(err)
+        }
       })
     }
     return this


### PR DESCRIPTION
Currently, we can't catch this:
```js
fastify.addHook("invalidHook", () => {});

try {
  await fastify.ready()
} catch (error) {
  // Unreachable
}
```