### PR TITLE
docs(reference): grammar and readability fixes

### DIFF
--- a/docs/Reference/Encapsulation.md
+++ b/docs/Reference/Encapsulation.md
@@ -51,8 +51,8 @@ fastify.register(async function authenticatedContext (childServer) {
   childServer.route({
     path: '/one',
     method: 'GET',
-    handler (request, response) {
-      response.send({
+    handler (request, reply) {
+      reply.send({
         answer: request.answer,
         // request.foo will be undefined as it is only defined in publicContext
         foo: request.foo,
@@ -69,8 +69,8 @@ fastify.register(async function publicContext (childServer) {
   childServer.route({
     path: '/two',
     method: 'GET',
-    handler (request, response) {
-      response.send({
+    handler (request, reply) {
+      reply.send({
         answer: request.answer,
         foo: request.foo,
         // request.bar will be undefined as it is only defined in grandchildContext
@@ -85,8 +85,8 @@ fastify.register(async function publicContext (childServer) {
     grandchildServer.route({
       path: '/three',
       method: 'GET',
-      handler (request, response) {
-        response.send({
+      handler (request, reply) {
+        reply.send({
           answer: request.answer,
           foo: request.foo,
           bar: request.bar
@@ -114,12 +114,12 @@ original diagram:
 To see this, start the server and issue requests:
 
 ```sh
-# curl -H 'authorization: Bearer abc123' http://127.0.0.1:8000/one
-{"answer":42}
-# curl http://127.0.0.1:8000/two
-{"answer":42,"foo":"foo"}
-# curl http://127.0.0.1:8000/three
-{"answer":42,"foo":"foo","bar":"bar"}
+curl -H 'authorization: Bearer abc123' http://127.0.0.1:8000/one
+# {"answer":42}
+curl http://127.0.0.1:8000/two
+# {"answer":42,"foo":"foo"}
+curl http://127.0.0.1:8000/three
+# {"answer":42,"foo":"foo","bar":"bar"}
 ```
 
 [bearer]: https://github.com/fastify/fastify-bearer-auth
@@ -127,13 +127,14 @@ To see this, start the server and issue requests:
 ## Sharing Between Contexts
 <a id="shared-context"></a>
 
-Each context in the prior example inherits _only_ from its parent contexts. Parent
-contexts cannot access entities within their descendant contexts. If needed,
-encapsulation can be broken using [fastify-plugin][fastify-plugin], making
-anything registered in a descendant context available to the parent context.
+Each context in the previous example inherits _only_ from its parent contexts.
+Parent contexts cannot access entities within their descendant contexts.
+If needed, encapsulation can be broken using [fastify-plugin][fastify-plugin],
+making anything registered in a descendant context available
+to the parent context.
 
-To allow `publicContext` access to the `bar` decorator in `grandchildContext`,
-rewrite the code as follows:
+To allow `publicContext` to access the `bar` decorator from `grandchildContext`,
+update the code as follows:
 
 ```js
 'use strict'
@@ -151,8 +152,8 @@ fastify.register(async function publicContext (childServer) {
   childServer.route({
     path: '/two',
     method: 'GET',
-    handler (request, response) {
-      response.send({
+    handler (request, reply) {
+      reply.send({
         answer: request.answer,
         foo: request.foo,
         bar: request.bar
@@ -168,8 +169,8 @@ fastify.register(async function publicContext (childServer) {
     grandchildServer.route({
       path: '/three',
       method: 'GET',
-      handler (request, response) {
-        response.send({
+      handler (request, reply) {
+        reply.send({
           answer: request.answer,
           foo: request.foo,
           bar: request.bar
@@ -185,10 +186,10 @@ fastify.listen({ port: 8000 })
 Restarting the server and re-issuing the requests for `/two` and `/three`:
 
 ```sh
-# curl http://127.0.0.1:8000/two
-{"answer":42,"foo":"foo","bar":"bar"}
-# curl http://127.0.0.1:8000/three
-{"answer":42,"foo":"foo","bar":"bar"}
+curl http://127.0.0.1:8000/two
+# {"answer":42,"foo":"foo","bar":"bar"}
+curl http://127.0.0.1:8000/three
+# {"answer":42,"foo":"foo","bar":"bar"}
 ```
 
 [fastify-plugin]: https://github.com/fastify/fastify-plugin

--- a/docs/Reference/HTTP2.md
+++ b/docs/Reference/HTTP2.md
@@ -1,16 +1,16 @@
 <h1 align="center">Fastify</h1>
 
-## HTTP2
+## HTTP/2
 
-_Fastify_ supports HTTP2 over HTTPS (h2) or plaintext (h2c).
+_Fastify_ supports HTTP/2 over HTTPS (h2) or plaintext (h2c).
 
-Currently, none of the HTTP2-specific APIs are available through _Fastify_, but
+Currently, none of the HTTP/2-specific APIs are available through _Fastify_, but
 Node's `req` and `res` can be accessed through the `Request` and `Reply`
 interfaces. PRs are welcome.
 
 ### Secure (HTTPS)
 
-HTTP2 is supported in all modern browsers __only over a secure connection__:
+HTTP/2 is supported in all modern browsers __only over a secure connection__:
 
 ```js
 'use strict'
@@ -32,11 +32,11 @@ fastify.get('/', function (request, reply) {
 fastify.listen({ port: 3000 })
 ```
 
-[ALPN negotiation](https://datatracker.ietf.org/doc/html/rfc7301) allows
-support for both HTTPS and HTTP/2 over the same socket.
+[ALPN negotiation](https://datatracker.ietf.org/doc/html/rfc7301) enables
+both HTTPS and HTTP/2 over the same socket.
 Node core `req` and `res` objects can be either
 [HTTP/1](https://nodejs.org/api/http.html) or
-[HTTP/2](https://nodejs.org/api/http2.html). _Fastify_ supports this out of the
+[HTTP/2](https://nodejs.org/api/http2.html). _Fastify_ supports both out of the
 box:
 
 ```js
@@ -53,7 +53,7 @@ const fastify = require('fastify')({
   }
 })
 
-// this route can be accessed through both protocols
+// This route can be accessed through both protocols
 fastify.get('/', function (request, reply) {
   reply.code(200).send({ hello: 'world' })
 })
@@ -61,7 +61,7 @@ fastify.get('/', function (request, reply) {
 fastify.listen({ port: 3000 })
 ```
 
-Test the new server with:
+Test the server with:
 
 ```
 $ npx h2url https://localhost:3000
@@ -69,7 +69,7 @@ $ npx h2url https://localhost:3000
 
 ### Plain or insecure
 
-For microservices, HTTP2 can connect in plain text, but this is not
+For microservices, HTTP/2 can connect in plain text, but this is not
 supported by browsers.
 
 ```js

--- a/docs/Reference/Index.md
+++ b/docs/Reference/Index.md
@@ -3,12 +3,12 @@
 ## Core Documents
 <a id="reference-core-docs"></a>
 
-For the full table of contents (TOC), see [below](#reference-toc). The following
-list is a subset of the full TOC that detail core Fastify APIs and concepts in
-order of most likely importance to the reader:
+For the full table of contents, see [below](#reference-toc). The following list
+is a subset of the full table of contents that details core Fastify APIs and
+concepts, ordered by likely importance to the reader:
 
 + [Server](./Server.md): Documents the core Fastify API. Includes documentation
-  for the factory function and the object returned by the factory function.
+  for the factory function and the resulting server instance.
 + [Lifecycle](./Lifecycle.md): Explains the Fastify request lifecycle and
   illustrates where [Hooks](./Hooks.md) are available for integrating with it.
 + [Routes](./Routes.md): Details how to register routes with Fastify and how
@@ -25,8 +25,8 @@ order of most likely importance to the reader:
   Fastify plugins are built.
 + [Decorators](./Decorators.md): Explains the server, request, and response
   decorator APIs.
-+ [Hooks](./Hooks.md): Details the API by which Fastify plugins can inject
-  themselves into Fastify's handling of the request lifecycle.
++ [Hooks](./Hooks.md): Details the API that allows plugins to integrate with
+  the request lifecycle.
 
 
 ## Reference Documentation Table Of Contents
@@ -42,18 +42,17 @@ This table of contents is in alphabetical order.
   Fastify plugins are built.
 + [Errors](./Errors.md): Details how Fastify handles errors and lists the
   standard set of errors Fastify generates.
-+ [Hooks](./Hooks.md): Details the API by which Fastify plugins can inject
-  themselves into Fastify's handling of the request lifecycle.
-+ [HTTP2](./HTTP2.md): Details Fastify's HTTP2 support.
++ [Hooks](./Hooks.md): Details the API that allows plugins to integrate with
+  the request lifecycle.
++ [HTTP/2](./HTTP2.md): Details Fastify's HTTP/2 support.
 + [Lifecycle](./Lifecycle.md): Explains the Fastify request lifecycle and
   illustrates where [Hooks](./Hooks.md) are available for integrating with it.
 + [Logging](./Logging.md): Details Fastify's included logging and how to
   customize it.
-+ [Long Term Support](./LTS.md): Explains Fastify's long term support (LTS)
-  guarantee and the exceptions possible to the [semver](https://semver.org)
-  contract.
-+ [Middleware](./Middleware.md): Details Fastify's support for Express.js style
-  middleware.
++ [Long Term Support](./LTS.md): Explains Fastify's long-term support guarantee
+  and the possible exceptions to the [semver](https://semver.org) contract.
++ [Middleware](./Middleware.md): Details Fastify's support for
+  Express.js-style middleware.
 + [Plugins](./Plugins.md): Explains Fastify's plugin architecture and API.
 + [Reply](./Reply.md): Details Fastify's response object available to each
   request handler.
@@ -64,8 +63,7 @@ This table of contents is in alphabetical order.
 + [Server](./Server.md): Documents the core Fastify API. Includes documentation
   for the factory function and the object returned by the factory function.
 + [TypeScript](./TypeScript.md): Documents Fastify's TypeScript support and
-  provides recommendations for writing applications in TypeScript that utilize
-  Fastify.
+  provides recommendations for TypeScript application development.
 + [Validation and Serialization](./Validation-and-Serialization.md): Details
   Fastify's support for validating incoming data and how Fastify serializes data
   for responses.

--- a/docs/Reference/LTS.md
+++ b/docs/Reference/LTS.md
@@ -24,7 +24,7 @@ in this document:
    and verified against alternative runtimes that are compatible with Node.js.
    The maintenance teams of these alternative runtimes are responsible for ensuring
    and guaranteeing these tests work properly.
-   1. [N|Solid](https://docs.nodesource.com/docs/product_suite) tests and
+   1. [N|Solid](https://docs.nodesource.com/docs/product_suite/) tests and
       verifies each Fastify major release against current N|Solid LTS versions.
       NodeSource ensures Fastify compatibility with N|Solid, aligning with the
       support scope of N|Solid LTS versions at the time of the Fastify release.

--- a/docs/Reference/LTS.md
+++ b/docs/Reference/LTS.md
@@ -11,10 +11,10 @@ in this document:
    date. The release date of any specific version can be found at
    [https://github.com/fastify/fastify/releases](https://github.com/fastify/fastify/releases).
 2. Major releases will receive security updates for an additional six months
-   from the release of the next major release. After this period we will still
-   review and release security fixes as long as they are provided by the
-   community and they do not violate other constraints, e.g. minimum supported
-   Node.js version.
+   from the release of the next major release. After this period, Fastify maintainers
+   will still review and release security fixes as long as they are provided
+   by the community and they do not violate other constraints,
+   e.g., minimum supported Node.js version.
 3. Major releases will be tested and verified against all Node.js release lines
    that are supported by the [Node.js LTS
    policy](https://github.com/nodejs/Release) within the LTS period of that
@@ -35,21 +35,21 @@ A "month" is defined as 30 consecutive days.
 > ## Security Releases and Semver
 >
 > As a consequence of providing long-term support for major releases, there are
-> occasions where we need to release breaking changes as a _minor_ version
-> release. Such changes will _always_ be noted in the [release
+> occasions when breaking changes must be released as a _minor_ version
+> release. Such changes will _always_ be documented in the [release
 > notes](https://github.com/fastify/fastify/releases).
 >
-> To avoid automatically receiving breaking security updates it is possible to
+> To avoid automatically receiving breaking security updates, it is possible to
 > use the tilde (`~`) range qualifier. For example, to get patches for the 3.15
 > release, and avoid automatically updating to the 3.16 release, specify the
 > dependency as `"fastify": "~3.15.x"`. This will leave your application
-> vulnerable, so please use it with caution.
+> vulnerable. Use this approach with caution.
 
 ### Security Support Beyond LTS
 
 Fastify's partner, HeroDevs, provides commercial security support through the
 OpenJS Ecosystem Sustainability Program for versions of Fastify that are EOL.
-For more information, see their [Never Ending Support][hd-link] service.
+For more information, see the [Never Ending Support][hd-link] service offered.
 
 ### Schedule
 <a id="lts-schedule"></a>
@@ -62,7 +62,7 @@ For more information, see their [Never Ending Support][hd-link] service.
 | 4.0.0   | 2022-06-08   | 2025-06-30      | 14, 16, 18, 20, 22 | v5(18), v5(20) |
 | 5.0.0   | 2024-09-17   | TBD             | 20, 22             | v5(20)         |
 
-### CI tested operating systems
+### CI Tested Operating Systems
 <a id="supported-os"></a>
 
 Fastify uses GitHub Actions for CI testing, please refer to [GitHub&#39;s
@@ -78,8 +78,7 @@ YAML workflow labels below:
 | Windows | `windows-latest`    | npm             | 20          | v5(20)        |
 | MacOS   | `macos-latest`      | npm             | 20          | v5(20)        |
 
-Using [yarn](https://yarnpkg.com/) might require passing the `--ignore-engines`
-flag.
+When using [yarn](https://yarnpkg.com/), the `--ignore-engines` flag may be required.
 
 [semver]: https://semver.org/
 

--- a/docs/Reference/Lifecycle.md
+++ b/docs/Reference/Lifecycle.md
@@ -3,7 +3,7 @@
 ## Lifecycle
 <a id="lifecycle"></a>
 
-This schema shows the internal lifecycle of Fastify.
+This diagram shows the internal lifecycle of Fastify.
 
 The right branch of each section shows the next phase of the lifecycle. The left
 branch shows the corresponding error code generated if the parent throws an
@@ -41,10 +41,11 @@ Incoming Request
                                                                             └─▶ onResponse Hook
 ```
 
-When `handlerTimeout` is configured, a timer starts after routing. If the
-response is not sent within the allowed time, `request.signal` is aborted and
-a 503 error is sent. The timer is cleared when the response finishes or when
-`reply.hijack()` is called. See [`handlerTimeout`](./Server.md#factory-handler-timeout).
+When [`handlerTimeout`](./Server.md#factory-handler-timeout) is configured, a
+timer starts after routing. If the response is not sent within the allowed time,
+`request.signal` is aborted and a `503 Service Unavailable` error is sent.
+The timer is cancelled when the response completes
+or when `reply.hijack()` is called.
 
 Before or during the `User Handler`, `reply.hijack()` can be called to:
 - Prevent Fastify from running subsequent hooks and the user handler
@@ -61,8 +62,8 @@ When the user handles the request, the result may be:
 - In an async handler: it returns a payload or throws an `Error`
 - In a sync handler: it sends a payload or an `Error` instance
 
-If the reply was hijacked, all subsequent steps are skipped. Otherwise, when
-submitted, the data flow is as follows:
+If the reply is hijacked, all subsequent steps are skipped.
+Otherwise, the data flows as follows:
 
 ```
                         ★ schema validation Error

--- a/docs/Reference/Logging.md
+++ b/docs/Reference/Logging.md
@@ -132,9 +132,9 @@ const fastify = require('fastify')({
 ```
 
 > ⚠ Warning:
-> Logging response headers may expose sensitive data and could violate privacy
-> regulations such as GDPR, including authentication data. Use the `redact`
-> option to remove sensitive fields.
+> Logging response headers may expose sensitive data, including authentication
+> data, and may violate privacy regulations.
+> Use [log redaction](#log-redaction) to remove sensitive information.
 > The following example is for demonstration purposes only:
 
 ```js

--- a/docs/Reference/Logging.md
+++ b/docs/Reference/Logging.md
@@ -13,8 +13,8 @@ As Fastify is focused on performance, it uses
 [pino](https://github.com/pinojs/pino) as its logger, with the default log
 level set to `'info'` when enabled.
 
-#### Basic logging setup
-Enabling the production JSON logger:
+#### Basic Logging Setup
+The following enables the production JSON logger:
 
 ```js
 const fastify = require('fastify')({
@@ -23,8 +23,8 @@ const fastify = require('fastify')({
 ```
 
 #### Environment-Specific Configuration
-Enabling the logger with appropriate configuration for local development,
-production, and test environments requires more configuration:
+Enabling the logger for local development, production, and test environments
+requires additional configuration:
 
 ```js
 const envToLogger = {
@@ -41,11 +41,13 @@ const envToLogger = {
   test: false,
 }
 const fastify = require('fastify')({
-  logger: envToLogger[environment] ?? true // defaults to true if no entry matches in the map
+  logger: envToLogger[environment] ?? true // defaults to true if no matching environment is found
 })
 ```
-⚠️ `pino-pretty` needs to be installed as a dev dependency. It is not included
-by default for performance reasons.
+
+> ⚠ Warning:
+> `pino-pretty` needs to be installed as a dev dependency. It is not included
+> by default for performance reasons.
 
 ### Usage
 The logger can be used in route handlers as follows:
@@ -57,22 +59,22 @@ fastify.get('/', options, function (request, reply) {
 })
 ```
 
-Trigger new logs outside route handlers using the Pino instance from the Fastify
-instance:
+To log outside route handlers, use the logger available on the Fastify instance:
+
 ```js
-fastify.log.info('Something important happened!');
+fastify.log.info('Something important happened!')
 ```
 
 #### Passing Logger Options
 To pass options to the logger, provide them to Fastify. See the
 [Pino documentation](https://github.com/pinojs/pino/blob/main/docs/api.md#options)
-for available options. To specify a file destination, use:
+for the full list of available options. To specify a file destination, use:
 
 ```js
 const fastify = require('fastify')({
   logger: {
     level: 'info',
-    file: '/path/to/file' // Will use pino.destination()
+    file: '/path/to/file' // Uses pino.destination()
   }
 })
 
@@ -103,20 +105,19 @@ const fastify = require('fastify')({
 #### Request ID Tracking
 By default, Fastify adds an ID to every request for easier tracking. If the
 `requestIdHeader` option is set and the corresponding header is present, its
-value is used; otherwise, a new incremental ID is generated. See Fastify Factory
-[`requestIdHeader`](./Server.md#factory-request-id-header) and Fastify Factory
+value is used; otherwise, a new incremental ID is generated. See the Fastify
+factory options [`requestIdHeader`](./Server.md#factory-request-id-header) and
 [`genReqId`](./Server.md#genreqid) for customization options.
 
 > ⚠ Warning:
-> Enabling `requestIdHeader` allows any callers to set `reqId` to a
-> value of their choosing.
-> No validation is performed on `requestIdHeader`.
+> Enabling `requestIdHeader` allows callers to set `reqId` to an arbitrary
+> value. No validation is performed on the header value.
 
 #### Serializers
 The default logger uses standard serializers for objects with `req`, `res`, and
 `err` properties. The `req` object is the Fastify [`Request`](./Request.md)
 object, and the `res` object is the Fastify [`Reply`](./Reply.md) object. This
-behavior can be customized with custom serializers.
+behavior can be overridden with custom serializers.
 
 ```js
 const fastify = require('fastify')({
@@ -129,8 +130,12 @@ const fastify = require('fastify')({
   }
 })
 ```
-For example, the response payload and headers could be logged using the approach
-below (not recommended):
+
+> ⚠ Warning:
+> Logging response headers may expose sensitive data and could violate privacy
+> regulations such as GDPR, including authentication data. Use the `redact`
+> option to remove sensitive fields.
+> The following example is for demonstration purposes only:
 
 ```js
 const fastify = require('fastify')({
@@ -151,22 +156,19 @@ const fastify = require('fastify')({
           url: request.url,
           path: request.routeOptions.url,
           parameters: request.params,
-          // Including headers in the log could violate privacy laws,
-          // e.g., GDPR. Use the "redact" option to remove sensitive
-          // fields. It could also leak authentication data in the logs.
           headers: request.headers
-        };
+        }
       }
     }
   }
-});
+})
 ```
 
 > ℹ️ Note:
 > In some cases, the [`Reply`](./Reply.md) object passed to the `res`
 > serializer cannot be fully constructed. When writing a custom `res`
-> serializer, check for the existence of any properties on `reply` aside from
-> `statusCode`, which is always present. For example, verify the existence of
+> serializer, verify that any properties other than `statusCode` exist on
+> `reply` before accessing them. For example, verify the existence of
 > `getHeaders` before calling it:
 
 ```js
@@ -187,15 +189,15 @@ const fastify = require('fastify')({
       },
     }
   }
-});
+})
 ```
 
 > ℹ️ Note:
-> The body cannot be serialized inside a `req` method because the
+> The body cannot be serialized inside the `req` serializer because the
 > request is serialized when the child logger is created. At that time, the body
 > is not yet parsed.
 
-See the following approach to log `req.body`:
+To log `req.body`, use the `preHandler` hook:
 
 ```js
 app.addHook('preHandler', function (req, reply, done) {
@@ -207,18 +209,20 @@ app.addHook('preHandler', function (req, reply, done) {
 ```
 
 > ℹ️ Note:
-> Ensure serializers never throw errors, as this can cause the Node
+> Ensure serializers never throw errors, as this can cause the Node.js
 > process to exit. See the
-> [Pino documentation](https://getpino.io/#/docs/api?id=opt-serializers) for more
-> information.
+> [Pino documentation](https://getpino.io/#/docs/api?id=opt-serializers) for
+> more information.
 
-*Any logger other than Pino will ignore this option.*
+*Any logger other than Pino will ignore the `serializers` option.*
 
 ### Using Custom Loggers
 A custom logger instance can be supplied by passing it as `loggerInstance`. The
-logger must conform to the Pino interface, with methods: `info`, `error`,
-`debug`, `fatal`, `warn`, `trace`, `silent`, `child`, and a string property
-`level`.
+logger must conform to the Pino interface with the following:
+
+- **Methods:** `info`, `error`, `debug`, `fatal`, `warn`, `trace`, `silent`,
+  `child`
+- **Properties:** `level` (string)
 
 Example:
 
@@ -239,7 +243,7 @@ fastify.get('/', function (request, reply) {
 
 ### Log Redaction
 
-[Pino](https://getpino.io) supports low-overhead log redaction for obscuring
+[Pino](https://getpino.io) supports low-overhead log redaction for masking
 values of specific properties in recorded logs. For example, log all HTTP
 headers except the `Authorization` header for security:
 
@@ -265,4 +269,5 @@ const fastify = Fastify({
 })
 ```
 
-See https://getpino.io/#/docs/redaction for more details.
+See the [Pino redaction documentation](https://getpino.io/#/docs/redaction) for
+more details.

--- a/docs/Reference/Middleware.md
+++ b/docs/Reference/Middleware.md
@@ -2,15 +2,13 @@
 
 ## Middleware
 
-Starting with Fastify v3.0.0, middleware is not supported out of the box and
-requires an external plugin such as
+As of Fastify v3.0.0, middleware is not supported out of the box and requires
+an external plugin such as
 [`@fastify/express`](https://github.com/fastify/fastify-express) or
 [`@fastify/middie`](https://github.com/fastify/middie).
 
-
-An example of registering the
-[`@fastify/express`](https://github.com/fastify/fastify-express) plugin to `use`
-Express middleware:
+The following example registers the `@fastify/express` plugin and uses Express
+middleware:
 
 ```js
 await fastify.register(require('@fastify/express'))
@@ -22,37 +20,35 @@ fastify.use(require('ienoopen')())
 fastify.use(require('x-xss-protection')())
 ```
 
-[`@fastify/middie`](https://github.com/fastify/middie) can also be used,
-which provides support for simple Express-style middleware with improved
-performance:
+[`@fastify/middie`](https://github.com/fastify/middie) can also be used, which
+provides support for simple Express-style middleware with improved performance:
 
 ```js
 await fastify.register(require('@fastify/middie'))
 fastify.use(require('cors')())
 ```
 
-Middleware can be encapsulated, allowing control over where it runs using
-`register` as explained in the [plugins guide](../Guides/Plugins-Guide.md).
+Middleware can be encapsulated using `register`, which controls where it runs,
+as explained in the [Plugins Guide](../Guides/Plugins-Guide.md).
 
-Fastify middleware does not expose the `send` method or other methods specific
-to the Fastify [Reply](./Reply.md#reply) instance. This is because Fastify wraps
-the incoming `req` and `res` Node instances using the
-[Request](./Request.md#request) and [Reply](./Reply.md#reply) objects
-internally, but this is done after the middleware phase. To create middleware,
-use the Node `req` and `res` instances. Alternatively, use the `preHandler` hook
-that already has the Fastify [Request](./Request.md#request) and
-[Reply](./Reply.md#reply) instances. For more information, see
-[Hooks](./Hooks.md#hooks).
+This is because Fastify wraps the incoming Node.js `req` and `res` objects into
+[Request](./Request.md#request) and [Reply](./Reply.md#reply) instances after
+the middleware phase. As a result, Fastify middleware does not expose the `send`
+method or other methods specific to the Fastify [Reply](./Reply.md#reply)
+instance. To create middleware, use the Node.js `req` and `res` objects.
+Alternatively, use the `preHandler` hook, which has access to the Fastify
+[Request](./Request.md#request) and [Reply](./Reply.md#reply) instances. For
+more information, see [Hooks](./Hooks.md).
 
-#### Restrict middleware execution to certain paths
+### Restrict Middleware Execution to Certain Paths
 <a id="restrict-usage"></a>
 
-To run middleware under certain paths, pass the path as the first parameter to
+To restrict middleware to specific paths, pass the path as the first argument to
 `use`.
 
 > ℹ️ Note:
 > This does not support routes with parameters
-> (e.g. `/user/:id/comments`) and wildcards are not supported in multiple paths.
+> (e.g., `/user/:id/comments`). Wildcards are not supported in multiple paths.
 
 ```js
 const path = require('node:path')
@@ -68,9 +64,9 @@ fastify.use('/css/(.*)', serveStatic(path.join(__dirname, '/assets')))
 fastify.use(['/css', '/js'], serveStatic(path.join(__dirname, '/assets')))
 ```
 
-### Alternatives
+### Fastify Alternatives
 
-Fastify offers alternatives to commonly used middleware, such as
+Fastify offers native alternatives to commonly used middleware, such as
 [`@fastify/helmet`](https://github.com/fastify/fastify-helmet) for
 [`helmet`](https://github.com/helmetjs/helmet),
 [`@fastify/cors`](https://github.com/fastify/fastify-cors) for

--- a/docs/Reference/Principles.md
+++ b/docs/Reference/Principles.md
@@ -3,8 +3,8 @@
 Every decision in the Fastify framework and its official plugins is guided by
 the following technical principles:
 
-1. “Zero” overhead in production
-2. “Good” developer experience
+1. "Zero" overhead in production
+2. "Good" developer experience
 3. Works great for small & big projects alike
 4. Easy to migrate to microservices (or even serverless) and back
 5. Security & data validation

--- a/docs/Reference/Warnings.md
+++ b/docs/Reference/Warnings.md
@@ -14,7 +14,7 @@
 
 ### Warnings In Fastify
 
-Fastify uses Node.js's [warning event](https://nodejs.org/api/process.html#event-warning)
+Fastify uses the Node.js [warning event](https://nodejs.org/api/process.html#event-warning)
 API to notify users of deprecated features and coding mistakes. Fastify's
 warnings are recognizable by the `FSTWRN` and `FSTDEP` prefixes. When
 encountering such a warning, it is highly recommended to determine the cause
@@ -22,7 +22,7 @@ using the [`--trace-warnings`](https://nodejs.org/api/cli.html#trace-warnings)
 and [`--trace-deprecation`](https://nodejs.org/api/cli.html#trace-deprecation)
 flags. These produce stack traces pointing to where the issue occurs in the
 application's code. Issues opened about warnings without this information will
-be closed due to lack of details.
+be closed.
 
 Warnings can also be disabled, though it is not recommended. If necessary, use
 one of the following methods:
@@ -33,15 +33,14 @@ one of the following methods:
 
 For more information on disabling warnings, see [Node's documentation](https://nodejs.org/api/cli.html).
 
-Disabling warnings may cause issues when upgrading Fastify versions. Only
-experienced users should consider disabling warnings.
+Disabling warnings is not recommended and may cause unexpected behavior.
 
 ### Fastify Warning Codes
 
 | Code | Description | How to solve | Discussion |
 | ---- | ----------- | ------------ | ---------- |
 | <a id="FSTWRN001">FSTWRN001</a> | The specified schema for a route is missing. This may indicate the schema is not well specified. | Check the schema for the route. | [#4647](https://github.com/fastify/fastify/pull/4647) |
-| <a id="FSTWRN002">FSTWRN002</a> | The %s plugin being registered mixes async and callback styles, which will result in an error in `fastify@5`. | Do not mix async and callback style. | [#5139](https://github.com/fastify/fastify/pull/5139) |
+| <a id="FSTWRN002">FSTWRN002</a> | The %s plugin being registered mixes async and callback styles, which results in an error in `fastify@5` and later. | Do not mix async and callback styles. | [#5139](https://github.com/fastify/fastify/pull/5139) |
 
 
 ### Fastify Deprecation Codes


### PR DESCRIPTION
Reread some of the smaller documentation pages during my lunch breaks over past week as they don't get much love, and found they needed a few tweaks for clarification and readability.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
