### PR TITLE
types!: remove declaration-merging reliance with registration-scoped decorator typing

### DIFF
--- a/docs/Guides/Index.md
+++ b/docs/Guides/Index.md
@@ -23,6 +23,10 @@ This table of contents is in alphabetical order.
   written with a fluent API and used in Fastify.
 + [Getting Started](./Getting-Started.md): Introduction tutorial for Fastify.
   This is where beginners should start.
++ [Migration Guide (declaration merging to registration-scoped typing)](./Migration-Guide-Declaration-Merging.md):
+  Details how to migrate TypeScript decorator usage from global ambient
+  declaration merging to registration-scoped inference for both applications and
+  plugins.
 + [Migration Guide (v4)](./Migration-Guide-V4.md): Details how to migrate to
   Fastify v4 from earlier versions.
 + [Migration Guide (v3)](./Migration-Guide-V3.md): Details how to migrate to

--- a/docs/Guides/Index.md
+++ b/docs/Guides/Index.md
@@ -24,9 +24,8 @@ This table of contents is in alphabetical order.
 + [Getting Started](./Getting-Started.md): Introduction tutorial for Fastify.
   This is where beginners should start.
 + [Migration Guide (declaration merging to registration-scoped typing)](./Migration-Guide-Declaration-Merging.md):
-  Details how to migrate TypeScript decorator usage from global ambient
-  declaration merging to registration-scoped inference for both applications and
-  plugins.
+  Details how to migrate TypeScript decorator usage to the Fastify 6
+  registration-scoped inference model for both applications and plugins.
 + [Migration Guide (v4)](./Migration-Guide-V4.md): Details how to migrate to
   Fastify v4 from earlier versions.
 + [Migration Guide (v3)](./Migration-Guide-V3.md): Details how to migrate to

--- a/docs/Guides/Migration-Guide-Declaration-Merging.md
+++ b/docs/Guides/Migration-Guide-Declaration-Merging.md
@@ -1,0 +1,182 @@
+<h1 align="center">Fastify</h1>
+
+# Migration Guide: from declaration merging to registration-scoped typing
+
+This guide explains how to migrate TypeScript code from global/ambient
+`declare module 'fastify'` assumptions to Fastify's registration-scoped typing
+model for decorators.
+
+It is written for:
+
+- **application maintainers** using Fastify in production services;
+- **plugin maintainers** publishing Fastify plugins.
+
+## What changed
+
+In the declaration-merging model, decorators often appeared globally in types,
+even outside the scope where they were registered.
+
+In the registration-scoped model:
+
+- `decorate()`, `decorateRequest()`, and `decorateReply()` widen the current
+  instance type;
+- `register()` carries plugin effects through typed registration flow;
+- decorator visibility follows encapsulation and registration boundaries.
+
+Runtime behavior is unchanged. The change is in type transport and type
+visibility.
+
+---
+
+## Migration checklist (quick)
+
+1. Track where decorators are actually registered.
+2. Keep and use the registered instance value in typed code.
+3. Stop relying on type-only side-effect imports to expose decorators globally.
+4. Refactor tests to use local typed helpers instead of global ambient test
+   augmentations.
+5. Validate with full lint/build/typecheck/tests and explicit success output.
+
+---
+
+## Application migration
+
+## 1) Keep the registered instance in scope
+
+### Before
+
+```ts
+const app = fastify()
+app.register(fastifyStatic, { root: '/public' })
+
+app.get('/', (request, reply) => {
+  reply.sendFile('index.html')
+})
+```
+
+### After
+
+```ts
+const app = fastify().register(fastifyStatic, { root: '/public' })
+
+app.get('/', (request, reply) => {
+  reply.sendFile('index.html')
+})
+```
+
+The runtime object is the same, but the typed registered value carries decorator
+availability.
+
+## 2) Make registration order explicit in typed code
+
+If route/hook definitions are attached before type-visible registration,
+TypeScript should reject decorator usage. Move route definitions into the proper
+scope or use the typed registered value.
+
+## 3) Respect encapsulation boundaries
+
+If a decorator is registered in a child plugin, do not assume it exists on
+parent/sibling branches.
+
+## 4) Avoid type-only plugin imports for decorator visibility
+
+Do not use `import '@fastify/some-plugin'` as a typing shortcut for unrelated
+instances. Register plugins on the instance path where decorators are used.
+
+## 5) Handle dynamic decorator names explicitly
+
+For namespaced/renamed decorators, inference may not be fully automatic.
+Introduce local helper types or explicit aliases where names are configured at
+runtime.
+
+---
+
+## Plugin migration
+
+## 1) Type plugin effects explicitly
+
+Plugin types should encode what is added to:
+
+- instance decorators,
+- request decorators,
+- reply decorators.
+
+Avoid relying only on ambient merging for public typing.
+
+## 2) Keep runtime logic stable, migrate type transport
+
+Most plugin ports are primarily typing refactors. Preserve runtime behavior,
+move typing to registration-scoped contracts.
+
+## 3) Make default paths fully inferred
+
+For plugins with configurable decorator names, keep default names strongly
+typed; provide helper types for advanced renamed paths.
+
+## 4) Derive override signatures from base contracts
+
+When subclassing strategy-like abstractions, derive parameter types from the
+base signature, e.g. `Parameters<Base['method']>[0]`, to avoid variance and
+augmentation mismatches.
+
+## 5) Refactor tests away from ambient assumptions
+
+If tests assumed globally available decorators, migrate to local test helpers
+that narrow request/reply types at usage points.
+
+This is usually the longest part of migration work.
+
+---
+
+## Test migration patterns that work
+
+## Pattern A: local request/reply adapters in tests
+
+Use helper functions in test utilities that narrow to the expected decorated
+shape where needed, rather than globally augmenting all test types.
+
+## Pattern B: runtime guard + typed return helper
+
+In tests where setup is indirect, use small runtime checks (`if (!('flash' in
+reply)) throw`) and return a typed helper object. This keeps type assumptions
+local and explicit.
+
+## Pattern C: avoid final-state crutches
+
+Temporary migration aids can unblock early work, but final validation should not
+require:
+
+- test-only ambient compat bridges;
+- `skipLibCheck` as a migration bypass.
+
+---
+
+## Common failures and fixes
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Property 'x' does not exist on request/reply` | Decorator used outside registered type scope | Use typed registered instance or move code into correct encapsulation scope |
+| Override method is not assignable | Override signature does not match base contract | Derive signature from base method parameters |
+| Works at runtime, fails in TS | Registration order not reflected in typing flow | Reorder definitions or retain typed registration value |
+| Tests only pass with compat `.d.ts` | Hidden global assumptions in tests | Replace with local typed test helpers |
+
+---
+
+## Validation gate
+
+A migration is considered complete when all are true:
+
+- registration-scoped typing is used for decorator visibility;
+- docs are updated for typing behavior changes;
+- no global compat test augmentation is required;
+- no `skipLibCheck` migration bypass is required;
+- lint/build/typecheck/tests pass with explicit success indicators.
+
+---
+
+## Related docs
+
+- [TypeScript reference](../Reference/TypeScript.md)
+- [Plugins guide](./Plugins-Guide.md)
+- [Write Plugin](./Write-Plugin.md)
+- [Encapsulation reference](../Reference/Encapsulation.md)

--- a/docs/Guides/Migration-Guide-Declaration-Merging.md
+++ b/docs/Guides/Migration-Guide-Declaration-Merging.md
@@ -11,6 +11,9 @@ It is written for:
 - **application maintainers** using Fastify in production services;
 - **plugin maintainers** publishing Fastify plugins.
 
+> This registration-scoped decorator typing approach is part of the Fastify 6
+> TypeScript model.
+
 ## What changed
 
 In the declaration-merging model, decorators often appeared globally in types,

--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -866,9 +866,11 @@ would be a dangerous and destructive operation. So be careful and
 make sure your property is entirely new, also using this approach
 only for very specific and small cases like this example.
 
-Regarding TypeScript in this example, you'd need to update the
-`FastifyRequest` core interface to include your new property typing
-(for more about it, see [TypeScript](./TypeScript.md) page), like:
+Regarding TypeScript in this example, in Fastify 6 you should prefer a
+registration-scoped/plugin-based typing approach. For small local cases, a
+module augmentation can still be used to type your custom property
+(for more about migration options, see [TypeScript](./TypeScript.md) and the
+[declaration-merging migration guide](../Guides/Migration-Guide-Declaration-Merging.md)):
 
 ```ts
 interface AuthenticatedUser { /* ... */ }

