### PR TITLE
fix: include hint and docs URL in FSTWRN004 warning message

### DIFF
--- a/docs/Reference/Warnings.md
+++ b/docs/Reference/Warnings.md
@@ -7,6 +7,8 @@
   - [Fastify Warning Codes](#fastify-warning-codes)
     - [FSTWRN001](#FSTWRN001)
     - [FSTWRN002](#FSTWRN002)
+    - [FSTWRN003](#FSTWRN003)
+    - [FSTWRN004](#FSTWRN004)
   - [Fastify Deprecation Codes](#fastify-deprecation-codes)
     - [FSTDEP022](#FSTDEP022)
 
@@ -41,6 +43,8 @@ Disabling warnings is not recommended and may cause unexpected behavior.
 | ---- | ----------- | ------------ | ---------- |
 | <a id="FSTWRN001">FSTWRN001</a> | The specified schema for a route is missing. This may indicate the schema is not well specified. | Check the schema for the route. | [#4647](https://github.com/fastify/fastify/pull/4647) |
 | <a id="FSTWRN002">FSTWRN002</a> | The %s plugin being registered mixes async and callback styles, which results in an error in `fastify@5` and later. | Do not mix async and callback styles. | [#5139](https://github.com/fastify/fastify/pull/5139) |
+| <a id="FSTWRN003">FSTWRN003</a> | The `%s` plugin mixes async and callback styles, which may lead to unhandled rejections. | Do not mix async and callback style. | [#6011](https://github.com/fastify/fastify/pull/6011) |
+| <a id="FSTWRN004">FSTWRN004</a> | An `errorHandler` is being overridden in the same scope, which can lead to subtle bugs. | Avoid calling `setErrorHandler` more than once in the same scope. For more information, see [Server documentation](https://fastify.dev/docs/latest/Reference/Server/#allowerrorhandleroverride). | [#6104](https://github.com/fastify/fastify/pull/6104) |
 
 
 ### Fastify Deprecation Codes

--- a/fastify.js
+++ b/fastify.js
@@ -776,7 +776,7 @@ function fastify (serverOptions) {
     if (!options.allowErrorHandlerOverride && this[kErrorHandlerAlreadySet]) {
       throw new FST_ERR_ERROR_HANDLER_ALREADY_SET()
     } else if (this[kErrorHandlerAlreadySet]) {
-      FSTWRN004("To disable this behavior, set 'allowErrorHandlerOverride' to false or ignore this message. For more information, visit: https://fastify.dev/docs/latest/Reference/Server/#allowerrorhandleroverride")
+      FSTWRN004()
     }
 
     this[kErrorHandlerAlreadySet] = true

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -30,7 +30,7 @@ const FSTWRN003 = createWarning({
 const FSTWRN004 = createWarning({
   name: 'FastifyWarning',
   code: 'FSTWRN004',
-  message: 'It seems that you are overriding an errorHandler in the same scope, which can lead to subtle bugs.',
+  message: 'It seems that you are overriding an errorHandler in the same scope, which can lead to subtle bugs. To disable this behavior, set \'allowErrorHandlerOverride\' to false. For more information, visit: https://fastify.dev/docs/latest/Reference/Server/#allowerrorhandleroverride',
   unlimited: true
 })
 


### PR DESCRIPTION
## Summary

The `FSTWRN004` warning was created in `lib/warnings.js` with a static
message that contained no `%s` format placeholder. As a result, the
hint string passed at the call site in `fastify.js` was silently dropped
by `process-warning`, and users who triggered the warning never saw the
actionable information about `allowErrorHandlerOverride`.

## Root Cause

`process-warning`'s `createWarning` only interpolates arguments when the
message contains `%s` placeholders. With no placeholder present, any
argument passed to the emitter function is a no-op.

## Changes

- **`lib/warnings.js`**: Embed the hint and docs URL directly into the
  static message of `FSTWRN004`.
- **`fastify.js`**: Remove the now-unused string argument from the
  `FSTWRN004()` call.
- **`test/set-error-handler.test.js`**: Add a test that asserts the
  warning is emitted with `name`, `code`, and the docs URL in the
  message when `setErrorHandler` is called more than once in the same
  scope.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
