### PR TITLE
fix: correct isCustomSerializerCompiler flag check

### DIFF
--- a/lib/schema-controller.js
+++ b/lib/schema-controller.js
@@ -31,7 +31,7 @@ function buildSchemaController (parentSchemaCtrl, opts) {
     bucket: (opts && opts.bucket) || buildSchemas,
     compilersFactory,
     isCustomValidatorCompiler: typeof opts?.compilersFactory?.buildValidator === 'function',
-    isCustomSerializerCompiler: typeof opts?.compilersFactory?.buildValidator === 'function'
+    isCustomSerializerCompiler: typeof opts?.compilersFactory?.buildSerializer === 'function'
   }
 
   return new SchemaController(undefined, option)

--- a/test/internals/schema-controller-perf.test.js
+++ b/test/internals/schema-controller-perf.test.js
@@ -22,6 +22,32 @@ test('SchemaController are NOT loaded when the controllers are custom', async t 
   t.assert.equal(stringifyModule, undefined, 'Stringify compiler is loaded')
 })
 
+test('isCustomSerializerCompiler is true when only a custom serializer is provided', async t => {
+  const { buildSchemaController } = require('../../lib/schema-controller')
+
+  const sc = buildSchemaController(null, {
+    compilersFactory: {
+      buildSerializer: () => () => { }
+    }
+  })
+
+  t.assert.equal(sc.isCustomValidatorCompiler, false, 'isCustomValidatorCompiler should be false')
+  t.assert.equal(sc.isCustomSerializerCompiler, true, 'isCustomSerializerCompiler should be true')
+})
+
+test('isCustomValidatorCompiler is true when only a custom validator is provided', async t => {
+  const { buildSchemaController } = require('../../lib/schema-controller')
+
+  const sc = buildSchemaController(null, {
+    compilersFactory: {
+      buildValidator: () => () => { }
+    }
+  })
+
+  t.assert.equal(sc.isCustomValidatorCompiler, true, 'isCustomValidatorCompiler should be true')
+  t.assert.equal(sc.isCustomSerializerCompiler, false, 'isCustomSerializerCompiler should be false')
+})
+
 test('SchemaController are loaded when the controllers are not custom', async t => {
   const app = Fastify()
   await app.ready()


### PR DESCRIPTION
## Summary

Fixes #6652

The `isCustomSerializerCompiler` flag in `lib/schema-controller.js` was checking `buildValidator` instead of `buildSerializer`, causing the flag to be incorrect when only a custom serializer compiler is provided.

## Changes

- Fixed the property check from `buildValidator` to `buildSerializer` on line 34
- Added tests verifying the flags are correctly set when only one custom compiler is provided

## Test plan

- [x] Existing tests pass
- [x] Added test for custom serializer-only configuration
- [x] Added test for custom validator-only configuration