### PR TITLE
feat: add request.mediaType

### DIFF
--- a/docs/Reference/Request.md
+++ b/docs/Reference/Request.md
@@ -38,6 +38,8 @@ Request is a core Fastify object containing the following fields:
 - `url` - The URL of the incoming request.
 - `originalUrl` - Similar to `url`, allows access to the original `url` in
   case of internal re-routing.
+- `mediaType` - The media type extracted from `Content-Type` header. When `Content-Type`
+  header is missing, it will return `undefined`.
 - `is404` - `true` if request is being handled by 404 handler, `false` otherwise.
 - `socket` - The underlying connection of the incoming request.
 - `signal` - An `AbortSignal` that aborts when the handler timeout

--- a/lib/handle-request.js
+++ b/lib/handle-request.js
@@ -11,7 +11,8 @@ const {
   kReplyIsError,
   kRouteContext,
   kFourOhFourContext,
-  kSupportedHTTPMethods
+  kSupportedHTTPMethods,
+  kRequestContentType
 } = require('./symbols')
 
 const channels = diagnostics.tracingChannel('fastify.request.handler')
@@ -51,13 +52,15 @@ function handleRequest (err, request, reply) {
       return
     }
 
-    const contentType = new ContentType(ctHeader)
-    if (contentType.isValid === false) {
+    // Nullish assignment is used to avoid creating a new ContentType instance
+    // It can be assigned when accessing the .mediaType in hooks
+    request[kRequestContentType] ??= new ContentType(ctHeader)
+    if (request[kRequestContentType].isValid === false) {
       reply[kReplyIsError] = true
       reply.status(415).send(new FST_ERR_CTP_INVALID_MEDIA_TYPE())
       return
     }
-    request[kRouteContext].contentTypeParser.run(contentType.toString(), handler, request, reply)
+    request[kRouteContext].contentTypeParser.run(request[kRequestContentType].toString(), handler, request, reply)
     return
   }
 

--- a/lib/handle-request.js
+++ b/lib/handle-request.js
@@ -52,9 +52,9 @@ function handleRequest (err, request, reply) {
       return
     }
 
-    // Nullish assignment is used to avoid creating a new ContentType instance
+    // Conditional assignment to avoid creating a new ContentType instance
     // It can be assigned when accessing the .mediaType in hooks
