### PR TITLE
docs: correct return503OnClosing comment in route.js

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -479,12 +479,13 @@ function buildRouting (options) {
         res.setHeader('Connection', 'close')
       }
 
-      // TODO remove return503OnClosing after Node v18 goes EOL
-      /* istanbul ignore else */
+      // Load-shedding fast path during drain. server.close() and
+      // closeIdleConnections() only reap idle sockets; requests already
+      // pipelined or arriving on an active keep-alive connection still reach
+      // this point with closing === true. Short-circuiting with 503 avoids
+      // running the full handler chain (and any downstream calls) for work
+      // the load balancer should redirect elsewhere.
       if (return503OnClosing) {
-        // On Node v19 we cannot test this behavior as it won't be necessary
-        // anymore. It will close all the idle connections before they reach this
-        // stage.
         const headers = {
           'Content-Type': 'application/json',
           'Content-Length': '80'


### PR DESCRIPTION
## Summary

The comment in \`lib/route.js\` around the 503 short-circuit on close claimed the path becomes unnecessary on Node v19+, with a TODO to remove \`return503OnClosing\` after Node v18 EOL. Both are misleading.

\`server.close()\` / \`closeIdleConnections()\` only reap **idle** sockets. Requests already pipelined onto an active connection, or arriving on a keep-alive socket that just finished a response, still reach the route layer with \`closing === true\` — on every supported Node version. The deleted-on-a-feature-branch tests in \`test/close-pipelining.test.js\` and the keep-alive case in \`test/close.test.js\` exercise exactly this path.

This PR is comment-only:

- Replace the Node v18 EOL TODO and the "won't be necessary on v19" comment with an explanation of why the branch exists (load-shedding fast path that skips the full handler chain for work the load balancer should redirect).
- Remove the \`/* istanbul ignore else */\` — the \`return503OnClosing: false\` path is covered by \`test/close-pipelining.test.js\` and \`test/http2/closing.test.js\`. Coverage on \`lib/route.js\` remains 100%.

No behavior change.

## Test plan

- [x] \`npm run unit\` passes (2223/2223)
- [x] \`npm run coverage\` passes; \`lib/route.js\` 100% stmts/branches/funcs/lines