### PR TITLE
feat: support customAttributeKeys in logger serializers

### DIFF
--- a/docs/Reference/Logging.md
+++ b/docs/Reference/Logging.md
@@ -206,6 +206,27 @@ app.addHook('preHandler', function (req, reply, done) {
 
 *Any logger other than Pino will ignore this option.*
 
+#### Custom Attribute Keys
+
+By default, Fastify logs use `req`, `res`, and `err` as attribute keys. These
+can be customized using the `customAttributeKeys` option:
+
+```js
+const fastify = require('fastify')({
+  logger: {
+    level: 'info',
+    customAttributeKeys: {
+      req: 'request',
+      res: 'response',
+      err: 'error'
+    }
+  }
+})
+```
+
+This will produce logs with `request`, `response`, and `error` keys instead of
+the default `req`, `res`, and `err`.
+
 ### Using Custom Loggers
 A custom logger instance can be supplied by passing it as `loggerInstance`. The
 logger must conform to the Pino interface, with methods: `info`, `error`,

--- a/fastify.js
+++ b/fastify.js
@@ -855,6 +855,8 @@ function processOptions (options, defaultRoute, onBadUrl) {
     throw new FST_ERR_AJV_CUSTOM_OPTIONS_OPT_NOT_ARR(typeof ajvOptions.plugins)
   }
 
+  const customAttributeKeys = options.logger?.customAttributeKeys
+
   const { logger, hasLogger } = createLogger(options)
 
   // Update the options with the fixed values
@@ -863,6 +865,7 @@ function processOptions (options, defaultRoute, onBadUrl) {
   options.maxRequestsPerSocket = options.maxRequestsPerSocket || defaultInitOptions.maxRequestsPerSocket
   options.requestTimeout = options.requestTimeout || defaultInitOptions.requestTimeout
   options.logger = logger
+  options.loggerCustomAttributeKeys = customAttributeKeys
   options.requestIdHeader = requestIdHeader
   options.requestIdLogLabel = requestIdLogLabel
   options.disableRequestLogging = disableRequestLogging

--- a/lib/logger-pino.js
+++ b/lib/logger-pino.js
@@ -13,6 +13,18 @@ const {
 } = require('./errors')
 
 function createPinoLogger (opts) {
+  const customAttributeKeys = opts.customAttributeKeys || {}
+  const reqKey = customAttributeKeys.req || 'req'
+  const resKey = customAttributeKeys.res || 'res'
+  const errKey = customAttributeKeys.err || 'err'
+
+  const defaultSerializers = {}
+  defaultSerializers[reqKey] = opts.serializers?.req || serializers.req
+  defaultSerializers[resKey] = opts.serializers?.res || serializers.res
+  defaultSerializers[errKey] = opts.serializers?.err || serializers.err
+
+  opts.serializers = Object.assign({}, defaultSerializers, opts.serializers)
+
   if (opts.stream && opts.file) {
     throw new FST_ERR_LOG_INVALID_DESTINATION()
   } else if (opts.file) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -18,6 +18,7 @@ const {
   kReplyIsRunningOnErrorHook,
   kReplyNextErrorHandler,
   kDisableRequestLogging,
+  kCustomAttributeKeys,
   kSchemaResponse,
   kReplyCacheSerializeFns,
   kSchemaController,
@@ -850,18 +851,21 @@ function onResponseCallback (err, request, reply) {
   }
 
   const responseTime = reply.elapsedTime
+  const attributeKeys = reply.log[kCustomAttributeKeys] || {}
+  const resKey = attributeKeys.resKey || 'res'
+  const errKey = attributeKeys.errKey || 'err'
 
   if (err != null) {
     reply.log.error({
-      res: reply,
-      err,
+      [resKey]: reply,
+      [errKey]: err,
       responseTime
     }, 'request errored')
     return
   }
 
   reply.log.info({
-    res: reply,
+    [resKey]: reply,
     responseTime
   }, 'request completed')
 }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -851,9 +851,7 @@ function onResponseCallback (err, request, reply) {
   }
 
   const responseTime = reply.elapsedTime
-  const attributeKeys = reply.log[kCustomAttributeKeys] || {}
-  const resKey = attributeKeys.resKey || 'res'
-  const errKey = attributeKeys.errKey || 'err'
+  const { resKey, errKey } = reply.log[kCustomAttributeKeys]
 
   if (err != null) {
     reply.log.error({

--- a/lib/route.js
+++ b/lib/route.js
@@ -43,6 +43,7 @@ const {
   kReplyIsError,
   kRequestPayloadStream,
   kDisableRequestLogging,
+  kCustomAttributeKeys,
   kSchemaErrorFormatter,
   kErrorHandler,
   kHasBeenDecorated,
@@ -71,6 +72,9 @@ const routerKeys = [
 function buildRouting (options) {
   const router = FindMyWay(options)
 
+  let reqKey = 'req'
+  let resKey = 'res'
+  let errKey = 'err'
   let avvio
   let fourOhFour
   let logger
@@ -92,6 +96,12 @@ function buildRouting (options) {
      * @param {*} fastifyArgs
      */
     setup (options, fastifyArgs) {
+      if (options?.loggerCustomAttributeKeys) {
+        resKey = options.loggerCustomAttributeKeys.res || resKey
+        reqKey = options.loggerCustomAttributeKeys.req || reqKey
+        errKey = options.loggerCustomAttributeKeys.err || errKey
+      }
+
       avvio = fastifyArgs.avvio
       fourOhFour = fastifyArgs.fourOhFour
       hasLogger = fastifyArgs.hasLogger
@@ -456,6 +466,7 @@ function buildRouting (options) {
     }
     const childLogger = createChildLogger(context, logger, req, id, loggerOpts)
     childLogger[kDisableRequestLogging] = disableRequestLogging
+    childLogger[kCustomAttributeKeys] = { reqKey, resKey, errKey }
 
     if (closing === true) {
       /* istanbul ignore next mac, windows */
@@ -500,7 +511,7 @@ function buildRouting (options) {
     const request = new context.Request(id, params, req, query, childLogger, context)
     const reply = new context.Reply(res, request, childLogger)
     if (disableRequestLogging === false) {
-      childLogger.info({ req: request }, 'incoming request')
+      childLogger.info({ [reqKey]: request }, 'incoming request')
     }
 
     if (hasLogger === true || context.onResponse !== null) {

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -14,6 +14,7 @@ const keys = {
   kState: Symbol('fastify.state'),
   kOptions: Symbol('fastify.options'),
   kDisableRequestLogging: Symbol('fastify.disableRequestLogging'),
+  kCustomAttributeKeys: Symbol('fastify.customAttributeKeys'),
   kPluginNameChain: Symbol('fastify.pluginNameChain'),
   kRouteContext: Symbol('fastify.context'),
   kGenReqId: Symbol('fastify.genReqId'),

--- a/test/logger/logger-custom.test.js
+++ b/test/logger/logger-custom.test.js
@@ -1,0 +1,312 @@
+'use strict'
+
+const { test } = require('node:test')
+const stream = require('node:stream')
+const split = require('split2')
+
+const Fastify = require('../../fastify')
+const { on } = stream
+
+test('logger customAttributeKeys option', { timeout: 60000 }, async (t) => {
+  t.plan(8)
+
+  await t.test('Should remap req serializer when customAttributeKeys.req is set', async (t) => {
+    t.plan(4)
+
+    const loggerStream = split(JSON.parse)
+    const fastify = Fastify({
+      logger: {
+        stream: loggerStream,
+        level: 'info',
+        customAttributeKeys: {
+          req: 'httpRequest'
+        }
+      }
+    })
+    t.after(() => fastify.close())
+
+    fastify.get('/', (req, reply) => {
+      reply.send({ hello: 'world' })
+    })
+
+    await fastify.ready()
+
+    const response = await fastify.inject({ method: 'GET', url: '/' })
+    t.assert.deepEqual(response.statusCode, 200)
+
+    for await (const [line] of on(loggerStream, 'data')) {
+      if (line.msg === 'incoming request') {
+        t.assert.ok(line.httpRequest, 'should have "httpRequest" key')
+        t.assert.ok(line.httpRequest.method, 'should have method in httpRequest')
+        t.assert.strictEqual(line.req, undefined, 'should not have "req" key')
+        break
+      }
+    }
+  })
+
+  await t.test('Should remap res serializer when customAttributeKeys.res is set', async (t) => {
+    t.plan(4)
+
+    const loggerStream = split(JSON.parse)
+    const fastify = Fastify({
+      logger: {
+        stream: loggerStream,
+        level: 'info',
+        customAttributeKeys: {
+          res: 'response'
+        }
+      }
+    })
+    t.after(() => fastify.close())
+
+    fastify.get('/', (req, reply) => {
+      reply.send({ hello: 'world' })
+    })
+
+    await fastify.ready()
+
+    const response = await fastify.inject({ method: 'GET', url: '/' })
+    t.assert.deepEqual(response.statusCode, 200)
+
+    for await (const [line] of on(loggerStream, 'data')) {
+      if (line.msg === 'request completed') {
+        t.assert.ok(line.response, 'should have "response" key')
+        t.assert.ok(line.response.statusCode, 'should have statusCode in response')
+        t.assert.strictEqual(line.res, undefined, 'should not have "res" key')
+        break
+      }
+    }
+  })
+
+  await t.test('Should remap multiple serializers with customAttributeKeys', async (t) => {
+    t.plan(5)
+
+    const loggerStream = split(JSON.parse)
+    const fastify = Fastify({
+      logger: {
+        stream: loggerStream,
+        level: 'info',
+        customAttributeKeys: {
+          req: 'request',
+          res: 'response'
+        }
+      }
+    })
+    t.after(() => fastify.close())
+
+    fastify.get('/', (req, reply) => {
+      reply.send({ hello: 'world' })
+    })
+
+    await fastify.ready()
+
+    const response = await fastify.inject({ method: 'GET', url: '/' })
+    t.assert.deepEqual(response.statusCode, 200)
+
+    let checkedRequest = false
+    let checkedResponse = false
+
+    for await (const [line] of on(loggerStream, 'data')) {
+      if (line.msg === 'incoming request' && !checkedRequest) {
+        t.assert.ok(line.request, 'should have "request" key')
+        t.assert.strictEqual(line.req, undefined, 'should not have "req" key')
+        checkedRequest = true
+      }
+      if (line.msg === 'request completed' && !checkedResponse) {
+        t.assert.ok(line.response, 'should have "response" key')
+        t.assert.strictEqual(line.res, undefined, 'should not have "res" key')
+        checkedResponse = true
+      }
+      if (checkedRequest && checkedResponse) break
+    }
+  })
+
+  await t.test('Should keep default serializer keys when customAttributeKeys is not provided', async (t) => {
+    t.plan(5)
+
+    const loggerStream = split(JSON.parse)
+    const fastify = Fastify({
+      logger: {
+        stream: loggerStream,
+        level: 'info'
+      }
+    })
+    t.after(() => fastify.close())
+
+    fastify.get('/', (req, reply) => {
+      reply.send({ hello: 'world' })
+    })
+
+    await fastify.ready()
+
+    const response = await fastify.inject({ method: 'GET', url: '/' })
+    t.assert.deepEqual(response.statusCode, 200)
+
+    let checkedReq = false
+    let checkedRes = false
+
+    for await (const [line] of on(loggerStream, 'data')) {
+      if (line.msg === 'incoming request' && !checkedReq) {
+        t.assert.ok(line.req, 'should have "req" key')
+        t.assert.strictEqual(line.request, undefined, 'should not have "request" key')
+        checkedReq = true
+      }
+      if (line.msg === 'request completed' && !checkedRes) {
+        t.assert.ok(line.res, 'should have "res" key')
+        t.assert.strictEqual(line.response, undefined, 'should not have "response" key')
+        checkedRes = true
+      }
+      if (checkedReq && checkedRes) break
+    }
+  })
+
+  await t.test('Should keep default key when customAttributeKeys has same value as default', async (t) => {
+    t.plan(3)
+
+    const loggerStream = split(JSON.parse)
+    const fastify = Fastify({
+      logger: {
+        stream: loggerStream,
+        level: 'info',
+        customAttributeKeys: {
+          req: 'req'
+        }
+      }
+    })
+    t.after(() => fastify.close())
+
+    fastify.get('/', (req, reply) => {
+      reply.send({ hello: 'world' })
+    })
+
+    await fastify.ready()
+
+    const response = await fastify.inject({ method: 'GET', url: '/' })
+    t.assert.deepEqual(response.statusCode, 200)
+
+    for await (const [line] of on(loggerStream, 'data')) {
+      if (line.msg === 'incoming request') {
+        t.assert.ok(line.req, 'should have "req" key')
+        t.assert.strictEqual(line.request, undefined, 'should not have "request" key')
+        break
+      }
+    }
+  })
+
+  await t.test('Should handle empty customAttributeKeys object', async (t) => {
+    t.plan(3)
+
+    const loggerStream = split(JSON.parse)
+    const fastify = Fastify({
+      logger: {
+        stream: loggerStream,
+        level: 'info',
+        customAttributeKeys: {}
+      }
+    })
+    t.after(() => fastify.close())
+
+    fastify.get('/', (req, reply) => {
+      reply.send({ hello: 'world' })
+    })
+
+    await fastify.ready()
+
+    const response = await fastify.inject({ method: 'GET', url: '/' })
+    t.assert.deepEqual(response.statusCode, 200)
+
+    for await (const [line] of on(loggerStream, 'data')) {
+      if (line.msg === 'incoming request') {
+        t.assert.ok(line.req, 'should have default "req" key')
+        t.assert.strictEqual(line.request, undefined, 'should not have "request" key')
+        break
+      }
+    }
+  })
+
+  await t.test('Should remap err serializer when customAttributeKeys.err is set', async (t) => {
+    t.plan(4)
+
+    const loggerStream = split(JSON.parse)
+    const fastify = Fastify({
+      logger: {
+        stream: loggerStream,
+        level: 'info',
+        customAttributeKeys: {
+          err: 'error'
+        }
+      }
+    })
+    t.after(() => fastify.close())
+
+    fastify.get('/', (req, reply) => {
+      throw new Error('test error')
+    })
+
+    fastify.setErrorHandler((err, req, reply) => {
+      // When using customAttributeKeys.err = 'error', you must log with the custom key
+      req.log.error({ error: err }, 'an error occurred')
+      reply.status(500).send({ error: 'Internal Server Error' })
+    })
+
+    await fastify.ready()
+
+    const response = await fastify.inject({ method: 'GET', url: '/' })
+    t.assert.deepEqual(response.statusCode, 500)
+
+    for await (const [line] of on(loggerStream, 'data')) {
+      if (line.msg === 'an error occurred') {
+        t.assert.ok(line.error, 'should have "error" key')
+        t.assert.ok(line.error.message, 'should have message in error')
+        t.assert.strictEqual(line.err, undefined, 'should not have "err" key')
+        break
+      }
+    }
+  })
+
+  await t.test('Should remap all three serializers (req, res, err) simultaneously', async (t) => {
+    t.plan(7)
+
+    const loggerStream = split(JSON.parse)
+    const fastify = Fastify({
+      logger: {
+        stream: loggerStream,
+        level: 'info',
+        customAttributeKeys: {
+          req: 'request',
+          res: 'response',
+          err: 'error'
+        }
+      }
+    })
+    t.after(() => fastify.close())
+
+    fastify.get('/', (req, reply) => {
+      reply.send({ hello: 'world' })
+    })
+
+    await fastify.ready()
+
+    const response = await fastify.inject({ method: 'GET', url: '/' })
+    t.assert.deepEqual(response.statusCode, 200)
+
+    let checkedRequest = false
+    let checkedResponse = false
+
+    for await (const [line] of on(loggerStream, 'data')) {
+      if (line.msg === 'incoming request' && !checkedRequest) {
+        t.assert.ok(line.request, 'should have "request" key')
+        t.assert.strictEqual(line.req, undefined, 'should not have "req" key')
+        t.assert.strictEqual(line.response, undefined, 'should not have "response" key on request log')
+        checkedRequest = true
+      }
+      if (line.msg === 'request completed' && !checkedResponse) {
+        t.assert.ok(line.response, 'should have "response" key')
+        t.assert.strictEqual(line.res, undefined, 'should not have "res" key')
+        t.assert.strictEqual(line.request, undefined, 'should not have "request" key on response log')
+        checkedResponse = true
+      }
+      if (checkedRequest && checkedResponse) break
+    }
+  })
+})

--- a/test/logger/logger-pino.test.js
+++ b/test/logger/logger-pino.test.js
@@ -1,0 +1,112 @@
+'use strict'
+
+const stream = require('node:stream')
+
+const t = require('node:test')
+const split = require('split2')
+
+const { createPinoLogger } = require('../../lib/logger-pino')
+const { on } = stream
+
+t.test('createPinoLogger unit tests', { timeout: 60000 }, async (t) => {
+  t.plan(3)
+
+  await t.test('Should use custom serializer when provided with custom attribute key for req', async (t) => {
+    t.plan(2)
+
+    const loggerStream = split(JSON.parse)
+
+    const logger = createPinoLogger({
+      stream: loggerStream,
+      level: 'info',
+      customAttributeKeys: {
+        req: 'httpRequest'
+      },
+      serializers: {
+        httpRequest: function (req) {
+          return {
+            customField: 'customReqValue'
+          }
+        }
+      }
+    })
+
+    logger.info({ httpRequest: { method: 'GET' } }, 'test message')
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    for await (const [line] of on(loggerStream, 'data')) {
+      if (line.msg === 'test message') {
+        t.assert.ok(line.httpRequest, 'should have httpRequest key')
+        t.assert.strictEqual(line.httpRequest.customField, 'customReqValue', 'should use custom serializer')
+        break
+      }
+    }
+  })
+
+  await t.test('Should use custom serializer when provided with custom attribute key for res', async (t) => {
+    t.plan(2)
+
+    const loggerStream = split(JSON.parse)
+
+    const logger = createPinoLogger({
+      stream: loggerStream,
+      level: 'info',
+      customAttributeKeys: {
+        res: 'httpResponse'
+      },
+      serializers: {
+        httpResponse: function (reply) {
+          return {
+            customField: 'customResValue'
+          }
+        }
+      }
+    })
+
+    logger.info({ httpResponse: { statusCode: 200 } }, 'test message')
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    for await (const [line] of on(loggerStream, 'data')) {
+      if (line.msg === 'test message') {
+        t.assert.ok(line.httpResponse, 'should have httpResponse key')
+        t.assert.strictEqual(line.httpResponse.customField, 'customResValue', 'should use custom serializer')
+        break
+      }
+    }
+  })
+
+  await t.test('Should use custom serializer when provided with custom attribute key for err', async (t) => {
+    t.plan(2)
+
+    const loggerStream = split(JSON.parse)
+
+    const logger = createPinoLogger({
+      stream: loggerStream,
+      level: 'info',
+      customAttributeKeys: {
+        err: 'httpError'
+      },
+      serializers: {
+        httpError: function () {
+          return {
+            customField: 'customErrValue'
+          }
+        }
+      }
+    })
+
+    logger.info({ httpError: new Error('test error') }, 'test message')
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    for await (const [line] of on(loggerStream, 'data')) {
+      if (line.msg === 'test message') {
+        t.assert.ok(line.httpError, 'should have httpError key')
+        t.assert.strictEqual(line.httpError.customField, 'customErrValue', 'should use custom serializer')
+        break
+      }
+    }
+  })
+})


### PR DESCRIPTION
Closes #4413 

## Summary

This PR adds support for `customAttributeKeys` option in the logger configuration, allowing users to customize the attribute keys used in log records (`req`, `res`, `err`).

This is particularly useful for cloud logging platforms like Google Cloud Logging, which expect specific field names (e.g., `httpRequest` instead of `req`).

## Example Usage

```js
const fastify = require('fastify')({
  logger: {
    level: 'info',
    customAttributeKeys: {
      req: 'httpRequest',
      res: 'response',
      err: 'error'
    },
    serializers: {
      req: function (req) {
        return {
          requestMethod: req.method,
          requestUrl: req.url,
          userAgent: req.headers['user-agent'],
          remoteIp: req.headers['x-forwarded-for']
        }
      }
    }
  }
})
```
#### Checklist

- [X] run `npm run test && npm run benchmark --if-present`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
