### PR TITLE
test: replace removed request properties and update docs

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1529,7 +1529,7 @@ plugins.
 > 🛈 Note:
 > Some config properties from the request object will be
 > undefined inside the custom not found handler. E.g.:
-> `request.routerPath`, `routerMethod` and `context.config`.
+> `request.routeOptions.url`, `routeOptions.method` and `routeOptions.config`.
 > This method design goal is to allow calling the common not found route.
 > To return a per-route customized 404 response, you can do it in
 > the response itself.

--- a/test/inject.test.js
+++ b/test/inject.test.js
@@ -479,7 +479,7 @@ test('Should not throw on access to routeConfig frameworkErrors handler - FST_ER
     frameworkErrors: function (err, req, res) {
       t.assert.ok(typeof req.id === 'string')
       t.assert.ok(req.raw instanceof Readable)
-      t.assert.deepStrictEqual(req.routerPath, undefined)
+      t.assert.deepStrictEqual(req.routeOptions.url, undefined)
       res.send(`${err.message} - ${err.code}`)
     }
   })


### PR DESCRIPTION
- replaces usage of the removed `req.routerPath` with the updated `req.routeOptions.url` in `inject.test.js`
- updates the note in the documentation to reflect the change from `request.routerPath`, `routerMethod`, and `context.config` to `request.routeOptions.url`, `routeOptions.method`, and `routeOptions.config` within the custom "not found" handler.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
