### PR TITLE
feat: optimize content type parser by using AsyncResource.bind()

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -177,15 +177,15 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
   if (parser === undefined) {
     if (request.is404) {
       handler(request, reply)
-    } else {
-      reply.send(new FST_ERR_CTP_INVALID_MEDIA_TYPE(contentType || undefined))
+      return
     }
 
-    // Early return to avoid allocating an AsyncResource if it's not needed
+    reply.send(new FST_ERR_CTP_INVALID_MEDIA_TYPE(contentType || undefined))
     return
   }
 
   const resource = new AsyncResource('content-type-parser:run', request)
+  const done = resource.bind(onDone)
 
   if (parser.asString === true || parser.asBuffer === true) {
     rawBody(
@@ -195,26 +195,24 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
       parser,
       done
     )
-  } else {
-    const result = parser.fn(request, request[kRequestPayloadStream], done)
-
-    if (result && typeof result.then === 'function') {
-      result.then(body => done(null, body), done)
-    }
+    return
   }
 
-  function done (error, body) {
-    // We cannot use resource.bind() because it is broken in node v12 and v14
-    resource.runInAsyncScope(() => {
-      resource.emitDestroy()
-      if (error) {
-        reply[kReplyIsError] = true
-        reply.send(error)
-      } else {
-        request.body = body
-        handler(request, reply)
-      }
-    })
+  const result = parser.fn(request, request[kRequestPayloadStream], done)
+
+  if (result && typeof result.then === 'function') {
+    result.then(body => { done(null, body) }, done)
+  }
+
+  function onDone (error, body) {
+    resource.emitDestroy()
+    if (error) {
+      reply[kReplyIsError] = true
+      reply.send(error)
+      return
+    }
+    request.body = body
+    handler(request, reply)
   }
 }
 

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -175,7 +175,7 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
   const parser = this.getParser(contentType)
 
   if (parser === undefined) {
-    if (request.is404) {
+    if (request.is404 === true) {
       handler(request, reply)
       return
     }
@@ -206,7 +206,7 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
 
   function onDone (error, body) {
     resource.emitDestroy()
-    if (error) {
+    if (error != null) {
       reply[kReplyIsError] = true
       reply.send(error)
       return

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -180,6 +180,7 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
       return
     }
 
+    reply[kReplyIsError] = true
     reply.send(new FST_ERR_CTP_INVALID_MEDIA_TYPE(contentType || undefined))
     return
   }

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -199,7 +199,6 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
   }
 
   const result = parser.fn(request, request[kRequestPayloadStream], done)
-
   if (result && typeof result.then === 'function') {
     result.then(body => { done(null, body) }, done)
   }
@@ -207,6 +206,9 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
   function onDone (error, body) {
     resource.emitDestroy()
     if (error != null) {
+      // We must close the connection as the client may
+      // send more data
+      reply.header('connection', 'close')
       reply[kReplyIsError] = true
       reply.send(error)
       return
@@ -222,16 +224,12 @@ function rawBody (request, reply, options, parser, done) {
   const contentLength = Number(request.headers['content-length'])
 
   if (contentLength > limit) {
-    // We must close the connection as the client is going
-    // to send this data anyway
-    reply.header('connection', 'close')
-    reply.send(new FST_ERR_CTP_BODY_TOO_LARGE())
+    done(new FST_ERR_CTP_BODY_TOO_LARGE(), undefined)
     return
   }
 
   let receivedLength = 0
   let body = asString ? '' : []
-
   const payload = request[kRequestPayloadStream] || request.raw
 
   if (asString) {
@@ -253,7 +251,7 @@ function rawBody (request, reply, options, parser, done) {
       payload.removeListener('data', onData)
       payload.removeListener('end', onEnd)
       payload.removeListener('error', onEnd)
-      reply.send(new FST_ERR_CTP_BODY_TOO_LARGE())
+      done(new FST_ERR_CTP_BODY_TOO_LARGE(), undefined)
       return
     }
 
@@ -269,12 +267,11 @@ function rawBody (request, reply, options, parser, done) {
     payload.removeListener('end', onEnd)
     payload.removeListener('error', onEnd)
 
-    if (err !== undefined) {
+    if (err != null) {
       if (!(typeof err.statusCode === 'number' && err.statusCode >= 400)) {
         err.statusCode = 400
       }
-      reply[kReplyIsError] = true
-      reply.code(err.statusCode).send(err)
+      done(err, undefined)
       return
     }
 
@@ -283,8 +280,7 @@ function rawBody (request, reply, options, parser, done) {
     }
 
     if (!Number.isNaN(contentLength) && (payload.receivedEncodedLength || receivedLength) !== contentLength) {
-      reply.header('connection', 'close')
-      reply.send(new FST_ERR_CTP_INVALID_CONTENT_LENGTH())
+      done(new FST_ERR_CTP_INVALID_CONTENT_LENGTH(), undefined)
       return
     }
 
@@ -294,7 +290,7 @@ function rawBody (request, reply, options, parser, done) {
 
     const result = parser.fn(request, body, done)
     if (result && typeof result.then === 'function') {
-      result.then(body => done(null, body), done)
+      result.then(body => { done(null, body) }, done)
     }
   }
 }

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -242,7 +242,7 @@ function rawBody (request, reply, options, parser, done) {
   payload.resume()
 
   function onData (chunk) {
-    receivedLength += chunk.length
+    receivedLength += asString ? Buffer.byteLength(chunk) : chunk.length
     const { receivedEncodedLength = 0 } = payload
     // The resulting body length must not exceed bodyLimit (see "zip bomb").
     // The case when encoded length is larger than received length is rather theoretical,

--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -217,7 +217,7 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
 }
 
 function rawBody (request, reply, options, parser, done) {
-  const asString = parser.asString
+  const asString = parser.asString === true
   const limit = options.limit === null ? parser.bodyLimit : options.limit
   const contentLength = Number(request.headers['content-length'])
 
@@ -230,11 +230,11 @@ function rawBody (request, reply, options, parser, done) {
   }
 
   let receivedLength = 0
-  let body = asString === true ? '' : []
+  let body = asString ? '' : []
 
   const payload = request[kRequestPayloadStream] || request.raw
 
-  if (asString === true) {
+  if (asString) {
     payload.setEncoding('utf8')
   }
 
@@ -257,7 +257,7 @@ function rawBody (request, reply, options, parser, done) {
       return
     }
 
-    if (asString === true) {
+    if (asString) {
       body += chunk
     } else {
       body.push(chunk)
@@ -278,7 +278,7 @@ function rawBody (request, reply, options, parser, done) {
       return
     }
 
-    if (asString === true) {
+    if (asString) {
       receivedLength = Buffer.byteLength(body)
     }
 
@@ -288,7 +288,7 @@ function rawBody (request, reply, options, parser, done) {
       return
     }
 
-    if (asString === false) {
+    if (!asString) {
       body = Buffer.concat(body)
     }
 
@@ -311,7 +311,7 @@ function getDefaultJsonParser (onProtoPoisoning, onConstructorPoisoning) {
     }
     try {
       done(null, secureJsonParse(body, parseOptions))
-    } catch (err) {
+    } catch {
       done(new FST_ERR_CTP_INVALID_JSON_BODY(), undefined)
     }
   }

--- a/test/body-limit.test.js
+++ b/test/body-limit.test.js
@@ -171,3 +171,54 @@ test('request.routeOptions.bodyLimit should be equal to server limit', async t =
   t.assert.ok(result.ok)
   t.assert.strictEqual(result.status, 200)
 })
+
+test('bodyLimit should use byte length for UTF-8 strings, not character length', async t => {
+  t.plan(4)
+
+  // Create a string with multi-byte UTF-8 characters
+  // Use Japanese characters that are 3 bytes each in UTF-8
+  const multiByteString = 'あああ' // 3 characters, 9 bytes in UTF-8
+  t.assert.strictEqual(multiByteString.length, 3) // 3 characters
+  t.assert.strictEqual(Buffer.byteLength(multiByteString, 'utf8'), 9) // 9 bytes
+
+  const fastify = Fastify()
+
+  // Add a custom text parser that returns the string as-is
+  fastify.addContentTypeParser('text/plain', { parseAs: 'string' }, (req, body, done) => {
+    done(null, body)
+  })
+
+  // Set body limit to 7 bytes - this should reject the string (9 bytes)
+  // even though string.length (3) would be under any reasonable limit
+  fastify.post('/test-utf8', {
+    bodyLimit: 5
+  }, (request, reply) => {
+    reply.send({ body: request.body, length: request.body.length })
+  })
+
+  await t.test('should reject body when byte length exceeds limit', async (t) => {
+    const result = await fastify.inject({
+      method: 'POST',
+      url: '/test-utf8',
+      headers: { 'Content-Type': 'text/plain', 'Content-Length': null },
+      payload: multiByteString
+    })
+
+    t.assert.strictEqual(result.statusCode, 413)
+  })
+
+  await t.test('should accept body when byte length is within limit', async (t) => {
+    const smallString = 'あ' // 1 character, 3 bytes, under the 7 byte limit
+
+    const result = await fastify.inject({
+      method: 'POST',
+      url: '/test-utf8',
+      headers: { 'Content-Type': 'text/plain' },
+      payload: smallString
+    })
+
+    t.assert.strictEqual(result.statusCode, 200)
+    t.assert.strictEqual(result.json().body, smallString)
+    t.assert.strictEqual(result.json().length, 1) // 1 character
+  })
+})

--- a/test/body-limit.test.js
+++ b/test/body-limit.test.js
@@ -191,7 +191,7 @@ test('bodyLimit should use byte length for UTF-8 strings, not character length',
   // Set body limit to 7 bytes - this should reject the string (9 bytes)
   // even though string.length (3) would be under any reasonable limit
   fastify.post('/test-utf8', {
-    bodyLimit: 5
+    bodyLimit: 7
   }, (request, reply) => {
     reply.send({ body: request.body, length: request.body.length })
   })


### PR DESCRIPTION
- Removes the TODO and uses `asyncResource.bind`
- Makes sure we call `emitDestroy` in all error cases