### PR TITLE
chore: removed simple-get from nullable validation test

### DIFF
--- a/test/nullable-validation.test.js
+++ b/test/nullable-validation.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { test } = require('node:test')
-const sget = require('simple-get').concat
 const Fastify = require('..')
 
 test('nullable string', (t, done) => {
@@ -52,8 +51,8 @@ test('nullable string', (t, done) => {
   })
 })
 
-test('object or null body', (t, done) => {
-  t.plan(5)
+test('object or null body', async (t) => {
+  t.plan(4)
 
   const fastify = Fastify()
 
@@ -88,24 +87,20 @@ test('object or null body', (t, done) => {
     }
   })
 
-  fastify.listen({ port: 0 }, (err) => {
-    t.assert.ifError(err)
-    t.after(() => { fastify.close() })
+  const fastifyServer = await fastify.listen({ port: 0 })
+  t.after(() => { fastify.close() })
 
-    sget({
-      method: 'POST',
-      url: 'http://localhost:' + fastify.server.address().port
-    }, (err, response, body) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 200)
-      t.assert.deepStrictEqual(JSON.parse(body), { isUndefinedBody: true })
-      done()
-    })
+  const result = await fetch(fastifyServer, {
+    method: 'POST'
   })
+
+  t.assert.ok(result.ok)
+  t.assert.strictEqual(result.status, 200)
+  t.assert.deepStrictEqual(await result.json(), { isUndefinedBody: true })
 })
 
-test('nullable body', (t, done) => {
-  t.plan(5)
+test('nullable body', async (t) => {
+  t.plan(4)
 
   const fastify = Fastify()
 
@@ -141,24 +136,20 @@ test('nullable body', (t, done) => {
     }
   })
 
-  fastify.listen({ port: 0 }, (err) => {
-    t.assert.ifError(err)
-    t.after(() => fastify.close())
+  const fastifyServer = await fastify.listen({ port: 0 })
+  t.after(() => fastify.close())
 
-    sget({
-      method: 'POST',
-      url: 'http://localhost:' + fastify.server.address().port
-    }, (err, response, body) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 200)
-      t.assert.deepStrictEqual(JSON.parse(body), { isUndefinedBody: true })
-      done()
-    })
+  const result = await fetch(fastifyServer, {
+    method: 'POST'
   })
+
+  t.assert.ok(result.ok)
+  t.assert.strictEqual(result.status, 200)
+  t.assert.deepStrictEqual(await result.json(), { isUndefinedBody: true })
 })
 
-test('Nullable body with 204', (t, done) => {
-  t.plan(5)
+test('Nullable body with 204', async (t) => {
+  t.plan(4)
 
   const fastify = Fastify()
 
@@ -183,18 +174,14 @@ test('Nullable body with 204', (t, done) => {
     }
   })
 
-  fastify.listen({ port: 0 }, (err) => {
-    t.assert.ifError(err)
-    t.after(() => fastify.close())
+  const fastifyServer = await fastify.listen({ port: 0 })
+  t.after(() => fastify.close())
 
-    sget({
-      method: 'POST',
-      url: 'http://localhost:' + fastify.server.address().port
-    }, (err, response, body) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 204)
-      t.assert.strictEqual(body.length, 0)
-      done()
-    })
+  const result = await fetch(fastifyServer, {
+    method: 'POST'
   })
+
+  t.assert.ok(result.ok)
+  t.assert.strictEqual(result.status, 204)
+  t.assert.strictEqual((await result.text()).length, 0)
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
