### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/docs/Guides/Getting-Started.md
+++ b/docs/Guides/Getting-Started.md
@@ -23,6 +23,11 @@ Install with yarn:
 yarn add fastify
 ```
 
+Install with Deno:
+```sh
+deno add fastify
+```
+
 ### Your first server
 <a id="first-server"></a>
 


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The Getting Started install section lists npm and yarn. Since Deno is a drop-in replacement for npm these days, this adds a Deno line in parity:

```sh
deno add fastify
```

Docs-only change. Totally fine to close this if you'd rather not. Happy to adjust.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
