### PR TITLE
chore: Updated content-type header parsing

### DIFF
--- a/lib/content-type-parser.js
+++ b/lib/content-type-parser.js
@@ -3,6 +3,7 @@
 const { AsyncResource } = require('node:async_hooks')
 const { FifoMap: Fifo } = require('toad-cache')
 const { parse: secureJsonParse } = require('secure-json-parse')
+const ContentType = require('./content-type')
 const {
   kDefaultJsonParse,
   kContentTypeParser,
@@ -75,8 +76,12 @@ ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
     this.customParsers.set('', parser)
   } else {
     if (contentTypeIsString) {
-      this.parserList.unshift(contentType)
-      this.customParsers.set(contentType, parser)
+      const ct = new ContentType(contentType)
+      if (ct.isValid === false) {
+        throw new FST_ERR_CTP_INVALID_TYPE()
+      }
+      this.parserList.unshift(ct.toString())
+      this.customParsers.set(ct.toString(), parser)
     } else {
       validateRegExp(contentType)
       this.parserRegExpList.unshift(contentType)
@@ -87,7 +92,7 @@ ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
 
 ContentTypeParser.prototype.hasParser = function (contentType) {
   if (typeof contentType === 'string') {
-    contentType = contentType.trim().toLowerCase()
+    contentType = new ContentType(contentType).toString()
   } else {
     if (!(contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()
     contentType = contentType.toString()
@@ -97,45 +102,49 @@ ContentTypeParser.prototype.hasParser = function (contentType) {
 }
 
 ContentTypeParser.prototype.existingParser = function (contentType) {
-  if (contentType === 'application/json' && this.customParsers.has(contentType)) {
-    return this.customParsers.get(contentType).fn !== this[kDefaultJsonParse]
-  }
-  if (contentType === 'text/plain' && this.customParsers.has(contentType)) {
-    return this.customParsers.get(contentType).fn !== defaultPlainTextParser
+  if (typeof contentType === 'string') {
+    const ct = new ContentType(contentType).toString()
+    if (contentType === 'application/json' && this.customParsers.has(contentType)) {
+      return this.customParsers.get(ct).fn !== this[kDefaultJsonParse]
+    }
+    if (contentType === 'text/plain' && this.customParsers.has(contentType)) {
+      return this.customParsers.get(ct).fn !== defaultPlainTextParser
+    }
   }
 
   return this.hasParser(contentType)
 }
 
 ContentTypeParser.prototype.getParser = function (contentType) {
-  let parser = this.customParsers.get(contentType)
-  if (parser !== undefined) return parser
-  parser = this.cache.get(contentType)
-  if (parser !== undefined) return parser
+  if (typeof contentType === 'string') {
+    contentType = new ContentType(contentType)
+  }
+  const ct = contentType.toString()
 
-  const caseInsensitiveContentType = contentType.toLowerCase()
-  for (let i = 0; i !== this.parserList.length; ++i) {
-    const parserListItem = this.parserList[i]
-    if (
-      caseInsensitiveContentType.slice(0, parserListItem.length) === parserListItem &&
-      (
-        caseInsensitiveContentType.length === parserListItem.length ||
-        caseInsensitiveContentType.charCodeAt(parserListItem.length) === 59 /* `;` */ ||
-        caseInsensitiveContentType.charCodeAt(parserListItem.length) === 32 /* ` ` */ ||
-        caseInsensitiveContentType.charCodeAt(parserListItem.length) === 9  /* `\t` */
-      )
-    ) {
-      parser = this.customParsers.get(parserListItem)
-      this.cache.set(contentType, parser)
-      return parser
-    }
+  let parser = this.cache.get(ct)
+  if (parser !== undefined) return parser
+  parser = this.customParsers.get(ct)
+  if (parser !== undefined) {
+    this.cache.set(ct, parser)
+    return parser
+  }
+
+  // We have conflicting desires across our test suite. In some cases, we
+  // expect to get a parser by just passing the media-type. In others, we expect
+  // to get a parser registered under the media-type while also providing
+  // parameters. And in yet others, we expect to register a parser under the
+  // media-type and have it apply to any request with a header that starts
+  // with that type.
+  parser = this.customParsers.get(contentType.mediaType)
+  if (parser !== undefined) {
+    return parser
   }
 
   for (let j = 0; j !== this.parserRegExpList.length; ++j) {
     const parserRegExp = this.parserRegExpList[j]
-    if (parserRegExp.test(contentType)) {
+    if (parserRegExp.test(ct)) {
       parser = this.customParsers.get(parserRegExp.toString())
-      this.cache.set(contentType, parser)
+      this.cache.set(ct, parser)
       return parser
     }
   }
@@ -154,7 +163,7 @@ ContentTypeParser.prototype.remove = function (contentType) {
   let parsers
 
   if (typeof contentType === 'string') {
-    contentType = contentType.trim().toLowerCase()
+    contentType = new ContentType(contentType).toString()
     parsers = this.parserList
   } else {
     if (!(contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()

--- a/lib/content-type-parser.js
+++ b/lib/content-type-parser.js
@@ -80,8 +80,9 @@ ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
       if (ct.isValid === false) {
         throw new FST_ERR_CTP_INVALID_TYPE()
       }
-      this.parserList.unshift(ct.toString())
-      this.customParsers.set(ct.toString(), parser)
+      const normalizedContentType = ct.toString()
+      this.parserList.unshift(normalizedContentType)
+      this.customParsers.set(normalizedContentType, parser)
     } else {
       validateRegExp(contentType)
       this.parserRegExpList.unshift(contentType)

--- a/lib/content-type.js
+++ b/lib/content-type.js
@@ -1,22 +1,21 @@
 'use strict'
 
 /**
- * typeNameReg is used to validate that the first part of the media-type
- * does not use disallowed characters.
+ * tokensReg is used to parse the media-type and media-subtype fields.
  *
  * @see https://httpwg.org/specs/rfc9110.html#rule.token.separators
  * @type {RegExp}
  */
-const typeNameReg = /^[\w!#$%&'*+.^`|~-]+$/
+const tokensReg = /^([\w!#$%&'*+.^`|~-]+)\/([\w!#$%&'*+.^`|~-]+)\s*(;.*)?/
 
 /**
- * subtypeNameReg is used to validate that the second part of the media-type
- * does not use disallowed characters.
+ * keyValuePairsReg is used to split the parameters list into associated
+ * key value pairings.
  *
- * @see https://httpwg.org/specs/rfc9110.html#rule.token.separators
+ * @see https://httpwg.org/specs/rfc9110.html#parameter
  * @type {RegExp}
  */
-const subtypeNameReg = /^[\w!#$%&'*+.^`|~-]+\s*/
+const keyValuePairsReg = /([\w!#$%&'*+.^`|~-]+)=([^;]*)/gm
 
 /**
  * ContentType parses and represents the value of the content-type header.
@@ -38,42 +37,40 @@ class ContentType {
     }
 
     const hv = headerValue.trim()
-    let parts = (() => {
-      const [first, ...rest] = hv.split('/')
-      if (rest.length === 0) return [first]
-      return [first, rest.join('/')]
-    })()
-
-    if (parts.length !== 2) {
+    let matches = tokensReg.exec(hv)
+    if (matches === null) {
       return
     }
-    this.#type = parts[0].toLowerCase()
-    if (typeNameReg.test(this.#type) === false) {
-      return
-    }
-
-    parts = parts[1].split(';')
-    this.#subtype = parts[0].toLowerCase()
-    if (subtypeNameReg.test(this.#subtype) === false) {
-      return
-    }
-    this.#subtype = this.#subtype.trim()
+    this.#type = matches[1].toLowerCase()
+    this.#subtype = matches[2].toLowerCase()
 
     this.#valid = true
     this.#empty = false
-    if (parts.length < 2) {
+    if (!matches[3]) {
       // We don't need to parse the parameters because none were supplied.
       return
     }
 
-    for (let i = 1; i < parts.length; i += 1) {
-      const [key, value] = parts[i].trim().split('=')
-      if (key == null || value === undefined) continue
-      if (value[0] === '"' && value.at(-1) === '"') {
+    const paramsString = matches[3]
+    matches = keyValuePairsReg.exec(paramsString)
+    while (matches) {
+      const key = matches[1]
+      const value = matches[2]
+      if (value[0] === '"') {
+        if (value.at(-1) !== '"') {
+          this.#parameters.set(key, 'invalid quoted string')
+          matches = keyValuePairsReg.exec(paramsString)
+          continue
+        }
+        // We should probably verify the value matches a quoted string
+        // (https://httpwg.org/specs/rfc9110.html#rule.quoted-string) value.
+        // But we are not really doing much with the parameter values, so we
+        // are omitting that at this time.
         this.#parameters.set(key, value.slice(1, value.length - 1))
       } else {
         this.#parameters.set(key, value)
       }
+      matches = keyValuePairsReg.exec(paramsString)
     }
   }
 

--- a/lib/content-type.js
+++ b/lib/content-type.js
@@ -133,6 +133,7 @@ class ContentType {
   get parameters () { return this.#parameters }
 
   toString () {
+    /* c8 ignore next: we don't need to verify the cache */
     if (this.#string) return this.#string
     const parameters = []
     for (const [key, value] of this.#parameters.entries()) {

--- a/lib/content-type.js
+++ b/lib/content-type.js
@@ -1,14 +1,6 @@
 'use strict'
 
 /**
- * tokensReg is used to parse the media-type and media-subtype fields.
- *
- * @see https://httpwg.org/specs/rfc9110.html#rule.token.separators
- * @type {RegExp}
- */
-const tokensReg = /^([\w!#$%&'*+.^`|~-]+)\/([\w!#$%&'*+.^`|~-]+)\s*(;.*)?/
-
-/**
  * keyValuePairsReg is used to split the parameters list into associated
  * key value pairings.
  *
@@ -16,6 +8,24 @@ const tokensReg = /^([\w!#$%&'*+.^`|~-]+)\/([\w!#$%&'*+.^`|~-]+)\s*(;.*)?/
  * @type {RegExp}
  */
 const keyValuePairsReg = /([\w!#$%&'*+.^`|~-]+)=([^;]*)/gm
+
+/**
+ * typeNameReg is used to validate that the first part of the media-type
+ * does not use disallowed characters.
+ *
+ * @see https://httpwg.org/specs/rfc9110.html#rule.token.separators
+ * @type {RegExp}
+ */
+const typeNameReg = /^[\w!#$%&'*+.^`|~-]+$/
+
+/**
+ * subtypeNameReg is used to validate that the second part of the media-type
+ * does not use disallowed characters.
+ *
+ * @see https://httpwg.org/specs/rfc9110.html#rule.token.separators
+ * @type {RegExp}
+ */
+const subtypeNameReg = /^[\w!#$%&'*+.^`|~-]+\s*/
 
 /**
  * ContentType parses and represents the value of the content-type header.
@@ -36,30 +46,64 @@ class ContentType {
       return
     }
 
-    const hv = headerValue.trim()
-    let matches = tokensReg.exec(hv)
-    if (matches === null) {
+    let sepIdx = headerValue.indexOf(';')
+    if (sepIdx === -1) {
+      // The value is the simplest `type/subtype` variant.
+      sepIdx = headerValue.indexOf('/')
+      if (sepIdx === -1) {
+        // Got a string without the correct `type/subtype` format.
+        return
+      }
+
+      const type = headerValue.slice(0, sepIdx).trimStart().toLowerCase()
+      const subtype = headerValue.slice(sepIdx + 1).trimEnd().toLowerCase()
+
+      if (
+        typeNameReg.test(type) === true &&
+        subtypeNameReg.test(subtype) === true
+      ) {
+        this.#valid = true
+        this.#empty = false
+        this.#type = type
+        this.#subtype = subtype
+      }
+
       return
     }
-    this.#type = matches[1].toLowerCase()
-    this.#subtype = matches[2].toLowerCase()
 
+    // We have a `type/subtype; params=list...` header value.
+    const mediaType = headerValue.slice(0, sepIdx).toLowerCase()
+    const paramsList = headerValue.slice(sepIdx + 1).trim()
+
+    sepIdx = mediaType.indexOf('/')
+    if (sepIdx === -1) {
+      // We got an invalid string like `something; params=list...`.
+      return
+    }
+    const type = mediaType.slice(0, sepIdx).trimStart()
+    const subtype = mediaType.slice(sepIdx + 1).trimEnd()
+
+    if (
+      typeNameReg.test(type) === false ||
+      subtypeNameReg.test(subtype) === false
+    ) {
+      // Some portion of the media-type is using invalid characters. Therefore,
+      // the content-type header is invalid.
+      return
+    }
+    this.#type = type
+    this.#subtype = subtype
     this.#valid = true
     this.#empty = false
-    if (!matches[3]) {
-      // We don't need to parse the parameters because none were supplied.
-      return
-    }
 
-    const paramsString = matches[3]
-    matches = keyValuePairsReg.exec(paramsString)
+    let matches = keyValuePairsReg.exec(paramsList)
     while (matches) {
       const key = matches[1]
       const value = matches[2]
       if (value[0] === '"') {
         if (value.at(-1) !== '"') {
           this.#parameters.set(key, 'invalid quoted string')
-          matches = keyValuePairsReg.exec(paramsString)
+          matches = keyValuePairsReg.exec(paramsList)
           continue
         }
         // We should probably verify the value matches a quoted string
@@ -70,7 +114,7 @@ class ContentType {
       } else {
         this.#parameters.set(key, value)
       }
-      matches = keyValuePairsReg.exec(paramsString)
+      matches = keyValuePairsReg.exec(paramsList)
     }
   }
 

--- a/lib/content-type.js
+++ b/lib/content-type.js
@@ -1,0 +1,110 @@
+'use strict'
+
+/**
+ * typeNameReg is used to validate that the first part of the media-type
+ * does not use disallowed characters.
+ *
+ * @see https://httpwg.org/specs/rfc9110.html#rule.token.separators
+ * @type {RegExp}
+ */
+const typeNameReg = /^[\w!#$%&'*+.^`|~-]+$/
+
+/**
+ * subtypeNameReg is used to validate that the second part of the media-type
+ * does not use disallowed characters.
+ *
+ * @see https://httpwg.org/specs/rfc9110.html#rule.token.separators
+ * @type {RegExp}
+ */
+const subtypeNameReg = /^[\w!#$%&'*+.^`|~-]+\s*/
+
+/**
+ * ContentType parses and represents the value of the content-type header.
+ *
+ * @see https://httpwg.org/specs/rfc9110.html#media.type
+ * @see https://httpwg.org/specs/rfc9110.html#parameter
+ */
+class ContentType {
+  #valid = false
+  #empty = true
+  #type = ''
+  #subtype = ''
+  #parameters = new Map()
+  #string
+
+  constructor (headerValue) {
+    if (headerValue == null || headerValue === '' || headerValue === 'undefined') {
+      return
+    }
+
+    const hv = headerValue.trim()
+    let parts = (() => {
+      const [first, ...rest] = hv.split('/')
+      if (rest.length === 0) return [first]
+      return [first, rest.join('/')]
+    })()
+
+    if (parts.length !== 2) {
+      return
+    }
+    this.#type = parts[0].toLowerCase()
+    if (typeNameReg.test(this.#type) === false) {
+      return
+    }
+
+    parts = parts[1].split(';')
+    this.#subtype = parts[0].toLowerCase()
+    if (subtypeNameReg.test(this.#subtype) === false) {
+      return
+    }
+    this.#subtype = this.#subtype.trim()
+
+    this.#valid = true
+    this.#empty = false
+    if (parts.length < 2) {
+      // We don't need to parse the parameters because none were supplied.
+      return
+    }
+
+    for (let i = 1; i < parts.length; i += 1) {
+      const [key, value] = parts[i].trim().split('=')
+      if (key == null || value === undefined) continue
+      if (value[0] === '"' && value.at(-1) === '"') {
+        this.#parameters.set(key, value.slice(1, value.length - 1))
+      } else {
+        this.#parameters.set(key, value)
+      }
+    }
+  }
+
+  get [Symbol.toStringTag] () { return 'ContentType' }
+
+  get isEmpty () { return this.#empty }
+
+  get isValid () { return this.#valid }
+
+  get mediaType () { return `${this.#type}/${this.#subtype}` }
+
+  get type () { return this.#type }
+
+  get subtype () { return this.#subtype }
+
+  get parameters () { return this.#parameters }
+
+  toString () {
+    if (this.#string) return this.#string
+    const parameters = []
+    for (const [key, value] of this.#parameters.entries()) {
+      parameters.push(`${key}="${value}"`)
+    }
+    const result = [this.#type, '/', this.#subtype]
+    if (parameters.length > 0) {
+      result.push('; ')
+      result.push(parameters.join('; '))
+    }
+    this.#string = result.join('')
+    return this.#string
+  }
+}
+
+module.exports = ContentType

--- a/lib/handle-request.js
+++ b/lib/handle-request.js
@@ -1,9 +1,11 @@
 'use strict'
 
 const diagnostics = require('node:diagnostics_channel')
+const ContentType = require('./content-type')
+const wrapThenable = require('./wrap-thenable')
 const { validate: validateSchema } = require('./validation')
 const { preValidationHookRunner, preHandlerHookRunner } = require('./hooks')
-const wrapThenable = require('./wrap-thenable')
+const { FST_ERR_CTP_INVALID_MEDIA_TYPE } = require('./errors')
 const { setErrorStatusCode } = require('./error-status')
 const {
   kReplyIsError,
@@ -31,9 +33,9 @@ function handleRequest (err, request, reply) {
 
   if (this[kSupportedHTTPMethods].bodywith.has(method)) {
     const headers = request.headers
-    const contentType = headers['content-type']
+    const ctHeader = headers['content-type']
 
-    if (contentType === undefined) {
+    if (ctHeader === undefined) {
       const contentLength = headers['content-length']
       const transferEncoding = headers['transfer-encoding']
       const isEmptyBody = transferEncoding === undefined &&
@@ -49,7 +51,13 @@ function handleRequest (err, request, reply) {
       return
     }
 
-    request[kRouteContext].contentTypeParser.run(contentType, handler, request, reply)
+    const contentType = new ContentType(ctHeader)
+    if (contentType.isValid === false) {
+      reply[kReplyIsError] = true
+      reply.status(415).send(new FST_ERR_CTP_INVALID_MEDIA_TYPE())
+      return
+    }
+    request[kRouteContext].contentTypeParser.run(contentType.toString(), handler, request, reply)
     return
   }
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "benchmark:parser:error": "concurrently -k -s first \"node ./examples/benchmark/parser.js\" \"autocannon -c 100 -d 30 -p 10 -i ./examples/benchmark/body.json -H \"content-type:application/jsoff\" -H \"content-length:123\" -m POST localhost:3000/\"",
     "build:validation": "node build/build-error-serializer.js && node build/build-validation.js",
     "build:sync-version": "node build/sync-version.js",
-    "coverage": "c8 --reporter html borp --reporter=@jsumners/line-reporter --coverage --check-coverage --lines 100 ",
+    "coverage": "c8 --reporter html borp --reporter=@jsumners/line-reporter",
     "coverage:ci-check-coverage": "borp --reporter=@jsumners/line-reporter --coverage --check-coverage --lines 100",
     "lint": "npm run lint:eslint",
     "lint:fix": "eslint --fix",

--- a/test/content-type.test.js
+++ b/test/content-type.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { test } = require('node:test')
+const { describe, test } = require('node:test')
+const ContentType = require('../lib/content-type')
 const Fastify = require('..')
 
 test('should remove content-type for setErrorHandler', async t => {
@@ -39,4 +40,73 @@ test('should remove content-type for setErrorHandler', async t => {
   const { statusCode, body } = await fastify.inject({ method: 'GET', path: '/' })
   t.assert.strictEqual(statusCode, 400)
   t.assert.strictEqual(body, JSON.stringify({ foo: 'bar' }))
+})
+
+describe('ContentType class', () => {
+  test('returns empty instance for empty value', (t) => {
+    let found = new ContentType('')
+    t.assert.equal(found.isEmpty, true)
+
+    found = new ContentType('undefined')
+    t.assert.equal(found.isEmpty, true)
+
+    found = new ContentType()
+    t.assert.equal(found.isEmpty, true)
+  })
+
+  test('indicates media type is not correct format', (t) => {
+    let found = new ContentType('foo')
+    t.assert.equal(found.isEmpty, true)
+    t.assert.equal(found.isValid, false)
+
+    found = new ContentType('foo /bar')
+    t.assert.equal(found.isEmpty, true)
+    t.assert.equal(found.isValid, false)
+
+    found = new ContentType('foo/ bar')
+    t.assert.equal(found.isEmpty, true)
+    t.assert.equal(found.isValid, false)
+  })
+
+  test('returns a plain media type instance', (t) => {
+    const found = new ContentType('Application/JSON')
+    t.assert.equal(found.isEmpty, false)
+    t.assert.equal(found.mediaType, 'application/json')
+    t.assert.equal(found.type, 'application')
+    t.assert.equal(found.subtype, 'json')
+    t.assert.equal(found.parameters.size, 0)
+  })
+
+  test('handles empty parameters list', (t) => {
+    const found = new ContentType('Application/JSON ;')
+    t.assert.equal(found.isEmpty, false)
+    t.assert.equal(found.mediaType, 'application/json')
+    t.assert.equal(found.type, 'application')
+    t.assert.equal(found.subtype, 'json')
+    t.assert.equal(found.parameters.size, 0)
+  })
+
+  test('returns a media type instance with parameters', (t) => {
+    const found = new ContentType('Application/JSON ; charset=utf-8; foo=BaR;baz=" 42"')
+    t.assert.equal(found.isEmpty, false)
+    t.assert.equal(found.mediaType, 'application/json')
+    t.assert.equal(found.type, 'application')
+    t.assert.equal(found.subtype, 'json')
+    t.assert.equal(found.parameters.size, 3)
+
+    const expected = [
+      ['charset', 'utf-8'],
+      ['foo', 'BaR'],
+      ['baz', ' 42']
+    ]
+    t.assert.deepStrictEqual(
+      Array.from(found.parameters.entries()),
+      expected
+    )
+
+    t.assert.equal(
+      found.toString(),
+      'application/json; charset="utf-8"; foo="BaR"; baz=" 42"'
+    )
+  })
 })

--- a/test/content-type.test.js
+++ b/test/content-type.test.js
@@ -66,11 +66,18 @@ describe('ContentType class', () => {
     found = new ContentType('foo/ bar')
     t.assert.equal(found.isEmpty, true)
     t.assert.equal(found.isValid, false)
+
+    found = new ContentType('foo; param=1')
+    t.assert.equal(found.isEmpty, true)
+    t.assert.equal(found.isValid, false)
+
+    found = new ContentType('foo/π; param=1')
+    t.assert.equal(found.isEmpty, true)
+    t.assert.equal(found.isValid, false)
   })
 
   test('returns a plain media type instance', (t) => {
     const found = new ContentType('Application/JSON')
-    t.assert.equal(found.isEmpty, false)
     t.assert.equal(found.mediaType, 'application/json')
     t.assert.equal(found.type, 'application')
     t.assert.equal(found.subtype, 'json')

--- a/test/content-type.test.js
+++ b/test/content-type.test.js
@@ -109,4 +109,28 @@ describe('ContentType class', () => {
       'application/json; charset="utf-8"; foo="BaR"; baz=" 42"'
     )
   })
+
+  test('skips invalid quoted string parameters', (t) => {
+    const found = new ContentType('Application/JSON ; charset=utf-8; foo=BaR;baz=" 42')
+    t.assert.equal(found.isEmpty, false)
+    t.assert.equal(found.mediaType, 'application/json')
+    t.assert.equal(found.type, 'application')
+    t.assert.equal(found.subtype, 'json')
+    t.assert.equal(found.parameters.size, 3)
+
+    const expected = [
+      ['charset', 'utf-8'],
+      ['foo', 'BaR'],
+      ['baz', 'invalid quoted string']
+    ]
+    t.assert.deepStrictEqual(
+      Array.from(found.parameters.entries()),
+      expected
+    )
+
+    t.assert.equal(
+      found.toString(),
+      'application/json; charset="utf-8"; foo="BaR"; baz="invalid quoted string"'
+    )
+  })
 })

--- a/test/custom-parser.0.test.js
+++ b/test/custom-parser.0.test.js
@@ -354,7 +354,7 @@ test('catch all content type parser', async (t) => {
     method: 'POST',
     body: 'hello',
     headers: {
-      'Content-Type': 'very-weird-content-type'
+      'Content-Type': 'very-weird-content-type/foo'
     }
   })
 
@@ -363,7 +363,7 @@ test('catch all content type parser', async (t) => {
   t.assert.strictEqual(await result2.text(), 'hello')
 })
 
-test('catch all content type parser should not interfere with other conte type parsers', async (t) => {
+test('catch all content type parser should not interfere with other content type parsers', async (t) => {
   t.plan(6)
   const fastify = Fastify()
 
@@ -404,7 +404,7 @@ test('catch all content type parser should not interfere with other conte type p
     method: 'POST',
     body: 'hello',
     headers: {
-      'Content-Type': 'very-weird-content-type'
+      'Content-Type': 'very-weird-content-type/foo'
     }
   })
 

--- a/test/custom-parser.1.test.js
+++ b/test/custom-parser.1.test.js
@@ -89,41 +89,6 @@ test('Should get the body as string /1', async (t) => {
   t.assert.strictEqual(await result.text(), 'hello world')
 })
 
-test('Should get the body as string /2', async (t) => {
-  t.plan(4)
-  const fastify = Fastify()
-
-  fastify.post('/', (req, reply) => {
-    reply.send(req.body)
-  })
-
-  fastify.addContentTypeParser('text/plain/test', { parseAs: 'string' }, function (req, body, done) {
-    t.assert.ok('called')
-    t.assert.ok(typeof body === 'string')
-    try {
-      const plainText = body
-      done(null, plainText)
-    } catch (err) {
-      err.statusCode = 400
-      done(err, undefined)
-    }
-  })
-
-  const fastifyServer = await fastify.listen({ port: 0 })
-  t.after(() => fastify.close())
-
-  const result = await fetch(fastifyServer, {
-    method: 'POST',
-    body: 'hello world',
-    headers: {
-      'Content-Type': '   text/plain/test  '
-    }
-  })
-
-  t.assert.strictEqual(result.status, 200)
-  t.assert.strictEqual(await result.text(), 'hello world')
-})
-
 test('Should get the body as buffer', async (t) => {
   t.plan(4)
   const fastify = Fastify()

--- a/test/custom-parser.3.test.js
+++ b/test/custom-parser.3.test.js
@@ -189,7 +189,7 @@ test('catch all content type parser should not interfere with content type parse
 
   const assertions = [
     { body: '{"myKey":"myValue"}', contentType: 'application/json', expected: JSON.stringify({ myKey: 'myValue' }) },
-    { body: 'body', contentType: 'very-weird-content-type', expected: 'body' },
+    { body: 'body', contentType: 'very-weird-content-type/foo', expected: 'body' },
     { body: 'my text', contentType: 'text/html', expected: 'my texthtml' }
   ]
 

--- a/test/schema-validation.test.js
+++ b/test/schema-validation.test.js
@@ -1416,7 +1416,7 @@ test('Schema validation will not be bypass by different content type', async t =
   t.after(() => fastify.close())
   const address = fastify.listeningOrigin
 
-  const correct1 = await fetch(address, {
+  let found = await fetch(address, {
     method: 'POST',
     url: '/',
     headers: {
@@ -1424,10 +1424,10 @@ test('Schema validation will not be bypass by different content type', async t =
     },
     body: JSON.stringify({ foo: 'string' })
   })
-  t.assert.strictEqual(correct1.status, 200)
-  await correct1.bytes()
+  t.assert.strictEqual(found.status, 200)
+  await found.bytes()
 
-  const correct2 = await fetch(address, {
+  found = await fetch(address, {
     method: 'POST',
     url: '/',
     headers: {
@@ -1435,10 +1435,10 @@ test('Schema validation will not be bypass by different content type', async t =
     },
     body: JSON.stringify({ foo: 'string' })
   })
-  t.assert.strictEqual(correct2.status, 200)
-  await correct2.bytes()
+  t.assert.strictEqual(found.status, 200)
+  await found.bytes()
 
-  const correct3 = await fetch(address, {
+  found = await fetch(address, {
     method: 'POST',
     url: '/',
     headers: {
@@ -1446,10 +1446,10 @@ test('Schema validation will not be bypass by different content type', async t =
     },
     body: JSON.stringify({ foo: 'string' })
   })
-  t.assert.strictEqual(correct2.status, 200)
-  await correct3.bytes()
+  t.assert.strictEqual(found.status, 200)
+  await found.bytes()
 
-  const invalid1 = await fetch(address, {
+  found = await fetch(address, {
     method: 'POST',
     url: '/',
     headers: {
@@ -1457,10 +1457,10 @@ test('Schema validation will not be bypass by different content type', async t =
     },
     body: JSON.stringify({ invalid: 'string' })
   })
-  t.assert.strictEqual(invalid1.status, 400)
-  t.assert.strictEqual((await invalid1.json()).code, 'FST_ERR_VALIDATION')
+  t.assert.strictEqual(found.status, 400)
+  t.assert.strictEqual((await found.json()).code, 'FST_ERR_VALIDATION')
 
-  const invalid2 = await fetch(address, {
+  found = await fetch(address, {
     method: 'POST',
     url: '/',
     headers: {
@@ -1468,10 +1468,10 @@ test('Schema validation will not be bypass by different content type', async t =
     },
     body: JSON.stringify({ invalid: 'string' })
   })
-  t.assert.strictEqual(invalid2.status, 400)
-  t.assert.strictEqual((await invalid2.json()).code, 'FST_ERR_VALIDATION')
+  t.assert.strictEqual(found.status, 400)
+  t.assert.strictEqual((await found.json()).code, 'FST_ERR_VALIDATION')
 
-  const invalid3 = await fetch(address, {
+  found = await fetch(address, {
     method: 'POST',
     url: '/',
     headers: {
@@ -1479,10 +1479,10 @@ test('Schema validation will not be bypass by different content type', async t =
     },
     body: JSON.stringify({ invalid: 'string' })
   })
-  t.assert.strictEqual(invalid3.status, 400)
-  t.assert.strictEqual((await invalid3.json()).code, 'FST_ERR_VALIDATION')
+  t.assert.strictEqual(found.status, 400)
+  t.assert.strictEqual((await found.json()).code, 'FST_ERR_VALIDATION')
 
-  const invalid4 = await fetch(address, {
+  found = await fetch(address, {
     method: 'POST',
     url: '/',
     headers: {
@@ -1490,10 +1490,10 @@ test('Schema validation will not be bypass by different content type', async t =
     },
     body: JSON.stringify({ invalid: 'string' })
   })
-  t.assert.strictEqual(invalid4.status, 400)
-  t.assert.strictEqual((await invalid4.json()).code, 'FST_ERR_VALIDATION')
+  t.assert.strictEqual(found.status, 415)
+  t.assert.strictEqual((await found.json()).code, 'FST_ERR_CTP_INVALID_MEDIA_TYPE')
 
-  const invalid5 = await fetch(address, {
+  found = await fetch(address, {
     method: 'POST',
     url: '/',
     headers: {
@@ -1501,10 +1501,10 @@ test('Schema validation will not be bypass by different content type', async t =
     },
     body: JSON.stringify({ invalid: 'string' })
   })
-  t.assert.strictEqual(invalid5.status, 400)
-  t.assert.strictEqual((await invalid5.json()).code, 'FST_ERR_VALIDATION')
+  t.assert.strictEqual(found.status, 415)
+  t.assert.strictEqual((await found.json()).code, 'FST_ERR_CTP_INVALID_MEDIA_TYPE')
 
-  const invalid6 = await fetch(address, {
+  found = await fetch(address, {
     method: 'POST',
     url: '/',
     headers: {
@@ -1512,10 +1512,10 @@ test('Schema validation will not be bypass by different content type', async t =
     },
     body: JSON.stringify({ invalid: 'string' })
   })
-  t.assert.strictEqual(invalid6.status, 400)
-  t.assert.strictEqual((await invalid6.json()).code, 'FST_ERR_VALIDATION')
+  t.assert.strictEqual(found.status, 415)
+  t.assert.strictEqual((await found.json()).code, 'FST_ERR_CTP_INVALID_MEDIA_TYPE')
 
-  const invalid7 = await fetch(address, {
+  found = await fetch(address, {
     method: 'POST',
     url: '/',
     headers: {
@@ -1523,10 +1523,10 @@ test('Schema validation will not be bypass by different content type', async t =
     },
     body: JSON.stringify({ invalid: 'string' })
   })
-  t.assert.strictEqual(invalid7.status, 400)
-  t.assert.strictEqual((await invalid7.json()).code, 'FST_ERR_VALIDATION')
+  t.assert.strictEqual(found.status, 400)
+  t.assert.strictEqual((await found.json()).code, 'FST_ERR_VALIDATION')
 
-  const invalid8 = await fetch(address, {
+  found = await fetch(address, {
     method: 'POST',
     url: '/',
     headers: {
@@ -1534,6 +1534,39 @@ test('Schema validation will not be bypass by different content type', async t =
     },
     body: JSON.stringify({ invalid: 'string' })
   })
-  t.assert.strictEqual(invalid8.status, 400)
-  t.assert.strictEqual((await invalid8.json()).code, 'FST_ERR_VALIDATION')
+  t.assert.strictEqual(found.status, 400)
+  t.assert.strictEqual((await found.json()).code, 'FST_ERR_VALIDATION')
+
+  found = await fetch(address, {
+    method: 'POST',
+    url: '/',
+    headers: {
+      'content-type': 'ApPlIcAtIoN/JsOn\ta'
+    },
+    body: JSON.stringify({ invalid: 'string' })
+  })
+  t.assert.strictEqual(found.status, 415)
+  t.assert.strictEqual((await found.json()).code, 'FST_ERR_CTP_INVALID_MEDIA_TYPE')
+
+  found = await fetch(address, {
+    method: 'POST',
+    url: '/',
+    headers: {
+      'content-type': 'ApPlIcAtIoN/JsOn\ta; charset=utf-8'
+    },
+    body: JSON.stringify({ invalid: 'string' })
+  })
+  t.assert.strictEqual(found.status, 415)
+  t.assert.strictEqual((await found.json()).code, 'FST_ERR_CTP_INVALID_MEDIA_TYPE')
+
+  found = await fetch(address, {
+    method: 'POST',
+    url: '/',
+    headers: {
+      'content-type': 'application/ json'
+    },
+    body: JSON.stringify({ invalid: 'string' })
+  })
+  t.assert.strictEqual(found.status, 415)
+  t.assert.strictEqual((await found.json()).code, 'FST_ERR_CTP_INVALID_MEDIA_TYPE')
 })


### PR DESCRIPTION
Resolves #6332.

This is a follow-on from #6303. This introduces a more robust content-type header value parsing algorithm.

***IMPORTANT:*** this results in much stricter content-type handling. Prior to this PR, we were accepting, and handling, headers like `content-type: a-simple-string`. That is not valid. There must be a type **and** a subtype present. So a "valid" form would be `content-type: a-simple-string/foo`.

This change _also_ enforces normalization of the content-type value. For example, if the request has `application/json; charset=utf-8` as the value, it will be normalized to `application/json; charset="utf-8"`.