### PR TITLE
refactor: remove abstract-logging and use optional chaining for logger

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,7 +1,9 @@
 'use strict'
 
 const fastify = require('../fastify')({
-  logger: false
+  logger: {
+    level: 'error'
+  }
 })
 
 const schema = {

--- a/fastify.js
+++ b/fastify.js
@@ -644,7 +644,7 @@ function fastify (serverOptions) {
       const reply = new Reply(res, request, childLogger)
 
       if (disableRequestLogging === false) {
-        childLogger.info({ req: request }, 'incoming request')
+        childLogger?.info({ req: request }, 'incoming request')
       }
 
       return options.frameworkErrors(new FST_ERR_BAD_URL(path), request, reply)
@@ -669,7 +669,7 @@ function fastify (serverOptions) {
           const reply = new Reply(res, request, childLogger)
 
           if (disableRequestLogging === false) {
-            childLogger.info({ req: request }, 'incoming request')
+            childLogger?.info({ req: request }, 'incoming request')
           }
 
           return options.frameworkErrors(new FST_ERR_ASYNC_CONSTRAINT(), request, reply)
@@ -937,7 +937,7 @@ function defaultClientErrorHandler (err, socket) {
   // Most devs do not know what to do with this error.
   // In the vast majority of cases, it's a network error and/or some
   // config issue on the load balancer side.
-  this.log.trace({ err }, `client ${errorLabel}`)
+  this.log?.trace({ err }, `client ${errorLabel}`)
   // Copying standard node behavior
   // https://github.com/nodejs/node/blob/6ca23d7846cb47e84fd344543e394e50938540be/lib/_http_server.js#L666
 

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -36,8 +36,8 @@ function handleError (reply, error, cb) {
       try {
         reply.raw.writeHead(reply.raw.statusCode, reply[kReplyHeaders])
       } catch (error) {
-        if (!reply.log[kDisableRequestLogging]) {
-          reply.log.warn(
+        if (!reply.log?.[kDisableRequestLogging]) {
+          reply.log?.warn(
             { req: reply.request, res: reply, err: error },
             error?.message
           )
@@ -86,15 +86,15 @@ function defaultErrorHandler (error, request, reply) {
     reply.code(statusCode >= 400 ? statusCode : 500)
   }
   if (reply.statusCode < 500) {
-    if (!reply.log[kDisableRequestLogging]) {
-      reply.log.info(
+    if (!reply.log?.[kDisableRequestLogging]) {
+      reply.log?.info(
         { res: reply, err: error },
         error?.message
       )
     }
   } else {
-    if (!reply.log[kDisableRequestLogging]) {
-      reply.log.error(
+    if (!reply.log?.[kDisableRequestLogging]) {
+      reply.log?.error(
         { req: request, res: reply, err: error },
         error?.message
       )
@@ -125,9 +125,9 @@ function fallbackErrorHandler (error, reply, cb) {
       }))
     }
   } catch (err) {
-    if (!reply.log[kDisableRequestLogging]) {
+    if (!reply.log?.[kDisableRequestLogging]) {
       // error is always FST_ERR_SCH_SERIALIZATION_BUILD because this is called from route/compileSchemasForSerialization
-      reply.log.error({ err, statusCode: res.statusCode }, 'The serializer for the given status code failed')
+      reply.log?.error({ err, statusCode: res.statusCode }, 'The serializer for the given status code failed')
     }
     reply.code(500)
     payload = serializeError(new FST_ERR_FAILED_ERROR_SERIALIZATION(err.message, error.message))

--- a/lib/four-oh-four.js
+++ b/lib/four-oh-four.js
@@ -50,7 +50,7 @@ function fourOhFour (options) {
     const { url, method } = request.raw
     const message = `Route ${method}:${url} not found`
     if (!disableRequestLogging) {
-      request.log.info(message)
+      request.log?.info(message)
     }
     reply.code(404).send({
       message,
@@ -173,13 +173,13 @@ function fourOhFour (options) {
     const id = getGenReqId(fourOhFourContext.server, req)
     const childLogger = createChildLogger(fourOhFourContext, logger, req, id)
 
-    childLogger.info({ req }, 'incoming request')
+    childLogger?.info({ req }, 'incoming request')
 
     const request = new Request(id, null, req, null, childLogger, fourOhFourContext)
     const reply = new Reply(res, request, childLogger)
 
-    request.log.warn('the default handler for 404 did not catch this, this is likely a fastify bug, please report it')
-    request.log.warn(router.prettyPrint())
+    request.log?.warn('the default handler for 404 did not catch this, this is likely a fastify bug, please report it')
+    request.log?.warn(router.prettyPrint())
     reply.code(404).send(new FST_ERR_NOT_FOUND())
   }
 }

--- a/lib/head-route.js
+++ b/lib/head-route.js
@@ -9,7 +9,7 @@ function headRouteOnSendHandler (req, reply, payload, done) {
 
   if (typeof payload.resume === 'function') {
     payload.on('error', (err) => {
-      reply.log.error({ err }, 'Error on Stream found for HEAD route')
+      reply.log?.error({ err }, 'Error on Stream found for HEAD route')
     })
     payload.resume()
     done(null, null)

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -190,7 +190,7 @@ function onListenHookRunner (server) {
   next()
 
   function next (err) {
-    err && server.log.error(err)
+    err && server.log?.error(err)
 
     if (
       i === hooksLen

--- a/lib/logger-factory.js
+++ b/lib/logger-factory.js
@@ -27,7 +27,9 @@ function createChildLogger (context, logger, req, reqId, loggerOpts) {
 
   // Optimization: bypass validation if the factory is our own default factory
   if (context.childLoggerFactory !== defaultChildLoggerFactory) {
-    validateLogger(child, true) // throw if the child is not a valid logger
+    // If parent logger exists, child must also be valid (not null/undefined unless parent is also null/undefined)
+    const allowNullChild = !logger
+    validateLogger(child, true, allowNullChild) // throw if the child is not a valid logger
   }
 
   return child
@@ -42,7 +44,7 @@ function createChildLogger (context, logger, req, reqId, loggerOpts) {
  * @returns {import('../types/logger.js').FastifyBaseLogger}
  */
 function defaultChildLoggerFactory (logger, bindings, opts) {
-  return logger.child(bindings, opts)
+  return logger?.child(bindings, opts) ?? null
 }
 
 /**
@@ -57,7 +59,12 @@ function defaultChildLoggerFactory (logger, bindings, opts) {
  * @throws {FST_ERR_LOG_INVALID_LOGGER} When the logger object is
  * missing required methods.
  */
-function validateLogger (logger, strict) {
+function validateLogger (logger, strict, allowNull) {
+  // Allow null or undefined as valid "no logger" states only if explicitly allowed
+  if ((logger === null || logger === undefined) && allowNull) {
+    return false
+  }
+
   const methods = ['info', 'error', 'debug', 'fatal', 'warn', 'trace', 'child']
   const missingMethods = logger
     ? methods.filter(method => !logger[method] || typeof logger[method] !== 'function')
@@ -77,11 +84,9 @@ function createLogger (options) {
     throw new FST_ERR_LOG_LOGGER_AND_LOGGER_INSTANCE_PROVIDED()
   }
 
-  if (!options.loggerInstance && !options.logger) {
-    const nullLogger = require('abstract-logging')
-    const logger = nullLogger
-    logger.child = () => logger
-    return { logger, hasLogger: false }
+  // If no logger configuration is provided, return null logger
+  if (!options.logger && !options.loggerInstance) {
+    return { logger: null, hasLogger: false }
   }
 
   const { createPinoLogger, serializers } = require('./logger-pino.js')

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -131,7 +131,7 @@ Reply.prototype.send = function (payload) {
   }
 
   if (this.sent === true) {
-    this.log.warn({ err: new FST_ERR_REP_ALREADY_SENT(this.request.url, this.request.method) })
+    this.log?.warn({ err: new FST_ERR_REP_ALREADY_SENT(this.request.url, this.request.method) })
     return this
   }
 
@@ -463,7 +463,7 @@ Reply.prototype.then = function (fulfilled, rejected) {
       if (rejected) {
         rejected(err)
       } else {
-        this.log && this.log.warn('unhandled rejection on reply.then')
+        this.log?.warn('unhandled rejection on reply.then')
       }
     } else {
       fulfilled()
@@ -553,7 +553,7 @@ function safeWriteHead (reply, statusCode) {
     res.writeHead(statusCode, reply[kReplyHeaders])
   } catch (err) {
     if (err.code === 'ERR_HTTP_HEADERS_SENT') {
-      reply.log.warn(`Reply was already sent, did you forget to "return reply" in the "${reply.request.raw.url}" (${reply.request.raw.method}) route?`)
+      reply.log?.warn(`Reply was already sent, did you forget to "return reply" in the "${reply.request.raw.url}" (${reply.request.raw.method}) route?`)
     }
     throw err
   }
@@ -671,11 +671,11 @@ function onSendEnd (reply, payload) {
 
 function logStreamError (logger, err, res) {
   if (err.code === 'ERR_STREAM_PREMATURE_CLOSE') {
-    if (!logger[kDisableRequestLogging]) {
-      logger.info({ res }, 'stream closed prematurely')
+    if (!logger?.[kDisableRequestLogging]) {
+      logger?.info({ res }, 'stream closed prematurely')
     }
   } else {
-    logger.warn({ err }, 'response terminated with an error with headers already sent')
+    logger?.warn({ err }, 'response terminated with an error with headers already sent')
   }
 }
 
@@ -723,7 +723,7 @@ function sendStream (payload, res, reply) {
       } else if (typeof payload.abort === 'function') {
         payload.abort()
       } else {
-        reply.log.warn('stream payload does not end properly')
+        reply.log?.warn('stream payload does not end properly')
       }
     }
   })
@@ -737,7 +737,7 @@ function sendStream (payload, res, reply) {
       res.setHeader(key, reply[kReplyHeaders][key])
     }
   } else {
-    reply.log.warn('response will send, but you shouldn\'t use res.writeHead in stream mode')
+    reply.log?.warn('response will send, but you shouldn\'t use res.writeHead in stream mode')
   }
   payload.pipe(res)
 }
@@ -843,14 +843,14 @@ function setupResponseListeners (reply) {
 }
 
 function onResponseCallback (err, request, reply) {
-  if (reply.log[kDisableRequestLogging]) {
+  if (reply.log?.[kDisableRequestLogging]) {
     return
   }
 
   const responseTime = reply.elapsedTime
 
   if (err != null) {
-    reply.log.error({
+    reply.log?.error({
       res: reply,
       err,
       responseTime
@@ -858,7 +858,7 @@ function onResponseCallback (err, request, reply) {
     return
   }
 
-  reply.log.info({
+  reply.log?.info({
     res: reply,
     responseTime
   }, 'request completed')
@@ -896,7 +896,7 @@ function buildReply (R) {
 
 function notFound (reply) {
   if (reply[kRouteContext][kFourOhFourContext] === null) {
-    reply.log.warn('Trying to send a NotFound error inside a 404 handler. Sending basic 404 response.')
+    reply.log?.warn('Trying to send a NotFound error inside a 404 handler. Sending basic 404 response.')
     reply.code(404).send('404 Not Found')
     return
   }

--- a/lib/route.js
+++ b/lib/route.js
@@ -444,7 +444,9 @@ function buildRouting (options) {
       loggerOpts.serializers = context.logSerializers
     }
     const childLogger = createChildLogger(context, logger, req, id, loggerOpts)
-    childLogger[kDisableRequestLogging] = disableRequestLogging
+    if (childLogger) {
+      childLogger[kDisableRequestLogging] = disableRequestLogging
+    }
 
     if (closing === true) {
       /* istanbul ignore next mac, windows */
@@ -464,7 +466,7 @@ function buildRouting (options) {
         }
         res.writeHead(503, headers)
         res.end('{"error":"Service Unavailable","message":"Service Unavailable","statusCode":503}')
-        childLogger.info({ res: { statusCode: 503 } }, 'request aborted - refusing to accept new requests as server is closing')
+        childLogger?.info({ res: { statusCode: 503 } }, 'request aborted - refusing to accept new requests as server is closing')
         return
       }
     }
@@ -489,7 +491,7 @@ function buildRouting (options) {
     const request = new context.Request(id, params, req, query, childLogger, context)
     const reply = new context.Reply(res, request, childLogger)
     if (disableRequestLogging === false) {
-      childLogger.info({ req: request }, 'incoming request')
+      childLogger?.info({ req: request }, 'incoming request')
     }
 
     if (hasLogger === true || context.onResponse !== null) {
@@ -531,7 +533,7 @@ function buildRouting (options) {
 
 function handleOnRequestAbortHooksErrors (reply, err) {
   if (err) {
-    reply.log.error({ err }, 'onRequestAborted hook failed')
+    reply.log?.error({ err }, 'onRequestAborted hook failed')
   }
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -374,7 +374,7 @@ function logServerAddress (server, listenTextResolver) {
   }
 
   for (const address of addresses) {
-    this.log.info(listenTextResolver(address))
+    this.log?.info(listenTextResolver(address))
   }
   return addresses[0]
 }

--- a/lib/wrap-thenable.js
+++ b/lib/wrap-thenable.js
@@ -58,7 +58,7 @@ function wrapThenable (thenable, reply, store) {
 
     try {
       if (reply.sent === true) {
-        reply.log.error({ err }, 'Promise errored, but reply.sent = true was set')
+        reply.log?.error({ err }, 'Promise errored, but reply.sent = true was set')
         return
       }
 

--- a/package.json
+++ b/package.json
@@ -206,7 +206,6 @@
     "@fastify/error": "^4.0.0",
     "@fastify/fast-json-stringify-compiler": "^5.0.0",
     "@fastify/proxy-addr": "^5.0.0",
-    "abstract-logging": "^2.0.1",
     "avvio": "^9.0.0",
     "fast-json-stringify": "^6.0.0",
     "find-my-way": "^9.0.0",

--- a/test/build-certificate.js
+++ b/test/build-certificate.js
@@ -6,7 +6,7 @@ const forge = require('node-forge')
 // from self-cert module
 function selfCert (opts) {
   const options = opts || {}
-  const log = opts.logger || require('abstract-logging')
+  const log = opts.logger
   const now = new Date()
 
   if (!options.attrs) options.attrs = {}
@@ -16,11 +16,11 @@ function selfCert (opts) {
     )
   }
 
-  log.debug('generating key pair')
+  log?.debug('generating key pair')
   const keys = forge.pki.rsa.generateKeyPair(options.bits || 2048)
-  log.debug('key pair generated')
+  log?.debug('key pair generated')
 
-  log.debug('generating self-signed certificate')
+  log?.debug('generating self-signed certificate')
   const cert = forge.pki.createCertificate()
   cert.publicKey = keys.publicKey
   cert.serialNumber = '01'
@@ -83,7 +83,7 @@ function selfCert (opts) {
   ])
 
   cert.sign(keys.privateKey)
-  log.debug('certificate generated')
+  log?.debug('certificate generated')
   return {
     privateKey: forge.pki.privateKeyToPem(keys.privateKey),
     publicKey: forge.pki.publicKeyToPem(keys.publicKey),

--- a/test/child-logger-factory.test.js
+++ b/test/child-logger-factory.test.js
@@ -6,16 +6,16 @@ const Fastify = require('..')
 test('Should accept a custom childLoggerFactory function', (t, done) => {
   t.plan(4)
 
-  const fastify = Fastify()
+  const fastify = Fastify({ logger: true })
   fastify.setChildLoggerFactory(function (logger, bindings, opts) {
     t.assert.ok(bindings.reqId)
     t.assert.ok(opts)
-    this.log.debug(bindings, 'created child logger')
-    return logger.child(bindings, opts)
+    this.log?.debug(bindings, 'created child logger')
+    return logger?.child(bindings, opts)
   })
 
   fastify.get('/', (req, reply) => {
-    req.log.info('log message')
+    req.log?.info('log message')
     reply.send()
   })
 
@@ -40,13 +40,13 @@ test('Should accept a custom childLoggerFactory function as option', (t, done) =
     childLoggerFactory: function (logger, bindings, opts) {
       t.assert.ok(bindings.reqId)
       t.assert.ok(opts)
-      this.log.debug(bindings, 'created child logger')
-      return logger.child(bindings, opts)
+      this.log?.debug(bindings, 'created child logger')
+      return logger?.child(bindings, opts)
     }
   })
 
   fastify.get('/', (req, reply) => {
-    req.log.info('log message')
+    req.log?.info('log message')
     reply.send()
   })
 
@@ -67,9 +67,9 @@ test('Should accept a custom childLoggerFactory function as option', (t, done) =
 test('req.log should be the instance returned by the factory', (t, done) => {
   t.plan(3)
 
-  const fastify = Fastify()
+  const fastify = Fastify({ logger: true })
   fastify.setChildLoggerFactory(function (logger, bindings, opts) {
-    this.log.debug('using root logger')
+    this.log?.debug('using root logger')
     return this.log
   })
 
@@ -96,9 +96,9 @@ test('req.log should be the instance returned by the factory', (t, done) => {
 test('should throw error if invalid logger is returned', (t, done) => {
   t.plan(2)
 
-  const fastify = Fastify()
+  const fastify = Fastify({ logger: true })
   fastify.setChildLoggerFactory(function () {
-    this.log.debug('returning an invalid logger, expect error')
+    this.log?.debug('returning an invalid logger, expect error')
     return undefined
   })
 

--- a/test/encapsulated-child-logger-factory.test.js
+++ b/test/encapsulated-child-logger-factory.test.js
@@ -7,12 +7,14 @@ const fp = require('fastify-plugin')
 test('encapsulates an child logger factory', async t => {
   t.plan(4)
 
-  const fastify = Fastify()
+  const fastify = Fastify({ logger: true })
   fastify.register(async function (fastify) {
     fastify.setChildLoggerFactory(function pluginFactory (logger, bindings, opts) {
-      const child = logger.child(bindings, opts)
-      child.customLog = function (message) {
-        t.assert.strictEqual(message, 'custom')
+      const child = logger?.child(bindings, opts)
+      if (child) {
+        child.customLog = function (message) {
+          t.assert.strictEqual(message, 'custom')
+        }
       }
       return child
     })
@@ -22,9 +24,11 @@ test('encapsulates an child logger factory', async t => {
   })
 
   fastify.setChildLoggerFactory(function globalFactory (logger, bindings, opts) {
-    const child = logger.child(bindings, opts)
-    child.globalLog = function (message) {
-      t.assert.strictEqual(message, 'global')
+    const child = logger?.child(bindings, opts)
+    if (child) {
+      child.globalLog = function (message) {
+        t.assert.strictEqual(message, 'global')
+      }
     }
     return child
   })
@@ -42,13 +46,15 @@ test('encapsulates an child logger factory', async t => {
 test('child logger factory set on root scope when using fastify-plugin', async t => {
   t.plan(4)
 
-  const fastify = Fastify()
+  const fastify = Fastify({ logger: true })
   fastify.register(fp(async function (fastify) {
     // Using fastify-plugin, the factory should be set on the root scope
     fastify.setChildLoggerFactory(function pluginFactory (logger, bindings, opts) {
-      const child = logger.child(bindings, opts)
-      child.customLog = function (message) {
-        t.assert.strictEqual(message, 'custom')
+      const child = logger?.child(bindings, opts)
+      if (child) {
+        child.customLog = function (message) {
+          t.assert.strictEqual(message, 'custom')
+        }
       }
       return child
     })

--- a/test/listen.4.test.js
+++ b/test/listen.4.test.js
@@ -74,7 +74,7 @@ test('listen on invalid port without callback rejects', t => {
 
 test('listen logs the port as info', async t => {
   t.plan(1)
-  const fastify = Fastify()
+  const fastify = Fastify({ logger: true })
   t.after(() => fastify.close())
 
   const msgs = []

--- a/test/logger/options.test.js
+++ b/test/logger/options.test.js
@@ -13,31 +13,24 @@ t.test('logger options', { timeout: 60000 }, async (t) => {
   t.plan(16)
 
   await t.test('logger can be silenced', (t) => {
-    t.plan(17)
+    t.plan(2)
     const fastify = Fastify({
       logger: false
     })
     t.after(() => fastify.close())
-    t.assert.ok(fastify.log)
-    t.assert.deepEqual(typeof fastify.log, 'object')
-    t.assert.deepEqual(typeof fastify.log.fatal, 'function')
-    t.assert.deepEqual(typeof fastify.log.error, 'function')
-    t.assert.deepEqual(typeof fastify.log.warn, 'function')
-    t.assert.deepEqual(typeof fastify.log.info, 'function')
-    t.assert.deepEqual(typeof fastify.log.debug, 'function')
-    t.assert.deepEqual(typeof fastify.log.trace, 'function')
-    t.assert.deepEqual(typeof fastify.log.child, 'function')
+    t.assert.strictEqual(fastify.log, null)
 
-    const childLog = fastify.log.child()
+    fastify.get('/', (req, reply) => {
+      req.log?.info('this should not throw')
+      reply.send({ hello: 'world' })
+    })
 
-    t.assert.deepEqual(typeof childLog, 'object')
-    t.assert.deepEqual(typeof childLog.fatal, 'function')
-    t.assert.deepEqual(typeof childLog.error, 'function')
-    t.assert.deepEqual(typeof childLog.warn, 'function')
-    t.assert.deepEqual(typeof childLog.info, 'function')
-    t.assert.deepEqual(typeof childLog.debug, 'function')
-    t.assert.deepEqual(typeof childLog.trace, 'function')
-    t.assert.deepEqual(typeof childLog.child, 'function')
+    return fastify.inject({
+      method: 'GET',
+      url: '/'
+    }).then(res => {
+      t.assert.strictEqual(res.statusCode, 200)
+    })
   })
 
   await t.test('Should set a custom logLevel for a plugin', async (t) => {

--- a/test/route.4.test.js
+++ b/test/route.4.test.js
@@ -98,12 +98,14 @@ test('throws when route-level error handler is not a function', t => {
 test('route child logger factory overrides default child logger factory', async t => {
   t.plan(2)
 
-  const fastify = Fastify()
+  const fastify = Fastify({ logger: true })
 
   const customRouteChildLogger = (logger, bindings, opts, req) => {
-    const child = logger.child(bindings, opts)
-    child.customLog = function (message) {
-      t.assert.strictEqual(message, 'custom')
+    const child = logger?.child(bindings, opts)
+    if (child) {
+      child.customLog = function (message) {
+        t.assert.strictEqual(message, 'custom')
+      }
     }
     return child
   }

--- a/test/route.5.test.js
+++ b/test/route.5.test.js
@@ -6,12 +6,14 @@ const Fastify = require('..')
 test('route child logger factory does not affect other routes', async t => {
   t.plan(4)
 
-  const fastify = Fastify()
+  const fastify = Fastify({ logger: true })
 
   const customRouteChildLogger = (logger, bindings, opts, req) => {
-    const child = logger.child(bindings, opts)
-    child.customLog = function (message) {
-      t.assert.strictEqual(message, 'custom')
+    const child = logger?.child(bindings, opts)
+    if (child) {
+      child.customLog = function (message) {
+        t.assert.strictEqual(message, 'custom')
+      }
     }
     return child
   }
@@ -30,7 +32,7 @@ test('route child logger factory does not affect other routes', async t => {
     method: 'GET',
     path: '/tea',
     handler: (req, res) => {
-      t.assert.ok(req.log.customLog instanceof Function)
+      t.assert.ok(!(req.log.customLog instanceof Function))
       res.send()
     }
   })
@@ -50,19 +52,23 @@ test('route child logger factory does not affect other routes', async t => {
 test('route child logger factory overrides global custom error handler', async t => {
   t.plan(4)
 
-  const fastify = Fastify()
+  const fastify = Fastify({ logger: true })
 
   const customGlobalChildLogger = (logger, bindings, opts, req) => {
-    const child = logger.child(bindings, opts)
-    child.globalLog = function (message) {
-      t.assert.strictEqual(message, 'global')
+    const child = logger?.child(bindings, opts)
+    if (child) {
+      child.globalLog = function (message) {
+        t.assert.strictEqual(message, 'global')
+      }
     }
     return child
   }
   const customRouteChildLogger = (logger, bindings, opts, req) => {
-    const child = logger.child(bindings, opts)
-    child.customLog = function (message) {
-      t.assert.strictEqual(message, 'custom')
+    const child = logger?.child(bindings, opts)
+    if (child) {
+      child.customLog = function (message) {
+        t.assert.strictEqual(message, 'custom')
+      }
     }
     return child
   }


### PR DESCRIPTION
## ⚠️ DO NOT MERGE - Experimental Performance Test

This PR is an **experiment** to measure the performance impact of removing `abstract-logging` and using native optional chaining (`?.`) instead.

## Summary

- Removes the `abstract-logging` dependency
- Replaces no-op logger with `null` when `logger: false`
- Uses optional chaining operator (`?.`) for all logger method calls
- Updates tests to handle `null` logger

## Changes

### Core Changes
- `lib/logger-factory.js`: Returns `{ logger: null, hasLogger: false }` instead of abstract-logging instance
- All logger method calls now use `?.` operator (e.g., `logger?.info()`)
- All logger property accesses now use `?.` operator (e.g., `logger?.[kDisableRequestLogging]`)

### Breaking Changes
- **BREAKING**: When `logger: false`, `fastify.log` is now `null` instead of a no-op logger object
- User code that accesses `fastify.log` without optional chaining will throw

### Test Changes
- Updated tests that expected no-op logger to handle `null` logger
- Tests that assign to logger properties now require `logger: true`

## Performance Impact

**This PR exists to benchmark the performance impact of using optional chaining vs abstract-logging.**

The hypothesis is that optional chaining may have a performance cost compared to calling no-op functions. This needs to be measured before considering this change for production.

## Test Plan

- [x] All unit tests pass
- [ ] Run benchmarks to compare performance
- [ ] Measure impact on hot paths

## Questions to Answer

1. What is the performance impact of `?.` operator vs calling no-op functions?
2. Is the performance acceptable for production use?
3. Does removing a dependency justify any performance loss?

🤖 Generated with [Claude Code](https://claude.com/claude-code)