### PR TITLE
fix: correct session.close() context in http2 timeout handler

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -283,8 +283,8 @@ function getServerInstance (options, httpHandler) {
 
   if (options.http2) {
     const server = typeof httpsOptions === 'object' ? http2.createSecureServer(httpsOptions, httpHandler) : http2.createServer(options.http, httpHandler)
-    server.on('session', (session) => session.setTimeout(options.http2SessionTimeout, function closeSession () {
-      this.close()
+    server.on('session', (session) => session.setTimeout(options.http2SessionTimeout, () => {
+      session.close()
     }))
 
     server.setTimeout(options.connectionTimeout)


### PR DESCRIPTION
Replace function declaration with arrow function to properly reference the session object when closing timed-out HTTP/2 sessions.

I would sometimes get this error in my web application with fastify v5.5.0:
```
172444 |   const httpsOptions = options.https === true ? {} : options.https
172445 |
172446 |   if (options.http2) {
172447 |     const server = typeof httpsOptions === 'object' ? http2.createSecureServer(httpsOptions, httpHandler) : http2.createServer(options.http, httpHandler)
172448 |     server.on('session', (session) => session.setTimeout(options.http2SessionTimeout, function closeSession () {
172449 |       this.close()
                    ^
TypeError: this.close is not a function. (In 'this.close()', 'this.close' is undefined)
```