### PR TITLE
docs(hooks): clarify how each application hook exposes Fastify instance

### DIFF
--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -429,7 +429,8 @@ Application hooks do not all expose the instance in the same way.
 | `onRoute` | via `this` (if using a `function` handler) |
 | `onRegister` | via the `instance` parameter |
 
-> **Note:** Arrow functions do not bind `this`. Use a `function` handler when you need the Fastify instance from `this`.
+> **Note:** Arrow functions do not bind `this`. Use a `function` handler when
+> you need the Fastify instance from `this`.
 
 ### onReady
 Triggered before the server starts listening for requests and when `.ready()` is

--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -416,6 +416,21 @@ You can hook into the application-lifecycle as well.
 - [onRoute](#onroute)
 - [onRegister](#onregister)
 
+### Accessing the Fastify instance in application hooks
+
+Application hooks do not all expose the instance in the same way.
+
+| Hook | How to access the instance |
+| --- | --- |
+| `onReady` | via `this` |
+| `onListen` | via `this` |
+| `onClose` | via the `instance` parameter |
+| `preClose` | via `this` |
+| `onRoute` | via `this` (if using a `function` handler) |
+| `onRegister` | via the `instance` parameter |
+
+> **Note:** Arrow functions do not bind `this`. Use a `function` handler when you need the Fastify instance from `this`.
+
 ### onReady
 Triggered before the server starts listening for requests and when `.ready()` is
 invoked. It cannot change the routes or add new hooks. Registered hook functions


### PR DESCRIPTION
#### Summary
- adds a dedicated section in `docs/Reference/Hooks.md` describing how each application hook exposes the Fastify instance
- clarifies which hooks use `this` and which expose `instance` as a parameter
- adds an explicit note about arrow functions not binding `this`

#### Related issue
resolves #4967

#### Checklist
- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)