### PR TITLE
fix(types): allow send() to accept PromiseLike payloads

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -154,6 +154,15 @@ Reply.prototype.send = function (payload) {
   }
 
   if (this.sent === true) {
+    // A thenable payload is dropped here, so nothing would ever observe its
+    // outcome: an eventual rejection would surface as an unhandled rejection
+    // (which terminates the process by default). Attach a handler that logs it
+    // instead.
+    if (isThenable(payload)) {
+      payload.then(noop, (err) => {
+        this.log.warn({ err }, 'Promise errored after the reply was already sent')
+      })
+    }
     this.log.warn({ err: new FST_ERR_REP_ALREADY_SENT(this.request.url, this.request.method) })
     return this
   }
@@ -169,7 +178,7 @@ Reply.prototype.send = function (payload) {
     return this
   }
 
-  if (payload !== null && typeof payload === 'object' && typeof payload.then === 'function') {
+  if (isThenable(payload)) {
     wrapThenable(payload, this)
     return this
   }
@@ -1076,6 +1085,10 @@ function serialize (context, data, statusCode, contentType) {
 }
 
 function noop () { }
+
+function isThenable (value) {
+  return value !== null && typeof value === 'object' && typeof value.then === 'function'
+}
 
 module.exports = Reply
 module.exports.buildReply = buildReply

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -59,6 +59,7 @@ const {
 } = require('./errors')
 const decorators = require('./decorate')
 const ContentType = require('./content-type.js')
+const wrapThenable = require('./wrap-thenable.js')
 
 const toString = Object.prototype.toString
 const HTTP2_WRITE_CHUNK_SIZE = 64 * 1024
@@ -165,6 +166,11 @@ Reply.prototype.send = function (payload) {
 
   if (payload === undefined) {
     onSendHook(this, payload)
+    return this
+  }
+
+  if (payload !== null && typeof payload === 'object' && typeof payload.then === 'function') {
+    wrapThenable(payload, this)
     return this
   }
 

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -1996,3 +1996,83 @@ test('reply.send(promise) sends the rejection reason as an error', async t => {
   const response = await fastify.inject({ method: 'GET', url: '/' })
   t.assert.strictEqual(response.statusCode, 500)
 })
+
+test('returning reply.send(promise) from a sync handler sends the resolved value', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.get('/', function (req, reply) {
+    return reply.send(Promise.resolve('asd'))
+  })
+
+  const response = await fastify.inject({ method: 'GET', url: '/' })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.strictEqual(response.body, 'asd')
+})
+
+test('reply.send(promise) inside an async handler sends the resolved value', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.get('/', async function (req, reply) {
+    reply.send(Promise.resolve('asd'))
+  })
+
+  const response = await fastify.inject({ method: 'GET', url: '/' })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.strictEqual(response.body, 'asd')
+})
+
+test('calling reply.send(promise) twice sends the payload that settles first', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.get('/', function (req, reply) {
+    reply.send(Promise.resolve('one'))
+    reply.send(Promise.resolve('two'))
+  })
+
+  const response = await fastify.inject({ method: 'GET', url: '/' })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.strictEqual(response.body, 'one')
+})
+
+test('calling reply.send(promise) twice is settle-ordered, not call-ordered', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+  const wait = (ms, value) => new Promise(resolve => setTimeout(() => resolve(value), ms))
+
+  fastify.get('/', function (req, reply) {
+    reply.send(wait(200, 'one'))
+    reply.send(wait(1, 'two'))
+  })
+
+  const response = await fastify.inject({ method: 'GET', url: '/' })
+  t.assert.strictEqual(response.statusCode, 200)
+  // The payload is not known until the promise settles, so the faster one wins
+  // even though it was passed to send() second.
+  t.assert.strictEqual(response.body, 'two')
+})
+
+test('a promise rejecting after the reply was sent is logged, not left unhandled', async t => {
+  t.plan(2)
+  const lines = []
+  const fastify = Fastify({
+    logger: { level: 'warn', stream: { write (line) { lines.push(JSON.parse(line)) } } }
+  })
+
+  fastify.get('/', function (req, reply) {
+    reply.send('immediate')
+    reply.send(Promise.reject(new Error('late boom')))
+  })
+
+  const response = await fastify.inject({ method: 'GET', url: '/' })
+  t.assert.strictEqual(response.body, 'immediate')
+
+  // Give the dropped promise a chance to reject.
+  await new Promise(resolve => setImmediate(resolve))
+  t.assert.ok(
+    lines.some(line => line.err && line.err.message === 'late boom'),
+    'the rejection of the ignored payload is reported'
+  )
+})

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -1971,3 +1971,28 @@ test('reply.send should not treat charset= inside a quoted parameter value as an
     'application/json; name="a=b;charset=fake"; charset=utf-8'
   )
 })
