### PR TITLE
fix: preserve keepAliveTimeout=0

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -867,7 +867,7 @@ function processOptions (options, defaultRoute, onBadUrl) {
 
   // Update the options with the fixed values
   options.connectionTimeout = options.connectionTimeout || defaultInitOptions.connectionTimeout
-  options.keepAliveTimeout = options.keepAliveTimeout || defaultInitOptions.keepAliveTimeout
+  options.keepAliveTimeout = options.keepAliveTimeout ?? defaultInitOptions.keepAliveTimeout
   options.maxRequestsPerSocket = options.maxRequestsPerSocket || defaultInitOptions.maxRequestsPerSocket
   options.requestTimeout = options.requestTimeout || defaultInitOptions.requestTimeout
   options.logger = logger

--- a/test/keep-alive-timeout.test.js
+++ b/test/keep-alive-timeout.test.js
@@ -5,7 +5,7 @@ const http = require('node:http')
 const { test } = require('node:test')
 
 test('keepAliveTimeout', t => {
-  t.plan(6)
+  t.plan(7)
 
   try {
     Fastify({ keepAliveTimeout: 1.3 })
@@ -23,6 +23,9 @@ test('keepAliveTimeout', t => {
 
   const httpServer = Fastify({ keepAliveTimeout: 1 }).server
   t.assert.strictEqual(httpServer.keepAliveTimeout, 1)
+
+  const zeroTimeoutServer = Fastify({ keepAliveTimeout: 0 }).server
+  t.assert.strictEqual(zeroTimeoutServer.keepAliveTimeout, 0)
 
   const httpsServer = Fastify({ keepAliveTimeout: 2, https: {} }).server
   t.assert.strictEqual(httpsServer.keepAliveTimeout, 2)


### PR DESCRIPTION
Fixes #6672

## Summary

Preserve an explicit `keepAliveTimeout: 0` instead of replacing it with the default `72000`.

Fastify currently normalizes `keepAliveTimeout` with `||`, so an explicit `0` is treated as unset. This switches that path to nullish coalescing so only `undefined` falls back to the default.

## Tests

- `node --test test/keep-alive-timeout.test.js`
- `node --test test/internals/initial-config.test.js`
- `npx eslint fastify.js test/keep-alive-timeout.test.js`

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
