### PR TITLE
fix: correct isCustomSerializerCompiler detection in schema-controller

### DIFF
--- a/lib/schema-controller.js
+++ b/lib/schema-controller.js
@@ -31,7 +31,7 @@ function buildSchemaController (parentSchemaCtrl, opts) {
     bucket: (opts && opts.bucket) || buildSchemas,
     compilersFactory,
     isCustomValidatorCompiler: typeof opts?.compilersFactory?.buildValidator === 'function',
-    isCustomSerializerCompiler: typeof opts?.compilersFactory?.buildValidator === 'function'
+    isCustomSerializerCompiler: typeof opts?.compilersFactory?.buildSerializer === 'function'
   }
 
   return new SchemaController(undefined, option)

--- a/test/internals/schema-controller-perf.test.js
+++ b/test/internals/schema-controller-perf.test.js
@@ -1,6 +1,7 @@
 const { sep } = require('node:path')
 const { test } = require('node:test')
 const Fastify = require('../../fastify')
+const { kSchemaController } = require('../../lib/symbols')
 
 test('SchemaController are NOT loaded when the controllers are custom', async t => {
   const app = Fastify({
@@ -37,4 +38,20 @@ test('SchemaController are loaded when the controllers are not custom', async t 
 
   t.assert.ok(ajvModule, 'Ajv compiler is loaded')
   t.assert.ok(stringifyModule, 'Stringify compiler is loaded')
+})
+
+test('isCustomSerializerCompiler reflects buildSerializer only', async t => {
+  const app = Fastify({
+    schemaController: {
+      compilersFactory: {
+        buildValidator: () => () => { }
+      }
+    }
+  })
+
+  await app.ready()
+
+  const schemaController = app[kSchemaController]
+  t.assert.equal(schemaController.isCustomValidatorCompiler, true)
+  t.assert.equal(schemaController.isCustomSerializerCompiler, false)
 })


### PR DESCRIPTION
The isCustomSerializerCompiler flag was incorrectly derived from opts.compilersFactory.buildValidator, due to a copy-paste error. This caused the flag to reflect the validator builder presence instead of the serializer builder, producing wrong results when only one of the two compiler builders was customized.