### PR TITLE
docs: use cross-platform compatible info emoji

### DIFF
--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -152,7 +152,7 @@ section.
 
 #### [Community](#community)
 
-> 🛈 Note:
+> ℹ️ Note:
 > Fastify community plugins are part of the broader community efforts,
 > and we are thankful for these contributions. However, they are not
 > maintained by the Fastify team.

--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -152,7 +152,7 @@ fastify.addContentTypeParser('text/xml', function (request, payload, done) {
 })
 ```
 
-> 🛈 Note: `function(req, done)` and `async function(req)` are
+> ℹ️ Note: `function(req, done)` and `async function(req)` are
 > still supported but deprecated.
 
 #### Body Parser

--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -34,7 +34,7 @@ are Request/Reply hooks and application hooks:
 - [Using Hooks to Inject Custom Properties](#using-hooks-to-inject-custom-properties)
 - [Diagnostics Channel Hooks](#diagnostics-channel-hooks)
 
-> 🛈 Note: The `done` callback is not available when using `async`/`await` or
+> ℹ️ Note: The `done` callback is not available when using `async`/`await` or
 > returning a `Promise`. If you do invoke a `done` callback in this situation
 > unexpected behavior may occur, e.g. duplicate invocation of handlers.
 
@@ -68,7 +68,7 @@ fastify.addHook('onRequest', async (request, reply) => {
 })
 ```
 
