### PR TITLE
Security: Potential Code Injection in Build Script via Unsanitized Version String

### DIFF
--- a/build/sync-version.js
+++ b/build/sync-version.js
@@ -6,6 +6,10 @@ const path = require('node:path')
 // package.json:version -> fastify.js:VERSION
 const { version } = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json')).toString('utf8'))
 
+if (!/^\d+\.\d+\.\d+/.test(version)) {
+  throw new Error(`Invalid version string: ${version}`)
+}
+
 const fastifyJs = path.join(__dirname, '..', 'fastify.js')
 
 fs.writeFileSync(fastifyJs, fs.readFileSync(fastifyJs).toString('utf8').replace(/const\s*VERSION\s*=.*/, `const VERSION = '${version}'`))


### PR DESCRIPTION
## Problem

The `version` value read from `package.json` is directly interpolated into a JavaScript source file using a template literal without any sanitization or escaping. If `package.json` is compromised (e.g., supply chain attack), a malicious version string like `'; require('child_process').exec('cmd'); '` would be injected as executable code into `fastify.js`.

**Severity**: `medium`
**File**: `build/sync-version.js`

## Solution

Sanitize the version string before interpolation. Validate it matches a semver pattern (e.g., `/^\d+\.\d+\.\d+/`) and/or escape single quotes: `const safeVersion = version.replace(/'/g, "\\'")` before using it in the template.

## Changes

- `build/sync-version.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
