### PR TITLE
docs(type-providers): clarify as const usage

### DIFF
--- a/docs/Reference/Type-Providers.md
+++ b/docs/Reference/Type-Providers.md
@@ -58,6 +58,26 @@ server.get('/route', {
 })
 ```
 
+When using raw JSON Schema objects with `JsonSchemaToTsProvider`, TypeScript
+must be able to see the exact literal values in the schema. Inline schemas, like
+the example above, are inferred from the route call. If the schema is moved into
+a separate variable, use `as const`:
+
+```typescript
+const querystringSchema = {
+  type: 'object',
+  properties: {
+    foo: { type: 'number' },
+    bar: { type: 'string' },
+  },
+  required: ['foo', 'bar']
+} as const
+```
+
+Without `as const`, TypeScript may widen schema values such as `type: 'object'`
+to `type: string`, which prevents `json-schema-to-ts` from inferring the route
+types. This assertion has no effect on the schema used by Fastify at runtime.
+
 ### TypeBox
 
 The following sets up a TypeBox Type Provider:


### PR DESCRIPTION
Clarifies that extracted raw JSON Schema variables should use `as const` with `JsonSchemaToTsProvider` so TypeScript preserves literal schema values for inference.

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
