### PR TITLE
fix(ci): ignore alternative runtime result

### DIFF
--- a/.github/workflows/ci-alternative-runtime.yml
+++ b/.github/workflows/ci-alternative-runtime.yml
@@ -25,6 +25,7 @@ permissions:
 jobs:
   test-unit:
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
     permissions:
       contents: read
     strategy:
@@ -51,7 +52,6 @@ jobs:
           npm install --ignore-scripts
 
       - name: Run tests
-        continue-on-error: true
         run: |
           npm run unit
 


### PR DESCRIPTION
The alternative NSolid runtime is making our CI red without reason.

Moving the boolean to job level, because the `nodesource/setup-nsolid@v1` is failing

Ref:

- #6034 
- https://github.com/fastify/fastify/actions/workflows/ci-alternative-runtime.yml