### PR TITLE
chore: update depedabot setting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,11 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+    ignore:
+      # TODO: remove ignore until neostandard support ESLint 10
+      - dependency-name: "eslint"
+      - dependency-name: "neostandard"
+      - dependency-name: "@stylistic/*"
     open-pull-requests-limit: 10
     groups:
       # Production dependencies with breaking changes

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,13 @@ updates:
       # Prefix all commit messages with "chore: "
       prefix: "chore"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "npm"
@@ -15,20 +21,19 @@ updates:
       # Prefix all commit messages with "chore: "
       prefix: "chore"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    versioning-strategy: "increase-if-necessary"
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     open-pull-requests-limit: 10
     groups:
-      # Production dependencies without breaking changes
+      # Production dependencies with breaking changes
       dependencies:
         dependency-type: "production"
-        update-types:
-        - "minor"
-        - "patch"
-      # Production dependencies with breaking changes
-      dependencies-major:
-        dependency-type: "production"
-        update-types:
-        - "major"
       # ESLint related dependencies
       dev-dependencies-eslint:
         patterns:


### PR DESCRIPTION
Proposed to update the dependabot configuration as follow.
- Only allows major updates
- Use versioning-strategy: "increase-if-necessary"
- Add cooldown to 7 days
- Reduce the cycle to "weekly"

The proposed change should address the issues.
- Reduce rubbish PR, for example update ^1.0.0 to ^1.0.1.
- Prevent updates newly publish packages.
- More frequent check on new major version updates.


There is no meaning to restrict a monthly check since we allows only `major`. 
At most delay the landing about 14 days.
I assume it can reduce the number of PR to around "2-3 (each repository) a year" and most of them would be Github Actions updates.



#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
