### PR TITLE
fix: guard request.hostname against ipv6 host with no closing bracket

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -246,12 +246,16 @@ Object.defineProperties(Request.prototype, {
   },
   hostname: {
     get () {
+      const host = this.host
       // Check for IPV6 Host
-      if (this.host[0] === '[') {
-        return this.host.slice(0, this.host.indexOf(']') + 1)
+      if (host[0] === '[') {
+        const closingBracket = host.indexOf(']')
+        // A bracketed value without a closing bracket cannot be sliced;
+        // return it unchanged so hostname stays consistent with host.
+        return closingBracket === -1 ? host : host.slice(0, closingBracket + 1)
       }
 
-      return this.host.split(':', 1)[0]
+      return host.split(':', 1)[0]
     }
   },
   port: {

--- a/test/request-hostname.test.js
+++ b/test/request-hostname.test.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const test = require('node:test')
+const Request = require('../lib/request')
+
+test('.hostname parses hostname correctly', (t) => {
+  const fixtures = [
+    {
+      expected: 'example.com',
+      req: {
+        headers: {
+          host: 'example.com:80'
+        }
+      }
+    },
+    {
+      expected: 'example.com',
+      req: {
+        headers: {
+          host: 'example.com'
+        }
+      }
+    },
+    {
+      expected: '[::1]',
+      req: {
+        headers: {
+          host: '[::1]:8080'
+        }
+      }
+    },
+    {
+      expected: '[::1]',
+      req: {
+        headers: {
+          host: '[::1]'
+        }
+      }
+    },
+    {
+      // bracketed value without a closing bracket: stays consistent with host
+      expected: '[::1',
+      req: {
+        headers: {
+          host: '[::1'
+        }
+      }
+    },
+    {
+      expected: '1.2.3.4',
+      req: {
+        headers: {
+          ':authority': '1.2.3.4:80'
+        }
+      }
+    },
+    {
+      expected: '',
+      req: {
+        headers: {}
+      }
+    }
+  ]
+
+  for (const fixture of fixtures) {
+    const req = new Request(1, {}, fixture.req, '', {}, {})
+    t.assert.equal(
+      req.hostname,
+      fixture.expected,
+      `${fixture.req.headers.host} should parse to ${fixture.expected}`
+    )
+  }
+})

--- a/test/request-hostname.test.js
+++ b/test/request-hostname.test.js
@@ -67,7 +67,7 @@ test('.hostname parses hostname correctly', (t) => {
     t.assert.equal(
       req.hostname,
       fixture.expected,
-      `${fixture.req.headers.host} should parse to ${fixture.expected}`
+      `${JSON.stringify(fixture.req.headers)} should parse to ${fixture.expected}`
     )
   }
 })


### PR DESCRIPTION
The IPv6 branch of the `hostname` getter slices on `this.host.indexOf(']') + 1` but never handles the not-found result. A Host header that opens a bracketed literal without a closing bracket, such as `Host: [::1`, makes `indexOf(']')` return -1, so the slice collapses to `slice(0, 0)` and `request.hostname` comes back empty while `request.host` is still `[::1`. I spotted this comparing the two host helpers in the file: `getLastEntryInMultiHeaderValue` guards `lastIndexOf(',') === -1` before slicing, but the IPv6 branch added for bracketed literals skips the equivalent check.

The fix returns the host unchanged when there is no closing bracket, mirroring that existing guard, so a non-empty host can no longer collapse to an empty hostname. Keeping the check inside the getter keeps callers that take host-based decisions on `request.hostname` aligned with `request.host` without each re-parsing the header. Left as is, an allow-list or tenant lookup keyed on `request.hostname` quietly receives an empty string for these malformed inputs while the attacker-supplied value still lives on `request.host`.
