### PR TITLE
fix: avoid double slash when joining nested prefixes

### DIFF
--- a/lib/plugin-override.js
+++ b/lib/plugin-override.js
@@ -82,7 +82,8 @@ function buildRoutePrefix (instancePrefix, pluginPrefix) {
   if (instancePrefix.endsWith('/') && pluginPrefix[0] === '/') {
     // Remove the extra '/' to avoid: '/first//second'
     pluginPrefix = pluginPrefix.slice(1)
-  } else if (pluginPrefix[0] !== '/') {
+  } else if (pluginPrefix[0] !== '/' && !instancePrefix.endsWith('/')) {
+    // Add the missing '/' to avoid: '/firstsecond'
     pluginPrefix = '/' + pluginPrefix
   }
 

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -241,6 +241,40 @@ test('Prefix with trailing /', (t, testDone) => {
   completion.patience.then(testDone)
 })
 
+test('Prefix with trailing / and nested prefix without leading /', (t, testDone) => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.register(function (fastify, opts, done) {
+    fastify.register(function (fastify, opts, done) {
+      fastify.get('/route', (req, reply) => {
+        reply.send({ hello: 'world' })
+      })
+      done()
+    }, { prefix: 'inner' })
+    done()
+  }, { prefix: '/v1/' })
+
+  const completion = waitForCb({ steps: 2 })
+  fastify.inject({
+    method: 'GET',
+    url: '/v1/inner/route'
+  }, (err, res) => {
+    t.assert.ifError(err)
+    t.assert.deepStrictEqual(JSON.parse(res.payload), { hello: 'world' })
+    completion.stepIn()
+  })
+  fastify.inject({
+    method: 'GET',
+    url: '/v1//inner/route'
+  }, (err, res) => {
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 404)
+    completion.stepIn()
+  })
+  completion.patience.then(testDone)
+})
+
 test('Prefix works multiple levels deep', (t, testDone) => {
   t.plan(2)
   const fastify = Fastify()


### PR DESCRIPTION
## What

`buildRoutePrefix` joins a parent register's prefix with a child register's
prefix and is meant to keep exactly one `/` between them (per the existing
`'/first//second'` comment). It misses the case where the parent prefix ends
with `/` and the child prefix has no leading `/`: it prepends a `/` anyway and
produces a double slash.

For example:

```js
fastify.register(function (instance, opts, done) {
  instance.register(function (sub, opts, done) {
    sub.get('/route', handler)
    done()
  }, { prefix: 'inner' })   // no leading slash
  done()
}, { prefix: '/v1/' })      // trailing slash
```

registers the route at `/v1//inner/route` instead of `/v1/inner/route`. With the
default `ignoreDuplicateSlashes: false`, `GET /v1/inner/route` then returns 404.

## How

Only prepend the separating `/` when the parent prefix does not already end with
one. This matches the existing route-path handling in `lib/route.js` ("Ensure
that '/prefix/' + '/route' gets registered as '/prefix/route'").

## Testing

Added a test in `test/route-prefix.test.js` for a trailing-slash parent prefix
combined with a no-leading-slash child prefix. It fails before the change and
passes after. Lint, the full unit suite, type tests, and the 100% coverage check
pass locally.
