### PR TITLE
fix(types): add isLevelEnabled to FastifyBaseLogger

### DIFF
--- a/test/types/logger.test-d.ts
+++ b/test/types/logger.test-d.ts
@@ -58,6 +58,7 @@ class CustomLoggerImpl implements CustomLogger {
   silent (...args: unknown[]) { }
 
   child (bindings: P.Bindings, options?: P.ChildLoggerOptions): CustomLoggerImpl { return new CustomLoggerImpl() }
+  isLevelEnabled (_level: string): boolean { return true }
 }
 
 const customLogger = new CustomLoggerImpl()
@@ -274,3 +275,7 @@ expect(childParent.child({}, { level: 'info', redact: ['pass', 'pin'], serialize
 expect(childParent.child).type.not.toBeCallableWith()
 
 expect(childParent.child).type.not.toBeCallableWith({}, { nonExist: true })
+
+expect(fastify().log.isLevelEnabled('info')).type.toBe<boolean>()
+expect(fastify().log.isLevelEnabled('trace')).type.toBe<boolean>()
+expect(fastify().log.isLevelEnabled('silent')).type.toBe<boolean>()

--- a/test/types/register.test-d.ts
+++ b/test/types/register.test-d.ts
@@ -164,7 +164,8 @@ const customLogger = {
   trace: () => { },
   debug: () => { },
   child: () => customLogger,
-  silent: () => { }
+  silent: () => { },
+  isLevelEnabled: (_level: string) => true
 }
 const serverWithTypeProviderAndLogger = fastify({
   loggerInstance: customLogger

--- a/test/types/request.test-d.ts
+++ b/test/types/request.test-d.ts
@@ -170,7 +170,8 @@ const customLogger: CustomLoggerInterface = {
   trace: () => { },
   debug: () => { },
   foo: () => { }, // custom severity logger method
-  child: () => customLogger
+  child: () => customLogger,
+  isLevelEnabled: (_level: string) => true
 }
 
 const serverWithCustomLogger = fastify({ loggerInstance: customLogger })

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -11,6 +11,7 @@ import type {
   BaseLogger,
   LogFn as FastifyLogFn,
   LevelWithSilent as LogLevel,
+  LevelWithSilentOrString,
   Bindings,
   ChildLoggerOptions,
   LoggerOptions as PinoLoggerOptions
@@ -26,6 +27,7 @@ export type {
 
 export interface FastifyBaseLogger extends Pick<BaseLogger, 'level' | 'info' | 'error' | 'debug' | 'fatal' | 'warn' | 'trace' | 'silent'> {
   child(bindings: Bindings, options?: ChildLoggerOptions): FastifyBaseLogger
+  isLevelEnabled(level: LevelWithSilentOrString): boolean
 }
 
 // TODO delete FastifyLoggerInstance in the next major release. It seems that it is enough to have only FastifyBaseLogger.


### PR DESCRIPTION
## What

`isLevelEnabled()` is available at runtime on all pino loggers but was
missing from the `FastifyBaseLogger` TypeScript interface, causing a
type error when calling `server.log.isLevelEnabled('trace')`.

## Changes

- `types/logger.d.ts`: imported `LevelWithSilentOrString` from pino and
  added `isLevelEnabled(level: LevelWithSilentOrString): boolean` to
  `FastifyBaseLogger`
- Updated three existing mock loggers in the type tests to implement the
  new required method

Fixes #5382

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
