### PR TITLE
docs: fix benchmarks typo and improve example code safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,14 +117,14 @@ npm i fastify
 
 // ESM
 import Fastify from 'fastify'
-
 const fastify = Fastify({
   logger: true
 })
-// CommonJs
-const fastify = require('fastify')({
-  logger: true
-})
+
+// OR CommonJs
+// const fastify = require('fastify')({
+//   logger: true
+// })
 
 // Declare a route
 fastify.get('/', (request, reply) => {


### PR DESCRIPTION
This PR introduces two improvements to the documentation:

1. **Benchmarks Section:** Fixed a formatting typo where a double colon (`__Method:__:`) caused incorrect rendering.
2. **Example Section:** Commented out the CommonJS example code block. Previously, copying the entire block caused a `SyntaxError` due to redeclaration of the `fastify` constant. Now it is safer for copy-pasting.