-    request[kRequestContentType] ??= new ContentType(ctHeader)
+    !request[kRequestContentType] && (request[kRequestContentType] = new ContentType(ctHeader))
     if (request[kRequestContentType].isValid === false) {
       reply[kReplyIsError] = true
       reply.status(415).send(new FST_ERR_CTP_INVALID_MEDIA_TYPE())

--- a/lib/request.js
+++ b/lib/request.js
@@ -10,6 +10,7 @@ const {
   kSchemaController,
   kOptions,
   kRequestCacheValidateFns,
+  kRequestContentType,
   kRouteContext,
   kRequestOriginalUrl,
   kRequestSignal,
@@ -17,6 +18,7 @@ const {
 } = require('./symbols')
 const { FST_ERR_REQ_INVALID_VALIDATION_INVOCATION, FST_ERR_DEC_UNDECLARED } = require('./errors')
 const decorators = require('./decorate')
+const ContentType = require('./content-type')
 
 const HTTP_PART_SYMBOL_MAP = {
   body: kSchemaBody,
@@ -280,6 +282,14 @@ Object.defineProperties(Request.prototype, {
     },
     set (headers) {
       this.additionalHeaders = headers
+    }
+  },
+  mediaType: {
+    get () {
+      if (!this[kRequestContentType] && this.headers['content-type'] !== undefined) {
+        this[kRequestContentType] = new ContentType(this.headers['content-type'])
+      }
+      return this[kRequestContentType]?.mediaType
     }
   },
   getValidationFunction: {

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -32,6 +32,7 @@ const keys = {
   kRequestPayloadStream: Symbol('fastify.RequestPayloadStream'),
   kRequestAcceptVersion: Symbol('fastify.RequestAcceptVersion'),
   kRequestCacheValidateFns: Symbol('fastify.request.cache.validateFns'),
+  kRequestContentType: Symbol('fastify.request.contentType'),
   kRequestOriginalUrl: Symbol('fastify.request.originalUrl'),
   kRequestSignal: Symbol('fastify.request.signal'),
   kHandlerTimeout: Symbol('fastify.handlerTimeout'),

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -162,9 +162,7 @@ function validate (context, request, execution) {
     if (typeof context[bodySchema] === 'function') {
       validatorFunction = context[bodySchema]
     } else if (context[bodySchema]) {
-      // TODO: add request.contentType and reuse it here
-      const contentType = getEssenceMediaType(request.headers['content-type'])
-      const contentSchema = context[bodySchema][contentType]
+      const contentSchema = context[bodySchema][request.mediaType]
       if (contentSchema) {
         validatorFunction = contentSchema
       }
@@ -260,16 +258,6 @@ function wrapValidationError (result, dataVar, schemaErrorFormatter) {
   error.validation = result
   error.validationContext = dataVar
   return error
-}
-
-/**
- * simple function to retrieve the essence media type
- * @param {string} header
- * @returns {string} Mimetype string.
- */
-function getEssenceMediaType (header) {
-  if (!header) return ''
-  return header.split(/[ ;]/, 1)[0].trim().toLowerCase()
 }
 
 module.exports = {

--- a/test/request-media-type.test.js
+++ b/test/request-media-type.test.js
@@ -1,0 +1,105 @@
+'use strict'
+
+const { test } = require('node:test')
+const Fastify = require('..')
+
+test('request.mediaType should match the content-type header', async (t) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  fastify.post('/', (request, reply) => {
+    t.assert.strictEqual(request.mediaType, 'application/json')
+    reply.send({ mediaType: request.mediaType })
+  })
+
+  const response = await fastify.inject({
+    method: 'POST',
+    url: '/',
+    body: JSON.stringify({ hello: 'world' }),
+    headers: {
+      'content-type': 'application/json'
+    }
+  })
+  const body = await response.json()
+  t.assert.strictEqual(body.mediaType, 'application/json')
+})
+
+test('request.mediaType should strip the charset parameter', async (t) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  fastify.post('/', (request, reply) => {
+    t.assert.strictEqual(request.mediaType, 'application/json')
+    reply.send({ mediaType: request.mediaType })
+  })
+
+  const response = await fastify.inject({
+    method: 'POST',
+    url: '/',
+    body: JSON.stringify({ hello: 'world' }),
+    headers: {
+      'content-type': 'application/json; charset=utf-8'
+    }
+  })
+  const body = await response.json()
+  t.assert.strictEqual(body.mediaType, 'application/json')
+})
+
+test('request.mediaType should strip the space', async (t) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  fastify.post('/', (request, reply) => {
+    t.assert.strictEqual(request.mediaType, 'application/json')
+    reply.send({ mediaType: request.mediaType })
+  })
+
+  const response = await fastify.inject({
+    method: 'POST',
+    url: '/',
+    body: JSON.stringify({ hello: 'world' }),
+    headers: {
+      'content-type': ' application/json ; charset=utf-8'
+    }
+  })
+  const body = await response.json()
+  t.assert.strictEqual(body.mediaType, 'application/json')
+})
+
+test('request.mediaType supported in hooks', async (t) => {
+  t.plan(5)
+
+  const fastify = Fastify()
+
+  fastify.post('/', {
+    preParsing: (request, reply, payload, done) => {
+      t.assert.strictEqual(request.mediaType, 'application/json')
+      done(null, payload)
+    },
+    preValidation: (request, reply, done) => {
+      t.assert.strictEqual(request.mediaType, 'application/json')
+      done()
+    },
+    preHandler: (request, reply, done) => {
+      t.assert.strictEqual(request.mediaType, 'application/json')
+      done()
+    }
+  }, (request, reply) => {
+    t.assert.strictEqual(request.mediaType, 'application/json')
+    reply.send({ mediaType: request.mediaType })
+  })
+
+  const response = await fastify.inject({
+    method: 'POST',
+    url: '/',
+    body: JSON.stringify({ hello: 'world' }),
+    headers: {
+      'content-type': 'application/json'
+    }
+  })
+  const body = await response.json()
+  t.assert.strictEqual(body.mediaType, 'application/json')
+})

--- a/test/schema-validation.test.js
+++ b/test/schema-validation.test.js
@@ -6,6 +6,7 @@ const Fastify = require('..')
 const AJV = require('ajv')
 const Schema = require('fluent-json-schema')
 const { waitForCb } = require('./toolkit')
+const { kRequestContentType } = require('../lib/symbols')
 
 const customSchemaCompilers = {
   body: new AJV({
@@ -1374,6 +1375,7 @@ test('Schema validation when no content type is provided', async t => {
     },
     preValidation: async (request) => {
       request.headers['content-type'] = undefined
+      request[kRequestContentType] = undefined
     }
   }, async () => 'ok')
 

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -84,6 +84,7 @@ export interface FastifyRequest<RouteGeneric extends RouteGenericInterface = Rou
   readonly is404: boolean;
   readonly socket: RawRequest['socket'];
   readonly signal: AbortSignal;
+  readonly mediaType: string | undefined;
 
   getValidationFunction(httpPart: HTTPRequestPart): ValidationFunction
   getValidationFunction(schema: { [key: string]: any }): ValidationFunction


### PR DESCRIPTION
Closes #6650

1. Add `mediaType` readonly property to `request` for public usage.
2. Add `kRequestContentType` property to `request` for caching the `ContentType` instance and internal usage.
3. Refactor the code and use `ContentType` to parse the header in all usage.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
