### PR TITLE
fix: validate logLevel at route registration time

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -243,6 +243,13 @@ const codes = {
     TypeError
   ),
 
+  FST_ERR_LOG_INVALID_LEVEL: createError(
+    'FST_ERR_LOG_INVALID_LEVEL',
+    "Invalid logLevel: '%s'. Valid levels are: %s",
+    500,
+    TypeError
+  ),
+
   /**
    * reply
   */

--- a/lib/route.js
+++ b/lib/route.js
@@ -28,7 +28,8 @@ const {
   FST_ERR_ROUTE_BODY_LIMIT_OPTION_NOT_INT,
   FST_ERR_ROUTE_HANDLER_TIMEOUT_OPTION_NOT_INT,
   FST_ERR_HANDLER_TIMEOUT,
-  FST_ERR_HOOK_INVALID_ASYNC_HANDLER
+  FST_ERR_HOOK_INVALID_ASYNC_HANDLER,
+  FST_ERR_LOG_INVALID_LEVEL
 } = require('./errors')
 
 const {
@@ -284,6 +285,14 @@ function buildRouting (options) {
       opts.routePath = path
       opts.prefix = prefix
       opts.logLevel = opts.logLevel || this[kLogLevel]
+
+      // Validate logLevel at registration time to prevent runtime crashes
+      if (opts.logLevel) {
+        const validLevels = ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent']
+        if (!validLevels.includes(opts.logLevel)) {
+          throw new FST_ERR_LOG_INVALID_LEVEL(opts.logLevel, validLevels.join(', '))
+        }
+      }
 
       if (this[kLogSerializers] || opts.logSerializers) {
         opts.logSerializers = Object.assign(Object.create(this[kLogSerializers]), opts.logSerializers)


### PR DESCRIPTION
## Summary

Validates `logLevel` during route registration instead of letting the server crash at runtime when a request hits a route with an invalid log level.

**Before:** Server starts normally, then crashes on the first request with `Error: unknown level invalid` from pino.

**After:** Server throws a descriptive `FST_ERR_LOG_INVALID_LEVEL` error at startup during route registration.

Fixes #6124

## Changes

- `lib/route.js`: Added validation of `opts.logLevel` against valid pino levels (`fatal`, `error`, `warn`, `info`, `debug`, `trace`, `silent`) during route registration
- `lib/errors.js`: Added `FST_ERR_LOG_INVALID_LEVEL` error code

## Reproduction

```js
const fastify = require('fastify')({ logger: true });
fastify.get('/', { logLevel: 'invalid' }, async () => 'hello world');
fastify.listen({ port: 3000 });
// Before: starts fine, crashes on first request
// After: throws FST_ERR_LOG_INVALID_LEVEL at registration
```

## Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the Developer's Certification of Origin