### PR TITLE
chore: refactor reply.send and prioritize kReplyIsError

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -39,7 +39,7 @@ function handleError (reply, error, cb) {
         if (!reply.log[kDisableRequestLogging]) {
           reply.log.warn(
             { req: reply.request, res: reply, err: error },
-            error && error.message
+            error?.message
           )
         }
         reply.raw.writeHead(reply.raw.statusCode)
@@ -89,14 +89,14 @@ function defaultErrorHandler (error, request, reply) {
     if (!reply.log[kDisableRequestLogging]) {
       reply.log.info(
         { res: reply, err: error },
-        error && error.message
+        error?.message
       )
     }
   } else {
     if (!reply.log[kDisableRequestLogging]) {
       reply.log.error(
         { req: request, res: reply, err: error },
-        error && error.message
+        error?.message
       )
     }
   }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -126,16 +126,16 @@ Reply.prototype.hijack = function () {
 }
 
 Reply.prototype.send = function (payload) {
-  if (this[kReplyIsRunningOnErrorHook] === true) {
+  if (this[kReplyIsRunningOnErrorHook]) {
     throw new FST_ERR_SEND_INSIDE_ONERR()
   }
 
-  if (this.sent) {
+  if (this.sent === true) {
     this.log.warn({ err: new FST_ERR_REP_ALREADY_SENT(this.request.url, this.request.method) })
     return this
   }
 
-  if (payload instanceof Error || this[kReplyIsError] === true) {
+  if (this[kReplyIsError] || payload instanceof Error) {
     this[kReplyIsError] = false
     onErrorHook(this, payload, onSendHook)
     return this
@@ -162,8 +162,8 @@ Reply.prototype.send = function (payload) {
       return this
     }
 
-    if (payload?.buffer instanceof ArrayBuffer) {
-      if (hasContentType === false) {
+    if (payload.buffer instanceof ArrayBuffer) {
+      if (!hasContentType) {
         this[kReplyHeaders]['content-type'] = CONTENT_TYPE.OCTET
       }
       const payloadToSend = Buffer.isBuffer(payload) ? payload : Buffer.from(payload.buffer, payload.byteOffset, payload.byteLength)
@@ -171,7 +171,7 @@ Reply.prototype.send = function (payload) {
       return this
     }
 
-    if (hasContentType === false && typeof payload === 'string') {
+    if (!hasContentType && typeof payload === 'string') {
       this[kReplyHeaders]['content-type'] = CONTENT_TYPE.PLAIN
       onSendHook(this, payload)
       return this
@@ -182,26 +182,24 @@ Reply.prototype.send = function (payload) {
     if (typeof payload !== 'string') {
       preSerializationHook(this, payload)
       return this
-    } else {
-      payload = this[kReplySerializer](payload)
     }
+    payload = this[kReplySerializer](payload)
 
     // The indexOf below also matches custom json mimetypes such as 'application/hal+json' or 'application/ld+json'
-  } else if (hasContentType === false || contentType.indexOf('json') > -1) {
-    if (hasContentType === false) {
+  } else if (!hasContentType || contentType.indexOf('json') !== -1) {
+    if (!hasContentType) {
       this[kReplyHeaders]['content-type'] = CONTENT_TYPE.JSON
-    } else {
+    } else if (contentType.indexOf('charset') === -1) {
       // If user doesn't set charset, we will set charset to utf-8
-      if (contentType.indexOf('charset') === -1) {
-        const customContentType = contentType.trim()
-        if (customContentType.endsWith(';')) {
-          // custom content-type is ended with ';'
-          this[kReplyHeaders]['content-type'] = `${customContentType} charset=utf-8`
-        } else {
-          this[kReplyHeaders]['content-type'] = `${customContentType}; charset=utf-8`
-        }
+      const customContentType = contentType.trim()
+      if (customContentType.endsWith(';')) {
+        // custom content-type is ended with ';'
+        this[kReplyHeaders]['content-type'] = `${customContentType} charset=utf-8`
+      } else {
+        this[kReplyHeaders]['content-type'] = `${customContentType}; charset=utf-8`
       }
     }
+
     if (typeof payload !== 'string') {
       preSerializationHook(this, payload)
       return this

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "bench": "branchcmp -r 2 -g -s \"npm run benchmark\"",
     "benchmark": "concurrently -k -s first \"node ./examples/benchmark/simple.js\" \"autocannon -c 100 -d 30 -p 10 localhost:3000/\"",
     "benchmark:parser": "concurrently -k -s first \"node ./examples/benchmark/parser.js\" \"autocannon -c 100 -d 30 -p 10 -i ./examples/benchmark/body.json -H \"content-type:application/jsoff\" -m POST localhost:3000/\"",
+    "benchmark:parser:error": "concurrently -k -s first \"node ./examples/benchmark/parser.js\" \"autocannon -c 100 -d 30 -p 10 -i ./examples/benchmark/body.json -H \"content-type:application/jsoff\" -H \"content-length:123\" -m POST localhost:3000/\"",
     "build:validation": "node build/build-error-serializer.js && node build/build-validation.js",
     "coverage": "c8 --reporter html borp --reporter=@jsumners/line-reporter --coverage --check-coverage --lines 100 ",
     "coverage:ci-check-coverage": "borp --reporter=@jsumners/line-reporter --coverage --check-coverage --lines 100",


### PR DESCRIPTION
- Refactors `reply.send` to prioritize `this[kReplyIsError]`, which is a simple boolean check, over `instanceof Error`

https://github.com/fastify/fastify/blob/afd7f509daec4d43ef9dac9d3ea1c8a0cf1ea092/lib/reply.js#L138

This should run faster when we throw one of our errors, and if it's not the case, the boolean check should be pretty much instant so it's another small win

- Also simplifies the branching of the method

New benchmark, `benchmark:parser:error`:

PR:
```sh
[1] Running 30s test @ http://localhost:3000/
[1] 100 connections with 10 pipelining factor
[1] 
[1] 
[1] ┌─────────┬────────┬──────────┬──────────┬──────────┬─────────────┬────────────┬──────────┐
[1] │ Stat    │ 2.5%   │ 50%      │ 97.5%    │ 99%      │ Avg         │ Stdev      │ Max      │
[1] ├─────────┼────────┼──────────┼──────────┼──────────┼─────────────┼────────────┼──────────┤
[1] │ Latency │ 584 ms │ 10221 ms │ 26984 ms │ 27559 ms │ 11858.67 ms │ 8067.32 ms │ 28066 ms │
[1] └─────────┴────────┴──────────┴──────────┴──────────┴─────────────┴────────────┴──────────┘
[1] ┌───────────┬────────┬────────┬─────────┬─────────┬───────────┬──────────┬────────┐
[1] │ Stat      │ 1%     │ 2.5%   │ 50%     │ 97.5%   │ Avg       │ Stdev    │ Min    │
[1] ├───────────┼────────┼────────┼─────────┼─────────┼───────────┼──────────┼────────┤
[1] │ Req/Sec   │ 6,871  │ 6,871  │ 8,415   │ 14,255  │ 10,026.94 │ 2,702.45 │ 6,868  │
[1] ├───────────┼────────┼────────┼─────────┼─────────┼───────────┼──────────┼────────┤
[1] │ Bytes/Sec │ 996 kB │ 996 kB │ 1.22 MB │ 2.07 MB │ 1.45 MB   │ 392 kB   │ 996 kB │
[1] └───────────┴────────┴────────┴─────────┴─────────┴───────────┴──────────┴────────┘
[1] 
[1] Req/Bytes counts sampled once per second.
[1] # of samples: 30
[1] 
[1] 0 2xx responses, 300798 non 2xx responses
[1] 3309k requests in 30.06s, 43.6 MB read
```
main:

```sh
[1] Running 30s test @ http://localhost:3000/
[1] 100 connections with 10 pipelining factor
[1] 
[1] 
[1] ┌─────────┬────────┬──────────┬──────────┬──────────┬─────────────┬────────────┬──────────┐
[1] │ Stat    │ 2.5%   │ 50%      │ 97.5%    │ 99%      │ Avg         │ Stdev      │ Max      │
[1] ├─────────┼────────┼──────────┼──────────┼──────────┼─────────────┼────────────┼──────────┤
[1] │ Latency │ 562 ms │ 10204 ms │ 26899 ms │ 27451 ms │ 11830.13 ms │ 7992.12 ms │ 27964 ms │
[1] └─────────┴────────┴──────────┴──────────┴──────────┴─────────────┴────────────┴──────────┘
[1] ┌───────────┬────────┬────────┬─────────┬────────┬──────────┬──────────┬────────┐
[1] │ Stat      │ 1%     │ 2.5%   │ 50%     │ 97.5%  │ Avg      │ Stdev    │ Min    │
[1] ├───────────┼────────┼────────┼─────────┼────────┼──────────┼──────────┼────────┤
[1] │ Req/Sec   │ 6,539  │ 6,539  │ 7,911   │ 13,807 │ 9,786.87 │ 2,691.72 │ 6,538  │
[1] ├───────────┼────────┼────────┼─────────┼────────┼──────────┼──────────┼────────┤
[1] │ Bytes/Sec │ 948 kB │ 948 kB │ 1.15 MB │ 2 MB   │ 1.42 MB  │ 390 kB   │ 948 kB │
[1] └───────────┴────────┴────────┴─────────┴────────┴──────────┴──────────┴────────┘
[1] 
[1] Req/Bytes counts sampled once per second.
[1] # of samples: 30
[1] 
[1] 0 2xx responses, 293605 non 2xx responses
[1] 3230k requests in 30.05s, 42.6 MB read
```