### PR TITLE
feat: add reply.noContent() and rename kRouteContext to kRouteCtx

### DIFF
--- a/lib/content-type-parser.js
+++ b/lib/content-type-parser.js
@@ -12,7 +12,7 @@ const {
   kState,
   kTestInternals,
   kReplyIsError,
-  kRouteContext
+  kRouteCtx
 } = require('./symbols')
 
 const {
@@ -203,7 +203,7 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
     rawBody(
       request,
       reply,
-      reply[kRouteContext]._parserOptions,
+      reply[kRouteCtx]._parserOptions,
       parser,
       done
     )

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -7,7 +7,7 @@ const {
   kReplyHeaders,
   kReplyNextErrorHandler,
   kReplyIsRunningOnErrorHook,
-  kRouteContext,
+  kRouteCtx,
   kDisableRequestLogging
 } = require('./symbols.js')
 
@@ -30,7 +30,7 @@ const rootErrorHandler = {
 function handleError (reply, error, cb) {
   reply[kReplyIsRunningOnErrorHook] = false
 
-  const context = reply[kRouteContext]
+  const context = reply[kRouteCtx]
   if (reply[kReplyNextErrorHandler] === false) {
     fallbackErrorHandler(error, reply, function (reply, payload) {
       try {
@@ -106,7 +106,7 @@ function fallbackErrorHandler (error, reply, cb) {
   reply[kReplyHeaders]['content-type'] = reply[kReplyHeaders]['content-type'] ?? 'application/json; charset=utf-8'
   let payload
   try {
-    const serializerFn = getSchemaSerializer(reply[kRouteContext], statusCode, reply[kReplyHeaders]['content-type'])
+    const serializerFn = getSchemaSerializer(reply[kRouteCtx], statusCode, reply[kReplyHeaders]['content-type'])
     if (serializerFn === false) {
       payload = serializeError({
         error: statusCodes[statusCode + ''],

--- a/lib/handle-request.js
+++ b/lib/handle-request.js
@@ -9,7 +9,7 @@ const { FST_ERR_CTP_INVALID_MEDIA_TYPE } = require('./errors')
 const { setErrorStatusCode } = require('./error-status')
 const {
   kReplyIsError,
-  kRouteContext,
+  kRouteCtx,
   kFourOhFourContext,
   kSupportedHTTPMethods
 } = require('./symbols')
@@ -47,7 +47,7 @@ function handleRequest (err, request, reply) {
         return
       }
 
-      request[kRouteContext].contentTypeParser.run('', handler, request, reply)
+      request[kRouteCtx].contentTypeParser.run('', handler, request, reply)
       return
     }
 
@@ -57,7 +57,7 @@ function handleRequest (err, request, reply) {
       reply.status(415).send(new FST_ERR_CTP_INVALID_MEDIA_TYPE())
       return
     }
-    request[kRouteContext].contentTypeParser.run(contentType.toString(), handler, request, reply)
+    request[kRouteCtx].contentTypeParser.run(contentType.toString(), handler, request, reply)
     return
   }
 
@@ -67,9 +67,9 @@ function handleRequest (err, request, reply) {
 
 function handler (request, reply) {
   try {
-    if (request[kRouteContext].preValidation !== null) {
+    if (request[kRouteCtx].preValidation !== null) {
       preValidationHookRunner(
-        request[kRouteContext].preValidation,
+        request[kRouteCtx].preValidation,
         request,
         reply,
         preValidationCallback
@@ -91,7 +91,7 @@ function preValidationCallback (err, request, reply) {
     return
   }
 
-  const validationErr = validateSchema(reply[kRouteContext], request)
+  const validationErr = validateSchema(reply[kRouteCtx], request)
   const isAsync = (validationErr && typeof validationErr.then === 'function') || false
 
   if (isAsync) {
@@ -104,7 +104,7 @@ function preValidationCallback (err, request, reply) {
 
 function validationCompleted (request, reply, validationErr) {
   if (validationErr) {
-    if (reply[kRouteContext].attachValidation === false) {
+    if (reply[kRouteCtx].attachValidation === false) {
       reply.send(validationErr)
       return
     }
@@ -113,9 +113,9 @@ function validationCompleted (request, reply, validationErr) {
   }
 
   // preHandler hook
-  if (request[kRouteContext].preHandler !== null) {
+  if (request[kRouteCtx].preHandler !== null) {
     preHandlerHookRunner(
-      request[kRouteContext].preHandler,
+      request[kRouteCtx].preHandler,
       request,
       reply,
       preHandlerCallback
@@ -128,7 +128,7 @@ function validationCompleted (request, reply, validationErr) {
 function preHandlerCallback (err, request, reply) {
   if (reply.sent) return
 
-  const context = request[kRouteContext]
+  const context = request[kRouteCtx]
 
   if (!channels.hasSubscribers || context[kFourOhFourContext] === null) {
     preHandlerCallbackInner(err, request, reply)
@@ -147,7 +147,7 @@ function preHandlerCallback (err, request, reply) {
 }
 
 function preHandlerCallbackInner (err, request, reply, store) {
-  const context = request[kRouteContext]
+  const context = request[kRouteCtx]
 
   try {
     if (err != null) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -21,7 +21,7 @@ const {
   kReplyCacheSerializeFns,
   kSchemaController,
   kOptions,
-  kRouteContext,
+  kRouteCtx,
   kTimeoutTimer,
   kOnAbort,
   kRequestSignal
@@ -77,9 +77,9 @@ function Reply (res, request, log) {
 Reply.props = []
 
 Object.defineProperties(Reply.prototype, {
-  [kRouteContext]: {
+  [kRouteCtx]: {
     get () {
-      return this.request[kRouteContext]
+      return this.request[kRouteCtx]
     }
   },
   elapsedTime: {
@@ -92,7 +92,7 @@ Object.defineProperties(Reply.prototype, {
   },
   server: {
     get () {
-      return this.request[kRouteContext].server
+      return this.request[kRouteCtx].server
     }
   },
   sent: {
@@ -339,12 +339,12 @@ Reply.prototype.getSerializationFunction = function (schemaOrStatus, contentType
 
   if (typeof schemaOrStatus === 'string' || typeof schemaOrStatus === 'number') {
     if (typeof contentType === 'string') {
-      serialize = this[kRouteContext][kSchemaResponse]?.[schemaOrStatus]?.[contentType]
+      serialize = this[kRouteCtx][kSchemaResponse]?.[schemaOrStatus]?.[contentType]
     } else {
-      serialize = this[kRouteContext][kSchemaResponse]?.[schemaOrStatus]
+      serialize = this[kRouteCtx][kSchemaResponse]?.[schemaOrStatus]
     }
   } else if (typeof schemaOrStatus === 'object') {
-    serialize = this[kRouteContext][kReplyCacheSerializeFns]?.get(schemaOrStatus)
+    serialize = this[kRouteCtx][kReplyCacheSerializeFns]?.get(schemaOrStatus)
   }
 
   return serialize
@@ -355,11 +355,11 @@ Reply.prototype.compileSerializationSchema = function (schema, httpStatus = null
   const { method, url } = request
 
   // Check if serialize function already compiled
-  if (this[kRouteContext][kReplyCacheSerializeFns]?.has(schema)) {
-    return this[kRouteContext][kReplyCacheSerializeFns].get(schema)
+  if (this[kRouteCtx][kReplyCacheSerializeFns]?.has(schema)) {
+    return this[kRouteCtx][kReplyCacheSerializeFns].get(schema)
   }
 
-  const serializerCompiler = this[kRouteContext].serializerCompiler ||
+  const serializerCompiler = this[kRouteCtx].serializerCompiler ||
     this.server[kSchemaController].serializerCompiler ||
     (
       // We compile the schemas if no custom serializerCompiler is provided
@@ -381,11 +381,11 @@ Reply.prototype.compileSerializationSchema = function (schema, httpStatus = null
   // if it is not used
   // TODO: Explore a central cache for all the schemas shared across
   // encapsulated contexts
-  if (this[kRouteContext][kReplyCacheSerializeFns] == null) {
-    this[kRouteContext][kReplyCacheSerializeFns] = new WeakMap()
+  if (this[kRouteCtx][kReplyCacheSerializeFns] == null) {
+    this[kRouteCtx][kReplyCacheSerializeFns] = new WeakMap()
   }
 
-  this[kRouteContext][kReplyCacheSerializeFns].set(schema, serializeFn)
+  this[kRouteCtx][kReplyCacheSerializeFns].set(schema, serializeFn)
 
   return serializeFn
 }
@@ -403,9 +403,9 @@ Reply.prototype.serializeInput = function (input, schema, httpStatus, contentTyp
 
   if (httpStatus != null) {
     if (contentType != null) {
-      serialize = this[kRouteContext][kSchemaResponse]?.[httpStatus]?.[contentType]
+      serialize = this[kRouteCtx][kSchemaResponse]?.[httpStatus]?.[contentType]
     } else {
-      serialize = this[kRouteContext][kSchemaResponse]?.[httpStatus]
+      serialize = this[kRouteCtx][kSchemaResponse]?.[httpStatus]
     }
 
     if (serialize == null) {
@@ -414,8 +414,8 @@ Reply.prototype.serializeInput = function (input, schema, httpStatus, contentTyp
     }
   } else {
     // Check if serialize function already compiled
-    if (this[kRouteContext][kReplyCacheSerializeFns]?.has(schema)) {
-      serialize = this[kRouteContext][kReplyCacheSerializeFns].get(schema)
+    if (this[kRouteCtx][kReplyCacheSerializeFns]?.has(schema)) {
+      serialize = this[kRouteCtx][kReplyCacheSerializeFns].get(schema)
     } else {
       serialize = this.compileSerializationSchema(schema, httpStatus, contentType)
     }
@@ -428,10 +428,10 @@ Reply.prototype.serialize = function (payload) {
   if (this[kReplySerializer] !== null) {
     return this[kReplySerializer](payload)
   } else {
-    if (this[kRouteContext] && this[kRouteContext][kReplySerializerDefault]) {
-      return this[kRouteContext][kReplySerializerDefault](payload, this.raw.statusCode)
+    if (this[kRouteCtx] && this[kRouteCtx][kReplySerializerDefault]) {
+      return this[kRouteCtx][kReplySerializerDefault](payload, this.raw.statusCode)
     } else {
-      return serialize(this[kRouteContext], payload, this.raw.statusCode)
+      return serialize(this[kRouteCtx], payload, this.raw.statusCode)
     }
   }
 }
@@ -452,6 +452,10 @@ Reply.prototype.redirect = function (url, code) {
   }
 
   return this.header('location', url).code(code).send()
+}
+
+Reply.prototype.noContent = function () {
+  return this.code(204).send()
 }
 
 Reply.prototype.callNotFound = function () {
@@ -498,9 +502,9 @@ Reply.prototype.getDecorator = function (name) {
 }
 
 function preSerializationHook (reply, payload) {
-  if (reply[kRouteContext].preSerialization !== null) {
+  if (reply[kRouteCtx].preSerialization !== null) {
     preSerializationHookRunner(
-      reply[kRouteContext].preSerialization,
+      reply[kRouteCtx].preSerialization,
       reply.request,
       reply,
       payload,
@@ -520,10 +524,10 @@ function preSerializationHookEnd (err, _request, reply, payload) {
   try {
     if (reply[kReplySerializer] !== null) {
       payload = reply[kReplySerializer](payload)
-    } else if (reply[kRouteContext] && reply[kRouteContext][kReplySerializerDefault]) {
-      payload = reply[kRouteContext][kReplySerializerDefault](payload, reply.raw.statusCode)
+    } else if (reply[kRouteCtx] && reply[kRouteCtx][kReplySerializerDefault]) {
+      payload = reply[kRouteCtx][kReplySerializerDefault](payload, reply.raw.statusCode)
     } else {
-      payload = serialize(reply[kRouteContext], payload, reply.raw.statusCode, reply[kReplyHeaders]['content-type'])
+      payload = serialize(reply[kRouteCtx], payload, reply.raw.statusCode, reply[kReplyHeaders]['content-type'])
     }
   } catch (e) {
     wrapSerializationError(e, reply)
@@ -535,13 +539,13 @@ function preSerializationHookEnd (err, _request, reply, payload) {
 }
 
 function wrapSerializationError (error, reply) {
-  error.serialization = reply[kRouteContext].config
+  error.serialization = reply[kRouteCtx].config
 }
 
 function onSendHook (reply, payload) {
-  if (reply[kRouteContext].onSend !== null) {
+  if (reply[kRouteCtx].onSend !== null) {
     onSendHookRunner(
-      reply[kRouteContext].onSend,
+      reply[kRouteCtx].onSend,
       reply.request,
       reply,
       payload,
@@ -880,10 +884,10 @@ function sendStreamTrailer (payload, res, reply) {
 }
 
 function onErrorHook (reply, error, cb) {
-  if (reply[kRouteContext].onError !== null && !reply[kReplyNextErrorHandler]) {
+  if (reply[kRouteCtx].onError !== null && !reply[kReplyNextErrorHandler]) {
     reply[kReplyIsRunningOnErrorHook] = true
     onSendHookRunner(
-      reply[kRouteContext].onError,
+      reply[kRouteCtx].onError,
       reply.request,
       reply,
       error,
@@ -902,7 +906,7 @@ function setupResponseListeners (reply) {
     reply.raw.removeListener('finish', onResFinished)
     reply.raw.removeListener('error', onResFinished)
 
-    const ctx = reply[kRouteContext]
+    const ctx = reply[kRouteCtx]
 
     // Clean up handler timeout / signal resources
     if (reply.request[kRequestSignal]) {
@@ -983,18 +987,18 @@ function buildReply (R) {
 }
 
 function notFound (reply) {
-  if (reply[kRouteContext][kFourOhFourContext] === null) {
+  if (reply[kRouteCtx][kFourOhFourContext] === null) {
     reply.log.warn('Trying to send a NotFound error inside a 404 handler. Sending basic 404 response.')
     reply.code(404).send('404 Not Found')
     return
   }
 
-  reply.request[kRouteContext] = reply[kRouteContext][kFourOhFourContext]
+  reply.request[kRouteCtx] = reply[kRouteCtx][kFourOhFourContext]
 
   // preHandler hook
-  if (reply[kRouteContext].preHandler !== null) {
+  if (reply[kRouteCtx].preHandler !== null) {
     preHandlerHookRunner(
-      reply[kRouteContext].preHandler,
+      reply[kRouteCtx].preHandler,
       reply.request,
       reply,
       internals.preHandlerCallback

--- a/lib/request.js
+++ b/lib/request.js
@@ -10,7 +10,7 @@ const {
   kSchemaController,
   kOptions,
   kRequestCacheValidateFns,
-  kRouteContext,
+  kRouteCtx,
   kRequestOriginalUrl,
   kRequestSignal,
   kOnAbort
@@ -28,7 +28,7 @@ const HTTP_PART_SYMBOL_MAP = {
 
 function Request (id, params, req, query, log, context) {
   this.id = id
-  this[kRouteContext] = context
+  this[kRouteCtx] = context
   this.params = params
   this.raw = req
   this.query = query
@@ -69,7 +69,7 @@ function buildRegularRequest (R) {
   const props = R.props.slice()
   function _Request (id, params, req, query, log, context) {
     this.id = id
-    this[kRouteContext] = context
+    this[kRouteCtx] = context
     this.params = params
     this.raw = req
     this.query = query
@@ -155,7 +155,7 @@ function assertsRequestDecoration (request, name) {
 Object.defineProperties(Request.prototype, {
   server: {
     get () {
-      return this[kRouteContext].server
+      return this[kRouteCtx].server
     }
   },
   url: {
@@ -179,7 +179,7 @@ Object.defineProperties(Request.prototype, {
   },
   routeOptions: {
     get () {
-      const context = this[kRouteContext]
+      const context = this[kRouteCtx]
       const routeLimit = context._parserOptions.limit
       const serverLimit = context.server.initialConfig.bodyLimit
       const version = context.server.hasConstraintStrategy('version') ? this.raw.headers['accept-version'] : undefined
@@ -203,7 +203,7 @@ Object.defineProperties(Request.prototype, {
   },
   is404: {
     get () {
-      return this[kRouteContext].config?.url === undefined
+      return this[kRouteCtx].config?.url === undefined
     }
   },
   socket: {
@@ -286,9 +286,9 @@ Object.defineProperties(Request.prototype, {
     value: function (httpPartOrSchema) {
       if (typeof httpPartOrSchema === 'string') {
         const symbol = HTTP_PART_SYMBOL_MAP[httpPartOrSchema]
-        return this[kRouteContext][symbol]
+        return this[kRouteCtx][symbol]
       } else if (typeof httpPartOrSchema === 'object') {
-        return this[kRouteContext][kRequestCacheValidateFns]?.get(httpPartOrSchema)
+        return this[kRouteCtx][kRequestCacheValidateFns]?.get(httpPartOrSchema)
       }
     }
   },
@@ -296,11 +296,11 @@ Object.defineProperties(Request.prototype, {
     value: function (schema, httpPart = null) {
       const { method, url } = this
 
-      if (this[kRouteContext][kRequestCacheValidateFns]?.has(schema)) {
-        return this[kRouteContext][kRequestCacheValidateFns].get(schema)
+      if (this[kRouteCtx][kRequestCacheValidateFns]?.has(schema)) {
+        return this[kRouteCtx][kRequestCacheValidateFns].get(schema)
       }
 
-      const validatorCompiler = this[kRouteContext].validatorCompiler ||
+      const validatorCompiler = this[kRouteCtx].validatorCompiler ||
         this.server[kSchemaController].validatorCompiler ||
         (
           // We compile the schemas if no custom validatorCompiler is provided
@@ -321,11 +321,11 @@ Object.defineProperties(Request.prototype, {
       // if it is not used
       // TODO: Explore a central cache for all the schemas shared across
       // encapsulated contexts
-      if (this[kRouteContext][kRequestCacheValidateFns] == null) {
-        this[kRouteContext][kRequestCacheValidateFns] = new WeakMap()
+      if (this[kRouteCtx][kRequestCacheValidateFns] == null) {
+        this[kRouteCtx][kRequestCacheValidateFns] = new WeakMap()
       }
 
-      this[kRouteContext][kRequestCacheValidateFns].set(schema, validateFn)
+      this[kRouteCtx][kRequestCacheValidateFns].set(schema, validateFn)
 
       return validateFn
     }
@@ -339,7 +339,7 @@ Object.defineProperties(Request.prototype, {
 
       if (symbol) {
         // Validate using the HTTP Request Part schema
-        validate = this[kRouteContext][symbol]
+        validate = this[kRouteCtx][symbol]
       }
 
       // We cannot compile if the schema is missed
@@ -351,8 +351,8 @@ Object.defineProperties(Request.prototype, {
       }
 
       if (validate == null) {
-        if (this[kRouteContext][kRequestCacheValidateFns]?.has(schema)) {
-          validate = this[kRouteContext][kRequestCacheValidateFns].get(schema)
+        if (this[kRouteCtx][kRequestCacheValidateFns]?.has(schema)) {
+          validate = this[kRouteCtx][kRequestCacheValidateFns].get(schema)
         } else {
           // We proceed to compile if there's no validate function yet
           validate = this.compileValidationSchema(schema, httpPart)

--- a/lib/route.js
+++ b/lib/route.js
@@ -48,7 +48,7 @@ const {
   kHasBeenDecorated,
   kRequestAcceptVersion,
   kRouteByFastify,
-  kRouteContext,
+  kRouteCtx,
   kRequestSignal,
   kTimeoutTimer,
   kOnAbort
@@ -645,8 +645,8 @@ function runPreParsing (err, request, reply) {
 
   request[kRequestPayloadStream] = request.raw
 
-  if (request[kRouteContext].preParsing !== null) {
-    preParsingHookRunner(request[kRouteContext].preParsing, request, reply, handleRequest.bind(request.server))
+  if (request[kRouteCtx].preParsing !== null) {
+    preParsingHookRunner(request[kRouteCtx].preParsing, request, reply, handleRequest.bind(request.server))
   } else {
     handleRequest.call(request.server, null, request, reply)
   }

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -15,7 +15,7 @@ const keys = {
   kOptions: Symbol('fastify.options'),
   kDisableRequestLogging: Symbol('fastify.disableRequestLogging'),
   kPluginNameChain: Symbol('fastify.pluginNameChain'),
-  kRouteContext: Symbol('fastify.context'),
+  kRouteCtx: Symbol('fastify.context'),
   kGenReqId: Symbol('fastify.genReqId'),
   kHttp2ServerSessions: Symbol('fastify.http2ServerSessions'),
   // Schema

--- a/test/context-config.test.js
+++ b/test/context-config.test.js
@@ -2,7 +2,7 @@
 
 const { test } = require('node:test')
 
-const { kRouteContext } = require('../lib/symbols')
+const { kRouteCtx } = require('../lib/symbols')
 const Fastify = require('..')
 
 const schema = {
@@ -14,7 +14,7 @@ const schema = {
 }
 
 function handler (req, reply) {
-  reply.send(reply[kRouteContext].config)
+  reply.send(reply[kRouteCtx].config)
 }
 
 test('config', async t => {

--- a/test/diagnostics-channel/error-before-handler.test.js
+++ b/test/diagnostics-channel/error-before-handler.test.js
@@ -24,7 +24,7 @@ test('diagnostics channel handles an error before calling context handler', t =>
   const error = new Error('oh no')
   const request = new Request()
   const reply = new Reply({}, request)
-  request[symbols.kRouteContext] = {
+  request[symbols.kRouteCtx] = {
     config: {
       url: '/foo',
       method: 'GET'

--- a/test/handler-context.test.js
+++ b/test/handler-context.test.js
@@ -1,6 +1,6 @@
 'use strict'
 const { test } = require('node:test')
-const { kRouteContext } = require('../lib/symbols')
+const { kRouteCtx } = require('../lib/symbols')
 const fastify = require('..')
 
 test('handlers receive correct `this` context', async (t) => {
@@ -33,11 +33,11 @@ test('handlers have access to the internal context', async (t) => {
 
   const instance = fastify()
   instance.get('/', { config: { foo: 'bar' } }, function (req, reply) {
-    t.assert.ok(reply[kRouteContext])
-    t.assert.ok(reply[kRouteContext].config)
-    t.assert.ok(typeof reply[kRouteContext].config, Object)
-    t.assert.ok(reply[kRouteContext].config.foo)
-    t.assert.strictEqual(reply[kRouteContext].config.foo, 'bar')
+    t.assert.ok(reply[kRouteCtx])
+    t.assert.ok(reply[kRouteCtx].config)
+    t.assert.ok(typeof reply[kRouteCtx].config, Object)
+    t.assert.ok(reply[kRouteCtx].config.foo)
+    t.assert.strictEqual(reply[kRouteCtx].config.foo, 'bar')
     reply.send()
   })
 

--- a/test/internals/content-type-parser.test.js
+++ b/test/internals/content-type-parser.test.js
@@ -3,7 +3,7 @@
 const { test } = require('node:test')
 const proxyquire = require('proxyquire')
 const { Readable } = require('node:stream')
-const { kTestInternals, kRouteContext } = require('../../lib/symbols')
+const { kTestInternals, kRouteCtx } = require('../../lib/symbols')
 const Request = require('../../lib/request')
 const Reply = require('../../lib/reply')
 
@@ -49,7 +49,7 @@ test('rawBody function', t => {
   internals.rawBody(
     request,
     reply,
-    reply[kRouteContext]._parserOptions,
+    reply[kRouteCtx]._parserOptions,
     parser,
     done
   )
@@ -102,7 +102,7 @@ test('Should support Webpack and faux modules', t => {
   internals.rawBody(
     request,
     reply,
-    reply[kRouteContext]._parserOptions,
+    reply[kRouteCtx]._parserOptions,
     parser,
     done
   )

--- a/test/internals/content-type.test.js
+++ b/test/internals/content-type.test.js
@@ -1,0 +1,233 @@
+'use strict'
+
+const { describe, test } = require('node:test')
+const ContentType = require('../../lib/content-type')
+
+describe('ContentType', () => {
+  describe('Symbol.toStringTag', () => {
+    test('identifies instances as ContentType', (t) => {
+      t.assert.equal(Object.prototype.toString.call(new ContentType('text/plain')), '[object ContentType]')
+      t.assert.equal(new ContentType('text/plain')[Symbol.toStringTag], 'ContentType')
+    })
+  })
+
+  describe('isEmpty', () => {
+    test('is true for nullish and empty constructor input', (t) => {
+      for (const value of [null, undefined, '', 'undefined']) {
+        const found = new ContentType(value)
+        t.assert.equal(found.isEmpty, true, `expected empty for ${String(value)}`)
+        t.assert.equal(found.isValid, false)
+      }
+    })
+
+    test('is false for a valid media type', (t) => {
+      const found = new ContentType('text/plain')
+      t.assert.equal(found.isEmpty, false)
+      t.assert.equal(found.isValid, true)
+    })
+  })
+
+  describe('isValid', () => {
+    test('is false when type/subtype format is missing or malformed', (t) => {
+      const invalid = [
+        'foo',
+        'foo; param=1',
+        'application/json<script>alert(1)</script>',
+        'application/json/extra/slashes',
+        'application/json(garbage)',
+        'application/json@evil',
+        'application/json\x00garbage',
+        'application/json whatever',
+        'application/    json whatever',
+        'foo /bar',
+        'foo/ bar',
+        '  text  /  html  '
+      ]
+
+      for (const value of invalid) {
+        const found = new ContentType(value)
+        t.assert.equal(found.isValid, false, `expected invalid for ${JSON.stringify(value)}`)
+        t.assert.equal(found.isEmpty, true, `expected empty for ${JSON.stringify(value)}`)
+      }
+    })
+
+    test('is false when the media type portion uses invalid characters with parameters', (t) => {
+      t.assert.equal(new ContentType('bad type/sub; p=1').isValid, false)
+      t.assert.equal(new ContentType('type/bad subtype; p=1').isValid, false)
+      t.assert.equal(new ContentType('foo/π; param=1').isValid, false)
+    })
+
+    test('is true for representative valid media types', (t) => {
+      const valid = [
+        'text/plain',
+        'application/json',
+        'application/vnd.api+json',
+        'application/x-custom',
+        'multipart/form-data; boundary=----WebKitFormBoundary'
+      ]
+
+      for (const value of valid) {
+        const found = new ContentType(value)
+        t.assert.equal(found.isValid, true, `expected valid for ${JSON.stringify(value)}`)
+        t.assert.equal(found.isEmpty, false, `expected non-empty for ${JSON.stringify(value)}`)
+      }
+    })
+  })
+
+  describe('type and subtype', () => {
+    test('normalize case and expose parsed tokens', (t) => {
+      const found = new ContentType('Application/JSON')
+      t.assert.equal(found.type, 'application')
+      t.assert.equal(found.subtype, 'json')
+    })
+
+    test('trim leading type whitespace and trailing subtype whitespace without parameters', (t) => {
+      const found = new ContentType('  application/json  ')
+      t.assert.equal(found.isValid, true)
+      t.assert.equal(found.type, 'application')
+      t.assert.equal(found.subtype, 'json')
+    })
+
+    test('preserve structured subtype tokens such as vendor trees and suffixes', (t) => {
+      const found = new ContentType('application/vnd.api+json')
+      t.assert.equal(found.type, 'application')
+      t.assert.equal(found.subtype, 'vnd.api+json')
+    })
+
+    test('remain empty strings on invalid input', (t) => {
+      const found = new ContentType('not-a-media-type')
+      t.assert.equal(found.type, '')
+      t.assert.equal(found.subtype, '')
+    })
+  })
+
+  describe('mediaType', () => {
+    test('combines normalized type and subtype', (t) => {
+      const found = new ContentType('TEXT/HTML')
+      t.assert.equal(found.mediaType, 'text/html')
+    })
+
+    test('returns a slash for invalid instances', (t) => {
+      t.assert.equal(new ContentType('').mediaType, '/')
+      t.assert.equal(new ContentType('invalid').mediaType, '/')
+    })
+
+    test('ignores parameters', (t) => {
+      const found = new ContentType('application/json; charset=utf-8')
+      t.assert.equal(found.mediaType, 'application/json')
+    })
+  })
+
+  describe('parameters', () => {
+    test('returns an empty Map for media types without parameters', (t) => {
+      const found = new ContentType('text/plain')
+      t.assert.ok(found.parameters instanceof Map)
+      t.assert.equal(found.parameters.size, 0)
+    })
+
+    test('returns an empty Map when the parameter list is empty', (t) => {
+      const found = new ContentType('Application/JSON ;')
+      t.assert.equal(found.parameters.size, 0)
+    })
+
+    test('parse unquoted parameter values', (t) => {
+      const found = new ContentType('application/json; foo=bar')
+      t.assert.deepStrictEqual(
+        Array.from(found.parameters.entries()),
+        [['foo', 'bar']]
+      )
+    })
+
+    test('store quoted parameter values including surrounding quotes', (t) => {
+      const found = new ContentType('application/json; charset="utf-8"; title="hello world"')
+      t.assert.deepStrictEqual(
+        Array.from(found.parameters.entries()),
+        [
+          ['charset', '"utf-8"'],
+          ['title', '"hello world"']
+        ]
+      )
+    })
+
+    test('preserve parameter value casing and interior whitespace', (t) => {
+      const found = new ContentType('Application/JSON ; charset=utf-8; foo=BaR;baz=" 42"')
+      t.assert.deepStrictEqual(
+        Array.from(found.parameters.entries()),
+        [
+          ['charset', 'utf-8'],
+          ['foo', 'BaR'],
+          ['baz', '" 42"']
+        ]
+      )
+    })
+
+    test('accept empty quoted parameter values', (t) => {
+      const found = new ContentType('application/json; empty=""')
+      t.assert.deepStrictEqual(
+        Array.from(found.parameters.entries()),
+        [['empty', '""']]
+      )
+    })
+
+    test('store a sentinel for unclosed quoted values', (t) => {
+      const found = new ContentType('Application/JSON ; charset=utf-8; foo=BaR;baz=" 42')
+      t.assert.deepStrictEqual(
+        Array.from(found.parameters.entries()),
+        [
+          ['charset', 'utf-8'],
+          ['foo', 'BaR'],
+          ['baz', 'invalid quoted string']
+        ]
+      )
+    })
+
+    test('ignore tokens that are not key=value pairs', (t) => {
+      const found = new ContentType('type/sub; badparam')
+      t.assert.equal(found.isValid, true)
+      t.assert.equal(found.parameters.size, 0)
+    })
+
+    test('keep the last value when duplicate keys appear', (t) => {
+      const found = new ContentType('application/json; duplicate=1; duplicate=2')
+      t.assert.deepStrictEqual(
+        Array.from(found.parameters.entries()),
+        [['duplicate', '2']]
+      )
+    })
+  })
+
+  describe('toString', () => {
+    test('returns the media type alone when there are no parameters', (t) => {
+      const found = new ContentType('text/plain')
+      t.assert.equal(found.toString(), 'text/plain')
+    })
+
+    test('serializes parameters with quoted values', (t) => {
+      const found = new ContentType('Application/JSON ; charset=utf-8; foo=BaR;baz=" 42"')
+      t.assert.equal(
+        found.toString(),
+        'application/json; charset="utf-8"; foo="BaR"; baz="" 42""'
+      )
+    })
+
+    test('serializes invalid quoted parameter values using the stored sentinel', (t) => {
+      const found = new ContentType('Application/JSON ; charset=utf-8; foo=BaR;baz=" 42')
+      t.assert.equal(
+        found.toString(),
+        'application/json; charset="utf-8"; foo="BaR"; baz="invalid quoted string"'
+      )
+    })
+
+    test('caches the serialized value', (t) => {
+      const found = new ContentType('text/plain; a=1')
+      const first = found.toString()
+      const second = found.toString()
+      t.assert.equal(first, second)
+      t.assert.equal(first, 'text/plain; a="1"')
+    })
+
+    test('returns a slash for invalid instances', (t) => {
+      t.assert.equal(new ContentType('').toString(), '/')
+    })
+  })
+})

--- a/test/internals/context.test.js
+++ b/test/internals/context.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { test } = require('node:test')
-const { kRouteContext } = require('../../lib/symbols')
+const { kRouteCtx } = require('../../lib/symbols')
 const Context = require('../../lib/context')
 
 const Fastify = require('../..')
@@ -14,10 +14,10 @@ test('context', async context => {
     const app = Fastify()
 
     app.get('/', (req, reply) => {
-      t.assert.ok(req[kRouteContext] instanceof Context)
-      t.assert.ok(reply[kRouteContext] instanceof Context)
-      t.assert.ok(!('undefined' in reply[kRouteContext]))
-      t.assert.ok(!('undefined' in req[kRouteContext]))
+      t.assert.ok(req[kRouteCtx] instanceof Context)
+      t.assert.ok(reply[kRouteCtx] instanceof Context)
+      t.assert.ok(!('undefined' in reply[kRouteCtx]))
+      t.assert.ok(!('undefined' in req[kRouteCtx]))
 
       reply.send('hello world!')
     })

--- a/test/internals/handle-request.test.js
+++ b/test/internals/handle-request.test.js
@@ -5,7 +5,7 @@ const handleRequest = require('../../lib/handle-request')
 const internals = require('../../lib/handle-request')[Symbol.for('internals')]
 const Request = require('../../lib/request')
 const Reply = require('../../lib/reply')
-const { kRouteContext } = require('../../lib/symbols')
+const { kRouteCtx } = require('../../lib/symbols')
 const buildSchema = require('../../lib/validation').compileSchemasForValidation
 
 const Ajv = require('ajv')
@@ -69,7 +69,7 @@ test('handler function - invalid schema', t => {
   buildSchema(context, schemaValidator)
   const request = {
     body: { hello: 'world' },
-    [kRouteContext]: context
+    [kRouteCtx]: context
   }
   internals.handler(request, new Reply(res, request))
 })
@@ -100,7 +100,7 @@ test('handler function - reply', t => {
     }
   }
   buildSchema(context, schemaValidator)
-  internals.handler({ [kRouteContext]: context }, new Reply(res, { [kRouteContext]: context }))
+  internals.handler({ [kRouteCtx]: context }, new Reply(res, { [kRouteCtx]: context }))
 })
 
 test('handler function - preValidationCallback with finished response', t => {
@@ -125,7 +125,7 @@ test('handler function - preValidationCallback with finished response', t => {
     onError: []
   }
   buildSchema(context, schemaValidator)
-  internals.handler({ [kRouteContext]: context }, new Reply(res, { [kRouteContext]: context }))
+  internals.handler({ [kRouteCtx]: context }, new Reply(res, { [kRouteCtx]: context }))
 })
 
 test('request should be defined in onSend Hook on post request with content type application/json', async t => {

--- a/test/internals/reply-serialize.test.js
+++ b/test/internals/reply-serialize.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { test } = require('node:test')
-const { kReplyCacheSerializeFns, kRouteContext } = require('../../lib/symbols')
+const { kReplyCacheSerializeFns, kRouteCtx } = require('../../lib/symbols')
 const Fastify = require('../../fastify')
 
 function getDefaultSchema () {
@@ -210,9 +210,9 @@ test('Reply#compileSerializationSchema', async t => {
     fastify.get('/', (req, reply) => {
       const input = { hello: 'world' }
 
-      t.assert.strictEqual(reply[kRouteContext][kReplyCacheSerializeFns], null)
+      t.assert.strictEqual(reply[kRouteCtx][kReplyCacheSerializeFns], null)
       t.assert.strictEqual(reply.compileSerializationSchema(getDefaultSchema())(input), JSON.stringify(input))
-      t.assert.ok(reply[kRouteContext][kReplyCacheSerializeFns] instanceof WeakMap)
+      t.assert.ok(reply[kRouteCtx][kReplyCacheSerializeFns] instanceof WeakMap)
       t.assert.strictEqual(reply.compileSerializationSchema(getDefaultSchema())(input), JSON.stringify(input))
 
       reply.send({ hello: 'world' })
@@ -417,9 +417,9 @@ test('Reply#getSerializationFunction', async t => {
 
     fastify.get('/', (req, reply) => {
       t.assert.ok(!reply.getSerializationFunction(getDefaultSchema()))
-      t.assert.strictEqual(reply[kRouteContext][kReplyCacheSerializeFns], null)
+      t.assert.strictEqual(reply[kRouteCtx][kReplyCacheSerializeFns], null)
       t.assert.ok(!reply.getSerializationFunction('200'))
-      t.assert.strictEqual(reply[kRouteContext][kReplyCacheSerializeFns], null)
+      t.assert.strictEqual(reply[kRouteCtx][kReplyCacheSerializeFns], null)
 
       reply.send({ hello: 'world' })
     })
@@ -699,9 +699,9 @@ test('Reply#serializeInput', async t => {
 
     fastify.get('/', (req, reply) => {
       const input = { hello: 'world' }
-      t.assert.strictEqual(reply[kRouteContext][kReplyCacheSerializeFns], null)
+      t.assert.strictEqual(reply[kRouteCtx][kReplyCacheSerializeFns], null)
       t.assert.strictEqual(reply.serializeInput(input, getDefaultSchema()), JSON.stringify(input))
-      t.assert.ok(reply[kRouteContext][kReplyCacheSerializeFns] instanceof WeakMap)
+      t.assert.ok(reply[kRouteCtx][kReplyCacheSerializeFns] instanceof WeakMap)
 
       reply.send({ hello: 'world' })
     })

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -13,7 +13,7 @@ const {
   kReplySerializer,
   kReplyIsError,
   kReplySerializerDefault,
-  kRouteContext
+  kRouteCtx
 } = require('../../lib/symbols')
 const fs = require('node:fs')
 const path = require('node:path')
@@ -52,7 +52,7 @@ test('Once called, Reply should return an object with methods', t => {
   t.assert.strictEqual(typeof reply.serialize, 'function')
   t.assert.strictEqual(typeof reply[kReplyHeaders], 'object')
   t.assert.deepStrictEqual(reply.raw, response)
-  t.assert.strictEqual(reply[kRouteContext], context)
+  t.assert.strictEqual(reply[kRouteCtx], context)
   t.assert.strictEqual(reply.routeOptions.config, context.config)
   t.assert.strictEqual(reply.routeOptions.schema, context.schema)
   t.assert.strictEqual(reply.request, request)
@@ -85,7 +85,7 @@ test('reply.send will logStream error and destroy the stream', t => {
     warn: () => { }
   }
 
-  const reply = new Reply(response, { [kRouteContext]: { onSend: null } }, log)
+  const reply = new Reply(response, { [kRouteCtx]: { onSend: null } }, log)
   reply.send(payload)
   payload.destroy(new Error('stream error'))
 
@@ -102,7 +102,7 @@ test('reply.send throw with circular JSON', t => {
     write: () => { },
     end: () => { }
   }
-  const reply = new Reply(response, { [kRouteContext]: { onSend: [] } })
+  const reply = new Reply(response, { [kRouteCtx]: { onSend: [] } })
   t.assert.throws(() => {
     const obj = {}
     obj.obj = obj
@@ -120,7 +120,7 @@ test('reply.send returns itself', t => {
     write: () => { },
     end: () => { }
   }
-  const reply = new Reply(response, { [kRouteContext]: { onSend: [] } })
+  const reply = new Reply(response, { [kRouteCtx]: { onSend: [] } })
   t.assert.strictEqual(reply.send('hello'), reply)
 })
 
@@ -163,7 +163,7 @@ test('reply.serialize should serialize payload', t => {
   t.plan(1)
   const response = { statusCode: 200 }
   const context = {}
-  const reply = new Reply(response, { [kRouteContext]: context })
+  const reply = new Reply(response, { [kRouteCtx]: context })
   t.assert.strictEqual(reply.serialize({ foo: 'bar' }), '{"foo":"bar"}')
 })
 
@@ -172,7 +172,7 @@ test('reply.serialize should serialize payload with a custom serializer', t => {
   let customSerializerCalled = false
   const response = { statusCode: 200 }
   const context = {}
-  const reply = new Reply(response, { [kRouteContext]: context })
+  const reply = new Reply(response, { [kRouteCtx]: context })
   reply.serializer((x) => (customSerializerCalled = true) && JSON.stringify(x))
   t.assert.strictEqual(reply.serialize({ foo: 'bar' }), '{"foo":"bar"}')
   t.assert.strictEqual(customSerializerCalled, true, 'custom serializer not called')
@@ -183,7 +183,7 @@ test('reply.serialize should serialize payload with a context default serializer
   let customSerializerCalled = false
   const response = { statusCode: 200 }
   const context = { [kReplySerializerDefault]: (x) => (customSerializerCalled = true) && JSON.stringify(x) }
-  const reply = new Reply(response, { [kRouteContext]: context })
+  const reply = new Reply(response, { [kRouteCtx]: context })
   t.assert.strictEqual(reply.serialize({ foo: 'bar' }), '{"foo":"bar"}')
   t.assert.strictEqual(customSerializerCalled, true, 'custom serializer not called')
 })
@@ -1883,7 +1883,7 @@ test('reply.send will intercept ERR_HTTP_HEADERS_SENT and log an error message',
     }
   }
 
-  const reply = new Reply(response, { [kRouteContext]: { onSend: null }, raw: { url: '/hello', method: 'GET' } }, log)
+  const reply = new Reply(response, { [kRouteCtx]: { onSend: null }, raw: { url: '/hello', method: 'GET' } }, log)
 
   try {
     reply.send('')

--- a/test/internals/request-validate.test.js
+++ b/test/internals/request-validate.test.js
@@ -2,7 +2,7 @@
 
 const { test } = require('node:test')
 const Ajv = require('ajv')
-const { kRequestCacheValidateFns, kRouteContext } = require('../../lib/symbols')
+const { kRequestCacheValidateFns, kRouteCtx } = require('../../lib/symbols')
 const Fastify = require('../../fastify')
 
 const defaultSchema = {
@@ -240,11 +240,11 @@ test('#compileValidationSchema', async subtest => {
       t.plan(5)
 
       fastify.get('/', (req, reply) => {
-        t.assert.strictEqual(req[kRouteContext][kRequestCacheValidateFns], null)
+        t.assert.strictEqual(req[kRouteCtx][kRequestCacheValidateFns], null)
         t.assert.ok(req.compileValidationSchema(defaultSchema) instanceof Function)
-        t.assert.ok(req[kRouteContext][kRequestCacheValidateFns] instanceof WeakMap)
+        t.assert.ok(req[kRouteCtx][kRequestCacheValidateFns] instanceof WeakMap)
         t.assert.ok(req.compileValidationSchema(Object.assign({}, defaultSchema)) instanceof Function)
-        t.assert.ok(req[kRouteContext][kRequestCacheValidateFns] instanceof WeakMap)
+        t.assert.ok(req[kRouteCtx][kRequestCacheValidateFns] instanceof WeakMap)
 
         reply.send({ hello: 'world' })
       })
@@ -432,7 +432,7 @@ test('#getValidationFunction', async subtest => {
       req.getValidationFunction(defaultSchema)
       req.getValidationFunction('body')
 
-      t.assert.strictEqual(req[kRouteContext][kRequestCacheValidateFns], null)
+      t.assert.strictEqual(req[kRouteCtx][kRequestCacheValidateFns], null)
       reply.send({ hello: 'world' })
     })
 
@@ -732,9 +732,9 @@ test('#validate', async subtest => {
       t.plan(3)
 
       fastify.get('/', (req, reply) => {
-        t.assert.strictEqual(req[kRouteContext][kRequestCacheValidateFns], null)
+        t.assert.strictEqual(req[kRouteCtx][kRequestCacheValidateFns], null)
         t.assert.strictEqual(req.validateInput({ hello: 'world' }, defaultSchema), true)
-        t.assert.ok(req[kRouteContext][kRequestCacheValidateFns] instanceof WeakMap)
+        t.assert.ok(req[kRouteCtx][kRequestCacheValidateFns] instanceof WeakMap)
 
         reply.send({ hello: 'world' })
       })

--- a/test/reply-no-content.test.js
+++ b/test/reply-no-content.test.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const { test } = require('node:test')
+const Fastify = require('..')
+
+test('noContent should return 204 with empty body', (t, done) => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  fastify.get('/no-content', function (request, reply) {
+    reply.noContent()
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/no-content'
+  }, (error, res) => {
+    t.assert.ifError(error)
+    t.assert.strictEqual(res.statusCode, 204)
+    t.assert.strictEqual(res.payload, '')
+    done()
+  })
+})
+
+test('noContent should be chainable', (t, done) => {
+  t.plan(1)
+
+  const fastify = Fastify()
+
+  fastify.get('/no-content-chain', function (request, reply) {
+    t.assert.strictEqual(reply.noContent(), reply)
+    done()
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/no-content-chain'
+  }, () => {})
+})

--- a/test/types/reply.test-d.ts
+++ b/test/types/reply.test-d.ts
@@ -31,6 +31,7 @@ const getHandler: RouteHandlerMethod = function (_request, reply) {
   expectAssignable<(key: string) => FastifyReply>(reply.removeHeader)
   expectAssignable<(key: string) => boolean>(reply.hasHeader)
   expectType<(url: string, statusCode?: number) => FastifyReply>(reply.redirect)
+  expectType<() => FastifyReply>(reply.noContent)
   expectType<() => FastifyReply>(reply.hijack)
   expectType<() => void>(reply.callNotFound)
   expectType<(contentType: string) => FastifyReply>(reply.type)

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -58,6 +58,7 @@ export interface FastifyReply<
   removeHeader(key: HttpHeader): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>;
   hasHeader(key: HttpHeader): boolean;
   redirect(url: string, statusCode?: number): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>;
+  noContent(): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>;
   writeEarlyHints(hints: Record<string, string | string[]>, callback?: () => void): void;
   hijack(): FastifyReply<RouteGeneric, RawServer, RawRequest, RawReply, ContextConfig, SchemaCompiler, TypeProvider>;
   callNotFound(): void;


### PR DESCRIPTION
## Summary

- Add `reply.noContent()` as a chainable helper that sends a 204 No Content response with an empty body
- Rename the internal `kRouteContext` symbol to `kRouteCtx` across request/reply handling for consistency
- Add tests for `noContent()` and expanded `ContentType` coverage

## Test plan

- [x] `test/reply-no-content.test.js` — verifies 204 status, empty body, and chainability
- [x] `test/internals/content-type.test.js` — ContentType validation and edge cases
- [x] Updated internals tests for `kRouteCtx` symbol rename
- [x] TypeScript definitions updated in `types/reply.d.ts`


Made with [Cursor](https://cursor.com)