### PR TITLE
fix: guard host/protocol getters against undefined socketAddr

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -119,8 +119,9 @@ function buildRequestWithTrustProxy (R, trustProxy) {
     },
     host: {
       get () {
-        const socketAddr = this.raw.socket?.remoteAddress
-        if (this.headers['x-forwarded-host'] && socketAddr != null && proxyFn(socketAddr, 0)) {
+        const socket = this.raw.socket
+        const socketAddr = socket?.remoteAddress
+        if (this.headers['x-forwarded-host'] && socket != null && proxyFn(socketAddr ?? '', 0)) {
           return getLastEntryInMultiHeaderValue(this.headers['x-forwarded-host'])
         }
         /**
@@ -134,8 +135,9 @@ function buildRequestWithTrustProxy (R, trustProxy) {
     },
     protocol: {
       get () {
-        const socketAddr = this.raw.socket?.remoteAddress
-        if (this.headers['x-forwarded-proto'] && socketAddr != null && proxyFn(socketAddr, 0)) {
+        const socket = this.raw.socket
+        const socketAddr = socket?.remoteAddress
+        if (this.headers['x-forwarded-proto'] && socket != null && proxyFn(socketAddr ?? '', 0)) {
           return getLastEntryInMultiHeaderValue(this.headers['x-forwarded-proto'])
         }
         if (this.socket) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -120,7 +120,7 @@ function buildRequestWithTrustProxy (R, trustProxy) {
     host: {
       get () {
         const socketAddr = this.raw.socket?.remoteAddress
-        if (this.headers['x-forwarded-host'] && socketAddr !== null && proxyFn(socketAddr, 0)) {
+        if (this.headers['x-forwarded-host'] && socketAddr != null && proxyFn(socketAddr, 0)) {
           return getLastEntryInMultiHeaderValue(this.headers['x-forwarded-host'])
         }
         /**
@@ -135,7 +135,7 @@ function buildRequestWithTrustProxy (R, trustProxy) {
     protocol: {
       get () {
         const socketAddr = this.raw.socket?.remoteAddress
-        if (this.headers['x-forwarded-proto'] && socketAddr !== null && proxyFn(socketAddr, 0)) {
+        if (this.headers['x-forwarded-proto'] && socketAddr != null && proxyFn(socketAddr, 0)) {
           return getLastEntryInMultiHeaderValue(this.headers['x-forwarded-proto'])
         }
         if (this.socket) {

--- a/test/internals/request.test.js
+++ b/test/internals/request.test.js
@@ -504,3 +504,23 @@ test('Request with trust proxy and undefined socket', t => {
   const request = new TpRequest('id', 'params', req, 'query', 'log')
   t.assert.deepStrictEqual(request.protocol, undefined)
 })
+
+test('Request with trust proxy and null socket does not trust x-forwarded-host/proto', t => {
+  t.plan(2)
+  const headers = {
+    'x-forwarded-host': 'spoofed.test',
+    'x-forwarded-proto': 'https',
+    host: 'real.test'
+  }
+  const req = {
+    method: 'GET',
+    url: '/',
+    socket: null,
+    headers
+  }
+
+  const TpRequest = Request.buildRequest(Request, true)
+  const request = new TpRequest('id', 'params', req, 'query', 'log')
+  t.assert.strictEqual(request.host, 'real.test')
+  t.assert.strictEqual(request.protocol, undefined)
+})


### PR DESCRIPTION
Fixes #6673

The trust proxy getters for `host` and `protocol` used `socketAddr !== null`, which incorrectly passes when `this.raw.socket?.remoteAddress` evaluates to `undefined` (e.g., on a destroyed socket). With permissive trust functions such as `trustProxy: true` or a numeric hop count, the trust function returns `true` for `undefined`, causing `x-forwarded-host` and `x-forwarded-proto` headers to be trusted without a valid socket address.

Changed `!== null` to `!= null` so both `null` and `undefined` are rejected.

- All 14 request tests pass
