### PR TITLE
refactor(content-type-parser): improve clarity with renamed parameter…

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -29,7 +29,7 @@ const {
 } = require('./errors')
 const { FSTSEC001 } = require('./warnings')
 
-function ContentTypeParser (bodyLimit, onProtoPoisoning, onConstructorPoisoning) {
+function ContentTypeParser(bodyLimit, onProtoPoisoning, onConstructorPoisoning) {
   this[kDefaultJsonParse] = getDefaultJsonParser(onProtoPoisoning, onConstructorPoisoning)
   // using a map instead of a plain object to avoid prototype hijack attacks
   this.customParsers = new Map()
@@ -203,7 +203,7 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
     }
   }
 
-  function done (error, body) {
+  function done(error, body) {
     // We cannot use resource.bind() because it is broken in node v12 and v14
     resource.runInAsyncScope(() => {
       resource.emitDestroy()
@@ -218,7 +218,7 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
   }
 }
 
-function rawBody (request, reply, options, parser, done) {
+function rawBody(request, reply, options, parser, done) {
   const asString = parser.asString
   const limit = options.limit === null ? parser.bodyLimit : options.limit
   const contentLength = Number(request.headers['content-length'])
@@ -245,7 +245,7 @@ function rawBody (request, reply, options, parser, done) {
   payload.on('error', onEnd)
   payload.resume()
 
-  function onData (chunk) {
+  function onData(chunk) {
     receivedLength += chunk.length
     const { receivedEncodedLength = 0 } = payload
     // The resulting body length must not exceed bodyLimit (see "zip bomb").
@@ -266,7 +266,7 @@ function rawBody (request, reply, options, parser, done) {
     }
   }
 
-  function onEnd (err) {
+  function onEnd(err) {
     payload.removeListener('data', onData)
     payload.removeListener('end', onEnd)
     payload.removeListener('error', onEnd)
@@ -301,12 +301,12 @@ function rawBody (request, reply, options, parser, done) {
   }
 }
 
-function getDefaultJsonParser (onProtoPoisoning, onConstructorPoisoning) {
+function getDefaultJsonParser(onProtoPoisoning, onConstructorPoisoning) {
   const parseOptions = { protoAction: onProtoPoisoning, constructorAction: onConstructorPoisoning }
 
   return defaultJsonParser
 
-  function defaultJsonParser (req, body, done) {
+  function defaultJsonParser(req, body, done) {
     if (body.length === 0) {
       done(new FST_ERR_CTP_EMPTY_JSON_BODY(), undefined)
       return
@@ -319,27 +319,29 @@ function getDefaultJsonParser (onProtoPoisoning, onConstructorPoisoning) {
   }
 }
 
-function defaultPlainTextParser (req, body, done) {
+function defaultPlainTextParser(req, body, done) {
   done(null, body)
 }
 
-function Parser (asString, asBuffer, bodyLimit, fn) {
+function Parser(asString, asBuffer, bodyLimit, fn) {
   this.asString = asString
   this.asBuffer = asBuffer
   this.bodyLimit = bodyLimit
   this.fn = fn
 }
 
-function buildContentTypeParser (c) {
-  const contentTypeParser = new ContentTypeParser()
-  contentTypeParser[kDefaultJsonParse] = c[kDefaultJsonParse]
-  contentTypeParser.customParsers = new Map(c.customParsers.entries())
-  contentTypeParser.parserList = c.parserList.slice()
-  contentTypeParser.parserRegExpList = c.parserRegExpList.slice()
-  return contentTypeParser
+
+function buildContentTypeParser(sourceParser) {
+  const clonedParser = new ContentTypeParser()
+  clonedParser[kDefaultJsonParse] = sourceParser[kDefaultJsonParse]
+  clonedParser.customParsers = new Map(sourceParser.customParsers.entries())
+  clonedParser.parserList = sourceParser.parserList.slice()
+  clonedParser.parserRegExpList = sourceParser.parserRegExpList.slice()
+  return clonedParser
 }
 
-function addContentTypeParser (contentType, opts, parser) {
+
+function addContentTypeParser(contentType, opts, parser) {
   if (this[kState].started) {
     throw new FST_ERR_CTP_INSTANCE_ALREADY_STARTED('addContentTypeParser')
   }
@@ -361,11 +363,11 @@ function addContentTypeParser (contentType, opts, parser) {
   return this
 }
 
-function hasContentTypeParser (contentType) {
+function hasContentTypeParser(contentType) {
   return this[kContentTypeParser].hasParser(contentType)
 }
 
-function removeContentTypeParser (contentType) {
+function removeContentTypeParser(contentType) {
   if (this[kState].started) {
     throw new FST_ERR_CTP_INSTANCE_ALREADY_STARTED('removeContentTypeParser')
   }
@@ -379,7 +381,7 @@ function removeContentTypeParser (contentType) {
   }
 }
 
-function removeAllContentTypeParsers () {
+function removeAllContentTypeParsers() {
   if (this[kState].started) {
     throw new FST_ERR_CTP_INSTANCE_ALREADY_STARTED('removeAllContentTypeParsers')
   }
@@ -387,7 +389,7 @@ function removeAllContentTypeParsers () {
   this[kContentTypeParser].removeAll()
 }
 
-function validateRegExp (regexp) {
+function validateRegExp(regexp) {
   // RegExp should either start with ^ or include ;?
   // It can ensure the user is properly detect the essence
   // MIME types.


### PR DESCRIPTION
### Summary

This PR improves the readability and maintainability of the `buildContentTypeParser` function by:

- Renaming the parameter from `c` to `sourceParser` for better clarity.
- Renaming the local variable to `clonedParser` to better reflect its purpose.

No functional changes were made; behavior remains the same.

### Motivation

Clear variable names and documentation help future contributors understand the code quickly and reduce cognitive load.

---

Thank you for considering this small but important readability improvement!
