### PR TITLE
docs: remove deprecated leveldb plugin and update ecosystem

### DIFF
--- a/docs/Guides/Database.md
+++ b/docs/Guides/Database.md
@@ -149,34 +149,6 @@ fastify.listen({ port: 3000 }, err => {
 })
 ```
 
-### [LevelDB](https://github.com/fastify/fastify-leveldb)
-Install the plugin by running `npm i @fastify/leveldb`
-
-*Usage:*
-```javascript
-const fastify = require('fastify')()
-
-fastify.register(
-  require('@fastify/leveldb'),
-  { name: 'db' }
-)
-
-fastify.get('/foo', async function (req, reply) {
-  const val = await this.level.db.get(req.query.key)
-  return val
-})
-
-fastify.post('/foo', async function (req, reply) {
-  await this.level.db.put(req.body.key, req.body.value)
-  return { status: 'ok' }
-})
-
-fastify.listen({ port: 3000 }, err => {
-  if (err) throw err
-  console.log(`server listening on ${fastify.server.address().port}`)
-})
-```
-
 ### Writing plugin for a database library
 We could write a plugin for a database
 library too (e.g. Knex, Prisma, or TypeORM).

--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -66,8 +66,6 @@ section.
   Fastify, internally uses [fast-jwt](https://github.com/nearform/fast-jwt).
 - [`@fastify/kafka`](https://github.com/fastify/fastify-kafka) Plugin to interact
   with Apache Kafka.
-- [`@fastify/leveldb`](https://github.com/fastify/fastify-leveldb) Plugin to
-  share a common LevelDB connection across Fastify.
 - [`@fastify/middie`](https://github.com/fastify/middie) Middleware engine for
   Fastify.
 - [`@fastify/mongodb`](https://github.com/fastify/fastify-mongodb) Fastify


### PR DESCRIPTION
Proposal:

- Removed `LevelDB` usage examples from `Database.md` as the plugin is now deprecated ( see here: https://www.npmjs.com/package/@fastify/leveldb )
- Cleaned up reference in `Ecosystem.md`.