### PR TITLE
docs: fix incorrect defaults, variable names, and code examples

### DIFF
--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -102,7 +102,7 @@ fastify.route(options)
   schemas for request validations. See the [Validation and
   Serialization](./Validation-and-Serialization.md#schema-validator)
   documentation.
-* `serializerCompiler({ { schema, method, url, httpStatus, contentType } })`:
+* `serializerCompiler({ schema, method, url, httpStatus, contentType })`:
   function that builds schemas for response serialization. See the [Validation and
   Serialization](./Validation-and-Serialization.md#schema-serializer)
   documentation.

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -472,7 +472,7 @@ enhance the server instance inside the `serverFactory` function before the
 ### `requestIdHeader`
 <a id="factory-request-id-header"></a>
 
-+ Default: `'request-id'`
++ Default: `false`
 
 The header name used to set the request-id. See [the
 request-id](./Logging.md#logging-request-id) section.
@@ -721,7 +721,7 @@ const fastify = require('fastify')({
       res.code(400)
       return res.send("Provided header is not valid")
     } else {
-      res.send(err)
+      res.send(error)
     }
   }
 })
@@ -847,7 +847,7 @@ function to sanitize a route's store object to use with the `prettyPrint`
 functions. This function should accept a single object and return an object.
 
 ```js
-fastify.get('/user/:username', (request, reply) => {
+const fastify = require('fastify')({
   routerOptions: {
     buildPrettyMeta: route => {
       const cleanMeta = Object.assign({}, route.store)
@@ -858,7 +858,7 @@ fastify.get('/user/:username', (request, reply) => {
       })
 
       return cleanMeta // this will show up in the pretty print output!
-    })
+    }
   }
 })
 ```
@@ -1062,8 +1062,9 @@ objects and do not provide Fastify's decorated helpers.
 ### `querystringParser`
 <a id="querystringparser"></a>
 
-The default query string parser that Fastify uses is the Node.js's core
-`querystring` module.
+The default query string parser that Fastify uses is a more performant fork
+of Node.js's core `querystring` module called
+[`fast-querystring`](https://github.com/anonrig/fast-querystring).
 
 You can use this option to use a custom parser, such as
 [`qs`](https://www.npmjs.com/package/qs).
@@ -1084,7 +1085,7 @@ You can also use Fastify's default parser but change some handling behavior,
 like the example below for case insensitive keys and values:
 
 ```js
-const querystring = require('node:querystring')
+const querystring = require('fast-querystring')
 const fastify = require('fastify')({
   routerOptions: {
     querystringParser: str => querystring.parse(str.toLowerCase())


### PR DESCRIPTION
## Summary

Fixes #6767

This PR fixes 5 documentation bugs:

1. **`requestIdHeader` default**: Changed incorrect default from `request-id` to `false` (matching the actual codebase behavior and the text that follows)
2. **`frameworkErrors` variable name**: Changed `res.send(err)` to `res.send(error)` to match the function parameter name
3. **`serializerCompiler` double brace**: Removed extra `{` from the function signature
4. **`buildPrettyMeta` example**: Restructured the example as a proper constructor `routerOptions` object instead of invalid code inside a route handler
5. **`querystringParser` default**: Updated the routerOptions section to correctly state the default is `fast-querystring` (not Node.js core `querystring`), and fixed the example import

## Files Changed

- `docs/Reference/Server.md`
- `docs/Reference/Routes.md`