### PR TITLE
refactor: use object spread instead of Object.assign in schemas

### DIFF
--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -37,7 +37,7 @@ Schemas.prototype.add = function (inputSchema) {
 }
 
 Schemas.prototype.getSchemas = function () {
-  return Object.assign({}, this.store)
+  return { ...this.store }
 }
 
 Schemas.prototype.getSchema = function (schemaId) {


### PR DESCRIPTION
## Motivation
This PR replaces the usage of `Object.assign({}, ...)` with the modern object spread syntax `{ ... }` in `lib/schemas.js`.

## Changes
- Refactored `Schemas.prototype.getSchemas` to use the spread operator for shallow cloning.
- This modernizes the syntax and improves readability while maintaining functionality.

## Test Plan
- Ran `npm run test` locally and all tests passed.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
