### PR TITLE
ci: remove label of citgm only on pull_request.labeled, add options for workflow_dispatch

### DIFF
--- a/.github/workflows/citgm.yml
+++ b/.github/workflows/citgm.yml
@@ -17,6 +17,7 @@ on:
           - 'lts/*'
           - 'nightly'
           - 'current'
+          - 'latest'
         default: '24'
       os:
         description: 'Operating System'
@@ -101,9 +102,9 @@ jobs:
           - '@fastify/zipkin'
     uses: './.github/workflows/citgm-package.yml'
     with:
-      os: ${{ inputs.os }}
+      os: ${{ github.event_name == 'workflow_dispatch' && inputs.os || 'ubuntu-latest' }}
       package: ${{ matrix.package }}
-      node-version: ${{ inputs.node-version }}
+      node-version: ${{ github.event_name == 'workflow_dispatch' && inputs.node-version || '24' }}
 
   remove-label:
     if: ${{ always() && github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'citgm-core-plugins' }}


### PR DESCRIPTION
The previous PR for citgm improved the usability, but it had a bug on when to try to remove the  label.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
