### PR TITLE
fix: align prefixed route alias url

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -280,6 +280,7 @@ function buildRouting (options) {
 
     function addNewRoute ({ path, prefixing = false, isFastify = false }) {
       const url = prefix + path
+      const configUrl = prefixing === true ? prefix : url
 
       opts.url = url
       opts.path = url
@@ -334,7 +335,7 @@ function buildRouting (options) {
       const constraints = opts.constraints || {}
       const config = {
         ...opts.config,
-        url,
+        url: configUrl,
         method: opts.method
       }
 

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -902,3 +902,38 @@ test('calls onRoute only once when prefixing', async t => {
 
   t.assert.deepStrictEqual(onRouteCalled, 1)
 })
+
+test('keeps routeOptions url consistent for prefixed / route aliases', async t => {
+  t.plan(3)
+  const fastify = Fastify({
+    ignoreTrailingSlash: false,
+    exposeHeadRoutes: false
+  })
+
+  const onRouteUrls = []
+  fastify.register(function (fastify, opts, next) {
+    fastify.addHook('onRoute', routeOptions => {
+      onRouteUrls.push(routeOptions.url)
+    })
+
+    fastify.route({
+      method: 'GET',
+      url: '/',
+      prefixTrailingSlash: 'both',
+      handler: (req, reply) => {
+        reply.send({ routeUrl: req.routeOptions.url })
+      }
+    })
+
+    next()
+  }, { prefix: '/prefix' })
+
+  await fastify.ready()
+
+  const withoutSlash = await fastify.inject('/prefix')
+  const withSlash = await fastify.inject('/prefix/')
+
+  t.assert.deepStrictEqual(onRouteUrls, ['/prefix'])
+  t.assert.deepStrictEqual(JSON.parse(withoutSlash.payload), { routeUrl: '/prefix' })
+  t.assert.deepStrictEqual(JSON.parse(withSlash.payload), { routeUrl: '/prefix' })
+})


### PR DESCRIPTION
Fixes #4424.\n\nWhen a plugin prefix registers a root route with `prefixTrailingSlash: 'both'`, Fastify adds an internal trailing-slash alias without running `onRoute` for that alias. The request-visible route URL should therefore stay aligned with the single user-visible route emitted through `onRoute`.\n\nThis keeps the internal router registration URL unchanged for matching `/prefix/`, but stores the canonical prefixed URL in the route config exposed through `request.routeOptions.url`.\n\nVerification:\n\n- `node --test test/route-prefix.test.js`\n- `npm run lint:eslint -- lib/route.js test/route-prefix.test.js`\n- `git diff --check`\n\nNote: I also tried `npm run unit -- test/route-prefix.test.js`, but the project borp config expanded to the full suite in this local sandbox. Several unrelated listen-based tests failed with `EPERM: operation not permitted ::1`; the targeted single-file Node test above passes.