### PR TITLE
chore: remove dependencie tap and others updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,3 @@ updates:
         patterns:
           - "ajv"
           - "ajv-*"
-    ignore:
-        - dependency-name: tap
-          update-types: ["version-update:semver-major"]

--- a/.taprc
+++ b/.taprc
@@ -1,7 +1,0 @@
-# vim: set filetype=yaml :
-node-arg:
-  - '--allow-natives-syntax'
-
-include:
-  - 'test/**/*.test.js'
-  - 'test/**/*.test.mjs'

--- a/package.json
+++ b/package.json
@@ -196,7 +196,6 @@
     "proxyquire": "^2.1.3",
     "simple-get": "^4.0.1",
     "split2": "^4.2.0",
-    "tap": "^21.0.0",
     "tsd": "^0.32.0",
     "typescript": "~5.8.2",
     "undici": "^6.13.0",

--- a/test/decorator-namespace.test._js_
+++ b/test/decorator-namespace.test._js_
@@ -2,8 +2,7 @@
 
 /* eslint no-prototype-builtins: 0 */
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const Fastify = require('..')
 const fp = require('fastify-plugin')
 
@@ -24,8 +23,8 @@ test('plugin namespace', async t => {
   }, { namepace: 'foo' })
 
   // ! but outside the plugin the decorator would be app.foo.utility()
-  t.ok(app.foo.utility)
+  t.assert.ok(app.foo.utility)
 
   const res = await app.inject('/')
-  t.same(res.json(), { utility: 'utility' })
+  t.assert.deepStrictEqual(res.json(), { utility: 'utility' })
 })

--- a/test/helper.js
+++ b/test/helper.js
@@ -12,7 +12,7 @@ module.exports.sleep = promisify(setTimeout)
 
 /**
  * @param method HTTP request method
- * @param t tap instance
+ * @param t node:test instance
  * @param isSetErrorHandler true: using setErrorHandler
  */
 module.exports.payloadMethod = function (method, t, isSetErrorHandler = false) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)



Proposals:

- Removed `tap` dependency, all tests in this repository have been converted from `tap` to `node:test`🎉 🔥, then you could remove the `tap` dependency.
- Update comment in `helper.js` file 🔥
- Migrated `decorator-namespace.test._js_` file to `tap` to `node:test`  🔥.  Honestly not if then it really serves 🤔 😄


I think you can also remove the `.taprc` file, it should not be needed for the CI, correct ?  🙂