### PR TITLE
fix(types): allow request.getValidationFunction() to return undefined

### DIFF
--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -90,8 +90,12 @@ const getHandler: RouteHandler = function (request, _reply) {
   expectType<AbortSignal>(request.signal)
   expectType<Error & { validation: any; validationContext: string } | undefined>(request.validationError)
   expectType<FastifyInstance>(request.server)
-  expectAssignable<(httpPart: HTTPRequestPart) => ExpectedGetValidationFunction | undefined>(request.getValidationFunction)
-  expectAssignable<(schema: { [key: string]: unknown }) => ExpectedGetValidationFunction | undefined>(request.getValidationFunction)
+  expectAssignable<
+    (httpPart: HTTPRequestPart) => ExpectedGetValidationFunction | undefined
+      >(request.getValidationFunction)
+  expectAssignable<
+    (schema: { [key: string]: unknown }) => ExpectedGetValidationFunction | undefined
+      >(request.getValidationFunction)
   expectType<ValidationFunction | undefined>(request.getValidationFunction('body'))
   expectType<ValidationFunction | undefined>(request.getValidationFunction({ type: 'object' }))
   expectAssignable<

--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -17,7 +17,7 @@ import fastify, {
 import { FastifyInstance } from '../../types/instance'
 import { FastifyBaseLogger } from '../../types/logger'
 import { FastifyReply } from '../../types/reply'
-import { FastifyRequest, RequestRouteOptions } from '../../types/request'
+import { FastifyRequest, RequestRouteOptions, ValidationFunction } from '../../types/request'
 import { FastifyRouteConfig, RouteGenericInterface } from '../../types/route'
 import { RequestHeadersDefault, RequestParamsDefault, RequestQuerystringDefault } from '../../types/utils'
 
@@ -90,8 +90,10 @@ const getHandler: RouteHandler = function (request, _reply) {
   expectType<AbortSignal>(request.signal)
   expectType<Error & { validation: any; validationContext: string } | undefined>(request.validationError)
   expectType<FastifyInstance>(request.server)
-  expectAssignable<(httpPart: HTTPRequestPart) => ExpectedGetValidationFunction>(request.getValidationFunction)
-  expectAssignable<(schema: { [key: string]: unknown }) => ExpectedGetValidationFunction>(request.getValidationFunction)
+  expectAssignable<(httpPart: HTTPRequestPart) => ExpectedGetValidationFunction | undefined>(request.getValidationFunction)
+  expectAssignable<(schema: { [key: string]: unknown }) => ExpectedGetValidationFunction | undefined>(request.getValidationFunction)
+  expectType<ValidationFunction | undefined>(request.getValidationFunction('body'))
+  expectType<ValidationFunction | undefined>(request.getValidationFunction({ type: 'object' }))
   expectAssignable<
           (input: { [key: string]: unknown }, schema: { [key: string]: unknown }, httpPart?: HTTPRequestPart) => boolean
             >(request.validateInput)

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -86,8 +86,8 @@ export interface FastifyRequest<RouteGeneric extends RouteGenericInterface = Rou
   readonly signal: AbortSignal;
   readonly mediaType: string | undefined;
 
-  getValidationFunction(httpPart: HTTPRequestPart): ValidationFunction
-  getValidationFunction(schema: { [key: string]: any }): ValidationFunction
+  getValidationFunction(httpPart: HTTPRequestPart): ValidationFunction | undefined
+  getValidationFunction(schema: { [key: string]: any }): ValidationFunction | undefined
   compileValidationSchema(schema: { [key: string]: any }, httpPart?: HTTPRequestPart): ValidationFunction
   validateInput(input: any, schema: { [key: string]: any }, httpPart?: HTTPRequestPart): boolean
   validateInput(input: any, httpPart?: HTTPRequestPart): boolean


### PR DESCRIPTION
## Description

`request.getValidationFunction()` is currently typed in `types/request.d.ts` as always returning `ValidationFunction`, but the runtime implementation in `lib/request.js` can return `undefined` when no cached validator exists or when the requested HTTP part is missing.

This PR updates the TypeScript declaration so the return type matches the actual behavior and the existing docs in `docs/Reference/Request.md`.

## Changes

- Change both `request.getValidationFunction()` overloads to return `ValidationFunction | undefined`
- Update type tests to cover the optional return value


#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
