### PR TITLE
chore: removed simple-get from use-semicolon-delimiter tests

### DIFF
--- a/test/use-semicolon-delimiter.test.js
+++ b/test/use-semicolon-delimiter.test.js
@@ -2,10 +2,9 @@
 
 const { test } = require('node:test')
 const Fastify = require('..')
-const sget = require('simple-get').concat
 
-test('use semicolon delimiter default false', (t, done) => {
-  t.plan(4)
+test('use semicolon delimiter default false', async (t) => {
+  t.plan(2)
 
   const fastify = Fastify()
 
@@ -13,23 +12,19 @@ test('use semicolon delimiter default false', (t, done) => {
     reply.send(req.query)
   })
 
-  fastify.listen({ port: 0 }, err => {
-    t.assert.ifError(err)
-    sget({
-      method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port + '/1234;foo=bar'
-    }, (err, response, body) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 200)
-      t.assert.deepStrictEqual(JSON.parse(body), {})
-      fastify.close()
-      done()
-    })
+  const fastifyServer = await fastify.listen({ port: 0 })
+  t.after(() => { fastify.close() })
+
+  const result = await fetch(fastifyServer + '/1234;foo=bar', {
+    method: 'GET'
   })
+  t.assert.strictEqual(result.status, 200)
+  const body = await result.json()
+  t.assert.deepStrictEqual(body, {})
 })
 
-test('use semicolon delimiter set to true', (t, done) => {
-  t.plan(4)
+test('use semicolon delimiter set to true', async (t) => {
+  t.plan(3)
   const fastify = Fastify({
     useSemicolonDelimiter: true
   })
@@ -38,26 +33,19 @@ test('use semicolon delimiter set to true', (t, done) => {
     reply.send(req.query)
   })
 
-  fastify.listen({ port: 0 }, err => {
-    t.assert.ifError(err)
+  const fastifyServer = await fastify.listen({ port: 0 })
+  t.after(() => { fastify.close() })
 
-    sget({
-      method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port + '/1234;foo=bar'
-    }, (err, response, body) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 200)
-      t.assert.deepStrictEqual(JSON.parse(body), {
-        foo: 'bar'
-      })
-      fastify.close()
-      done()
-    })
+  const result = await fetch(fastifyServer + '/1234;foo=bar')
+  t.assert.ok(result.ok)
+  t.assert.strictEqual(result.status, 200)
+  t.assert.deepStrictEqual(await result.json(), {
+    foo: 'bar'
   })
 })
 
-test('use semicolon delimiter set to false', (t, done) => {
-  t.plan(4)
+test('use semicolon delimiter set to false', async (t) => {
+  t.plan(3)
 
   const fastify = Fastify({
     useSemicolonDelimiter: false
@@ -67,24 +55,17 @@ test('use semicolon delimiter set to false', (t, done) => {
     reply.send(req.query)
   })
 
-  fastify.listen({ port: 0 }, err => {
-    t.assert.ifError(err)
+  const fastifyServer = await fastify.listen({ port: 0 })
+  t.after(() => { fastify.close() })
 
-    sget({
-      method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port + '/1234;foo=bar'
-    }, (err, response, body) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 200)
-      t.assert.deepStrictEqual(JSON.parse(body), {})
-      fastify.close()
-      done()
-    })
-  })
+  const result = await fetch(fastifyServer + '/1234;foo=bar')
+  t.assert.ok(result.ok)
+  t.assert.strictEqual(result.status, 200)
+  t.assert.deepStrictEqual(await result.json(), {})
 })
 
-test('use semicolon delimiter set to false return 404', (t, done) => {
-  t.plan(3)
+test('use semicolon delimiter set to false return 404', async (t) => {
+  t.plan(2)
 
   const fastify = Fastify({
     useSemicolonDelimiter: false
@@ -94,17 +75,10 @@ test('use semicolon delimiter set to false return 404', (t, done) => {
     reply.send(req.query)
   })
 
-  fastify.listen({ port: 0 }, err => {
-    t.assert.ifError(err)
+  const fastifyServer = await fastify.listen({ port: 0 })
+  t.after(() => { fastify.close() })
 
-    sget({
-      method: 'GET',
-      url: 'http://localhost:' + fastify.server.address().port + '/1234;foo=bar'
-    }, (err, response, body) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 404)
-      fastify.close()
-      done()
-    })
-  })
+  const result = await fetch(fastifyServer + '/1234;foo=bar')
+  t.assert.ok(!result.ok)
+  t.assert.strictEqual(result.status, 404)
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
