### PR TITLE
docs(warnings): fix duplicated "not" in code reuse comment

### DIFF
--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -8,9 +8,9 @@ const { createWarning } = require('process-warning')
  *   - FSTSEC001
  *   - FSTDEP022
  *
- * Deprecation Codes FSTDEP001 - FSTDEP021 were used by v4 and MUST NOT not be reused.
+ * Deprecation Codes FSTDEP001 - FSTDEP021 were used by v4 and MUST NOT be reused.
  *                             - FSTDEP022 is used by v5 and MUST NOT be reused.
- * Warning Codes FSTWRN001 - FSTWRN002 were used by v4 and MUST NOT not be reused.
+ * Warning Codes FSTWRN001 - FSTWRN002 were used by v4 and MUST NOT be reused.
  */
 
 const FSTWRN001 = createWarning({


### PR DESCRIPTION

**Repo:** fastify/fastify (⭐ 32000)
**Type:** docs
**Files changed:** 1
**Lines:** +2/-2

## What
Fixes a small grammatical error in the JSDoc-style comment block at the top of `lib/warnings.js`. The comment said "MUST NOT not be reused" (double negation) on two lines describing reserved deprecation/warning codes; both occurrences are corrected to "MUST NOT be reused".

## Why
The double "not" reverses the intended meaning ("must not not be reused" literally means "must be reused"), which is the opposite of the maintainers' intent: the listed code ranges are reserved and must not be reused. Other lines in the same block already use the correct phrasing ("MUST NOT be reused"), so this aligns the wording for future contributors who consult this list when adding new warning codes.

## Testing
Comment-only change in a doc block; no runtime behavior is affected. Verified the file still parses (no syntax change) and `grep "MUST NOT not"` returns no further occurrences in the repo.

## Risk
Low — comment-only edit, no code paths touched.
