### PR TITLE
docs(hooks): document this binding for onRoute hook and add test assertion

### DIFF
--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -564,6 +564,7 @@ fastify.addHook('preClose', async () => {
 Triggered when a new route is registered. Listeners are passed a [`routeOptions`](./Routes.md#routes-options)
 object as the sole parameter. The interface is synchronous, and, as such, the
 listeners are not passed a callback. This hook is encapsulated.
+Hook functions are invoked with `this` bound to the associated Fastify instance.
 
 ```js
 fastify.addHook('onRoute', (routeOptions) => {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -814,6 +814,16 @@ test('onRoute hook should not be called when it registered after route', (t, tes
   })
 })
 
+
+test('onRoute this refers to the Fastify instance', (t, testDone) => {
+  t.plan(1)
+  const fastify = Fastify()
+  fastify.addHook('onRoute', function (routeOptions) {
+    t.assert.strictEqual(this.pluginName, fastify.pluginName, 'the this binding is the Fastify instance')
+  })
+  fastify.get('/test-route', function (req, reply) { reply.send() })
+  fastify.close(testDone)
+})
 test('onResponse hook should log request error', (t, testDone) => {
   t.plan(4)
 


### PR DESCRIPTION
The `onRoute` hook's `this` context is bound to the Fastify instance that registered the hook, but this behaviour was not documented. Add a sentence to the onRoute section consistent with the existing `onReady` and `onListen` documentation, and add a focused test assertion that verifies the binding.

Closes #4967