### PR TITLE
ci(ci-alternative-runtime): add node v22 to alternative runtime CIs

### DIFF
--- a/.github/workflows/ci-alternative-runtime.yml
+++ b/.github/workflows/ci-alternative-runtime.yml
@@ -35,6 +35,9 @@ jobs:
           - runtime: nsolid
             node-version: 20
             nsolid-version: 5
+          - runtime: nsolid
+            node-version: 22
+            nsolid-version: 5
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/integration-alternative-runtimes.yml
+++ b/.github/workflows/integration-alternative-runtimes.yml
@@ -30,9 +30,12 @@ jobs:
         node-version: [20]
         pnpm-version: [8]
         include:
-          - nsolid-version: 5
+          - runtime: nsolid
             node-version: 20
-            runtime: nsolid
+            nsolid-version: 5
+          - runtime: nsolid
+            node-version: 22
+            nsolid-version: 5
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Adds node v22, current LTS, to alternative runtime CIs

I suppose our policy is still to keep this up to date as long as it doesn't cause issues