### PR TITLE
docs: Simplify and tighten decorators example

### DIFF
--- a/docs/Guides/Plugins-Guide.md
+++ b/docs/Guides/Plugins-Guide.md
@@ -204,12 +204,12 @@ of an *arrow function expression*.
 
 You can do the same for the `request` object:
 ```js
-fastify.decorate('getHeader', (req, header) => {
-  return req.headers[header]
+fastify.decorate('getBoolHeader', (req, name) => {
+  return req.headers[name] ?? false // We return `false` if header is missing
 })
 
 fastify.addHook('preHandler', (request, reply, done) => {
-  request.isHappy = fastify.getHeader(request.raw, 'happy')
+  request.isHappy = fastify.getBoolHeader(request, 'happy')
   done()
 })
 
@@ -219,14 +219,14 @@ fastify.get('/happiness', (request, reply) => {
 ```
 Again, it works, but it can be much better!
 ```js
-fastify.decorateRequest('setHeader', function (header) {
-  this.isHappy = this.headers[header]
+fastify.decorateRequest('setBoolHeader', function (name) {
+  this.isHappy = this.headers[name] ?? false
 })
 
 fastify.decorateRequest('isHappy', false) // This will be added to the Request object prototype, yay speed!
 
 fastify.addHook('preHandler', (request, reply, done) => {
-  request.setHeader('happy')
+  request.setBoolHeader('happy')
   done()
 })
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Summary

This PR improves the Decorators documentation by making the decorate() vs decorateRequest() examples:

- functionally correct
- idiomatic Fastify
- aligned with the teaching intent of the section

## Rationale

### 1. Avoid implicit `undefined` behavior

The original examples relied on this pattern:

```js
req.headers[header]
```

When the header is missing, this returns `undefined`, which then propagates into `request.isHappy`.  
This subtly undermines the purpose of declaring a default value via (note: I know this is here primarily for V8 reasons):

```js
fastify.decorateRequest('isHappy', false)
```

The updated examples explicitly fall back to `false` when the header is missing:

```js
req.headers[name] ?? false
```

This makes the examples deterministic and avoids accidental `undefined` values leaking into request state.

* * *

### 2. Make boolean intent explicit in naming

The original names (`getHeader`, `setHeader`) suggested generic header access, but the examples are specifically about deriving a **boolean flag** from a header.

Renaming to:

* `getBoolHeader`
    
* `setBoolHeader`
    

makes the intent clearer and avoids implying that the functions deal with arbitrary header values or mutation of headers.

This helps readers focus on _why_ decorators are being used rather than on incidental string handling.

* * *

### 3. Keep the teaching focus intact

The examples are meant to illustrate:

* The difference between `decorate()` (server-level utilities)
    
* And `decorateRequest()` (request-scoped state and behavior)
    

By tightening the semantics (boolean return + default preservation), the examples now reinforce that lesson without introducing edge cases that distract from the core concept.
