### PR TITLE
fix(types): support path alias in route options

### DIFF
--- a/test/types/route.test-d.ts
+++ b/test/types/route.test-d.ts
@@ -88,6 +88,13 @@ type LowerCaseHTTPMethods = 'delete' | 'get' | 'head' | 'patch' | 'post' | 'put'
     handler: routeHandler
   })).type.toBe<FastifyInstance>()
 
+  // route method with path alias
+  expect(fastify().route({
+    method: method as HTTPMethods,
+    path: '/',
+    handler: routeHandler
+  })).type.toBe<FastifyInstance>()
+
   const lowerCaseMethod: LowerCaseHTTPMethods = method.toLowerCase() as LowerCaseHTTPMethods
 
   // method as method
@@ -454,6 +461,11 @@ expect(fastify().route).type.not.toBeCallableWith({
   method: 'GET',
   handler: routeHandler,
   schemaErrorFormatter: 500
+})
+
+expect(fastify().route).type.not.toBeCallableWith({
+  method: 'GET',
+  handler: routeHandler
 })
 
 expect(fastify().route({

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -163,7 +163,7 @@ export interface RouteShorthandMethod<
 /**
  * Fastify route method options.
  */
-export interface RouteOptions<
+export interface RouteOptionsCommon<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
@@ -174,9 +174,22 @@ export interface RouteOptions<
   Logger extends FastifyBaseLogger = FastifyBaseLogger
 > extends RouteShorthandOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> {
   method: HTTPMethods | HTTPMethods[];
-  url: string;
   handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>;
 }
+
+export type RouteOptions<
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
+  RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
+  ContextConfig = ContextConfigDefault,
+  SchemaCompiler extends FastifySchema = FastifySchema,
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+  Logger extends FastifyBaseLogger = FastifyBaseLogger
+> = RouteOptionsCommon<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> & (
+  { url: string, path?: string }
+  | { url?: string, path: string }
+)
 
 export type RouteHandler<
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,


### PR DESCRIPTION
Fixed Fastify issue #6012 by updating the TypeScript route options type to support `path` as an alias for `url` in `fastify().route()`.

Fastify already supports this behavior at runtime through `opts.url || opts.path`, but the TypeScript definition required `url`, so valid route declarations using `path` failed type checking.

The fix splits the shared route option fields into `RouteOptionsCommon` and defines `RouteOptions` as a strict union requiring either `url` or `path`. This keeps the type safe while allowing both supported route forms.

Added type tests to verify that `fastify().route({ path: '/', method, handler })` is accepted, and that route options without both `url` and `path` are still rejected.