### PR TITLE
types: decouple serializer contracts from compiler package

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -671,9 +671,11 @@ const fastify = require('fastify')({
 ### `serializerOpts`
 <a id="serializer-opts"></a>
 
-Customize the options of the default
+Customize the options passed to Fastify's default serializer builder, which is
+[`@fastify/fast-json-stringify-compiler`](https://github.com/fastify/fast-json-stringify-compiler).
+Those options are forwarded to
 [`fast-json-stringify`](https://github.com/fastify/fast-json-stringify#options)
-instance that serializes the response's payload:
+to serialize the response payload:
 
 ```js
 const fastify = require('fastify')({

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -3,9 +3,8 @@ import * as http2 from 'node:http2'
 import * as https from 'node:https'
 import { Socket } from 'node:net'
 
-import { BuildCompilerFromPool, ValidatorFactory } from '@fastify/ajv-compiler'
+import { BuildCompilerFromPool } from '@fastify/ajv-compiler'
 import { FastifyError } from '@fastify/error'
-import { Options as FJSOptions, SerializerFactory } from '@fastify/fast-json-stringify-compiler'
 import { Config as FindMyWayConfig, ConstraintStrategy, HTTPVersion } from 'find-my-way'
 import { InjectOptions, CallbackFunc as LightMyRequestCallback, Chain as LightMyRequestChain, Response as LightMyRequestResponse } from 'light-my-request'
 
@@ -28,7 +27,7 @@ import { FastifyRegister, FastifyRegisterOptions, RegisterOptions } from './type
 import { FastifyReply } from './types/reply'
 import { FastifyRequest, RequestGenericInterface } from './types/request'
 import { RouteGenericInterface, RouteHandler, RouteHandlerMethod, RouteOptions, RouteShorthandMethod, RouteShorthandOptions, RouteShorthandOptionsWithHandler } from './types/route'
-import { FastifySchema, FastifySchemaValidationError, FastifySchemaCompiler, FastifySerializerCompiler, SchemaErrorDataVar, SchemaErrorFormatter } from './types/schema'
+import { FastifySchema, FastifySchemaValidationError, FastifySchemaCompiler, FastifySchemaControllerOptions, FastifySerializerCompiler, FastifySerializerOptions, SchemaErrorDataVar, SchemaErrorFormatter } from './types/schema'
 import { FastifyServerFactory, FastifyServerFactoryHandler } from './types/server-factory'
 import { FastifyTypeProvider, FastifyTypeProviderDefault, SafePromiseLike } from './types/type-provider'
 import { ContextConfigDefault, HTTPMethods, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RawServerDefault, RequestBodyDefault, RequestHeadersDefault, RequestParamsDefault, RequestQuerystringDefault } from './types/utils'
@@ -127,7 +126,7 @@ declare namespace fastify {
     onConstructorPoisoning?: ConstructorAction,
     logger?: boolean | FastifyLoggerOptions<RawServer> & PinoLoggerOptions,
     loggerInstance?: Logger
-    serializerOpts?: FJSOptions | Record<string, unknown>,
+    serializerOpts?: FastifySerializerOptions,
     serverFactory?: FastifyServerFactory<RawServer>,
     caseSensitive?: boolean,
     allowUnsafeRegex?: boolean,
@@ -140,17 +139,7 @@ declare namespace fastify {
     constraints?: {
       [name: string]: ConstraintStrategy<FindMyWayVersion<RawServer>, unknown>,
     },
-    schemaController?: {
-      bucket?: (parentSchemas?: unknown) => {
-        add(schema: unknown): FastifyInstance;
-        getSchema(schemaId: string): unknown;
-        getSchemas(): Record<string, unknown>;
-      };
-      compilersFactory?: {
-        buildValidator?: ValidatorFactory;
-        buildSerializer?: SerializerFactory;
-      };
-    };
+    schemaController?: FastifySchemaControllerOptions;
     return503OnClosing?: boolean,
     ajv?: Parameters<BuildCompilerFromPool>[1],
     frameworkErrors?: <RequestGeneric extends RequestGenericInterface = RequestGenericInterface, TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault, SchemaCompiler extends FastifySchema = FastifySchema>(

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -126,7 +126,7 @@ declare namespace fastify {
     onConstructorPoisoning?: ConstructorAction,
     logger?: boolean | FastifyLoggerOptions<RawServer> & PinoLoggerOptions,
     loggerInstance?: Logger
-    serializerOpts?: FastifySerializerOptions,
+    serializerOpts?: FastifySerializerOptions | Record<string, unknown>,
     serverFactory?: FastifyServerFactory<RawServer>,
     caseSensitive?: boolean,
     allowUnsafeRegex?: boolean,

--- a/types/schema.d.ts
+++ b/types/schema.d.ts
@@ -1,5 +1,4 @@
 import { ValidatorFactory } from '@fastify/ajv-compiler'
-import { SerializerFactory } from '@fastify/fast-json-stringify-compiler'
 import { FastifyInstance, SafePromiseLike } from '../fastify'
 /**
  * Schemas in Fastify follow the JSON-Schema standard. For this reason
@@ -44,6 +43,24 @@ export type FastifySchemaCompiler<T> = (routeSchema: FastifyRouteSchemaDef<T>) =
 
 export type FastifySerializerCompiler<T> = (routeSchema: FastifyRouteSchemaDef<T>) => (data: any) => string
 
+export interface FastifySerializerOptions {
+  [key: string]: any;
+}
+
+export interface FastifySerializerRouteDefinition {
+  method: string;
+  url: string;
+  httpStatus: string;
+  schema?: unknown;
+}
+
+export type FastifySchemaSerializer = (doc: any) => string
+
+export type FastifySerializerFactory = (
+  externalSchemas?: unknown,
+  serializerOpts?: FastifySerializerOptions
+) => (routeDef: FastifySerializerRouteDefinition) => FastifySchemaSerializer
+
 export interface FastifySchemaControllerOptions {
   bucket?: (parentSchemas?: unknown) => {
     add(schema: unknown): FastifyInstance;
@@ -52,7 +69,7 @@ export interface FastifySchemaControllerOptions {
   };
   compilersFactory?: {
     buildValidator?: ValidatorFactory;
-    buildSerializer?: SerializerFactory;
+    buildSerializer?: FastifySerializerFactory;
   };
 }
 


### PR DESCRIPTION
## Context
Part of #6507.

This follows the direction discussed in the issue comments: keep runtime behavior unchanged for now and focus on typing/docs around serializer configuration.

## What changed
- removed direct public type dependency on `@fastify/fast-json-stringify-compiler` from `fastify.d.ts`
- introduced local serializer contract types in `types/schema.d.ts`:
  - `FastifySerializerOptions`
  - `FastifySerializerRouteDefinition`
  - `FastifySchemaSerializer`
  - `FastifySerializerFactory`
- switched `schemaController` typing in `fastify.d.ts` to reuse `FastifySchemaControllerOptions`
- clarified `serializerOpts` docs to explain options forwarding to the default serializer builder

## Notes
- no runtime behavior changes
- no dependency changes

## Validation
- `npx tsd --files test/types/schema.test-d.ts`
- `npx eslint fastify.d.ts types/schema.d.ts`
- `npx markdownlint-cli2 docs/Reference/Server.md`