### PR TITLE
fix: use JSON.stringify in onBadUrl for proper escaping

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -647,10 +647,15 @@ function fastify (serverOptions) {
 
       return options.frameworkErrors(new FST_ERR_BAD_URL(path), request, reply)
     }
-    const body = `{"error":"Bad Request","code":"FST_ERR_BAD_URL","message":"'${path}' is not a valid url component","statusCode":400}`
+    const body = JSON.stringify({
+      error: 'Bad Request',
+      code: 'FST_ERR_BAD_URL',
+      message: `'${path}' is not a valid url component`,
+      statusCode: 400
+    })
     res.writeHead(400, {
       'Content-Type': 'application/json',
-      'Content-Length': body.length
+      'Content-Length': Buffer.byteLength(body)
     })
     res.end(body)
   }

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -1845,6 +1845,26 @@ test('400 in case of bad url (pre find-my-way v2.2.0 was a 404)', async t => {
       done()
     })
   })
+
+  await t.test('Bad URL with special characters should be properly JSON escaped', (t, done) => {
+    t.plan(3)
+    const fastify = Fastify()
+    fastify.get('/hello/:id', () => t.assert.fail('we should not be here'))
+    fastify.inject({
+      url: '/hello/%world%22test',
+      method: 'GET'
+    }, (err, response) => {
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 400)
+      t.assert.deepStrictEqual(JSON.parse(response.payload), {
+        error: 'Bad Request',
+        message: '\'/hello/%world%22test\' is not a valid url component',
+        statusCode: 400,
+        code: 'FST_ERR_BAD_URL'
+      })
+      done()
+    })
+  })
 })
 
 test('setNotFoundHandler should be chaining fastify instance', async t => {


### PR DESCRIPTION
## Summary
- Use `JSON.stringify` to properly escape special characters in the bad URL path instead of template string interpolation
- Use `Buffer.byteLength` for accurate Content-Length calculation with multi-byte characters
- Add test case to verify JSON escaping works correctly

## Test plan
- [x] Added test case for bad URL with special characters that need JSON escaping
- [x] Existing tests pass