### PR TITLE
fix: allow pino logger instance assignment

### DIFF
--- a/test/types/fastify.test-d.ts
+++ b/test/types/fastify.test-d.ts
@@ -3,6 +3,7 @@ import * as http from 'node:http'
 import * as http2 from 'node:http2'
 import * as https from 'node:https'
 import { Socket } from 'node:net'
+import pino from 'pino'
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd'
 import fastify, {
   ConnectionError,
@@ -176,6 +177,9 @@ const customLogger = {
 expectAssignable<
   FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse, FastifyBaseLogger>
 >(fastify({ logger: customLogger }))
+const pinoLogger = pino()
+const pinoLoggerServer: FastifyInstance = fastify({ loggerInstance: pinoLogger })
+expectAssignable<FastifyInstance>(pinoLoggerServer)
 expectAssignable<FastifyInstance>(fastify({ serverFactory: () => http.createServer() }))
 expectAssignable<FastifyInstance>(fastify({ caseSensitive: true }))
 expectAssignable<FastifyInstance>(fastify({ requestIdHeader: 'request-id' }))

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -483,7 +483,7 @@ export interface FastifyInstance<
    * which allows for modifying or adding child logger bindings and logger options, or
    * returning a completely custom child logger implementation.
    */
-  childLoggerFactory: FastifyChildLoggerFactory<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  childLoggerFactory: FastifyChildLoggerFactory<RawServer, RawRequest, RawReply, FastifyBaseLogger, TypeProvider>;
 
   /**
    * Hook function that is called when creating a child logger instance for each request
@@ -502,7 +502,7 @@ export interface FastifyInstance<
    * }
    * ```
    */
-  setChildLoggerFactory(factory: FastifyChildLoggerFactory<RawServer, RawRequest, RawReply, Logger, TypeProvider>): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  setChildLoggerFactory(factory: FastifyChildLoggerFactory<RawServer, RawRequest, RawReply, FastifyBaseLogger, TypeProvider>): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
 
   /**
    * Fastify schema validator for all routes.

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -75,7 +75,7 @@ export interface RouteShorthandOptions<
     request: FastifyRequest<RouteGeneric, RawServer, RawRequest, NoInfer<SchemaCompiler>, TypeProvider, ContextConfig, Logger>,
     reply: FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, NoInfer<SchemaCompiler>, TypeProvider>
   ) => void;
-  childLoggerFactory?: FastifyChildLoggerFactory<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  childLoggerFactory?: FastifyChildLoggerFactory<RawServer, RawRequest, RawReply, FastifyBaseLogger, TypeProvider>;
   schemaErrorFormatter?: SchemaErrorFormatter;
 
   // hooks


### PR DESCRIPTION
Fixes #4960.

This updates the `childLoggerFactory` type surfaces to accept `FastifyBaseLogger` instead of the concrete logger generic inferred from `loggerInstance`. That avoids making `FastifyInstance<..., pino.Logger>` fail assignment to the default `FastifyInstance` type under strict function types.

The added type test covers assigning a Fastify instance created with `loggerInstance: pino()` to `FastifyInstance`.

Verification:
- Red before fix: `npx tsd --files test/types/fastify.test-d.ts` failed on the new Pino logger instance assignment.
- Green after fix: `npx tsd --files test/types/fastify.test-d.ts`
- `npm run test:types`
- `npm run lint`
- `git diff --check`
- `npm test`