### PR TITLE
perf: optimize memory allocation in defaultSchemaErrorFormatter

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -85,14 +85,17 @@ function Context ({
 }
 
 function defaultSchemaErrorFormatter (errors, dataVar) {
-  let text = ''
+  const firstError = errors[0]
+  let text = dataVar + (firstError.instancePath || '') + ' ' + firstError.message
+
   const separator = ', '
 
-  for (let i = 0; i !== errors.length; ++i) {
+  for (let i = 1; i !== errors.length; ++i) {
     const e = errors[i]
-    text += dataVar + (e.instancePath || '') + ' ' + e.message + separator
+    text += separator + dataVar + (e.instancePath || '') + ' ' + e.message
   }
-  return new Error(text.slice(0, -separator.length))
+
+  return new Error(text)
 }
 
 module.exports = Context


### PR DESCRIPTION
Hi team! 👋

While reviewing `lib/config-validator.js`, I noticed a small opportunity to optimize the memory allocation in the `defaultSchemaErrorFormatter` function.

**Current Behavior:**
The current implementation uses `slice(0, -separator.length)` at the end of the loop. This creates a new string object in memory, which triggers unnecessary Garbage Collection, especially if the server is hit with a high volume of bad requests that fail schema validation.

**Proposed Change:**
I applied a simple loop unrolling technique:
- Extract the first error formatting outside the loop.
- Start the loop from index `1`.
- Prepend the `separator` instead of appending it.

**Benefits:**
1. Avoids the `slice()` completely, saving memory allocation.
2. Keeps the loop "branchless" (no `if` statements inside the loop), maintaining fast V8 execution.
3. Fully adheres to the existing StandardJS formatting.

Let me know if this makes sense for the repository!

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)