### PR TITLE
docs: fix variable shadowing bug in Database guide

### DIFF
--- a/docs/Guides/Database.md
+++ b/docs/Guides/Database.md
@@ -190,11 +190,11 @@ const knex = require('knex')
 
 function knexPlugin(fastify, options, done) {
   if(!fastify.knex) {
-    const knex = knex(options)
-    fastify.decorate('knex', knex)
+    const db = knex(options)
+    fastify.decorate('knex', db)
 
     fastify.addHook('onClose', (fastify, done) => {
-      if (fastify.knex === knex) {
+      if (fastify.knex === db) {
         fastify.knex.destroy(done)
       }
     })
@@ -203,7 +203,7 @@ function knexPlugin(fastify, options, done) {
   done()
 }
 
-export default fp(knexPlugin, { name: 'fastify-knex-example' })
+module.exports = fp(knexPlugin, { name: 'fastify-knex-example' })
 ```
 
 ### Writing a plugin for a database engine

--- a/docs/Guides/Prototype-Poisoning.md
+++ b/docs/Guides/Prototype-Poisoning.md
@@ -7,7 +7,7 @@
 ## History behind prototype poisoning
 <a id="pp"></a>
 
-Based on the article by Eran Hammer,the issue is created by a web security bug.
+Based on the article by Eran Hammer, the issue is created by a web security bug.
 It is also a perfect illustration of the efforts required to maintain
 open-source software and the limitations of existing communication channels.
 


### PR DESCRIPTION
## What

Fixed a variable shadowing bug and module syntax inconsistency in the Database guide's Knex plugin example.

## Why

While following the Database guide to create a Knex plugin, I noticed the example code would throw a `ReferenceError` at runtime:

```js
const knex = require('knex')       // outer variable

function knexPlugin(fastify, options, done) {
  if(!fastify.knex) {
    const knex = knex(options)     // ReferenceError: Cannot access 'knex' before initialization
```

The `const knex` declaration shadows the outer `knex` variable, and since `const` declarations are hoisted but not initialized, calling `knex(options)` tries to access the local `knex` before it's assigned.

The example also mixed `require()` (CommonJS) with `export default` (ESM) in the same code block.

## How

- Renamed the local variable from `knex` to `db` to avoid shadowing
- Changed `export default` to `module.exports` to match the CommonJS `require()` imports
- Also fixed a missing space after comma in `Prototype-Poisoning.md`

## Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] Tests pass
- [x] Lint passes (`npm run lint` and `npm run lint:markdown`)
- [x] Documentation is changed
- [x] Commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)