### PR TITLE
fix: handle abort signal in fastify.listen in edge cases

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -37,14 +37,18 @@ function createServer (options, httpHandler) {
       listenOptions.cb = cb
     }
     if (listenOptions.signal) {
-      if (typeof listenOptions.signal.on !== 'function' && typeof listenOptions.signal.addEventListener !== 'function') {
+      const { signal } = listenOptions
+
+      if (typeof signal.on !== 'function' && typeof signal.addEventListener !== 'function') {
         throw new FST_ERR_LISTEN_OPTIONS_INVALID('Invalid options.signal')
       }
 
-      if (listenOptions.signal.aborted) {
+      if (signal.aborted) {
+        this.closeReason = signal.reason
         this.close()
       } else {
-        const onAborted = () => {
+        const onAborted = (event) => {
+          this.closeReason = event.target.reason
           this.close()
         }
         listenOptions.signal.addEventListener('abort', onAborted, { once: true })
@@ -133,6 +137,12 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
       return
     }
 
+    if (this.closeReason) {
+      // while invoking dns.lookup, listening was aborted
+      onListen()
+      return
+    }
+
     const isMainServerListening = mainServer.listening && serverOpts.serverFactory
 
     let binding = 0
@@ -199,15 +209,36 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
 }
 
 function listenCallback (server, listenOptions) {
+  let abortListeningCleanup
+  let wasAbortedHandled = false
   const wrap = (err) => {
     server.removeListener('error', wrap)
     server.removeListener('listening', wrap)
+    abortListeningCleanup?.()
     if (!err) {
       const address = logServerAddress.call(this, server, listenOptions.listenTextResolver || defaultResolveServerListeningText)
       listenOptions.cb(null, address)
     } else {
       this[kState].listening = false
       listenOptions.cb(err, null)
+    }
+  }
+  const { signal } = listenOptions
+
+  if (typeof signal?.addEventListener === 'function') {
+    if (signal.aborted) {
+      wasAbortedHandled = true
+      wrap(signal.reason)
+    } else {
+      const doRejectPromise = (event) => {
+        wasAbortedHandled = true
+        wrap(event.target.reason)
+      }
+      abortListeningCleanup = () => {
+        signal.removeEventListener('abort', doRejectPromise)
+      }
+
+      signal.addEventListener('abort', doRejectPromise, { once: true })
     }
   }
 
@@ -221,11 +252,17 @@ function listenCallback (server, listenOptions) {
       return listenOptions.cb(new FST_ERR_REOPENED_SERVER(), null)
     }
 
+    if (wasAbortedHandled) {
+      return
+    }
+
     server.once('error', wrap)
     if (!this[kState].closing) {
       server.once('listening', wrap)
       server.listen(listenOptions)
       this[kState].listening = true
+    } else if (this.closeReason) {
+      wrap(this.closeReason)
     }
   }
 }
@@ -238,12 +275,14 @@ function listenPromise (server, listenOptions) {
     return Promise.reject(new FST_ERR_REOPENED_SERVER())
   }
 
-  return this.ready().then(() => {
+  return this.ready(null, listenOptions).then(() => {
     let errEventHandler
     let listeningEventHandler
+    let abortListeningCleanup
     function cleanup () {
       server.removeListener('error', errEventHandler)
       server.removeListener('listening', listeningEventHandler)
+      abortListeningCleanup?.()
     }
     const errEvent = new Promise((resolve, reject) => {
       errEventHandler = (err) => {
@@ -261,6 +300,23 @@ function listenPromise (server, listenOptions) {
       }
       server.once('listening', listeningEventHandler)
     })
+
+    const { signal } = listenOptions
+
+    if (typeof signal?.addEventListener === 'function') {
+      if (signal.aborted) {
+        return Promise.reject(signal.reason)
+      } else {
+        const doRejectPromise = (event) => {
+          errEventHandler(event.target.reason)
+        }
+        abortListeningCleanup = () => {
+          signal.removeEventListener('abort', doRejectPromise)
+        }
+
+        signal.addEventListener('abort', doRejectPromise, { once: true })
+      }
+    }
 
     server.listen(listenOptions)
 


### PR DESCRIPTION
Resolve #6230

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
