### PR TITLE
fix: derive request.port from request.host

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -258,8 +258,7 @@ Object.defineProperties(Request.prototype, {
   port: {
     get () {
       const portReg = /(?<port>:\d+)$/
-      const host = this.headers.host ?? this.headers[':authority'] ?? ''
-      const matches = portReg.exec(host)
+      const matches = portReg.exec(this.host)
       if (matches === null || matches[1] === undefined) {
         return null
       }

--- a/test/internals/request.test.js
+++ b/test/internals/request.test.js
@@ -413,6 +413,27 @@ test('Request with trust proxy - handles multiple entries in x-forwarded-host/pr
   t.assert.strictEqual(request.protocol, 'https')
 })
 
+test('Request with trust proxy - port is derived from x-forwarded-host', t => {
+  t.plan(3)
+  const headers = {
+    'x-forwarded-for': '2.2.2.2, 1.1.1.1',
+    'x-forwarded-host': 'fastify.test:1234',
+    host: 'localhost:5678'
+  }
+  const req = {
+    method: 'GET',
+    url: '/',
+    socket: { remoteAddress: 'ip' },
+    headers
+  }
+
+  const TpRequest = Request.buildRequest(Request, true)
+  const request = new TpRequest('id', 'params', req, 'query', 'log')
+  t.assert.strictEqual(request.host, 'fastify.test:1234')
+  t.assert.strictEqual(request.hostname, 'fastify.test')
+  t.assert.strictEqual(request.port, 1234)
+})
+
 test('Request with trust proxy - plain', t => {
   t.plan(1)
   const headers = {


### PR DESCRIPTION
The `port` getter was reading from `this.headers.host` (the raw Host header) while `hostname` reads from `this.host`. When trust proxy is enabled, `this.host` returns `X-Forwarded-Host`, so `hostname` and `port` were derived from different sources. This caused inconsistent values that could mislead security decisions relying on both. The `port` getter now uses `this.host`, keeping it consistent with `hostname`.