### PR TITLE
docs: update ajv-errors guidance

### DIFF
--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -920,8 +920,8 @@ For custom error responses in the schema, see
 [example](https://github.com/fastify/example/blob/HEAD/validation-messages/custom-errors-messages.js)
 usage.
 
-> Install version 1.0.1 of `ajv-errors`, as later versions are not compatible
-> with AJV v6 (the version shipped by Fastify v3).
+> Fastify v5 uses AJV v8, so install an `ajv-errors` version compatible with
+> AJV v8. Fastify v3 users should stay on `ajv-errors@1.0.1`.
 
 Below is an example showing how to add **custom error messages for each
 property** of a schema by supplying custom AJV options. Inline comments in the

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -920,8 +920,8 @@ For custom error responses in the schema, see
 [example](https://github.com/fastify/example/blob/HEAD/validation-messages/custom-errors-messages.js)
 usage.
 
-> Fastify v5 uses AJV v8, so install an `ajv-errors` version that supports
-> AJV v8. Fastify v3 requires `ajv-errors@1.0.1`, which supports AJV v6.
+> Fastify v5 uses AJV v8 and requires a compatible `ajv-errors` version.
+> Fastify v3 requires `ajv-errors@1.0.1`, which supports AJV v6.
 
 Below is an example showing how to add **custom error messages for each
 property** of a schema by supplying custom AJV options. Inline comments in the

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -922,6 +922,8 @@ usage.
 
 > Fastify v5 uses AJV v8 and requires a compatible `ajv-errors` version.
 > Fastify v3 requires `ajv-errors@1.0.1`, which supports AJV v6.
+> See the [AJV compiler versions table](https://github.com/fastify/ajv-compiler/#versions)
+> for the AJV version used by each Fastify release.
 
 Below is an example showing how to add **custom error messages for each
 property** of a schema by supplying custom AJV options. Inline comments in the

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -920,8 +920,8 @@ For custom error responses in the schema, see
 [example](https://github.com/fastify/example/blob/HEAD/validation-messages/custom-errors-messages.js)
 usage.
 
-> Fastify v5 uses AJV v8, so install an `ajv-errors` version compatible with
-> AJV v8. Fastify v3 users should stay on `ajv-errors@1.0.1`.
+> Fastify v5 uses AJV v8, so install an `ajv-errors` version that supports
+> AJV v8. Fastify v3 requires `ajv-errors@1.0.1`, which supports AJV v6.
 
 Below is an example showing how to add **custom error messages for each
 property** of a schema by supplying custom AJV options. Inline comments in the


### PR DESCRIPTION
Updates the validation docs so the `ajv-errors` note matches Fastify v5 / AJV v8 while keeping the old v3 guidance scoped to Fastify v3.

Refs fastify/help#1113.

Checks:
- npm.cmd run lint:markdown -- docs/Reference/Validation-and-Serialization.md
- git diff --check