### PR TITLE
fix: (types) allow FastifySchemaValidationError[] as an error

### DIFF
--- a/test/types/schema.test-d.ts
+++ b/test/types/schema.test-d.ts
@@ -72,6 +72,27 @@ expectAssignable<FastifyInstance>(server.post('/test', {
   }
 }, async req => req.body))
 
+expectAssignable<FastifyInstance>(server.post('/test', {
+  validatorCompiler: ({ schema }) => {
+    return data => {
+      if (!data || data.constructor !== Object) {
+        return {
+          error: [
+            {
+              keyword: 'type',
+              instancePath: '',
+              schemaPath: '#/type',
+              params: { type: 'object' },
+              message: 'value is not an object'
+            }
+          ]
+        }
+      }
+      return { value: data }
+    }
+  }
+}, async req => req.body))
+
 expectAssignable<FastifyInstance>(server.setValidatorCompiler<FastifySchema & { validate: Record<string, unknown> }>(
   function ({ schema }) {
     return new Ajv().compile(schema)

--- a/types/schema.d.ts
+++ b/types/schema.d.ts
@@ -33,7 +33,7 @@ export interface FastifySchemaValidationError {
 }
 
 export interface FastifyValidationResult {
-  (data: any): boolean | SafePromiseLike<any> | { error?: Error, value?: any }
+  (data: any): boolean | SafePromiseLike<any> | { error?: Error | FastifySchemaValidationError[], value?: any }
   errors?: FastifySchemaValidationError[] | null;
 }
 


### PR DESCRIPTION
This PR adds a type to the `error` property of `FastifyValidationResult` that the code at runtime handles but is invisible:

https://github.com/fastify/fastify/blob/9a67d3a4875e2c078f9f710035a7625819853677/lib/validation.js#L241-L255

This code calls `schemaErrorFormatter` if the property is not an error object, which by default handles an array of FastifySchemaValidationError objects:

https://github.com/fastify/fastify/blob/9a67d3a4875e2c078f9f710035a7625819853677/lib/context.js#L84-L93

Not having this type causes Type Providers in the ecosystem to assert the type incorrectly:

https://github.com/fastify/fastify-type-provider-typebox/blob/2c8319e69070482b83bb527c9ae8fe7fcbcc4d94/index.mts#L26

https://github.com/fastify/fastify-type-provider-typebox/pull/243/files#diff-382414b6b7a87c32132ad230c522280fe2a6d4efdaf7e32cc5ef3917dbb0404dR35

https://github.com/turkerdev/fastify-type-provider-zod/blob/4e658779dbc788356b9b9e3c67fea6d17aca801e/src/core.ts#L187-L189
