### PR TITLE
docs(Warnings): remove retired FSTWRN002 warning code

### DIFF
--- a/docs/Reference/Warnings.md
+++ b/docs/Reference/Warnings.md
@@ -6,7 +6,6 @@
   - [Warnings In Fastify](#warnings-in-fastify)
   - [Fastify Warning Codes](#fastify-warning-codes)
     - [FSTWRN001](#FSTWRN001)
-    - [FSTWRN002](#FSTWRN002)
     - [FSTWRN003](#FSTWRN003)
     - [FSTWRN004](#FSTWRN004)
   - [Fastify Deprecation Codes](#fastify-deprecation-codes)
@@ -42,7 +41,6 @@ Disabling warnings is not recommended and may cause unexpected behavior.
 | Code | Description | How to solve | Discussion |
 | ---- | ----------- | ------------ | ---------- |
 | <a id="FSTWRN001">FSTWRN001</a> | The specified schema for a route is missing. This may indicate the schema is not well specified. | Check the schema for the route. | [#4647](https://github.com/fastify/fastify/pull/4647) |
-| <a id="FSTWRN002">FSTWRN002</a> | The %s plugin being registered mixes async and callback styles, which results in an error in `fastify@5` and later. | Do not mix async and callback styles. | [#5139](https://github.com/fastify/fastify/pull/5139) |
 | <a id="FSTWRN003">FSTWRN003</a> | The `%s` plugin mixes async and callback styles, which may lead to unhandled rejections. | Do not mix async and callback style. | [#6011](https://github.com/fastify/fastify/pull/6011) |
 | <a id="FSTWRN004">FSTWRN004</a> | An `errorHandler` is being overridden in the same scope, which can lead to subtle bugs. | Avoid calling `setErrorHandler` more than once in the same scope. For more information, see [Server documentation](https://fastify.dev/docs/latest/Reference/Server/#allowerrorhandleroverride). | [#6104](https://github.com/fastify/fastify/pull/6104) |
 


### PR DESCRIPTION
`FSTWRN002` is listed in the **Fastify Warning Codes** table (and TOC), but it is a retired v4 code. `lib/warnings.js` does not define or export it, and its header comment states: *"Warning Codes FSTWRN001 - FSTWRN002 were used by v4 and MUST NOT be reused."* The only remaining reference is that intentional reservation comment.

Retired codes are removed from this document by convention: the **Fastify Deprecation Codes** table now lists only the active `FSTDEP022`, after retired codes were dropped in prior cleanups (e.g. #5604, #5609, #5611, #5613, #5616, #5618). `FSTWRN002` looks like it was simply missed during the v5 cleanup.

Docs only — removes the stale TOC entry and table row for `FSTWRN002`. No behavior change.
