### PR TITLE
docs: add common performance degradation guidance

### DIFF
--- a/docs/Guides/Recommendations.md
+++ b/docs/Guides/Recommendations.md
@@ -7,6 +7,7 @@ This document contains a set of recommendations when using Fastify.
 - [Use A Reverse Proxy](#use-a-reverse-proxy)
   - [HAProxy](#haproxy)
   - [Nginx](#nginx)
+- [Common Causes Of Performance Degradation](#common-causes-of-performance-degradation)
 - [Kubernetes](#kubernetes)
 - [Capacity Planning For Production](#capacity)
 - [Running Multiple Instances](#multiple)
@@ -281,6 +282,26 @@ server {
 ```
 
 [nginx]: https://nginx.org/
+
+## Common Causes Of Performance Degradation
+<a id="degradation"></a>
+
+These patterns can reduce throughput or increase latency in production:
+
+- Prefer static or simple parametric routes on hot paths. RegExp routes are
+  expensive, and routes with many parameters can also hurt router performance.
+  See [Routes - URL building](../Reference/Routes.md#url-building).
+- Use route constraints carefully. Version constraints can degrade router
+  performance, and asynchronous custom constraints should be treated as a last
+  resort. See [Routes - Constraints](../Reference/Routes.md#constraints).
+- Prefer Fastify plugins/hooks over generic middleware when possible. Fastify's
+  middleware adapters work, but native integrations are typically better for
+  performance-sensitive paths. See [Middleware](../Reference/Middleware.md).
+- Define response schemas to speed up JSON serialization. See
+  [Getting Started - Response](./Getting-Started.md#response).
+- Keep Ajv `allErrors` disabled unless you have a strict reason to enable it.
+  This reduces overhead and avoids known risk patterns documented by Ajv/Fastify.
+  See [Validation and Serialization - Validator Compiler](../Reference/Validation-and-Serialization.md#schema-validator).
 
 ## Kubernetes
 <a id="kubernetes"></a>


### PR DESCRIPTION
## Summary
Adds a focused section to `docs/Guides/Recommendations.md` listing common causes of performance degradation and linking to existing Fastify docs sections that already describe each tradeoff.

## Changes
- Add TOC entry for the new section
- Add `Common Causes Of Performance Degradation` section with practical guidance
- Link to existing references for routes, constraints, middleware, response schema serialization, and Ajv validator settings

Closes #4832
