### PR TITLE
ci(link-checker): fix root-relative links resolution

### DIFF
--- a/.github/workflows/links-check.yml
+++ b/.github/workflows/links-check.yml
@@ -31,7 +31,7 @@ jobs:
           # As external links behavior is not predictable, we check only internal links
           # to ensure consistency.
           # See: https://github.com/lycheeverse/lychee-action/issues/17#issuecomment-1162586751
-          args: --offline --verbose --no-progress --root-dir . './**/*.md'
+          args: --offline --verbose --no-progress --root-dir "$(pwd)" './**/*.md'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 


### PR DESCRIPTION
Fixes #6522

## Summary

The link checker was failing to resolve root-relative links such as:

/docs/Reference/TypeScript.md

This happens because lychee requires the `--root-dir` option to correctly resolve local root-relative paths.

## Changes

Added `--root-dir .` to the lychee arguments in the GitHub Actions workflow.

## Result

This fixes false positives from the link checker when running locally and in CI, without affecting runtime code.