### PR TITLE
ci: run the test suite under Deno

### DIFF
--- a/.github/workflows/ci-deno.yml
+++ b/.github/workflows/ci-deno.yml
@@ -1,0 +1,54 @@
+name: ci Deno
+
+on:
+  push:
+    branches:
+      - main
+      - next
+      - 'v*'
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test-unit:
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        deno-version: [v2.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      # Node is used only to install fastify's dev dependencies; the test
+      # files themselves are run by Deno via its `node:test` compatibility.
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: ${{ matrix.deno-version }}
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Run unit tests with Deno
+        run: deno test --allow-all --no-check --no-lock test/

--- a/.github/workflows/ci-deno.yml
+++ b/.github/workflows/ci-deno.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deno-version: canary
+        deno-version: [v2.9.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
@@ -42,7 +42,7 @@ jobs:
           deno-version: ${{ matrix.deno-version }}
 
       - name: Install dependencies
-        run: deno install --ignore-scripts
+        run: deno install
 
       - name: Run unit tests with Deno
         run: deno test --allow-all --no-check --no-lock test/

--- a/.github/workflows/ci-deno.yml
+++ b/.github/workflows/ci-deno.yml
@@ -16,7 +16,7 @@ on:
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
-  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  group: "${{ github.workflow }}-${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
   cancel-in-progress: true
 
 permissions:
@@ -30,25 +30,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deno-version: [v2.x]
+        deno-version: canary
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
-      # Node is used only to install fastify's dev dependencies; the test
-      # files themselves are run by Deno via its `node:test` compatibility.
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 20
-
-      - uses: denoland/setup-deno@v2
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: ${{ matrix.deno-version }}
 
       - name: Install dependencies
-        run: npm install --ignore-scripts
+        run: deno install --ignore-scripts
 
       - name: Run unit tests with Deno
         run: deno test --allow-all --no-check --no-lock test/


### PR DESCRIPTION
👋 Bartek from the Deno team here. This is the companion to #6797: a CI workflow that runs fastify's existing test suite under Deno.

Deno runs fastify's `node:test` files directly through its `node:test` compatibility layer, so no test rewrites are needed. The new `.github/workflows/ci-deno.yml` installs the dev dependencies with Node, then runs the suite with `deno test --allow-all test/` across Linux, macOS, and Windows on Deno 2.x.

### Status: draft

Running the full suite today gives roughly **1272 passing / 50 failing**. Digging into the failures, almost all of them trace back to **two bugs in Deno's `node:test` compatibility**, not to fastify. I've reduced both to minimal, fastify-free repros and filed them upstream:

1. **`t.after()` runs too early** — denoland/deno#35390. A parent test's `t.after()` hook fires after the *first* subtest instead of after the parent completes, closing shared servers early. This cascades into most of the failures (later subtests get `Connection refused`, and `server.address()` then returns `null`).
2. **Nested top-level `test()` rejected** — denoland/deno#35391. Calling the top-level `test()` inside another test throws `Nested Deno.test() calls are not supported`, which Node allows.

We're going to fix both on the Deno side. Once they land, I expect the suite to be green (or very close), and I'll update this PR. Opening as a draft so you can see the wiring and the path to passing.

If you're happy with the approach, the plan is to get this green and keep it that way, per the conditions you raised in #6797.

_This PR was opened with AI assistance under human supervision._
