### PR TITLE
perf: use native WebStream API instead of Readable.fromWeb wrapper

### DIFF
--- a/examples/benchmark/webstream.js
+++ b/examples/benchmark/webstream.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const fastify = require('../../fastify')({
+  logger: false
+})
+
+const payload = JSON.stringify({ hello: 'world' })
+
+fastify.get('/', function (req, reply) {
+  const stream = new ReadableStream({
+    start (controller) {
+      controller.enqueue(payload)
+      controller.close()
+    }
+  })
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      'content-type': 'application/json; charset=utf-8'
+    }
+  })
+})
+
+fastify.listen({ port: 3000 }, (err, address) => {
+  if (err) throw err
+  console.log(`Server listening on ${address}`)
+})

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const eos = require('node:stream').finished
-const Readable = require('node:stream').Readable
 
 const {
   kFourOhFourContext,
@@ -685,8 +684,59 @@ function sendWebStream (payload, res, reply) {
   if (payload.locked) {
     throw new FST_ERR_REP_READABLE_STREAM_LOCKED()
   }
-  const nodeStream = Readable.fromWeb(payload)
-  sendStream(nodeStream, res, reply)
+
+  let sourceOpen = true
+  let errorLogged = false
+  const reader = payload.getReader()
+
+  eos(res, function (err) {
+    if (sourceOpen) {
+      if (err != null && res.headersSent && !errorLogged) {
+        errorLogged = true
+        logStreamError(reply.log, err, res)
+      }
+      reader.cancel().catch(noop)
+    }
+  })
+
+  if (!res.headersSent) {
+    for (const key in reply[kReplyHeaders]) {
+      res.setHeader(key, reply[kReplyHeaders][key])
+    }
+  } else {
+    reply.log.warn('response will send, but you shouldn\'t use res.writeHead in stream mode')
+  }
+
+  function onRead (result) {
+    if (result.done) {
+      sourceOpen = false
+      sendTrailer(null, res, reply)
+      return
+    }
+    /* c8 ignore next 5 - race condition: eos handler typically fires first */
+    if (res.destroyed) {
+      sourceOpen = false
+      reader.cancel().catch(noop)
+      return
+    }
+    res.write(result.value)
+    reader.read().then(onRead, onReadError)
+  }
+
+  function onReadError (err) {
+    sourceOpen = false
+    if (res.headersSent || reply.request.raw.aborted === true) {
+      if (!errorLogged) {
+        errorLogged = true
+        logStreamError(reply.log, err, reply)
+      }
+      res.destroy()
+    } else {
+      onErrorHook(reply, err)
+    }
+  }
+
+  reader.read().then(onRead, onReadError)
 }
 
 function sendStream (payload, res, reply) {

--- a/test/web-api.test.js
+++ b/test/web-api.test.js
@@ -330,3 +330,140 @@ test('allow to pipe with undici.fetch', async (t) => {
   t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.json(), { ok: true })
 })
+
+test('WebStream error before headers sent should trigger error handler', async (t) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  fastify.get('/', function (request, reply) {
+    const stream = new ReadableStream({
+      start (controller) {
+        controller.error(new Error('stream error'))
+      }
+    })
+    reply.send(stream)
+  })
+
+  const response = await fastify.inject({ method: 'GET', path: '/' })
+
+  t.assert.strictEqual(response.statusCode, 500)
+  t.assert.strictEqual(response.json().message, 'stream error')
+})
+
+test('WebStream error after headers sent should destroy response', (t, done) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.get('/', function (request, reply) {
+    const stream = new ReadableStream({
+      start (controller) {
+        controller.enqueue('hello')
+      },
+      pull (controller) {
+        setTimeout(() => {
+          controller.error(new Error('stream error'))
+        }, 10)
+      }
+    })
+    reply.header('content-type', 'text/plain').send(stream)
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.assert.ifError(err)
+
+    const http = require('node:http')
+    let finished = false
+    http.get(`http://localhost:${fastify.server.address().port}`, (res) => {
+      res.on('close', () => {
+        if (!finished) {
+          finished = true
+          t.assert.ok('response closed')
+          done()
+        }
+      })
+      res.resume()
+    })
+  })
+})
+
+test('WebStream should cancel reader when response is destroyed', (t, done) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  let readerCancelled = false
+
+  fastify.get('/', function (request, reply) {
+    const stream = new ReadableStream({
+      start (controller) {
+        controller.enqueue('hello')
+      },
+      pull (controller) {
+        return new Promise(() => {})
+      },
+      cancel () {
+        readerCancelled = true
+      }
+    })
+    reply.header('content-type', 'text/plain').send(stream)
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.assert.ifError(err)
+
+    const http = require('node:http')
+    const req = http.get(`http://localhost:${fastify.server.address().port}`, (res) => {
+      res.once('data', () => {
+        req.destroy()
+        setTimeout(() => {
+          t.assert.strictEqual(readerCancelled, true)
+          done()
+        }, 50)
+      })
+    })
+  })
+})
+
+test('WebStream should warn when headers already sent', async (t) => {
+  t.plan(2)
+
+  let warnCalled = false
+  const spyLogger = {
+    level: 'warn',
+    fatal: () => { },
+    error: () => { },
+    warn: (msg) => {
+      if (typeof msg === 'string' && msg.includes('writeHead')) {
+        warnCalled = true
+      }
+    },
+    info: () => { },
+    debug: () => { },
+    trace: () => { },
+    child: () => spyLogger
+  }
+
+  const fastify = Fastify({ loggerInstance: spyLogger })
+  t.after(() => fastify.close())
+
+  fastify.get('/', function (request, reply) {
+    reply.raw.writeHead(200, { 'content-type': 'text/plain' })
+    const stream = new ReadableStream({
+      start (controller) {
+        controller.enqueue('hello')
+        controller.close()
+      }
+    })
+    reply.send(stream)
+  })
+
+  await fastify.listen({ port: 0 })
+
+  const response = await fetch(`http://localhost:${fastify.server.address().port}/`)
+  t.assert.strictEqual(response.status, 200)
+  t.assert.strictEqual(warnCalled, true)
+})