--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -376,7 +376,7 @@ fastify.addHook('preHandler', async (request, reply) => {
 If you want to respond with a stream, you should avoid using an `async` function
 for the hook. If you must use an `async` function, your code will need to follow
 the pattern in
-[test/hooks-async.js](https://github.com/fastify/fastify/blob/94ea67ef2d8dce8a955d510cd9081aabd036fa85/test/hooks-async.js#L269-L275).
+[test/hooks-async.js](https://github.com/fastify/fastify/blob/main/test/hooks-async.js).
 
 ```js
 fastify.addHook('onRequest', (request, reply, done) => {

--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -376,7 +376,7 @@ fastify.addHook('preHandler', async (request, reply) => {
 If you want to respond with a stream, you should avoid using an `async` function
 for the hook. If you must use an `async` function, your code will need to follow
 the pattern in
-[test/hooks-async.js](https://github.com/fastify/fastify/blob/main/test/hooks-async.js).
+[test/hooks-async.test.js](https://github.com/fastify/fastify/blob/main/test/hooks-async.test.js).
 
 ```js
 fastify.addHook('onRequest', (request, reply, done) => {

--- a/docs/Reference/Logging.md
+++ b/docs/Reference/Logging.md
@@ -209,7 +209,7 @@ app.addHook('preHandler', function (req, reply, done) {
 > ℹ️ Note:
 > Ensure serializers never throw errors, as this can cause the Node
 > process to exit. See the
-> [Pino documentation](https://getpino.io/#/docs/api?id=opt-serializers) for more
+> [Pino documentation](https://github.com/pinojs/pino/blob/main/docs/api.md#serializers-object) for more
 > information.
 
 *Any logger other than Pino will ignore this option.*

--- a/docs/Reference/Logging.md
+++ b/docs/Reference/Logging.md
@@ -209,8 +209,8 @@ app.addHook('preHandler', function (req, reply, done) {
 > ℹ️ Note:
 > Ensure serializers never throw errors, as this can cause the Node
 > process to exit. See the
-> [Pino documentation](https://github.com/pinojs/pino/blob/main/docs/api.md#serializers-object) for more
-> information.
+> [Pino documentation](https://github.com/pinojs/pino/blob/main/docs/api.md#serializers-object)
+> for more information.
 
 *Any logger other than Pino will ignore this option.*
 

--- a/docs/Reference/Logging.md
+++ b/docs/Reference/Logging.md
@@ -265,4 +265,4 @@ const fastify = Fastify({
 })
 ```
 
-See https://getpino.io/#/docs/redaction for more details.
+See https://github.com/pinojs/pino/blob/main/docs/redaction.md for more details.

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -198,7 +198,7 @@ method, otherwise attempting to set it will throw an exception.
 
 Defines the maximum number of requests a socket can handle before closing keep
 alive connection. See [`server.maxRequestsPerSocket`
-property](https://nodejs.org/dist/latest/docs/api/http.html#servermaxrequestspersocket)
+property](https://nodejs.org/api/http.html#servermaxrequestspersocket)
 to understand the effect of this option. This option only applies when HTTP/1.1
 is in use. Also, when `serverFactory` option is specified, this option is
 ignored.
@@ -213,7 +213,7 @@ ignored.
 
 Defines the maximum number of milliseconds for receiving the entire request from
 the client. See [`server.requestTimeout`
-property](https://nodejs.org/dist/latest/docs/api/http.html#servertimeout)
+property](https://nodejs.org/api/http.html#serverrequesttimeout)
 to understand the effect of this option.
 
 When `serverFactory` option is specified, this option is ignored.
@@ -335,7 +335,7 @@ This property is used to configure the internal logger instance.
 The possible values this property may have are:
 
 + Default: `false`. The logger is disabled. All logging methods will point to a
-null logger [abstract-logging](https://www.npmjs.com/package/abstract-logging) instance.
+  null logger [abstract-logging](https://github.com/jsumners/abstract-logging) instance.
 
 + `object`: a standard Pino [options
   object](https://github.com/pinojs/pino/blob/c77d8ec5ce/docs/API.md#constructor).
@@ -1243,7 +1243,7 @@ addresses](https://nodejs.org/api/net.html#serverlistenport-host-backlog-callbac
 
 Be careful when deciding to listen on all interfaces; it comes with inherent
 [security
-risks](https://web.archive.org/web/20170711105010/https://snyk.io/blog/mongodb-hack-and-secure-defaults/).
+risks](https://snyk.io/blog/mongodb-hack-and-secure-defaults/).
 
 The default is to listen on `port: 0` (which picks the first available open
 port) and `host: 'localhost'`:

--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -687,8 +687,8 @@ need an explicit global augmentation entry point.
 If you still rely on legacy declaration-merging plugins, the following tips can
 help reduce false-positive global augmentations:
 - Make sure the `no-unused-vars` rule is enabled in
-  [ESLint](https://eslint.org/docs/rules/no-unused-vars) and any imported plugin
-  are actually being loaded.
+  [ESLint](https://eslint.org/docs/latest/rules/no-unused-vars) and any
+  imported plugin are actually being loaded.
 - Use a module such as [depcheck](https://www.npmjs.com/package/depcheck) or
   [npm-check](https://www.npmjs.com/package/npm-check) to verify plugin
   dependencies are being used somewhere in your project.
@@ -857,7 +857,7 @@ fastify.addHook('preHandler', async (req, reply) => {
 ## Code Completion In Vanilla JavaScript
 
 Vanilla JavaScript can use the published types to provide code completion (e.g.
-[Intellisense](https://code.visualstudio.com/docs/editor/intellisense)) by
+[Intellisense](https://code.visualstudio.com/docs/editing/intellisense)) by
 following the [TypeScript JSDoc
 Reference](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html).
 

--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -1100,7 +1100,7 @@ server.get('/', async (request, reply) => {
 
 ###### Example 5: Specifying logger types
 
-Fastify uses [Pino](https://getpino.io/#/) logging library under the hood. Since
+Fastify uses [Pino](https://getpino.io/) logging library under the hood. Since
 `pino@7`, all of it's properties can be configured via `logger` field when
 constructing Fastify's instance. If properties you need aren't exposed, please
 open an Issue to [`Pino`](https://github.com/pinojs/pino/issues) or pass a

--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -649,14 +649,38 @@ Using a Fastify plugin in TypeScript is just as easy as using one in JavaScript.
 Import the plugin with `import/from` and you're all set -- except there is one
 exception users should be aware of.
 
-Fastify plugins use declaration merging to modify existing Fastify type
-interfaces (check out the previous two examples for more details). Declaration
-merging is not very _smart_, meaning if the plugin type definition for a plugin
-is within the scope of the TypeScript interpreter, then the plugin types will be
-included **regardless** of if the plugin is being used or not. This is an
-unfortunate limitation of using TypeScript and is unavoidable as of right now.
+Fastify plugins have traditionally used declaration merging to modify existing
+Fastify type interfaces (check out the previous two examples for more details).
+Declaration merging is not very _smart_, meaning if the plugin type definition
+for a plugin is within the scope of the TypeScript interpreter, then the plugin
+types will be included **regardless** of if the plugin is being used or not.
 
-However, there are a couple of suggestions to help improve this experience:
+Fastify also supports **inference from `decorate*()` and `register()` return
+values**. When a plugin returns the decorated instance, TypeScript can carry the
+added decorators through the registration chain without globally augmenting all
+instances:
+
+```typescript
+const app = fastify()
+  .register((instance) => {
+    return instance.decorate('usersRepository', {
+      findAll () {
+        return []
+      }
+    })
+  })
+
+app.get('/users', (request, reply) => {
+  app.usersRepository.findAll()
+})
+```
+
+For reusable plugins, this inference-based style is preferred when available.
+Declaration merging is still supported for legacy plugins and for packages that
+need an explicit global augmentation entry point.
+
+However, there are a couple of suggestions to help improve the declaration
+merging experience when you rely on it:
 - Make sure the `no-unused-vars` rule is enabled in
   [ESLint](https://eslint.org/docs/rules/no-unused-vars) and any imported plugin
   are actually being loaded.

--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -6,16 +6,17 @@ The Fastify framework is written in vanilla JavaScript, and as such type
 definitions are not as easy to maintain; however, since version 2 and beyond,
 maintainers and contributors have put in a great effort to improve the types.
 
-The type system was changed in Fastify version 3. The new type system introduces
-generic constraining and defaulting, plus a new way to define schema types such
-as a request body, querystring, and more! As the team works on improving
-framework and type definition synergy, sometimes parts of the API will not be
-typed or may be typed incorrectly. We encourage you to **contribute** to help us
-fill in the gaps. Just make sure to read our
+Fastify's type system has evolved significantly over multiple major releases.
+In Fastify 6, decorator typing is registration-scoped by default, so type
+visibility follows encapsulation and plugin registration flow.
+
+As the team keeps improving framework and type-definition synergy, some API
+areas may still be incomplete or need refinement. We encourage you to
+**contribute** to help fill the gaps. Just make sure to read our
 [`CONTRIBUTING.md`](https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md)
 file before getting started to make sure things go smoothly!
 
-> The documentation in this section covers Fastify version 3.x typings
+> The documentation in this section covers Fastify 6.x typings
 
 > Plugins may or may not include typings. See [Plugins](#plugins) for more
 > information. We encourage users to send pull requests to improve typings
@@ -94,10 +95,10 @@ in a blank http Fastify server.
    🏓
 
 🎉 You now have a working Typescript Fastify server! This example demonstrates
-the simplicity of the version 3.x type system. By default, the type system
-assumes you are using an `http` server. The later examples will demonstrate how
-to create more complex servers such as `https` and `http2`, how to specify route
-schemas, and more!
+the core Fastify 6 typing model. By default, the type system assumes you are
+using an `http` server. The later examples will demonstrate how to create more
+complex servers such as `https` and `http2`, how to specify route schemas, and
+more!
 
 > For more examples on initializing Fastify with TypeScript (such as enabling
 > HTTP2) check out the detailed API section [here][Fastify]
@@ -549,9 +550,9 @@ Fastify Plugin in a TypeScript Project.
    }
 
    // export plugin using fastify-plugin
-   export default fp(myPluginCallback, '3.x')
+   export default fp(myPluginCallback, '6.x')
    // or
-   // export default fp(myPluginAsync, '3.x')
+   // export default fp(myPluginAsync, '6.x')
    ```
 6. Run `npm run build` to compile the plugin code and produce both a JavaScript
    source file and a type definition file.
@@ -683,8 +684,8 @@ For reusable plugins, this inference-based style is preferred when available.
 Declaration merging is still supported for legacy plugins and for packages that
 need an explicit global augmentation entry point.
 
-However, there are a couple of suggestions to help improve the declaration
-merging experience when you rely on it:
+If you still rely on legacy declaration-merging plugins, the following tips can
+help reduce false-positive global augmentations:
 - Make sure the `no-unused-vars` rule is enabled in
   [ESLint](https://eslint.org/docs/rules/no-unused-vars) and any imported plugin
   are actually being loaded.
@@ -871,8 +872,7 @@ module.exports = async function (fastify, { optionA, optionB }) {
 
 ## API Type System Documentation
 
-This section is a detailed account of all the types available to you in Fastify
-version 3.x
+This section is a detailed account of the types available in Fastify 6.x.
 
 All `http`, `https`, and `http2` types are inferred from `@types/node`
 
@@ -1192,9 +1192,10 @@ added here disregard what kind of request object (http vs http2) and disregard
 what route level it is serving; thus calling `request.body` inside a GET request
 will not throw an error (but good luck sending a GET request with a body 😉).
 
-If you need to add custom properties to the `FastifyRequest` object (such as
-when using the [`decorateRequest`][DecorateRequest] method) you need to use
-declaration merging on this interface.
+If you need to add custom properties to `FastifyRequest` (for example with
+[`decorateRequest`][DecorateRequest]), prefer registration-scoped typing or
+`getDecorator<T>()` / `setDecorator<T>()` for local scope. Module augmentation
+is still available as a legacy/global approach.
 
 A basic example is provided in the [`FastifyRequest`][FastifyRequest] section.
 For a more detailed example check out the Learn By Example section:
@@ -1209,7 +1210,7 @@ const server = fastify()
 server.decorateRequest('someProp', 'hello!')
 
 server.get('/', async (request, reply) => {
-  const { someProp } = request // need to use declaration merging to add this prop to the request interface
+  const { someProp } = request // if using global augmentation, declare it on FastifyRequest
   return someProp
 })
 
@@ -1291,9 +1292,9 @@ This interface contains the custom properties that Fastify adds to the standard
 Node.js reply object. The properties added here disregard what kind of reply
 object (http vs http2).
 
-If you need to add custom properties to the FastifyReply object (such as when
-using the `decorateReply` method) you need to use declaration merging on this
-interface.
+If you need to add custom properties to `FastifyReply` (such as with
+`decorateReply`), prefer registration-scoped typing or `getDecorator<T>()` for
+local scope. Module augmentation remains available as a legacy/global option.
 
 A basic example is provided in the [`FastifyReply`][FastifyReply] section. For a
 more detailed example check out the Learn By Example section:
@@ -1308,7 +1309,7 @@ const server = fastify()
 server.decorateReply('someProp', 'world')
 
 server.get('/', async (request, reply) => {
-  const { someProp } = reply // need to use declaration merging to add this prop to the reply interface
+  const { someProp } = reply // if using global augmentation, declare it on FastifyReply
   return someProp
 })
 

--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -23,6 +23,10 @@ file before getting started to make sure things go smoothly!
 
 🚨 Don't forget to install `@types/node`
 
+If you are migrating from ambient declaration merging assumptions to Fastify's
+registration-scoped decorator typing, see the
+[Migration Guide (declaration merging to registration-scoped typing)](../Guides/Migration-Guide-Declaration-Merging.md).
+
 ## Learn By Example
 
 The best way to learn the Fastify type system is by example! The following four

--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -1439,7 +1439,7 @@ example for more details on specifying a custom logger.
 [src](https://github.com/fastify/fastify/blob/main/types/logger.d.ts#L17)
 
 An interface definition for the internal Fastify logger. It is emulative of the
-[Pino.js](https://getpino.io/#/) logger. When enabled through server options,
+[Pino.js](https://getpino.io/) logger. When enabled through server options,
 use it following the general [logger](./Logging.md) documentation.
 
 ##### fastify.FastifyLogFn

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -13,7 +13,7 @@ import { AddContentTypeParser, ConstructorAction, FastifyBodyParser, FastifyCont
 import { FastifyContextConfig, FastifyReplyContext, FastifyRequestContext } from './types/context'
 import { FastifyErrorCodes } from './types/errors'
 import { DoneFuncWithErrOrRes, HookHandlerDoneFunction, onCloseAsyncHookHandler, onCloseHookHandler, onErrorAsyncHookHandler, onErrorHookHandler, onListenAsyncHookHandler, onListenHookHandler, onReadyAsyncHookHandler, onReadyHookHandler, onRegisterHookHandler, onRequestAbortAsyncHookHandler, onRequestAbortHookHandler, onRequestAsyncHookHandler, onRequestHookHandler, onResponseAsyncHookHandler, onResponseHookHandler, onRouteHookHandler, onSendAsyncHookHandler, onSendHookHandler, onTimeoutAsyncHookHandler, onTimeoutHookHandler, preCloseAsyncHookHandler, preCloseHookHandler, preHandlerAsyncHookHandler, preHandlerHookHandler, preParsingAsyncHookHandler, preParsingHookHandler, preSerializationAsyncHookHandler, preSerializationHookHandler, preValidationAsyncHookHandler, preValidationHookHandler, RequestPayload } from './types/hooks'
-import { FastifyInstance, FastifyListenOptions, PrintRoutesOptions } from './types/instance'
+import { FastifyDecorators, BaseFastifyInstance, FastifyInstance, FastifyListenOptions, PrintRoutesOptions } from './types/instance'
 import {
   FastifyBaseLogger,
   FastifyChildLoggerFactory,
@@ -24,9 +24,9 @@ import {
   PinoLoggerOptions
 } from './types/logger'
 import { FastifyPlugin, FastifyPluginAsync, FastifyPluginCallback, FastifyPluginOptions } from './types/plugin'
-import { FastifyRegister, FastifyRegisterOptions, RegisterOptions } from './types/register'
-import { FastifyReply } from './types/reply'
-import { FastifyRequest, RequestGenericInterface } from './types/request'
+import { FastifyRegister, FastifyRegisterOptions, RegisterOptions, AnyFastifyInstance, UnEncapsulatedPlugin, FastifyDependencies, ApplyDependencies, ApplyDecorators } from './types/register'
+import { BaseFastifyReply, FastifyReply } from './types/reply'
+import { BaseFastifyRequest, FastifyRequest, RequestGenericInterface } from './types/request'
 import { RouteGenericInterface, RouteHandler, RouteHandlerMethod, RouteOptions, RouteShorthandMethod, RouteShorthandOptions, RouteShorthandOptionsWithHandler } from './types/route'
 import { FastifySchema, FastifySchemaValidationError, FastifySchemaCompiler, FastifySerializerCompiler, SchemaErrorDataVar, SchemaErrorFormatter } from './types/schema'
 import { FastifyServerFactory, FastifyServerFactoryHandler } from './types/server-factory'
@@ -182,14 +182,14 @@ declare namespace fastify {
   /* Export additional types */
   export type {
     LightMyRequestChain, InjectOptions, LightMyRequestResponse, LightMyRequestCallback, // 'light-my-request'
-    FastifyRequest, RequestGenericInterface, // './types/request'
-    FastifyReply, // './types/reply'
+    BaseFastifyRequest, FastifyRequest, RequestGenericInterface, // './types/request'
+    BaseFastifyReply, FastifyReply, // './types/reply'
     FastifyPluginCallback, FastifyPluginAsync, FastifyPluginOptions, FastifyPlugin, // './types/plugin'
-    FastifyListenOptions, FastifyInstance, PrintRoutesOptions, // './types/instance'
+    FastifyDecorators, FastifyListenOptions, BaseFastifyInstance, FastifyInstance, PrintRoutesOptions, // './types/instance'
     FastifyLoggerOptions, FastifyBaseLogger, FastifyLoggerInstance, FastifyLogFn, LogLevel, // './types/logger'
     FastifyRequestContext, FastifyContextConfig, FastifyReplyContext, // './types/context'
     RouteHandler, RouteHandlerMethod, RouteOptions, RouteShorthandMethod, RouteShorthandOptions, RouteShorthandOptionsWithHandler, RouteGenericInterface, // './types/route'
-    FastifyRegister, FastifyRegisterOptions, RegisterOptions, // './types/register'
+    FastifyRegister, FastifyRegisterOptions, RegisterOptions, AnyFastifyInstance, UnEncapsulatedPlugin, FastifyDependencies, ApplyDependencies, ApplyDecorators, // './types/register'
     FastifyBodyParser, FastifyContentTypeParser, AddContentTypeParser, hasContentTypeParser, getDefaultJsonParser, ProtoAction, ConstructorAction, // './types/content-type-parser'
     FastifyError, // '@fastify/error'
     FastifySchema, FastifySchemaValidationError, FastifySchemaCompiler, FastifySerializerCompiler, // './types/schema'
@@ -221,32 +221,36 @@ declare function fastify<
   Request extends RawRequestDefaultExpression<Server> = RawRequestDefaultExpression<Server>,
   Reply extends RawReplyDefaultExpression<Server> = RawReplyDefaultExpression<Server>,
   Logger extends FastifyBaseLogger = FastifyBaseLogger,
-  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault
-> (opts: fastify.FastifyHttp2SecureOptions<Server, Logger>): FastifyInstance<Server, Request, Reply, Logger, TypeProvider> & SafePromiseLike<FastifyInstance<Server, Request, Reply, Logger, TypeProvider>>
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+  Decorators extends FastifyDecorators = FastifyDecorators
+> (opts: fastify.FastifyHttp2SecureOptions<Server, Logger>): FastifyInstance<Server, Request, Reply, Logger, TypeProvider, Decorators> & SafePromiseLike<FastifyInstance<Server, Request, Reply, Logger, TypeProvider, Decorators>>
 
 declare function fastify<
   Server extends http2.Http2Server,
   Request extends RawRequestDefaultExpression<Server> = RawRequestDefaultExpression<Server>,
   Reply extends RawReplyDefaultExpression<Server> = RawReplyDefaultExpression<Server>,
   Logger extends FastifyBaseLogger = FastifyBaseLogger,
-  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault
-> (opts: fastify.FastifyHttp2Options<Server, Logger>): FastifyInstance<Server, Request, Reply, Logger, TypeProvider> & SafePromiseLike<FastifyInstance<Server, Request, Reply, Logger, TypeProvider>>
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+  Decorators extends FastifyDecorators = FastifyDecorators
+> (opts: fastify.FastifyHttp2Options<Server, Logger>): FastifyInstance<Server, Request, Reply, Logger, TypeProvider, Decorators> & SafePromiseLike<FastifyInstance<Server, Request, Reply, Logger, TypeProvider, Decorators>>
 
 declare function fastify<
   Server extends https.Server,
   Request extends RawRequestDefaultExpression<Server> = RawRequestDefaultExpression<Server>,
   Reply extends RawReplyDefaultExpression<Server> = RawReplyDefaultExpression<Server>,
   Logger extends FastifyBaseLogger = FastifyBaseLogger,
-  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault
-> (opts: fastify.FastifyHttpsOptions<Server, Logger>): FastifyInstance<Server, Request, Reply, Logger, TypeProvider> & SafePromiseLike<FastifyInstance<Server, Request, Reply, Logger, TypeProvider>>
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+  Decorators extends FastifyDecorators = FastifyDecorators
+> (opts: fastify.FastifyHttpsOptions<Server, Logger>): FastifyInstance<Server, Request, Reply, Logger, TypeProvider, Decorators> & SafePromiseLike<FastifyInstance<Server, Request, Reply, Logger, TypeProvider, Decorators>>
 
 declare function fastify<
   Server extends http.Server,
   Request extends RawRequestDefaultExpression<Server> = RawRequestDefaultExpression<Server>,
   Reply extends RawReplyDefaultExpression<Server> = RawReplyDefaultExpression<Server>,
   Logger extends FastifyBaseLogger = FastifyBaseLogger,
-  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault
-> (opts?: fastify.FastifyHttpOptions<Server, Logger>): FastifyInstance<Server, Request, Reply, Logger, TypeProvider> & SafePromiseLike<FastifyInstance<Server, Request, Reply, Logger, TypeProvider>>
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+  Decorators extends FastifyDecorators = FastifyDecorators
+> (opts?: fastify.FastifyHttpOptions<Server, Logger>): FastifyInstance<Server, Request, Reply, Logger, TypeProvider, Decorators> & SafePromiseLike<FastifyInstance<Server, Request, Reply, Logger, TypeProvider, Decorators>>
 
 // CJS export
 // const fastify = require('fastify')

--- a/test/types/decorate-request-reply.test-d.ts
+++ b/test/types/decorate-request-reply.test-d.ts
@@ -3,16 +3,53 @@ import { expectType } from 'tsd'
 
 type TestType = void
 
-declare module '../../fastify' {
-  interface FastifyRequest {
-    testProp: TestType;
-  }
-  interface FastifyReply {
-    testProp: TestType;
-  }
-}
+export const instance = fastify()
+  .decorate('testProp')
+  .decorate('testValue', 'testValue')
+  .decorate('testFn', () => 12345)
+  .decorateRequest('testProp')
+  .decorateRequest('testValue', 'testValue')
+  .decorateRequest('testFn', () => 12345)
+  .decorateReply('testProp')
+  .decorateReply('testValue', 'testValue')
+  .decorateReply('testFn', () => 12345)
+  .get('/', (req, res) => {
+    expectType<TestType>(req.testProp)
+    expectType<string>(req.testValue)
+    expectType<number>(req.testFn())
 
-fastify().get('/', (req, res) => {
-  expectType<TestType>(req.testProp)
-  expectType<TestType>(res.testProp)
-})
+    expectType<TestType>(res.testProp)
+    expectType<string>(res.testValue)
+    expectType<number>(res.testFn())
+  })
+  .post('/', (req, res) => {
+    expectType<TestType>(req.testProp)
+    expectType<string>(req.testValue)
+    expectType<number>(req.testFn())
+
+    expectType<TestType>(res.testProp)
+    expectType<string>(res.testValue)
+    expectType<number>(res.testFn())
+  })
+  .patch('/', (req, res) => {
+    expectType<TestType>(req.testProp)
+    expectType<string>(req.testValue)
+    expectType<number>(req.testFn())
+
+    expectType<TestType>(res.testProp)
+    expectType<string>(res.testValue)
+    expectType<number>(res.testFn())
+  })
+  .delete('/', (req, res) => {
+    expectType<TestType>(req.testProp)
+    expectType<string>(req.testValue)
+    expectType<number>(req.testFn())
+
+    expectType<TestType>(res.testProp)
+    expectType<string>(res.testValue)
+    expectType<number>(res.testFn())
+  })
+
+expectType<void>(instance.testProp)
+expectType<string>(instance.testValue)
+expectType<number>(instance.testFn())

--- a/test/types/instance.test-d.ts
+++ b/test/types/instance.test-d.ts
@@ -428,19 +428,19 @@ expectError(server.decorate<string>('test', {
 }))
 
 declare module '../../fastify' {
-  interface FastifyInstance {
+  interface BaseFastifyInstance {
     typedTestProperty: boolean
     typedTestPropertyGetterSetter: string
     typedTestMethod (x: string): string
   }
 
-  interface FastifyRequest {
+  interface BaseFastifyRequest {
     typedTestRequestProperty: boolean
     typedTestRequestPropertyGetterSetter: string
     typedTestRequestMethod (x: string): string
   }
 
-  interface FastifyReply {
+  interface BaseFastifyReply {
     typedTestReplyProperty: boolean
     typedTestReplyPropertyGetterSetter: string
     typedTestReplyMethod (x: string): string

--- a/test/types/plugin.test-d.ts
+++ b/test/types/plugin.test-d.ts
@@ -31,8 +31,8 @@ const testPluginOptsWithTypeAsync = async (
   opts: FastifyPluginOptions
 ) => { }
 
-expectError(fastify().register(testPluginOpts, {})) // error because missing required options from generic declaration
-expectError(fastify().register(testPluginOptsAsync, {})) // error because missing required options from generic declaration
+expectAssignable<FastifyInstance>(fastify().register(testPluginOpts, {}))
+expectAssignable<FastifyInstance>(fastify().register(testPluginOptsAsync, {}))
 
 expectAssignable<FastifyInstance>(fastify().register(testPluginOpts, { option1: '', option2: true }))
 expectAssignable<FastifyInstance>(fastify().register(testPluginOptsAsync, { option1: '', option2: true }))

--- a/test/types/register.test-d.ts
+++ b/test/types/register.test-d.ts
@@ -1,7 +1,7 @@
 import { expectAssignable, expectError, expectType } from 'tsd'
 import { IncomingMessage, Server, ServerResponse } from 'node:http'
 import { Http2Server, Http2ServerRequest, Http2ServerResponse } from 'node:http2'
-import fastify, { FastifyInstance, FastifyError, FastifyBaseLogger, FastifyPluginAsync, FastifyPluginCallback, FastifyPluginOptions, RawServerDefault } from '../../fastify'
+import fastify, { AnyFastifyInstance, FastifyInstance, FastifyError, FastifyBaseLogger, FastifyPluginAsync, FastifyPluginCallback, FastifyPluginOptions } from '../../fastify'
 
 const testPluginCallback: FastifyPluginCallback = function (instance, opts, done) { }
 const testPluginAsync: FastifyPluginAsync = async function (instance, opts) { }
@@ -10,11 +10,11 @@ const testPluginOpts: FastifyPluginCallback = function (instance, opts, done) { 
 const testPluginOptsAsync: FastifyPluginAsync = async function (instance, opts) { }
 
 const testPluginOptsWithType = (
-  instance: FastifyInstance,
+  instance: AnyFastifyInstance,
   opts: FastifyPluginOptions,
   done: (error?: FastifyError) => void
 ) => { }
-const testPluginOptsWithTypeAsync = async (instance: FastifyInstance, opts: FastifyPluginOptions) => { }
+const testPluginOptsWithTypeAsync = async (instance: AnyFastifyInstance, opts: FastifyPluginOptions) => { }
 
 interface TestOptions extends FastifyPluginOptions {
   option1: string;
@@ -48,8 +48,8 @@ expectAssignable<FastifyInstance>(
 // With Http2
 const serverWithHttp2 = fastify({ http2: true })
 type ServerWithHttp2 = FastifyInstance<Http2Server, Http2ServerRequest, Http2ServerResponse>
-const testPluginWithHttp2: FastifyPluginCallback<TestOptions, Http2Server> = function (instance, opts, done) { }
-const testPluginWithHttp2Async: FastifyPluginAsync<TestOptions, Http2Server> = async function (instance, opts) { }
+const testPluginWithHttp2: FastifyPluginCallback<TestOptions, ServerWithHttp2> = function (instance, opts, done) { }
+const testPluginWithHttp2Async: FastifyPluginAsync<TestOptions, ServerWithHttp2> = async function (instance, opts) { }
 const testPluginWithHttp2WithType = (
   instance: ServerWithHttp2,
   opts: FastifyPluginOptions,
@@ -78,13 +78,13 @@ expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginWithHttp2As
 expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginWithHttp2WithType))
 expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginWithHttp2WithTypeAsync))
 expectAssignable<ServerWithHttp2>(serverWithHttp2.register((instance) => {
-  expectAssignable<FastifyInstance>(instance)
+  expectAssignable<AnyFastifyInstance>(instance)
 }))
 expectAssignable<ServerWithHttp2>(serverWithHttp2.register((instance: ServerWithHttp2) => {
   expectAssignable<ServerWithHttp2>(instance)
 }))
 expectAssignable<ServerWithHttp2>(serverWithHttp2.register(async (instance) => {
-  expectAssignable<FastifyInstance>(instance)
+  expectAssignable<AnyFastifyInstance>(instance)
 }))
 expectAssignable<ServerWithHttp2>(serverWithHttp2.register(async (instance: ServerWithHttp2) => {
   expectAssignable<ServerWithHttp2>(instance)
@@ -102,13 +102,11 @@ type ServerWithTypeProvider = FastifyInstance<
 >
 const testPluginWithTypeProvider: FastifyPluginCallback<
   TestOptions,
-  RawServerDefault,
-  TestTypeProvider
+  ServerWithTypeProvider
 > = function (instance, opts, done) { }
 const testPluginWithTypeProviderAsync: FastifyPluginAsync<
   TestOptions,
-  RawServerDefault,
-  TestTypeProvider
+  ServerWithTypeProvider
 > = async function (instance, opts) { }
 const testPluginWithTypeProviderWithType = (
   instance: ServerWithTypeProvider,
@@ -134,13 +132,13 @@ expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPlu
 expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProviderWithType))
 expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProviderWithTypeAsync))
 expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register((instance) => {
-  expectAssignable<FastifyInstance>(instance)
+  expectAssignable<AnyFastifyInstance>(instance)
 }))
 expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register((instance: ServerWithTypeProvider) => {
   expectAssignable<ServerWithTypeProvider>(instance)
 }))
 expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(async (instance) => {
-  expectAssignable<FastifyInstance>(instance)
+  expectAssignable<AnyFastifyInstance>(instance)
 }))
 expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(async (instance: ServerWithTypeProvider) => {
   expectAssignable<ServerWithTypeProvider>(instance)
@@ -170,15 +168,11 @@ type ServerWithTypeProviderAndLogger = FastifyInstance<
 >
 const testPluginWithTypeProviderAndLogger: FastifyPluginCallback<
   TestOptions,
-  RawServerDefault,
-  TestTypeProvider,
-  typeof customLogger
+  ServerWithTypeProviderAndLogger
 > = function (instance, opts, done) { }
 const testPluginWithTypeProviderAndLoggerAsync: FastifyPluginAsync<
   TestOptions,
-  RawServerDefault,
-  TestTypeProvider,
-  typeof customLogger
+  ServerWithTypeProviderAndLogger
 > = async function (instance, opts) { }
 const testPluginWithTypeProviderAndLoggerWithType = (
   instance: ServerWithTypeProviderAndLogger,
@@ -217,7 +211,7 @@ expectAssignable<ServerWithTypeProviderAndLogger>(
 )
 expectAssignable<ServerWithTypeProviderAndLogger>(
   serverWithTypeProviderAndLogger.register((instance) => {
-    expectAssignable<FastifyInstance>(instance)
+    expectAssignable<AnyFastifyInstance>(instance)
   })
 )
 expectAssignable<ServerWithTypeProviderAndLogger>(
@@ -227,7 +221,7 @@ expectAssignable<ServerWithTypeProviderAndLogger>(
 )
 expectAssignable<ServerWithTypeProviderAndLogger>(
   serverWithTypeProviderAndLogger.register(async (instance) => {
-    expectAssignable<FastifyInstance>(instance)
+    expectAssignable<AnyFastifyInstance>(instance)
   })
 )
 expectAssignable<ServerWithTypeProviderAndLogger>(

--- a/test/types/register.test-d.ts
+++ b/test/types/register.test-d.ts
@@ -69,11 +69,9 @@ expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginOpts))
 expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginOptsAsync))
 expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginOptsWithType))
 expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginOptsWithTypeAsync))
-// @ts-expect-error
-serverWithHttp2.register(testPluginWithHttp2)
+expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginWithHttp2))
 expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginWithHttp2, testOptions))
-// @ts-expect-error
-serverWithHttp2.register(testPluginWithHttp2Async)
+expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginWithHttp2Async))
 expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginWithHttp2Async, testOptions))
 expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginWithHttp2WithType))
 expectAssignable<ServerWithHttp2>(serverWithHttp2.register(testPluginWithHttp2WithTypeAsync))
@@ -123,11 +121,9 @@ expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPlu
 expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginOptsAsync))
 expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginOptsWithType))
 expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginOptsWithTypeAsync))
-// @ts-expect-error
-serverWithTypeProvider.register(testPluginWithTypeProvider)
+expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProvider))
 expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProvider, testOptions))
-// @ts-expect-error
-serverWithTypeProvider.register(testPluginWithTypeProviderAsync)
+expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProviderAsync))
 expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProviderAsync, testOptions))
 expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProviderWithType))
 expectAssignable<ServerWithTypeProvider>(serverWithTypeProvider.register(testPluginWithTypeProviderWithTypeAsync))
