### PR TITLE
Validate logLevel in route options at registration time (#6124)

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -436,6 +436,12 @@ const codes = {
     500,
     TypeError
   ),
+  FST_ERR_ROUTE_INVALID_LOG_LEVEL: createError(
+    'FST_ERR_ROUTE_INVALID_LOG_LEVEL',
+    "Invalid logLevel '%s'. Must be one of: trace, debug, info, warn, error, fatal, silent",
+    500,
+    TypeError
+  ),
 
   /**
    *  again listen when close server

--- a/lib/route.js
+++ b/lib/route.js
@@ -28,7 +28,8 @@ const {
   FST_ERR_ROUTE_BODY_LIMIT_OPTION_NOT_INT,
   FST_ERR_ROUTE_HANDLER_TIMEOUT_OPTION_NOT_INT,
   FST_ERR_HANDLER_TIMEOUT,
-  FST_ERR_HOOK_INVALID_ASYNC_HANDLER
+  FST_ERR_HOOK_INVALID_ASYNC_HANDLER,
+  FST_ERR_ROUTE_INVALID_LOG_LEVEL
 } = require('./errors')
 
 const {
@@ -284,6 +285,13 @@ function buildRouting (options) {
       opts.routePath = path
       opts.prefix = prefix
       opts.logLevel = opts.logLevel || this[kLogLevel]
+
+      if (opts.logLevel) {
+        const validLogLevels = ['trace', 'debug', 'info', 'warn', 'error', 'fatal', 'silent']
+        if (!validLogLevels.includes(opts.logLevel)) {
+          throw new FST_ERR_ROUTE_INVALID_LOG_LEVEL(opts.logLevel)
+        }
+      }
 
       if (this[kLogSerializers] || opts.logSerializers) {
         opts.logSerializers = Object.assign(Object.create(this[kLogSerializers]), opts.logSerializers)


### PR DESCRIPTION
## Summary

Validate the `logLevel` route option during route registration to prevent runtime crashes when an invalid log level is used.

## Problem

When a route is defined with an invalid `logLevel` (e.g. `'invalid'`), the error is not caught during registration. Instead, the server crashes at runtime when the route is hit, because pino's `logger.child({ level: 'invalid' })` throws an error.

```js
fastify.get('/', { logLevel: 'invalid' }, async () => 'hello');
// No error at registration!
// But crashes at runtime when GET / is called
```

## Fix

Add validation for `opts.logLevel` during route registration in `lib/route.js`. Invalid values now throw `FST_ERR_ROUTE_INVALID_LOG_LEVEL` immediately, following the same pattern as other route option validations (e.g. `bodyLimit`, `handlerTimeout`).

**Valid levels**: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `silent`

## Changes

- `lib/route.js`: Added log level validation after `opts.logLevel` assignment
- `lib/errors.js`: Added `FST_ERR_ROUTE_INVALID_LOG_LEVEL` error code

## Testing

```js
// Before: silently accepts, crashes at runtime
// After: throws immediately
fastify.get('/', { logLevel: 'invalid' }, handler);
// => FST_ERR_ROUTE_INVALID_LOG_LEVEL: Invalid logLevel 'invalid'. Must be one of: trace, debug, info, warn, error, fatal, silent

// Valid levels still work:
fastify.get('/ok', { logLevel: 'info' }, handler); // ✓
```

Fixes #6124