### PR TITLE
fix: correct isCustomSerializerCompiler flag check

### DIFF
--- a/lib/schema-controller.js
+++ b/lib/schema-controller.js
@@ -31,7 +31,7 @@ function buildSchemaController (parentSchemaCtrl, opts) {
     bucket: (opts && opts.bucket) || buildSchemas,
     compilersFactory,
     isCustomValidatorCompiler: typeof opts?.compilersFactory?.buildValidator === 'function',
-    isCustomSerializerCompiler: typeof opts?.compilersFactory?.buildValidator === 'function'
+    isCustomSerializerCompiler: typeof opts?.compilersFactory?.buildSerializer === 'function'
   }
 
   return new SchemaController(undefined, option)

--- a/test/internals/schema-controller-perf.test.js
+++ b/test/internals/schema-controller-perf.test.js
@@ -1,6 +1,7 @@
 const { sep } = require('node:path')
 const { test } = require('node:test')
 const Fastify = require('../../fastify')
+const { kSchemaController } = require('../../lib/symbols')
 
 test('SchemaController are NOT loaded when the controllers are custom', async t => {
   const app = Fastify({
@@ -20,6 +21,38 @@ test('SchemaController are NOT loaded when the controllers are custom', async t 
 
   t.assert.equal(ajvModule, undefined, 'Ajv compiler is loaded')
   t.assert.equal(stringifyModule, undefined, 'Stringify compiler is loaded')
+})
+
+test('isCustomSerializerCompiler flag is set correctly when only buildSerializer is provided', async t => {
+  const app = Fastify({
+    schemaController: {
+      compilersFactory: {
+        buildSerializer: () => () => { }
+      }
+    }
+  })
+
+  await app.ready()
+
+  const schemaController = app[kSchemaController]
+  t.assert.equal(schemaController.isCustomValidatorCompiler, false, 'isCustomValidatorCompiler should be false')
+  t.assert.equal(schemaController.isCustomSerializerCompiler, true, 'isCustomSerializerCompiler should be true')
+})
+
+test('isCustomValidatorCompiler flag is set correctly when only buildValidator is provided', async t => {
+  const app = Fastify({
+    schemaController: {
+      compilersFactory: {
+        buildValidator: () => () => { }
+      }
+    }
+  })
+
+  await app.ready()
+
+  const schemaController = app[kSchemaController]
+  t.assert.equal(schemaController.isCustomValidatorCompiler, true, 'isCustomValidatorCompiler should be true')
+  t.assert.equal(schemaController.isCustomSerializerCompiler, false, 'isCustomSerializerCompiler should be false')
 })
 
 test('SchemaController are loaded when the controllers are not custom', async t => {


### PR DESCRIPTION
## Summary

Fixes #6652. This replaces PR #6655 which was accidentally closed.

The `isCustomSerializerCompiler` flag in `lib/schema-controller.js` was incorrectly checking `opts?.compilersFactory?.buildValidator` instead of `opts?.compilersFactory?.buildSerializer`. This caused the flag to always mirror `isCustomValidatorCompiler` rather than independently tracking whether a custom serializer compiler was provided.

## Changes

- **`lib/schema-controller.js`**: Changed the `isCustomSerializerCompiler` initialization to check `buildSerializer` instead of `buildValidator`
- **`test/internals/schema-controller-perf.test.js`**: Added two test cases verifying that `isCustomSerializerCompiler` and `isCustomValidatorCompiler` are set independently based on which compiler factory functions are provided