### PR TITLE
docs: fix bugs in Testing, Serverless, and other guides

### DIFF
--- a/docs/Guides/Fluent-Schema.md
+++ b/docs/Guides/Fluent-Schema.md
@@ -78,7 +78,7 @@ const addressSchema = S.object()
 const commonSchemas = S.object()
   .id('https://fastify/demo')
   .definition('addressSchema', addressSchema)
-  .definition('otherSchema', otherSchema) // You can add any schemas you need
+  // .definition('otherSchema', otherSchema) // You can add any other schemas you need
 
 fastify.addSchema(commonSchemas)
 

--- a/docs/Guides/Migration-Guide-V5.md
+++ b/docs/Guides/Migration-Guide-V5.md
@@ -540,7 +540,7 @@ and [#4682](https://github.com/fastify/fastify/issues/4682) for more information
 The `getDefaultRoute` and `setDefaultRoute` methods have been removed in v5.
 
 See [#4485](https://github.com/fastify/fastify/pull/4485)
-and [#4480](https://github.com/fastify/fastify/pull/4485)
+and [#4480](https://github.com/fastify/fastify/pull/4480)
 for more information.
 This was already deprecated in v4 as `FSTDEP014`,
 so you should have already updated your code.

--- a/docs/Guides/Serverless.md
+++ b/docs/Guides/Serverless.md
@@ -247,7 +247,7 @@ and run it with `npm run dev`.
 ### Deploy
 ```bash
 gcloud functions deploy fastifyFunction \
---runtime nodejs14 --trigger-http --region $GOOGLE_REGION --allow-unauthenticated
+--runtime nodejs20 --trigger-http --region $GOOGLE_REGION --allow-unauthenticated
 ```
 
 #### Read logs
@@ -257,7 +257,7 @@ gcloud functions logs read
 
 #### Example request to `/hello` endpoint
 ```bash
-curl -X POST https://$GOOGLE_REGION-$GOOGLE_PROJECT.cloudfunctions.net/me \
+curl -X POST https://$GOOGLE_REGION-$GOOGLE_PROJECT.cloudfunctions.net/fastifyFunction \
   -H "Content-Type: application/json" \
   -d '{ "name": "Fastify" }'
 {"message":"Hello Fastify!"}
@@ -451,9 +451,9 @@ You can add any valid `Dockerfile` that packages and runs a Node app. A basic
 docs](https://github.com/knative/docs/blob/2d654d1fd6311750cc57187a86253c52f273d924/docs/serving/samples/hello-world/helloworld-nodejs/Dockerfile).
 
 ```Dockerfile
-# Use the official Node.js 10 image.
+# Use the official Node.js 20 image.
 # https://hub.docker.com/_/node
-FROM node:10
+FROM node:20
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app

--- a/docs/Guides/Testing.md
+++ b/docs/Guides/Testing.md
@@ -458,16 +458,15 @@ const { test }= require("node:test");
 const myPlugin = require("../plugin/myFirstPlugin");
 
 test("Test the Plugin Route", async t => {
-    t.plan(5)
+    t.plan(4)
     const fastify = Fastify()
 
     fastify.register(myPlugin)
 
     fastify.get("/", async (request, reply) => {
         // Testing the fastify decorators
-        t.assert.ifError(request.helloRequest)
-        t.assert.ok(request.helloRequest, "Hello World")
-        t.assert.ok(fastify.helloInstance, "Hello Fastify Instance")
+        t.assert.strictEqual(request.helloRequest, "Hello World")
+        t.assert.strictEqual(fastify.helloInstance, "Hello Fastify Instance")
         return ({ message: request.helloRequest })
     })
 

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -744,7 +744,7 @@ For example:
 const schema = {
   response: {
     200: {
-      description: 'Response schema that support different content types'
+      description: 'Response schema that support different content types',
       content: {
         'application/json': {
           schema: {


### PR DESCRIPTION
## Summary

Fixes several documentation bugs across multiple guide and reference files:

### Testing.md
- **Bug fix**: `t.assert.ifError(request.helloRequest)` in the plugin test example would **throw** because `ifError` throws when the value is truthy (not null/undefined). Since `request.helloRequest` is `"Hello World"`, this assertion would crash the test. Replaced with `strictEqual` assertions that actually verify the decorator values.
- Updated `t.plan(5)` → `t.plan(4)` to match the corrected assertion count.

### Serverless.md
- Updated outdated Node.js versions: `FROM node:10` → `FROM node:20` and `--runtime nodejs14` → `--runtime nodejs20` (Node.js 10 and 14 are EOL; Fastify v5 requires Node.js 20+).
- Fixed wrong endpoint URL in curl example: `/me` → `/fastifyFunction` to match the `gcloud functions deploy fastifyFunction` command above it.

### Migration-Guide-V5.md
- Fixed wrong PR link: `[#4480](https://github.com/fastify/fastify/pull/4485)` → `[#4480](https://github.com/fastify/fastify/pull/4480)`.

### Validation-and-Serialization.md
- Added missing comma in response schema code example (missing comma after `description` property would cause a syntax error).

### Fluent-Schema.md
- Commented out undefined `otherSchema` variable in the `$ref-way` example that would throw `ReferenceError` if the code is copied as-is.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)