### PR TITLE
deprecate request metadata accessors for security-sensitive use

### DIFF
--- a/docs/Reference/Request.md
+++ b/docs/Reference/Request.md
@@ -16,24 +16,31 @@ Request is a core Fastify object containing the following fields:
   [encapsulation context](./Encapsulation.md).
 - `id` - The request ID.
 - `log` - The logger instance of the incoming request.
-- `ip` - The IP address of the incoming request.
-- `ips` - An array of the IP addresses, ordered from closest to furthest, in the
-  `X-Forwarded-For` header of the incoming request (only when the
-  [`trustProxy`](./Server.md#factory-trust-proxy) option is enabled).
-- `host` - The host of the incoming request (derived from `X-Forwarded-Host`
-  header when the [`trustProxy`](./Server.md#factory-trust-proxy) option is
-  enabled). For HTTP/2 compatibility, it returns `:authority` if no host header
-  exists. The host header may return an empty string if `requireHostHeader` is
-  `false`, not provided with HTTP/1.0, or removed by schema validation.
-  ⚠ Security: this value comes from client-controlled headers; only trust it
-  when you control proxy behavior and have validated or allow-listed hosts.
-  No additional validation is performed beyond RFC parsing (see
-  [RFC 9110, section 7.2](https://www.rfc-editor.org/rfc/rfc9110#section-7.2) and
-  [RFC 3986, section 3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2)).
-- `hostname` - The hostname derived from the `host` property of the incoming request.
-- `port` - The port from the `host` property, which may refer to the port the
-  server is listening on.
-- `protocol` - The protocol of the incoming request (`https` or `http`).
+- `ip` - **Deprecated**. The IP address of the incoming request.
+- `ips` - **Deprecated**. An array of the IP addresses, ordered from closest to
+  furthest, in the `X-Forwarded-For` header of the incoming request (only when
+  the [`trustProxy`](./Server.md#factory-trust-proxy) option is enabled).
+- `host` - **Deprecated**. The host of the incoming request (derived from
+  `X-Forwarded-Host` header when the
+  [`trustProxy`](./Server.md#factory-trust-proxy) option is enabled). For
+  HTTP/2 compatibility, it returns `:authority` if no host header exists. The
+  host header may return an empty string if `requireHostHeader` is `false`, not
+  provided with HTTP/1.0, or removed by schema validation.
+- `hostname` - **Deprecated**. The hostname derived from the `host` property of
+  the incoming request.
+- `port` - **Deprecated**. The port from the `host` property, which may refer
+  to the port the server is listening on.
+- `protocol` - **Deprecated**. The protocol of the incoming request (`https` or
+  `http`).
+
+> ⚠️ Security warning:
+> `request.ip`, `request.ips`, `request.host`, `request.hostname`,
+> `request.port`, and `request.protocol` are derived from untrusted request
+> metadata (socket information and/or client-controlled forwarding/host
+> headers). They are convenience accessors only and MUST NOT be used for
+> authentication, authorization, origin validation, redirect safety, or any
+> other security decision.
+
 - `method` - The method of the incoming request.
 - `url` - The URL of the incoming request.
 - `originalUrl` - Similar to `url`, allows access to the original `url` in
@@ -112,12 +119,12 @@ fastify.post('/:params', options, function (request, reply) {
   console.log(request.raw)
   console.log(request.server)
   console.log(request.id)
-  console.log(request.ip)
-  console.log(request.ips)
-  console.log(request.host)
-  console.log(request.hostname)
-  console.log(request.port)
-  console.log(request.protocol)
+  console.log(request.ip) // deprecated
+  console.log(request.ips) // deprecated
+  console.log(request.host) // deprecated
+  console.log(request.hostname) // deprecated
+  console.log(request.port) // deprecated
+  console.log(request.protocol) // deprecated
   console.log(request.url)
   console.log(request.routeOptions.method)
   console.log(request.routeOptions.bodyLimit)

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -560,12 +560,17 @@ For more examples, refer to the
 You may access the `ip`, `ips`, `host` and `protocol` values on the
 [`request`](./Request.md) object.
 
+> ⚠️ Security warning:
+> These accessors are deprecated and derived from untrusted request metadata.
+> Do not use them for authentication, authorization, origin checks, or any
+> other security decisions.
+
 ```js
 fastify.get('/', (request, reply) => {
-  console.log(request.ip)
-  console.log(request.ips)
-  console.log(request.host)
-  console.log(request.protocol)
+  console.log(request.ip) // deprecated
+  console.log(request.ips) // deprecated
+  console.log(request.host) // deprecated
+  console.log(request.protocol) // deprecated
 })
 ```
 

--- a/docs/Reference/Warnings.md
+++ b/docs/Reference/Warnings.md
@@ -9,6 +9,7 @@
     - [FSTWRN002](#FSTWRN002)
   - [Fastify Deprecation Codes](#fastify-deprecation-codes)
     - [FSTDEP022](#FSTDEP022)
+    - [FSTDEP023](#FSTDEP023)
 
 ## Warnings
 
@@ -55,4 +56,5 @@ Deprecation codes are supported by the Node.js CLI options:
 
 | Code | Description | How to solve | Discussion |
 | ---- | ----------- | ------------ | ---------- |
-| <a id="FSTDEP022">FSTDEP022</a> | You are trying to access the deprecated router options on top option properties. | Use `options.routerOptions`. | [#5985](https://github.com/fastify/fastify/pull/5985)
+| <a id="FSTDEP022">FSTDEP022</a> | You are trying to access the deprecated router options on top option properties. | Use `options.routerOptions`. | [#5985](https://github.com/fastify/fastify/pull/5985) |
+| <a id="FSTDEP023">FSTDEP023</a> | You are trying to access deprecated request metadata accessors such as `request.host`, `request.hostname`, `request.port`, `request.protocol`, `request.ip`, or `request.ips`. | Read request headers or socket data directly and perform explicit validation/trust checks. Never use these values for security decisions. | -

--- a/lib/request.js
+++ b/lib/request.js
@@ -16,6 +16,7 @@ const {
   kOnAbort
 } = require('./symbols')
 const { FST_ERR_REQ_INVALID_VALIDATION_INVOCATION, FST_ERR_DEC_UNDECLARED } = require('./errors')
+const { FSTDEP023 } = require('./warnings')
 const decorators = require('./decorate')
 
 const HTTP_PART_SYMBOL_MAP = {
@@ -24,6 +25,17 @@ const HTTP_PART_SYMBOL_MAP = {
   params: kSchemaParams,
   querystring: kSchemaQuerystring,
   query: kSchemaQuerystring
+}
+
+const deprecatedRequestAccessorsWarned = new Set()
+
+function emitDeprecatedRequestAccessorWarning (accessor) {
+  if (deprecatedRequestAccessorsWarned.has(accessor)) {
+    return
+  }
+
+  deprecatedRequestAccessorsWarned.add(accessor)
+  FSTDEP023(accessor)
 }
 
 function Request (id, params, req, query, log, context) {
@@ -106,18 +118,21 @@ function buildRequestWithTrustProxy (R, trustProxy) {
   Object.defineProperties(_Request.prototype, {
     ip: {
       get () {
+        emitDeprecatedRequestAccessorWarning('ip')
         const addrs = proxyAddr.all(this.raw, proxyFn)
         return addrs[addrs.length - 1]
       }
     },
     ips: {
       get () {
+        emitDeprecatedRequestAccessorWarning('ips')
         return proxyAddr.all(this.raw, proxyFn)
       }
     },
     host: {
       get () {
-        if (this.ip !== undefined && this.headers['x-forwarded-host']) {
+        emitDeprecatedRequestAccessorWarning('host')
+        if (this.socket !== undefined && this.headers['x-forwarded-host']) {
           return getLastEntryInMultiHeaderValue(this.headers['x-forwarded-host'])
         }
         /**
@@ -131,6 +146,7 @@ function buildRequestWithTrustProxy (R, trustProxy) {
     },
     protocol: {
       get () {
+        emitDeprecatedRequestAccessorWarning('protocol')
         if (this.headers['x-forwarded-proto']) {
           return getLastEntryInMultiHeaderValue(this.headers['x-forwarded-proto'])
         }
@@ -225,13 +241,21 @@ Object.defineProperties(Request.prototype, {
   },
   ip: {
     get () {
+      emitDeprecatedRequestAccessorWarning('ip')
       if (this.socket) {
         return this.socket.remoteAddress
       }
     }
   },
+  ips: {
+    get () {
+      emitDeprecatedRequestAccessorWarning('ips')
+      return undefined
+    }
+  },
   host: {
     get () {
+      emitDeprecatedRequestAccessorWarning('host')
       /**
        * The last fallback supports the following cases:
        * 1. http.requireHostHeader === false
@@ -243,6 +267,7 @@ Object.defineProperties(Request.prototype, {
   },
   hostname: {
     get () {
+      emitDeprecatedRequestAccessorWarning('hostname')
       // Check for IPV6 Host
       if (this.host[0] === '[') {
         return this.host.slice(0, this.host.indexOf(']') + 1)
@@ -253,6 +278,7 @@ Object.defineProperties(Request.prototype, {
   },
   port: {
     get () {
+      emitDeprecatedRequestAccessorWarning('port')
       // first try taking port from host
       const portFromHost = parseInt(this.host.split(':').slice(-1)[0])
       if (!isNaN(portFromHost)) {
@@ -270,6 +296,7 @@ Object.defineProperties(Request.prototype, {
   },
   protocol: {
     get () {
+      emitDeprecatedRequestAccessorWarning('protocol')
       if (this.socket) {
         return this.socket.encrypted ? 'https' : 'http'
       }

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -3,13 +3,16 @@
 const { createWarning } = require('process-warning')
 
 /**
- * Deprecation codes:
+ * Warning codes:
  *   - FSTWRN001
  *   - FSTSEC001
+ *
+ * Deprecation codes:
  *   - FSTDEP022
+ *   - FSTDEP023
  *
  * Deprecation Codes FSTDEP001 - FSTDEP021 were used by v4 and MUST NOT not be reused.
- *                             - FSTDEP022 is used by v5 and MUST NOT be reused.
+ *                             - FSTDEP022 - FSTDEP023 are used by v5 and MUST NOT be reused.
  * Warning Codes FSTWRN001 - FSTWRN002 were used by v4 and MUST NOT not be reused.
  */
 
@@ -48,10 +51,18 @@ const FSTDEP022 = createWarning({
   unlimited: true
 })
 
+const FSTDEP023 = createWarning({
+  name: 'FastifyWarning',
+  code: 'FSTDEP023',
+  message: 'The request.%s accessor is deprecated and will be removed in `fastify@6`. These values are derived from untrusted request metadata and MUST NOT be used for security decisions.',
+  unlimited: true
+})
+
 module.exports = {
   FSTWRN001,
   FSTWRN003,
   FSTWRN004,
   FSTSEC001,
-  FSTDEP022
+  FSTDEP022,
+  FSTDEP023
 }

--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -1,4 +1,4 @@
-import { expectAssignable, expectError, expectType } from 'tsd'
+import { expectAssignable, expectDeprecated, expectError, expectType } from 'tsd'
 import fastify, {
   ContextConfigDefault,
   FastifyContextConfig,
@@ -66,11 +66,18 @@ const getHandler: RouteHandler = function (request, _reply) {
   expectType<string>(request.method)
   expectType<Readonly<RequestRouteOptions>>(request.routeOptions)
   expectType<boolean>(request.is404)
+  expectDeprecated(request.hostname)
+  expectDeprecated(request.host)
+  expectDeprecated(request.port)
+  expectDeprecated(request.ip)
+  expectDeprecated(request.ips)
+  expectDeprecated(request.protocol)
   expectType<string>(request.hostname)
   expectType<string>(request.host)
   expectType<number>(request.port)
   expectType<string>(request.ip)
   expectType<string[] | undefined>(request.ips)
+  expectType<'http' | 'https'>(request.protocol)
   expectType<RawRequestDefaultExpression>(request.raw)
   expectType<RequestBodyDefault>(request.body)
   expectType<RequestParamsDefault>(request.params)

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -71,13 +71,31 @@ export interface FastifyRequest<RouteGeneric extends RouteGenericInterface = Rou
    * @deprecated Use `raw` property
    */
   readonly req: RawRequest & RouteGeneric['Headers']; // this enables the developer to extend the existing http(s|2) headers list
+  /**
+   * @deprecated This value is derived from untrusted request metadata. Do not use it for security decisions.
+   */
   readonly ip: string;
+  /**
+   * @deprecated This value is derived from untrusted request metadata. Do not use it for security decisions.
+   */
   readonly ips?: string[];
+  /**
+   * @deprecated This value is derived from untrusted request metadata. Do not use it for security decisions.
+   */
   readonly host: string;
+  /**
+   * @deprecated This value is derived from untrusted request metadata. Do not use it for security decisions.
+   */
   readonly port: number;
+  /**
+   * @deprecated This value is derived from untrusted request metadata. Do not use it for security decisions.
+   */
   readonly hostname: string;
   readonly url: string;
   readonly originalUrl: string;
+  /**
+   * @deprecated This value is derived from untrusted request metadata. Do not use it for security decisions.
+   */
   readonly protocol: 'http' | 'https';
   readonly method: string;
   readonly routeOptions: Readonly<RequestRouteOptions<ContextConfig, SchemaCompiler>>


### PR DESCRIPTION
I’m tired of receiving security reports against those, so I propose we deprecate them and remove them in the next major.