### PR TITLE
fix: do not trust forwarded host/proto when socket is missing

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -119,8 +119,8 @@ function buildRequestWithTrustProxy (R, trustProxy) {
     },
     host: {
       get () {
-        const socketAddr = this.raw.socket?.remoteAddress
-        if (this.headers['x-forwarded-host'] && socketAddr !== null && proxyFn(socketAddr, 0)) {
+        const socket = this.raw.socket
+        if (this.headers['x-forwarded-host'] && socket != null && proxyFn(socket.remoteAddress, 0)) {
           return getLastEntryInMultiHeaderValue(this.headers['x-forwarded-host'])
         }
         /**
@@ -134,8 +134,8 @@ function buildRequestWithTrustProxy (R, trustProxy) {
     },
     protocol: {
       get () {
-        const socketAddr = this.raw.socket?.remoteAddress
-        if (this.headers['x-forwarded-proto'] && socketAddr !== null && proxyFn(socketAddr, 0)) {
+        const socket = this.raw.socket
+        if (this.headers['x-forwarded-proto'] && socket != null && proxyFn(socket.remoteAddress, 0)) {
           return getLastEntryInMultiHeaderValue(this.headers['x-forwarded-proto'])
         }
         if (this.socket) {

--- a/test/internals/request.test.js
+++ b/test/internals/request.test.js
@@ -487,11 +487,13 @@ test('Request with undefined socket', t => {
   t.assert.ok(request.compileValidationSchema instanceof Function)
 })
 
-test('Request with trust proxy and undefined socket', t => {
-  t.plan(1)
+test('Request with trust proxy and undefined socket does not trust x-forwarded-host/proto', t => {
+  t.plan(2)
   const headers = {
+    host: 'hostname',
     'x-forwarded-for': '2.2.2.2, 1.1.1.1',
-    'x-forwarded-host': 'fastify.test'
+    'x-forwarded-host': 'fastify.test',
+    'x-forwarded-proto': 'https'
   }
   const req = {
     method: 'GET',
@@ -502,5 +504,27 @@ test('Request with trust proxy and undefined socket', t => {
 
   const TpRequest = Request.buildRequest(Request, true)
   const request = new TpRequest('id', 'params', req, 'query', 'log')
+  t.assert.strictEqual(request.host, 'hostname')
+  t.assert.deepStrictEqual(request.protocol, undefined)
+})
+
+test('Request with trust proxy and null socket does not trust x-forwarded-host/proto', t => {
+  t.plan(2)
+  const headers = {
+    host: 'hostname',
+    'x-forwarded-for': '2.2.2.2, 1.1.1.1',
+    'x-forwarded-host': 'fastify.test',
+    'x-forwarded-proto': 'https'
+  }
+  const req = {
+    method: 'GET',
+    url: '/',
+    socket: null,
+    headers
+  }
+
+  const TpRequest = Request.buildRequest(Request, true)
+  const request = new TpRequest('id', 'params', req, 'query', 'log')
+  t.assert.strictEqual(request.host, 'hostname')
   t.assert.deepStrictEqual(request.protocol, undefined)
 })

--- a/test/trust-proxy.test.js
+++ b/test/trust-proxy.test.js
@@ -272,3 +272,24 @@ test('trust proxy with number and null socket remoteAddress', t => {
   t.assert.ok(request.ip, 'ip is defined')
   t.assert.strictEqual(request.ip, '1.1.1.1', 'gets ip from x-forwarded-for')
 })
+
+test('trust proxy does not trust x-forwarded-host/proto when socket is null', t => {
+  t.plan(2)
+
+  const headers = {
+    host: 'real.test',
+    'x-forwarded-host': 'spoofed.test',
+    'x-forwarded-proto': 'https'
+  }
+  const req = {
+    method: 'GET',
+    url: '/',
+    socket: null,
+    headers
+  }
+
+  const TpRequest = buildRequest(Request, true)
+  const request = new TpRequest('id', 'params', req, 'query', 'log')
+  t.assert.strictEqual(request.host, 'real.test', 'falls back to host header')
+  t.assert.strictEqual(request.protocol, undefined, 'does not trust x-forwarded-proto')
+})


### PR DESCRIPTION
Fixes #6673

## Description

The `host` and `protocol` getters in `lib/request.js` were checking
`this.raw.socket?.remoteAddress !== null`, which still passes when `socket`
itself is `null` or `undefined` because optional chaining returns `undefined`.

This change gates forwarded header trust on the socket object itself:

- keep trusting `socket.remoteAddress === undefined` for the IISNode case from `#6606`
- stop trusting `x-forwarded-host` / `x-forwarded-proto` when `socket` is missing

## Changes

- check `this.raw.socket != null` before trusting forwarded host/protocol
- add regression tests for missing sockets in `test/internals/request.test.js`
- add a trust-proxy regression test for `socket: null` in `test/trust-proxy.test.js`

## Testing

- `npm run unit -- test/trust-proxy.test.js test/internals/request.test.js`
- `npx eslint lib/request.js test/internals/request.test.js test/trust-proxy.test.js`
