### PR TITLE
fix: remove format placeholder from FST_ERR_CTP_INVALID_MEDIA_TYPE message

### DIFF
--- a/lib/content-type-parser.js
+++ b/lib/content-type-parser.js
@@ -192,7 +192,7 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
     }
 
     reply[kReplyIsError] = true
-    reply.send(new FST_ERR_CTP_INVALID_MEDIA_TYPE(contentType || undefined))
+    reply.send(new FST_ERR_CTP_INVALID_MEDIA_TYPE())
     return
   }
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -110,7 +110,7 @@ const codes = {
   ),
   FST_ERR_CTP_INVALID_MEDIA_TYPE: createError(
     'FST_ERR_CTP_INVALID_MEDIA_TYPE',
-    'Unsupported Media Type: %s',
+    'Unsupported Media Type',
     415
   ),
   FST_ERR_CTP_INVALID_CONTENT_LENGTH: createError(

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -302,7 +302,7 @@ test('Error thrown 415 from content type is null and make post request to server
   t.plan(3)
 
   const fastify = Fastify()
-  const errMsg = new FST_ERR_CTP_INVALID_MEDIA_TYPE(undefined).message
+  const errMsg = new FST_ERR_CTP_INVALID_MEDIA_TYPE().message
 
   fastify.post('/', (req, reply) => {
   })
@@ -697,6 +697,30 @@ test('content-type regexp list should be cloned when plugin override', async t =
     t.assert.strictEqual(headers['content-type'], 'image/png')
     t.assert.strictEqual(payload, 'png')
   }
+})
+
+test('invalid content-type error message should not contain format placeholder', (t, done) => {
+  t.plan(4)
+
+  const fastify = Fastify()
+
+  fastify.post('/', (req, reply) => {
+    reply.send('ok')
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    headers: { 'Content-Type': 'invalid-content-type' },
+    body: 'test'
+  }, (err, res) => {
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 415)
+    const body = JSON.parse(res.body)
+    t.assert.strictEqual(body.code, 'FST_ERR_CTP_INVALID_MEDIA_TYPE')
+    t.assert.strictEqual(body.message, 'Unsupported Media Type')
+    done()
+  })
 })
 
 test('content-type fail when not a valid type', async t => {

--- a/test/internals/errors.test.js
+++ b/test/internals/errors.test.js
@@ -165,7 +165,7 @@ test('FST_ERR_CTP_INVALID_MEDIA_TYPE', t => {
   const error = new errors.FST_ERR_CTP_INVALID_MEDIA_TYPE()
   t.assert.strictEqual(error.name, 'FastifyError')
   t.assert.strictEqual(error.code, 'FST_ERR_CTP_INVALID_MEDIA_TYPE')
-  t.assert.strictEqual(error.message, 'Unsupported Media Type: %s')
+  t.assert.strictEqual(error.message, 'Unsupported Media Type')
   t.assert.strictEqual(error.statusCode, 415)
   t.assert.ok(error instanceof Error)
 })


### PR DESCRIPTION
## Summary

- The error message template `'Unsupported Media Type: %s'` produced the literal string `%s` when instantiated without arguments (as in `lib/handle-request.js`).
- Rather than reflecting the raw `content-type` header back to the client (which would expose unsanitized user input in error responses and logs), the template is changed to the static message `'Unsupported Media Type'`.
- Both callsites (`lib/handle-request.js` and `lib/content-type-parser.js`) now instantiate the error with no arguments.

## Breaking change

This is a **minor breaking change** for consumers that match on the exact `error.message` string (previously `'Unsupported Media Type: <content-type>'`, now `'Unsupported Media Type'`). The error code `FST_ERR_CTP_INVALID_MEDIA_TYPE` and HTTP status `415` are unchanged and should be used for programmatic error handling instead.

## Test plan

- [x] Added test that sends an invalid content-type header and asserts the error message is `'Unsupported Media Type'` (no `%s` placeholder)
- [x] Updated existing error unit test to expect the new message
- [x] All tests pass (2164 pass, 0 fail)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)