### PR TITLE
feat: add double schema bucket for validator and serializer

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -224,6 +224,8 @@ function fastify (serverOptions) {
     addSchema,
     getSchema: schemaController.getSchema.bind(schemaController),
     getSchemas: schemaController.getSchemas.bind(schemaController),
+    getValidatorSchemas: schemaController.getValidatorSchemas.bind(schemaController),
+    getSerializerSchemas: schemaController.getSerializerSchemas.bind(schemaController),
     setValidatorCompiler,
     setSerializerCompiler,
     setSchemaController,
@@ -615,10 +617,10 @@ function fastify (serverOptions) {
   }
 
   // wrapper that we expose to the user for schemas handling
-  function addSchema (schema) {
+  function addSchema (schema, options) {
     throwIfAlreadyStarted('Cannot call "addSchema"!')
-    this[kSchemaController].add(schema)
-    this[kChildren].forEach(child => child.addSchema(schema))
+    this[kSchemaController].add(schema, options)
+    this[kChildren].forEach(child => child.addSchema(schema, options))
     return this
   }
 
@@ -755,6 +757,8 @@ function fastify (serverOptions) {
     this[kSchemaController] = schemaController
     this.getSchema = schemaController.getSchema.bind(schemaController)
     this.getSchemas = schemaController.getSchemas.bind(schemaController)
+    this.getValidatorSchemas = schemaController.getValidatorSchemas.bind(schemaController)
+    this.getSerializerSchemas = schemaController.getSerializerSchemas.bind(schemaController)
     return this
   }
 

--- a/lib/schema-controller.js
+++ b/lib/schema-controller.js
@@ -80,7 +80,7 @@ class SchemaController {
 
     if (addValidator) this.validatorBucket.add(schema)
     if (addSerializer) this.serializerBucket.add(schema)
-    
+
     return this
   }
 

--- a/lib/schema-controller.js
+++ b/lib/schema-controller.js
@@ -45,31 +45,59 @@ class SchemaController {
     this.compilersFactory = this.opts.compilersFactory
 
     if (parent) {
-      this.schemaBucket = this.opts.bucket(parent.getSchemas())
+      this.validatorBucket = this.opts.bucket(parent.getValidatorSchemas())
+      this.serializerBucket = this.opts.bucket(parent.getSerializerSchemas())
       this.validatorCompiler = parent.getValidatorCompiler()
       this.serializerCompiler = parent.getSerializerCompiler()
       this.isCustomValidatorCompiler = parent.isCustomValidatorCompiler
       this.isCustomSerializerCompiler = parent.isCustomSerializerCompiler
       this.parent = parent
     } else {
-      this.schemaBucket = this.opts.bucket()
+      this.validatorBucket = this.opts.bucket()
+      this.serializerBucket = this.opts.bucket()
       this.isCustomValidatorCompiler = this.opts.isCustomValidatorCompiler || false
       this.isCustomSerializerCompiler = this.opts.isCustomSerializerCompiler || false
     }
   }
 
   // Bucket interface
-  add (schema) {
+  add (schema, options) {
     this.addedSchemas = true
-    return this.schemaBucket.add(schema)
+
+    let addValidator = true
+    let addSerializer = true
+
+    if (options) {
+      if (options.validator !== undefined && options.serializer === undefined) {
+        addSerializer = !options.validator
+      } else if (options.serializer !== undefined && options.validator === undefined) {
+        addValidator = !options.serializer
+      } else {
+        addValidator = options.validator !== false
+        addSerializer = options.serializer !== false
+      }
+    }
+
+    if (addValidator) this.validatorBucket.add(schema)
+    if (addSerializer) this.serializerBucket.add(schema)
+    
+    return this
   }
 
   getSchema (schemaId) {
-    return this.schemaBucket.getSchema(schemaId)
+    return this.validatorBucket.getSchema(schemaId) || this.serializerBucket.getSchema(schemaId)
   }
 
   getSchemas () {
-    return this.schemaBucket.getSchemas()
+    return Object.assign({}, this.serializerBucket.getSchemas(), this.validatorBucket.getSchemas())
+  }
+
+  getValidatorSchemas () {
+    return this.validatorBucket.getSchemas()
+  }
+
+  getSerializerSchemas () {
+    return this.serializerBucket.getSchemas()
   }
 
   setValidatorCompiler (validatorCompiler) {
@@ -142,7 +170,7 @@ class SchemaController {
     if (isReady) {
       return
     }
-    this.validatorCompiler = this.getValidatorBuilder()(this.schemaBucket.getSchemas(), serverOptions.ajv)
+    this.validatorCompiler = this.getValidatorBuilder()(this.validatorBucket.getSchemas(), serverOptions.ajv)
   }
 
   /**
@@ -156,7 +184,7 @@ class SchemaController {
       return
     }
 
-    this.serializerCompiler = this.getSerializerBuilder()(this.schemaBucket.getSchemas(), serverOptions.serializerOpts)
+    this.serializerCompiler = this.getSerializerBuilder()(this.serializerBucket.getSchemas(), serverOptions.serializerOpts)
   }
 }
 

--- a/lib/schema-controller.js
+++ b/lib/schema-controller.js
@@ -184,7 +184,10 @@ class SchemaController {
       return
     }
 
-    this.serializerCompiler = this.getSerializerBuilder()(this.serializerBucket.getSchemas(), serverOptions.serializerOpts)
+    this.serializerCompiler = this.getSerializerBuilder()(
+      this.serializerBucket.getSchemas(),
+      serverOptions.serializerOpts
+    )
   }
 }
 

--- a/test/schema-double-bucket.test.js
+++ b/test/schema-double-bucket.test.js
@@ -1,0 +1,74 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const Fastify = require('..')
+
+test('Double schema bucket - schema available for both', t => {
+  const fastify = Fastify()
+  
+  fastify.addSchema({
+    $id: 'urn:schema:both',
+    type: 'object',
+    properties: {
+      hello: { type: 'string' }
+    }
+  })
+
+  assert.ok(fastify.getValidatorSchemas()['urn:schema:both'])
+  assert.ok(fastify.getSerializerSchemas()['urn:schema:both'])
+})
+
+test('Double schema bucket - schema available for validator only', t => {
+  const fastify = Fastify()
+  
+  fastify.addSchema({
+    $id: 'urn:schema:validator',
+    type: 'object',
+    properties: {
+      hello: { type: 'string' }
+    }
+  }, { validator: true })
+
+  assert.ok(fastify.getValidatorSchemas()['urn:schema:validator'])
+  assert.equal(fastify.getSerializerSchemas()['urn:schema:validator'], undefined)
+})
+
+test('Double schema bucket - schema available for serializer only', t => {
+  const fastify = Fastify()
+  
+  fastify.addSchema({
+    $id: 'urn:schema:serializer',
+    type: 'object',
+    properties: {
+      hello: { type: 'string' }
+    }
+  }, { serializer: true })
+
+  assert.equal(fastify.getValidatorSchemas()['urn:schema:serializer'], undefined)
+  assert.ok(fastify.getSerializerSchemas()['urn:schema:serializer'])
+})
+
+test('Double schema bucket - getSchemas returns merged schema', t => {
+  const fastify = Fastify()
+  
+  fastify.addSchema({
+    $id: 'urn:schema:serializer',
+    type: 'object',
+    properties: {
+      hello: { type: 'string' }
+    }
+  }, { serializer: true })
+
+  fastify.addSchema({
+    $id: 'urn:schema:validator',
+    type: 'object',
+    properties: {
+      hello: { type: 'string' }
+    }
+  }, { validator: true })
+
+  const schemas = fastify.getSchemas()
+  assert.ok(schemas['urn:schema:validator'])
+  assert.ok(schemas['urn:schema:serializer'])
+})

--- a/test/schema-double-bucket.test.js
+++ b/test/schema-double-bucket.test.js
@@ -6,7 +6,7 @@ const Fastify = require('..')
 
 test('Double schema bucket - schema available for both', t => {
   const fastify = Fastify()
-  
+
   fastify.addSchema({
     $id: 'urn:schema:both',
     type: 'object',
@@ -21,7 +21,7 @@ test('Double schema bucket - schema available for both', t => {
 
 test('Double schema bucket - schema available for validator only', t => {
   const fastify = Fastify()
-  
+
   fastify.addSchema({
     $id: 'urn:schema:validator',
     type: 'object',
@@ -36,7 +36,7 @@ test('Double schema bucket - schema available for validator only', t => {
 
 test('Double schema bucket - schema available for serializer only', t => {
   const fastify = Fastify()
-  
+
   fastify.addSchema({
     $id: 'urn:schema:serializer',
     type: 'object',
@@ -51,7 +51,7 @@ test('Double schema bucket - schema available for serializer only', t => {
 
 test('Double schema bucket - getSchemas returns merged schema', t => {
   const fastify = Fastify()
-  
+
   fastify.addSchema({
     $id: 'urn:schema:serializer',
     type: 'object',

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -133,9 +133,11 @@ export interface FastifyInstance<
   addresses(): AddressInfo[]
   withTypeProvider<Provider extends FastifyTypeProvider>(): FastifyInstance<RawServer, RawRequest, RawReply, Logger, Provider>;
 
-  addSchema(schema: unknown): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+  addSchema(schema: unknown, options?: { validator?: boolean, serializer?: boolean }): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
   getSchema(schemaId: string): unknown;
   getSchemas(): Record<string, unknown>;
+  getValidatorSchemas(): Record<string, unknown>;
+  getSerializerSchemas(): Record<string, unknown>;
 
   after(): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider> & SafePromiseLike<undefined>;
   after(afterListener: (err: Error | null) => void): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;


### PR DESCRIPTION
resolves #3402

This PR implements the "Double Schema Bucket" feature discussed in #3402 to resolve compatibility issues when passing schemas containing newer JSON Schema drafts (e.g., 2020-12) to both `ajv` (which supports it) and `fast-json-stringify` (which throws errors as it only supports up to draft 07).

### Changes:
- **`lib/schema-controller.js`**: Split the core schema container into discrete `validatorBucket` and `serializerBucket` instances.
- **`fastify.js`**: Added an `options` parameter to `addSchema(schema, options)` supporting `{ validator?: boolean, serializer?: boolean }` config object.
- **`types/instance.d.ts`**: Updated TypeScript definitions for the new options argument and exposed getters.
- **`test/schema-double-bucket.test.js`**: Added unit tests to ensure scopes do not leak when adding schemas targeted at specific compilers.

*Note: The feature is completely backward compatible. Calling `addSchema(schema)` without options continues to add the schema to both buckets as it always has.*

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)