### PR TITLE
docs: remove HackerOne reporting link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,7 +71,8 @@ Fastify falls under the [OpenJS CNA](https://cna.openjsf.org/).
 A CVE will be assigned as part of our responsible disclosure process.
 
 > ℹ️ Note:
-> Fastify's [HackerOne](https://hackerone.com/fastify) program is now closed.
+> Fastify's HackerOne program is closed. Submit new vulnerability reports only
+> through the GitHub Security page linked above.
 
 ### Strict measures when reporting vulnerabilities
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,8 +71,7 @@ Fastify falls under the [OpenJS CNA](https://cna.openjsf.org/).
 A CVE will be assigned as part of our responsible disclosure process.
 
 > ℹ️ Note:
-> Fastify's HackerOne program is closed. Submit new vulnerability reports only
-> through the GitHub Security page linked above.
+> Fastify's HackerOne program is closed.
 
 ### Strict measures when reporting vulnerabilities
 


### PR DESCRIPTION
Closes #6468

Removes the active HackerOne link from the security policy now that the program is closed, and directs new vulnerability reports to GitHub Security instead.

Checks:
- npx --yes markdownlint-cli2@0.22.0 SECURITY.md
- git diff --check