### PR TITLE
feat: expose isInjectionRequest on fastify instance

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -268,6 +268,7 @@ function fastify (serverOptions) {
     addHttpMethod,
     // fake http injection
     inject,
+    isInjectionRequest,
     // pretty print of the registered routes
     printRoutes,
     // custom error handling
@@ -502,6 +503,13 @@ function fastify (serverOptions) {
         })
       }, opts)
     }
+  }
+
+  function isInjectionRequest (req) {
+    if (lightMyRequest === undefined) {
+      lightMyRequest = require('light-my-request')
+    }
+    return lightMyRequest.isInjection(req.raw ?? req)
   }
 
   function ready (cb) {

--- a/test/inject.test.js
+++ b/test/inject.test.js
@@ -500,3 +500,37 @@ test('Should not throw on access to routeConfig frameworkErrors handler - FST_ER
     }
   )
 })
+
+test('isInjectionRequest should exist', t => {
+  t.plan(2)
+  const fastify = Fastify()
+  t.assert.ok(fastify.isInjectionRequest)
+  t.assert.strictEqual(typeof fastify.isInjectionRequest, 'function')
+})
+
+test('isInjectionRequest returns true for injected requests', async t => {
+  t.plan(1)
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.get('/test', (req, reply) => {
+    t.assert.strictEqual(fastify.isInjectionRequest(req), true)
+    reply.send({ ok: true })
+  })
+
+  await fastify.inject({ method: 'GET', url: '/test' })
+})
+
+test('isInjectionRequest returns false for real HTTP requests', async t => {
+  t.plan(1)
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.get('/test', (req, reply) => {
+    t.assert.strictEqual(fastify.isInjectionRequest(req), false)
+    reply.send({ ok: true })
+  })
+
+  const address = await fastify.listen({ port: 0 })
+  await fetch(address + '/test')
+})

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -167,6 +167,8 @@ export interface FastifyInstance<
   inject(opts: InjectOptions | string): Promise<LightMyRequestResponse>;
   inject(): LightMyRequestChain;
 
+  isInjectionRequest(req: FastifyRequest | RawRequest): boolean;
+
   listen(opts: FastifyListenOptions, callback: (err: Error | null, address: string) => void): void;
   listen(opts?: FastifyListenOptions): Promise<string>;
   listen(callback: (err: Error | null, address: string) => void): void;


### PR DESCRIPTION
Adds `fastify.isInjectionRequest(req)` as a convenience wrapper around
`light-my-request`'s `isInjection()`. Returns `true` when the request
was made via `fastify.inject()`, `false` for real HTTP requests.

Closes #5615

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)