### PR TITLE
docs: fix defaultRoute anchor link

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -43,7 +43,7 @@ describes the properties available in that options object.
     - [`buildPrettyMeta`](#buildprettymeta)
     - [`caseSensitive`](#casesensitive)
     - [`constraints`](#constraints)
-    - [`defaultRoute`](#defaultroute)
+    - [`defaultRoute`](#default-route)
     - [`ignoreDuplicateSlashes`](#ignoreduplicateslashes)
     - [`ignoreTrailingSlash`](#ignoretrailingslash)
     - [`maxParamLength`](#maxparamlength)
@@ -922,7 +922,7 @@ const fastify = require('fastify')({
 ```
 
 ### `defaultRoute`
-<a id="on-bad-url"></a>
+<a id="default-route"></a>
 
 Fastify uses [find-my-way](https://github.com/delvedor/find-my-way) which supports,
 can pass a default route with the option defaultRoute.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

## Description

Fixes the defaultRoute documentation anchor in Server.md.

The defaultRoute section was using the same anchor ID as onBadUrl, causing incorrect table-of-contents navigation. This change assigns a unique anchor ID and updates the TOC link accordingly.

<!--
Thank you for your pull request...
...
-->