### PR TITLE
chore: fix type test

### DIFF
--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -65,12 +65,12 @@ expectType<
 >(fastify({ http2: true, https: {}, http2SessionTimeout: 1000 }))
 expectType<LightMyRequestChain>(fastify({ http2: true, https: {} }).inject())
 expectType<
-  FastifyInstance<https.Server, http.IncomingMessage, http.ServerResponse> &
-  SafePromiseLike<FastifyInstance<https.Server, http.IncomingMessage, http.ServerResponse>>
+  FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse> &
+  SafePromiseLike<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>>
 >(fastify({ schemaController: {} }))
 expectType<
-  FastifyInstance<https.Server, http.IncomingMessage, http.ServerResponse> &
-  SafePromiseLike<FastifyInstance<https.Server, http.IncomingMessage, http.ServerResponse>>
+  FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse> &
+  SafePromiseLike<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>>
 >(
   fastify({
     schemaController: {


### PR DESCRIPTION
This is only a tiny change in one of the type tests. I was playing with different testing tools and noticed that this particular test is only passing using `tsd` (both `expect-type` and `tstyche` report an error). After this change, the test is still passing using `tsd` and the other tools do not report an error anymore. Must be a bug in `tsd`, because the same test is also passing with negated `expectNotType()`. These are huge typings, so I will not investigate.

By the way, I bump into this issue while trying out new implementation of TSTyche which does not patch TypeScript any more (reference: https://github.com/fastify/fastify/issues/6033#issuecomment-3000079012). It is still fresh and most likely has defects. So far all works very well with `fastify` type tests. 

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
