### PR TITLE
fix(types): allow http2: false in FastifyHttpOptions and FastifyHttpsOptions

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -66,14 +66,16 @@ declare namespace fastify {
     Server extends https.Server,
     Logger extends FastifyBaseLogger = FastifyBaseLogger
   > = FastifyServerOptions<Server, Logger> & {
-    https: https.ServerOptions | null
+    https: https.ServerOptions | null,
+    http2?: false
   }
 
   export type FastifyHttpOptions<
     Server extends http.Server,
     Logger extends FastifyBaseLogger = FastifyBaseLogger
   > = FastifyServerOptions<Server, Logger> & {
-    http?: http.ServerOptions | null
+    http?: http.ServerOptions | null,
+    http2?: false
   }
 
   type FindMyWayVersion<RawServer extends RawServerBase> = RawServer extends http.Server ? HTTPVersion.V1 : HTTPVersion.V2

--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -79,6 +79,17 @@ expectType<
   })
 )
 
+// http2: false should resolve to an http1 server
+expectType<
+  FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse> &
+  SafePromiseLike<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>>
+>(fastify({ http2: false }))
+// https with http2: false should resolve to an https server
+expectType<
+  FastifyInstance<https.Server, http.IncomingMessage, http.ServerResponse> &
+  SafePromiseLike<FastifyInstance<https.Server, http.IncomingMessage, http.ServerResponse>>
+>(fastify({ https: {}, http2: false }))
+
 expectError(fastify<http2.Http2Server>({ http2: false })) // http2 option must be true
 expectError(fastify<http2.Http2SecureServer>({ http2: false })) // http2 option must be true
 expectError(


### PR DESCRIPTION
## What

Added `http2?: false` to `FastifyHttpOptions` and `FastifyHttpsOptions` type definitions so that explicitly passing `http2: false` does not cause a TypeScript error.

## Why

While setting up a Fastify server with a configuration flag for http2, I ran into a type error when passing `http2: false`:

```ts
const app = fastify({
  http2: config.USE_HTTP2, // Type error when USE_HTTP2 is false
  logger: true,
})
```

The runtime code in `lib/server.js` handles `http2: false` correctly (it falls through to `http.createServer`), but the TypeScript types only accept `http2: true` in the http2-specific options and don't include `http2` at all in the http/https options. This forces users to use workarounds like conditional spreading.

## How

- Added `http2?: false` to `FastifyHttpOptions` (http1 server options)
- Added `http2?: false` to `FastifyHttpsOptions` (https server options)
- Added type tests verifying that `fastify({ http2: false })` resolves to an http1 server
- Added type tests verifying that `fastify({ https: {}, http2: false })` resolves to an https server
- Existing `expectError` tests still verify that `fastify<Http2Server>({ http2: false })` remains an error

All tests pass:
- `npm run test:typescript` — tsd + tsc pass
- `npm run unit` — 2204 pass, 0 fail
- `npm run lint` — clean

## Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] Tests pass
- [x] Lint passes
- [x] Type tests added
- [x] Commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)

Closes #5682