### PR TITLE
perf: cache parsed ContentType objects in ContentTypeParser

### DIFF
--- a/lib/content-type-parser.js
+++ b/lib/content-type-parser.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { AsyncResource } = require('node:async_hooks')
-const { FifoMap: Fifo } = require('toad-cache')
+const { FifoMap: Fifo, LruMap: Lru } = require('toad-cache')
 const { parse: secureJsonParse } = require('secure-json-parse')
 const ContentType = require('./content-type')
 const {
@@ -39,6 +39,15 @@ function ContentTypeParser (bodyLimit, onProtoPoisoning, onConstructorPoisoning)
   this.parserList = ['application/json', 'text/plain']
   this.parserRegExpList = []
   this.cache = new Fifo(100)
+  this.ctCache = new Lru(100)
+}
+
+ContentTypeParser.prototype.getContentType = function (raw) {
+  let ct = this.ctCache.get(raw)
+  if (ct !== undefined) return ct
+  ct = new ContentType(raw)
+  this.ctCache.set(raw, ct)
+  return ct
 }
 
 ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
@@ -160,6 +169,7 @@ ContentTypeParser.prototype.removeAll = function () {
   this.parserRegExpList = []
   this.parserList = []
   this.cache = new Fifo(100)
+  this.ctCache = new Lru(100)
 }
 
 ContentTypeParser.prototype.remove = function (contentType) {

--- a/lib/handle-request.js
+++ b/lib/handle-request.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const diagnostics = require('node:diagnostics_channel')
-const ContentType = require('./content-type')
 const wrapThenable = require('./wrap-thenable')
 const { validate: validateSchema } = require('./validation')
 const { preValidationHookRunner, preHandlerHookRunner } = require('./hooks')
@@ -54,7 +53,9 @@ function handleRequest (err, request, reply) {
 
     // Conditional assignment to avoid creating a new ContentType instance
     // It can be assigned when accessing the .mediaType in hooks
-    !request[kRequestContentType] && (request[kRequestContentType] = new ContentType(ctHeader))
+    if (!request[kRequestContentType]) {
+      request[kRequestContentType] = request[kRouteContext].contentTypeParser.getContentType(ctHeader)
+    }
     if (request[kRequestContentType].isValid === false) {
       reply[kReplyIsError] = true
       reply.status(415).send(new FST_ERR_CTP_INVALID_MEDIA_TYPE())

--- a/lib/request.js
+++ b/lib/request.js
@@ -18,7 +18,6 @@ const {
 } = require('./symbols')
 const { FST_ERR_REQ_INVALID_VALIDATION_INVOCATION, FST_ERR_DEC_UNDECLARED } = require('./errors')
 const decorators = require('./decorate')
-const ContentType = require('./content-type')
 
 const HTTP_PART_SYMBOL_MAP = {
   body: kSchemaBody,
@@ -287,7 +286,7 @@ Object.defineProperties(Request.prototype, {
   mediaType: {
     get () {
       if (!this[kRequestContentType] && this.headers['content-type'] !== undefined) {
-        this[kRequestContentType] = new ContentType(this.headers['content-type'])
+        this[kRequestContentType] = this[kRouteContext].contentTypeParser.getContentType(this.headers['content-type'])
       }
       return this[kRequestContentType]?.mediaType
     }


### PR DESCRIPTION
## Motivation

The `ContentType` constructor is expensive: it runs two compiled regexes,
`indexOf`, `toLowerCase`, and allocates a `new Map()` on every call. In
practice, the same handful of `Content-Type` header values (e.g.
`application/json`, `application/json; charset=utf-8`) appear on every
incoming request with a body. Previously, a new `ContentType` instance was
constructed on each request in both `handleRequest` and the `request.mediaType`
getter with no caching.

## Changes

**`lib/content-type-parser.js`**
- Added `this.ctCache = new Fifo(100)` to the constructor and `removeAll()`
- Added `ContentTypeParser.prototype.getContentType(raw)`: returns a cached
  `ContentType` for the given raw header string, or parses and caches it on
  first encounter. `Fifo(100)` is intentionally generous — real-world traffic
  typically sees 10–20 distinct `Content-Type` values, so eviction is
  effectively never.

**`lib/handle-request.js`**
- `new ContentType(ctHeader)` → `contentTypeParser.getContentType(ctHeader)`
- Removed now-unused `ContentType` import

**`lib/request.js`**
- Same change in the `mediaType` getter
- Removed now-unused `ContentType` import

## Benchmark

7 runs, 300,000 iterations each, bias-controlled:

| Scenario | Old avg (ms) | New avg (ms) | Diff |
|---|---|---|---|
| single (`application/json`) | 89.73 | 6.63 | **+92.61%** |
| mixed (5 distinct types) | 145.63 | 7.19 | **+95.06%** |

## Tests

1622/1622 passing, 2 skipped (platform-specific).

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
