### PR TITLE
ci: ignore scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,13 +193,13 @@ jobs:
           npm install --ignore-scripts
       - name: install webpack stack
         run: |
-          cd test/bundler/webpack && npm install
+          cd test/bundler/webpack && npm install --ignore-scripts
       - name: Test webpack bundle
         run: |
           cd test/bundler/webpack && npm run test
       - name: install esbuild stack
         run: |
-          cd test/bundler/esbuild && npm install
+          cd test/bundler/esbuild && npm install --ignore-scripts
       - name: Test esbuild bundle
         run: |
           cd test/bundler/esbuild && npm run test

--- a/.github/workflows/citgm-package.yml
+++ b/.github/workflows/citgm-package.yml
@@ -87,7 +87,7 @@ jobs:
         - name: Install Dependencies for ${{inputs.package}}
           working-directory: package
           run: |
-            npm install
+            npm install --ignore-scripts
         - name: Sym Link Fastify
           working-directory: package
           run: |

--- a/.github/workflows/integration-alternative-runtimes.yml
+++ b/.github/workflows/integration-alternative-runtimes.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install Production
         run: |
-          pnpm install --prod
+          pnpm install --ignore-scripts --prod
 
       - name: Run server
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install Production
         run: |
-          pnpm install --prod
+          pnpm install --ignore-scripts --prod
 
       - name: Run server
         run: |

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           version: ${{ matrix.pnpm-version }}
 
-      - run: pnpm install
+      - run: pnpm install --ignore-scripts
 
       - name: Run tests
         run: |
@@ -70,7 +70,7 @@ jobs:
       - name: Install with yarn
         run: |
           curl -o- -L https://yarnpkg.com/install.sh | bash
-          yarn install --ignore-engines
+          yarn install --ignore-engines --ignore-scripts
 
       - run: yarn
 


### PR DESCRIPTION
Add the `--ignore-scripts` arg to disable the execution of any scripts by third-party packages.

See https://snyk.io/blog/npm-security-preventing-supply-chain-attacks/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
