### PR TITLE
fix(reply): align string JSON serialization with documented behavior

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -188,6 +188,20 @@ Reply.prototype.send = function (payload) {
 
     // The indexOf below also matches custom json mimetypes such as 'application/hal+json' or 'application/ld+json'
   } else if (!hasContentType || contentType.indexOf('json') !== -1) {
+    if (
+      typeof payload === 'string' &&
+      this[kReplySerializer] === null
+    ) {
+      const trimmed = payload.trim()
+      const looksLikeJson =
+      (trimmed[0] === '{' && trimmed[trimmed.length - 1] === '}') ||
+      (trimmed[0] === '[' && trimmed[trimmed.length - 1] === ']')
+
+      if (!looksLikeJson) {
+        payload = JSON.stringify(payload)
+      }
+    }
+
     if (!hasContentType) {
       this[kReplyHeaders]['content-type'] = CONTENT_TYPE.JSON
     } else if (contentType.indexOf('charset') === -1) {


### PR DESCRIPTION
### Summary

This PR fixes a mismatch between Fastify documentation and runtime behavior
when sending string payloads with `application/json` content-type.

Previously, `reply.send("Hello")` would bypass serialization and send a raw
string even when JSON was explicitly set. This change ensures string payloads
are serialized only in the JSON branch while preserving existing behavior
for streams, hijacked replies, and hooks.

### Key points

- serializes string payloads only when content-type includes `json`
- avoids double serialization for already-JSON strings
- preserves hijack and lifecycle hook semantics
- all existing tests pass without modification

### Context

Related discussion in #6291
