### PR TITLE
docs: expand on statement to make clearer

### DIFF
--- a/docs/Guides/Plugins-Guide.md
+++ b/docs/Guides/Plugins-Guide.md
@@ -372,7 +372,7 @@ for example.
 that the stuff I create inside will not be available outside?*
 
 Yes, I said that. However, what I didn't tell you is that you can tell Fastify
-to avoid this behavior with the
+to bypass this behavior with the
 [`fastify-plugin`](https://github.com/fastify/fastify-plugin) module.
 ```js
 const fp = require('fastify-plugin')

--- a/docs/Guides/Plugins-Guide.md
+++ b/docs/Guides/Plugins-Guide.md
@@ -141,7 +141,9 @@ Let's step back for a moment and dig deeper into this: every time you use the
 mentioned above.
 
 Do note that encapsulation applies to the ancestors and siblings, but not the
-children.
+children. That is, a plugin's decorators, hooks, or routes are accessible only
+within its own scope and any plugins registered inside it, not to those
+registered before or alongside it:
 ```js
 fastify.register((instance, opts, done) => {
   instance.decorate('util', (a, b) => a + b)

--- a/docs/Guides/Plugins-Guide.md
+++ b/docs/Guides/Plugins-Guide.md
@@ -140,10 +140,9 @@ Let's step back for a moment and dig deeper into this: every time you use the
 `register` API, a new context is created that avoids the negative situations
 mentioned above.
 
-Do note that encapsulation applies to the ancestors and siblings, but not the
-children. That is, a plugin's decorators, hooks, or routes are accessible only
-within its own scope and any plugins registered inside it, not to those
-registered before or alongside it:
+In Fastify, encapsulation ensures that a plugin’s decorators, hooks, and routes
+are available only within its own scope and its descendants, not to its ancestors
+or sibling plugins.
 ```js
 fastify.register((instance, opts, done) => {
   instance.decorate('util', (a, b) => a + b)

--- a/docs/Guides/Plugins-Guide.md
+++ b/docs/Guides/Plugins-Guide.md
@@ -140,9 +140,8 @@ Let's step back for a moment and dig deeper into this: every time you use the
 `register` API, a new context is created that avoids the negative situations
 mentioned above.
 
-In Fastify, encapsulation ensures that a plugin’s decorators, hooks, and routes
-are available only within its own scope and its descendants, not to its ancestors
-or sibling plugins.
+Do note that encapsulation applies to the ancestors and siblings, but not the
+children.
 ```js
 fastify.register((instance, opts, done) => {
   instance.decorate('util', (a, b) => a + b)


### PR DESCRIPTION
The current explanation isn't clear, as it uses ideas that require the reader to map meaning onto. So it's best to expound on it.