### PR TITLE
chore(lint): enforce max-len and comma-dangle rules (#6029)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,13 +7,16 @@ module.exports = [
       'lib/config-validator.js',
       'lib/error-serializer.js',
       'test/same-shape.test.js',
-      'test/types/import.js'
+      'test/types/import.js',
     ],
-    ts: true
+    ts: true,
   }),
   {
     rules: {
-      'comma-dangle': ['error', 'never']
-    }
-  }
+
+      'comma-dangle': ['error', 'always-multiline'],
+
+      'max-len': ['error', { code: 100, ignoreUrls: true }],
+    },
+  },
 ]


### PR DESCRIPTION
Hi 👋, I’ve updated the ESLint configuration as discussed in #6029. Please review when you have a moment.

This PR addresses issue #6029 by updating eslint.config.js:
- Adds "max-len" rule with 100-character limit.
- Enforces "comma-dangle" as "always-multiline".
