### PR TITLE
docs: fix incorrect defaults and code examples in Server.md

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -521,7 +521,7 @@ out [hyperid](https://github.com/mcollina/hyperid).
 > ℹ️ Note:
 > `genReqId` will be not called if the header set in
 > <code>[requestIdHeader](#requestidheader)</code> is available (defaults to
-> 'request-id').
+> `false`).
 
 ```js
 let i = 0
@@ -721,7 +721,7 @@ const fastify = require('fastify')({
       res.code(400)
       return res.send("Provided header is not valid")
     } else {
-      res.send(err)
+      res.send(error)
     }
   }
 })
@@ -847,7 +847,7 @@ function to sanitize a route's store object to use with the `prettyPrint`
 functions. This function should accept a single object and return an object.
 
 ```js
-fastify.get('/user/:username', (request, reply) => {
+const fastify = require('fastify')({
   routerOptions: {
     buildPrettyMeta: route => {
       const cleanMeta = Object.assign({}, route.store)
@@ -858,7 +858,7 @@ fastify.get('/user/:username', (request, reply) => {
       })
 
       return cleanMeta // this will show up in the pretty print output!
-    })
+    }
   }
 })
 ```
@@ -1062,8 +1062,9 @@ objects and do not provide Fastify's decorated helpers.
 ### `querystringParser`
 <a id="querystringparser"></a>
 
-The default query string parser that Fastify uses is the Node.js's core
-`querystring` module.
+The default query string parser that Fastify uses is a more performant fork
+of Node.js's core `querystring` module called
+[`fast-querystring`](https://github.com/anonrig/fast-querystring).
 
 You can use this option to use a custom parser, such as
 [`qs`](https://www.npmjs.com/package/qs).
@@ -1084,7 +1085,7 @@ You can also use Fastify's default parser but change some handling behavior,
 like the example below for case insensitive keys and values:
 
 ```js
-const querystring = require('node:querystring')
+const querystring = require('fast-querystring')
 const fastify = require('fastify')({
   routerOptions: {
     querystringParser: str => querystring.parse(str.toLowerCase())

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -519,7 +519,7 @@ generation behavior as shown below. For generating `UUID`s you may want to check
 out [hyperid](https://github.com/mcollina/hyperid).
 
 > ℹ️ Note:
-> `genReqId` will be not called if the header set in
+> `genReqId` will not be called if the header set in
 > <code>[requestIdHeader](#requestidheader)</code> is available (defaults to
 > `false`).
 


### PR DESCRIPTION
Fixes #6767

Corrects four documentation inaccuracies in `docs/Reference/Server.md`:

1. **`genReqId` note** (line ~523): stated `requestIdHeader` defaults to `'request-id'`, but the actual default is `false` (see `fastify.js` line 877).

2. **`frameworkErrors` example** (line ~724): the handler parameter is `error` but the example referenced undefined `err`.

3. **`buildPrettyMeta` example** (lines ~849-863): was incorrectly nested inside a route handler (`fastify.get(...)`), making it syntactically invalid. Corrected to show it as a factory `routerOptions` configuration.

4. **`querystringParser` under routerOptions** (lines ~1065-1093): stated the default is "Node.js's core `querystring` module" and imported `node:querystring` in the example. The actual default is [`fast-querystring`](https://github.com/anonrig/fast-querystring), matching the description in the top-level factory option section.

Bug 3 from the issue (`serializerCompiler` double braces in Routes.md) appears to already be fixed on main.
