### PR TITLE
test: skip IPv6 test if its support is not present

### DIFF
--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,10 +1,13 @@
 'use strict'
 
 const dns = require('node:dns')
+const { networkInterfaces } = require('node:os')
 const { test } = require('node:test')
 const Fastify = require('..')
 const undici = require('undici')
 const proxyquire = require('proxyquire')
+
+const isIPv6Missing = !Object.values(networkInterfaces()).flat().some(({ family }) => family === 'IPv6')
 
 test('listen should accept null port', async t => {
   const fastify = Fastify()
@@ -81,7 +84,7 @@ test('Test for hostname and port', async (t) => {
   await fetch('http://localhost:8000/host')
 })
 
-test('Test for IPV6 port', async (t) => {
+test('Test for IPV6 port', { skip: isIPv6Missing }, async (t) => {
   t.plan(3)
   const app = Fastify()
   t.after(() => app.close())


### PR DESCRIPTION
Avoid failing with `EAFNOSUPPORT` when IPv6 is not supported.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
