### PR TITLE
fix: normalize prefixed root route urls

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -280,6 +280,7 @@ function buildRouting (options) {
 
     function addNewRoute ({ path, prefixing = false, isFastify = false }) {
       const url = prefix + path
+      const contextUrl = prefixing ? prefix : url
 
       opts.url = url
       opts.path = url
@@ -334,7 +335,7 @@ function buildRouting (options) {
       const constraints = opts.constraints || {}
       const config = {
         ...opts.config,
-        url,
+        url: contextUrl,
         method: opts.method
       }
 

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -529,6 +529,45 @@ test('matches both /prefix and /prefix/  with a / route - prefixTrailingSlash: "
   completion.patience.then(testDone)
 })
 
+test('returns canonical routeOptions.url for prefixTrailingSlash: "both" prefix root route', async t => {
+  t.plan(3)
+
+  const fastify = Fastify({
+    ignoreTrailingSlash: false
+  })
+  t.after(() => { fastify.close() })
+
+  fastify.register(async function (fastify) {
+    fastify.get('/', {
+      prefixTrailingSlash: 'both'
+    }, async request => {
+      return { routeUrl: request.routeOptions.url }
+    })
+
+    fastify.get('/bar/', async request => {
+      return { routeUrl: request.routeOptions.url }
+    })
+  }, { prefix: '/prefix' })
+
+  const prefix = await fastify.inject({
+    method: 'GET',
+    url: '/prefix'
+  })
+  t.assert.deepStrictEqual(prefix.json(), { routeUrl: '/prefix' })
+
+  const prefixWithSlash = await fastify.inject({
+    method: 'GET',
+    url: '/prefix/'
+  })
+  t.assert.deepStrictEqual(prefixWithSlash.json(), { routeUrl: '/prefix' })
+
+  const nestedWithSlash = await fastify.inject({
+    method: 'GET',
+    url: '/prefix/bar/'
+  })
+  t.assert.deepStrictEqual(nestedWithSlash.json(), { routeUrl: '/prefix/bar/' })
+})
+
 test('matches both /prefix and /prefix/  with a / route - prefixTrailingSlash: "both", ignoreDuplicateSlashes: false', (t, testDone) => {
   t.plan(4)
   const fastify = Fastify({


### PR DESCRIPTION
## Problem

When a plugin prefix registers a root route with `prefixTrailingSlash: both`, Fastify adds a second internal route for the trailing-slash variant without firing `onRoute` again. That hidden route currently exposes `/prefix/` through `request.routeOptions.url`, even though the visible route exposed to plugins is `/prefix`.

This makes route metadata inconsistent for plugins that key behavior off the route URL.

Fixes #4424.

## Solution

I kept the hidden trailing-slash route registered for matching, but made its request context use the canonical prefixed root URL. The router still matches `/prefix/`, while `request.routeOptions.url` now reports `/prefix` for both `/prefix` and `/prefix/` requests.

I also added regression coverage to make sure nested routes that intentionally end with a slash, like `/prefix/bar/`, still preserve their trailing slash.

## Testing

- `node --test test/route-prefix.test.js`
- `npx eslint lib/route.js test/route-prefix.test.js`
- `git diff --check`