### PR TITLE
docs(Errors): fix incorrect usage of root fastify inside plugin scope

### DIFF
--- a/docs/Reference/Errors.md
+++ b/docs/Reference/Errors.md
@@ -216,7 +216,7 @@ fastify.register((app, options, next) => {
   })
 
   app.get('/bad', async () => {
-    // Throws a non-Error type, 'bar'
+    // Throws a non-Error type, 'foo'
     throw 'foo'
   })
 

--- a/docs/Reference/Errors.md
+++ b/docs/Reference/Errors.md
@@ -211,16 +211,16 @@ fastify.setErrorHandler((error, request, reply) => {
 
 fastify.register((app, options, next) => {
   // Register child error handler
-  fastify.setErrorHandler((error, request, reply) => {
+  app.setErrorHandler((error, request, reply) => {
     throw error
   })
 
-  fastify.get('/bad', async () => {
+  app.get('/bad', async () => {
     // Throws a non-Error type, 'bar'
     throw 'foo'
   })
 
-  fastify.get('/good', async () => {
+  app.get('/good', async () => {
     // Throws an Error instance, 'bar'
     throw new Error('bar')
   })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Summary

Use plugin-scoped instance (`app`) instead of root `fastify` inside `register()`.

## Why

Using the root instance inside a plugin bypasses plugin encapsulation, which is the main purpose of plugin scoping.

## Change

Replaced `fastify` with `app` in plugin example.

```Typescript
fastify.register((app, options, next) => {
  // Register child error handler
  app.setErrorHandler((error, request, reply) => {
    throw error
  })

  app.get('/bad', async () => {
    // Throws a non-Error type, 'bar'
    throw 'foo'
  })

  app.get('/good', async () => {
    // Throws an Error instance, 'bar'
    throw new Error('bar')
  })
```

#### Checklist

- [x] documentation is changed or added
- [x]  No breaking changes
- [x] Improves documentation accuracy
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
