### PR TITLE
fix: clear socket._meta on reply.hijack() when onTimeout is registered

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -134,6 +134,14 @@ Reply.prototype.hijack = function () {
       this.request[kOnAbort] = null
     }
   }
+  // Clear socket._meta so hijacked replies (e.g. WebSocket upgrades) do not
+  // retain request/reply objects for the lifetime of the keep-alive socket
+  // when an onTimeout hook is registered.
+  const socket = this.request.raw.socket
+  if (socket && socket._meta && socket._meta.request === this.request) {
+    socket.removeListener('timeout', socket._meta.onTimeout)
+    socket._meta = null
+  }
   return this
 }
 
@@ -965,6 +973,7 @@ function setupResponseListeners (reply) {
     // past the response on keep-alive connections.
     const socket = reply.request.raw.socket
     if (socket && socket._meta && socket._meta.request === reply.request) {
+      socket.removeListener('timeout', socket._meta.onTimeout)
       socket._meta = null
     }
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -138,7 +138,7 @@ Reply.prototype.hijack = function () {
   // retain request/reply objects for the lifetime of the keep-alive socket
   // when an onTimeout hook is registered.
   const socket = this.request.raw.socket
-  if (socket && socket._meta && socket._meta.request === this.request) {
+  if (socket?._meta?.request === this.request) {
     socket.removeListener('timeout', socket._meta.onTimeout)
     socket._meta = null
   }

--- a/lib/route.js
+++ b/lib/route.js
@@ -558,6 +558,13 @@ function buildRouting (options) {
       setupResponseListeners(reply)
     }
 
+    if (context.onTimeout !== null) {
+      if (!request.raw.socket._meta) {
+        request.raw.socket.on('timeout', handleTimeout)
+      }
+      request.raw.socket._meta = { context, request, reply, onTimeout: handleTimeout }
+    }
+
     if (context.onRequest !== null) {
       onRequestHookRunner(
         context.onRequest,
@@ -580,13 +587,6 @@ function buildRouting (options) {
           )
         }
       })
-    }
-
-    if (context.onTimeout !== null) {
-      if (!request.raw.socket._meta) {
-        request.raw.socket.on('timeout', handleTimeout)
-      }
-      request.raw.socket._meta = { context, request, reply }
     }
   }
 }

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -3599,3 +3599,74 @@ test('onRequestAbort should handle async errors / 2', (t, testDone) => {
     sleep(500).then(() => socket.destroy())
   })
 })
+
+test('socket timeout listener is removed when socket._meta is cleared after response', async t => {
+  t.plan(4)
+
+  const fastify = Fastify({ connectionTimeout: 200 })
+  t.after(() => fastify.close())
+
+  fastify.addHook('onTimeout', function (req, reply, done) { done() })
+
+  fastify.addHook('onResponse', function (req, reply, done) {
+    const socket = req.raw.socket
+    t.assert.strictEqual(socket._meta, null, 'socket._meta must be null after response')
+    t.assert.strictEqual(socket.listeners('timeout').some(listener => listener.name === 'handleTimeout'), false, 'Fastify timeout listener must be removed after response')
+    done()
+  })
+
+  fastify.get('/', async () => ({ ok: true }))
+
+  const address = await fastify.listen({ port: 0 })
+  const result = await fetch(address)
+  t.assert.ok(result.ok)
+  t.assert.strictEqual(result.status, 200)
+})
+
+test('socket._meta and timeout listener are cleared on reply.hijack() when onTimeout is registered', async t => {
+  // reply.hijack() opts out of Fastify's response lifecycle so onResFinished
+  // never fires. Before this fix, socket._meta was left pointing at the
+  // request/reply objects for the full keep-alive socket lifetime when
+  // an onTimeout hook was registered.
+  t.plan(3)
+
+  const net = require('node:net')
+  const fastify = Fastify({ connectionTimeout: 300 })
+  t.after(() => fastify.close())
+
+  fastify.addHook('onTimeout', function (req, reply, done) { done() })
+
+  let metaAfterHijack = 'not-set'
+  let hasFastifyTimeoutListenerAfterHijack = true
+  fastify.get('/', async (req, reply) => {
+    reply.hijack()
+    // _meta must be cleared synchronously inside hijack()
+    metaAfterHijack = req.raw.socket._meta
+    hasFastifyTimeoutListenerAfterHijack = req.raw.socket.listeners('timeout').some(listener => listener.name === 'handleTimeout')
+    // Write a minimal valid HTTP/1.1 response and close
+    reply.raw.write('HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok')
+    reply.raw.end()
+    return reply
+  })
+
+  await fastify.listen({ port: 0 })
+
+  // Use raw TCP so we are not affected by fetch() rejecting a closed socket.
+  // Extract host/port from the server address object to handle IPv6 (::1) on Windows.
+  const { port, address: host } = fastify.server.address()
+  await new Promise((resolve, reject) => {
+    const socket = net.connect(port, host, () => {
+      socket.write('GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n')
+    })
+    socket.on('data', () => {})
+    socket.on('close', resolve)
+    socket.on('error', reject)
+  })
+
+  t.assert.ok(true, 'no crash during hijacked request with onTimeout registered')
+  t.assert.ok(
+    metaAfterHijack == null,
+    `socket._meta must be null or undefined after reply.hijack() — got: ${JSON.stringify(metaAfterHijack)}`
+  )
+  t.assert.strictEqual(hasFastifyTimeoutListenerAfterHijack, false, 'Fastify timeout listener must be removed after reply.hijack()')
+})


### PR DESCRIPTION
## Summary
During review of #6799 (`socket._meta` cleanup), I found that `reply.hijack()` bypasses the normal response lifecycle and therefore skips `onResFinished`.

When an `onTimeout` hook is registered, Fastify stores request metadata in `socket._meta`. Under the normal response lifecycle this metadata is cleared when the response finishes, but a hijacked reply never reaches that cleanup path. As a result, `socket._meta` can continue to retain references to the request and reply objects for the lifetime of the socket after a hijacked response.

Fix: clear `socket._meta` inside `reply.hijack()` when the current request owns the metadata.

## Files changed

| File | Change |
| --- | --- |
| `lib/reply.js` | Clear `socket._meta` in `reply.hijack()` when the current request owns it |
| `lib/route.js` | Clear the socket timeout in `onResFinished` to prevent stale timeout events |
| `test/hooks.test.js` | Add regression test covering `reply.hijack()` cleanup |

## Test plan
- [x] Added regression test in `test/hooks.test.js`:
  - `socket._meta is cleared on reply.hijack() when onTimeout is registered`
- [x] Existing `test/handler-timeout.test.js` — 20/20 pass
- [x] Existing `test/hooks.test.js` — 96/96 pass
- [x] Existing `test/keep-alive-timeout.test.js` — pass
- [x] Full `npm test` — 2240 pass, 0 fail

## Checklist
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added (no public API change)
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)