### PR TITLE
fix: derive request.port from x-forwarded-host when trustProxy enabled

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -141,6 +141,24 @@ function buildRequestWithTrustProxy (R, trustProxy) {
           return this.socket.encrypted ? 'https' : 'http'
         }
       }
+    },
+    port: {
+      get () {
+        const portReg = /(?<port>:\d+)$/
+        // First try the (possibly forwarded) host
+        let host = this.host
+        const matches = portReg.exec(host)
+        if (matches === null || matches[1] === undefined) {
+          // Fallback to raw Host header (like non-trust-proxy behavior)
+          host = this.headers.host ?? this.headers[':authority'] ?? ''
+          const fallbackMatches = portReg.exec(host)
+          if (fallbackMatches === null || fallbackMatches[1] === undefined) {
+            return null
+          }
+          return parseInt(fallbackMatches.groups.port.slice(1), 10)
+        }
+        return parseInt(matches.groups.port.slice(1), 10)
+      }
     }
   })
 

--- a/test/trust-proxy.test.js
+++ b/test/trust-proxy.test.js
@@ -163,6 +163,30 @@ test('trust proxy protocol', async t => {
   await fetchForwardedRequest(fastifyServer, '1.1.1.1', '/trustproxyprotocols', 'ipsum, dolor')
 })
 
+test('trust proxy derives port from x-forwarded-host', async t => {
+  t.plan(2)
+  const app = fastify({
+    trustProxy: true
+  })
+  t.after(() => app.close())
+
+  app.get('/forwarded-port', function (req, reply) {
+    t.assert.strictEqual(req.port, 8080, 'port derived from x-forwarded-host')
+    reply.code(200).send({ port: req.port })
+  })
+
+  const fastifyServer = await app.listen({ port: 0 })
+
+  // Send x-forwarded-host with a port
+  const response = await fetch(fastifyServer + '/forwarded-port', {
+    headers: {
+      'X-Forwarded-For': '1.1.1.1',
+      'X-Forwarded-Host': 'example.com:8080'
+    }
+  })
+  t.assert.strictEqual(response.status, 200)
+})
+
 test('trust proxy ignores forwarded headers from untrusted connections', async t => {
   t.plan(3)
 


### PR DESCRIPTION
## Problem (#6671)

When `trustProxy` is enabled, `request.host` returns the value from the `X-Forwarded-Host` header. However, `request.port` was still reading from the raw `Host` header, causing `port` and `host` to be inconsistent.

For example, with `X-Forwarded-Host: fastify.test:1234`:
- `request.host` = `fastify.test:1234` (correct)
- `request.hostname` = `fastify.test` (correct)
- `request.port` = actual server port (incorrect -- should be `1234`)

This directly contradicts the [documentation](https://fastify.dev/docs/latest/Reference/Request/):
> port - The port from the host property

## Fix

Added a `port` getter to `buildRequestWithTrustProxy` that:
1. First tries to extract the port from `this.host` (which respects `X-Forwarded-Host`)
2. Falls back to the raw `Host` header if the forwarded host has no port

This matches the behavior of `hostname`, which already derives from `this.host` in trust proxy mode.

## Testing

- All 2250 existing tests pass
- Added new test: "trust proxy derives port from x-forwarded-host"
- Tested manually with both forwarded and non-forwarded hosts