### PR TITLE
fix: clear socket._meta after response to prevent keep-alive leaks

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -961,6 +961,13 @@ function setupResponseListeners (reply) {
       }
     }
 
+    // Fix: release socket._meta so request/reply objects are not retained
+    // past the response on keep-alive connections.
+    const socket = reply.request.raw.socket
+    if (socket && socket._meta && socket._meta.request === reply.request) {
+      socket._meta = null
+    }
+
     if (ctx && ctx.onResponse !== null) {
       onResponseHookRunner(
         ctx.onResponse,

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -3278,6 +3278,28 @@ test('onTimeout should be triggered and socket _meta is set', async t => {
   }
 })
 
+test('socket._meta is cleared after response to prevent keep-alive leaks', async t => {
+  t.plan(3)
+  const fastify = Fastify({ connectionTimeout: 500 })
+  t.after(() => { fastify.close() })
+
+  fastify.addHook('onTimeout', function (req, res, done) { done() })
+
+  fastify.addHook('onResponse', function (req, reply, done) {
+    t.assert.strictEqual(req.raw.socket._meta, null, 'socket._meta must be null after response')
+    done()
+  })
+
+  fastify.get('/', async (req, reply) => {
+    return { hello: 'world' }
+  })
+
+  const address = await fastify.listen({ port: 0 })
+  const result = await fetch(address)
+  t.assert.ok(result.ok)
+  t.assert.strictEqual(result.status, 200)
+})
+
 test('registering invalid hooks should throw an error', async t => {
   t.plan(3)
 


### PR DESCRIPTION
## Summary

- **`socket._meta` held context/request/reply alive for the full lifetime of a keep-alive socket**; now cleared in `onResFinished` when the current request owns `_meta` (`socket._meta.request === request` check prevents a race where a concurrent request has already updated `_meta`)

## Files changed

| File | Change |
|---|---|
| `lib/reply.js` | In `onResFinished`: clears `socket._meta` when this request owns it |

## Test plan

- [x] Added test in `test/hooks.test.js` — registers an `onTimeout` hook (which triggers `_meta` to be set), then asserts `socket._meta === null` inside `onResponse`, which fires after the cleanup runs
- [x] Existing `test/handler-timeout.test.js` — 19/19 pass
- [x] Existing `test/hooks.test.js` — 92/92 pass (covers `onRequestAbort` and `onTimeout`)
- [x] Existing `test/keep-alive-timeout.test.js` — 2/2 pass
- [x] Existing `test/client-timeout.test.js` — pass

## Checklist

- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added (no public API change)
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)