-> 🛈 Note: In the [onRequest](#onrequest) hook, `request.body` will always be
+> ℹ️ Note: In the [onRequest](#onrequest) hook, `request.body` will always be
 > `undefined`, because the body parsing happens before the
 > [preValidation](#prevalidation) hook.
 
@@ -98,16 +98,16 @@ fastify.addHook('preParsing', async (request, reply, payload) => {
 })
 ```
 
-> 🛈 Note: In the [preParsing](#preparsing) hook, `request.body` will always be
+> ℹ️ Note: In the [preParsing](#preparsing) hook, `request.body` will always be
 > `undefined`, because the body parsing happens before the
 > [preValidation](#prevalidation) hook.
 
-> 🛈 Note: You should also add a `receivedEncodedLength` property to the
+> ℹ️ Note: You should also add a `receivedEncodedLength` property to the
 > returned stream. This property is used to correctly match the request payload
 > with the `Content-Length` header value. Ideally, this property should be updated
 > on each received chunk.
 
-> 🛈 Note: The size of the returned stream is checked to not exceed the limit
+> ℹ️ Note: The size of the returned stream is checked to not exceed the limit
 > set in [`bodyLimit`](./Server.md#bodylimit) option.
 
 ### preValidation
@@ -166,7 +166,7 @@ fastify.addHook('preSerialization', async (request, reply, payload) => {
 })
 ```
 
-> 🛈 Note: The hook is NOT called if the payload is a `string`, a `Buffer`, a
+> ℹ️ Note: The hook is NOT called if the payload is a `string`, a `Buffer`, a
 > `stream`, or `null`.
 
 ### onError
@@ -196,7 +196,7 @@ user
 *(Note that the default error handler always sends the error back to the
 user)*.
 
-> 🛈 Note: Unlike the other hooks, passing an error to the `done` function is not
+> ℹ️ Note: Unlike the other hooks, passing an error to the `done` function is not
 > supported.
 
 ### onSend
@@ -233,7 +233,7 @@ fastify.addHook('onSend', (request, reply, payload, done) => {
 > to `0`, whereas the `Content-Length` header will not be set if the payload is
 > `null`.
 
-> 🛈 Note: If you change the payload, you may only change it to a `string`, a
+> ℹ️ Note: If you change the payload, you may only change it to a `string`, a
 > `Buffer`, a `stream`, a `ReadableStream`, a `Response`, or `null`.
 
 
@@ -256,7 +256,7 @@ The `onResponse` hook is executed when a response has been sent, so you will not
 be able to send more data to the client. It can however be useful for sending
 data to external services, for example, to gather statistics.
 
-> 🛈 Note: Setting `disableRequestLogging` to `true` will disable any error log
+> ℹ️ Note: Setting `disableRequestLogging` to `true` will disable any error log
 > inside the `onResponse` hook. In this case use `try - catch` to log errors.
 
 ### onTimeout
@@ -298,7 +298,7 @@ The `onRequestAbort` hook is executed when a client closes the connection before
 the entire request has been processed. Therefore, you will not be able to send
 data to the client.
 
-> 🛈 Note: Client abort detection is not completely reliable.
+> ℹ️ Note: Client abort detection is not completely reliable.
 > See: [`Detecting-When-Clients-Abort.md`](../Guides/Detecting-When-Clients-Abort.md)
 
 ### Manage Errors from a hook
@@ -452,7 +452,7 @@ fastify.addHook('onListen', async function () {
 })
 ```
 
-> 🛈 Note: This hook will not run when the server is started using
+> ℹ️ Note: This hook will not run when the server is started using
 > fastify.inject()` or `fastify.ready()`.
 
 ### onClose
@@ -576,7 +576,7 @@ This hook can be useful if you are developing a plugin that needs to know when a
 plugin context is formed, and you want to operate in that specific context, thus
 this hook is encapsulated.
 
-> 🛈 Note: This hook will not be called if a plugin is wrapped inside
+> ℹ️ Note: This hook will not be called if a plugin is wrapped inside
 > [`fastify-plugin`](https://github.com/fastify/fastify-plugin).
 ```js
 fastify.decorate('data', [])
@@ -774,7 +774,7 @@ fastify.route({
 })
 ```
 
-> 🛈 Note: Both options also accept an array of functions.
+> ℹ️ Note: Both options also accept an array of functions.
 
 ## Using Hooks to Inject Custom Properties
 <a id="using-hooks-to-inject-custom-properties"></a>
@@ -861,7 +861,7 @@ channel.subscribe(function ({ fastify }) {
 })
 ```
 
-> 🛈 Note: The TracingChannel class API is currently experimental and may undergo
+> ℹ️ Note: The TracingChannel class API is currently experimental and may undergo
 > breaking changes even in semver-patch releases of Node.js.
 
 Five other events are published on a per-request basis following the

--- a/docs/Reference/Logging.md
+++ b/docs/Reference/Logging.md
@@ -157,7 +157,7 @@ const fastify = require('fastify')({
 });
 ```
 
-> 🛈 Note: In some cases, the [`Reply`](./Reply.md) object passed to the `res`
+> ℹ️ Note: In some cases, the [`Reply`](./Reply.md) object passed to the `res`
 > serializer cannot be fully constructed. When writing a custom `res`
 > serializer, check for the existence of any properties on `reply` aside from
 > `statusCode`, which is always present. For example, verify the existence of
@@ -184,7 +184,7 @@ const fastify = require('fastify')({
 });
 ```
 
-> 🛈 Note: The body cannot be serialized inside a `req` method because the
+> ℹ️ Note: The body cannot be serialized inside a `req` method because the
 request is serialized when the child logger is created. At that time, the body
 is not yet parsed.
 
@@ -199,7 +199,7 @@ app.addHook('preHandler', function (req, reply, done) {
 })
 ```
 
-> 🛈 Note: Ensure serializers never throw errors, as this can cause the Node
+> ℹ️ Note: Ensure serializers never throw errors, as this can cause the Node
 > process to exit. See the
 > [Pino documentation](https://getpino.io/#/docs/api?id=opt-serializers) for more
 > information.

--- a/docs/Reference/Middleware.md
+++ b/docs/Reference/Middleware.md
@@ -50,7 +50,7 @@ that already has the Fastify [Request](./Request.md#request) and
 To run middleware under certain paths, pass the path as the first parameter to
 `use`.
 
-> 🛈 Note: This does not support routes with parameters
+> ℹ️ Note: This does not support routes with parameters
 > (e.g. `/user/:id/comments`) and wildcards are not supported in multiple paths.
 
 ```js

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -151,7 +151,7 @@ fastify.get('/', async function (req, rep) {
 Sets a response header. If the value is omitted or undefined, it is coerced to
 `''`.
 
-> 🛈 Note: The header's value must be properly encoded using
+> ℹ️ Note: The header's value must be properly encoded using
 > [`encodeURI`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI)
 > or similar modules such as
 > [`encodeurl`](https://www.npmjs.com/package/encodeurl). Invalid characters
@@ -260,10 +260,10 @@ requires heavy resources to be sent after the `data`, for example,
 `Server-Timing` and `Etag`. It can ensure the client receives the response data
 as soon as possible.
 
-> 🛈 Note: The header `Transfer-Encoding: chunked` will be added once you use
+> ℹ️ Note: The header `Transfer-Encoding: chunked` will be added once you use
 > the trailer. It is a hard requirement for using trailer in Node.js.
 
-> 🛈 Note: Any error passed to `done` callback will be ignored. If you interested
+> ℹ️ Note: Any error passed to `done` callback will be ignored. If you interested
 > in the error, you can turn on `debug` level logging.*
 
 ```js
@@ -314,7 +314,7 @@ reply.getTrailer('server-timing') // undefined
 Redirects a request to the specified URL, the status code is optional, default
 to `302` (if status code is not already set by calling `code`).
 
-> 🛈 Note: The input URL must be properly encoded using
+> ℹ️ Note: The input URL must be properly encoded using
 > [`encodeURI`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI)
 > or similar modules such as
 > [`encodeurl`](https://www.npmjs.com/package/encodeurl). Invalid URLs will
@@ -823,7 +823,7 @@ automatically create an error structured as the following:
 You can add custom properties to the Error object, such as `headers`, that will
 be used to enhance the HTTP response.
 
-> 🛈 Note: If you are passing an error to `send` and the statusCode is less than
+> ℹ️ Note: If you are passing an error to `send` and the statusCode is less than
 > 400, Fastify will automatically set it at 500.
 
 Tip: you can simplify errors by using the
@@ -871,7 +871,7 @@ fastify.get('/', {
 If you want to customize error handling, check out
 [`setErrorHandler`](./Server.md#seterrorhandler) API.
 
-> 🛈 Note: you are responsible for logging when customizing the error handler.
+> ℹ️ Note: you are responsible for logging when customizing the error handler.
 
 API:
 

--- a/docs/Reference/Request.md
+++ b/docs/Reference/Request.md
@@ -84,7 +84,7 @@ This operation adds new values to the request headers, accessible via
 For performance reasons, `Symbol('fastify.RequestAcceptVersion')` may be added
 to headers on `not found` routes.
 
-> 🛈 Note: Schema validation may mutate the `request.headers` and
+> ℹ️ Note: Schema validation may mutate the `request.headers` and
 > `request.raw.headers` objects, causing the headers to become empty.
 
 ```js

--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -137,7 +137,7 @@ fastify.route(options)
 
 * `reply` is defined in [Reply](./Reply.md).
 
-> 🛈 Note: The documentation for `onRequest`, `preParsing`, `preValidation`,
+> ℹ️ Note: The documentation for `onRequest`, `preParsing`, `preValidation`,
 > `preHandler`, `preSerialization`, `onSend`, and `onResponse` is detailed in
 > [Hooks](./Hooks.md). To send a response before the request is handled by the
 > `handler`, see [Respond to a request from
@@ -233,7 +233,7 @@ const opts = {
 fastify.get('/', opts)
 ```
 
-> 🛈 Note: Specifying the handler in both `options` and as the third parameter to
+> ℹ️ Note: Specifying the handler in both `options` and as the third parameter to
 > the shortcut method throws a duplicate `handler` error.
 
 ### Url building
@@ -402,7 +402,7 @@ This approach supports both `callback-style` and `async-await` with minimal
 trade-off. However, it is recommended to use only one style for consistent
 error handling within your application.
 
-> 🛈 Note: Every async function returns a promise by itself.
+> ℹ️ Note: Every async function returns a promise by itself.
 
 ### Route Prefixing
 <a id="route-prefixing"></a>

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -193,7 +193,7 @@ to understand the effect of this option. This option only applies when HTTP/1.1
 is in use. Also, when `serverFactory` option is specified, this option is
 ignored.
 
-> 🛈 Note:
+> ℹ️ Note:
 >  At the time of writing, only node >= v16.10.0 supports this option.
 
 ### `requestTimeout`
@@ -211,7 +211,7 @@ It must be set to a non-zero value (e.g. 120 seconds) to protect against potenti
 Denial-of-Service attacks in case the server is deployed without a reverse proxy
 in front.
 
-> 🛈 Note:
+> ℹ️ Note:
 >  At the time of writing, only node >= v14.11.0 supports this option
 
 ### `ignoreTrailingSlash`
@@ -529,7 +529,7 @@ Especially in distributed systems, you may want to override the default ID
 generation behavior as shown below. For generating `UUID`s you may want to check
 out [hyperid](https://github.com/mcollina/hyperid).
 
-> 🛈 Note:
+> ℹ️ Note:
 > `genReqId` will be not called if the header set in
 > <code>[requestIdHeader](#requestidheader)</code> is available (defaults to
 > 'request-id').
@@ -581,7 +581,7 @@ fastify.get('/', (request, reply) => {
 })
 ```
 
-> 🛈 Note:
+> ℹ️ Note:
 > If a request contains multiple `x-forwarded-host` or `x-forwarded-proto`
 > headers, it is only the last one that is used to derive `request.hostname`
 > and `request.protocol`.
@@ -736,7 +736,7 @@ Fastify provides default error handlers for the most common use cases. It is
 possible to override one or more of those handlers with custom code using this
 option.
 
-> 🛈 Note:
+> ℹ️ Note:
 > Only `FST_ERR_BAD_URL` and `FST_ERR_ASYNC_CONSTRAINT` are implemented at present.
 
 ```js
@@ -789,7 +789,7 @@ function defaultClientErrorHandler (err, socket) {
 }
 ```
 
-> 🛈 Note:
+> ℹ️ Note:
 > `clientErrorHandler` operates with raw sockets. The handler is expected to
 > return a properly formed HTTP response that includes a status line, HTTP headers
 > and a message body. Before attempting to write the socket, the handler should
@@ -1357,7 +1357,7 @@ Set the schema error formatter for all routes. See
 Set the schema serializer compiler for all routes. See
 [#schema-serializer](./Validation-and-Serialization.md#schema-serializer).
 
-> 🛈 Note:
+> ℹ️ Note:
 > [`setReplySerializer`](#set-reply-serializer) has priority if set!
 
 #### validatorCompiler
@@ -1490,7 +1490,7 @@ lifecycle](./Lifecycle.md#lifecycle). *async-await* is supported as well.
 You can also register [`preValidation`](./Hooks.md#route-hooks) and
 [`preHandler`](./Hooks.md#route-hooks) hooks for the 404 handler.
 
-> 🛈 Note:
+> ℹ️ Note:
 > The `preValidation` hook registered using this method will run for a
 > route that Fastify does not recognize and **not** when a route handler manually
 > calls [`reply.callNotFound`](./Reply.md#call-not-found). In which case, only
@@ -1526,7 +1526,7 @@ plugins are registered. If you would like to augment the behavior of the default
 arguments `fastify.setNotFoundHandler()` within the context of these registered
 plugins.
 
-> 🛈 Note:
+> ℹ️ Note:
 > Some config properties from the request object will be
 > undefined inside the custom not found handler. E.g.:
 > `request.routeOptions.url`, `routeOptions.method` and `routeOptions.config`.

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -432,7 +432,7 @@ fastify.setValidatorCompiler(({ schema, method, url, httpPart }) => {
   return ajv.compile(schema)
 })
 ```
-> 🛈 Note: When using a custom validator instance, add schemas to the validator
+> ℹ️ Note: When using a custom validator instance, add schemas to the validator
 > instead of Fastify. Fastify's `addSchema` method will not recognize the custom
 > validator.
 


### PR DESCRIPTION
Previous icon was not visible in Safari. See https://github.com/fastify/fastify/pull/6132#discussion_r2097602170