### PR TITLE
fix: check buildSerializer for isCustomSerializerCompiler flag

### DIFF
--- a/lib/schema-controller.js
+++ b/lib/schema-controller.js
@@ -31,7 +31,7 @@ function buildSchemaController (parentSchemaCtrl, opts) {
     bucket: (opts && opts.bucket) || buildSchemas,
     compilersFactory,
     isCustomValidatorCompiler: typeof opts?.compilersFactory?.buildValidator === 'function',
-    isCustomSerializerCompiler: typeof opts?.compilersFactory?.buildValidator === 'function'
+    isCustomSerializerCompiler: typeof opts?.compilersFactory?.buildSerializer === 'function'
   }
 
   return new SchemaController(undefined, option)

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -2196,3 +2196,33 @@ test('setSchemaController: custom validator instance should not mutate headers s
 
   await fastify.ready()
 })
+
+test('schemaController: isCustomSerializerCompiler is true when only buildSerializer is provided', t => {
+  t.plan(2)
+  const fastify = Fastify({
+    schemaController: {
+      compilersFactory: {
+        buildSerializer: function () {
+          return () => data => JSON.stringify(data)
+        }
+      }
+    }
+  })
+  t.assert.strictEqual(fastify[kSchemaController].isCustomSerializerCompiler, true)
+  t.assert.strictEqual(fastify[kSchemaController].isCustomValidatorCompiler, false)
+})
+
+test('schemaController: isCustomValidatorCompiler is true when only buildValidator is provided', t => {
+  t.plan(2)
+  const fastify = Fastify({
+    schemaController: {
+      compilersFactory: {
+        buildValidator: function () {
+          return () => () => true
+        }
+      }
+    }
+  })
+  t.assert.strictEqual(fastify[kSchemaController].isCustomValidatorCompiler, true)
+  t.assert.strictEqual(fastify[kSchemaController].isCustomSerializerCompiler, false)
+})


### PR DESCRIPTION
Closes #6652

`buildSchemaController` was reading `opts.compilersFactory.buildValidator` twice when deriving the two `isCustom*Compiler` flags, so a user passing only a custom `buildSerializer` would still see `isCustomSerializerCompiler === false`. One-character fix plus a couple of regression tests that lock in the matrix both ways.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)