### PR TITLE
feat(types): expose ReplyType helper

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -25,7 +25,7 @@ import {
 } from './types/logger'
 import { FastifyPlugin, FastifyPluginAsync, FastifyPluginCallback, FastifyPluginOptions } from './types/plugin'
 import { FastifyRegister, FastifyRegisterOptions, RegisterOptions } from './types/register'
-import { FastifyReply } from './types/reply'
+import { FastifyReply, ReplyType } from './types/reply'
 import { FastifyRequest, RequestGenericInterface } from './types/request'
 import { RouteGenericInterface, RouteHandler, RouteHandlerMethod, RouteOptions, RouteShorthandMethod, RouteShorthandOptions, RouteShorthandOptionsWithHandler } from './types/route'
 import { FastifySchema, FastifySchemaValidationError, FastifySchemaCompiler, FastifySerializerCompiler, SchemaErrorDataVar, SchemaErrorFormatter } from './types/schema'
@@ -182,7 +182,7 @@ declare namespace fastify {
   export type {
     LightMyRequestChain, InjectOptions, LightMyRequestResponse, LightMyRequestCallback, // 'light-my-request'
     FastifyRequest, RequestGenericInterface, // './types/request'
-    FastifyReply, // './types/reply'
+    FastifyReply, ReplyType, // './types/reply'
     FastifyPluginCallback, FastifyPluginAsync, FastifyPluginOptions, FastifyPlugin, // './types/plugin'
     FastifyListenOptions, FastifyInstance, PrintRoutesOptions, // './types/instance'
     FastifyLoggerOptions, FastifyBaseLogger, FastifyLoggerInstance, FastifyLogFn, LogLevel, // './types/logger'

--- a/test/types/reply.test-d.ts
+++ b/test/types/reply.test-d.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'node:buffer'
 import { expectAssignable, expectError, expectType } from 'tsd'
-import fastify, { FastifyContextConfig, FastifyReply, FastifyRequest, FastifySchema, FastifyTypeProviderDefault, RawRequestDefaultExpression, RouteHandler, RouteHandlerMethod } from '../../fastify'
+import fastify, { FastifyContextConfig, FastifyReply, FastifyRequest, FastifySchema, FastifyTypeProviderDefault, RawRequestDefaultExpression, ReplyType, RouteHandler, RouteHandlerMethod } from '../../fastify'
 import { FastifyInstance } from '../../types/instance'
 import { FastifyLoggerInstance } from '../../types/logger'
 import { ResolveReplyTypeWithRouteGeneric } from '../../types/reply'
@@ -123,6 +123,9 @@ const typedHandler: RouteHandler<ReplyPayload> = async (request, reply) => {
   // When Reply type is specified, send() requires a payload argument
   expectType<((...args: [payload: ReplyPayload['Reply']]) => FastifyReply<ReplyPayload, RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>>)>(reply.send)
   expectType<((...args: [payload: ReplyPayload['Reply']]) => FastifyReply<ReplyPayload, RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>>)>(reply.code(100).send)
+
+  const inferredReplyType: ReplyType<typeof reply> = { test: true }
+  expectType<ReplyPayload['Reply']>(inferredReplyType)
 }
 
 const server = fastify()

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -79,3 +79,8 @@ export interface FastifyReply<
   removeTrailer(key: string): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>;
   getDecorator<T>(name: string | symbol): T;
 }
+
+export type ReplyType<TReply extends FastifyReply> =
+  TReply extends FastifyReply<any, any, any, any, any, any, any, infer InferredReplyType>
+    ? InferredReplyType
+    : never


### PR DESCRIPTION
## Summary

- add ReplyType helper to extract reply generic from FastifyReply
- re-export ReplyType from fastify type entry
- add type test coverage\n\n## Testing\n- not run (type-only change)

Fixes https://github.com/fastify/fastify/issues/6469