### PR TITLE
docs: fix doubled braces in serializerCompiler signature

### DIFF
--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -102,7 +102,7 @@ fastify.route(options)
   schemas for request validations. See the [Validation and
   Serialization](./Validation-and-Serialization.md#schema-validator)
   documentation.
-* `serializerCompiler({ { schema, method, url, httpStatus, contentType } })`:
+* `serializerCompiler({ schema, method, url, httpStatus, contentType })`:
   function that builds schemas for response serialization. See the [Validation and
   Serialization](./Validation-and-Serialization.md#schema-serializer)
   documentation.


### PR DESCRIPTION
## Problem

In the Routes reference, the `serializerCompiler` entry has a malformed signature with doubled braces:

```
* `serializerCompiler({ { schema, method, url, httpStatus, contentType } })`:
```

`({ { ... } })` is invalid JS object-destructuring syntax. The correct single-brace form is confirmed by two canonical references in the same docs — `Reference/Server.md` (`function serializerCompiler ({ schema, method, url, httpStatus, contentType })`) and `Reference/Validation-and-Serialization.md` (`setSerializerCompiler(({ schema, method, url, httpStatus, contentType }) => {`) — and by the parallel `validatorCompiler({ schema, method, url, httpPart })` entry one line above.

## Fix

Collapse `({ { ... } })` → `({ ... })` in `docs/Reference/Routes.md`. Docs-only, one line.
