### PR TITLE
docs(serverless): clarify Firebase route analytics expectations

### DIFF
--- a/docs/Guides/Serverless.md
+++ b/docs/Guides/Serverless.md
@@ -359,6 +359,17 @@ Final step is to export the Fastify app instance to Firebase's own
 exports.app = onRequest(fastifyApp)
 ```
 
+### Route-level analytics in Firebase
+
+When you export a single `onRequest()` function, Firebase and Google Cloud
+Functions report metrics at the function level (the exported name), not at each
+Fastify route.
+
+If you need route-specific dashboards in Firebase, you can export multiple
+functions that all forward to the same Fastify app and assign each export a
+different route at deployment time. This keeps one Fastify app while exposing
+multiple function names for analytics.
+
 ### Local test
 
 Install the Firebase tools functions so you can use the CLI:


### PR DESCRIPTION
## Problem\n- Closes #4670\n- Firebase  + Fastify can be confusing when expecting per-route metrics in Cloud Functions dashboards.\n\n## Changes\n- Add a short note in  under Firebase Functions explaining that metrics are function-level for a single export.\n- Document a practical workaround: export multiple function names that point to the same Fastify app when route-level dashboard separation is required.\n\n## Validation\n- markdownlint-cli2 v0.21.0 (markdownlint v0.40.0)