### PR TITLE
fix: premature request.signal abort on POST

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -218,10 +218,11 @@ Object.defineProperties(Request.prototype, {
       if (ac) return ac.signal
       ac = new AbortController()
       this[kRequestSignal] = ac
+      const raw = this.raw
       const onAbort = () => {
-        if (!ac.signal.aborted) ac.abort()
+        if (raw.aborted && !ac.signal.aborted) ac.abort()
       }
-      this.raw.on('close', onAbort)
+      raw.on('close', onAbort)
       this[kOnAbort] = onAbort
       return ac.signal
     }

--- a/lib/route.js
+++ b/lib/route.js
@@ -545,10 +545,12 @@ function buildRouting (options) {
       }, handlerTimeout)
 
       const onAbort = () => {
-        if (req.aborted && !ac.signal.aborted) {
-          ac.abort()
+        if (req.aborted) {
+          if (!ac.signal.aborted) {
+            ac.abort()
+          }
+          clearTimeout(request[kTimeoutTimer])
         }
-        clearTimeout(request[kTimeoutTimer])
       }
       req.on('close', onAbort)
       request[kOnAbort] = onAbort

--- a/lib/route.js
+++ b/lib/route.js
@@ -545,7 +545,7 @@ function buildRouting (options) {
       }, handlerTimeout)
 
       const onAbort = () => {
-        if (!ac.signal.aborted) {
+        if (req.aborted && !ac.signal.aborted) {
           ac.abort()
         }
         clearTimeout(request[kTimeoutTimer])

--- a/test/handler-timeout.test.js
+++ b/test/handler-timeout.test.js
@@ -353,6 +353,30 @@ test('does not abort when request body stream closes', async t => {
   t.assert.strictEqual(res.status, 200)
 })
 
+test('slow handler returns 503 with FST_ERR_HANDLER_TIMEOUT for POST with body', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.post('/', { handlerTimeout: 50 }, async () => {
+    await sleep(500)
+    return 'too late'
+  })
+
+  await fastify.listen({ port: 0 })
+  t.after(() => fastify.close())
+
+  const { port } = fastify.server.address()
+  const res = await fetch(`http://127.0.0.1:${port}/`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ test: true })
+  })
+
+  t.assert.strictEqual(res.status, 503)
+  const payload = await res.json()
+  t.assert.strictEqual(payload.code, 'FST_ERR_HANDLER_TIMEOUT')
+})
+
 // --- Race: handler completes just as timeout fires ---
 
 test('no double-send when handler completes near timeout boundary', async t => {

--- a/test/handler-timeout.test.js
+++ b/test/handler-timeout.test.js
@@ -5,7 +5,7 @@ const net = require('node:net')
 const Fastify = require('..')
 const { Readable } = require('node:stream')
 const { kTimeoutTimer, kOnAbort } = require('../lib/symbols')
-const { setTimeout } = require('node:timers/promises')
+const { setTimeout: sleep } = require('node:timers/promises')
 
 // --- Option validation ---
 
@@ -81,9 +81,9 @@ test('client disconnect aborts lazily created signal (no handlerTimeout)', async
   await new Promise((resolve) => {
     const client = net.connect(address.port, () => {
       client.write('GET / HTTP/1.1\r\nHost: localhost\r\n\r\n')
-      globalThis.setTimeout(() => {
+      setTimeout(() => {
         client.destroy()
-        globalThis.setTimeout(resolve, 100)
+        setTimeout(resolve, 100)
       }, 50)
     })
   })
@@ -98,7 +98,7 @@ test('slow handler returns 503 with FST_ERR_HANDLER_TIMEOUT', async t => {
   const fastify = Fastify()
 
   fastify.get('/', { handlerTimeout: 50 }, async () => {
-    await setTimeout(500)
+    await sleep(500)
     return 'too late'
   })
 
@@ -127,7 +127,7 @@ test('route-level handlerTimeout overrides server default', async t => {
   const fastify = Fastify({ handlerTimeout: 5000 })
 
   fastify.get('/slow', { handlerTimeout: 50 }, async () => {
-    await setTimeout(500)
+    await sleep(500)
     return 'too late'
   })
 
@@ -168,7 +168,7 @@ test('request.signal aborts when timeout fires with reason', async t => {
     request.signal.addEventListener('abort', () => {
       signalReason = request.signal.reason
     })
-    await setTimeout(500)
+    await sleep(500)
     return 'too late'
   })
 
@@ -211,7 +211,7 @@ test('reply.hijack() clears timeout timer', async t => {
   fastify.get('/', { handlerTimeout: 100 }, async (request, reply) => {
     reply.hijack()
     // Write after the original timeout would have fired
-    await setTimeout(200)
+    await sleep(200)
     reply.raw.writeHead(200, { 'Content-Type': 'text/plain' })
     reply.raw.end('hijacked response')
   })
@@ -237,7 +237,7 @@ test('route-level errorHandler receives FST_ERR_HANDLER_TIMEOUT', async t => {
       reply.code(504).send({ custom: 'timeout' })
     }
   }, async () => {
-    await setTimeout(500)
+    await sleep(500)
     return 'too late'
   })
 
@@ -318,10 +318,10 @@ test('client disconnect aborts request.signal', async t => {
   await new Promise((resolve) => {
     const client = net.connect(address.port, () => {
       client.write('GET / HTTP/1.1\r\nHost: localhost\r\n\r\n')
-      globalThis.setTimeout(() => {
+      setTimeout(() => {
         client.destroy()
         // Give the server time to process the close event
-        globalThis.setTimeout(resolve, 100)
+        setTimeout(resolve, 100)
       }, 50)
     })
   })
@@ -336,7 +336,7 @@ test('does not abort when request body stream closes', async t => {
 
   fastify.post('/', { handlerTimeout: 100 }, async (request) => {
     t.assert.strictEqual(request.signal.aborted, false)
-    await setTimeout(0, undefined, { signal: request.signal })
+    await sleep(0, undefined, { signal: request.signal })
     return 'ok'
   })
 
@@ -361,7 +361,7 @@ test('no double-send when handler completes near timeout boundary', async t => {
 
   fastify.get('/', { handlerTimeout: 50 }, async (request, reply) => {
     // Respond just before timeout
-    await setTimeout(40)
+    await sleep(40)
     reply.send({ ok: true })
     return reply
   })
@@ -382,7 +382,7 @@ test('routes inherit server-level handlerTimeout', async t => {
   fastify.get('/', async (request) => {
     // Verify the signal is present (inherited from server default)
     t.assert.ok(request.signal instanceof AbortSignal)
-    await setTimeout(500)
+    await sleep(500)
     return 'too late'
   })
 

--- a/test/handler-timeout.test.js
+++ b/test/handler-timeout.test.js
@@ -5,6 +5,7 @@ const net = require('node:net')
 const Fastify = require('..')
 const { Readable } = require('node:stream')
 const { kTimeoutTimer, kOnAbort } = require('../lib/symbols')
+const { setTimeout } = require('node:timers/promises')
 
 // --- Option validation ---
 
@@ -80,9 +81,9 @@ test('client disconnect aborts lazily created signal (no handlerTimeout)', async
   await new Promise((resolve) => {
     const client = net.connect(address.port, () => {
       client.write('GET / HTTP/1.1\r\nHost: localhost\r\n\r\n')
-      setTimeout(() => {
+      globalThis.setTimeout(() => {
         client.destroy()
-        setTimeout(resolve, 100)
+        globalThis.setTimeout(resolve, 100)
       }, 50)
     })
   })
@@ -97,7 +98,7 @@ test('slow handler returns 503 with FST_ERR_HANDLER_TIMEOUT', async t => {
   const fastify = Fastify()
 
   fastify.get('/', { handlerTimeout: 50 }, async () => {
-    await new Promise(resolve => setTimeout(resolve, 500))
+    await setTimeout(500)
     return 'too late'
   })
 
@@ -126,7 +127,7 @@ test('route-level handlerTimeout overrides server default', async t => {
   const fastify = Fastify({ handlerTimeout: 5000 })
 
   fastify.get('/slow', { handlerTimeout: 50 }, async () => {
-    await new Promise(resolve => setTimeout(resolve, 500))
+    await setTimeout(500)
     return 'too late'
   })
 
@@ -167,7 +168,7 @@ test('request.signal aborts when timeout fires with reason', async t => {
     request.signal.addEventListener('abort', () => {
       signalReason = request.signal.reason
     })
-    await new Promise(resolve => setTimeout(resolve, 500))
+    await setTimeout(500)
     return 'too late'
   })
 
@@ -210,7 +211,7 @@ test('reply.hijack() clears timeout timer', async t => {
   fastify.get('/', { handlerTimeout: 100 }, async (request, reply) => {
     reply.hijack()
     // Write after the original timeout would have fired
-    await new Promise(resolve => setTimeout(resolve, 200))
+    await setTimeout(200)
     reply.raw.writeHead(200, { 'Content-Type': 'text/plain' })
     reply.raw.end('hijacked response')
   })
@@ -236,7 +237,7 @@ test('route-level errorHandler receives FST_ERR_HANDLER_TIMEOUT', async t => {
       reply.code(504).send({ custom: 'timeout' })
     }
   }, async () => {
-    await new Promise(resolve => setTimeout(resolve, 500))
+    await setTimeout(500)
     return 'too late'
   })
 
@@ -317,10 +318,10 @@ test('client disconnect aborts request.signal', async t => {
   await new Promise((resolve) => {
     const client = net.connect(address.port, () => {
       client.write('GET / HTTP/1.1\r\nHost: localhost\r\n\r\n')
-      setTimeout(() => {
+      globalThis.setTimeout(() => {
         client.destroy()
         // Give the server time to process the close event
-        setTimeout(resolve, 100)
+        globalThis.setTimeout(resolve, 100)
       }, 50)
     })
   })
@@ -336,7 +337,7 @@ test('no double-send when handler completes near timeout boundary', async t => {
 
   fastify.get('/', { handlerTimeout: 50 }, async (request, reply) => {
     // Respond just before timeout
-    await new Promise(resolve => setTimeout(resolve, 40))
+    await setTimeout(40)
     reply.send({ ok: true })
     return reply
   })
@@ -357,7 +358,7 @@ test('routes inherit server-level handlerTimeout', async t => {
   fastify.get('/', async (request) => {
     // Verify the signal is present (inherited from server default)
     t.assert.ok(request.signal instanceof AbortSignal)
-    await new Promise(resolve => setTimeout(resolve, 500))
+    await setTimeout(500)
     return 'too late'
   })
 

--- a/test/handler-timeout.test.js
+++ b/test/handler-timeout.test.js
@@ -334,7 +334,7 @@ test('does not abort when request body stream closes', async t => {
 
   const fastify = Fastify()
 
-  fastify.post('/', { handlerTimeout: 100 }, async (request) => {
+  fastify.post('/', { handlerTimeout: 1000 }, async (request) => {
     t.assert.strictEqual(request.signal.aborted, false)
     await sleep(0, undefined, { signal: request.signal })
     return 'ok'

--- a/test/handler-timeout.test.js
+++ b/test/handler-timeout.test.js
@@ -329,6 +329,30 @@ test('client disconnect aborts request.signal', async t => {
   t.assert.strictEqual(signalAborted, true)
 })
 
+test('does not abort when request body stream closes', async t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  fastify.post('/', { handlerTimeout: 100 }, async (request) => {
+    t.assert.strictEqual(request.signal.aborted, false)
+    await setTimeout(0, undefined, { signal: request.signal })
+    return 'ok'
+  })
+
+  await fastify.listen({ port: 0 })
+  t.after(() => fastify.close())
+
+  const { port } = fastify.server.address()
+  const res = await fetch(`http://127.0.0.1:${port}/`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ test: true })
+  })
+
+  t.assert.strictEqual(res.status, 200)
+})
+
 // --- Race: handler completes just as timeout fires ---
 
 test('no double-send when handler completes near timeout boundary', async t => {


### PR DESCRIPTION
## Summary

I ran into a bug when trying to use the `handlerTimeout` option introduced in https://github.com/fastify/fastify/pull/6521.

I managed to narrow it down to only requests with bodies, and did some debugging to identify the root cause from there.

What it boils down to is that the 'close' event on the raw `IncomingMessage` fires both when the request body stream is fully consumed and when the underlying connection is aborted. The `handlerTimeout` abort listeners treated every close as a disconnect, so POST requests with a body had their `request.signal` aborted as soon as the body finished streaming, and before the handler had a chance to use it.

This fix guards the `onAbort` listeners with an aborted check on the `IncomingMessage` so the signal only aborts when the client genuinely disconnects, leaving normal body completion alone.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
