### PR TITLE
docs(hooks): document this binding for preClose hook and strengthen test assertion

### DIFF
--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -532,9 +532,11 @@ connections or Server-Sent Events streams that must be explicitly terminated for
 _It is unlikely you will need to use this hook_,
 use the [`onClose`](#onclose) for the most common case.
 
+Hook functions are invoked with `this` bound to the associated Fastify instance.
+
 ```js
 // callback style
-fastify.addHook('preClose', (done) => {
+fastify.addHook('preClose', function (done) {
   // Some code
   done()
 })

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -629,7 +629,7 @@ test('preClose callback', (t, done) => {
   fastify.addHook('preClose', preClose)
 
   function preClose (done) {
-    t.assert.ok(typeof this === typeof fastify)
+    t.assert.strictEqual(this.pluginName, fastify.pluginName, 'the this binding is the right instance')
     preCloseCalled = true
     done()
   }
@@ -657,7 +657,7 @@ test('preClose async', async t => {
 
   async function preClose () {
     preCloseCalled = true
-    t.assert.ok(typeof this === typeof fastify)
+    t.assert.strictEqual(this.pluginName, fastify.pluginName, 'the this binding is the right instance')
   }
 
   await fastify.listen({ port: 0 })


### PR DESCRIPTION
## What this PR does

Documents the `this` binding for the `preClose` hook in `docs/Reference/Hooks.md`, and strengthens the corresponding test assertions in `test/close.test.js`.

### Problem

The `preClose` section in the docs did not state that hook functions receive a `this` binding. Its callback-style code example used an arrow function, which would break `this` binding if copied literally. Both neighbouring sections (`onReady`, `onListen`) already documented this and used the `function` keyword.

The two `preClose` tests used `t.assert.ok(typeof this === typeof fastify)` — a weak type-equality check that passes even when `this` is bound to the wrong object, as long as both are objects.

### Changes

**`docs/Reference/Hooks.md` — `preClose` section:**
- Added: "Hook functions are invoked with `this` bound to the associated Fastify instance."
- Changed callback example from arrow function to `function` keyword

**`test/close.test.js` — `preClose callback` and `preClose async` tests:**
- Replaced `t.assert.ok(typeof this === typeof fastify)` with `t.assert.strictEqual(this.pluginName, fastify.pluginName, 'the this binding is the right instance')`
- Matches the pattern already used in `test/hooks.on-ready.test.js`

### Testing

`node --test test/close.test.js` → 22/22 pass, exit code 0. No logic changes; no API changes.

Closes #4967
