### PR TITLE
fix: hook async flaky

### DIFF
--- a/test/hooks-async.test.js
+++ b/test/hooks-async.test.js
@@ -10,7 +10,7 @@ const { waitForCb } = require('./toolkit')
 
 process.removeAllListeners('warning')
 
-test('async hooks', (t, testDone) => {
+test('async hooks', t => {
   t.plan(21)
   const fastify = Fastify({ exposeHeadRoutes: false })
   fastify.addHook('onRequest', async function (request, reply) {
@@ -37,7 +37,7 @@ test('async hooks', (t, testDone) => {
   })
 
   const completion = waitForCb({
-    steps: 3
+    steps: 6
   })
   fastify.addHook('onResponse', async function (request, reply) {
     await sleep(1)
@@ -71,6 +71,7 @@ test('async hooks', (t, testDone) => {
       t.assert.strictEqual(response.statusCode, 200)
       t.assert.strictEqual(response.headers['content-length'], '' + body.length)
       t.assert.deepStrictEqual(JSON.parse(body), { hello: 'world' })
+      completion.stepIn()
     })
     sget({
       method: 'HEAD',
@@ -78,6 +79,7 @@ test('async hooks', (t, testDone) => {
     }, (err, response, body) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 500)
+      completion.stepIn()
     })
     sget({
       method: 'DELETE',
@@ -85,10 +87,11 @@ test('async hooks', (t, testDone) => {
     }, (err, response, body) => {
       t.assert.ifError(err)
       t.assert.strictEqual(response.statusCode, 500)
+      completion.stepIn()
     })
-
-    completion.patience.then(testDone)
   })
+
+  return completion.patience
 })
 
 test('modify payload', (t, testDone) => {


### PR DESCRIPTION
This is a tentative to fix the hook-async flaky test

References:
- https://github.com/fastify/fastify/actions/runs/15452115950/job/43496716783?pr=6154
- https://github.com/fastify/fastify/actions/runs/15451905460/job/43495806687

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
