### PR TITLE
ci: drop Node.js 20 from yarn matrix in package-manager-ci.yml

### DIFF
--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         # Maintenance and active LTS
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
Proposal:

Dependabot updated the `borp` dependency, causing an error in the pipeline ( see here: https://github.com/fastify/fastify/pull/6633 and screenshot ), to avoid having to perform a second revert which we already did a month ago ( see here:  https://github.com/fastify/fastify/pull/6564), it would be best to remove Node.js version 20 for Yarn, so the pipeline turns green again, even though we might consider removing Node.js version 20 right now ?, there are still two weeks left until the end of its lifecycle (EOF)

---

<img width="1719" height="630" alt="screenshot-error-pipeline" src="https://github.com/user-attachments/assets/4a9b39af-82ed-4baf-8c71-ee1805a00b18" />

---


Change made:

- drop Node.js v20 from yarn matrix in `package-manager-ci.yml`


cc @fastify/leads @fastify/core

