### PR TITLE
docs: add codemods section to v5 migration guide

### DIFF
--- a/docs/Guides/Migration-Guide-V5.md
+++ b/docs/Guides/Migration-Guide-V5.md
@@ -8,7 +8,9 @@ work after upgrading.
 
 ## Codemods
 
-To streamline the migration process, you can use our official codemods. These automated scripts help you safely and quickly upgrade your codebase to Fastify v5.
+To streamline the migration process, you can use our official codemods. 
+These automated scripts help you safely and quickly upgrade your codebase 
+to Fastify v5.
 
 You can run the codemod directly using `npx`:
 

--- a/docs/Guides/Migration-Guide-V5.md
+++ b/docs/Guides/Migration-Guide-V5.md
@@ -6,6 +6,16 @@ Before migrating to v5, please ensure that you have fixed all deprecation
 warnings from v4. All v4 deprecations have been removed and will no longer
 work after upgrading.
 
+## Codemods
+
+To streamline the migration process, you can use our official codemods. These automated scripts help you safely and quickly upgrade your codebase to Fastify v5.
+
+You can run the codemod directly using `npx`:
+
+```bash
+npx codemod fastify/5/migrationRecipe
+```
+
 ## Long Term Support Cycle
 
 Fastify v5 will only support Node.js v20+. If you are using an older version of


### PR DESCRIPTION
Related to #5717

## Summary
Added a dedicated "Codemods" section in the V5 Migration Guide to help developers auto-migrate their codebase to Fastify v5.