### PR TITLE
fix: chunk large HTTP/2 buffer replies

### DIFF
--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -705,6 +705,11 @@ If you are sending a stream and you have not set a `'Content-Type'` header,
 As noted above, streams are considered to be pre-serialized, so they will be
 sent unmodified without response validation.
 
+When sending streams over HTTP/2, Fastify does not change the chunks emitted by
+the stream. If a stream can emit very large chunks, split them in your
+application code, for example by using `fs.createReadStream()` or a transform
+stream that emits smaller chunks.
+
 See special note about error handling for streams in
 [`setErrorHandler`](./Server.md#seterrorhandler).
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -60,6 +60,7 @@ const {
 const decorators = require('./decorate')
 
 const toString = Object.prototype.toString
+const HTTP2_WRITE_CHUNK_SIZE = 64 * 1024
 
 function Reply (res, request, log) {
   this.raw = res
@@ -677,9 +678,52 @@ function onSendEnd (reply, payload) {
 
   safeWriteHead(reply, statusCode)
   // write payload first
-  res.write(payload)
-  // then send trailers
-  sendTrailer(payload, res, reply)
+  writePayload(payload, res, reply)
+}
+
+function isHttp2Reply (reply) {
+  return reply.request.raw?.httpVersionMajor === 2
+}
+
+function writePayload (payload, res, reply) {
+  if (!isHttp2Reply(reply) || Buffer.byteLength(payload) <= HTTP2_WRITE_CHUNK_SIZE) {
+    res.write(payload)
+    // then send trailers
+    sendTrailer(payload, res, reply)
+    return
+  }
+
+  writeHttp2Payload(payload, res, () => {
+    // then send trailers
+    sendTrailer(payload, res, reply)
+  })
+}
+
+function writeHttp2Payload (payload, res, done) {
+  const buffer = Buffer.isBuffer(payload) ? payload : Buffer.from(payload)
+  let offset = 0
+
+  function writeChunk () {
+    while (offset < buffer.length) {
+      /* c8 ignore next 3 - defensive guard for aborted responses */
+      if (res.destroyed || res.writableEnded) {
+        return
+      }
+
+      const end = Math.min(offset + HTTP2_WRITE_CHUNK_SIZE, buffer.length)
+      const shouldContinue = res.write(buffer.subarray(offset, end))
+      offset = end
+
+      if (shouldContinue === false) {
+        res.once('drain', writeChunk)
+        return
+      }
+    }
+
+    done()
+  }
+
+  writeChunk()
 }
 
 function logStreamError (logger, err, res) {

--- a/test/http2/plain.test.js
+++ b/test/http2/plain.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { test } = require('node:test')
+const http2 = require('node:http2')
 const Fastify = require('../..')
 const h2url = require('h2url')
 const msg = { hello: 'world' }
@@ -64,5 +65,139 @@ test('http2 plain test', async t => {
 
     t.assert.strictEqual(JSON.parse(res.body).hostname, host.split(':')[0])
     t.assert.strictEqual(JSON.parse(res.body).port, parseInt(host.split(':')[1]))
+  })
+})
+
+test('http2 large non-stream replies are sent completely', async t => {
+  const modes = ['buffer', 'string']
+
+  for (const mode of modes) {
+    await t.test(mode, async t => {
+      const fastify = Fastify({ http2: true })
+      const payload = mode === 'buffer'
+        ? Buffer.alloc((64 * 1024) + 1, 'a')
+        : 'a'.repeat((64 * 1024) + 1)
+      const contentLength = Buffer.byteLength(payload)
+
+      fastify.get('/large', async (req, reply) => {
+        reply.header('content-type', 'application/octet-stream')
+        reply.header('content-length', contentLength)
+
+        return payload
+      })
+
+      await fastify.listen({ port: 0, host: '127.0.0.1' })
+
+      const client = http2.connect(`http://127.0.0.1:${fastify.server.address().port}`)
+      t.after(() => {
+        client.close()
+        return fastify.close()
+      })
+
+      await new Promise((resolve, reject) => {
+        const large = client.request({
+          [http2.constants.HTTP2_HEADER_METHOD]: http2.constants.HTTP2_METHOD_GET,
+          [http2.constants.HTTP2_HEADER_PATH]: '/large'
+        })
+        const chunks = []
+
+        large.on('error', reject)
+        large.on('data', chunk => {
+          chunks.push(chunk)
+        })
+        large.on('end', () => {
+          t.assert.strictEqual(Buffer.concat(chunks).length, contentLength)
+          resolve()
+        })
+        large.end()
+      })
+    })
+  }
+})
+
+test('http2 large buffer replies can be cancelled without rejecting the next stream', async t => {
+  const fastify = Fastify({ http2: true })
+  const payload = Buffer.alloc(32 * 1024 * 1024, 'a')
+  let smallHit = false
+
+  fastify.get('/large', async (req, reply) => {
+    reply.header('content-type', 'application/octet-stream')
+    reply.header('content-length', payload.length)
+
+    return payload
+  })
+
+  fastify.get('/small', async () => {
+    smallHit = true
+    return 'ok'
+  })
+
+  await fastify.listen({ port: 0, host: '127.0.0.1' })
+
+  const client = http2.connect(`http://127.0.0.1:${fastify.server.address().port}`)
+  t.after(() => {
+    client.close()
+    return fastify.close()
+  })
+
+  await new Promise((resolve, reject) => {
+    let cancelTimer
+    let requestTimer
+    let timeout
+
+    function cleanup () {
+      clearTimeout(cancelTimer)
+      clearTimeout(requestTimer)
+      clearTimeout(timeout)
+    }
+
+    const large = client.request({
+      [http2.constants.HTTP2_HEADER_METHOD]: http2.constants.HTTP2_METHOD_GET,
+      [http2.constants.HTTP2_HEADER_PATH]: '/large'
+    })
+    let largeResponded = false
+
+    large.on('error', err => {
+      if (!largeResponded) {
+        cleanup()
+        reject(err)
+      }
+    })
+    large.on('response', () => {
+      largeResponded = true
+      large.pause()
+      cancelTimer = setTimeout(() => {
+        large.close(http2.constants.NGHTTP2_CANCEL)
+      }, 100)
+      requestTimer = setTimeout(() => {
+        const small = client.request({
+          [http2.constants.HTTP2_HEADER_METHOD]: http2.constants.HTTP2_METHOD_GET,
+          [http2.constants.HTTP2_HEADER_PATH]: '/small'
+        })
+        let body = ''
+
+        timeout = setTimeout(() => {
+          cleanup()
+          reject(new Error('timed out waiting for /small response'))
+        }, 3000)
+
+        small.setEncoding('utf8')
+        small.on('error', err => {
+          cleanup()
+          reject(err)
+        })
+        small.on('data', chunk => {
+          body += chunk
+        })
+        small.on('end', () => {
+          cleanup()
+          t.assert.strictEqual(body, 'ok')
+          t.assert.strictEqual(smallHit, true)
+          resolve()
+        })
+        small.end()
+      }, 200)
+    })
+    large.end()
   })
 })


### PR DESCRIPTION
Chunk large non-stream HTTP/2 payload writes to avoid poisoning the session after cancellation.

User-provided streams remain unmodified; docs note apps should chunk large stream emissions.

Tests:
- node --test test/http2/plain.test.js
- node --test test/http2/*.test.js
- npm run lint
- npx markdownlint-cli2 docs/Reference/Reply.md --no-globs
