### PR TITLE
docs: fix incorrect defaults, variable names, and code examples in Server.md (#6767)

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -472,7 +472,7 @@ enhance the server instance inside the `serverFactory` function before the
 ### `requestIdHeader`
 <a id="factory-request-id-header"></a>
 
-+ Default: `'request-id'`
++ Default: `false`
 
 The header name used to set the request-id. See [the
 request-id](./Logging.md#logging-request-id) section.
@@ -721,7 +721,7 @@ const fastify = require('fastify')({
       res.code(400)
       return res.send("Provided header is not valid")
     } else {
-      res.send(err)
+      res.send(error)
     }
   }
 })
@@ -847,19 +847,21 @@ function to sanitize a route's store object to use with the `prettyPrint`
 functions. This function should accept a single object and return an object.
 
 ```js
-fastify.get('/user/:username', (request, reply) => {
+const fastify = require('fastify')({
   routerOptions: {
-    buildPrettyMeta: route => {
+    buildPrettyMeta: (route) => {
       const cleanMeta = Object.assign({}, route.store)
-
       // remove private properties
       Object.keys(cleanMeta).forEach(k => {
         if (typeof k === 'symbol') delete cleanMeta[k]
       })
-
       return cleanMeta // this will show up in the pretty print output!
-    })
+    }
   }
+})
+
+fastify.get('/user/:username', (request, reply) => {
+  reply.send({ user: request.params.username })
 })
 ```
 
@@ -1062,8 +1064,9 @@ objects and do not provide Fastify's decorated helpers.
 ### `querystringParser`
 <a id="querystringparser"></a>
 
-The default query string parser that Fastify uses is the Node.js's core
-`querystring` module.
+The default query string parser that Fastify uses is the more performant fork
+of Node.js's core `querystring` module called
+[`fast-querystring`](https://github.com/anonrig/fast-querystring).
 
 You can use this option to use a custom parser, such as
 [`qs`](https://www.npmjs.com/package/qs).
@@ -1084,7 +1087,7 @@ You can also use Fastify's default parser but change some handling behavior,
 like the example below for case insensitive keys and values:
 
 ```js
-const querystring = require('node:querystring')
+const querystring = require('fast-querystring')
 const fastify = require('fastify')({
   routerOptions: {
     querystringParser: str => querystring.parse(str.toLowerCase())


### PR DESCRIPTION
## Summary

Fixes #6767

This PR addresses all five documentation bugs reported in the issue:

### Changes to `docs/Reference/Server.md`

1. **`requestIdHeader` default** (~line 475): Changed `+ Default: 'request-id'` to `+ Default: false` to match the actual codebase default. The surrounding text already correctly stated "By default `requestIdHeader` is set to `false`" — the Default line was self-contradicting.

2. **`frameworkErrors` example** (~line 724): Fixed undefined variable `res.send(err)` → `res.send(error)`. The function parameter is named `error`, so `err` was a bug that would throw `ReferenceError` if executed.

3. **`querystringParser` in routerOptions** (~lines 1065-1087): Updated the description from "Node.js's core `querystring` module" to correctly reference [`fast-querystring`](https://github.com/anonrig/fast-querystring), matching the top-level factory option description. The example code was also updated to `require('fast-querystring')` instead of `require('node:querystring')`.

4. **`buildPrettyMeta` example** (~lines 849-863): The original example showed `buildPrettyMeta` nested inside a route handler body as a JavaScript label, which is syntactically invalid JS. Rewrote the example to correctly demonstrate `buildPrettyMeta` as a `routerOptions` constructor option, with a separate route registration.

### Changes to `docs/Reference/Routes.md`

5. **`serializerCompiler` signature** (~line 105): Reviewed the signature — it is already correct in the current `main` branch (no double braces). No change needed.

#### Checklist

- [x] run `npm run test` (doc-only change, no tests affected)
- [x] documentation is changed or added (this PR IS the documentation fix)
- [x] commit message and code follows the [Code of Conduct](https://github.com/fastify/fastify/blob/main/CODE_OF_CONDUCT.md)