### PR TITLE
feat: add fastifyTiming plugin for request timing

### DIFF
--- a/examples/timing-plugin-example.js
+++ b/examples/timing-plugin-example.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const fastify = require('../fastify')({
+  logger: true
+})
+
+fastify.register(require('../lib/timing-plugin'))
+
+fastify.get('/', function (req, reply) {
+  reply.send({ hello: 'world' })
+})
+
+fastify.get('/slow', function (req, reply) {
+  setTimeout(() => {
+    reply.send({ message: 'slow response' })
+  }, 100)
+})
+
+fastify.listen({ port: 3000 }, (err, address) => {
+  if (err) {
+    throw err
+  }
+  console.log(`Server listening at ${address}`)
+  console.log(`\nExample usage:`)
+  console.log(`  GET /          - Basic request with X-Response-Time header`)
+  console.log(`  GET /slow      - Request with 100ms delay`)
+  console.log(`\nTo use custom header name, register the plugin with options:`)
+  console.log(`  fastify.register(require('../lib/timing-plugin'), {`)
+  console.log(`    headerName: 'X-Custom-Response-Time'`)
+  console.log(`  })`)
+})

--- a/lib/timing-plugin.js
+++ b/lib/timing-plugin.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const fp = require('fastify-plugin')
+
+function fastifyTiming (fastify, opts, done) {
+  const headerName = opts.headerName || 'X-Response-Time'
+
+  fastify.addHook('onRequest', (request, reply, next) => {
+    request.startTime = process.hrtime.bigint()
+    next()
+  })
+
+  fastify.addHook('onSend', (request, reply, payload, next) => {
+    const endTime = process.hrtime.bigint()
+    const durationNs = endTime - request.startTime
+    const durationMs = Number(durationNs) / 1e6
+    reply.header(headerName, durationMs.toFixed(2))
+    next()
+  })
+
+  done()
+}
+
+module.exports = fp(fastifyTiming, {
+  fastify: '5.x',
+  name: 'fastify-timing'
+})

--- a/test/timing-plugin.test.js
+++ b/test/timing-plugin.test.js
@@ -1,0 +1,149 @@
+'use strict'
+
+const { test } = require('node:test')
+const Fastify = require('..')
+const timingPlugin = require('../lib/timing-plugin')
+
+test('timing plugin should add X-Response-Time header', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.register(timingPlugin)
+
+  fastify.get('/', (req, reply) => {
+    reply.send({ hello: 'world' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/'
+  })
+
+  t.assert.ok(response.headers['x-response-time'], 'X-Response-Time header should exist')
+  t.assert.strictEqual(response.statusCode, 200, 'Response status should be 200')
+})
+
+test('timing plugin should return reasonable response time value', async t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.register(timingPlugin)
+
+  fastify.get('/', (req, reply) => {
+    reply.send({ hello: 'world' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/'
+  })
+
+  const responseTime = response.headers['x-response-time']
+  t.assert.ok(responseTime, 'X-Response-Time header should exist')
+
+  const responseTimeNum = parseFloat(responseTime)
+  t.assert.ok(!isNaN(responseTimeNum), 'Response time should be a number')
+  t.assert.ok(responseTimeNum > 0, 'Response time should be greater than 0')
+})
+
+test('timing plugin should support custom header name', async t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.register(timingPlugin, {
+    headerName: 'X-Custom-Response-Time'
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.send({ hello: 'world' })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/'
+  })
+
+  t.assert.ok(response.headers['x-custom-response-time'], 'Custom header should exist')
+  t.assert.ok(!response.headers['x-response-time'], 'Default header should not exist')
+
+  const responseTime = response.headers['x-custom-response-time']
+  const responseTimeNum = parseFloat(responseTime)
+  t.assert.ok(responseTimeNum > 0, 'Custom header value should be greater than 0')
+})
+
+test('timing plugin should not affect normal response content', async t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.register(timingPlugin)
+
+  const expectedResponse = { hello: 'world', message: 'test' }
+  fastify.get('/', (req, reply) => {
+    reply.send(expectedResponse)
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/'
+  })
+
+  t.assert.strictEqual(response.statusCode, 200, 'Response status should be 200')
+  t.assert.ok(response.headers['x-response-time'], 'X-Response-Time header should exist')
+  t.assert.deepStrictEqual(JSON.parse(response.payload), expectedResponse, 'Response body should match expected')
+})
+
+test('timing plugin should handle concurrent requests independently', async t => {
+  t.plan(6)
+  const fastify = Fastify()
+
+  fastify.register(timingPlugin)
+
+  fastify.get('/fast', (req, reply) => {
+    reply.send({ type: 'fast' })
+  })
+
+  fastify.get('/slow', (req, reply) => {
+    setTimeout(() => {
+      reply.send({ type: 'slow' })
+    }, 50)
+  })
+
+  const [response1, response2] = await Promise.all([
+    fastify.inject({ method: 'GET', url: '/slow' }),
+    fastify.inject({ method: 'GET', url: '/fast' })
+  ])
+
+  t.assert.strictEqual(response1.statusCode, 200, 'Slow request status should be 200')
+  t.assert.strictEqual(response2.statusCode, 200, 'Fast request status should be 200')
+
+  t.assert.ok(response1.headers['x-response-time'], 'Slow request should have X-Response-Time header')
+  t.assert.ok(response2.headers['x-response-time'], 'Fast request should have X-Response-Time header')
+
+  const responseTime1 = parseFloat(response1.headers['x-response-time'])
+  const responseTime2 = parseFloat(response2.headers['x-response-time'])
+
+  t.assert.ok(responseTime1 > 0, 'Slow request response time should be greater than 0')
+  t.assert.ok(responseTime2 > 0, 'Fast request response time should be greater than 0')
+})
+
+test('timing plugin should work with async handlers', async t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.register(timingPlugin)
+
+  fastify.get('/', async (req, reply) => {
+    return { hello: 'async world' }
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/'
+  })
+
+  t.assert.strictEqual(response.statusCode, 200, 'Response status should be 200')
+  t.assert.ok(response.headers['x-response-time'], 'X-Response-Time header should exist')
+
+  const responseTime = parseFloat(response.headers['x-response-time'])
+  t.assert.ok(responseTime > 0, 'Response time should be greater than 0')
+})

--- a/types/timing-plugin.d.ts
+++ b/types/timing-plugin.d.ts
@@ -1,0 +1,10 @@
+import { FastifyPluginCallback } from './plugin'
+
+export interface FastifyTimingPluginOptions {
+  headerName?: string
+}
+
+declare const fastifyTiming: FastifyPluginCallback<FastifyTimingPluginOptions>
+
+export default fastifyTiming
+export { fastifyTiming }


### PR DESCRIPTION
## Summary

- Add fastifyTiming plugin to lib/timing-plugin.js using onRequest/onSend hooks with process.hrtime.bigint() for high-precision timing, adds X-Response-Time header (configurable name)
- Add types/timing-plugin.d.ts with full TypeScript type declarations
- Add examples/timing-plugin-example.js usage example
- Add test/timing-plugin.test.js with 6 test cases

## Test plan

- [x] Header existence verified
- [x] Header value is positive number
- [x] Custom header name works
- [x] Plugin does not affect response content
- [x] Concurrent requests have independent timing
- [x] Compatible with async handlers

Generated with Claude Code