### PR TITLE
docs: Fix incorrect variable use

### DIFF
--- a/docs/Guides/Plugins-Guide.md
+++ b/docs/Guides/Plugins-Guide.md
@@ -337,11 +337,11 @@ fastify.register((instance, opts, done) => {
     }
   })
 
-  fastify.get('/plugin1', {config: {useUtil: true}}, (request, reply) => {
+  instance.get('/plugin1', {config: {useUtil: true}}, (request, reply) => {
     reply.send(request)
   })
 
-  fastify.get('/plugin2', (request, reply) => {
+  instance.get('/plugin2', (request, reply) => {
     reply.send(request)
   })
 


### PR DESCRIPTION
Fixes incorrect variable use. We want to register the routes on the encapsulated Fastify instance in this example (the one we just added hooks to), not the global one.