### PR TITLE
fix: avoid mutating shared routerOptions across instances

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -614,7 +614,9 @@ function runPreParsing (err, request, reply) {
 }
 
 function buildRouterOptions (options, defaultOptions) {
-  const routerOptions = options.routerOptions || Object.create(null)
+  const routerOptions = options.routerOptions == null
+    ? Object.create(null)
+    : Object.assign(Object.create(null), options.routerOptions)
 
   const usedDeprecatedOptions = routerKeys.filter(key => Object.hasOwn(options, key))
 


### PR DESCRIPTION
## Problem

Reusing the same `routerOptions` object across multiple Fastify instances can fail with:

`TypeError: Cannot read properties of null (reading 'server')`

`buildRouterOptions()` was mutating the user-provided `options.routerOptions` object in place while filling defaults (including instance-bound callbacks like `defaultRoute` / `onBadUrl`).

## Fix

- clone `options.routerOptions` before filling defaults
- avoid mutating user-provided config objects

## Tests

- add regression test: `Should allow reusing a routerOptions object across instances`
- add regression test: `Should not mutate user-provided routerOptions object`
- ensure cleanup uses `t.after()` so instances are always closed

Fixes #6512
