### PR TITLE
fix: validate logLevel in route options

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -285,6 +285,13 @@ function buildRouting (options) {
       opts.prefix = prefix
       opts.logLevel = opts.logLevel || this[kLogLevel]
 
+      if (opts.logLevel) {
+        const validLevels = ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent']
+        if (!validLevels.includes(opts.logLevel)) {
+          throw new TypeError(`Invalid logLevel "${opts.logLevel}" for route "${opts.url}". Must be one of: ${validLevels.join(', ')}`)
+        }
+      }
+
       if (this[kLogSerializers] || opts.logSerializers) {
         opts.logSerializers = Object.assign(Object.create(this[kLogSerializers]), opts.logSerializers)
       }


### PR DESCRIPTION
Passing an invalid logLevel in route options (e.g. a typo like "inf" instead of "info") crashes the server deep inside pino with an unhelpful error. This adds validation at route registration time so you get a clear TypeError that names the route and lists the valid levels.

Fixes #6124