### PR TITLE
perf: nits in reply.js

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -215,12 +215,8 @@ Reply.prototype.send = function (payload) {
 
 Reply.prototype.getHeader = function (key) {
   key = key.toLowerCase()
-  const res = this.raw
-  let value = this[kReplyHeaders][key]
-  if (value === undefined && res.hasHeader(key)) {
-    value = res.getHeader(key)
-  }
-  return value
+  const value = this[kReplyHeaders][key]
+  return value !== undefined ? value : this.raw.getHeader(key)
 }
 
 Reply.prototype.getHeaders = function () {
@@ -315,12 +311,12 @@ Reply.prototype.removeTrailer = function (key) {
 }
 
 Reply.prototype.code = function (code) {
-  const intValue = Number(code)
-  if (isNaN(intValue) || intValue < 100 || intValue > 599) {
+  const statusCode = +code
+  if (!(statusCode >= 100 && statusCode <= 599)) {
     throw new FST_ERR_BAD_STATUS_CODE(code || String(code))
   }
 
-  this.raw.statusCode = intValue
+  this.raw.statusCode = statusCode
   this[kReplyHasStatusCode] = true
   return this
 }
@@ -500,11 +496,11 @@ function preSerializationHook (reply, payload) {
       preSerializationHookEnd
     )
   } else {
-    preSerializationHookEnd(null, reply.request, reply, payload)
+    preSerializationHookEnd(null, undefined, reply, payload)
   }
 }
 
-function preSerializationHookEnd (err, request, reply, payload) {
+function preSerializationHookEnd (err, _request, reply, payload) {
   if (err != null) {
     onErrorHook(reply, err)
     return


### PR DESCRIPTION
Might be a stretch to call it perf:, this is some minor nits that might/hopefully help with readability somewhat.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
