### PR TITLE
fix: handle abort signal in fastify.listen

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -211,6 +211,7 @@ function fastify (options) {
       started: false,
       ready: false,
       booting: false,
+      aborted: false,
       readyPromise: null
     },
     [kKeepAliveConnections]: keepAliveConnections,

--- a/lib/server.js
+++ b/lib/server.js
@@ -41,10 +41,14 @@ function createServer (options, httpHandler) {
         throw new FST_ERR_LISTEN_OPTIONS_INVALID('Invalid options.signal')
       }
 
+      // copy the current signal state
+      this[kState].aborted = listenOptions.signal.aborted
+
       if (listenOptions.signal.aborted) {
-        this.close()
+        return this.close()
       } else {
         const onAborted = () => {
+          this[kState].aborted = true
           this.close()
         }
         listenOptions.signal.addEventListener('abort', onAborted, { once: true })

--- a/lib/server.js
+++ b/lib/server.js
@@ -44,7 +44,7 @@ function createServer (options, httpHandler) {
       // copy the current signal state
       this[kState].aborted = listenOptions.signal.aborted
 
-      if (listenOptions.signal.aborted) {
+      if (this[kState].aborted) {
         return this.close()
       } else {
         const onAborted = () => {
@@ -130,7 +130,7 @@ function multipleBindings (mainServer, httpHandler, serverOpts, listenOptions, o
 
   // let's check if we need to bind additional addresses
   dns.lookup(listenOptions.host, { all: true }, (dnsErr, addresses) => {
-    if (dnsErr) {
+    if (dnsErr || this[kState].aborted) {
       // not blocking the main server listening
       // this.log.warn('dns.lookup error:', dnsErr)
       onListen()
@@ -243,6 +243,9 @@ function listenPromise (server, listenOptions) {
   }
 
   return this.ready().then(() => {
+    // skip listen when aborted during ready
+    if (this[kState].aborted) return
+
     let errEventHandler
     let listeningEventHandler
     function cleanup () {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,9 +1,11 @@
 'use strict'
 
+const dns = require('node:dns')
 const { test } = require('node:test')
 const Fastify = require('..')
 const sget = require('simple-get').concat
 const undici = require('undici')
+const proxyquire = require('proxyquire')
 
 test('listen should accept null port', async t => {
   const fastify = Fastify()
@@ -119,6 +121,64 @@ test('abort signal', async t => {
     const address = await fastify.listen({ port: 1234, signal: controller.signal })
     t.assert.ok(address)
     controller.abort()
+    await resolver.promise
+  })
+
+  await t.test('should close server when aborted during fastify.ready - promise', async (t) => {
+    t.plan(2)
+    const resolver = {}
+    resolver.promise = new Promise(function (resolve) {
+      resolver.resolve = resolve
+    })
+    function onClose (instance, done) {
+      t.assert.strictEqual(instance, fastify)
+      done()
+      resolver.resolve()
+    }
+
+    const controller = new AbortController()
+
+    const fastify = Fastify()
+    fastify.addHook('onClose', onClose)
+    const promise = fastify.listen({ port: 1234, signal: controller.signal })
+    controller.abort()
+    const address = await promise
+    // since the main server is not listening yet, or will not listen
+    // it should return undefined
+    t.assert.strictEqual(address, undefined)
+    await resolver.promise
+  })
+
+  await t.test('should close server when aborted during dns.lookup - promise', async (t) => {
+    t.plan(2)
+    const Fastify = proxyquire('..', {
+      './lib/server.js': proxyquire('../lib/server.js', {
+        'node:dns': {
+          lookup: function (host, option, callback) {
+            controller.abort()
+            dns.lookup(host, option, callback)
+          }
+        }
+      })
+    })
+    const resolver = {}
+    resolver.promise = new Promise(function (resolve) {
+      resolver.resolve = resolve
+    })
+    function onClose (instance, done) {
+      t.assert.strictEqual(instance, fastify)
+      done()
+      resolver.resolve()
+    }
+
+    const controller = new AbortController()
+
+    const fastify = Fastify()
+    fastify.addHook('onClose', onClose)
+    const address = await fastify.listen({ port: 1234, signal: controller.signal })
+    // since the main server is already listening then close
+    // it should return address
+    t.assert.ok(address)
     await resolver.promise
   })
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -101,7 +101,7 @@ test('abort signal', async t => {
   })
 
   await t.test('should close server when aborted after - promise', async (t) => {
-    t.plan(1)
+    t.plan(2)
     const resolver = {}
     resolver.promise = new Promise(function (resolve) {
       resolver.resolve = resolve
@@ -116,7 +116,8 @@ test('abort signal', async t => {
 
     const fastify = Fastify()
     fastify.addHook('onClose', onClose)
-    await fastify.listen({ port: 1234, signal: controller.signal })
+    const address = await fastify.listen({ port: 1234, signal: controller.signal })
+    t.assert.ok(address)
     controller.abort()
     await resolver.promise
   })
@@ -140,7 +141,7 @@ test('abort signal', async t => {
   })
 
   await t.test('should close server when aborted before - promise', async (t) => {
-    t.plan(1)
+    t.plan(2)
     const resolver = {}
     resolver.promise = new Promise(function (resolve) {
       resolver.resolve = resolve
@@ -156,7 +157,8 @@ test('abort signal', async t => {
 
     const fastify = Fastify()
     fastify.addHook('onClose', onClose)
-    await fastify.listen({ port: 1234, signal: controller.signal })
+    const address = await fastify.listen({ port: 1234, signal: controller.signal })
+    t.assert.strictEqual(address, undefined) // ensure the API signature
     await resolver.promise
   })
 


### PR DESCRIPTION
Fixes #6230 

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
