### PR TITLE
docs: update vulnerability reporting to use GitHub Security

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,10 +46,11 @@ explicitly enabled via configuration options
 ## Reporting vulnerabilities
 
 Individuals who find potential vulnerabilities in Fastify are invited to
-complete a vulnerability report via the dedicated pages:
+complete a vulnerability report via the GitHub Security page:
 
-1. [HackerOne](https://hackerone.com/fastify)
-2. [GitHub Security Advisory](https://github.com/fastify/fastify/security/advisories/new)
+https://github.com/fastify/fastify/security/advisories/new
+
+Note: Our [HackerOne](https://hackerone.com/fastify) program is now closed.
 
 ### Strict measures when reporting vulnerabilities
 


### PR DESCRIPTION
## Summary
- Update SECURITY.md to direct vulnerability reports to GitHub Security Advisories
- Note that HackerOne program is now closed (link preserved for historical reference)

## Test plan
- [ ] Verify links work correctly