### PR TITLE
chore: upgrade borp to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "ajv-i18n": "^4.2.0",
     "ajv-merge-patch": "^5.0.1",
     "autocannon": "^8.0.0",
-    "borp": "^0.21.0",
+    "borp": "^1.0.0",
     "branch-comparer": "^1.1.0",
     "concurrently": "^9.1.2",
     "cross-env": "^10.0.0",


### PR DESCRIPTION
Proposal:

- Upgrade `borp` dependency from `^0.21.0` to `^1.0.0` ( see here: https://github.com/mcollina/borp/releases/tag/v1.0.0 )