### PR TITLE
docs: document favicon.ico pitfall with parametric routes

### DIFF
--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -328,6 +328,22 @@ Prefer a single parameter approach, especially on routes that are on the hot
 path of your application. For more details, see
 [find-my-way](https://github.com/delvedor/find-my-way).
 
+> **Note:** When using parametric or wildcard routes, be aware that web browsers
+> automatically request `/favicon.ico` on every page load. If no static route
+> handles this path, the request will match parametric or wildcard routes, which
+> may cause unexpected behavior or unwanted log entries. To avoid this, register
+> a static route for `/favicon.ico`:
+>
+> ```js
+> fastify.get('/favicon.ico', async (request, reply) => {
+>   reply.code(204).send()
+> })
+> ```
+>
+> Alternatively, use
+> [`fastify-no-icon`](https://github.com/jsumners/fastify-no-icon) to handle
+> this automatically.
+
 To include a colon in a path without declaring a parameter, use a double colon.
 For example:
 ```js


### PR DESCRIPTION
## What

Added a note in the Routes documentation (URL building section) warning about the `favicon.ico` pitfall when using parametric or wildcard routes.

## Why

While working with Fastify, I noticed that browsers automatically request `/favicon.ico` on every page load. When a server has parametric routes like `/:id` or wildcard routes like `/*`, the favicon request unexpectedly matches these routes, causing confusing behavior and noisy log entries.

As discussed in #6278, maintainers agreed this should be documented.

## How

Added a blockquote note after the parametric/wildcard routes section with:
- An explanation of why this happens
- A simple workaround (static route returning 204)
- A reference to [`fastify-no-icon`](https://github.com/jsumners/fastify-no-icon) as a ready-made solution

## Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] Tests pass
- [x] Lint passes (`npm run lint` and `npm run lint:markdown`)
- [x] Documentation is changed
- [x] Commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)

Closes #6278