### PR TITLE
docs: set sidebar order for introductory pages

### DIFF
--- a/docs/Guides/Database.md
+++ b/docs/Guides/Database.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 <h1 align="center">Fastify</h1>
 
 ## Database

--- a/docs/Guides/Getting-Started.md
+++ b/docs/Guides/Getting-Started.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 0
+---
+
 <h1 align="center">Fastify</h1>
 
 ## Getting Started

--- a/docs/Guides/Recommendations.md
+++ b/docs/Guides/Recommendations.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 <h1 align="center">Fastify</h1>
 
 ## Recommendations

--- a/docs/Guides/Testing.md
+++ b/docs/Guides/Testing.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 3
+---
+
 <h1 style="text-align: center;">Fastify</h1>
 
 # Testing


### PR DESCRIPTION
Fixes fastify/website#308

This PR set sidebar position for introductory pages, making them listed before more advanced topics, in the order of:
* Getting-Started.md
* Database.md
* Recommendations.md
* Testing.md

Docusaurus sidebar docs:
https://docusaurus.io/docs/sidebar/autogenerated#doc-item-metadata




#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
