### PR TITLE
fix(route): skip default child logger creation when logger is disabled

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -54,7 +54,7 @@ const {
   kOnAbort
 } = require('./symbols.js')
 const { buildErrorHandler } = require('./error-handler')
-const { createChildLogger } = require('./logger-factory.js')
+const { createChildLogger, defaultChildLoggerFactory } = require('./logger-factory.js')
 const { getGenReqId } = require('./req-id-gen-factory.js')
 const { FSTDEP022 } = require('./warnings')
 
@@ -458,15 +458,16 @@ function buildRouting (options) {
   // HTTP request entry point, the routing has already been executed
   function routeHandler (req, res, params, context, query) {
     const id = getGenReqId(context.server, req)
-
-    const loggerOpts = {
-      level: context.logLevel
-    }
-
-    if (context.logSerializers) {
-      loggerOpts.serializers = context.logSerializers
-    }
-    const childLogger = createChildLogger(context, logger, req, id, loggerOpts)
+    const childLogger = hasLogger === false && context.childLoggerFactory === defaultChildLoggerFactory
+      ? logger
+      : createChildLogger(context, logger, req, id, context.logSerializers
+        ? {
+            level: context.logLevel,
+            serializers: context.logSerializers
+          }
+        : {
+            level: context.logLevel
+          })
     // Set initial value; will be re-evaluated after FastifyRequest is constructed if it's a function
     childLogger[kDisableRequestLogging] = disableRequestLoggingFn ? false : disableRequestLogging
 

--- a/test/child-logger-factory.test.js
+++ b/test/child-logger-factory.test.js
@@ -126,3 +126,32 @@ test('should throw error if invalid logger is returned', (t, done) => {
     }, { code: 'FST_ERR_LOG_INVALID_LOGGER' })
   })
 })
+
+test('should not create a child logger when logger is false and default factory is used', async t => {
+  t.plan(3)
+
+  const fastify = Fastify({
+    logger: false
+  })
+
+  let called = 0
+  fastify.log.child = function () {
+    called++
+    return this
+  }
+
+  t.after(() => fastify.close())
+
+  fastify.get('/', (req, reply) => {
+    t.assert.strictEqual(req.log, fastify.log)
+    reply.send({ ok: true })
+  })
+
+  const res = await fastify.inject({
+    method: 'GET',
+    url: '/'
+  })
+
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(called, 0)
+})


### PR DESCRIPTION
## Summary

When `logger: false` is configured, Fastify currently still goes through the default child logger creation path for requests.

This change avoids that extra `logger.child()` call when logging is disabled and the default child logger factory is in use, while preserving the existing behavior for custom `childLoggerFactory` implementations.

## Changes

- short-circuit request logger creation when:
  - logging is disabled
  - the route is using the default child logger factory
- keep custom child logger factories working even when `logger: false`
- add test coverage to verify the default child logger path is skipped in the disabled-logger case

## Why

Fastify already provides a no-op logger when logging is disabled, so creating another default child logger adds no value.

The optimization should only apply to the default factory path. User-defined child logger factories may still be intentional, even with `logger: false`, so this change does not bypass them.

## Benchmarks

### Before

```console
$ npm run benchmark
...
[1] Running 30s test @ http://localhost:3000/
[1] 100 connections with 10 pipelining factor
[1]
[1]
[1] ┌─────────┬──────┬──────┬───────┬───────┬─────────┬─────────┬────────┐
[1] │ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%   │ Avg     │ Stdev   │ Max    │
[1] ├─────────┼──────┼──────┼───────┼───────┼─────────┼─────────┼────────┤
[1] │ Latency │ 4 ms │ 9 ms │ 13 ms │ 13 ms │ 8.62 ms │ 3.67 ms │ 314 ms │
[1] └─────────┴──────┴──────┴───────┴───────┴─────────┴─────────┴────────┘
[1] ┌───────────┬─────────┬─────────┬─────────┬─────────┬────────────┬──────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg        │ Stdev    │ Min     │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼────────────┼──────────┼─────────┤
[1] │ Req/Sec   │ 96,831  │ 96,831  │ 110,079 │ 113,215 │ 109,546.67 │ 3,023.18 │ 96,770  │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼────────────┼──────────┼─────────┤
[1] │ Bytes/Sec │ 18.2 MB │ 18.2 MB │ 20.7 MB │ 21.3 MB │ 20.6 MB    │ 569 kB   │ 18.2 MB │
[1] └───────────┴─────────┴─────────┴─────────┴─────────┴────────────┴──────────┴─────────┘
[1]
[1] Req/Bytes counts sampled once per second.
[1] # of samples: 30
[1]
[1] 3288k requests in 30.02s, 618 MB read
[1] autocannon -c 100 -d 30 -p 10 localhost:3000/ exited with code 0
```

### After

```console
$ npm run benchmark
...
[1] Running 30s test @ http://localhost:3000/
[1] 100 connections with 10 pipelining factor
[1]
[1]
[1] ┌─────────┬──────┬──────┬───────┬───────┬─────────┬─────────┬────────┐
[1] │ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%   │ Avg     │ Stdev   │ Max    │
[1] ├─────────┼──────┼──────┼───────┼───────┼─────────┼─────────┼────────┤
[1] │ Latency │ 4 ms │ 9 ms │ 13 ms │ 13 ms │ 8.64 ms │ 4.21 ms │ 370 ms │
[1] └─────────┴──────┴──────┴───────┴───────┴─────────┴─────────┴────────┘
[1] ┌───────────┬─────────┬─────────┬─────────┬─────────┬────────────┬──────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg        │ Stdev    │ Min     │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼────────────┼──────────┼─────────┤
[1] │ Req/Sec   │ 99,007  │ 99,007  │ 110,207 │ 113,343 │ 109,386.67 │ 3,402.31 │ 99,004  │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼────────────┼──────────┼─────────┤
[1] │ Bytes/Sec │ 18.6 MB │ 18.6 MB │ 20.7 MB │ 21.3 MB │ 20.6 MB    │ 638 kB   │ 18.6 MB │
[1] └───────────┴─────────┴─────────┴─────────┴─────────┴────────────┴──────────┴─────────┘
[1]
[1] Req/Bytes counts sampled once per second.
[1] # of samples: 30
[1]
[1] 3283k requests in 30.01s, 617 MB read
[1] autocannon -c 100 -d 30 -p 10 localhost:3000/ exited with code 0
```


#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
