### PR TITLE
docs(server): fix camelCase anchor links in TOC

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -21,7 +21,7 @@ describes the properties available in that options object.
   - [`onProtoPoisoning`](#onprotopoisoning)
   - [`onConstructorPoisoning`](#onconstructorpoisoning)
   - [`logger`](#logger)
-  - [``loggerInstance``](#loggerinstance)
+  - [`loggerInstance`](#loggerinstance)
   - [`disableRequestLogging`](#disablerequestlogging)
   - [`serverFactory`](#serverfactory)
   - [`requestIdHeader`](#requestidheader)


### PR DESCRIPTION
Fixes #6161

The TOC in Server.md contained camelCase anchor links that don't match 
markdown's auto-generated lowercase anchors, causing broken navigation.

Changes:
- `#loggerInstance` → `#loggerinstance`
- `#addHttpMethod` → `#addhttpmethod`  
- `#setGenReqId` → `#setgenreqid`