### PR TITLE
feat: enhance route shorthand types and relative test

### DIFF
--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -419,6 +419,45 @@ expectType<FastifyInstance>(fastify().route({
   handler: routeHandler
 }))
 
+function buildHook<TReq extends FastifyRequest> (
+  relation: string,
+  object: string | ((req: TReq) => string)
+) {
+  return async function (this: FastifyInstance, req: TReq) {
+    expectType<FastifyInstance>(this)
+    expectType<TReq>(req)
+
+    if (typeof object === 'string') {
+      return `${relation} for ${object}`
+    } else {
+      return object(req)
+    }
+  }
+}
+
+fastify().post('/', {
+  schema: {
+    params: {
+      type: 'object',
+      properties: {
+        id: { type: 'string' }
+      }
+    },
+    body: {
+      type: 'object',
+      properties: {
+        foo: { type: 'string' }
+      }
+    }
+  },
+  preHandler: buildHook('preHandler', (req) => `preHandler for ${req.params}`),
+  preValidation: buildHook('preValidation', (req) => `preValidation for ${req.params}`),
+  preParsing: buildHook('preParsing', (req) => `preParsing for ${req.params}`)
+}, (req) => {
+  expectType<unknown>(req.params)
+  expectType<unknown>(req.body)
+})
+
 expectType<FastifyInstance>(fastify().route({
   url: '/',
   method: 'OPTIONS',

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -45,7 +45,7 @@ export interface RouteConstraint {
 /**
  * Route shorthand options for the various shorthand methods
  */
-type RouteShorthandHook<T extends (...args: any) => any> = (...args: Parameters<T>) => void | Promise<unknown>
+type RouteShorthandHook<T extends (...args: any) => any> = T
 
 export interface RouteShorthandOptions<
   RawServer extends RawServerBase = RawServerDefault,


### PR DESCRIPTION
This PR enhances route shorthand types for hooks that, after the last release, return `never` during inference.
It also adds a type test to check the behaviour.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
