### PR TITLE
fix: avoid duplicate closeIdleConnections call on native servers

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -381,8 +381,7 @@ function fastify (serverOptions) {
       hookRunnerApplication('preClose', fastify[kAvvioBoot], fastify, function () {
         if (fastify[kState].listening) {
           /* istanbul ignore next: Cannot test this without Node.js core support */
-          if (forceCloseConnections === 'idle') {
-            // Not needed in Node 19
+          if (forceCloseConnections === 'idle' && options.serverFactory) {
             instance.server.closeIdleConnections()
             /* istanbul ignore next: Cannot test this without Node.js core support */
           } else if (serverHasCloseAllConnections && forceCloseConnections) {

--- a/test/close-pipelining.test.js
+++ b/test/close-pipelining.test.js
@@ -41,8 +41,7 @@ test('Should return 503 while closing - pipelining', async t => {
 })
 
 test('Should close the socket abruptly - pipelining - return503OnClosing: false', async t => {
-  // Since Node v20, we will always invoke server.closeIdleConnections()
-  // therefore our socket will be closed
+  // Native Node servers close idle keep-alive sockets as part of server.close().
   const fastify = Fastify({
     return503OnClosing: false,
     forceCloseConnections: false

--- a/test/close-pipelining.test.js
+++ b/test/close-pipelining.test.js
@@ -41,7 +41,7 @@ test('Should return 503 while closing - pipelining', async t => {
 })
 
 test('Should close the socket abruptly - pipelining - return503OnClosing: false', async t => {
-  // Native Node servers close idle keep-alive sockets as part of server.close().
+  // Node.js will always invoke server.closeIdleConnections() therefore our socket will be closed
   const fastify = Fastify({
     return503OnClosing: false,
     forceCloseConnections: false

--- a/test/custom-http-server.test.js
+++ b/test/custom-http-server.test.js
@@ -63,6 +63,44 @@ async function setup () {
     )
   })
 
+  test('Should not make an extra closeIdleConnections call for native servers', async t => {
+    const fastify = Fastify({
+      forceCloseConnections: 'idle'
+    })
+
+    await fastify.listen({ port: 0 })
+
+    let called = 0
+    fastify.server.closeIdleConnections = function () {
+      called++
+    }
+
+    await fastify.close()
+
+    t.assert.strictEqual(called, 1)
+  })
+
+  test('Should preserve the extra closeIdleConnections call for custom servers', async t => {
+    let called = 0
+    const fastify = Fastify({
+      forceCloseConnections: 'idle',
+      serverFactory (handler) {
+        const server = http.createServer(handler)
+        const originalCloseIdleConnections = server.closeIdleConnections.bind(server)
+        server.closeIdleConnections = function () {
+          called++
+          return originalCloseIdleConnections()
+        }
+        return server
+      }
+    })
+
+    await fastify.listen({ port: 0 })
+    await fastify.close()
+
+    t.assert.strictEqual(called, 2)
+  })
+
   test('Should accept user defined serverFactory and ignore secondary server creation', async t => {
     const server = http.createServer(() => { })
     t.after(() => new Promise(resolve => server.close(resolve)))


### PR DESCRIPTION
## Summary

Avoid an extra `closeIdleConnections()` call when Fastify is using a native Node.js server and `forceCloseConnections: 'idle'`.

Native HTTP servers already close idle keep-alive sockets as part of `server.close()`, so the additional Fastify call is redundant there. The explicit call is still preserved for custom `serverFactory` servers to maintain the existing `forceCloseConnections: 'idle'` behavior.

## Changes

- Restrict the extra `closeIdleConnections()` call in the shutdown path to `serverFactory` servers only.
- Update the pipelining test comment to reflect native Node.js server behavior more accurately.
- Add coverage to verify:
  - native servers do not get an extra `closeIdleConnections()` call
  - custom servers created through `serverFactory` still receive the extra call

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
