### PR TITLE
fix: remove unnecessary body length check in contentTypeParser

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -276,10 +276,6 @@ function rawBody (request, reply, options, parser, done) {
       return
     }
 
-    if (asString) {
-      receivedLength = Buffer.byteLength(body)
-    }
-
     if (!Number.isNaN(contentLength) && (payload.receivedEncodedLength || receivedLength) !== contentLength) {
       done(new FST_ERR_CTP_INVALID_CONTENT_LENGTH(), undefined)
       return


### PR DESCRIPTION
We don't need the final operation now that we add the correct byteLength when the payload is parsed as string:

https://github.com/fastify/fastify/blob/e3b5b6e88a3b57bfbc8fb98b4300dced95fc896a/lib/contentTypeParser.js#L246