### PR TITLE
docs: fix typo in hash.digest function

### DIFF
--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -279,14 +279,14 @@ const { createHash } = require('node:crypto')
 reply.trailer('content-md5', function(reply, payload, done) {
   const hash = createHash('md5')
   hash.update(payload)
-  done(null, hash.disgest('hex'))
+  done(null, hash.digest('hex'))
 })
 
 // when you prefer async-await
 reply.trailer('content-md5', async function(reply, payload) {
   const hash = createHash('md5')
   hash.update(payload)
-  return hash.disgest('hex')
+  return hash.digest('hex')
 })
 ```
 


### PR DESCRIPTION
#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

`hash.disgest()` -> `hash.digest()`

Reference: <https://nodejs.org/docs/latest/api/crypto.html#hashdigestencoding>