### PR TITLE
docs: fix incorrect code examples in Hooks and Server reference

### DIFF
--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -737,9 +737,9 @@ fastify.addHook('onResponse', (request, reply, done) => {
   done()
 })
 
-fastify.addHook('preParsing', (request, reply, done) => {
+fastify.addHook('preParsing', (request, reply, payload, done) => {
   // Your code
-  done()
+  done(null, payload)
 })
 
 fastify.addHook('preValidation', (request, reply, done) => {
@@ -790,9 +790,9 @@ fastify.route({
     // this hook will always be executed after the shared `onResponse` hooks
     done()
   },
-  preParsing: function (request, reply, done) {
+  preParsing: function (request, reply, payload, done) {
     // This hook will always be executed after the shared `preParsing` hooks
-    done()
+    done(null, payload)
   },
   preValidation: function (request, reply, done) {
     // This hook will always be executed after the shared `preValidation` hooks

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -720,7 +720,7 @@ const fastify = require('fastify')({
       res.code(400)
       return res.send("Provided header is not valid")
     } else {
-      res.send(err)
+      res.send(error)
     }
   }
 })
@@ -2249,7 +2249,7 @@ fastify.get('/', {
       return
     }
 
-    fastify.errorHandler(error, request, response)
+    fastify.errorHandler(error, request, reply)
   }
 }, handler)
 ```


### PR DESCRIPTION
## What

Fixed four incorrect code examples that would throw runtime errors if copy-pasted:

1. **`Hooks.md` line 740** — `preParsing` addHook example was missing the required
   `payload` parameter: `(request, reply, done)` → `(request, reply, payload, done)`.

2. **`Hooks.md` line 793** — Same `preParsing` fix in the route options syntax.

3. **`Server.md` line 723** — `frameworkErrors` example referenced `err` but the
   handler parameter is named `error`.

4. **`Server.md` line 2252** — `errorHandler` example passed `response` but the
   handler parameter is named `reply`.

## Why

The `preParsing` hook runner (`lib/hooks.js:344`) invokes the callback with four
arguments: `(request, reply, payload, next)`. With only three parameters declared,
`done` binds to the payload stream instead of the `next` callback — calling `done()`
throws `TypeError` at runtime.

The variable name mismatches (`err`/`error`, `response`/`reply`) throw
`ReferenceError` at runtime since the referenced variables are never declared.

The correct `preParsing` signature `(request, reply, payload, done)` is already
documented in the main preParsing section (line 89), but the route level hooks
section further down used the wrong signature.

## Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] Tests pass (`npm run unit` — 2203 pass, 0 fail)
- [x] Lint passes (`npm run lint`)
- [x] Commit message follows project conventions