### PR TITLE
fix: prevent duplicate res.end in sendTrailer with sync callbacks

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -830,10 +830,12 @@ function sendTrailer (payload, res, reply) {
   const trailers = {}
   let handled = 0
   let skipped = true
+  let sent = false
   function send () {
     // add trailers when all handler handled
     /* istanbul ignore else */
-    if (handled === 0) {
+    if (handled === 0 && !sent) {
+      sent = true
       res.addTrailers(trailers)
       // we need to properly close the stream
       // after trailers sent

--- a/test/reply-trailers.test.js
+++ b/test/reply-trailers.test.js
@@ -192,6 +192,39 @@ test('error in trailers should be ignored', (t, testDone) => {
   })
 })
 
+test('send is called once when multiple trailer callbacks run synchronously', (t, testDone) => {
+  t.plan(5)
+  const fastify = Fastify()
+  let endCalls = 0
+
+  fastify.get('/', function (request, reply) {
+    const originalEnd = reply.raw.end.bind(reply.raw)
+    reply.raw.end = function (...args) {
+      endCalls++
+      return originalEnd(...args)
+    }
+    reply.trailer('Return-Early', function (reply, payload, done) {
+      done(null, 'a')
+    })
+    reply.trailer('Content-MD5', function (reply, payload, done) {
+      done(null, 'b')
+    })
+    reply.send('hello')
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (error, res) => {
+    t.assert.ifError(error)
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.trailers['return-early'], 'a')
+    t.assert.strictEqual(res.trailers['content-md5'], 'b')
+    t.assert.strictEqual(endCalls, 1)
+    testDone()
+  })
+})
+
 describe('trailer handler counter', () => {
   const data = JSON.stringify({ hello: 'world' })
   const hash = createHash('md5')

--- a/test/reply-trailers.test.js
+++ b/test/reply-trailers.test.js
@@ -193,15 +193,21 @@ test('error in trailers should be ignored', (t, testDone) => {
 })
 
 test('send is called once when multiple trailer callbacks run synchronously', (t, testDone) => {
-  t.plan(5)
+  t.plan(6)
   const fastify = Fastify()
   let endCalls = 0
+  let addTrailersCalls = 0
 
   fastify.get('/', function (request, reply) {
     const originalEnd = reply.raw.end.bind(reply.raw)
     reply.raw.end = function (...args) {
       endCalls++
       return originalEnd(...args)
+    }
+    const originalAddTrailers = reply.raw.addTrailers.bind(reply.raw)
+    reply.raw.addTrailers = function (...args) {
+      addTrailersCalls++
+      return originalAddTrailers(...args)
     }
     reply.trailer('Return-Early', function (reply, payload, done) {
       done(null, 'a')
@@ -221,6 +227,7 @@ test('send is called once when multiple trailer callbacks run synchronously', (t
     t.assert.strictEqual(res.trailers['return-early'], 'a')
     t.assert.strictEqual(res.trailers['content-md5'], 'b')
     t.assert.strictEqual(endCalls, 1)
+    t.assert.strictEqual(addTrailersCalls, 1)
     testDone()
   })
 })


### PR DESCRIPTION
#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
