### PR TITLE
docs: add anyOf nullable coercion behavior (#6411)

### DIFF
--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -329,6 +329,21 @@ server.setValidatorCompiler(req => {
 })
 ```
 
+When type coercion is enabled, using `anyOf` with nullable primitive
+types can produce unexpected results. In the example below, values
+such as `0` may be coerced to `null` because Ajv evaluates `anyOf`
+schemas in order and applies type coercion during schema matching.
+
+```json
+{
+  "anyOf": [
+    { "type": "null" },
+    { "type": "number" }
+  ]
+}
+```
+
+
 For more information, see [Ajv Coercion](https://ajv.js.org/coercion.html).
 
 #### Ajv Plugins


### PR DESCRIPTION
This PR adds a short note to the validation documentation clarifying the
interaction between `anyOf`, nullable primitive types, and AJV type coercion.

Fixes #6411

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
