### PR TITLE
fix: update typescript pino type to pick

### DIFF
--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -20,7 +20,7 @@ export type Bindings = pino.Bindings
 
 export type ChildLoggerOptions = pino.ChildLoggerOptions
 
-export interface FastifyBaseLogger extends pino.BaseLogger {
+export interface FastifyBaseLogger extends Pick<pino.BaseLogger, 'level' | 'info' | 'error' | 'debug' | 'fatal' | 'warn' | 'trace' | 'silent'> {
   child(bindings: Bindings, options?: ChildLoggerOptions): FastifyBaseLogger
 }
 


### PR DESCRIPTION
#### Checklist

updates typescript pino type to pick 

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
