### PR TITLE
docs: updated SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,10 @@ project and its official plugins.
 ## Reporting vulnerabilities
 
 Individuals who find potential vulnerabilities in Fastify are invited to
-complete a vulnerability report via the dedicated HackerOne page:
-[https://hackerone.com/fastify](https://hackerone.com/fastify).
+complete a vulnerability report via the dedicated pages:
+
+1. [HackerOne](https://hackerone.com/fastify)
+2. [GitHub Security Advisory](https://github.com/fastify/fastify/security/advisories/new)
 
 ### Strict measures when reporting vulnerabilities
 
@@ -15,13 +17,13 @@ It is of the utmost importance that you read carefully and follow these
 guidelines to ensure the ecosystem as a whole isn't disrupted due to improperly
 reported vulnerabilities:
 
-* Avoid creating new "informative" reports on HackerOne. Only create new
-  HackerOne reports on a vulnerability if you are absolutely sure this should be
+* Avoid creating new "informative" reports. Only create new
+  reports on a vulnerability if you are absolutely sure this should be
   tagged as an actual vulnerability. Third-party vendors and individuals are
-  tracking any new vulnerabilities reported in HackerOne and will flag them as
-  such for their customers (think about snyk, npm audit, ...).
-* HackerOne reports should never be created and triaged by the same person. If
-  you are creating a HackerOne report for a vulnerability that you found, or on
+  tracking any new vulnerabilities reported in HackerOne or GitHub and will flag
+  them as such for their customers (think about snyk, npm audit, ...).
+* Security reports should never be created and triaged by the same person. If
+  you are creating a report for a vulnerability that you found, or on
   behalf of someone else, there should always be a 2nd Security Team member who
   triages it. If in doubt, invite more Fastify Collaborators to help triage the
   validity of the report. In any case, the report should follow the same process
@@ -39,8 +41,8 @@ reported vulnerabilities:
 
 ### Vulnerabilities found outside this process
 
-⚠ The Fastify project does not support any reporting outside the HackerOne
-process.
+⚠ The Fastify project does not support any reporting outside the process mentioned
+in this document.
 
 ## Handling vulnerability reports
 
@@ -54,9 +56,9 @@ Within 4 business days, a member of the security team provides a first answer to
 the individual who submitted the potential vulnerability. The possible responses
 can be:
 
-* Acceptance: what was reported is considered as a new vulnerability
-* Rejection: what was reported is not considered as a new vulnerability
-* Need more information: the security team needs more information in order to
+* **Acceptance**: what was reported is considered as a new vulnerability
+* **Rejection**: what was reported is not considered as a new vulnerability
+* **Need more information**: the security team needs more information in order to
   evaluate what was reported.
 
 Triaging should include updating issue fields:
@@ -100,7 +102,7 @@ If the package maintainer is actively developing a patch, an additional delay
 can be added with the approval of the security team and the individual who
 reported the vulnerability.
 
-At this point, a CVE should be requested through the HackerOne platform through
+At this point, a CVE should be requested through the selected platform through
 the UI, which should include the Report ID and a summary.
 
 Within HackerOne, this is handled through a "public disclosure request".
@@ -110,8 +112,8 @@ Disclosure](https://docs.hackerone.com/hackers/disclosure.html)
 
 ## The Fastify Security team
 
-The core team is responsible for the management of HackerOne program and this
-policy and process.
+The core team is responsible for the management of the security program and
+this policy and process.
 
 Members of this team are expected to keep all information that they have
 privileged access to by being on the team completely private to the team. This


### PR DESCRIPTION
This PR has 2 commits:

1. the first one is just the copy-paste from our current policy: https://github.com/fastify/.github/blob/main/SECURITY.md?plain=1
2. the second commit is an upgrade to accept security issues via GitHub. This feature is already turned on and can't be turned on due our OSS status:

- Enforced by GH:
<img width="921" alt="image" src="https://github.com/user-attachments/assets/7e187ffe-885d-4d0e-95b5-859bade8fedf" />

- Disable button blocked:
<img width="803" alt="image" src="https://github.com/user-attachments/assets/9638371e-ac5f-43c3-841b-9a90caf78cb8" />

---

This PR wants to improve the security approach between our community and maintainers.

The shared https://github.com/fastify/.github/blob/main/SECURITY.md file will stay live for all our plugins and will get the same improvement ad this PR to list the GH Security Advisory to the accepted reporting tools.

Side note, this PR is coming as feedback we got from our [PRIVATE DISCUSSION - DON'T SHARE PUBLICLY](https://github.com/orgs/fastify/discussions/55)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