+
+test('reply.send(promise) resolves the promise and sends its value', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.get('/', function (req, reply) {
+    reply.send(Promise.resolve({ hello: 'world' }))
+  })
+
+  const response = await fastify.inject({ method: 'GET', url: '/' })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(response.json(), { hello: 'world' })
+})
+
+test('reply.send(promise) sends the rejection reason as an error', async t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  fastify.get('/', function (req, reply) {
+    reply.send(Promise.reject(new Error('kaboom')))
+  })
+
+  const response = await fastify.inject({ method: 'GET', url: '/' })
+  t.assert.strictEqual(response.statusCode, 500)
+})

--- a/test/types/instance.tst.ts
+++ b/test/types/instance.tst.ts
@@ -88,12 +88,12 @@ interface ReplyPayload {
 // typed sync error handler
 server.setErrorHandler<CustomError, ReplyPayload>((error, request, reply) => {
   expect(error).type.toBe<CustomError>()
-  expect(reply.send).type.toBe<((...args: [payload: ReplyPayload['Reply']]) => FastifyReply<ReplyPayload, RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>>)>()
+  expect(reply.send).type.toBe<((...args: [payload: ReplyPayload['Reply'] | PromiseLike<ReplyPayload['Reply']>]) => FastifyReply<ReplyPayload, RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>>)>()
 })
 // typed async error handler send
 server.setErrorHandler<CustomError, ReplyPayload>(async (error, request, reply) => {
   expect(error).type.toBe<CustomError>()
-  expect(reply.send).type.toBe<((...args: [payload: ReplyPayload['Reply']]) => FastifyReply<ReplyPayload, RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>>)>()
+  expect(reply.send).type.toBe<((...args: [payload: ReplyPayload['Reply'] | PromiseLike<ReplyPayload['Reply']>]) => FastifyReply<ReplyPayload, RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>>)>()
 })
 // typed async error handler return
 server.setErrorHandler<CustomError, ReplyPayload>(async (error, request, reply) => {

--- a/test/types/reply.tst.ts
+++ b/test/types/reply.tst.ts
@@ -34,7 +34,7 @@ const getHandler: RouteHandlerMethod = function (_request, reply) {
   expect(reply.writeEarlyHints).type.toBe<
     (hints: Record<string, string | string[]>, callback?: (() => void) | undefined) => void
   >()
-  expect(reply.send).type.toBe<((...args: [payload?: unknown]) => FastifyReply)>()
+  expect(reply.send).type.toBe<((...args: [payload?: unknown | PromiseLike<unknown>]) => FastifyReply)>()
   expect(reply.header).type.toBeAssignableTo<(key: string, value: any) => FastifyReply>()
   expect(reply.headers).type.toBeAssignableTo<(values: { [key: string]: any }) => FastifyReply>()
   expect(reply.getHeader).type.toBeAssignableTo<(key: string) => number | string | string[] | undefined>()
@@ -133,9 +133,9 @@ interface ReplyHttpCodesWithNoContent {
 }
 
 const typedHandler: RouteHandler<ReplyPayload> = async (request, reply) => {
-  // When Reply type is specified, send() requires a payload argument
-  expect(reply.send).type.toBe<((...args: [payload: ReplyPayload['Reply']]) => FastifyReply<ReplyPayload, RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>>)>()
-  expect(reply.code(100).send).type.toBe<((...args: [payload: ReplyPayload['Reply']]) => FastifyReply<ReplyPayload, RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>>)>()
+  // When Reply type is specified, send() requires a payload argument (direct value or Promise)
+  expect(reply.send).type.toBe<((...args: [payload: ReplyPayload['Reply'] | PromiseLike<ReplyPayload['Reply']>]) => FastifyReply<ReplyPayload, RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>>)>()
+  expect(reply.code(100).send).type.toBe<((...args: [payload: ReplyPayload['Reply'] | PromiseLike<ReplyPayload['Reply']>]) => FastifyReply<ReplyPayload, RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>>)>()
 }
 
 const server = fastify()
@@ -155,7 +155,7 @@ server.get<ReplyPayload>('/get-generic-return', async function handler (request,
 })
 server.get<ReplyPayload>('/get-generic-send-error', async function handler (request, reply) {
   reply.send({
-    // @ts-expect-error  'foo' does not exist in type '{ test: boolean; }'.
+    // @ts-expect-error  'foo' does not exist in type '{ test: boolean; } | PromiseLike<{ test: boolean; }>'.
     foo: 'bar'
   })
 })
@@ -179,7 +179,7 @@ server.get<ReplyUnion>('/get-generic-union-return', async function handler (requ
 })
 server.get<ReplyUnion>('/get-generic-union-send-error-1', async function handler (request, reply) {
   reply.send({
-    // @ts-expect-error  'successes' does not exist in type '{ success: boolean; } | { error: string; }'.
+    // @ts-expect-error  'successes' does not exist in type '{ success: boolean; } | { error: string; } | PromiseLike<{ success: boolean; } | { error: string; }>'.
     successes: true
   })
 })
@@ -205,12 +205,12 @@ server.get<ReplyHttpCodes>('/get-generic-http-codes-send', async function handle
 })
 server.get<ReplyHttpCodes>('/get-generic-http-codes-send-error-1', async function handler (request, reply) {
   reply.code(200)
-  // @ts-expect-error  Argument of type '"def"' is not assignable to parameter of type '"abc"'.
+  // @ts-expect-error  Argument of type '"def"' is not assignable to parameter of type '"abc" | PromiseLike<"abc">'.
     .send('def')
 })
 server.get<ReplyHttpCodes>('/get-generic-http-codes-send-error-2', async function handler (request, reply) {
   reply.code(201)
-  // @ts-expect-error  Argument of type 'number' is not assignable to parameter of type 'boolean'.
+  // @ts-expect-error  Argument of type '0' is not assignable to parameter of type 'boolean | PromiseLike<boolean>'.
     .send(0)
 })
 server.get<ReplyHttpCodes>('/get-generic-http-codes-send-error-3', async function handler (request, reply) {
@@ -221,7 +221,7 @@ server.get<ReplyHttpCodes>('/get-generic-http-codes-send-error-3', async functio
 })
 server.get<ReplyHttpCodes>('/get-generic-http-codes-send-error-4', async function handler (request, reply) {
   reply.code(100)
-  // @ts-expect-error  Argument of type 'string' is not assignable to parameter of type 'number'.
+  // @ts-expect-error  Argument of type 'string' is not assignable to parameter of type 'number | PromiseLike<number>'.
     .send('asdasd')
 })
 server.get<ReplyHttpCodes>('/get-generic-http-codes-send-error-5', async function handler (request, reply) {
@@ -237,7 +237,7 @@ server.get<ReplyArrayPayload>('/get-generic-array-send', async function handler 
 })
 server.get<InvalidReplyHttpCodes>('get-invalid-http-codes-reply-error', async function handler (request, reply) {
   reply.code(200)
-  // @ts-expect-error  Argument of type 'string' is not assignable to parameter of type '{ '1xx': number; 200: string; 999: boolean; }'.
+  // @ts-expect-error  Argument of type 'string' is not assignable to parameter of type '{ '1xx': number; 200: string; 999: boolean; } | PromiseLike<{ '1xx': number; 200: string; 999: boolean; }>'.
     .send('')
 })
 server.get<InvalidReplyHttpCodes>('get-invalid-http-codes-reply-error', async function handler (request, reply) {
@@ -280,6 +280,21 @@ server.get<ReplyVoid>('/get-void-send-empty', async function handler (request, r
 // Test: send() without arguments is valid when Reply type is undefined
 server.get<ReplyUndefined>('/get-undefined-send-empty', async function handler (request, reply) {
   reply.send()
+})
+
+// Test: send() accepts a Promise<T> when Reply type is specified (matches runtime behavior via wrap-thenable)
+server.get<ReplyPayload>('/get-generic-send-promise', async function handler (request, reply) {
+  reply.send(Promise.resolve({ test: true }))
+})
+// Test: send() accepts Promise with async function that resolves the payload
+server.get<ReplyPayload>('/get-generic-send-async', async function handler (request, reply) {
+  const fetchData = async (): Promise<ReplyPayload['Reply']> => ({ test: true })
+  reply.send(fetchData())
+})
+// Test: send() with Promise should error when Promise resolves to wrong type
+server.get<ReplyPayload>('/get-generic-send-promise-wrong-type', async function handler (request, reply) {
+  // @ts-expect-error  Argument of type 'Promise<{ foo: string; }>' is not assignable to parameter of type '{ test: boolean; } | PromiseLike<{ test: boolean; }>'.
+  reply.send(Promise.resolve({ foo: 'bar' }))
 })
 
 // Issue #5534 scenario: HTTP status codes with 204 No Content

--- a/test/types/type-provider.tst.ts
+++ b/test/types/type-provider.tst.ts
@@ -479,9 +479,11 @@ server.withTypeProvider<TypeBoxProvider>().get(
     res.send('hello')
     res.send(42)
     res.send({ error: 'error' })
-    expect(res.code(200).send).type.toBe<((...args: [payload: string]) => typeof res)>()
-    expect(res.code(400).send).type.toBe<((...args: [payload: number]) => typeof res)>()
-    expect(res.code(500).send).type.toBe<((...args: [payload: { error: string }]) => typeof res)>()
+    expect(res.code(200).send).type.toBe<((...args: [payload: string | PromiseLike<string>]) => typeof res)>()
+    expect(res.code(400).send).type.toBe<((...args: [payload: number | PromiseLike<number>]) => typeof res)>()
+    expect(res.code(500).send).type.toBe<
+      (...args: [payload: { error: string } | PromiseLike<{ error: string }>]) => typeof res
+    >()
   }
 )
 
@@ -712,10 +714,11 @@ server.withTypeProvider<JsonSchemaToTsProvider>().get(
     res.send('hello')
     res.send(42)
     res.send({ error: 'error' })
-    expect(res.code(200).send).type.toBe<((...args: [payload: string]) => typeof res)>()
-    expect(res.code(400).send).type.toBe<((...args: [payload: number]) => typeof res)>()
+    expect(res.code(200).send).type.toBe<((...args: [payload: string | PromiseLike<string>]) => typeof res)>()
+    expect(res.code(400).send).type.toBe<((...args: [payload: number | PromiseLike<number>]) => typeof res)>()
     expect(res.code(500).send).type.toBe<
-      ((...args: [payload: { [x: string]: unknown; error?: string }]) => typeof res)
+      (...args: [payload: { [x: string]: unknown; error?: string } |
+        PromiseLike<{ [x: string]: unknown; error?: string }>]) => typeof res
     >()
   }
 )

--- a/types/type-provider.d.ts
+++ b/types/type-provider.d.ts
@@ -143,9 +143,12 @@ export type SafePromiseLike<T> = PromiseLike<T> & { __linterBrands: 'SafePromise
  * - When ReplyType is unknown (default/unspecified), payload is optional
  * - When ReplyType is undefined or void, payload is optional (returning undefined is valid)
  * - Otherwise, payload is required
+ *
+ * send() also accepts a PromiseLike<ReplyType>: the runtime resolves it and
+ * sends the resolved value (or the rejection reason as an error).
  */
 export type SendArgs<ReplyType> = unknown extends ReplyType
-  ? [payload?: ReplyType]
+  ? [payload?: ReplyType | PromiseLike<ReplyType>]
   : [ReplyType] extends [undefined | void]
-      ? [payload?: ReplyType]
-      : [payload: ReplyType]
+      ? [payload?: ReplyType | PromiseLike<ReplyType>]
+      : [payload: ReplyType | PromiseLike<ReplyType>]


### PR DESCRIPTION
## What this does

Two things, which are separable:

**1. Makes `reply.send(promise)` actually work at runtime.** `SendArgs` is widened to accept `PromiseLike<ReplyType>`, and `Reply.prototype.send` routes a thenable payload through the existing `wrap-thenable` path instead of serializing the promise object itself.

**2. Stops a dropped thenable from crashing the process.** When `send()` bails out through the `this.sent === true` branch, the payload is discarded. If that payload is a promise that later rejects, nothing has attached a handler to it, so it surfaces as an unhandled rejection — fatal by default on modern Node. `send()` now attaches a handler that logs it instead. This one is a robustness fix that applies regardless of whether (1) is wanted, since a JS user can pass a promise today whether or not the types permit it.

## Behaviour

- `reply.send(Promise.resolve(x))` sends `x`; a rejection is sent through the error path.
- With two promise payloads, the one that **settles** first wins, not the one `send()` was called for first — the payload isn't known until settlement. Asserted explicitly in `calling reply.send(promise) twice is settle-ordered, not call-ordered`, since it differs from the plain-value case.

## Tests

`test/internals/reply.test.js` covers resolve, reject, `return reply.send(promise)` from a sync handler, `send()` inside an async handler, double-send with already-resolved promises, double-send settling out of order, and the dropped-rejection case. Type tests updated in `reply.tst.ts`, `type-provider.tst.ts`, `instance.tst.ts`.

Locally: 89 unit tests in `reply.test.js`, tstyche 1284 assertions across 16 files, lint clean.

## Status

Opened originally as a types-only change. It grew into the above because the widened type would otherwise have described behaviour the runtime did not implement. See the discussion below on whether the feature is wanted at all.