--- a/test/web-api.test.js
+++ b/test/web-api.test.js
@@ -5,6 +5,7 @@ const Fastify = require('../fastify')
 const fs = require('node:fs')
 const { Readable } = require('node:stream')
 const { fetch: undiciFetch } = require('undici')
+const http = require('node:http')
 
 test('should response with a ReadableStream', async (t) => {
   t.plan(2)
@@ -374,7 +375,6 @@ test('WebStream error after headers sent should destroy response', (t, done) => 
   fastify.listen({ port: 0 }, err => {
     t.assert.ifError(err)
 
-    const http = require('node:http')
     let finished = false
     http.get(`http://localhost:${fastify.server.address().port}`, (res) => {
       res.on('close', () => {
@@ -415,7 +415,6 @@ test('WebStream should cancel reader when response is destroyed', (t, done) => {
   fastify.listen({ port: 0 }, err => {
     t.assert.ifError(err)
 
-    const http = require('node:http')
     const req = http.get(`http://localhost:${fastify.server.address().port}`, (res) => {
       res.once('data', () => {
         req.destroy()
@@ -437,7 +436,7 @@ test('WebStream should warn when headers already sent', async (t) => {
     fatal: () => { },
     error: () => { },
     warn: (msg) => {
-      if (typeof msg === 'string' && msg.includes('writeHead')) {
+      if (typeof msg === 'string' && msg.includes('use res.writeHead in stream mode')) {
         warnCalled = true
       }
     },


### PR DESCRIPTION
## Summary

- Remove Node.js stream wrapping overhead by using the WebStream reader API directly
- Provides ~20% throughput improvement when returning `Response` objects or `ReadableStream` from route handlers
- Add benchmark for WebStream performance testing
- Add tests for WebStream error handling paths

## Benchmark Results

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Req/sec | 26,931 | 32,335 | **+20%** |
| Latency (avg) | 36.6 ms | 30.4 ms | **-17%** |

## Changes

- `lib/reply.js`: Rewrote `sendWebStream()` to use `reader.getReader()` and `reader.read()` directly instead of `Readable.fromWeb()`
- `examples/benchmark/webstream.js`: New benchmark file for WebStream performance testing
- `test/web-api.test.js`: Added tests for error handling paths (stream errors before/after headers sent, headers already sent warning)

## Test plan

- [x] All existing tests pass
- [x] New error handling tests added
- [x] 100% code coverage for reply.js
- [x] Benchmark verified ~20% improvement