### PR TITLE
feat: validate route params against schema at startup

### DIFF
--- a/build/build-validation.js
+++ b/build/build-validation.js
@@ -45,6 +45,7 @@ const defaultInitOptions = {
   exposeHeadRoutes: true,
   useSemicolonDelimiter: false,
   allowErrorHandlerOverride: true, // TODO: set to false in v6
+  validateRouteParams: false,
   routerOptions: {
     ignoreTrailingSlash: false,
     ignoreDuplicateSlashes: false,
@@ -111,6 +112,7 @@ const schema = {
     http2SessionTimeout: { type: 'integer', default: defaultInitOptions.http2SessionTimeout },
     exposeHeadRoutes: { type: 'boolean', default: defaultInitOptions.exposeHeadRoutes },
     useSemicolonDelimiter: { type: 'boolean', default: defaultInitOptions.useSemicolonDelimiter },
+    validateRouteParams: { type: 'boolean', default: defaultInitOptions.validateRouteParams },
     routerOptions: {
       type: 'object',
       additionalProperties: true,

--- a/fastify.js
+++ b/fastify.js
@@ -75,7 +75,8 @@ const {
   FST_ERR_SCHEMA_ERROR_FORMATTER_NOT_FN,
   FST_ERR_ERROR_HANDLER_NOT_FN,
   FST_ERR_ERROR_HANDLER_ALREADY_SET,
-  FST_ERR_ROUTE_METHOD_INVALID
+  FST_ERR_ROUTE_METHOD_INVALID,
+  FST_ERR_ROUTE_PARAMS_SCHEMA_MISMATCH
 } = errorCodes
 
 const { buildErrorHandler } = require('./lib/error-handler.js')
@@ -441,6 +442,61 @@ function fastify (serverOptions) {
     throwIfAlreadyStarted,
     keepAliveConnections
   })
+
+  // When validateRouteParams is enabled, check that every route's schema.params
+  // properties match the dynamic parameters in the route URL at startup time.
+  if (options.validateRouteParams === true) {
+    const kRoutes = Symbol('fastify.validateRouteParams.routes')
+    fastify[kRoutes] = []
+
+    fastify.addHook('onRoute', function (routeOptions) {
+      fastify[kRoutes].push(routeOptions)
+    })
+
+    fastify.addHook('onReady', function () {
+      for (const routeOptions of fastify[kRoutes]) {
+        const schema = routeOptions.schema
+        if (!schema || !schema.params) {
+          continue
+        }
+
+        // Only validate object schemas with properties
+        const schemaParams = schema.params.properties
+        if (!schemaParams) {
+          continue
+        }
+
+        const route = fastify.findRoute({
+          method: Array.isArray(routeOptions.method) ? routeOptions.method[0] : routeOptions.method,
+          url: routeOptions.url,
+          constraints: routeOptions.constraints
+        })
+
+        if (!route) {
+          continue
+        }
+
+        const schemaParamNames = Object.keys(schemaParams)
+        const urlParamNames = Object.keys(route.params)
+
+        for (const param of schemaParamNames) {
+          if (!urlParamNames.includes(param)) {
+            throw new FST_ERR_ROUTE_PARAMS_SCHEMA_MISMATCH(
+              `Route '${routeOptions.url}' has a schema param '${param}' but it is not in the route path`
+            )
+          }
+        }
+
+        for (const param of urlParamNames) {
+          if (!schemaParamNames.includes(param)) {
+            throw new FST_ERR_ROUTE_PARAMS_SCHEMA_MISMATCH(
+              `Route '${routeOptions.url}' has a path param ':${param}' but it is not defined in the schema`
+            )
+          }
+        }
+      }
+    })
+  }
 
   // Delay configuring clientError handler so that it can access fastify state.
   server.on('clientError', options.clientErrorHandler.bind(fastify))

--- a/lib/config-validator.js
+++ b/lib/config-validator.js
@@ -3,7 +3,7 @@
 "use strict";
 module.exports = validate10;
 module.exports.default = validate10;
-const schema11 = {"type":"object","additionalProperties":false,"properties":{"connectionTimeout":{"type":"integer","default":0},"keepAliveTimeout":{"type":"integer","default":72000},"forceCloseConnections":{"oneOf":[{"type":"string","pattern":"idle"},{"type":"boolean"}]},"maxRequestsPerSocket":{"type":"integer","default":0,"nullable":true},"requestTimeout":{"type":"integer","default":0},"handlerTimeout":{"type":"integer","default":0},"bodyLimit":{"type":"integer","default":1048576},"caseSensitive":{"type":"boolean","default":true},"allowUnsafeRegex":{"type":"boolean","default":false},"http2":{"type":"boolean"},"https":{"if":{"not":{"oneOf":[{"type":"boolean"},{"type":"null"},{"type":"object","additionalProperties":false,"required":["allowHTTP1"],"properties":{"allowHTTP1":{"type":"boolean"}}}]}},"then":{"setDefaultValue":true}},"ignoreTrailingSlash":{"type":"boolean","default":false},"ignoreDuplicateSlashes":{"type":"boolean","default":false},"disableRequestLogging":{"default":false},"maxParamLength":{"type":"integer","default":100},"onProtoPoisoning":{"type":"string","default":"error"},"onConstructorPoisoning":{"type":"string","default":"error"},"pluginTimeout":{"type":"integer","default":10000},"requestIdHeader":{"anyOf":[{"type":"boolean"},{"type":"string"}],"default":false},"requestIdLogLabel":{"type":"string","default":"reqId"},"http2SessionTimeout":{"type":"integer","default":72000},"exposeHeadRoutes":{"type":"boolean","default":true},"useSemicolonDelimiter":{"type":"boolean","default":false},"routerOptions":{"type":"object","additionalProperties":true,"properties":{"ignoreTrailingSlash":{"type":"boolean","default":false},"ignoreDuplicateSlashes":{"type":"boolean","default":false},"maxParamLength":{"type":"integer","default":100},"allowUnsafeRegex":{"type":"boolean","default":false},"useSemicolonDelimiter":{"type":"boolean","default":false}}},"constraints":{"type":"object","additionalProperties":{"type":"object","required":["name","storage","validate","deriveConstraint"],"additionalProperties":true,"properties":{"name":{"type":"string"},"storage":{},"validate":{},"deriveConstraint":{}}}}}};
+const schema11 = {"type":"object","additionalProperties":false,"properties":{"connectionTimeout":{"type":"integer","default":0},"keepAliveTimeout":{"type":"integer","default":72000},"forceCloseConnections":{"oneOf":[{"type":"string","pattern":"idle"},{"type":"boolean"}]},"maxRequestsPerSocket":{"type":"integer","default":0,"nullable":true},"requestTimeout":{"type":"integer","default":0},"handlerTimeout":{"type":"integer","default":0},"bodyLimit":{"type":"integer","default":1048576},"caseSensitive":{"type":"boolean","default":true},"allowUnsafeRegex":{"type":"boolean","default":false},"http2":{"type":"boolean"},"https":{"if":{"not":{"oneOf":[{"type":"boolean"},{"type":"null"},{"type":"object","additionalProperties":false,"required":["allowHTTP1"],"properties":{"allowHTTP1":{"type":"boolean"}}}]}},"then":{"setDefaultValue":true}},"ignoreTrailingSlash":{"type":"boolean","default":false},"ignoreDuplicateSlashes":{"type":"boolean","default":false},"disableRequestLogging":{"default":false},"maxParamLength":{"type":"integer","default":100},"onProtoPoisoning":{"type":"string","default":"error"},"onConstructorPoisoning":{"type":"string","default":"error"},"pluginTimeout":{"type":"integer","default":10000},"requestIdHeader":{"anyOf":[{"type":"boolean"},{"type":"string"}],"default":false},"requestIdLogLabel":{"type":"string","default":"reqId"},"http2SessionTimeout":{"type":"integer","default":72000},"exposeHeadRoutes":{"type":"boolean","default":true},"useSemicolonDelimiter":{"type":"boolean","default":false},"validateRouteParams":{"type":"boolean","default":false},"routerOptions":{"type":"object","additionalProperties":true,"properties":{"ignoreTrailingSlash":{"type":"boolean","default":false},"ignoreDuplicateSlashes":{"type":"boolean","default":false},"maxParamLength":{"type":"integer","default":100},"allowUnsafeRegex":{"type":"boolean","default":false},"useSemicolonDelimiter":{"type":"boolean","default":false}}},"constraints":{"type":"object","additionalProperties":{"type":"object","required":["name","storage","validate","deriveConstraint"],"additionalProperties":true,"properties":{"name":{"type":"string"},"storage":{},"validate":{},"deriveConstraint":{}}}}}};
 const func2 = Object.prototype.hasOwnProperty;
 const pattern0 = new RegExp("idle", "u");
 
@@ -71,6 +71,9 @@ data.exposeHeadRoutes = true;
 }
 if(data.useSemicolonDelimiter === undefined){
 data.useSemicolonDelimiter = false;
+}
+if(data.validateRouteParams === undefined){
+data.validateRouteParams = false;
 }
 const _errs1 = errors;
 for(const key0 in data){
@@ -1004,52 +1007,52 @@ data["useSemicolonDelimiter"] = coerced25;
 }
 var valid0 = _errs67 === errors;
 if(valid0){
-if(data.routerOptions !== undefined){
-let data23 = data.routerOptions;
+let data23 = data.validateRouteParams;
 const _errs69 = errors;
-if(errors === _errs69){
-if(data23 && typeof data23 == "object" && !Array.isArray(data23)){
-if(data23.ignoreTrailingSlash === undefined){
-data23.ignoreTrailingSlash = false;
-}
-if(data23.ignoreDuplicateSlashes === undefined){
-data23.ignoreDuplicateSlashes = false;
-}
-if(data23.maxParamLength === undefined){
-data23.maxParamLength = 100;
-}
-if(data23.allowUnsafeRegex === undefined){
-data23.allowUnsafeRegex = false;
-}
-if(data23.useSemicolonDelimiter === undefined){
-data23.useSemicolonDelimiter = false;
-}
-let data24 = data23.ignoreTrailingSlash;
-const _errs72 = errors;
-if(typeof data24 !== "boolean"){
+if(typeof data23 !== "boolean"){
 let coerced26 = undefined;
 if(!(coerced26 !== undefined)){
-if(data24 === "false" || data24 === 0 || data24 === null){
+if(data23 === "false" || data23 === 0 || data23 === null){
 coerced26 = false;
 }
-else if(data24 === "true" || data24 === 1){
+else if(data23 === "true" || data23 === 1){
 coerced26 = true;
 }
 else {
-validate10.errors = [{instancePath:instancePath+"/routerOptions/ignoreTrailingSlash",schemaPath:"#/properties/routerOptions/properties/ignoreTrailingSlash/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
+validate10.errors = [{instancePath:instancePath+"/validateRouteParams",schemaPath:"#/properties/validateRouteParams/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
 return false;
 }
 }
 if(coerced26 !== undefined){
-data24 = coerced26;
-if(data23 !== undefined){
-data23["ignoreTrailingSlash"] = coerced26;
+data23 = coerced26;
+if(data !== undefined){
+data["validateRouteParams"] = coerced26;
 }
 }
 }
-var valid7 = _errs72 === errors;
-if(valid7){
-let data25 = data23.ignoreDuplicateSlashes;
+var valid0 = _errs69 === errors;
+if(valid0){
+if(data.routerOptions !== undefined){
+let data24 = data.routerOptions;
+const _errs71 = errors;
+if(errors === _errs71){
+if(data24 && typeof data24 == "object" && !Array.isArray(data24)){
+if(data24.ignoreTrailingSlash === undefined){
+data24.ignoreTrailingSlash = false;
+}
+if(data24.ignoreDuplicateSlashes === undefined){
+data24.ignoreDuplicateSlashes = false;
+}
+if(data24.maxParamLength === undefined){
+data24.maxParamLength = 100;
+}
+if(data24.allowUnsafeRegex === undefined){
+data24.allowUnsafeRegex = false;
+}
+if(data24.useSemicolonDelimiter === undefined){
+data24.useSemicolonDelimiter = false;
+}
+let data25 = data24.ignoreTrailingSlash;
 const _errs74 = errors;
 if(typeof data25 !== "boolean"){
 let coerced27 = undefined;
@@ -1061,69 +1064,69 @@ else if(data25 === "true" || data25 === 1){
 coerced27 = true;
 }
 else {
-validate10.errors = [{instancePath:instancePath+"/routerOptions/ignoreDuplicateSlashes",schemaPath:"#/properties/routerOptions/properties/ignoreDuplicateSlashes/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
+validate10.errors = [{instancePath:instancePath+"/routerOptions/ignoreTrailingSlash",schemaPath:"#/properties/routerOptions/properties/ignoreTrailingSlash/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
 return false;
 }
 }
 if(coerced27 !== undefined){
 data25 = coerced27;
-if(data23 !== undefined){
-data23["ignoreDuplicateSlashes"] = coerced27;
+if(data24 !== undefined){
+data24["ignoreTrailingSlash"] = coerced27;
 }
 }
 }
 var valid7 = _errs74 === errors;
 if(valid7){
-let data26 = data23.maxParamLength;
+let data26 = data24.ignoreDuplicateSlashes;
 const _errs76 = errors;
-if(!(((typeof data26 == "number") && (!(data26 % 1) && !isNaN(data26))) && (isFinite(data26)))){
-let dataType28 = typeof data26;
+if(typeof data26 !== "boolean"){
 let coerced28 = undefined;
 if(!(coerced28 !== undefined)){
-if(dataType28 === "boolean" || data26 === null
-              || (dataType28 === "string" && data26 && data26 == +data26 && !(data26 % 1))){
-coerced28 = +data26;
+if(data26 === "false" || data26 === 0 || data26 === null){
+coerced28 = false;
+}
+else if(data26 === "true" || data26 === 1){
+coerced28 = true;
+}
+else {
+validate10.errors = [{instancePath:instancePath+"/routerOptions/ignoreDuplicateSlashes",schemaPath:"#/properties/routerOptions/properties/ignoreDuplicateSlashes/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
+return false;
+}
+}
+if(coerced28 !== undefined){
+data26 = coerced28;
+if(data24 !== undefined){
+data24["ignoreDuplicateSlashes"] = coerced28;
+}
+}
+}
+var valid7 = _errs76 === errors;
+if(valid7){
+let data27 = data24.maxParamLength;
+const _errs78 = errors;
+if(!(((typeof data27 == "number") && (!(data27 % 1) && !isNaN(data27))) && (isFinite(data27)))){
+let dataType29 = typeof data27;
+let coerced29 = undefined;
+if(!(coerced29 !== undefined)){
+if(dataType29 === "boolean" || data27 === null
+              || (dataType29 === "string" && data27 && data27 == +data27 && !(data27 % 1))){
+coerced29 = +data27;
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/routerOptions/maxParamLength",schemaPath:"#/properties/routerOptions/properties/maxParamLength/type",keyword:"type",params:{type: "integer"},message:"must be integer"}];
 return false;
 }
 }
-if(coerced28 !== undefined){
-data26 = coerced28;
-if(data23 !== undefined){
-data23["maxParamLength"] = coerced28;
-}
-}
-}
-var valid7 = _errs76 === errors;
-if(valid7){
-let data27 = data23.allowUnsafeRegex;
-const _errs78 = errors;
-if(typeof data27 !== "boolean"){
-let coerced29 = undefined;
-if(!(coerced29 !== undefined)){
-if(data27 === "false" || data27 === 0 || data27 === null){
-coerced29 = false;
-}
-else if(data27 === "true" || data27 === 1){
-coerced29 = true;
-}
-else {
-validate10.errors = [{instancePath:instancePath+"/routerOptions/allowUnsafeRegex",schemaPath:"#/properties/routerOptions/properties/allowUnsafeRegex/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
-return false;
-}
-}
 if(coerced29 !== undefined){
 data27 = coerced29;
-if(data23 !== undefined){
-data23["allowUnsafeRegex"] = coerced29;
+if(data24 !== undefined){
+data24["maxParamLength"] = coerced29;
 }
 }
 }
 var valid7 = _errs78 === errors;
 if(valid7){
-let data28 = data23.useSemicolonDelimiter;
+let data28 = data24.allowUnsafeRegex;
 const _errs80 = errors;
 if(typeof data28 !== "boolean"){
 let coerced30 = undefined;
@@ -1135,18 +1138,43 @@ else if(data28 === "true" || data28 === 1){
 coerced30 = true;
 }
 else {
-validate10.errors = [{instancePath:instancePath+"/routerOptions/useSemicolonDelimiter",schemaPath:"#/properties/routerOptions/properties/useSemicolonDelimiter/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
+validate10.errors = [{instancePath:instancePath+"/routerOptions/allowUnsafeRegex",schemaPath:"#/properties/routerOptions/properties/allowUnsafeRegex/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
 return false;
 }
 }
 if(coerced30 !== undefined){
 data28 = coerced30;
-if(data23 !== undefined){
-data23["useSemicolonDelimiter"] = coerced30;
+if(data24 !== undefined){
+data24["allowUnsafeRegex"] = coerced30;
 }
 }
 }
 var valid7 = _errs80 === errors;
+if(valid7){
+let data29 = data24.useSemicolonDelimiter;
+const _errs82 = errors;
+if(typeof data29 !== "boolean"){
+let coerced31 = undefined;
+if(!(coerced31 !== undefined)){
+if(data29 === "false" || data29 === 0 || data29 === null){
+coerced31 = false;
+}
+else if(data29 === "true" || data29 === 1){
+coerced31 = true;
+}
+else {
+validate10.errors = [{instancePath:instancePath+"/routerOptions/useSemicolonDelimiter",schemaPath:"#/properties/routerOptions/properties/useSemicolonDelimiter/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
+return false;
+}
+}
+if(coerced31 !== undefined){
+data29 = coerced31;
+if(data24 !== undefined){
+data24["useSemicolonDelimiter"] = coerced31;
+}
+}
+}
+var valid7 = _errs82 === errors;
 }
 }
 }
@@ -1157,49 +1185,49 @@ validate10.errors = [{instancePath:instancePath+"/routerOptions",schemaPath:"#/p
 return false;
 }
 }
-var valid0 = _errs69 === errors;
+var valid0 = _errs71 === errors;
 }
 else {
 var valid0 = true;
 }
 if(valid0){
 if(data.constraints !== undefined){
-let data29 = data.constraints;
-const _errs82 = errors;
-if(errors === _errs82){
-if(data29 && typeof data29 == "object" && !Array.isArray(data29)){
-for(const key2 in data29){
-let data30 = data29[key2];
-const _errs85 = errors;
-if(errors === _errs85){
+let data30 = data.constraints;
+const _errs84 = errors;
+if(errors === _errs84){
 if(data30 && typeof data30 == "object" && !Array.isArray(data30)){
+for(const key2 in data30){
+let data31 = data30[key2];
+const _errs87 = errors;
+if(errors === _errs87){
+if(data31 && typeof data31 == "object" && !Array.isArray(data31)){
 let missing1;
-if(((((data30.name === undefined) && (missing1 = "name")) || ((data30.storage === undefined) && (missing1 = "storage"))) || ((data30.validate === undefined) && (missing1 = "validate"))) || ((data30.deriveConstraint === undefined) && (missing1 = "deriveConstraint"))){
+if(((((data31.name === undefined) && (missing1 = "name")) || ((data31.storage === undefined) && (missing1 = "storage"))) || ((data31.validate === undefined) && (missing1 = "validate"))) || ((data31.deriveConstraint === undefined) && (missing1 = "deriveConstraint"))){
 validate10.errors = [{instancePath:instancePath+"/constraints/" + key2.replace(/~/g, "~0").replace(/\//g, "~1"),schemaPath:"#/properties/constraints/additionalProperties/required",keyword:"required",params:{missingProperty: missing1},message:"must have required property '"+missing1+"'"}];
 return false;
 }
 else {
-if(data30.name !== undefined){
-let data31 = data30.name;
-if(typeof data31 !== "string"){
-let dataType31 = typeof data31;
-let coerced31 = undefined;
-if(!(coerced31 !== undefined)){
-if(dataType31 == "number" || dataType31 == "boolean"){
-coerced31 = "" + data31;
+if(data31.name !== undefined){
+let data32 = data31.name;
+if(typeof data32 !== "string"){
+let dataType32 = typeof data32;
+let coerced32 = undefined;
+if(!(coerced32 !== undefined)){
+if(dataType32 == "number" || dataType32 == "boolean"){
+coerced32 = "" + data32;
 }
-else if(data31 === null){
-coerced31 = "";
+else if(data32 === null){
+coerced32 = "";
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/constraints/" + key2.replace(/~/g, "~0").replace(/\//g, "~1")+"/name",schemaPath:"#/properties/constraints/additionalProperties/properties/name/type",keyword:"type",params:{type: "string"},message:"must be string"}];
 return false;
 }
 }
-if(coerced31 !== undefined){
-data31 = coerced31;
-if(data30 !== undefined){
-data30["name"] = coerced31;
+if(coerced32 !== undefined){
+data32 = coerced32;
+if(data31 !== undefined){
+data31["name"] = coerced32;
 }
 }
 }
@@ -1211,7 +1239,7 @@ validate10.errors = [{instancePath:instancePath+"/constraints/" + key2.replace(/
 return false;
 }
 }
-var valid8 = _errs85 === errors;
+var valid8 = _errs87 === errors;
 if(!valid8){
 break;
 }
@@ -1222,10 +1250,11 @@ validate10.errors = [{instancePath:instancePath+"/constraints",schemaPath:"#/pro
 return false;
 }
 }
-var valid0 = _errs82 === errors;
+var valid0 = _errs84 === errors;
 }
 else {
 var valid0 = true;
+}
 }
 }
 }
@@ -1262,5 +1291,5 @@ return errors === 0;
 }
 
 
-module.exports.defaultInitOptions = {"connectionTimeout":0,"keepAliveTimeout":72000,"maxRequestsPerSocket":0,"requestTimeout":0,"handlerTimeout":0,"bodyLimit":1048576,"caseSensitive":true,"allowUnsafeRegex":false,"disableRequestLogging":false,"ignoreTrailingSlash":false,"ignoreDuplicateSlashes":false,"maxParamLength":100,"onProtoPoisoning":"error","onConstructorPoisoning":"error","pluginTimeout":10000,"requestIdHeader":false,"requestIdLogLabel":"reqId","http2SessionTimeout":72000,"exposeHeadRoutes":true,"useSemicolonDelimiter":false,"allowErrorHandlerOverride":true,"routerOptions":{"ignoreTrailingSlash":false,"ignoreDuplicateSlashes":false,"maxParamLength":100,"allowUnsafeRegex":false,"useSemicolonDelimiter":false}}
+module.exports.defaultInitOptions = {"connectionTimeout":0,"keepAliveTimeout":72000,"maxRequestsPerSocket":0,"requestTimeout":0,"handlerTimeout":0,"bodyLimit":1048576,"caseSensitive":true,"allowUnsafeRegex":false,"disableRequestLogging":false,"ignoreTrailingSlash":false,"ignoreDuplicateSlashes":false,"maxParamLength":100,"onProtoPoisoning":"error","onConstructorPoisoning":"error","pluginTimeout":10000,"requestIdHeader":false,"requestIdLogLabel":"reqId","http2SessionTimeout":72000,"exposeHeadRoutes":true,"useSemicolonDelimiter":false,"allowErrorHandlerOverride":true,"validateRouteParams":false,"routerOptions":{"ignoreTrailingSlash":false,"ignoreDuplicateSlashes":false,"maxParamLength":100,"allowUnsafeRegex":false,"useSemicolonDelimiter":false}}
 /* c8 ignore stop */

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -448,6 +448,11 @@ const codes = {
     500,
     TypeError
   ),
+  FST_ERR_ROUTE_PARAMS_SCHEMA_MISMATCH: createError(
+    'FST_ERR_ROUTE_PARAMS_SCHEMA_MISMATCH',
+    '%s',
+    500
+  ),
 
   /**
    *  again listen when close server

--- a/test/validate-route-params.test.js
+++ b/test/validate-route-params.test.js
@@ -1,0 +1,202 @@
+'use strict'
+
+const { test } = require('node:test')
+const Fastify = require('..')
+
+test('validateRouteParams - should not throw when params match schema', async (t) => {
+  t.plan(1)
+
+  const fastify = Fastify({ validateRouteParams: true })
+
+  fastify.get('/artists/:artistId', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          artistId: { type: 'string' }
+        }
+      }
+    },
+    handler: (req, reply) => reply.send({ artistId: req.params.artistId })
+  })
+
+  await t.assert.doesNotReject(fastify.ready())
+  await fastify.close()
+})
+
+test('validateRouteParams - should throw when schema has a param not in route path', async (t) => {
+  t.plan(2)
+
+  const fastify = Fastify({ validateRouteParams: true })
+
+  fastify.get('/artists/:artistId', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          artistId: { type: 'string' },
+          albumId: { type: 'string' }
+        }
+      }
+    },
+    handler: (req, reply) => reply.send({})
+  })
+
+  await t.assert.rejects(
+    fastify.ready(),
+    (err) => {
+      t.assert.ok(err.message.includes('albumId'))
+      return true
+    }
+  )
+  await fastify.close()
+})
+
+test('validateRouteParams - should throw when route path has a param not in schema', async (t) => {
+  t.plan(2)
+
+  const fastify = Fastify({ validateRouteParams: true })
+
+  fastify.get('/artists/:artistId/albums/:albumId', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          artistId: { type: 'string' }
+        }
+      }
+    },
+    handler: (req, reply) => reply.send({})
+  })
+
+  await t.assert.rejects(
+    fastify.ready(),
+    (err) => {
+      t.assert.ok(err.message.includes('albumId'))
+      return true
+    }
+  )
+  await fastify.close()
+})
+
+test('validateRouteParams - should not validate when no schema is present', async (t) => {
+  t.plan(1)
+
+  const fastify = Fastify({ validateRouteParams: true })
+
+  fastify.get('/artists/:artistId', {
+    handler: (req, reply) => reply.send({})
+  })
+
+  await t.assert.doesNotReject(fastify.ready())
+  await fastify.close()
+})
+
+test('validateRouteParams - should not validate when schema has no params', async (t) => {
+  t.plan(1)
+
+  const fastify = Fastify({ validateRouteParams: true })
+
+  fastify.get('/artists/:artistId', {
+    schema: {
+      querystring: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' }
+        }
+      }
+    },
+    handler: (req, reply) => reply.send({})
+  })
+
+  await t.assert.doesNotReject(fastify.ready())
+  await fastify.close()
+})
+
+test('validateRouteParams - disabled by default', async (t) => {
+  t.plan(1)
+
+  // Should not throw even with mismatched params because validation is disabled
+  const fastify = Fastify()
+
+  fastify.get('/artists/:artistId', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          artistId: { type: 'string' },
+          unknownParam: { type: 'string' }
+        }
+      }
+    },
+    handler: (req, reply) => reply.send({})
+  })
+
+  await t.assert.doesNotReject(fastify.ready())
+  await fastify.close()
+})
+
+test('validateRouteParams - should work with multiple routes', async (t) => {
+  t.plan(1)
+
+  const fastify = Fastify({ validateRouteParams: true })
+
+  fastify.get('/artists/:artistId', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          artistId: { type: 'string' }
+        }
+      }
+    },
+    handler: (req, reply) => reply.send({})
+  })
+
+  fastify.get('/albums/:albumId', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          albumId: { type: 'string' }
+        }
+      }
+    },
+    handler: (req, reply) => reply.send({})
+  })
+
+  await t.assert.doesNotReject(fastify.ready())
+  await fastify.close()
+})
+
+test('validateRouteParams - should handle routes without dynamic params and no schema params', async (t) => {
+  t.plan(1)
+
+  const fastify = Fastify({ validateRouteParams: true })
+
+  fastify.get('/health', {
+    handler: (req, reply) => reply.send({ status: 'ok' })
+  })
+
+  await t.assert.doesNotReject(fastify.ready())
+  await fastify.close()
+})
+
+test('validateRouteParams - should not validate when schema.params has no properties', async (t) => {
+  t.plan(1)
+
+  const fastify = Fastify({ validateRouteParams: true })
+
+  // Schema params defined without explicit properties (e.g. just a type) - skip validation
+  fastify.get('/artists/:artistId', {
+    schema: {
+      params: {
+        type: 'object'
+      }
+    },
+    handler: (req, reply) => reply.send({})
+  })
+
+  await t.assert.doesNotReject(fastify.ready())
+  await fastify.close()
+})


### PR DESCRIPTION
## Summary

Fixes #5215

Adds a new `validateRouteParams` boolean option (defaults to `false`) to the Fastify constructor that validates consistency between route path parameters and `schema.params.properties` at startup.

### How it works

When `validateRouteParams: true` is set, Fastify registers internal `onRoute` and `onReady` hooks that:
1. Collect all registered routes via `onRoute`
2. On `onReady`, call `fastify.findRoute()` for each route and cross-check the URL params against `schema.params.properties`
3. Throw `FST_ERR_ROUTE_PARAMS_SCHEMA_MISMATCH` if:
   - A schema param is defined that doesn't exist in the route path
   - A route path param exists that isn't defined in the schema

### Usage

```js
const fastify = require('fastify')({ validateRouteParams: true })

// This will throw at startup:
fastify.get('/artists/:artistId', {
  schema: {
    params: {
      type: 'object',
      properties: {
        artistId: { type: 'string' },
        unknownParam: { type: 'string' } // not in path!
      }
    }
  },
  handler: (req, reply) => reply.send({})
})

await fastify.ready() // throws FST_ERR_ROUTE_PARAMS_SCHEMA_MISMATCH
```

### Changes

- `build/build-validation.js`: Added `validateRouteParams` to the config schema (boolean, default `false`)
- `lib/config-validator.js`: Rebuilt from `build-validation.js` with new option
- `lib/errors.js`: Added `FST_ERR_ROUTE_PARAMS_SCHEMA_MISMATCH` error code
- `fastify.js`: Implemented the validation logic using `onRoute`/`onReady` hooks
- `test/validate-route-params.test.js`: 9 tests covering all cases

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>