### PR TITLE
fix: typescript tests pino v9.8.0 msgPrefix property

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "fast-json-stringify": "^6.0.0",
     "find-my-way": "^9.0.0",
     "light-my-request": "^6.0.0",
-    "pino": "^9.0.0",
+    "pino": "^9.8.0",
     "process-warning": "^5.0.0",
     "rfdc": "^1.3.1",
     "secure-json-parse": "^4.0.0",

--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -44,6 +44,7 @@ class CustomLoggerImpl implements CustomLogger {
   trace (...args: unknown[]) { console.log(args) }
   debug (...args: unknown[]) { console.log(args) }
   silent (...args: unknown[]) { }
+  get msgPrefix (): string | undefined { return undefined }
 
   child (bindings: P.Bindings, options?: P.ChildLoggerOptions): CustomLoggerImpl { return new CustomLoggerImpl() }
 }

--- a/test/types/register.test-d.ts
+++ b/test/types/register.test-d.ts
@@ -124,6 +124,7 @@ const customLogger = {
   trace: () => { },
   debug: () => { },
   child: () => customLogger,
+  msgPrefix: undefined,
   silent: () => { }
 }
 const serverWithTypeProviderAndLogger = fastify({

--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -147,6 +147,7 @@ const customLogger: CustomLoggerInterface = {
   fatal: () => { },
   trace: () => { },
   debug: () => { },
+  msgPrefix: undefined,
   foo: () => { }, // custom severity logger method
   child: () => customLogger
 }


### PR DESCRIPTION
#### Checklist

typescript tests are failing because `pino v9.8.0` introduced `msgPrefix` in this PR https://github.com/pinojs/pino/pull/2232
- pin pino to v9.8.0
- fixes typescript tests

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
