### PR TITLE
doc: remove HackerOne from SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,10 +6,9 @@ project and its official plugins.
 ## Reporting vulnerabilities
 
 Individuals who find potential vulnerabilities in Fastify are invited to
-complete a vulnerability report via the dedicated pages:
+complete a vulnerability report via the GitHub Security Advisory:
 
-1. [HackerOne](https://hackerone.com/fastify)
-2. [GitHub Security Advisory](https://github.com/fastify/fastify/security/advisories/new)
+[GitHub Security Advisory](https://github.com/fastify/fastify/security/advisories/new)
 
 ### Strict measures when reporting vulnerabilities
 
@@ -20,7 +19,7 @@ reported vulnerabilities:
 * Avoid creating new "informative" reports. Only create new
   reports on a vulnerability if you are absolutely sure this should be
   tagged as an actual vulnerability. Third-party vendors and individuals are
-  tracking any new vulnerabilities reported in HackerOne or GitHub and will flag
+  tracking any new vulnerabilities reported in GitHub Security Advisory and will flag
   them as such for their customers (think about snyk, npm audit, ...).
 * Security reports should never be created and triaged by the same person. If
   you are creating a report for a vulnerability that you found, or on
@@ -65,8 +64,7 @@ Triaging should include updating issue fields:
 * Asset - set/create the module affected by the report
 * Severity - TBD, currently left empty
 
-Reference: [HackerOne: Submitting
-Reports](https://docs.hackerone.com/hackers/submitting-reports.html)
+Reference: [GitHub Security Advisory](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/creating-a-repository-security-advisory)
 
 ### Correction follow-up
 
@@ -95,20 +93,15 @@ The report's vulnerable versions upper limit should be set to:
 Within 90 days after the triage date, the vulnerability must be made public.
 
 **Severity**: Vulnerability severity is assessed using [CVSS
-v.3](https://www.first.org/cvss/user-guide). More information can be found on
-[HackerOne documentation](https://docs.hackerone.com/hackers/severity.html)
+v.3](https://www.first.org/cvss/user-guide).
 
 If the package maintainer is actively developing a patch, an additional delay
 can be added with the approval of the security team and the individual who
 reported the vulnerability.
 
-At this point, a CVE should be requested through the selected platform through
-the UI, which should include the Report ID and a summary.
+At this point, a CVE should be requested through GitHub Security Advisory, which should include the Report ID and a summary.
 
-Within HackerOne, this is handled through a "public disclosure request".
-
-Reference: [HackerOne:
-Disclosure](https://docs.hackerone.com/hackers/disclosure.html)
+Reference: [GitHub Security Advisories](https://docs.github.com/en/code-security/security-advisories)
 
 ## The Fastify Security team
 


### PR DESCRIPTION
**doc: remove HackerOne from SECURITY.md**
```
While talking with Matteo, he informed we no
longer use H1 for reports (since June).

So, I believe the right thing to do is to use
GSA for the entire organization, as it makes
the review process more easy.
```