### PR TITLE
chore: removed simple-get from async-delay-request tests

### DIFF
--- a/test/diagnostics-channel/async-delay-request.test.js
+++ b/test/diagnostics-channel/async-delay-request.test.js
@@ -2,13 +2,11 @@
 
 const diagnostics = require('node:diagnostics_channel')
 const { test } = require('node:test')
-const sget = require('simple-get').concat
 const Fastify = require('../..')
-const { getServerUrl } = require('../helper')
 const Request = require('../../lib/request')
 const Reply = require('../../lib/reply')
 
-test('diagnostics channel async events fire in expected order', (t, done) => {
+test('diagnostics channel async events fire in expected order', async t => {
   t.plan(19)
   let callOrder = 0
   let firstEncounteredMessage
@@ -56,19 +54,12 @@ test('diagnostics channel async events fire in expected order', (t, done) => {
     }
   })
 
-  fastify.listen({ port: 0 }, function (err) {
-    if (err) t.assert.ifError(err)
+  t.after(() => { fastify.close() })
 
-    t.after(() => { fastify.close() })
+  const fastifyServer = await fastify.listen({ port: 0 })
 
-    sget({
-      method: 'GET',
-      url: getServerUrl(fastify) + '/'
-    }, (err, response, body) => {
-      t.assert.ifError(err)
-      t.assert.strictEqual(response.statusCode, 200)
-      t.assert.deepStrictEqual(JSON.parse(body), { hello: 'world' })
-      done()
-    })
-  })
+  const result = await fetch(fastifyServer + '/')
+  t.assert.ok(result.ok)
+  t.assert.strictEqual(result.status, 200)
+  t.assert.deepStrictEqual(await result.json(), { hello: 'world' })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
