### PR TITLE
docs: Fix broken link to TypeBox doc website wrt AJV setup

### DIFF
--- a/docs/Reference/Type-Providers.md
+++ b/docs/Reference/Type-Providers.md
@@ -88,8 +88,8 @@ server.get('/route', {
 ```
 
 See the [TypeBox
-documentation](https://github.com/sinclairzx81/typebox#validation)
-for setting up AJV to work with TypeBox.
+documentation](https://sinclairzx81.github.io/typebox/#/docs/overview/2_setup)
+for setting-up AJV to work with TypeBox.
 
 ### Zod
 


### PR DESCRIPTION
See title.

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

