### PR TITLE
test: fix test when localhost has multiple addresses

### DIFF
--- a/test/listen.1.test.js
+++ b/test/listen.1.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { networkInterfaces } = require('node:os')
 const { test, before } = require('node:test')
 const Fastify = require('..')
 const helper = require('./helper')
@@ -41,7 +42,14 @@ test('Async/await listen with arguments', async t => {
   })
   const addr = await fastify.listen({ port: 0, host: '0.0.0.0' })
   const address = fastify.server.address()
-  t.assert.strictEqual(addr, `http://127.0.0.1:${address.port}`)
+  const { protocol, hostname, port, pathname } = new URL(addr)
+  t.assert.strictEqual(protocol, 'http:')
+  t.assert.ok(Object.values(networkInterfaces())
+    .flat()
+    .filter(({ internal }) => internal)
+    .some(({ address }) => address === hostname))
+  t.assert.strictEqual(pathname, '/')
+  t.assert.strictEqual(Number(port), address.port)
   t.assert.deepEqual(address, {
     address: '0.0.0.0',
     family: 'IPv4',


### PR DESCRIPTION
This PR assumes that sorting in algorithm introduced in https://github.com/fastify/fastify/pull/5476 works as intended, and `fastify.listen({ host: '0.0.0.0' })` is *not* obligated to return `127.0.0.1` when system has other localhost addresses.

Relevant function: https://github.com/fastify/fastify/blob/5317c9068a43a02b671cd6df7392dd45a9aabaac/lib/server.js#L363-L374

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
