### PR TITLE
docs: add React 18 streaming example using reply.hijack

### DIFF
--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -981,7 +981,8 @@ For more details, see:
 ## React 18 Streaming Example
 
 React 18 introduces `renderToPipeableStream` for server-side streaming.  
-Fastify requires `reply.hijack()` to allow streaming without prematurely locking headers or status codes.
+Fastify requires `reply.hijack()` to allow streaming  
+without prematurely locking headers or status codes.
 
 ```js
 import Fastify from 'fastify'


### PR DESCRIPTION
This PR adds a React 18 server-side streaming example using renderToPipeableStream.

- Demonstrates correct use of `reply.hijack()` to stream React content without locking headers prematurely.
- Warns against using `reply.raw.write('')` which causes early response start.
- Shows how to set UTF-8 encoding for correct emoji rendering.
- References issue #6358 for context.

No changes to Fastify core behavior.


#### Checklist

- [ ✔️] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [✔️ ] documentation is changed or added
- [ ✔️] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
