### PR TITLE
fix: validate logLevel during route registration

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -224,6 +224,15 @@ function buildRouting (options) {
     validateBodyLimitOption(opts.bodyLimit)
     validateHandlerTimeoutOption(opts.handlerTimeout)
 
+    if (opts.logLevel !== undefined && opts.logLevel !== null) {
+      const validLogLevels = ['trace', 'debug', 'info', 'warn', 'error', 'fatal', 'silent']
+      if (typeof opts.logLevel !== 'string' || !validLogLevels.includes(opts.logLevel)) {
+        throw new TypeError(
+          `Invalid logLevel: '${opts.logLevel}'. Valid values are: ${validLogLevels.join(', ')}`
+        )
+      }
+    }
+
     const shouldExposeHead = opts.exposeHeadRoute ?? globalExposeHeadRoutes
 
     let isGetRoute = false


### PR DESCRIPTION
## Summary

Fixes #6124

When an invalid `logLevel` is provided in route options, the server crashes at runtime when the first request hits the route — pino's `child()` throws when it encounters an unknown level. This crash only happens under traffic, making it hard to debug.

## Fix

Validate `logLevel` during route registration (alongside existing `bodyLimit` and `handlerTimeout` validation). Invalid values now throw a clear `TypeError` at startup:

```
TypeError: Invalid logLevel: 'invalid'. Valid values are: trace, debug, info, warn, error, fatal, silent
```

## Example

```js
// Before: crashes at runtime when / is hit
fastify.get('/', { logLevel: 'invalid' }, handler)

// After: throws immediately during route registration
// TypeError: Invalid logLevel: 'invalid'. Valid values are: ...
```