### PR TITLE
Security: Unsanitized User-Controlled Request ID from HTTP Header

### DIFF
--- a/lib/req-id-gen-factory.js
+++ b/lib/req-id-gen-factory.js
@@ -40,9 +40,12 @@ function buildDefaultGenReqId () {
   }
 }
 
+const maxRequestIdLength = 256
+
 function buildOptionalHeaderReqId (requestIdHeader, genReqId) {
   return function (req) {
-    return req.headers[requestIdHeader] || genReqId(req)
+    const headerVal = req.headers[requestIdHeader]
+    return (headerVal && headerVal.length <= maxRequestIdLength) ? headerVal : genReqId(req)
   }
 }
 


### PR DESCRIPTION
## Problem

In `buildOptionalHeaderReqId`, the request ID is taken directly from a user-controlled HTTP header (`req.headers[requestIdHeader]`) without any validation on length, format, or content. This value is typically propagated into log entries. An attacker can supply extremely long values (causing log bloat / storage DoS) or specially crafted strings that may cause issues in downstream log processing systems.

**Severity**: `low`
**File**: `lib/req-id-gen-factory.js`

## Solution

Add validation to the header-derived request ID: truncate to a reasonable maximum length (e.g., 256 characters) and optionally strip or reject control characters. For example: `const headerVal = req.headers[requestIdHeader]; return (headerVal && headerVal.length <= 256) ? headerVal : genReqId(req)`.

## Changes

- `lib/req-id-gen-factory.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
