### PR TITLE
fix: restore trustProxy function for number and string types, add null check for socketAddr

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -47,16 +47,14 @@ function getTrustProxyFn (tp) {
   }
   if (typeof tp === 'number') {
     // Support trusting hop count
-    return function (a, i) { return a != null && i < tp }
+    return function (a, i) { return i < tp }
   }
   if (typeof tp === 'string') {
     // Support comma-separated tps
     const values = tp.split(',').map(it => it.trim())
-    const trust = proxyAddr.compile(values)
-    return function (a, i) { return a != null && trust(a, i) }
+    return proxyAddr.compile(values)
   }
-  const trust = proxyAddr.compile(tp)
-  return function (a, i) { return a != null && trust(a, i) }
+  return proxyAddr.compile(tp)
 }
 
 function buildRequest (R, trustProxy) {
@@ -119,7 +117,8 @@ function buildRequestWithTrustProxy (R, trustProxy) {
     },
     host: {
       get () {
-        if (this.headers['x-forwarded-host'] && proxyFn(this.raw.socket?.remoteAddress, 0)) {
+        const socketAddr = this.raw.socket?.remoteAddress
+        if (this.headers['x-forwarded-host'] && socketAddr !== null && proxyFn(socketAddr, 0)) {
           return getLastEntryInMultiHeaderValue(this.headers['x-forwarded-host'])
         }
         /**
@@ -133,7 +132,8 @@ function buildRequestWithTrustProxy (R, trustProxy) {
     },
     protocol: {
       get () {
-        if (this.headers['x-forwarded-proto'] && proxyFn(this.raw.socket?.remoteAddress, 0)) {
+        const socketAddr = this.raw.socket?.remoteAddress
+        if (this.headers['x-forwarded-proto'] && socketAddr !== null && proxyFn(socketAddr, 0)) {
           return getLastEntryInMultiHeaderValue(this.headers['x-forwarded-proto'])
         }
         if (this.socket) {

--- a/test/trust-proxy.test.js
+++ b/test/trust-proxy.test.js
@@ -3,6 +3,8 @@
 const { test, before } = require('node:test')
 const fastify = require('..')
 const helper = require('./helper')
+const Request = require('../lib/request')
+const buildRequest = Request.buildRequest
 
 const fetchForwardedRequest = async (fastifyServer, forHeader, path, protoHeader) => {
   const headers = {
@@ -218,4 +220,55 @@ test('trust proxy reads forwarded headers from trusted connections', async t => 
       'X-Forwarded-Proto': 'https'
     }
   })
+})
+
+test('trust proxy with number and undefined socket remoteAddress', t => {
+  t.plan(3)
+
+  // Test case for issue #6606: trustProxy: 1 with undefined/null socket.remoteAddress
+  // This simulates IISNode on Windows where socket.remoteAddress may be undefined
+  const headers = {
+    'x-forwarded-for': '2.2.2.2, 1.1.1.1',
+    'x-forwarded-host': 'fastify.test',
+    'x-forwarded-proto': 'https'
+  }
+  // socket must exist but remoteAddress can be undefined
+  // This is what happens in IISNode with enableXFF="true"
+  const req = {
+    method: 'GET',
+    url: '/',
+    socket: { remoteAddress: undefined },
+    headers
+  }
+
+  const TpRequest = buildRequest(Request, 1)
+  const request = new TpRequest('id', 'params', req, 'query', 'log')
+  // Even with undefined socket.remoteAddress, req.ip should be populated from X-Forwarded-For
+  t.assert.ok(request.ip, 'ip is defined')
+  // With trustProxy: 1, we trust 1 hop from socket. Since socket.remoteAddress is undefined,
+  // the hop count check should skip it and we get 1.1.1.1 (the first trusted address from X-Forwarded-For)
+  t.assert.strictEqual(request.ip, '1.1.1.1', 'gets ip from x-forwarded-for')
+  // The host should also work correctly
+  t.assert.strictEqual(request.host, 'fastify.test', 'gets host from x-forwarded-host')
+})
+
+test('trust proxy with number and null socket remoteAddress', t => {
+  t.plan(2)
+
+  // Test case for trustProxy: 1 with null socket.remoteAddress
+  const headers = {
+    'x-forwarded-for': '2.2.2.2, 1.1.1.1',
+    'x-forwarded-host': 'fastify.test'
+  }
+  const req = {
+    method: 'GET',
+    url: '/',
+    socket: { remoteAddress: null },
+    headers
+  }
+
+  const TpRequest = buildRequest(Request, 1)
+  const request = new TpRequest('id', 'params', req, 'query', 'log')
+  t.assert.ok(request.ip, 'ip is defined')
+  t.assert.strictEqual(request.ip, '1.1.1.1', 'gets ip from x-forwarded-for')
 })


### PR DESCRIPTION
Fixes #6606

## Description

The regression was introduced when the proxy trust function was changed to check for null addresses. This caused issues with IISNode on Windows where  may be undefined/null with .

## Changes

- Removed the `a != null` check from number and string trust proxy functions
- Added explicit null checks in host and protocol getters
- Added tests for `trustProxy: 1` with undefined and null socket remoteAddress

## Testing

All existing tests pass, plus new tests for the IISNode scenario.