### PR TITLE
docs(ecosystem): add @thecodepace/fastify-http-query

### DIFF
--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -232,6 +232,9 @@ section.
   Plugin to generate routes automatically with valid json content
 - [`@scalar/fastify-api-reference`](https://github.com/scalar/scalar/tree/main/integrations/fastify)
   Beautiful OpenAPI/Swagger API references for Fastify
+- [`@thecodepace/fastify-http-query`](https://github.com/TheCodePace/fastify-http-query)
+  Fastify plugin enabling the HTTP `QUERY` method (a safe, idempotent, cacheable
+  method with a body) per the IETF draft `draft-ietf-http-bis-safe-method-w-body`.
 - [`@trubavuong/fastify-seaweedfs`](https://github.com/trubavuong/fastify-seaweedfs)
   SeaweedFS for Fastify
 - [`@yeliex/fastify-problem-details`](https://github.com/yeliex/fastify-problem-details)

--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -234,7 +234,7 @@ section.
   Beautiful OpenAPI/Swagger API references for Fastify
 - [`@thecodepace/fastify-http-query`](https://github.com/TheCodePace/fastify-http-query)
   Fastify plugin enabling the HTTP `QUERY` method (a safe, idempotent, cacheable
-  method with a body) per the IETF draft `draft-ietf-http-bis-safe-method-w-body`.
+  method with a body).
 - [`@trubavuong/fastify-seaweedfs`](https://github.com/trubavuong/fastify-seaweedfs)
   SeaweedFS for Fastify
 - [`@yeliex/fastify-problem-details`](https://github.com/yeliex/fastify-problem-details)


### PR DESCRIPTION
Adds **@thecodepace/fastify-http-query** to the [community plugins list](https://fastify.dev/ecosystem/) in `docs/Guides/Ecosystem.md`.

- **Plugin:** [@thecodepace/fastify-http-query](https://github.com/TheCodePace/fastify-http-query)
- **npm:** [https://www.npmjs.com/package/@thecodepace/fastify-http-query](https://www.npmjs.com/package/@thecodepace/fastify-http-query)
- **License:** MIT
- **What it does:** Enables the HTTP `QUERY` method (a safe, idempotent, cacheable request with a body) per the IETF draft `draft-ietf-http-bis-safe-method-w-body`.

The entry is placed alphabetically in the `[Community]` section, between `@scalar/fastify-api-reference` and `@trubavuong/fastify-seaweedfs`. The `Lint Ecosystem Order` CI check has been validated locally before push.