### PR TITLE
refactor(decorate): replace `find` with `some` in `hasKey` for correct boolean semantics

### DIFF
--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -87,8 +87,7 @@ function checkExistence (instance, name) {
 }
 
 function hasKey (fn, name) {
-  const props = fn.props
-  return props ? props.some(p => p.key === name) : false
+  return fn.props ? fn.props.some(p => p.key === name) : false
 }
 
 function checkRequestExistence (name) {

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -87,10 +87,8 @@ function checkExistence (instance, name) {
 }
 
 function hasKey (fn, name) {
-  if (fn.props) {
-    return fn.props.find(({ key }) => key === name)
-  }
-  return false
+  const props = fn.props
+  return props ? props.some(p => p.key === name) : false
 }
 
 function checkRequestExistence (name) {


### PR DESCRIPTION
## Summary
`hasKey` is intended to return a boolean, but the current implementation
uses `Array.prototype.find` which returns the matched element or `undefined`.
While this works in boolean contexts due to truthy/falsy evaluation,
`Array.prototype.some` is the semantically correct method here since
the caller never needs the matched element — only whether it exists.

## Changes
- `lib/decorate.js`: replaced `find` with `some` in `hasKey`

## Notes
- No behavioral change, all existing tests pass
- Not a style preference — `some` is the correct tool when the
  return value is used exclusively as a boolean

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
