### PR TITLE
doc: add RafaelGSS to security team

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -125,13 +125,15 @@ work as a member of the Fastify Core team.
 ### Members
 
 * [__Matteo Collina__](https://github.com/mcollina),
-  <https://twitter.com/matteocollina>, <https://www.npmjs.com/~matteo.collina>
+  <https://x.com/matteocollina>, <https://www.npmjs.com/~matteo.collina>
 * [__Tomas Della Vedova__](https://github.com/delvedor),
-  <https://twitter.com/delvedor>, <https://www.npmjs.com/~delvedor>
+  <https://x.com/delvedor>, <https://www.npmjs.com/~delvedor>
 * [__Vincent Le Goff__](https://github.com/zekth)
 * [__KaKa Ng__](https://github.com/climba03003)
 * [__James Sumners__](https://github.com/jsumners),
-  <https://twitter.com/jsumners79>, <https://www.npmjs.com/~jsumners>
+  <https://x.com/jsumners79>, <https://www.npmjs.com/~jsumners>
+* [__Rafael Gonzaga__](https://github.com/RafaelGSS),
+  <https://x.com/_rafaelgss>, <https://www.npmjs.com/~rafaelgss>
 
 ## OpenSSF CII Best Practices
 


### PR DESCRIPTION
I used to be more active in the project in the past, but life got in the way.

Now, as part of the OpenJS  - Alpha Omega project, I can invest more time helping on the security side of Fastify. So, if acceptable, I'd love to help on this.