### PR TITLE
fix: use ContentType parser for response schema lookup

### DIFF
--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -10,6 +10,7 @@ const {
   FST_ERR_SCH_DUPLICATE,
   FST_ERR_SCH_CONTENT_MISSING_SCHEMA
 } = require('./errors')
+const ContentType = require('./content-type')
 
 const SCHEMAS_SOURCE = ['params', 'body', 'querystring', 'query', 'headers']
 
@@ -147,10 +148,10 @@ function getSchemaSerializer (context, statusCode, contentType) {
     return false
   }
   if (responseSchemaDef[statusCode]) {
-    if (responseSchemaDef[statusCode].constructor === Object && contentType) {
-      const mediaName = contentType.split(';', 1)[0]
-      if (responseSchemaDef[statusCode][mediaName]) {
-        return responseSchemaDef[statusCode][mediaName]
+    const ct = new ContentType(contentType)
+    if (responseSchemaDef[statusCode].constructor === Object && ct.isValid) {
+      if (responseSchemaDef[statusCode][ct.mediaType]) {
+        return responseSchemaDef[statusCode][ct.mediaType]
       }
 
       // fallback to match all media-type
@@ -164,10 +165,10 @@ function getSchemaSerializer (context, statusCode, contentType) {
   }
   const fallbackStatusCode = (statusCode + '')[0] + 'xx'
   if (responseSchemaDef[fallbackStatusCode]) {
-    if (responseSchemaDef[fallbackStatusCode].constructor === Object && contentType) {
-      const mediaName = contentType.split(';', 1)[0]
-      if (responseSchemaDef[fallbackStatusCode][mediaName]) {
-        return responseSchemaDef[fallbackStatusCode][mediaName]
+    const ct = new ContentType(contentType)
+    if (responseSchemaDef[fallbackStatusCode].constructor === Object && ct.isValid) {
+      if (responseSchemaDef[fallbackStatusCode][ct.mediaType]) {
+        return responseSchemaDef[fallbackStatusCode][ct.mediaType]
       }
 
       // fallback to match all media-type
@@ -181,10 +182,10 @@ function getSchemaSerializer (context, statusCode, contentType) {
     return responseSchemaDef[fallbackStatusCode]
   }
   if (responseSchemaDef.default) {
-    if (responseSchemaDef.default.constructor === Object && contentType) {
-      const mediaName = contentType.split(';', 1)[0]
-      if (responseSchemaDef.default[mediaName]) {
-        return responseSchemaDef.default[mediaName]
+    const ct = new ContentType(contentType)
+    if (responseSchemaDef.default.constructor === Object && ct.isValid) {
+      if (responseSchemaDef.default[ct.mediaType]) {
+        return responseSchemaDef.default[ct.mediaType]
       }
 
       // fallback to match all media-type

--- a/test/schema-serialization.test.js
+++ b/test/schema-serialization.test.js
@@ -1169,3 +1169,111 @@ test('allow default as status code and used as last fallback', (t, testDone) => 
     testDone()
   })
 })
+
+test('response schema is applied when Content-Type has whitespace before parameters', (t, testDone) => {
+  t.plan(3)
+
+  const fastify = Fastify()
+  fastify.get('/', {
+    schema: {
+      response: {
+        200: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['public'],
+                additionalProperties: false,
+                properties: {
+                  public: { type: 'string' }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }, function (req, reply) {
+    reply.header('Content-Type', 'application/json ; charset=utf-8')
+    reply.send({ public: 'ok', secret: 'SHOULD_BE_STRIPPED' })
+  })
+
+  fastify.inject('/', (err, res) => {
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.json(), { public: 'ok' })
+    testDone()
+  })
+})
+
+test('response schema is applied when Content-Type has tab before semicolon', (t, testDone) => {
+  t.plan(3)
+
+  const fastify = Fastify()
+  fastify.get('/', {
+    schema: {
+      response: {
+        200: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['public'],
+                additionalProperties: false,
+                properties: {
+                  public: { type: 'string' }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }, function (req, reply) {
+    reply.header('Content-Type', 'application/json\t; charset=utf-8')
+    reply.send({ public: 'ok', secret: 'SHOULD_BE_STRIPPED' })
+  })
+
+  fastify.inject('/', (err, res) => {
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.json(), { public: 'ok' })
+    testDone()
+  })
+})
+
+test('response schema is applied when Content-Type has trailing semicolon only', (t, testDone) => {
+  t.plan(3)
+
+  const fastify = Fastify()
+  fastify.get('/', {
+    schema: {
+      response: {
+        200: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['public'],
+                additionalProperties: false,
+                properties: {
+                  public: { type: 'string' }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }, function (req, reply) {
+    reply.header('Content-Type', 'application/json ;')
+    reply.send({ public: 'ok', secret: 'SHOULD_BE_STRIPPED' })
+  })
+
+  fastify.inject('/', (err, res) => {
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.json(), { public: 'ok' })
+    testDone()
+  })
+})


### PR DESCRIPTION
The response schema lookup was using a naive `split(';', 1)[0]` to extract the media type from Content-Type headers. This fails when there is whitespace before the semicolon. Switched to the existing `ContentType` parser which handles this correctly.