### PR TITLE
docs: update Reply.send() documentation for string serialization

### DIFF
--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -671,9 +671,20 @@ fastify.get('/json', options, function (request, reply) {
 If you pass a string to `send` without a `Content-Type`, it will be sent as
 `text/plain; charset=utf-8`. If you set the `Content-Type` header and pass a
 string to `send`, it will be serialized with the custom serializer if one is
-set, otherwise, it will be sent unmodified (unless the `Content-Type` header is
-set to `application/json; charset=utf-8`, in which case it will be
-JSON-serialized like an object — see the section above).
+set, otherwise, it will be sent unmodified.
+
+> **Note:** Even when the `Content-Type` header is set to `application/json`,
+> strings are sent unmodified by default. To serialize a string as JSON, you
+> must set a custom serializer:
+
+```js
+fastify.get('/json-string', async function (request, reply) {
+  reply
+    .type('application/json; charset=utf-8')
+    .serializer(JSON.stringify)
+    .send('Hello') // Returns "Hello" (JSON-encoded string)
+})
+```
 ```js
 fastify.get('/json', options, function (request, reply) {
   reply.send('plain string')


### PR DESCRIPTION
Fixes #6291

## Summary

The documentation previously claimed that reply.send(string) would automatically JSON-serialize strings when Content-Type is set to application/json. This behavior has never been implemented - strings are sent unmodified by default.

After discussion with maintainers in the issue, it was decided to update the documentation rather than change the behavior, since this behavior has existed since v2.12.0 (5-6 years) and changing it could be a breaking change.

## Changes

- Corrected the misleading documentation in docs/Reference/Reply.md under the Strings section
- Added a note explaining that strings are sent unmodified by default, even when Content-Type is application/json
- Added an example showing users how to use .serializer(JSON.stringify) to serialize strings as JSON when needed

This aligns the documentation with the actual behavior and provides users with a clear workaround.