### PR TITLE
feat: return 414 URI Too Long when maxParamLength is exceeded

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -76,6 +76,49 @@ const routerKeys = [
 function buildRouting (options) {
   const router = FindMyWay(options)
 
+  // Wrap the defaultRoute to detect maxParamLength violations and return 414
+  // instead of 404. When find-my-way can't route because a param exceeds
+  // maxParamLength, it returns null (same as "not found"). We detect this by
+  // temporarily raising the limit and re-checking with find().
+  const originalDefaultRoute = router.defaultRoute
+  if (originalDefaultRoute !== null) {
+    const maxParamLen = router.maxParamLength
+    router.defaultRoute = function (req, res, ctx) {
+      // Try to detect if this 404 is actually a param-too-long case
+      const method = req.method
+      let url = req.url
+      // Strip querystring for find()
+      const qsIdx = url.indexOf('?')
+      if (qsIdx !== -1) url = url.slice(0, qsIdx)
+
+      // Temporarily raise maxParamLength and re-check
+      router.maxParamLength = 1000000
+      const matched = router.find(method, url)
+      router.maxParamLength = maxParamLen
+
+      if (matched !== null) {
+        // The route exists but the param exceeded maxParamLength → 414
+        const body = JSON.stringify({
+          error: 'URI Too Long',
+          code: 'FST_ERR_REQ_URI_TOO_LONG',
+          message: `'${req.url}' parameter value exceeds the maxParamLength limit of ${maxParamLen} characters`,
+          statusCode: 414
+        })
+        res.statusCode = 414
+        res.setHeader('Content-Type', 'application/json')
+        res.setHeader('Content-Length', Buffer.byteLength(body))
+        res.end(body)
+        return
+      }
+
+      // Genuine 404 — delegate to original handler
+      if (ctx === undefined) {
+        return originalDefaultRoute(req, res)
+      }
+      return originalDefaultRoute.call(ctx, req, res)
+    }
+  }
+
   let avvio
   let fourOhFour
   let logger

--- a/test/router-options.test.js
+++ b/test/router-options.test.js
@@ -84,7 +84,7 @@ test('Should honor maxParamLength option', async (t) => {
     method: 'GET',
     url: '/test/123456789abcd'
   })
-  t.assert.strictEqual(resError.statusCode, 404)
+  t.assert.strictEqual(resError.statusCode, 414)
 })
 
 test('Should expose router options via getters on request and reply', (t, done) => {
@@ -727,7 +727,7 @@ test('Should honor routerOptions.maxParamLength', async (t) => {
     method: 'GET',
     url: '/test/123456789abcd'
   })
-  t.assert.strictEqual(resError.statusCode, 404)
+  t.assert.strictEqual(resError.statusCode, 414)
 })
 
 test('Should honor routerOptions.allowUnsafeRegex', async (t) => {
@@ -928,7 +928,7 @@ test('Should honor routerOptions.maxParamLength over maxParamLength option', asy
     method: 'GET',
     url: '/test/123456789abcd'
   })
-  t.assert.strictEqual(resError.statusCode, 404)
+  t.assert.strictEqual(resError.statusCode, 414)
 })
 
 test('Should honor routerOptions.allowUnsafeRegex over allowUnsafeRegex option', async (t) => {


### PR DESCRIPTION
Fixes #6697

## Problem

When a route parameter exceeds `maxParamLength`, Fastify returns `404 Not Found` instead of the semantically correct `414 URI Too Long`. This is misleading — developers waste time debugging whether the route exists, whether encoding is broken, etc.

## Solution

Wraps the router's `defaultRoute` to detect `maxParamLength` violations. When a request does not match any route, we temporarily raise `maxParamLength` and re-check with `find()`. If the route now matches, we know the param was too long and return `414` with a clear error message. Genuine 404s still return `404`.

## Changes

- **lib/route.js**: Wrap the router's `defaultRoute` with maxParamLength detection logic
- **test/router-options.test.js**: Update three tests to expect `414` instead of `404` for param-too-long cases

## Example

A route `GET /test/:id` with `maxParamLength: 10`:

Before: `GET /test/123456789012345` → 404
After: `GET /test/123456789012345` → 414