### PR TITLE
fix: resolve broken links in documentation (#6385)

### DIFF
--- a/docs/Guides/Benchmarking.md
+++ b/docs/Guides/Benchmarking.md
@@ -16,7 +16,7 @@ The modules we will use:
   concurrently.
 - [Npx](https://github.com/npm/npx): NPM package runner used to run scripts
   against different Node.js Versions and execute local binaries. Shipped with
-  npm@5.2.0.
+`npm@5.2.0`.
 
 ## Simple
 

--- a/docs/Guides/Database.md
+++ b/docs/Guides/Database.md
@@ -238,11 +238,11 @@ database's schema and prevent data loss.
 
 As stated at the beginning of the guide, Fastify is database agnostic and any
 Node.js database migration tool can be used with it. We will give an example of
-using [Postgrator](https://www.npmjs.com/package/postgrator) which has support
+using [Postgrator](https://github.com/rickbergfalk/postgrator) which has support
 for Postgres, MySQL, SQL Server and SQLite. For MongoDB migrations, please check
-[migrate-mongo](https://www.npmjs.com/package/migrate-mongo).
+[migrate-mongo](https://github.com/seppevs/migrate-mongo).
 
-#### [Postgrator](https://www.npmjs.com/package/postgrator)
+#### [Postgrator](https://github.com/rickbergfalk/postgrator)
 
 Postgrator is Node.js SQL migration tool that uses a directory of SQL scripts to
 alter the database schema. Each file in a migrations folder needs to follow the

--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -9,7 +9,7 @@ section.
 #### [Core](#core)
 
 - [`@fastify/accepts`](https://github.com/fastify/fastify-accepts) to have
-  [accepts](https://www.npmjs.com/package/accepts) in your request object.
+  [accepts](https://github.com/jshttp/accepts) in your request object.
 - [`@fastify/accepts-serializer`](https://github.com/fastify/fastify-accepts-serializer)
   to serialize to output according to the `Accept` header.
 - [`@fastify/auth`](https://github.com/fastify/fastify-auth) Run multiple auth
@@ -276,8 +276,8 @@ section.
   Postgres plugin with auto SQL injection attack prevention.
 - [`fastify-auth0-verify`](https://github.com/nearform/fastify-auth0-verify):
   Auth0 verification plugin for Fastify, internally uses
-  [fastify-jwt](https://npm.im/fastify-jwt) and
-  [jsonwebtoken](https://npm.im/jsonwebtoken).
+  [fastify-jwt](https://github.com/fastify/fastify-jwt) and
+  [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken).
 - [`fastify-autocrud`](https://github.com/paranoiasystem/fastify-autocrud)
   Plugin to auto-generate CRUD routes as fast as possible.
 - [`fastify-autoroutes`](https://github.com/GiovanniCardamone/fastify-autoroutes)
@@ -306,7 +306,7 @@ section.
 - [`fastify-bree`](https://github.com/climba03003/fastify-bree) Fastify plugin
   to add [bree](https://github.com/breejs/bree) support.
 - [`fastify-bugsnag`](https://github.com/ZigaStrgar/fastify-bugsnag) Fastify plugin
-  to add support for [Bugsnag](https://www.bugsnag.com/) error reporting.
+  to add support for [Bugsnag](https://docs.bugsnag.com/) error reporting.
 - [`fastify-cacheman`](https://gitlab.com/aalfiann/fastify-cacheman)
   Small and efficient cache provider for Node.js with In-memory, File, Redis
    and MongoDB engines for Fastify
@@ -570,7 +570,7 @@ middlewares into Fastify plugins
   thread pool plugin using [Piscina](https://github.com/piscinajs/piscina).
 - [`fastify-polyglot`](https://github.com/beliven-it/fastify-polyglot) A plugin
   to handle i18n using
-  [node-polyglot](https://www.npmjs.com/package/node-polyglot).
+  [node-polyglot](https://github.com/airbnb/polyglot.js).
 - [`fastify-postgraphile`](https://github.com/alemagio/fastify-postgraphile)
   Plugin to integrate [PostGraphile](https://www.graphile.org/postgraphile/) in
   a Fastify project.


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Description</h2>
<p>This PR fixes broken links found in the documentation as reported in #6385.</p>
<p>During automated link checking with <code>markdown-link-check</code>, several links were failing due to rate-limiting and bot protection from npmjs.com and npm.im domains. This PR resolves these issues by replacing them with stable GitHub repository links.</p>
<h2>Changes Made</h2>
<ul>
<li><strong>Benchmarking.md</strong>: Fixed <code>npm@5.2.0</code> being incorrectly detected as a mailto link by wrapping it in backticks</li>
<li><strong>Database.md</strong>: Replaced npmjs.com links with GitHub repository links for <code>postgrator</code> and <code>migrate-mongo</code></li>
<li><strong>Ecosystem.md</strong>: Replaced npm.im and npmjs.com links with GitHub repository links for <code>accepts</code>, <code>fastify-jwt</code>, <code>jsonwebtoken</code>, <code>node-polyglot</code>, and updated Bugsnag link to docs site</li>
</ul>
<h2>Why These Changes?</h2>
<p>The original links to npmjs.com and npm.im were returning 403/0 status errors during automated link checking due to:</p>
<ul>
<li>Rate-limiting from npmjs.com</li>
<li>Bot protection mechanisms</li>
</ul>
<p>GitHub repository links are:</p>
<ul>
<li>More stable for automated checks</li>
<li>Provide direct access to source code and documentation</li>
<li>Don't have aggressive rate-limiting</li>
<li>Equally useful for developers</li>
</ul>
<h2>Testing</h2>
<p>Verified all links pass using <code>markdown-link-check</code>:</p>
<pre><code class="language-powershell">Get-ChildItem docs\Guides -Filter *.md | ForEach-Object { markdown-link-check $_.FullName }
</code></pre>
<p>All previously broken links (8 total) now work correctly. ✅</p>
<h2>Link Changes Summary</h2>

File | Old Link | New Link | Status
-- | -- | -- | --
Benchmarking.md | npm@5.2.0 | `npm@5.2.0` | ✅ Fixed
Database.md | npmjs.com/package/postgrator | github.com/rickbergfalk/postgrator | ✅ Fixed
Database.md | npmjs.com/package/migrate-mongo | github.com/seppevs/migrate-mongo | ✅ Fixed
Ecosystem.md | npmjs.com/package/accepts | github.com/jshttp/accepts | ✅ Fixed
Ecosystem.md | npm.im/fastify-jwt | github.com/fastify/fastify-jwt | ✅ Fixed
Ecosystem.md | npm.im/jsonwebtoken | github.com/auth0/node-jsonwebtoken | ✅ Fixed
Ecosystem.md | www.bugsnag.com | docs.bugsnag.com | ✅ Fixed
Ecosystem.md | npmjs.com/package/node-polyglot | github.com/airbnb/polyglot.js | ✅ Fixed


<p>Fixes #6385</p>
<hr>
<h4>Checklist</h4>
<ul>
<li>[x] run <code>npm run test &amp;&amp; npm run benchmark</code> (not applicable - documentation-only changes)</li>
<li>[ ] tests and/or benchmarks are included (not applicable - documentation-only changes)</li>
<li>[x] documentation is changed or added</li>
<li>[x] commit message and code follows the <a href="https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11">Developer's Certification of Origin</a> and the <a href="https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md">Code of conduct</a></li>
</ul>
<p><strong>Note:</strong> Tests and benchmarks are not applicable for this PR as it only contains documentation link fixes with no code changes.</p></body></html><!--EndFragment-->
</body>
</html>## Description
This PR fixes broken links found in the documentation as reported in #6385.

During automated link checking with `markdown-link-check`, several links were failing due to rate-limiting and bot protection from npmjs.com and npm.im domains. This PR resolves these issues by replacing them with stable GitHub repository links.

## Changes Made
- **Benchmarking.md**: Fixed `npm@5.2.0` being incorrectly detected as a mailto link by wrapping it in backticks
- **Database.md**: Replaced npmjs.com links with GitHub repository links for `postgrator` and `migrate-mongo` 
- **Ecosystem.md**: Replaced npm.im and npmjs.com links with GitHub repository links for `accepts`, `fastify-jwt`, `jsonwebtoken`, `node-polyglot`, and updated Bugsnag link to docs site

## Why These Changes?
The original links to npmjs.com and npm.im were returning 403/0 status errors during automated link checking due to:
- Rate-limiting from npmjs.com
- Bot protection mechanisms

GitHub repository links are:
- More stable for automated checks
- Provide direct access to source code and documentation
- Don't have aggressive rate-limiting
- Equally useful for developers

## Testing
Verified all links pass using `markdown-link-check`:
```powershell
Get-ChildItem docs\Guides -Filter *.md | ForEach-Object { markdown-link-check $_.FullName }
```

All previously broken links (8 total) now work correctly. ✅

## Link Changes Summary
| File | Old Link | New Link | Status |
|------|----------|----------|--------|
| Benchmarking.md | `npm@5.2.0` | `` `npm@5.2.0` `` | ✅ Fixed |
| Database.md | npmjs.com/package/postgrator | github.com/rickbergfalk/postgrator | ✅ Fixed |
| Database.md | npmjs.com/package/migrate-mongo | github.com/seppevs/migrate-mongo | ✅ Fixed |
| Ecosystem.md | npmjs.com/package/accepts | github.com/jshttp/accepts | ✅ Fixed |
| Ecosystem.md | npm.im/fastify-jwt | github.com/fastify/fastify-jwt | ✅ Fixed |
| Ecosystem.md | npm.im/jsonwebtoken | github.com/auth0/node-jsonwebtoken | ✅ Fixed |
| Ecosystem.md | www.bugsnag.com | docs.bugsnag.com | ✅ Fixed |
| Ecosystem.md | npmjs.com/package/node-polyglot | github.com/airbnb/polyglot.js | ✅ Fixed |

Fixes #6385

---

#### Checklist
- [x] run `npm run test && npm run benchmark` (not applicable - documentation-only changes)
- [ ] tests and/or benchmarks are included (not applicable - documentation-only changes)
- [x] documentation is changed or added
- [x] commit message and code follows the [[Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [[Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

**Note:** Tests and benchmarks are not applicable for this PR as it only contains documentation link fixes with no code changes.