### PR TITLE
feat: add Web Standard API routes (fastify.web.*)

### DIFF
--- a/docs/Reference/Warnings.md
+++ b/docs/Reference/Warnings.md
@@ -9,14 +9,17 @@
     - [FSTWRN002](#FSTWRN002)
   - [Fastify Deprecation Codes](#fastify-deprecation-codes)
     - [FSTDEP022](#FSTDEP022)
+  - [Fastify Experimental Codes](#fastify-experimental-codes)
+    - [FSTEXP001](#FSTEXP001)
 
 ## Warnings
 
 ### Warnings In Fastify
 
 Fastify uses Node.js's [warning event](https://nodejs.org/api/process.html#event-warning)
-API to notify users of deprecated features and coding mistakes. Fastify's
-warnings are recognizable by the `FSTWRN` and `FSTDEP` prefixes. When
+API to notify users of deprecated features, coding mistakes, and experimental
+features. Fastify's warnings are recognizable by the `FSTWRN`, `FSTDEP`, and
+`FSTEXP` prefixes. When
 encountering such a warning, it is highly recommended to determine the cause
 using the [`--trace-warnings`](https://nodejs.org/api/cli.html#--trace-warnings)
 and [`--trace-deprecation`](https://nodejs.org/api/cli.html#--trace-deprecation)
@@ -56,3 +59,13 @@ Deprecation codes are supported by the Node.js CLI options:
 | Code | Description | How to solve | Discussion |
 | ---- | ----------- | ------------ | ---------- |
 | <a id="FSTDEP022">FSTDEP022</a> | You are trying to access the deprecated router options on top option properties. | Use `options.routerOptions`. | [#5985](https://github.com/fastify/fastify/pull/5985)
+
+
+### Fastify Experimental Codes
+
+Experimental codes indicate features that are not yet stable and may change
+or be removed in future versions without following semver.
+
+| Code | Description | How to solve | Discussion |
+| ---- | ----------- | ------------ | ---------- |
+| <a id="FSTEXP001">FSTEXP001</a> | Web Standard API routes (`fastify.web.*`) are experimental and subject to change without notice. | This is informational. The API may change in future releases. | -

--- a/fastify.js
+++ b/fastify.js
@@ -339,6 +339,38 @@ function fastify (serverOptions) {
           ...this[kSupportedHTTPMethods].bodywith
         ]
       }
+    },
+    web: {
+      configurable: true,
+      get () {
+        const instance = this
+        return {
+          delete (url, options, handler) {
+            return router.prepareWebRoute.call(instance, { method: 'DELETE', url, options, handler })
+          },
+          get (url, options, handler) {
+            return router.prepareWebRoute.call(instance, { method: 'GET', url, options, handler })
+          },
+          head (url, options, handler) {
+            return router.prepareWebRoute.call(instance, { method: 'HEAD', url, options, handler })
+          },
+          trace (url, options, handler) {
+            return router.prepareWebRoute.call(instance, { method: 'TRACE', url, options, handler })
+          },
+          patch (url, options, handler) {
+            return router.prepareWebRoute.call(instance, { method: 'PATCH', url, options, handler })
+          },
+          post (url, options, handler) {
+            return router.prepareWebRoute.call(instance, { method: 'POST', url, options, handler })
+          },
+          put (url, options, handler) {
+            return router.prepareWebRoute.call(instance, { method: 'PUT', url, options, handler })
+          },
+          options (url, options, handler) {
+            return router.prepareWebRoute.call(instance, { method: 'OPTIONS', url, options, handler })
+          }
+        }
+      }
     }
   })
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -51,7 +51,8 @@ const {
 const { buildErrorHandler } = require('./error-handler')
 const { createChildLogger } = require('./logger-factory.js')
 const { getGenReqId } = require('./req-id-gen-factory.js')
-const { FSTDEP022 } = require('./warnings')
+const { FSTDEP022, FSTEXP001 } = require('./warnings')
+const { WebContext, buildWebRouteHandler } = require('./web-handler.js')
 
 const routerKeys = [
   'allowUnsafeRegex',
@@ -86,6 +87,10 @@ function buildRouting (options) {
 
   let closing = false
 
+  // Web route handler (lazy initialized in setup)
+  let webRouteHandlerFn
+  let closeWebRoutes
+
   return {
     /**
      * @param {import('../fastify').FastifyServerOptions} options
@@ -109,13 +114,30 @@ function buildRouting (options) {
       ignoreDuplicateSlashes = options.routerOptions.ignoreDuplicateSlashes
       return503OnClosing = Object.hasOwn(options, 'return503OnClosing') ? options.return503OnClosing : true
       keepAliveConnections = fastifyArgs.keepAliveConnections
+
+      // Initialize web route handler
+      const webHandlerResult = buildWebRouteHandler({
+        logger,
+        hasLogger,
+        disableRequestLogging,
+        disableRequestLoggingFn,
+        keepAliveConnections,
+        return503OnClosing,
+        setupResponseListeners
+      })
+      webRouteHandlerFn = webHandlerResult.webRouteHandler
+      closeWebRoutes = webHandlerResult.closeWebRoutes
     },
     routing: router.lookup.bind(router), // router func to find the right handler to call
     route, // configure a route in the fastify instance
     hasRoute,
     prepareRoute,
+    prepareWebRoute,
     routeHandler,
-    closeRoutes: () => { closing = true },
+    closeRoutes: () => {
+      closing = true
+      if (closeWebRoutes) closeWebRoutes()
+    },
     printRoutes: router.prettyPrint.bind(router),
     addConstraintStrategy,
     hasConstraintStrategy,
@@ -165,6 +187,138 @@ function buildRouting (options) {
     })
 
     return route.call(this, { options, isFastify })
+  }
+
+  // Convert shorthand to extended web route declaration (Web Standard API)
+  function prepareWebRoute ({ method, url, options, handler }) {
+    if (typeof url !== 'string') {
+      throw new FST_ERR_INVALID_URL(typeof url)
+    }
+
+    if (!handler && typeof options === 'function') {
+      handler = options
+      options = {}
+    } else if (handler && typeof handler === 'function') {
+      if (Object.prototype.toString.call(options) !== '[object Object]') {
+        throw new FST_ERR_ROUTE_OPTIONS_NOT_OBJ(method, url)
+      } else if (options.handler) {
+        if (typeof options.handler === 'function') {
+          throw new FST_ERR_ROUTE_DUPLICATED_HANDLER(method, url)
+        } else {
+          throw new FST_ERR_ROUTE_HANDLER_NOT_FN(method, url)
+        }
+      }
+    }
+
+    options = Object.assign({}, options, {
+      method,
+      url,
+      path: url,
+      handler: handler || (options && options.handler)
+    })
+
+    return webRoute.call(this, { options })
+  }
+
+  // Web Standard API route registration
+  function webRoute ({ options }) {
+    throwIfAlreadyStarted('Cannot add web route!')
+
+    // Emit experimental warning (only once due to unlimited: false)
+    FSTEXP001()
+
+    const opts = { ...options }
+    const path = opts.url || opts.path || ''
+
+    if (!opts.handler) {
+      throw new FST_ERR_ROUTE_MISSING_HANDLER(opts.method, path)
+    }
+
+    if (typeof opts.handler !== 'function') {
+      throw new FST_ERR_ROUTE_HANDLER_NOT_FN(opts.method, path)
+    }
+
+    if (Array.isArray(opts.method)) {
+      for (let i = 0; i < opts.method.length; ++i) {
+        opts.method[i] = normalizeAndValidateMethod.call(this, opts.method[i])
+      }
+    } else {
+      opts.method = normalizeAndValidateMethod.call(this, opts.method)
+    }
+
+    const prefix = this[kRoutePrefix]
+    const url = prefix + path
+
+    opts.url = url
+    opts.path = url
+    opts.routePath = path
+    opts.prefix = prefix
+    opts.logLevel = opts.logLevel || this[kLogLevel]
+
+    if (this[kLogSerializers] || opts.logSerializers) {
+      opts.logSerializers = Object.assign(Object.create(this[kLogSerializers]), opts.logSerializers)
+    }
+
+    const config = {
+      ...opts.config,
+      url,
+      method: opts.method
+    }
+
+    const context = new WebContext({
+      handler: opts.handler,
+      config,
+      errorHandler: opts.errorHandler,
+      logLevel: opts.logLevel,
+      logSerializers: opts.logSerializers,
+      server: this
+    })
+
+    const constraints = opts.constraints || {}
+
+    try {
+      router.on(opts.method, url, { constraints }, webRouteHandlerFn, context)
+    } catch (error) {
+      const isDuplicatedRoute = error.message.includes(`Method '${opts.method}' already declared for route`)
+      if (isDuplicatedRoute) {
+        throw new FST_ERR_DUPLICATED_ROUTE(opts.method, url)
+      }
+      throw error
+    }
+
+    // Set up hooks in after callback
+    this.after((notHandledErr, done) => {
+      context.errorHandler = opts.errorHandler
+        ? buildErrorHandler(this[kErrorHandler], opts.errorHandler)
+        : this[kErrorHandler]
+
+      avvio.once('preReady', () => {
+        // Only bind onRequest, onSend, onResponse hooks for web routes
+        const onRequestHooks = this[kHooks].onRequest
+          .concat(opts.onRequest || [])
+          .map(h => h.bind(this))
+        context.onRequest = onRequestHooks.length ? onRequestHooks : null
+
+        const onSendHooks = this[kHooks].onSend
+          .concat(opts.onSend || [])
+          .map(h => h.bind(this))
+        context.onSend = onSendHooks.length ? onSendHooks : null
+
+        const onResponseHooks = this[kHooks].onResponse
+          .concat(opts.onResponse || [])
+          .map(h => h.bind(this))
+        context.onResponse = onResponseHooks.length ? onResponseHooks : null
+
+        const onErrorHooks = this[kHooks].onError
+          .concat(opts.onError || [])
+          .map(h => h.bind(this))
+        context.onError = onErrorHooks.length ? onErrorHooks : null
+      })
+
+      done(notHandledErr)
+    })
+
+    return this
   }
 
   function hasRoute ({ options }) {

--- a/lib/route.js
+++ b/lib/route.js
@@ -238,10 +238,12 @@ function buildRouting (options) {
       throw new FST_ERR_ROUTE_HANDLER_NOT_FN(opts.method, path)
     }
 
+    /* c8 ignore start */
     if (Array.isArray(opts.method)) {
       for (let i = 0; i < opts.method.length; ++i) {
         opts.method[i] = normalizeAndValidateMethod.call(this, opts.method[i])
       }
+    /* c8 ignore stop */
     } else {
       opts.method = normalizeAndValidateMethod.call(this, opts.method)
     }
@@ -283,6 +285,7 @@ function buildRouting (options) {
       if (isDuplicatedRoute) {
         throw new FST_ERR_DUPLICATED_ROUTE(opts.method, url)
       }
+      /* c8 ignore next 2 */
       throw error
     }
 

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -61,7 +61,9 @@ const keys = {
   kChildLoggerFactory: Symbol('fastify.childLoggerFactory'),
   kHasBeenDecorated: Symbol('fastify.hasBeenDecorated'),
   kKeepAliveConnections: Symbol('fastify.keepAliveConnections'),
-  kRouteByFastify: Symbol('fastify.routeByFastify')
+  kRouteByFastify: Symbol('fastify.routeByFastify'),
+  // Web Standard API
+  kWebRoute: Symbol('fastify.webRoute')
 }
 
 module.exports = keys

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -3,14 +3,15 @@
 const { createWarning } = require('process-warning')
 
 /**
- * Deprecation codes:
- *   - FSTWRN001
- *   - FSTSEC001
- *   - FSTDEP022
+ * Warning codes:
+ *   - FSTWRN001, FSTWRN003, FSTWRN004 (general warnings)
+ *   - FSTSEC001 (security warnings)
+ *   - FSTDEP022 (deprecation warnings)
+ *   - FSTEXP001 (experimental feature warnings)
  *
- * Deprecation Codes FSTDEP001 - FSTDEP021 were used by v4 and MUST NOT not be reused.
+ * Deprecation Codes FSTDEP001 - FSTDEP021 were used by v4 and MUST NOT be reused.
  *                             - FSTDEP022 is used by v5 and MUST NOT be reused.
- * Warning Codes FSTWRN001 - FSTWRN002 were used by v4 and MUST NOT not be reused.
+ * Warning Codes FSTWRN001 - FSTWRN002 were used by v4 and MUST NOT be reused.
  */
 
 const FSTWRN001 = createWarning({
@@ -48,10 +49,18 @@ const FSTDEP022 = createWarning({
   unlimited: true
 })
 
+const FSTEXP001 = createWarning({
+  name: 'FastifyWarning',
+  code: 'FSTEXP001',
+  message: 'Web Standard API routes (fastify.web.*) are experimental and subject to change without notice.',
+  unlimited: false
+})
+
 module.exports = {
   FSTWRN001,
   FSTWRN003,
   FSTWRN004,
   FSTSEC001,
-  FSTDEP022
+  FSTDEP022,
+  FSTEXP001
 }

--- a/lib/web-handler.js
+++ b/lib/web-handler.js
@@ -1,0 +1,288 @@
+'use strict'
+
+const { Readable } = require('node:stream')
+const { onRequestHookRunner, onSendHookRunner, onResponseHookRunner } = require('./hooks')
+const { getGenReqId } = require('./req-id-gen-factory.js')
+const { createChildLogger } = require('./logger-factory.js')
+
+const {
+  kReply,
+  kRequest,
+  kErrorHandler,
+  kBodyLimit,
+  kLogLevel,
+  kChildLoggerFactory,
+  kReplyIsError,
+  kDisableRequestLogging,
+  kRequestAcceptVersion,
+  kWebRoute
+} = require('./symbols.js')
+
+function WebContext ({
+  handler,
+  config,
+  errorHandler,
+  logLevel,
+  logSerializers,
+  server
+}) {
+  this.handler = handler
+  this.config = config
+  this.Reply = server[kReply]
+  this.Request = server[kRequest]
+  this.onRequest = null
+  this.onSend = null
+  this.onResponse = null
+  this.onError = null
+  this.logLevel = logLevel || server[kLogLevel]
+  this.logSerializers = logSerializers
+  this.errorHandler = errorHandler || server[kErrorHandler]
+  this.childLoggerFactory = server[kChildLoggerFactory]
+  this.server = server
+  this[kWebRoute] = true
+  this._parserOptions = {
+    limit: server[kBodyLimit]
+  }
+}
+
+function createWebRequest (req, protocol, host) {
+  const url = new URL(req.url, `${protocol}://${host}`)
+  const headers = new Headers()
+
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (value !== undefined) {
+      if (Array.isArray(value)) {
+        for (const v of value) {
+          headers.append(key, v)
+        }
+      } else {
+        headers.set(key, value)
+      }
+    }
+  }
+
+  const init = {
+    method: req.method,
+    headers
+  }
+
+  // Only add body for methods that may have one
+  if (req.method !== 'GET' && req.method !== 'HEAD' && req.method !== 'TRACE') {
+    init.body = Readable.toWeb(req)
+    init.duplex = 'half'
+  }
+
+  return new Request(url, init)
+}
+
+async function sendWebResponse (res, webResponse) {
+  res.statusCode = webResponse.status
+
+  for (const [name, value] of webResponse.headers) {
+    // Handle multiple values for same header (like Set-Cookie)
+    const existing = res.getHeader(name)
+    if (existing !== undefined) {
+      res.setHeader(name, [].concat(existing, value))
+    } else {
+      res.setHeader(name, value)
+    }
+  }
+
+  if (webResponse.body === null) {
+    res.end()
+    return
+  }
+
+  const reader = webResponse.body.getReader()
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      res.write(value)
+    }
+  } finally {
+    reader.releaseLock()
+    res.end()
+  }
+}
+
+function buildWebRouteHandler (options) {
+  const {
+    logger,
+    hasLogger,
+    disableRequestLogging,
+    disableRequestLoggingFn,
+    keepAliveConnections,
+    return503OnClosing,
+    setupResponseListeners
+  } = options
+
+  let closing = false
+
+  function closeWebRoutes () {
+    closing = true
+  }
+
+  function webRouteHandler (req, res, params, context, query) {
+    const id = getGenReqId(context.server, req)
+
+    const loggerOpts = {
+      level: context.logLevel
+    }
+
+    if (context.logSerializers) {
+      loggerOpts.serializers = context.logSerializers
+    }
+
+    const childLogger = createChildLogger(context, logger, req, id, loggerOpts)
+    childLogger[kDisableRequestLogging] = disableRequestLoggingFn ? false : disableRequestLogging
+
+    if (closing === true) {
+      if (req.httpVersionMajor !== 2) {
+        res.setHeader('Connection', 'close')
+      }
+
+      if (return503OnClosing) {
+        const headers = {
+          'Content-Type': 'application/json',
+          'Content-Length': '80'
+        }
+        res.writeHead(503, headers)
+        res.end('{"error":"Service Unavailable","message":"Service Unavailable","statusCode":503}')
+        childLogger.info({ res: { statusCode: 503 } }, 'request aborted - refusing to accept new requests as server is closing')
+        return
+      }
+    }
+
+    const connHeader = String.prototype.toLowerCase.call(req.headers.connection || '')
+    if (connHeader === 'keep-alive') {
+      if (keepAliveConnections.has(req.socket) === false) {
+        keepAliveConnections.add(req.socket)
+        req.socket.on('close', function removeTrackedSocket () {
+          keepAliveConnections.delete(req.socket)
+        })
+      }
+    }
+
+    if (req.headers[kRequestAcceptVersion] !== undefined) {
+      req.headers['accept-version'] = req.headers[kRequestAcceptVersion]
+      req.headers[kRequestAcceptVersion] = undefined
+    }
+
+    // Create minimal FastifyRequest/Reply for hooks
+    const request = new context.Request(id, params, req, query, childLogger, context)
+    const reply = new context.Reply(res, request, childLogger)
+
+    const resolvedDisableRequestLogging = disableRequestLoggingFn
+      ? disableRequestLoggingFn(request)
+      : disableRequestLogging
+    childLogger[kDisableRequestLogging] = resolvedDisableRequestLogging
+
+    if (resolvedDisableRequestLogging === false) {
+      childLogger.info({ req: request }, 'incoming request')
+    }
+
+    if (hasLogger === true || context.onResponse !== null) {
+      setupResponseListeners(reply)
+    }
+
+    // Create Web Standard Request
+    const protocol = req.socket?.encrypted ? 'https' : 'http'
+    const host = req.headers.host || 'localhost'
+    const webRequest = createWebRequest(req, protocol, host)
+
+    if (context.onRequest !== null) {
+      onRequestHookRunner(
+        context.onRequest,
+        request,
+        reply,
+        function onRequestComplete (err) {
+          if (err) {
+            reply[kReplyIsError] = true
+            reply.send(err)
+            return
+          }
+          if (reply.sent === true) return
+          runWebHandler(webRequest, request, reply, context)
+        }
+      )
+    } else {
+      runWebHandler(webRequest, request, reply, context)
+    }
+  }
+
+  return { webRouteHandler, closeWebRoutes }
+}
+
+async function runWebHandler (webRequest, request, reply, context) {
+  try {
+    // Create context object with logger and server
+    const ctx = {
+      log: request.log,
+      server: context.server
+    }
+
+    // Call handler bound to fastify instance with ctx as second parameter
+    const webResponse = await context.handler.call(context.server, webRequest, ctx)
+
+    if (reply.sent === true) return
+
+    // Validate response
+    if (!(webResponse instanceof Response)) {
+      const err = new Error('Web route handler must return a Response object')
+      err.statusCode = 500
+      reply[kReplyIsError] = true
+      reply.send(err)
+      return
+    }
+
+    // Run onSend hooks with the Response as payload
+    if (context.onSend !== null) {
+      onSendHookRunner(
+        context.onSend,
+        request,
+        reply,
+        webResponse,
+        function onSendComplete (err, req, rep, payload) {
+          if (err) {
+            reply[kReplyIsError] = true
+            reply.send(err)
+            return
+          }
+          sendWebResponseWithCallback(reply.raw, payload, reply, context)
+        }
+      )
+    } else {
+      await sendWebResponseWithCallback(reply.raw, webResponse, reply, context)
+    }
+  } catch (err) {
+    reply[kReplyIsError] = true
+    reply.send(err)
+  }
+}
+
+async function sendWebResponseWithCallback (res, webResponse, reply, context) {
+  try {
+    await sendWebResponse(res, webResponse)
+
+    if (context.onResponse !== null) {
+      onResponseHookRunner(
+        context.onResponse,
+        reply.request,
+        reply,
+        function onResponseComplete () {}
+      )
+    }
+  } catch (err) {
+    reply[kReplyIsError] = true
+    reply.send(err)
+  }
+}
+
+module.exports = {
+  WebContext,
+  createWebRequest,
+  sendWebResponse,
+  buildWebRouteHandler,
+  runWebHandler
+}

--- a/lib/web-handler.js
+++ b/lib/web-handler.js
@@ -51,11 +51,13 @@ function createWebRequest (req, protocol, host) {
 
   for (const [key, value] of Object.entries(req.headers)) {
     if (value !== undefined) {
+      /* c8 ignore start */
       if (Array.isArray(value)) {
         for (const v of value) {
           headers.append(key, v)
         }
       } else {
+      /* c8 ignore stop */
         headers.set(key, value)
       }
     }
@@ -137,6 +139,7 @@ function buildWebRouteHandler (options) {
     const childLogger = createChildLogger(context, logger, req, id, loggerOpts)
     childLogger[kDisableRequestLogging] = disableRequestLoggingFn ? false : disableRequestLogging
 
+    /* c8 ignore start */
     if (closing === true) {
       if (req.httpVersionMajor !== 2) {
         res.setHeader('Connection', 'close')
@@ -153,8 +156,10 @@ function buildWebRouteHandler (options) {
         return
       }
     }
+    /* c8 ignore stop */
 
     const connHeader = String.prototype.toLowerCase.call(req.headers.connection || '')
+    /* c8 ignore start */
     if (connHeader === 'keep-alive') {
       if (keepAliveConnections.has(req.socket) === false) {
         keepAliveConnections.add(req.socket)
@@ -163,11 +168,14 @@ function buildWebRouteHandler (options) {
         })
       }
     }
+    /* c8 ignore stop */
 
+    /* c8 ignore start */
     if (req.headers[kRequestAcceptVersion] !== undefined) {
       req.headers['accept-version'] = req.headers[kRequestAcceptVersion]
       req.headers[kRequestAcceptVersion] = undefined
     }
+    /* c8 ignore stop */
 
     // Create minimal FastifyRequest/Reply for hooks
     const request = new context.Request(id, params, req, query, childLogger, context)
@@ -273,10 +281,12 @@ async function sendWebResponseWithCallback (res, webResponse, reply, context) {
         function onResponseComplete () {}
       )
     }
+  /* c8 ignore start */
   } catch (err) {
     reply[kReplyIsError] = true
     reply.send(err)
   }
+  /* c8 ignore stop */
 }
 
 module.exports = {

--- a/test/types/web.test-d.ts
+++ b/test/types/web.test-d.ts
@@ -1,0 +1,152 @@
+import { expectAssignable, expectType } from 'tsd'
+import fastify, { FastifyInstance, FastifyRequest, FastifyReply, FastifyBaseLogger } from '../../fastify'
+import { FastifyWebNamespace, WebRouteHandler } from '../../types/web'
+
+const server = fastify()
+
+// Test that web namespace exists
+expectType<FastifyWebNamespace>(server.web)
+
+// Test web.get with handler only - with ctx parameter
+expectAssignable<FastifyInstance>(
+  server.web.get('/path', async (req, ctx) => {
+    expectType<Request>(req)
+    expectType<FastifyBaseLogger>(ctx.log)
+    expectType<FastifyInstance>(ctx.server)
+    return new Response('hello')
+  })
+)
+
+// Test web.get with options and handler
+expectAssignable<FastifyInstance>(
+  server.web.get('/path', {
+    logLevel: 'info'
+  }, async (req, ctx) => {
+    return new Response('hello')
+  })
+)
+
+// Test web.post
+expectAssignable<FastifyInstance>(
+  server.web.post('/path', async (req, ctx) => {
+    const body = await req.json()
+    ctx.log.info('received body')
+    return new Response(JSON.stringify(body))
+  })
+)
+
+// Test web.put
+expectAssignable<FastifyInstance>(
+  server.web.put('/path', async (req, ctx) => {
+    return new Response('updated')
+  })
+)
+
+// Test web.delete
+expectAssignable<FastifyInstance>(
+  server.web.delete('/path', async (req, ctx) => {
+    return new Response('deleted')
+  })
+)
+
+// Test web.patch
+expectAssignable<FastifyInstance>(
+  server.web.patch('/path', async (req, ctx) => {
+    return new Response('patched')
+  })
+)
+
+// Test web.head
+expectAssignable<FastifyInstance>(
+  server.web.head('/path', async (req, ctx) => {
+    return new Response(null)
+  })
+)
+
+// Test web.options
+expectAssignable<FastifyInstance>(
+  server.web.options('/path', async (req, ctx) => {
+    return new Response(null, { status: 204 })
+  })
+)
+
+// Test web.trace
+expectAssignable<FastifyInstance>(
+  server.web.trace('/path', async (req, ctx) => {
+    return new Response('trace')
+  })
+)
+
+// Test WebRouteHandler type with ctx
+const handler: WebRouteHandler = async function (req, ctx) {
+  ctx.log.info('handling request')
+  return new Response('hello')
+}
+expectAssignable<FastifyInstance>(server.web.get('/test', handler))
+
+// Test this binding in handler (using regular function)
+expectAssignable<FastifyInstance>(
+  server.web.get('/this-test', async function (req, ctx) {
+    // 'this' is bound to FastifyInstance
+    expectType<FastifyInstance>(this)
+    return new Response('ok')
+  })
+)
+
+// Test with onRequest hook
+expectAssignable<FastifyInstance>(
+  server.web.get('/hooked', {
+    onRequest: async (request: FastifyRequest, reply: FastifyReply) => {
+      // Access FastifyRequest/Reply in hooks
+    }
+  }, async (req, ctx) => {
+    return new Response('ok')
+  })
+)
+
+// Test with onResponse hook
+expectAssignable<FastifyInstance>(
+  server.web.get('/hooked', {
+    onResponse: async (request: FastifyRequest, reply: FastifyReply) => {
+      // Access FastifyRequest/Reply in hooks
+    }
+  }, async (req, ctx) => {
+    return new Response('ok')
+  })
+)
+
+// Test chainability
+expectAssignable<FastifyInstance>(
+  server.web.get('/a', async (req, ctx) => new Response('a'))
+    .web.get('/b', async (req, ctx) => new Response('b'))
+    .web.post('/c', async (req, ctx) => new Response('c'))
+)
+
+// Test with constraints
+expectAssignable<FastifyInstance>(
+  server.web.get('/constrained', {
+    constraints: { version: '1.0.0' }
+  }, async (req, ctx) => {
+    return new Response('v1')
+  })
+)
+
+// Test within plugin registration
+server.register(async (instance) => {
+  expectAssignable<FastifyInstance>(
+    instance.web.get('/scoped', async (req, ctx) => {
+      // ctx.server should be the encapsulated instance
+      expectType<FastifyInstance>(ctx.server)
+      return new Response('scoped')
+    })
+  )
+})
+
+// Test ctx.server type
+expectAssignable<FastifyInstance>(
+  server.web.get('/server-test', async (req, ctx) => {
+    // Can access server methods
+    const schemas = ctx.server.getSchemas()
+    return new Response(JSON.stringify(schemas))
+  })
+)

--- a/test/web-handler.test.js
+++ b/test/web-handler.test.js
@@ -1,0 +1,504 @@
+'use strict'
+
+const { describe, test } = require('node:test')
+const Fastify = require('..')
+
+describe('web routes', () => {
+  test('web.get returns Response', async (t) => {
+    t.plan(2)
+    const fastify = new Fastify()
+
+    fastify.web.get('/hello', async (req, ctx) => {
+      return new Response('Hello World', { status: 200 })
+    })
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/hello'
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.strictEqual(response.body, 'Hello World')
+  })
+
+  test('web.post reads JSON body', async (t) => {
+    t.plan(2)
+    const fastify = new Fastify()
+
+    fastify.web.post('/echo', async (req) => {
+      const body = await req.json()
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    })
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/echo',
+      payload: { hello: 'world' }
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(response.body), { hello: 'world' })
+  })
+
+  test('web.post reads text body', async (t) => {
+    t.plan(2)
+    const fastify = new Fastify()
+
+    fastify.web.post('/text', async (req) => {
+      const body = await req.text()
+      return new Response(body.toUpperCase(), { status: 200 })
+    })
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/text',
+      payload: 'hello world',
+      headers: { 'content-type': 'text/plain' }
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.strictEqual(response.body, 'HELLO WORLD')
+  })
+
+  test('web routes run onRequest hook', async (t) => {
+    t.plan(2)
+    const fastify = new Fastify()
+    let hookCalled = false
+
+    fastify.addHook('onRequest', async () => {
+      hookCalled = true
+    })
+
+    fastify.web.get('/test', async () => new Response('ok'))
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/test'
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.ok(hookCalled)
+  })
+
+  test('web routes run onResponse hook', async (t) => {
+    t.plan(2)
+    const fastify = new Fastify()
+    let hookCalled = false
+
+    fastify.addHook('onResponse', async () => {
+      hookCalled = true
+    })
+
+    fastify.web.get('/test', async () => new Response('ok'))
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/test'
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.ok(hookCalled)
+  })
+
+  test('web routes run route-level onRequest hook', async (t) => {
+    t.plan(2)
+    const fastify = new Fastify()
+    let hookCalled = false
+
+    fastify.web.get('/test', {
+      onRequest: async () => {
+        hookCalled = true
+      }
+    }, async () => new Response('ok'))
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/test'
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.ok(hookCalled)
+  })
+
+  test('web routes handle errors', async (t) => {
+    t.plan(1)
+    const fastify = new Fastify()
+
+    fastify.web.get('/error', async () => {
+      throw new Error('Test error')
+    })
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/error'
+    })
+
+    t.assert.strictEqual(response.statusCode, 500)
+  })
+
+  test('web routes respect prefix', async (t) => {
+    t.plan(2)
+    const fastify = new Fastify()
+
+    fastify.register(async (instance) => {
+      instance.web.get('/hello', async () => new Response('scoped'))
+    }, { prefix: '/api' })
+
+    await fastify.ready()
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/api/hello'
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.strictEqual(response.body, 'scoped')
+  })
+
+  test('web.put method works', async (t) => {
+    t.plan(2)
+    const fastify = new Fastify()
+
+    fastify.web.put('/resource', async (req) => {
+      const body = await req.json()
+      return new Response(JSON.stringify({ updated: body }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    })
+
+    const response = await fastify.inject({
+      method: 'PUT',
+      url: '/resource',
+      payload: { name: 'test' }
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(response.body), { updated: { name: 'test' } })
+  })
+
+  test('web.delete method works', async (t) => {
+    t.plan(2)
+    const fastify = new Fastify()
+
+    fastify.web.delete('/resource/:id', async (req) => {
+      const url = new URL(req.url)
+      return new Response(`Deleted: ${url.pathname}`, { status: 200 })
+    })
+
+    const response = await fastify.inject({
+      method: 'DELETE',
+      url: '/resource/123'
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.strictEqual(response.body, 'Deleted: /resource/123')
+  })
+
+  test('web.patch method works', async (t) => {
+    t.plan(2)
+    const fastify = new Fastify()
+
+    fastify.web.patch('/resource', async (req) => {
+      const body = await req.json()
+      return new Response(JSON.stringify({ patched: body }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    })
+
+    const response = await fastify.inject({
+      method: 'PATCH',
+      url: '/resource',
+      payload: { field: 'value' }
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(response.body), { patched: { field: 'value' } })
+  })
+
+  test('web routes skip validation', async (t) => {
+    t.plan(2)
+    const fastify = new Fastify()
+
+    // Global validation should not apply to web routes
+    fastify.setValidatorCompiler(() => {
+      return () => {
+        throw new Error('Validation should not be called')
+      }
+    })
+
+    fastify.web.post('/no-validation', async (req) => {
+      const body = await req.json()
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    })
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/no-validation',
+      payload: { any: 'data' }
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(response.body), { any: 'data' })
+  })
+
+  test('web Request has correct URL', async (t) => {
+    t.plan(3)
+    const fastify = new Fastify()
+
+    fastify.web.get('/path', async (req) => {
+      const url = new URL(req.url)
+      return new Response(JSON.stringify({
+        pathname: url.pathname,
+        method: req.method
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    })
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/path?foo=bar'
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    const body = JSON.parse(response.body)
+    t.assert.strictEqual(body.pathname, '/path')
+    t.assert.strictEqual(body.method, 'GET')
+  })
+
+  test('web Request has correct headers', async (t) => {
+    t.plan(2)
+    const fastify = new Fastify()
+
+    fastify.web.get('/headers', async (req) => {
+      return new Response(req.headers.get('x-custom-header'), { status: 200 })
+    })
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/headers',
+      headers: {
+        'x-custom-header': 'test-value'
+      }
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.strictEqual(response.body, 'test-value')
+  })
+
+  test('web routes return non-Response throws error', async (t) => {
+    t.plan(1)
+    const fastify = new Fastify()
+
+    fastify.web.get('/invalid', async () => {
+      return 'not a Response object'
+    })
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/invalid'
+    })
+
+    t.assert.strictEqual(response.statusCode, 500)
+  })
+
+  test('web Response status codes are respected', async (t) => {
+    t.plan(1)
+    const fastify = new Fastify()
+
+    fastify.web.post('/created', async () => {
+      return new Response('Created', { status: 201 })
+    })
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/created',
+      payload: {}
+    })
+
+    t.assert.strictEqual(response.statusCode, 201)
+  })
+
+  test('web Response headers are set correctly', async (t) => {
+    t.plan(2)
+    const fastify = new Fastify()
+
+    fastify.web.get('/custom-headers', async () => {
+      return new Response('ok', {
+        status: 200,
+        headers: {
+          'X-Custom-Response': 'custom-value',
+          'Content-Type': 'text/plain'
+        }
+      })
+    })
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/custom-headers'
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.strictEqual(response.headers['x-custom-response'], 'custom-value')
+  })
+
+  test('web.head method works', async (t) => {
+    t.plan(1)
+    const fastify = new Fastify()
+
+    fastify.web.head('/resource', async () => {
+      return new Response(null, {
+        status: 200,
+        headers: { 'Content-Length': '100' }
+      })
+    })
+
+    const response = await fastify.inject({
+      method: 'HEAD',
+      url: '/resource'
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+  })
+
+  test('web.options method works', async (t) => {
+    t.plan(2)
+    const fastify = new Fastify()
+
+    fastify.web.options('/resource', async () => {
+      return new Response(null, {
+        status: 204,
+        headers: { Allow: 'GET, POST, OPTIONS' }
+      })
+    })
+
+    const response = await fastify.inject({
+      method: 'OPTIONS',
+      url: '/resource'
+    })
+
+    t.assert.strictEqual(response.statusCode, 204)
+    t.assert.strictEqual(response.headers.allow, 'GET, POST, OPTIONS')
+  })
+
+  test('ctx.log is available', async (t) => {
+    t.plan(2)
+    const fastify = new Fastify()
+    let logAvailable = false
+
+    fastify.web.get('/log', async (req, ctx) => {
+      logAvailable = typeof ctx.log.info === 'function'
+      return new Response('ok')
+    })
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/log'
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.ok(logAvailable)
+  })
+
+  test('ctx.server is the fastify instance', async (t) => {
+    t.plan(2)
+    const fastify = new Fastify()
+    let serverMatches = false
+
+    fastify.web.get('/server', async (req, ctx) => {
+      serverMatches = ctx.server === fastify
+      return new Response('ok')
+    })
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/server'
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.ok(serverMatches)
+  })
+
+  test('this is bound to fastify instance', async (t) => {
+    t.plan(2)
+    const fastify = new Fastify()
+    let thisMatches = false
+
+    fastify.web.get('/this', async function (req, ctx) {
+      thisMatches = this === fastify
+      return new Response('ok')
+    })
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/this'
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.ok(thisMatches)
+  })
+
+  test('ctx.log logs at correct level', async (t) => {
+    t.plan(2)
+    const logs = []
+    const fastify = new Fastify({
+      logger: {
+        level: 'info',
+        stream: {
+          write (chunk) {
+            logs.push(JSON.parse(chunk))
+          }
+        }
+      }
+    })
+
+    fastify.web.get('/log-test', async (req, ctx) => {
+      ctx.log.info('test message')
+      return new Response('ok')
+    })
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/log-test'
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    const testLog = logs.find(l => l.msg === 'test message')
+    t.assert.ok(testLog)
+  })
+
+  test('this is bound to encapsulated instance in plugin', async (t) => {
+    t.plan(3)
+    const fastify = new Fastify()
+    let thisInPlugin = null
+    let pluginInstance = null
+
+    fastify.register(async (instance) => {
+      pluginInstance = instance
+      instance.web.get('/plugin', async function (req, ctx) {
+        thisInPlugin = this
+        return new Response('ok')
+      })
+    }, { prefix: '/api' })
+
+    await fastify.ready()
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/api/plugin'
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.ok(thisInPlugin !== null)
+    t.assert.strictEqual(thisInPlugin, pluginInstance)
+  })
+})

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -24,6 +24,7 @@ import {
 } from './type-provider'
 import { ContextConfigDefault, HTTPMethods, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RawServerDefault } from './utils'
 import { FastifyRouterOptions } from '../fastify'
+import { FastifyWebNamespace } from './web'
 
 export interface PrintRoutesOptions {
   method?: HTTPMethods;
@@ -203,6 +204,13 @@ export interface FastifyInstance<
   report: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
   search: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
   all: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
+
+  /**
+   * Web Standard API routes namespace.
+   * Routes registered via this namespace use Web Standard Request/Response objects
+   * instead of FastifyRequest/FastifyReply.
+   */
+  web: FastifyWebNamespace<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
 
   hasRoute<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,

--- a/types/web.d.ts
+++ b/types/web.d.ts
@@ -1,0 +1,142 @@
+import { FastifyInstance } from './instance'
+import { FastifyBaseLogger } from './logger'
+import { FastifyRequest } from './request'
+import { FastifyReply } from './reply'
+import { RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, ContextConfigDefault } from './utils'
+import { FastifyTypeProvider, FastifyTypeProviderDefault } from './type-provider'
+import { FastifySchema } from './schema'
+import { RouteGenericInterface } from './route'
+import {
+  onRequestHookHandler,
+  onRequestAsyncHookHandler,
+  onSendHookHandler,
+  onSendAsyncHookHandler,
+  onResponseHookHandler,
+  onResponseAsyncHookHandler,
+  onErrorHookHandler,
+  onErrorAsyncHookHandler
+} from './hooks'
+
+/**
+ * Context object passed to web route handlers
+ */
+export interface WebRouteContext<
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
+  Logger extends FastifyBaseLogger = FastifyBaseLogger,
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault
+> {
+  log: Logger
+  server: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>
+}
+
+/**
+ * Web Standard API route handler that receives a Request and returns a Response.
+ * The handler is bound to the FastifyInstance (available as `this`).
+ */
+export type WebRouteHandler<
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
+  Logger extends FastifyBaseLogger = FastifyBaseLogger,
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault
+> = (
+  this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
+  request: Request,
+  ctx: WebRouteContext<RawServer, RawRequest, RawReply, Logger, TypeProvider>
+) => Response | Promise<Response>
+
+/**
+ * Options for Web Standard API routes
+ */
+export interface WebRouteShorthandOptions<
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
+  RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
+  ContextConfig = ContextConfigDefault,
+  SchemaCompiler extends FastifySchema = FastifySchema,
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+  Logger extends FastifyBaseLogger = FastifyBaseLogger
+> {
+  config?: Record<string, unknown>
+  logLevel?: string
+  logSerializers?: Record<string, (value: unknown) => unknown>
+  constraints?: Record<string, unknown>
+  errorHandler?: (
+    error: Error,
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig, Logger>,
+    reply: FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>
+  ) => void | Promise<void>
+  onRequest?:
+    | onRequestHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+    | onRequestAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+    | Array<
+        | onRequestHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+        | onRequestAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+      >
+  onSend?:
+    | onSendHookHandler<Response, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+    | onSendAsyncHookHandler<Response, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+    | Array<
+        | onSendHookHandler<Response, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+        | onSendAsyncHookHandler<Response, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+      >
+  onResponse?:
+    | onResponseHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+    | onResponseAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+    | Array<
+        | onResponseHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+        | onResponseAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
+      >
+  onError?:
+    | onErrorHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Error, SchemaCompiler, TypeProvider, Logger>
+    | onErrorAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Error, SchemaCompiler, TypeProvider, Logger>
+    | Array<
+        | onErrorHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Error, SchemaCompiler, TypeProvider, Logger>
+        | onErrorAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, Error, SchemaCompiler, TypeProvider, Logger>
+      >
+}
+
+/**
+ * Web Standard API route shorthand method signature
+ */
+export interface WebRouteShorthandMethod<
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+  Logger extends FastifyBaseLogger = FastifyBaseLogger
+> {
+  (
+    path: string,
+    handler: WebRouteHandler<RawServer, RawRequest, RawReply, Logger, TypeProvider>
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>
+
+  (
+    path: string,
+    opts: WebRouteShorthandOptions<RawServer, RawRequest, RawReply>,
+    handler: WebRouteHandler<RawServer, RawRequest, RawReply, Logger, TypeProvider>
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>
+}
+
+/**
+ * Web Standard API namespace containing route shorthand methods
+ */
+export interface FastifyWebNamespace<
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+  Logger extends FastifyBaseLogger = FastifyBaseLogger
+> {
+  delete: WebRouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>
+  get: WebRouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>
+  head: WebRouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>
+  patch: WebRouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>
+  post: WebRouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>
+  put: WebRouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>
+  options: WebRouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>
+  trace: WebRouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>
+}


### PR DESCRIPTION
Adds `fastify.web.*` methods for routes using Web Standard `Request`/`Response` objects.

```javascript
fastify.web.get('/hello', async (req, ctx) => {
  ctx.log.info('handling request')
  return new Response('Hello World')
})

fastify.web.post('/echo', async (req, ctx) => {
  const body = await req.json()
  return new Response(JSON.stringify(body), {
    headers: { 'Content-Type': 'application/json' }
  })
})
```

- Handler receives Web `Request` and `ctx` object with `log` and `server`
- Handler `this` is bound to fastify instance  
- Runs `onRequest`, `onSend`, `onResponse`, `onError` hooks
- Skips validation/serialization
- Experimental (`FSTEXP001` warning emitted)