### PR TITLE
chore: remove simple-get from propfind

### DIFF
--- a/test/http-methods/propfind.test.js
+++ b/test/http-methods/propfind.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { test } = require('node:test')
-const sget = require('simple-get').concat
 const fastify = require('../../')()
 fastify.addHttpMethod('PROPFIND', { hasBody: true })
 
@@ -74,73 +73,64 @@ test('propfind test', async t => {
     fastify.close()
   })
 
-  await t.test('request - propfind', (t, done) => {
+  await t.test('request - propfind', async t => {
     t.plan(3)
-    sget({
-      url: `http://localhost:${fastify.server.address().port}/`,
+    const result = await fetch(`http://localhost:${fastify.server.address().port}/`, {
       method: 'PROPFIND'
-    }, (err, response, body) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 207)
-      t.assert.strictEqual(response.headers['content-length'], '' + body.length)
-      done()
     })
+    t.assert.ok(result.ok)
+    t.assert.strictEqual(result.status, 207)
+    const body = await result.text()
+    t.assert.strictEqual(result.headers.get('content-length'), '' + body.length)
   })
 
-  await t.test('request with other path - propfind', (t, done) => {
+  await t.test('request with other path - propfind', async t => {
     t.plan(3)
-    sget({
-      url: `http://localhost:${fastify.server.address().port}/test`,
+    const result = await fetch(`http://localhost:${fastify.server.address().port}/test`, {
       method: 'PROPFIND'
-    }, (err, response, body) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 207)
-      t.assert.strictEqual(response.headers['content-length'], '' + body.length)
-      done()
     })
+    t.assert.ok(result.ok)
+    t.assert.strictEqual(result.status, 207)
+    const body = await result.text()
+    t.assert.strictEqual(result.headers.get('content-length'), '' + body.length)
   })
 
   // the body test uses a text/plain content type instead of application/xml because it requires
   // a specific content type parser
-  await t.test('request with body - propfind', (t, done) => {
+  await t.test('request with body - propfind', async t => {
     t.plan(3)
-    sget({
-      url: `http://localhost:${fastify.server.address().port}/test`,
+    const result = await fetch(`http://localhost:${fastify.server.address().port}/test`, {
+      method: 'PROPFIND',
       headers: { 'content-type': 'text/plain' },
-      body: bodySample,
-      method: 'PROPFIND'
-    }, (err, response, body) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 207)
-      t.assert.strictEqual(response.headers['content-length'], '' + body.length)
-      done()
+      body: bodySample
     })
+    t.assert.ok(result.ok)
+    t.assert.strictEqual(result.status, 207)
+    const body = await result.text()
+    t.assert.strictEqual(result.headers.get('content-length'), '' + body.length)
   })
 
-  await t.test('request with body and no content type (415 error) - propfind', (t, done) => {
+  await t.test('request with body and no content type (415 error) - propfind', async t => {
     t.plan(3)
-    sget({
-      url: `http://localhost:${fastify.server.address().port}/test`,
+    const result = await fetch(`http://localhost:${fastify.server.address().port}/test`, {
+      method: 'PROPFIND',
       body: bodySample,
-      method: 'PROPFIND'
-    }, (err, response, body) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 415)
-      t.assert.strictEqual(response.headers['content-length'], '' + body.length)
-      done()
+      headers: { 'content-type': '' }
     })
+    t.assert.ok(!result.ok)
+    t.assert.strictEqual(result.status, 415)
+    const body = await result.text()
+    t.assert.strictEqual(result.headers.get('content-length'), '' + body.length)
   })
 
-  await t.test('request without body - propfind', (t, done) => {
+  await t.test('request without body - propfind', async t => {
     t.plan(3)
-    sget({
-      url: `http://localhost:${fastify.server.address().port}/test`,
+    const result = await fetch(`http://localhost:${fastify.server.address().port}/test`, {
       method: 'PROPFIND'
-    }, (err, response, body) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 207)
-      t.assert.strictEqual(response.headers['content-length'], '' + body.length)
-      done()
     })
+    t.assert.ok(result.ok)
+    t.assert.strictEqual(result.status, 207)
+    const body = await result.text()
+    t.assert.strictEqual(result.headers.get('content-length'), '' + body.length)
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
