### PR TITLE
fix(types): use void return in RouteShorthandHook for callback compatibility

### DIFF
--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -59,6 +59,12 @@ const asyncPreHandler = async (request: FastifyRequest) => {
 
 fastify().get('/', { preHandler: asyncPreHandler }, async () => 'this is an example')
 
+// Verify that RouteHandlerMethod is assignable to route hook options (e.g. passport compatibility)
+const handlerAsHook: RouteHandlerMethod = function (_request, _reply) {}
+fastify().get('/', { preValidation: handlerAsHook }, async () => 'ok')
+fastify().get('/', { preHandler: handlerAsHook }, async () => 'ok')
+fastify().get('/', { onRequest: handlerAsHook }, async () => 'ok')
+
 fastify().get(
   '/',
   { config: { foo: 'bar', bar: 100, includeMessage: true } },

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -45,7 +45,7 @@ export interface RouteConstraint {
 /**
  * Route shorthand options for the various shorthand methods
  */
-type RouteShorthandHook<T extends (...args: any) => any> = (...args: Parameters<T>) => void | Promise<unknown>
+type RouteShorthandHook<T extends (...args: any) => any> = (...args: Parameters<T>) => void
 
 export interface RouteShorthandOptions<
   RawServer extends RawServerBase = RawServerDefault,


### PR DESCRIPTION
The `RouteShorthandHook` type introduced in #6514 uses `void | Promise<unknown>` as its return type. This breaks TypeScript's callback void substitutability rule: when `void` appears in a union, the special rule that allows any return type in callback position no longer applies. As a result, `RouteHandlerMethod` (which returns `unknown`) cannot be assigned to route hook options like `preValidation` in shorthand methods.

This is a regression from v5.8.0 that breaks compatibility with `@fastify/passport` and any other code that passes a `RouteHandlerMethod` as a route hook.

**Root cause:** TypeScript treats `void` specially in callback return types - any return type is assignable to `void`. But when `void` is part of a union (`void | Promise<unknown>`), this substitutability rule does not apply, so `unknown` is no longer assignable.

**Fix:** Change the return type from `void | Promise<unknown>` to just `void`. The `void` return type already accepts `Promise<unknown>` through callback void substitutability, making the explicit union both unnecessary and the source of the incompatibility.

Fixes #6576

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)