### PR TITLE
docs(hooks): document this binding for onRegister hook and add test assertion

### DIFF
--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -634,6 +634,8 @@ this hook is encapsulated.
 > ℹ️ Note:
 > This hook will not be called if a plugin is wrapped inside
 > [`fastify-plugin`](https://github.com/fastify/fastify-plugin).
+
+Hook functions are invoked with `this` bound to the parent Fastify instance (the calling scope), while `instance` refers to the newly created child instance.
 ```js
 fastify.decorate('data', [])
 
@@ -651,7 +653,7 @@ fastify.register(async (instance, opts) => {
   console.log(instance.data) // []
 }, { prefix: '/hello' })
 
-fastify.addHook('onRegister', (instance, opts) => {
+fastify.addHook('onRegister', function (instance, opts) {
   // Create a new array from the old one
   // but without keeping the reference
   // allowing the user to have encapsulated
@@ -956,3 +958,4 @@ channel.subscribe((msg) => {
   console.log(msg.request, msg.reply)
 })
 ```
+

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -3109,6 +3109,24 @@ test('onRegister hook should be called (encapsulation)', (t, testDone) => {
   })
 })
 
+test('onRegister this refers to parent instance', (t, done) => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.addHook('onRegister', function (instance, opts) {
+    t.assert.strictEqual(this.pluginName, fastify.pluginName, 'the this binding is the parent Fastify instance')
+  })
+
+  fastify.register(function (instance, opts, done) {
+    done()
+  })
+
+  fastify.ready((err) => {
+    t.assert.ifError(err)
+    done()
+  })
+})
+
 test('early termination, onRequest', (t, testDone) => {
   t.plan(3)
 
@@ -3576,3 +3594,4 @@ test('onRequestAbort should handle async errors / 2', (t, testDone) => {
     sleep(500).then(() => socket.destroy())
   })
 })
+


### PR DESCRIPTION
The onRegister hook's this context was left undocumented when PR #5675 updated the binding from the newly created child instance to the parent Fastify instance. This adds a sentence to the onRegister section of Hooks.md clarifying that this refers to the parent Fastify instance while instance refers to the child, switches the code example callback to use the function keyword (necessary for correct this binding), and adds a standalone test in test/hooks.test.js that asserts the pluginName equality to confirm the binding is correct.

Closes #4967