### PR TITLE
fix: Add missing hide boolean to FastifySchema

### DIFF
--- a/types/schema.d.ts
+++ b/types/schema.d.ts
@@ -13,6 +13,7 @@ export interface FastifySchema {
   params?: unknown;
   headers?: unknown;
   response?: unknown;
+  hide?: boolean;
 }
 
 export interface FastifyRouteSchemaDef<T> {


### PR DESCRIPTION
Trying to solve:

> error TS2353: Object literal may only specify known properties, and 'hide' does not exist in type 'FastifySchema'.

I'm using `{ schema: { hide: true }, logLevel: 'silent' }`.

However, I got a production build error: `error TS2353: Object literal may only specify known properties, and 'hide' does not exist in type 'FastifySchema'.`

That being said; `hide: true` is allowed and works as expected, see also: https://github.com/fastify/fastify-swagger?tab=readme-ov-file#hide-a-route

Yet, the Fastify schema is missing this property causing the build error. It seems that TypeScript is using the FastifySchema interface. Hence I try to expend this interface to resolve the issue.

If you agree with this change, I can also update the docs (https://fastify.dev/docs/latest/Reference/Routes/#routes-options).

Please, let me know what you think. 

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
