### PR TITLE
Issue 420 rate

### DIFF
--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -480,6 +480,7 @@ arrive.
 
 The hook function takes the Fastify instance as a first argument,
 and a `done` callback for synchronous hook functions.
+Hook functions are invoked with `this` bound to the associated Fastify instance.
 ```js
 // callback style
 fastify.addHook('onClose', (instance, done) => {
@@ -531,10 +532,11 @@ connections or Server-Sent Events streams that must be explicitly terminated for
 `server.close()` to complete.
 _It is unlikely you will need to use this hook_,
 use the [`onClose`](#onclose) for the most common case.
+Hook functions are invoked with `this` bound to the associated Fastify instance.
 
 ```js
 // callback style
-fastify.addHook('preClose', (done) => {
+fastify.addHook('preClose', function (done) {
   // Some code
   done()
 })
@@ -564,9 +566,10 @@ fastify.addHook('preClose', async () => {
 Triggered when a new route is registered. Listeners are passed a [`routeOptions`](./Routes.md#routes-options)
 object as the sole parameter. The interface is synchronous, and, as such, the
 listeners are not passed a callback. This hook is encapsulated.
+Hook functions are invoked with `this` bound to the associated Fastify instance.
 
 ```js
-fastify.addHook('onRoute', (routeOptions) => {
+fastify.addHook('onRoute', function (routeOptions) {
   //Some code
   routeOptions.method
   routeOptions.schema
@@ -630,6 +633,7 @@ created. The hook will be executed **before** the registered code.
 This hook can be useful if you are developing a plugin that needs to know when a
 plugin context is formed, and you want to operate in that specific context, thus
 this hook is encapsulated.
+Hook functions are invoked with `this` bound to the parent Fastify instance.
 
 > ℹ️ Note:
 > This hook will not be called if a plugin is wrapped inside
@@ -651,7 +655,7 @@ fastify.register(async (instance, opts) => {
   console.log(instance.data) // []
 }, { prefix: '/hello' })
 
-fastify.addHook('onRegister', (instance, opts) => {
+fastify.addHook('onRegister', function (instance, opts) {
   // Create a new array from the old one
   // but without keeping the reference
   // allowing the user to have encapsulated

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -629,7 +629,7 @@ test('preClose callback', (t, done) => {
   fastify.addHook('preClose', preClose)
 
   function preClose (done) {
-    t.assert.ok(typeof this === typeof fastify)
+    t.assert.strictEqual(this, fastify)
     preCloseCalled = true
     done()
   }
@@ -657,7 +657,7 @@ test('preClose async', async t => {
 
   async function preClose () {
     preCloseCalled = true
-    t.assert.ok(typeof this === typeof fastify)
+    t.assert.strictEqual(this, fastify)
   }
 
   await fastify.listen({ port: 0 })

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -3577,3 +3577,44 @@ test('onRequestAbort should handle async errors / 2', (t, testDone) => {
     sleep(500).then(() => socket.destroy())
   })
 })
+
+test('onRoute hook this context binding', (t, testDone) => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.addHook('onRoute', function (routeOptions) {
+    t.assert.strictEqual(this, fastify)
+    t.assert.ok(routeOptions.method === 'GET' || routeOptions.method === 'HEAD')
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.send()
+  })
+
+  fastify.ready(err => {
+    t.assert.ifError(err)
+    testDone()
+  })
+})
+
+test('onRegister hook this context binding', (t, testDone) => {
+  t.plan(3)
+  const fastify = Fastify()
+  let instanceFromHook
+
+  fastify.addHook('onRegister', function (instance, opts) {
+    t.assert.strictEqual(this, fastify)
+    instanceFromHook = instance
+  })
+
+  fastify.register((instance, opts, done) => {
+    t.assert.strictEqual(instance, instanceFromHook)
+    done()
+  })
+
+  fastify.ready(err => {
+    t.assert.ifError(err)
+    testDone()
+  })
+})
+

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -3617,4 +3617,3 @@ test('onRegister hook this context binding', (t, testDone) => {
     testDone()
   })
 })
-

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -3579,7 +3579,7 @@ test('onRequestAbort should handle async errors / 2', (t, testDone) => {
 })
 
 test('onRoute hook this context binding', (t, testDone) => {
-  t.plan(3)
+  t.plan(5)
   const fastify = Fastify()
 
   fastify.addHook('onRoute', function (routeOptions) {


### PR DESCRIPTION
Updated `test/hooks.test.js`:
  - Changed `t.plan` to 5 and allowed both GET and HEAD methods for the onRoute hook, fixing the failing test.
  - Removed the extra blank line at the end of the file to satisfy ESLint (`@stylistic/no-multiple-empty-lines`).