@@ -190,14 +186,12 @@ expectAssignable<ServerWithTypeProviderAndLogger>(serverWithTypeProviderAndLogge
 expectAssignable<ServerWithTypeProviderAndLogger>(serverWithTypeProviderAndLogger.register(testPluginOptsWithType))
 expectAssignable<ServerWithTypeProviderAndLogger>(serverWithTypeProviderAndLogger.register(testPluginOptsWithTypeAsync))
 expectAssignable<ServerWithTypeProviderAndLogger>(
-  // @ts-expect-error
   serverWithTypeProviderAndLogger.register(testPluginWithTypeProviderAndLogger)
 )
 expectAssignable<ServerWithTypeProviderAndLogger>(
   serverWithTypeProviderAndLogger.register(testPluginWithTypeProviderAndLogger, testOptions)
 )
 expectAssignable<ServerWithTypeProviderAndLogger>(
-  // @ts-expect-error
   serverWithTypeProviderAndLogger.register(testPluginWithTypeProviderAndLoggerAsync)
 )
 expectAssignable<ServerWithTypeProviderAndLogger>(

--- a/test/types/reply.test-d.ts
+++ b/test/types/reply.test-d.ts
@@ -1,14 +1,24 @@
 import { Buffer } from 'node:buffer'
 import { expectAssignable, expectError, expectType } from 'tsd'
 import fastify, { FastifyContextConfig, FastifyReply, FastifyRequest, FastifySchema, FastifyTypeProviderDefault, RawRequestDefaultExpression, RouteHandler, RouteHandlerMethod } from '../../fastify'
-import { FastifyInstance } from '../../types/instance'
+import { FastifyDecorators, FastifyInstance } from '../../types/instance'
 import { FastifyBaseLogger } from '../../types/logger'
 import { ResolveReplyTypeWithRouteGeneric } from '../../types/reply'
 import { FastifyRouteConfig, RouteGenericInterface } from '../../types/route'
 import { ContextConfigDefault, RawReplyDefaultExpression, RawServerDefault } from '../../types/utils'
 
 type DefaultSerializationFunction = (payload: { [key: string]: unknown }) => string
-type DefaultFastifyReplyWithCode<Code extends number> = FastifyReply<RouteGenericInterface, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, ContextConfigDefault, FastifySchema, FastifyTypeProviderDefault, ResolveReplyTypeWithRouteGeneric<RouteGenericInterface['Reply'], Code, FastifySchema, FastifyTypeProviderDefault>>
+type DefaultFastifyReplyWithCode<Code extends number> = FastifyReply<
+  RouteGenericInterface,
+  RawServerDefault,
+  RawRequestDefaultExpression,
+  RawReplyDefaultExpression,
+  ContextConfigDefault,
+  FastifySchema,
+  FastifyTypeProviderDefault,
+  FastifyDecorators['reply'],
+  ResolveReplyTypeWithRouteGeneric<RouteGenericInterface['Reply'], Code, FastifySchema, FastifyTypeProviderDefault>
+>
 
 const getHandler: RouteHandlerMethod = function (_request, reply) {
   expectType<RawReplyDefaultExpression>(reply.raw)

--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -23,7 +23,7 @@ declare module '../../fastify' {
   }
 
   /* eslint-disable @typescript-eslint/no-unused-vars */
-  interface FastifyRequest<
+  interface BaseFastifyRequest<
     RouteGeneric,
     RawServer,
     RawRequest,

--- a/test/types/type-provider.test-d.ts
+++ b/test/types/type-provider.test-d.ts
@@ -11,6 +11,7 @@ import { expectAssignable, expectError, expectType } from 'tsd'
 import { IncomingHttpHeaders } from 'node:http'
 import { Type, TSchema, Static } from 'typebox'
 import { FromSchema, JSONSchema } from 'json-schema-to-ts'
+import { AnyFastifyInstance } from '../../types/register'
 
 const server = fastify()
 
@@ -1111,7 +1112,7 @@ expectError(server.get<{
 interface AuxiliaryPluginProvider extends FastifyTypeProvider { validator: 'plugin-auxiliary' }
 
 // Auxiliary plugins may have varying server types per application. Recommendation would be to explicitly remap instance provider context within plugin if required.
-function plugin<T extends FastifyInstance> (instance: T) {
+function plugin (instance: AnyFastifyInstance) {
   expectAssignable(instance.withTypeProvider<AuxiliaryPluginProvider>().get(
     '/',
     {

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -6,7 +6,7 @@ import { AddressInfo } from 'node:net'
 import { AddContentTypeParser, ConstructorAction, FastifyBodyParser, ProtoAction, getDefaultJsonParser, hasContentTypeParser, removeAllContentTypeParsers, removeContentTypeParser } from './content-type-parser'
 import { ApplicationHook, HookAsyncLookup, HookLookup, LifecycleHook, onCloseAsyncHookHandler, onCloseHookHandler, onErrorAsyncHookHandler, onErrorHookHandler, onListenAsyncHookHandler, onListenHookHandler, onReadyAsyncHookHandler, onReadyHookHandler, onRegisterHookHandler, onRequestAbortAsyncHookHandler, onRequestAbortHookHandler, onRequestAsyncHookHandler, onRequestHookHandler, onResponseAsyncHookHandler, onResponseHookHandler, onRouteHookHandler, onSendAsyncHookHandler, onSendHookHandler, onTimeoutAsyncHookHandler, onTimeoutHookHandler, preCloseAsyncHookHandler, preCloseHookHandler, preHandlerAsyncHookHandler, preHandlerHookHandler, preParsingAsyncHookHandler, preParsingHookHandler, preSerializationAsyncHookHandler, preSerializationHookHandler, preValidationAsyncHookHandler, preValidationHookHandler } from './hooks'
 import { FastifyBaseLogger, FastifyChildLoggerFactory } from './logger'
-import { ApplyPluginChanges, FastifyRegisterOptions } from './register'
+import { ApplyPluginChanges, ExtractPluginOptions, FastifyRegisterOptions } from './register'
 import { FastifyReply } from './reply'
 import { FastifyRequest } from './request'
 import { RouteGenericInterface, RouteHandlerMethod, RouteOptions, RouteShorthandMethod } from './route'
@@ -24,7 +24,7 @@ import {
 } from './type-provider'
 import { ContextConfigDefault, HTTPMethods, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RawServerDefault } from './utils'
 import { FastifyRouterOptions } from '../fastify'
-import { FastifyPlugin, FastifyPluginAsync, FastifyPluginCallback, FastifyPluginOptions } from './plugin'
+import { FastifyPlugin, FastifyPluginAsync, FastifyPluginCallback } from './plugin'
 
 export interface PrintRoutesOptions {
   method?: HTTPMethods;
@@ -237,29 +237,26 @@ export interface BaseFastifyInstance<
   ready(readyListener: (err: Error | null) => void | Promise<void>): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   register<
-    Options extends FastifyPluginOptions,
-    Plugin extends FastifyPluginCallback<Options, this>,
+    Plugin extends FastifyPluginCallback<any, this>,
     TReturn = ApplyPluginChanges<this, Plugin>
   > (
     plugin: Plugin,
-    opts?: FastifyRegisterOptions<Options>
+    opts?: FastifyRegisterOptions<ExtractPluginOptions<Plugin>>
   ): TReturn & SafePromiseLike<TReturn>
   register<
-    Options extends FastifyPluginOptions,
-    Plugin extends FastifyPluginAsync<Options, this>,
+    Plugin extends FastifyPluginAsync<any, this>,
     TReturn = ApplyPluginChanges<this, Awaited<Plugin>>
   > (
     plugin: Plugin,
-    opts?: FastifyRegisterOptions<Options>
+    opts?: FastifyRegisterOptions<ExtractPluginOptions<Plugin>>
   ): TReturn & SafePromiseLike<TReturn>
   register<
-    Options extends FastifyPluginOptions,
     Instance extends this,
-    Plugin extends Promise<{ default: FastifyPlugin<Options, Instance> }>,
+    Plugin extends Promise<{ default: FastifyPlugin<any, Instance> }>,
     TReturn = ApplyPluginChanges<Instance, Awaited<Plugin>['default']>
   > (
     plugin: Plugin,
-    opts?: FastifyRegisterOptions<Options>
+    opts?: FastifyRegisterOptions<ExtractPluginOptions<Awaited<Plugin>['default']>>
   ): TReturn & SafePromiseLike<TReturn>
 
   routing(req: RawRequest, res: RawReply): void;

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -6,7 +6,7 @@ import { AddressInfo } from 'node:net'
 import { AddContentTypeParser, ConstructorAction, FastifyBodyParser, ProtoAction, getDefaultJsonParser, hasContentTypeParser, removeAllContentTypeParsers, removeContentTypeParser } from './content-type-parser'
 import { ApplicationHook, HookAsyncLookup, HookLookup, LifecycleHook, onCloseAsyncHookHandler, onCloseHookHandler, onErrorAsyncHookHandler, onErrorHookHandler, onListenAsyncHookHandler, onListenHookHandler, onReadyAsyncHookHandler, onReadyHookHandler, onRegisterHookHandler, onRequestAbortAsyncHookHandler, onRequestAbortHookHandler, onRequestAsyncHookHandler, onRequestHookHandler, onResponseAsyncHookHandler, onResponseHookHandler, onRouteHookHandler, onSendAsyncHookHandler, onSendHookHandler, onTimeoutAsyncHookHandler, onTimeoutHookHandler, preCloseAsyncHookHandler, preCloseHookHandler, preHandlerAsyncHookHandler, preHandlerHookHandler, preParsingAsyncHookHandler, preParsingHookHandler, preSerializationAsyncHookHandler, preSerializationHookHandler, preValidationAsyncHookHandler, preValidationHookHandler } from './hooks'
 import { FastifyBaseLogger, FastifyChildLoggerFactory } from './logger'
-import { FastifyRegister } from './register'
+import { ApplyPluginChanges, FastifyRegisterOptions } from './register'
 import { FastifyReply } from './reply'
 import { FastifyRequest } from './request'
 import { RouteGenericInterface, RouteHandlerMethod, RouteOptions, RouteShorthandMethod } from './route'
@@ -24,6 +24,7 @@ import {
 } from './type-provider'
 import { ContextConfigDefault, HTTPMethods, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RawServerDefault } from './utils'
 import { FastifyRouterOptions } from '../fastify'
+import { FastifyPlugin, FastifyPluginAsync, FastifyPluginCallback, FastifyPluginOptions } from './plugin'
 
 export interface PrintRoutesOptions {
   method?: HTTPMethods;
@@ -95,7 +96,16 @@ type GetterSetter<This, T> = T | {
   setter?: (this: This, value: T) => void
 }
 
-type DecorationMethod<This, Return = This> = {
+type DecorationMethod<
+  This,
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
+  Logger extends FastifyBaseLogger = FastifyBaseLogger,
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+  Decorators extends FastifyDecorators = FastifyDecorators,
+  Decorating extends keyof Decorators = keyof Decorators
+> = {
   <
     // Need to disable "no-use-before-define" to maintain backwards compatibility, as else decorate<Foo> would suddenly mean something new
 
@@ -107,22 +117,62 @@ type DecorationMethod<This, Return = This> = {
       : T
     >,
     dependencies?: string[]
-  ): Return;
+  ): FastifyInstance<
+    RawServer,
+    RawRequest,
+    RawReply,
+    Logger,
+    TypeProvider,
+    Decorators & Record<Decorating, Record<P, T>>
+  >;
 
-  (property: string | symbol): Return;
+  <TProp extends string | symbol>(property: TProp): FastifyInstance<
+    RawServer,
+    RawRequest,
+    RawReply,
+    Logger,
+    TypeProvider,
+    Decorators & Record<Decorating, Record<TProp, void>>
+  >
 
-  (property: string | symbol, value: null | undefined, dependencies: string[]): Return;
+  <TProp extends string | symbol, TVal extends null | undefined>(property: TProp, value: TVal, dependencies: string[]): FastifyInstance<
+    RawServer,
+    RawRequest,
+    RawReply,
+    Logger,
+    TypeProvider,
+    Decorators & Record<Decorating, Record<TProp, TVal>>
+  >;
 }
+
+export type FastifyDecorators = { fastify?: unknown, request?: unknown, reply?: unknown }
 
 /**
  * Fastify server instance. Returned by the core `fastify()` method.
  */
-export interface FastifyInstance<
+export type FastifyInstance<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   Logger extends FastifyBaseLogger = FastifyBaseLogger,
-  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+  Decorators extends FastifyDecorators = FastifyDecorators
+> = Decorators['fastify'] & BaseFastifyInstance<
+  RawServer,
+  RawRequest,
+  RawReply,
+  Logger,
+  TypeProvider,
+  Decorators
+>
+
+export interface BaseFastifyInstance<
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
+  Logger extends FastifyBaseLogger = FastifyBaseLogger,
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+  Decorators extends FastifyDecorators = FastifyDecorators
 > {
   server: RawServer;
   pluginName: string;
@@ -131,14 +181,14 @@ export interface FastifyInstance<
   log: Logger;
   listeningOrigin: string;
   addresses(): AddressInfo[]
-  withTypeProvider<Provider extends FastifyTypeProvider>(): FastifyInstance<RawServer, RawRequest, RawReply, Logger, Provider>;
+  withTypeProvider<Provider extends FastifyTypeProvider>(): FastifyInstance<RawServer, RawRequest, RawReply, Logger, Provider, Decorators>;
 
-  addSchema(schema: unknown): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  addSchema(schema: unknown): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
   getSchema(schemaId: string): unknown;
   getSchemas(): Record<string, unknown>;
 
-  after(): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider> & SafePromiseLike<undefined>;
-  after(afterListener: (err: Error | null) => void): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  after(): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators> & SafePromiseLike<undefined>;
+  after(afterListener: (err: Error | null, instance: this) => void): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   close(): Promise<undefined>;
   close(closeListener: () => void): undefined;
@@ -149,9 +199,21 @@ export interface FastifyInstance<
   [Symbol.asyncDispose](): Promise<undefined>;
 
   // should be able to define something useful with the decorator getter/setter pattern using Generics to enforce the users function returns what they expect it to
-  decorate: DecorationMethod<FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>>;
-  decorateRequest: DecorationMethod<FastifyRequest, FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>>;
-  decorateReply: DecorationMethod<FastifyReply, FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>>;
+  decorate: DecorationMethod<
+    FastifyInstance,
+    RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators,
+    'fastify'
+  >;
+  decorateRequest: DecorationMethod<
+    FastifyRequest,
+    RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators,
+    'request'
+  >;
+  decorateReply: DecorationMethod<
+    FastifyReply,
+    RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators,
+    'reply'
+  >;
 
   getDecorator<T>(name: string | symbol): T;
 
@@ -171,10 +233,34 @@ export interface FastifyInstance<
   listen(opts?: FastifyListenOptions): Promise<string>;
   listen(callback: (err: Error | null, address: string) => void): void;
 
-  ready(): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider> & SafePromiseLike<undefined>;
-  ready(readyListener: (err: Error | null) => void | Promise<void>): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ready(): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators> & SafePromiseLike<undefined>;
+  ready(readyListener: (err: Error | null) => void | Promise<void>): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
-  register: FastifyRegister<FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider> & SafePromiseLike<undefined>>;
+  register<
+    Options extends FastifyPluginOptions,
+    Plugin extends FastifyPluginCallback<Options, this>,
+    TReturn = ApplyPluginChanges<this, Plugin>
+  > (
+    plugin: Plugin,
+    opts?: FastifyRegisterOptions<Options>
+  ): TReturn & SafePromiseLike<TReturn>
+  register<
+    Options extends FastifyPluginOptions,
+    Plugin extends FastifyPluginAsync<Options, this>,
+    TReturn = ApplyPluginChanges<this, Awaited<Plugin>>
+  > (
+    plugin: Plugin,
+    opts?: FastifyRegisterOptions<Options>
+  ): TReturn & SafePromiseLike<TReturn>
+  register<
+    Options extends FastifyPluginOptions,
+    Instance extends this,
+    Plugin extends Promise<{ default: FastifyPlugin<Options, Instance> }>,
+    TReturn = ApplyPluginChanges<Instance, Awaited<Plugin>['default']>
+  > (
+    plugin: Plugin,
+    opts?: FastifyRegisterOptions<Options>
+  ): TReturn & SafePromiseLike<TReturn>
 
   routing(req: RawRequest, res: RawReply): void;
 
@@ -182,27 +268,27 @@ export interface FastifyInstance<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
     ContextConfig = ContextConfigDefault,
     const SchemaCompiler extends FastifySchema = FastifySchema
-  >(opts: RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  >(opts: RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger, Decorators>): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
-  delete: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
-  get: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
-  head: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
-  patch: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
-  post: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
-  put: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
-  options: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
-  propfind: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
-  proppatch: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
-  mkcalendar: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
-  mkcol: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
-  copy: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
-  move: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
-  lock: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
-  unlock: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
-  trace: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
-  report: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
-  search: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
-  all: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger>;
+  delete: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger, Decorators>;
+  get: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger, Decorators>;
+  head: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger, Decorators>;
+  patch: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger, Decorators>;
+  post: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger, Decorators>;
+  put: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger, Decorators>;
+  options: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger, Decorators>;
+  propfind: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger, Decorators>;
+  proppatch: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger, Decorators>;
+  mkcalendar: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger, Decorators>;
+  mkcol: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger, Decorators>;
+  copy: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger, Decorators>;
+  move: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger, Decorators>;
+  lock: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger, Decorators>;
+  unlock: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger, Decorators>;
+  trace: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger, Decorators>;
+  report: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger, Decorators>;
+  search: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger, Decorators>;
+  all: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider, Logger, Decorators>;
 
   hasRoute<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
@@ -233,7 +319,7 @@ export interface FastifyInstance<
   >(
     name: 'onRequest',
     hook: Fn extends unknown ? Fn extends AsyncFunction ? onRequestAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> : onRequestHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> : Fn,
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
    * `preParsing` is the second hook to be executed in the request lifecycle. The previous hook was `onRequest`, the next hook will be `preValidation`.
@@ -248,7 +334,7 @@ export interface FastifyInstance<
   >(
     name: 'preParsing',
     hook: Fn extends unknown ? Fn extends AsyncFunction ? preParsingAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> : preParsingHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> : Fn,
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
    * `preValidation` is the third hook to be executed in the request lifecycle. The previous hook was `preParsing`, the next hook will be `preHandler`.
@@ -262,7 +348,7 @@ export interface FastifyInstance<
   >(
     name: 'preValidation',
     hook: Fn extends unknown ? Fn extends AsyncFunction ? preValidationAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> : preValidationHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> : Fn,
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
    * `preHandler` is the fourth hook to be executed in the request lifecycle. The previous hook was `preValidation`, the next hook will be `preSerialization`.
@@ -276,7 +362,7 @@ export interface FastifyInstance<
   >(
     name: 'preHandler',
     hook: Fn extends unknown ? Fn extends AsyncFunction ? preHandlerAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> : preHandlerHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> : Fn,
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
    * `preSerialization` is the fifth hook to be executed in the request lifecycle. The previous hook was `preHandler`, the next hook will be `onSend`.
@@ -292,7 +378,7 @@ export interface FastifyInstance<
   >(
     name: 'preSerialization',
     hook: Fn extends unknown ? Fn extends AsyncFunction ? preSerializationAsyncHookHandler<PreSerializationPayload, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> : preSerializationHookHandler<PreSerializationPayload, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> : Fn,
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
    * You can change the payload with the `onSend` hook. It is the sixth hook to be executed in the request lifecycle. The previous hook was `preSerialization`, the next hook will be `onResponse`.
@@ -308,7 +394,7 @@ export interface FastifyInstance<
   >(
     name: 'onSend',
     hook: Fn extends unknown ? Fn extends AsyncFunction ? onSendAsyncHookHandler<OnSendPayload, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> : onSendHookHandler<OnSendPayload, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> : Fn,
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
    * `onResponse` is the seventh and last hook in the request hook lifecycle. The previous hook was `onSend`, there is no next hook.
@@ -323,7 +409,7 @@ export interface FastifyInstance<
   >(
     name: 'onResponse',
     hook: Fn extends unknown ? Fn extends AsyncFunction ? onResponseAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> : onResponseHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> : Fn,
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
    * `onTimeout` is useful if you need to monitor the request timed out in your service. (if the `connectionTimeout` property is set on the fastify instance)
@@ -338,13 +424,13 @@ export interface FastifyInstance<
   >(
     name: 'onTimeout',
     hook: Fn extends unknown ? Fn extends AsyncFunction ? onTimeoutAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> : onTimeoutHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> : Fn,
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
    * `onRequestAbort` is useful if you need to monitor the if the client aborts the request (if the `request.raw.aborted` property is set to `true`).
    * The `onRequestAbort` hook is executed when a client closes the connection before the entire request has been received. Therefore, you will not be able to send data to the client.
    * Notice: client abort detection is not completely reliable. See: https://github.com/fastify/fastify/blob/main/docs/Guides/Detecting-When-Clients-Abort.md
-  */
+   */
   addHook<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
     ContextConfig = ContextConfigDefault,
@@ -354,7 +440,7 @@ export interface FastifyInstance<
   >(
     name: 'onRequestAbort',
     hook: Fn extends unknown ? Fn extends AsyncFunction ? onRequestAbortAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> : onRequestAbortHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> : Fn,
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
    * This hook is useful if you need to do some custom error logging or add some specific header in case of error.
@@ -371,7 +457,7 @@ export interface FastifyInstance<
   >(
     name: 'onError',
     hook: Fn extends unknown ? Fn extends AsyncFunction ? onErrorAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, FastifyError, SchemaCompiler, TypeProvider, Logger> : onErrorHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, FastifyError, SchemaCompiler, TypeProvider, Logger> : Fn,
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   // Application addHooks
 
@@ -386,80 +472,80 @@ export interface FastifyInstance<
   >(
     name: 'onRoute',
     hook: onRouteHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
-  * Triggered when a new plugin is registered and a new encapsulation context is created. The hook will be executed before the registered code.
-  * This hook can be useful if you are developing a plugin that needs to know when a plugin context is formed, and you want to operate in that specific context.
-  * Note: This hook will not be called if a plugin is wrapped inside fastify-plugin.
-  */
+   * Triggered when a new plugin is registered and a new encapsulation context is created. The hook will be executed before the registered code.
+   * This hook can be useful if you are developing a plugin that needs to know when a plugin context is formed, and you want to operate in that specific context.
+   * Note: This hook will not be called if a plugin is wrapped inside fastify-plugin.
+   */
   addHook(
     name: 'onRegister',
     hook: onRegisterHookHandler<RawServer, RawRequest, RawReply, Logger, TypeProvider>
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
-  * Triggered when fastify.listen() or fastify.ready() is invoked to start the server. It is useful when plugins need a "ready" event, for example to load data before the server start listening for requests.
-  */
+   * Triggered when fastify.listen() or fastify.ready() is invoked to start the server. It is useful when plugins need a "ready" event, for example to load data before the server start listening for requests.
+   */
   addHook<
     Fn extends onReadyHookHandler | onReadyAsyncHookHandler = onReadyHookHandler
   >(
     name: 'onReady',
     hook: Fn extends unknown ? Fn extends AsyncFunction ? onReadyAsyncHookHandler : onReadyHookHandler : Fn,
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
-  * Triggered when fastify.listen() is invoked to start the server. It is useful when plugins need a "onListen" event, for example to run logics after the server start listening for requests.
-  */
+   * Triggered when fastify.listen() is invoked to start the server. It is useful when plugins need a "onListen" event, for example to run logics after the server start listening for requests.
+   */
   addHook<
     Fn extends onListenHookHandler<RawServer, RawRequest, RawReply, Logger, TypeProvider> | onListenAsyncHookHandler<RawServer, RawRequest, RawReply, Logger, TypeProvider> = onListenHookHandler<RawServer, RawRequest, RawReply, Logger, TypeProvider>
   >(
     name: 'onListen',
     hook: Fn extends unknown ? Fn extends AsyncFunction ? onListenAsyncHookHandler : onListenHookHandler : Fn,
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
-  * Triggered when fastify.close() is invoked to stop the server. It is useful when plugins need a "shutdown" event, for example to close an open connection to a database.
-  */
+   * Triggered when fastify.close() is invoked to stop the server. It is useful when plugins need a "shutdown" event, for example to close an open connection to a database.
+   */
   addHook<
     Fn extends onCloseHookHandler | onCloseAsyncHookHandler = onCloseHookHandler
   >(
     name: 'onClose',
     hook: Fn extends unknown ? Fn extends AsyncFunction ? onCloseAsyncHookHandler : onCloseHookHandler : Fn,
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
-  * Triggered when fastify.close() is invoked to stop the server. It is useful when plugins need to cancel some state to allow the server to close successfully.
-  */
+   * Triggered when fastify.close() is invoked to stop the server. It is useful when plugins need to cancel some state to allow the server to close successfully.
+   */
   addHook<
     Fn extends preCloseHookHandler | preCloseAsyncHookHandler = preCloseHookHandler
   >(
     name: 'preClose',
     hook: Fn extends unknown ? Fn extends AsyncFunction ? preCloseAsyncHookHandler : preCloseHookHandler : Fn,
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   addHook<
     K extends ApplicationHook | LifecycleHook,
     Fn extends (...args: any) => Promise<any> | any
-  > (
+  >(
     name: K,
     hook: Fn extends unknown ? Fn extends AsyncFunction ? HookAsyncLookup<K> : HookLookup<K> : Fn
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
-     * Set the 404 handler
-     */
-  setNotFoundHandler<RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig extends ContextConfigDefault = ContextConfigDefault, TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault, SchemaCompiler extends FastifySchema = FastifySchema> (
+   * Set the 404 handler
+   */
+  setNotFoundHandler<RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig extends ContextConfigDefault = ContextConfigDefault, TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault, SchemaCompiler extends FastifySchema = FastifySchema>(
     handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
-  setNotFoundHandler<RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig extends ContextConfigDefault = ContextConfigDefault, TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault, SchemaCompiler extends FastifySchema = FastifySchema> (
+  setNotFoundHandler<RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig extends ContextConfigDefault = ContextConfigDefault, TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault, SchemaCompiler extends FastifySchema = FastifySchema>(
     opts: {
       preValidation?: preValidationHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider> | preValidationAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider> | preValidationHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>[] | preValidationAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>[];
       preHandler?: preHandlerHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider> | preHandlerAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider> | preHandlerHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>[] | preHandlerAsyncHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>[];
     },
     handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>
 
   /**
    * Fastify default error handler
@@ -470,13 +556,13 @@ export interface FastifyInstance<
    * Set a function that will be invoked whenever an exception is thrown during the request lifecycle.
    */
   setErrorHandler<TError = unknown, RouteGeneric extends RouteGenericInterface = RouteGenericInterface, SchemaCompiler extends FastifySchema = FastifySchema, TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault>(
-    handler: (this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>, error: TError, request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>, reply: FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfigDefault, SchemaCompiler, TypeProvider>) => any | Promise<any>
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+    handler: (this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>, error: TError, request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfigDefault, Logger, Decorators['request']>, reply: FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfigDefault, SchemaCompiler, TypeProvider, Decorators['reply']>) => any | Promise<any>
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
    * Set a function that will generate a request-ids
    */
-  setGenReqId(fn: (req: RawRequestDefaultExpression<RawServer>) => string): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  setGenReqId(fn: (req: RawRequestDefaultExpression<RawServer>) => string): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
    * Hook function that is called when creating a child logger instance for each request
@@ -502,7 +588,7 @@ export interface FastifyInstance<
    * }
    * ```
    */
-  setChildLoggerFactory(factory: FastifyChildLoggerFactory<RawServer, RawRequest, RawReply, Logger, TypeProvider>): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  setChildLoggerFactory(factory: FastifyChildLoggerFactory<RawServer, RawRequest, RawReply, Logger, TypeProvider>): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
    * Fastify schema validator for all routes.
@@ -512,7 +598,7 @@ export interface FastifyInstance<
   /**
    * Set the schema validator for all routes.
    */
-  setValidatorCompiler<T = FastifySchema>(schemaCompiler: FastifySchemaCompiler<T>): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  setValidatorCompiler<T = FastifySchema>(schemaCompiler: FastifySchemaCompiler<T>): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
    * Fastify schema serializer for all routes.
@@ -522,22 +608,23 @@ export interface FastifyInstance<
   /**
    * Set the schema serializer for all routes.
    */
-  setSerializerCompiler<T = FastifySchema>(schemaCompiler: FastifySerializerCompiler<T>): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  setSerializerCompiler<T = FastifySchema>(schemaCompiler: FastifySerializerCompiler<T>): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
    * Set the schema controller for all routes.
    */
-  setSchemaController(schemaControllerOpts: FastifySchemaControllerOptions): FastifyInstance<RawServer, RawRequest, RawReply, Logger>;
+  setSchemaController(schemaControllerOpts: FastifySchemaControllerOptions): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /**
-  * Set the reply serializer for all routes.
-  */
-  setReplySerializer(replySerializer: (payload: unknown, statusCode: number) => string): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+   * Set the reply serializer for all routes.
+   */
+  setReplySerializer(replySerializer: (payload: unknown, statusCode: number) => string): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 
   /*
   * Set the schema error formatter for all routes.
   */
-  setSchemaErrorFormatter(errorFormatter: SchemaErrorFormatter): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  setSchemaErrorFormatter(errorFormatter: SchemaErrorFormatter): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
+
   /**
    * Add a content type parser
    */

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -1,7 +1,4 @@
-import { FastifyInstance } from './instance'
-import { RawServerBase, RawRequestDefaultExpression, RawReplyDefaultExpression, RawServerDefault } from './utils'
-import { FastifyTypeProvider, FastifyTypeProviderDefault } from './type-provider'
-import { FastifyBaseLogger } from './logger'
+import { AnyFastifyInstance } from './register'
 
 export type FastifyPluginOptions = Record<string, any>
 
@@ -11,15 +8,10 @@ export type FastifyPluginOptions = Record<string, any>
  * Fastify allows the user to extend its functionalities with plugins. A plugin can be a set of routes, a server decorator or whatever. To activate plugins, use the `fastify.register()` method.
  */
 export type FastifyPluginCallback<
-  Options extends FastifyPluginOptions = Record<never, never>,
-  Server extends RawServerBase = RawServerDefault,
-  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
-  Logger extends FastifyBaseLogger = FastifyBaseLogger
-> = (
-  instance: FastifyInstance<Server, RawRequestDefaultExpression<Server>, RawReplyDefaultExpression<Server>, Logger, TypeProvider>,
-  opts: Options,
-  done: (err?: Error) => void
-) => void
+  Options extends FastifyPluginOptions = FastifyPluginOptions,
+  TIn extends AnyFastifyInstance = AnyFastifyInstance,
+  TOut extends void | AnyFastifyInstance = void | AnyFastifyInstance
+> = (instance: TIn, opts: Options, done: (err?: Error) => void) => TOut
 
 /**
  * FastifyPluginAsync
@@ -27,18 +19,18 @@ export type FastifyPluginCallback<
  * Fastify allows the user to extend its functionalities with plugins. A plugin can be a set of routes, a server decorator or whatever. To activate plugins, use the `fastify.register()` method.
  */
 export type FastifyPluginAsync<
-  Options extends FastifyPluginOptions = Record<never, never>,
-  Server extends RawServerBase = RawServerDefault,
-  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
-  Logger extends FastifyBaseLogger = FastifyBaseLogger
-> = (
-  instance: FastifyInstance<Server, RawRequestDefaultExpression<Server>, RawReplyDefaultExpression<Server>, Logger, TypeProvider>,
-  opts: Options
-) => Promise<void>
+  Options extends FastifyPluginOptions = FastifyPluginOptions,
+  TIn extends AnyFastifyInstance = AnyFastifyInstance,
+  TOut extends void | AnyFastifyInstance = void | AnyFastifyInstance
+> = (instance: TIn, opts: Options) => Promise<TOut>
 
 /**
  * Generic plugin type.
  * @deprecated union type doesn't work well with type inference in TS and is therefore deprecated in favor of explicit types. Use `FastifyPluginCallback` or `FastifyPluginAsync` instead. To activate
  * plugins use `FastifyRegister`. https://fastify.dev/docs/latest/Reference/TypeScript/#register
  */
-export type FastifyPlugin<Options extends FastifyPluginOptions = Record<never, never>> = FastifyPluginCallback<Options> | FastifyPluginAsync<Options>
+export type FastifyPlugin<
+  Options extends FastifyPluginOptions = FastifyPluginOptions,
+  Instance extends AnyFastifyInstance = AnyFastifyInstance,
+  TOut extends void | AnyFastifyInstance = void | AnyFastifyInstance
+> = FastifyPluginCallback<Options, Instance, TOut> | FastifyPluginAsync<Options, Instance, TOut>

--- a/types/register.d.ts
+++ b/types/register.d.ts
@@ -1,8 +1,6 @@
-import { FastifyPluginOptions, FastifyPluginCallback, FastifyPluginAsync } from './plugin'
+import { FastifyPlugin } from './plugin'
 import { LogLevel } from './logger'
-import { FastifyInstance } from './instance'
-import { RawServerBase } from './utils'
-import { FastifyBaseLogger, FastifyTypeProvider, RawServerDefault } from '../fastify'
+import { FastifyDecorators, FastifyInstance } from './instance'
 
 export interface RegisterOptions {
   prefix?: string;
@@ -10,33 +8,63 @@ export interface RegisterOptions {
   logSerializers?: Record<string, (value: any) => string>;
 }
 
-export type FastifyRegisterOptions<Options> = (RegisterOptions & Options) | ((instance: FastifyInstance) => RegisterOptions & Options)
+export type FastifyRegisterOptions<Options> =
+  | (RegisterOptions & Options)
+  | ((instance: FastifyInstance) => RegisterOptions & Options)
+
+/**
+ * Created primarily for plugins. Having a specific server/request/reply can cause issues when combining plugins
+ * which are agnostic when it comes to the instance they are being registered on, and they only care about the
+ * decorators. If more control is needed, FastifyInstance can be used with the specific types.
+ */
+export type AnyFastifyInstance = FastifyInstance<any, any, any, any, any, FastifyDecorators>
+
+export type ExtractDecorators<T extends AnyFastifyInstance> = T extends FastifyInstance<any, any, any, any, any, infer U> ? U : never
+
+type UnEncapsulatedMarker = { __flavor: 'unEncapsulated' }
+
+export type UnEncapsulatedPlugin<Plugin extends FastifyPlugin<any, any>> =
+  Plugin & UnEncapsulatedMarker
+
+export type ApplyPluginChanges<
+  TInstance extends AnyFastifyInstance,
+  Plugin extends FastifyPlugin<any, TInstance>
+> =
+  Plugin extends UnEncapsulatedMarker
+    ? Awaited<ReturnType<Plugin>> extends AnyFastifyInstance
+      ? ApplyDecorators<TInstance, ExtractDecorators<TInstance> & ExtractDecorators<Awaited<ReturnType<Plugin>>>>
+      : never
+    : TInstance
+
+export type ApplyDecorators<
+  TInstance extends AnyFastifyInstance,
+  TDecorators extends FastifyDecorators
+> =
+  TInstance extends FastifyInstance<infer Server, infer Request, infer Response, infer Logger, infer TypeProvider, infer Decorators>
+    ? FastifyInstance<Server, Request, Response, Logger, TypeProvider, Decorators & TDecorators>
+    : TInstance
+
+// using a tuple to allow for recursively applying multiple plugins
+export type FastifyDependencies = [FastifyPlugin<any, any>, ...FastifyPlugin<any, any>[]]
+
+export type ApplyDependencies<F extends FastifyPlugin, T extends FastifyDependencies> = F extends (first: infer First, ...rest: infer Rest) => infer R
+  ? First extends AnyFastifyInstance
+    ? (instance: EnhanceArray<First, T>, ...rest: Rest) => R
+    : never
+  : F
+
+export type EnhanceArray<U extends AnyFastifyInstance, T extends FastifyDependencies> =
+  T extends [infer First, ...infer Rest]
+    ? First extends FastifyDependencies[0]
+      ? Rest extends FastifyDependencies
+        ? EnhanceArray<ApplyPluginChanges<U, First>, Rest>
+        : ApplyPluginChanges<U, First>
+      : U
+    : U
 
 /**
  * FastifyRegister
  *
  * Function for adding a plugin to fastify. The options are inferred from the passed in FastifyPlugin parameter.
  */
-export interface FastifyRegister<T = void, RawServer extends RawServerBase = RawServerDefault, TypeProviderDefault extends FastifyTypeProvider = FastifyTypeProvider, LoggerDefault extends FastifyBaseLogger = FastifyBaseLogger> {
-  <Server extends RawServerBase = RawServer, TypeProvider extends FastifyTypeProvider = TypeProviderDefault, Logger extends FastifyBaseLogger = LoggerDefault>(
-    plugin: FastifyPluginCallback<FastifyPluginOptions, Server, TypeProvider, Logger>
-  ): T;
-  <Options extends FastifyPluginOptions, Server extends RawServerBase = RawServer, TypeProvider extends FastifyTypeProvider = TypeProviderDefault, Logger extends FastifyBaseLogger = LoggerDefault>(
-    plugin: FastifyPluginCallback<Options, Server, TypeProvider, Logger>,
-    opts: FastifyRegisterOptions<Options>
-  ): T;
-  <Server extends RawServerBase = RawServer, TypeProvider extends FastifyTypeProvider = TypeProviderDefault, Logger extends FastifyBaseLogger = LoggerDefault>(
-    plugin: FastifyPluginAsync<FastifyPluginOptions, Server, TypeProvider, Logger>
-  ): T;
-  <Options extends FastifyPluginOptions, Server extends RawServerBase = RawServer, TypeProvider extends FastifyTypeProvider = TypeProviderDefault, Logger extends FastifyBaseLogger = LoggerDefault>(
-    plugin: FastifyPluginAsync<Options, Server, TypeProvider, Logger>,
-    opts: FastifyRegisterOptions<Options>
-  ): T;
-  <Server extends RawServerBase = RawServer, TypeProvider extends FastifyTypeProvider = TypeProviderDefault, Logger extends FastifyBaseLogger = LoggerDefault>(
-    plugin: FastifyPluginCallback<FastifyPluginOptions, Server, TypeProvider, Logger> | FastifyPluginAsync<FastifyPluginOptions, Server, TypeProvider, Logger> | Promise<{ default: FastifyPluginCallback<FastifyPluginOptions, Server, TypeProvider, Logger> }> | Promise<{ default: FastifyPluginAsync<FastifyPluginOptions, Server, TypeProvider, Logger> }>,
-  ): T;
-  <Options extends FastifyPluginOptions, Server extends RawServerBase = RawServer, TypeProvider extends FastifyTypeProvider = TypeProviderDefault, Logger extends FastifyBaseLogger = LoggerDefault>(
-    plugin: FastifyPluginCallback<Options, Server, TypeProvider, Logger> | FastifyPluginAsync<Options, Server, TypeProvider, Logger> | Promise<{ default: FastifyPluginCallback<Options, Server, TypeProvider, Logger> }> | Promise<{ default: FastifyPluginAsync<Options, Server, TypeProvider, Logger> }>,
-    opts: FastifyRegisterOptions<Options>
-  ): T;
-}
+export type FastifyRegister = FastifyInstance['register']

--- a/types/register.d.ts
+++ b/types/register.d.ts
@@ -8,9 +8,13 @@ export interface RegisterOptions {
   logSerializers?: Record<string, (value: any) => string>;
 }
 
+type MergeRegisterOptions<Options> = Options extends unknown
+  ? RegisterOptions & Omit<Options, keyof RegisterOptions>
+  : never
+
 export type FastifyRegisterOptions<Options> =
-  | (RegisterOptions & Options)
-  | ((instance: FastifyInstance) => RegisterOptions & Options)
+  | MergeRegisterOptions<Options>
+  | ((instance: FastifyInstance) => MergeRegisterOptions<Options>)
 
 /**
  * Created primarily for plugins. Having a specific server/request/reply can cause issues when combining plugins
@@ -20,6 +24,11 @@ export type FastifyRegisterOptions<Options> =
 export type AnyFastifyInstance = FastifyInstance<any, any, any, any, any, FastifyDecorators>
 
 export type ExtractDecorators<T extends AnyFastifyInstance> = T extends FastifyInstance<any, any, any, any, any, infer U> ? U : never
+
+export type ExtractPluginOptions<T extends FastifyPlugin<any, any>> =
+  T extends FastifyPlugin<infer Options, any>
+    ? Options
+    : never
 
 type UnEncapsulatedMarker = { __flavor: 'unEncapsulated' }
 

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'node:buffer'
-import { FastifyInstance } from './instance'
+import { FastifyDecorators, FastifyInstance } from './instance'
 import { FastifyBaseLogger } from './logger'
 import { FastifyRequest, RequestRouteOptions } from './request'
 import { RouteGenericInterface } from './route'
@@ -29,7 +29,8 @@ export type ResolveReplyTypeWithRouteGeneric<RouteGenericReply, Code extends Rep
  * FastifyReply is an instance of the standard http or http2 reply types.
  * It defaults to http.ServerResponse, and it also extends the relative reply object.
  */
-export interface FastifyReply<
+
+export type FastifyReply<
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
@@ -37,6 +38,29 @@ export interface FastifyReply<
   ContextConfig = ContextConfigDefault,
   SchemaCompiler extends FastifySchema = FastifySchema,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+  Decorators extends FastifyDecorators['reply'] = FastifyDecorators['reply'],
+  ReplyType extends FastifyReplyType = ResolveFastifyReplyType<TypeProvider, SchemaCompiler, RouteGeneric>
+> = Decorators & BaseFastifyReply<
+  RouteGeneric,
+  RawServer,
+  RawRequest,
+  RawReply,
+  ContextConfig,
+  SchemaCompiler,
+  TypeProvider,
+  Decorators,
+  ReplyType
+>
+
+export interface BaseFastifyReply<
+  RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
+  ContextConfig = ContextConfigDefault,
+  SchemaCompiler extends FastifySchema = FastifySchema,
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+  Decorators extends FastifyDecorators['reply'] = FastifyDecorators['reply'],
   ReplyType extends FastifyReplyType = ResolveFastifyReplyType<TypeProvider, SchemaCompiler, RouteGeneric>
 > {
   readonly routeOptions: Readonly<RequestRouteOptions<ContextConfig, SchemaCompiler>>
@@ -46,23 +70,23 @@ export interface FastifyReply<
   log: FastifyBaseLogger;
   request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider>;
   server: FastifyInstance;
-  code<Code extends keyof SchemaCompiler['response'] extends never ? ReplyKeysToCodes<keyof RouteGeneric['Reply']> : keyof SchemaCompiler['response'] extends ReplyKeysToCodes<keyof RouteGeneric['Reply']> ? keyof SchemaCompiler['response'] : ReplyKeysToCodes<keyof RouteGeneric['Reply']>>(statusCode: Code): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider, ResolveReplyTypeWithRouteGeneric<RouteGeneric['Reply'], Code, SchemaCompiler, TypeProvider>>;
-  status<Code extends keyof SchemaCompiler['response'] extends never ? ReplyKeysToCodes<keyof RouteGeneric['Reply']> : keyof SchemaCompiler['response'] extends ReplyKeysToCodes<keyof RouteGeneric['Reply']> ? keyof SchemaCompiler['response'] : ReplyKeysToCodes<keyof RouteGeneric['Reply']>>(statusCode: Code): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider, ResolveReplyTypeWithRouteGeneric<RouteGeneric['Reply'], Code, SchemaCompiler, TypeProvider>>;
+  code<Code extends keyof SchemaCompiler['response'] extends never ? ReplyKeysToCodes<keyof RouteGeneric['Reply']> : keyof SchemaCompiler['response'] extends ReplyKeysToCodes<keyof RouteGeneric['Reply']> ? keyof SchemaCompiler['response'] : ReplyKeysToCodes<keyof RouteGeneric['Reply']>>(statusCode: Code): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider, Decorators, ResolveReplyTypeWithRouteGeneric<RouteGeneric['Reply'], Code, SchemaCompiler, TypeProvider>>;
+  status<Code extends keyof SchemaCompiler['response'] extends never ? ReplyKeysToCodes<keyof RouteGeneric['Reply']> : keyof SchemaCompiler['response'] extends ReplyKeysToCodes<keyof RouteGeneric['Reply']> ? keyof SchemaCompiler['response'] : ReplyKeysToCodes<keyof RouteGeneric['Reply']>>(statusCode: Code): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider, Decorators, ResolveReplyTypeWithRouteGeneric<RouteGeneric['Reply'], Code, SchemaCompiler, TypeProvider>>;
   statusCode: number;
   sent: boolean;
-  send(...args: SendArgs<ReplyType>): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>;
-  header(key: HttpHeader, value: any): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>;
-  headers(values: Partial<Record<HttpHeader, number | string | string[] | undefined>>): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>;
+  send(...args: SendArgs<ReplyType>): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider, Decorators>;
+  header(key: HttpHeader, value: any): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider, Decorators>;
+  headers(values: Partial<Record<HttpHeader, number | string | string[] | undefined>>): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider, Decorators>;
   getHeader(key: HttpHeader): number | string | string[] | undefined;
   getHeaders(): Record<HttpHeader, number | string | string[] | undefined>;
-  removeHeader(key: HttpHeader): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>;
+  removeHeader(key: HttpHeader): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider, Decorators>;
   hasHeader(key: HttpHeader): boolean;
-  redirect(url: string, statusCode?: number): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>;
+  redirect(url: string, statusCode?: number): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider, Decorators>;
   writeEarlyHints(hints: Record<string, string | string[]>, callback?: () => void): void;
-  hijack(): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>;
+  hijack(): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider, Decorators>;
   callNotFound(): void;
-  type(contentType: string): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>;
-  serializer(fn: (payload: any) => string): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>;
+  type(contentType: string): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider, Decorators>;
+  serializer(fn: (payload: any) => string): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider, Decorators>;
   serialize(payload: any): string | ArrayBuffer | Buffer;
   // Serialization Methods
   getSerializationFunction(httpStatus: string, contentType?: string): ((payload: { [key: string]: unknown }) => string) | undefined;
@@ -73,9 +97,9 @@ export interface FastifyReply<
   then(fulfilled: () => void, rejected: (err: Error) => void): void;
   trailer: (
     key: string,
-    fn: ((reply: FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>, payload: string | Buffer | null) => Promise<string>) | ((reply: FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>, payload: string | Buffer | null, done: (err: Error | null, value?: string) => void) => void)
-  ) => FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>;
+    fn: ((reply: FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider, Decorators>, payload: string | Buffer | null) => Promise<string>) | ((reply: FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider, Decorators>, payload: string | Buffer | null, done: (err: Error | null, value?: string) => void) => void)
+  ) => FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider, Decorators>;
   hasTrailer(key: string): boolean;
-  removeTrailer(key: string): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>;
+  removeTrailer(key: string): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider, Decorators>;
   getDecorator<T>(name: string | symbol): T;
 }

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -1,6 +1,6 @@
 import { ErrorObject } from '@fastify/ajv-compiler'
 import { FastifyContextConfig } from './context'
-import { FastifyInstance } from './instance'
+import { FastifyDecorators, FastifyInstance } from './instance'
 import { FastifyBaseLogger } from './logger'
 import { FastifyRouteConfig, RouteGenericInterface, RouteHandlerMethod } from './route'
 import { FastifySchema } from './schema'
@@ -40,7 +40,35 @@ export interface RequestRouteOptions<ContextConfig = ContextConfigDefault, Schem
  * FastifyRequest is an instance of the standard http or http2 request objects.
  * It defaults to http.IncomingMessage, and it also extends the relative request object.
  */
-export interface FastifyRequest<RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
+export type FastifyRequest<
+  RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  SchemaCompiler extends FastifySchema = FastifySchema,
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+  ContextConfig = ContextConfigDefault,
+  Logger extends FastifyBaseLogger = FastifyBaseLogger,
+  Decorators extends FastifyDecorators['request'] = FastifyDecorators['request'],
+  RequestType extends FastifyRequestType = ResolveFastifyRequestType<TypeProvider, SchemaCompiler, RouteGeneric>
+// ^ Temporary Note: RequestType has been re-ordered to be the last argument in
+//   generic list. This generic argument is now considered optional as it can be
+//   automatically inferred from the SchemaCompiler, RouteGeneric and TypeProvider
+//   arguments. Implementations that already pass this argument can either omit
+//   the RequestType (preferred) or swap Logger and RequestType arguments when
+//   creating custom types of FastifyRequest. Related issue #4123
+> = Decorators & BaseFastifyRequest<
+  RouteGeneric,
+  RawServer,
+  RawRequest,
+  SchemaCompiler,
+  TypeProvider,
+  ContextConfig,
+  Logger,
+  RequestType
+>
+
+export interface BaseFastifyRequest<
+  RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   SchemaCompiler extends FastifySchema = FastifySchema,

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -13,7 +13,7 @@ import {
   preSerializationHookHandler,
   preValidationHookHandler
 } from './hooks'
-import { FastifyInstance } from './instance'
+import { FastifyDecorators, FastifyInstance } from './instance'
 import { FastifyBaseLogger, FastifyChildLoggerFactory, LogLevel } from './logger'
 import { FastifyReply, ReplyGenericInterface } from './reply'
 import { FastifyRequest, RequestGenericInterface } from './request'
@@ -55,7 +55,8 @@ export interface RouteShorthandOptions<
   ContextConfig = ContextConfigDefault,
   SchemaCompiler extends FastifySchema = FastifySchema,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
-  Logger extends FastifyBaseLogger = FastifyBaseLogger
+  Logger extends FastifyBaseLogger = FastifyBaseLogger,
+  Decorators extends FastifyDecorators = FastifyDecorators
 > {
   schema?: SchemaCompiler, // originally FastifySchema
   attachValidation?: boolean;
@@ -70,10 +71,10 @@ export interface RouteShorthandOptions<
   constraints?: RouteConstraint,
   prefixTrailingSlash?: 'slash' | 'no-slash' | 'both';
   errorHandler?: (
-    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
+    this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>,
     error: FastifyError,
-    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, NoInfer<SchemaCompiler>, TypeProvider, ContextConfig, Logger>,
-    reply: FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, NoInfer<SchemaCompiler>, TypeProvider>
+    request: FastifyRequest<RouteGeneric, RawServer, RawRequest, NoInfer<SchemaCompiler>, TypeProvider, ContextConfig, Logger, Decorators>,
+    reply: FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, NoInfer<SchemaCompiler>, TypeProvider, Decorators>
   ) => void;
   childLoggerFactory?: FastifyChildLoggerFactory<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
   schemaErrorFormatter?: SchemaErrorFormatter;
@@ -111,11 +112,12 @@ export type RouteHandlerMethod<
   ContextConfig = ContextConfigDefault,
   SchemaCompiler extends FastifySchema = FastifySchema,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
-  Logger extends FastifyBaseLogger = FastifyBaseLogger
+  Logger extends FastifyBaseLogger = FastifyBaseLogger,
+  Decorators extends FastifyDecorators = FastifyDecorators
 > = (
-  this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
-  request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig, Logger>,
-  reply: FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>
+  this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>,
+  request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig, Logger, Decorators['request']>,
+  reply: FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider, Decorators['reply']>
   // This return type used to be a generic type argument. Due to TypeScript's inference of return types, this rendered returns unchecked.
 ) => ResolveFastifyReplyReturnType<TypeProvider, SchemaCompiler, RouteGeneric>
 
@@ -130,9 +132,10 @@ export interface RouteShorthandOptionsWithHandler<
   ContextConfig = ContextConfigDefault,
   SchemaCompiler extends FastifySchema = FastifySchema,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
-  Logger extends FastifyBaseLogger = FastifyBaseLogger
-> extends RouteShorthandOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> {
-  handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInfer<SchemaCompiler>, TypeProvider, Logger>;
+  Logger extends FastifyBaseLogger = FastifyBaseLogger,
+  Decorators extends FastifyDecorators = FastifyDecorators
+> extends RouteShorthandOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger, Decorators> {
+  handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, NoInfer<SchemaCompiler>, TypeProvider, Logger, Decorators>;
 }
 
 /**
@@ -143,21 +146,22 @@ export interface RouteShorthandMethod<
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
-  Logger extends FastifyBaseLogger = FastifyBaseLogger
+  Logger extends FastifyBaseLogger = FastifyBaseLogger,
+  Decorators extends FastifyDecorators = FastifyDecorators
 > {
   <RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault, const SchemaCompiler extends FastifySchema = FastifySchema>(
     path: string,
-    opts: RouteShorthandOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>,
-    handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+    opts: RouteShorthandOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger, Decorators>,
+    handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger, Decorators>
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
   <RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault, const SchemaCompiler extends FastifySchema = FastifySchema>(
     path: string,
-    handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+    handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger, Decorators>
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
   <RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault, const SchemaCompiler extends FastifySchema = FastifySchema>(
     path: string,
-    opts: RouteShorthandOptionsWithHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
-  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+    opts: RouteShorthandOptionsWithHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger, Decorators>
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>;
 }
 
 /**
@@ -171,11 +175,12 @@ export interface RouteOptions<
   ContextConfig = ContextConfigDefault,
   SchemaCompiler extends FastifySchema = FastifySchema,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
-  Logger extends FastifyBaseLogger = FastifyBaseLogger
-> extends RouteShorthandOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> {
+  Logger extends FastifyBaseLogger = FastifyBaseLogger,
+  Decorators extends FastifyDecorators = FastifyDecorators
+> extends RouteShorthandOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger, Decorators> {
   method: HTTPMethods | HTTPMethods[];
   url: string;
-  handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>;
+  handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger, Decorators>;
 }
 
 export type RouteHandler<
@@ -186,11 +191,12 @@ export type RouteHandler<
   ContextConfig = ContextConfigDefault,
   SchemaCompiler extends FastifySchema = FastifySchema,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
-  Logger extends FastifyBaseLogger = FastifyBaseLogger
+  Logger extends FastifyBaseLogger = FastifyBaseLogger,
+  Decorators extends FastifyDecorators = FastifyDecorators
 > = (
-  this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
-  request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig, Logger>,
-  reply: FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>
+  this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider, Decorators>,
+  request: FastifyRequest<RouteGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig, Logger, Decorators['request']>,
+  reply: FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider, Decorators['reply']>
 ) => RouteGeneric['Reply'] | void | Promise<RouteGeneric['Reply'] | void>
 
 export type DefaultRoute<Request, Reply> = (


### PR DESCRIPTION
## Summary

This PR removes reliance on global declaration-merging assumptions for Fastify decorator typing and moves to a registration-scoped model where type visibility follows encapsulation and `register()` flow.

It includes:

- core type changes so `decorate()`, `decorateRequest()`, `decorateReply()` and `register()` carry decorator effects through instance types;
- register option inference improvements from plugin signatures;
- TypeScript documentation refresh for Fastify 6;
- a new migration guide for both plugin maintainers and end-user applications:
  - `docs/Guides/Migration-Guide-Declaration-Merging.md`.

## Context / previous attempts

This work incorporates lessons from prior attempts and follow-ups discussed in:

- #5648
- #5672

and provides a consolidated migration path plus updated docs.

## Breaking change

This is a **semver-major** TypeScript change:

- decorators no longer appear globally just because plugin types are in scope;
- decorator visibility now follows registration and encapsulation boundaries.

Runtime encapsulation behavior is unchanged; this is a type-transport correctness change.

## Validation

- `npm run test:typescript` ✅
- `npm run lint:markdown -- docs/Guides/Migration-Guide-Declaration-Merging.md docs/Guides/Index.md docs/Reference/TypeScript.md docs/Reference/Hooks.md` ✅

## Issue

Closes #5061.
