### PR TITLE
docs: clarify anyOf nullable coercion behavior with primitive types

### DIFF
--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -329,6 +329,31 @@ server.setValidatorCompiler(req => {
 })
 ```
 
+When type coercion is enabled, using `anyOf` with nullable primitive types
+can produce unexpected results. For example, a value of `0` or `false` may be
+coerced to `null` because Ajv evaluates `anyOf` schemas in order and applies
+type coercion during matching. This means the `{ "type": "null" }` branch can
+match before the intended type:
+
+```json
+{
+  "anyOf": [
+    { "type": "null" },
+    { "type": "number" }
+  ]
+}
+```
+
+To avoid this, use the `nullable` keyword instead of `anyOf` for primitive
+types:
+
+```json
+{
+  "type": "number",
+  "nullable": true
+}
+```
+
 For more information, see [Ajv Coercion](https://ajv.js.org/coercion.html).
 
 #### Ajv Plugins


### PR DESCRIPTION
When type coercion is enabled, using `anyOf` with a `null` type before a primitive type (`number`, `boolean`) causes Ajv to coerce falsy values like `0` and `false` to `null`. This documents the pitfall and recommends using the `nullable` keyword instead.

Fixes #6411

This picks up where #6429 left off (which was closed after an accidental merge/revert).

#### Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md)
- [x] `npm run lint` passes
- [x] Documentation only change