### PR TITLE
fix(types): Fix use of "esModuleInterop: false"

### DIFF
--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -7,7 +7,7 @@ import { FastifySchema } from './schema'
 import { FastifyTypeProvider, FastifyTypeProviderDefault } from './type-provider'
 import { ContextConfigDefault, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RawServerDefault } from './utils'
 
-import pino from 'pino'
+import * as pino from 'pino'
 
 /**
  * Standard Fastify logging function

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -7,20 +7,24 @@ import { FastifySchema } from './schema'
 import { FastifyTypeProvider, FastifyTypeProviderDefault } from './type-provider'
 import { ContextConfigDefault, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RawServerDefault } from './utils'
 
-import * as pino from 'pino'
+import type {
+  BaseLogger,
+  LogFn as FastifyLogFn,
+  LevelWithSilent as LogLevel,
+  Bindings,
+  ChildLoggerOptions,
+  LoggerOptions as PinoLoggerOptions
+} from 'pino'
 
-/**
- * Standard Fastify logging function
- */
-export type FastifyLogFn = pino.LogFn
+export type {
+  FastifyLogFn,
+  LogLevel,
+  Bindings,
+  ChildLoggerOptions,
+  PinoLoggerOptions
+}
 
-export type LogLevel = pino.LevelWithSilent
-
-export type Bindings = pino.Bindings
-
-export type ChildLoggerOptions = pino.ChildLoggerOptions
-
-export interface FastifyBaseLogger extends Pick<pino.BaseLogger, 'level' | 'info' | 'error' | 'debug' | 'fatal' | 'warn' | 'trace' | 'silent'> {
+export interface FastifyBaseLogger extends Pick<BaseLogger, 'level' | 'info' | 'error' | 'debug' | 'fatal' | 'warn' | 'trace' | 'silent'> {
   child(bindings: Bindings, options?: ChildLoggerOptions): FastifyBaseLogger
 }
 
@@ -33,8 +37,6 @@ export type FastifyLoggerInstance = FastifyBaseLogger
 export interface FastifyLoggerStreamDestination {
   write(msg: string): void;
 }
-
-export type PinoLoggerOptions = pino.LoggerOptions
 
 // TODO: once node 18 is EOL, this type can be replaced with plain FastifyReply.
 /**


### PR DESCRIPTION
Pino 9.8 changed its type definitions to be more correct (see https://github.com/pinojs/pino/pull/2223 and linked discussions), but that causes problems for projects that don't set "esModuleInterop: true" (see https://github.com/pinojs/pino/issues/2253).

Doing a namespace import (so fastify.d.ts can see pino's types) should address this.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included - _see below_
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

No tests are included. I locally tested the issue by temporarily modifying package.json's `test:typescript` command to build with `--esModuleInterop false`. Running the `tsc` command multiple times under different combinations of compiler options seems potentially involved, but I can add that to this PR if there's interest.