### PR TITLE
fix: Fix MIT Licence file to conform to standard

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 The Fastify Team (members are listed in the README file)
+Copyright (c) 2016-present The Fastify Team (members are listed in the README file)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,6 @@
 MIT License
 
-Copyright (c) 2016-present The Fastify Team
-
-The Fastify team members are listed at https://github.com/fastify/fastify#team
-and in the README file.
+Copyright (c) 2016 The Fastify Team (members are listed in the README file)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Fixes the MIT Licence file to conform to the  GitHub template standard so that it can get properly picked up by GitHub integrations used by 3rd parties, automated crawlers and AI.

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/09a1ffbd-9c44-401f-9757-81dc86497b73" />

**BEFORE:**
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/bb616f70-f666-4b6f-af16-0a090086e1fc" />
<img width="70%" alt="image" src="https://github.com/user-attachments/assets/05bee1de-9818-4e24-bceb-19c316f49b38" />


**NOW:**
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/346d48cc-fc98-485f-82ef-fbea954398b4" />
<img width="70%" alt="image" src="https://github.com/user-attachments/assets/b2dab54f-7d57-4d76-94c8-b4428fa284db" />

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
