### PR TITLE
feat(findRoute): expose route config

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -6,7 +6,7 @@ const handleRequest = require('./handle-request.js')
 const { onRequestAbortHookRunner, lifecycleHooks, preParsingHookRunner, onTimeoutHookRunner, onRequestHookRunner } = require('./hooks')
 const { normalizeSchema } = require('./schemas')
 const { parseHeadOnSendHandlers } = require('./head-route.js')
-const cloneRouteConfig = require('rfdc')({ circles: true, proto: true })
+const deepClone = require('rfdc')({ circles: true, proto: true })
 
 const {
   compileSchemasForValidation,
@@ -189,7 +189,7 @@ function buildRouting (options) {
         searchParams: route.searchParams
       }
       if (route.store?.config) {
-        result.config = cloneRouteConfig(route.store.config)
+        result.config = deepClone(route.store.config)
       }
       return result
     } else {

--- a/lib/route.js
+++ b/lib/route.js
@@ -188,7 +188,7 @@ function buildRouting (options) {
         params: route.params,
         searchParams: route.searchParams
       }
-      if (options.cloneRouteConfig === true && route.store?.config) {
+      if (route.store?.config) {
         result.config = cloneRouteConfig(route.store.config)
       }
       return result

--- a/lib/route.js
+++ b/lib/route.js
@@ -6,6 +6,7 @@ const handleRequest = require('./handle-request.js')
 const { onRequestAbortHookRunner, lifecycleHooks, preParsingHookRunner, onTimeoutHookRunner, onRequestHookRunner } = require('./hooks')
 const { normalizeSchema } = require('./schemas')
 const { parseHeadOnSendHandlers } = require('./head-route.js')
+const cloneRouteConfig = require('rfdc')({ circles: true, proto: true })
 
 const {
   compileSchemasForValidation,
@@ -182,11 +183,15 @@ function buildRouting (options) {
       // we must reduce the expose surface, otherwise
       // we provide the ability for the user to modify
       // all the route and server information in runtime
-      return {
+      const result = {
         handler: route.handler,
         params: route.params,
         searchParams: route.searchParams
       }
+      if (options.cloneRouteConfig === true && route.store?.config) {
+        result.config = cloneRouteConfig(route.store.config)
+      }
+      return result
     } else {
       return null
     }

--- a/test/find-route.test.js
+++ b/test/find-route.test.js
@@ -151,7 +151,7 @@ test('findRoute should not expose store', t => {
   t.assert.strictEqual(route.store, undefined)
 })
 
-test('findRoute should return cloned config when cloneRouteConfig is true', t => {
+test('findRoute should return cloned config', t => {
   t.plan(3)
   const fastify = Fastify()
 
@@ -162,8 +162,7 @@ test('findRoute should return cloned config when cloneRouteConfig is true', t =>
 
   const route = fastify.findRoute({
     method: 'GET',
-    url: '/artists/123',
-    cloneRouteConfig: true
+    url: '/artists/123'
   })
 
   t.assert.ok(route.config)
@@ -173,24 +172,7 @@ test('findRoute should return cloned config when cloneRouteConfig is true', t =>
   route.config.customOption = 'modified'
   const route2 = fastify.findRoute({
     method: 'GET',
-    url: '/artists/456',
-    cloneRouteConfig: true
+    url: '/artists/456'
   })
   t.assert.strictEqual(route2.config.customOption, 'value')
-})
-
-test('findRoute should not return config when cloneRouteConfig is false or not set', t => {
-  t.plan(2)
-  const fastify = Fastify()
-
-  fastify.get('/test', {
-    config: { foo: 'bar' },
-    handler: (req, reply) => reply.send('ok')
-  })
-
-  const route1 = fastify.findRoute({ method: 'GET', url: '/test' })
-  t.assert.strictEqual(route1.config, undefined)
-
-  const route2 = fastify.findRoute({ method: 'GET', url: '/test', cloneRouteConfig: false })
-  t.assert.strictEqual(route2.config, undefined)
 })

--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -4,7 +4,7 @@ import { expectAssignable, expectError, expectType } from 'tsd'
 import fastify, { FastifyInstance, FastifyReply, FastifyRequest, RouteHandlerMethod } from '../../fastify'
 import { RequestPayload } from '../../types/hooks'
 import { FindMyWayFindResult } from '../../types/instance'
-import { HTTPMethods, RawServerDefault } from '../../types/utils'
+import { ContextConfigDefault, HTTPMethods, RawServerDefault } from '../../types/utils'
 
 /*
  * Testing Fastify HTTP Routes and Route Shorthands.
@@ -503,7 +503,7 @@ expectType<boolean>(fastify().hasRoute({
   }
 }))
 
-expectType<Omit<FindMyWayFindResult<RawServerDefault>, 'store'>>(
+expectType<Omit<FindMyWayFindResult<RawServerDefault>, 'store'> & { config?: ContextConfigDefault } | null>(
   fastify().findRoute({
     url: '/',
     method: 'get'
@@ -511,10 +511,13 @@ expectType<Omit<FindMyWayFindResult<RawServerDefault>, 'store'>>(
 )
 
 // we should not expose store
-expectError(fastify().findRoute({
+const foundRoute = fastify().findRoute({
   url: '/',
   method: 'get'
-}).store)
+})
+if (foundRoute) {
+  expectError(foundRoute.store)
+}
 
 expectType<FastifyInstance>(fastify().route({
   url: '/',

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -214,7 +214,7 @@ export interface FastifyInstance<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
     ContextConfig = ContextConfigDefault,
     SchemaCompiler extends FastifySchema = FastifySchema
-  >(opts: Pick<RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>, 'method' | 'url' | 'constraints'>): Omit<FindMyWayFindResult<RawServer>, 'store'>;
+  >(opts: Pick<RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>, 'method' | 'url' | 'constraints'> & { cloneRouteConfig?: boolean }): Omit<FindMyWayFindResult<RawServer>, 'store'> & { config?: ContextConfig } | null;
 
   // addHook: overloads
 

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -214,7 +214,7 @@ export interface FastifyInstance<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
     ContextConfig = ContextConfigDefault,
     SchemaCompiler extends FastifySchema = FastifySchema
-  >(opts: Pick<RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>, 'method' | 'url' | 'constraints'> & { cloneRouteConfig?: boolean }): Omit<FindMyWayFindResult<RawServer>, 'store'> & { config?: ContextConfig } | null;
+  >(opts: Pick<RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>, 'method' | 'url' | 'constraints'>): Omit<FindMyWayFindResult<RawServer>, 'store'> & { config?: ContextConfig } | null;
 
   // addHook: overloads
 


### PR DESCRIPTION
## Summary

Expose the route's `config` on `findRoute()` results.

`findRoute()` now returns a deep clone of `route.store.config` (when present) as `result.config`, so callers can read route-level configuration without exposing `route.store`.

This helps plugins like @fastify/cors during preflight requests, where `req.routeOptions.config` refers to the wildcard OPTIONS route.

## Changes

- `findRoute()` now includes `config` on the returned object (deep-cloned via `rfdc`, already a Fastify dependency)
- Keep the existing "do not expose store" contract
- Fix TypeScript return type to include `| null`
- Add tests for the new behaviour

## Usage

```js
const route = fastify.findRoute({ method: 'GET', url: '/users/123' })

if (route) {
  console.log(route.config)
}
```

## Motivation

Fixes: fastify/fastify-cors#389

Route-level CORS configuration doesn't work with preflight requests because OPTIONS requests are handled by a wildcard route (`OPTIONS *`), so `req.routeOptions.config` refers to the wildcard route, not the target route.

With this change, @fastify/cors can look up the target route's config during preflight handling.

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
