### PR TITLE
fix(types): add missing version to request.routeOptions

### DIFF
--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -78,6 +78,7 @@ const getHandler: RouteHandler = function (request, _reply) {
   expectType<FastifySchema | undefined>(request.routeOptions.schema)
   expectType<RouteHandlerMethod>(request.routeOptions.handler)
   expectType<string | undefined>(request.routeOptions.url)
+  expectType<string | undefined>(request.routeOptions.version)
 
   expectType<RequestHeadersDefault & RawRequestDefaultExpression['headers']>(request.headers)
   request.headers = {}

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -32,6 +32,7 @@ export interface RequestRouteOptions<ContextConfig = ContextConfigDefault, Schem
   config: FastifyContextConfig & FastifyRouteConfig & ContextConfig;
   schema?: SchemaCompiler; // it is empty for 404 requests
   handler: RouteHandlerMethod;
+  version?: string;
 }
 
 /**


### PR DESCRIPTION
Ref.
- https://fastify.dev/docs/latest/Reference/Request/#request
- https://github.com/fastify/fastify/blob/7090d75d3769d6e05ddc577d465c2f6b9e0d62db/lib/request.js#L181-L192
