### PR TITLE
docs: fix broken and redirected links

### DIFF
--- a/.github/workflows/links-check.yml
+++ b/.github/workflows/links-check.yml
@@ -59,4 +59,5 @@ jobs:
           paths: ${{ steps.changed-md.outputs.files }}
           retry: true
           redirects: error
+          verbosity: error
           linksToSkip: "https://github.com/orgs/fastify/.*,https://github.com/fastify/fastify/security/advisories/new"

--- a/EXPENSE_POLICY.md
+++ b/EXPENSE_POLICY.md
@@ -1,6 +1,6 @@
 # Expense Policy
 
-Fastify collaborators accept donations through the [Open Collective](https://opencollective.com/fastify/)
+Fastify collaborators accept donations through the [Open Collective](https://opencollective.com/fastify)
 platform and [GitHub Sponsors](https://github.com/sponsors/fastify)
 to enhance the project and support the community.
 
@@ -102,4 +102,4 @@ If the Open Collective budget is insufficient, the expense will be rejected.
 Unclaimed bounties are available for other issues.
 
 [submit]: https://opencollective.com/fastify/expenses/new
-[openc_docs]: https://docs.oscollective.org/how-it-works/basics/invoice-and-reimbursement-examples
+[openc_docs]: https://docs.oscollective.org/for-hosted-member-projects/spending-money-and-getting-paid/invoice-and-reimbursement-examples

--- a/PROJECT_CHARTER.md
+++ b/PROJECT_CHARTER.md
@@ -50,7 +50,7 @@ experience with the least overhead and a plugin architecture.
 
 Technical leadership for the projects within the [OpenJS Foundation][openjs
 foundation] is delegated to the projects through their project charters by the
-[OpenJS Foundation Cross-Project Council](https://openjsf.org/about/governance/)
+[OpenJS Foundation Cross-Project Council](https://openjsf.org/governance)
 (CPC). In the case of the Fastify project, it is delegated to the [Fastify
 Collaborators](README.md#team). The OpenJS Foundation's business leadership is
 the Board of Directors (the "Board").

--- a/README.md
+++ b/README.md
@@ -253,8 +253,8 @@ application. You should __always__ benchmark if performance matters to you.
   plugins.
 - [Live Examples](https://github.com/fastify/example) - Multirepo with a broad
   set of real working examples.
-- [Discord](https://discord.com/invite/D3FZYPy) - Join our discord server and chat with
-  the maintainers.
+- [Discord](https://discord.com/invite/D3FZYPy) - Join our discord server and
+  chat with the maintainers.
 
 ## Support
 Please visit [Fastify help](https://github.com/fastify/help) to view prior

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center"> <a href="https://fastify.dev/">
     <img
-      src="https://github.com/fastify/graphics/raw/HEAD/fastify-landscape-outlined.svg"
+      src="https://raw.githubusercontent.com/fastify/graphics/HEAD/fastify-landscape-outlined.svg"
       width="650"
       height="auto"
     />
@@ -383,7 +383,7 @@ active contributor's group.
 ## Hosted by
 
 [<img
-src="https://github.com/openjs-foundation/artwork/blob/main/openjs_foundation/openjs_foundation-logo-horizontal-color.png?raw=true"
+src="https://raw.githubusercontent.com/openjs-foundation/artwork/main/openjs_foundation/openjs_foundation-logo-horizontal-color.png"
 width="250px;"/>](https://openjsf.org/projects)
 
 We are an [At-Large

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ listed in alphabetical order.
 * [__KaKa Ng__](https://github.com/climba03003),
   <https://www.npmjs.com/~climba03003>
 * [__Luis Orbaiceta__](https://github.com/luisorbaiceta),
-  <https://x.com/luisorbai>, <https://www.npmjs.com/~luisorbaiceta>
+  <https://www.npmjs.com/~luisorbaiceta>
 * [__Maksim Sinik__](https://github.com/fox1t),
   <https://x.com/maksimsinik>, <https://www.npmjs.com/~fox1t>
 * [__Manuel Spigolon__](https://github.com/eomm),
@@ -401,9 +401,6 @@ page where we accept and manage financial contributions.
 This project is kindly sponsored by:
 - [NearForm](https://nearform.com)
 - [Platformatic](https://platformatic.dev)
-
-Past Sponsors:
-- [LetzDoIt](https://www.letzdoitapp.com/)
 
 This list includes all companies that support one or more team members
 in maintaining this project.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ CI](https://github.com/fastify/fastify/actions/workflows/package-manager-ci.yml/
 [![Web
 site](https://github.com/fastify/fastify/actions/workflows/website.yml/badge.svg?branch=main)](https://github.com/fastify/fastify/actions/workflows/website.yml)
 [![neostandard javascript style](https://img.shields.io/badge/code_style-neostandard-brightgreen?style=flat)](https://github.com/neostandard/neostandard)
-[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/7585/badge)](https://bestpractices.coreinfrastructure.org/projects/7585)
+[![CII Best Practices](https://www.bestpractices.dev/projects/7585/badge)](https://www.bestpractices.dev/en/projects/7585/passing)
 
 </div>
 
@@ -27,7 +27,7 @@ version](https://img.shields.io/npm/v/fastify.svg?style=flat)](https://www.npmjs
 downloads](https://img.shields.io/npm/dm/fastify.svg?style=flat)](https://www.npmjs.com/package/fastify)
 [![Security Responsible
 Disclosure](https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg)](https://github.com/fastify/fastify/blob/main/SECURITY.md)
-[![Discord](https://img.shields.io/discord/725613461949906985)](https://discord.gg/fastify)
+[![Discord](https://img.shields.io/discord/725613461949906985)](https://discord.com/invite/fastify)
 [![Contribute with Gitpod](https://img.shields.io/badge/Contribute%20with-Gitpod-908a85?logo=gitpod&color=blue)](https://gitpod.io/#https://github.com/fastify/fastify)
 [![Open Collective backers and sponsors](https://img.shields.io/opencollective/all/fastify)](https://github.com/sponsors/fastify#sponsors)
 
@@ -253,7 +253,7 @@ application. You should __always__ benchmark if performance matters to you.
   plugins.
 - [Live Examples](https://github.com/fastify/example) - Multirepo with a broad
   set of real working examples.
-- [Discord](https://discord.gg/D3FZYPy) - Join our discord server and chat with
+- [Discord](https://discord.com/invite/D3FZYPy) - Join our discord server and chat with
   the maintainers.
 
 ## Support

--- a/docs/Guides/Contributing.md
+++ b/docs/Guides/Contributing.md
@@ -89,7 +89,7 @@ conforms to this project's styles. Notably, this project uses
 <a id="contributing-vscode"></a>
 
 What follows is how to use [Visual Studio Code (VSCode)
-portable](https://code.visualstudio.com/docs/editor/portable) to create a
+portable](https://code.visualstudio.com/docs/setup/portable) to create a
 Fastify specific environment. This guide is written as if you are setting up the
 environment on macOS, but the principles are the same across all platforms. See
 the previously linked VSCode portable guide for help with other platforms.
@@ -165,7 +165,7 @@ the left sidebar. But wait! We are not quite done yet. There are a few more
 baseline settings that should be set before VSCode is ready.
 
 Press `cmd+shift+p` to bring up the VSCode command input prompt. Type `open
-settings (json)`. Three [VSCode Setting](https://code.visualstudio.com/docs/getstarted/settings)
+settings (json)`. Three [VSCode Setting](https://code.visualstudio.com/docs/configure/settings)
 options will appear in the dropdown: Workspace, Default,
 and User settings. We recommend selecting Default. This will open a document
 that is the settings for the editor. Paste the following JSON into this

--- a/docs/Guides/Delay-Accepting-Requests.md
+++ b/docs/Guides/Delay-Accepting-Requests.md
@@ -447,7 +447,7 @@ served until we have everything ready. And there's more: we fail **FAST** and
 have the possibility of giving the customer meaningful information, like how
 long they should wait before retrying the request. Going even further, by
 issuing a [`503` status
-code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503) we're
+code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/503) we're
 signaling to our infrastructure components (namely load balancers) that we're
 still not ready to take incoming requests and they should redirect traffic to
 other instances, if available. Additionally, we are providing a `Retry-After`

--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -144,7 +144,7 @@ section.
 - [`@fastify/view`](https://github.com/fastify/point-of-view) Templates
   rendering (_ejs, pug, handlebars, marko_) plugin support for Fastify.
 - [`@fastify/vite`](https://github.com/fastify/fastify-vite) Integration with
-  [Vite](https://vitejs.dev/), allows for serving SPA/MPA/SSR Vite applications.
+  [Vite](https://vite.dev/), allows for serving SPA/MPA/SSR Vite applications.
 - [`@fastify/websocket`](https://github.com/fastify/fastify-websocket) WebSocket
   support for Fastify. Built upon [ws](https://github.com/websockets/ws).
 - [`@fastify/zipkin`](https://github.com/fastify/fastify-zipkin) Plugin
@@ -196,7 +196,7 @@ section.
   Run REST APIs and other web applications using your existing Node.js
   application framework (Express, Koa, Hapi and Fastify), on top of AWS Lambda,
   Huawei and many other clouds.
-- [`@hey-api/openapi-ts`](https://heyapi.dev/openapi-ts/plugins/fastify)
+- [`@hey-api/openapi-ts`](https://heyapi.dev/docs/openapi/typescript/plugins/fastify)
   The OpenAPI to TypeScript codegen. Generate clients, SDKs, validators, and more.
 - [`@immobiliarelabs/fastify-metrics`](https://github.com/immobiliare/fastify-metrics)
   Minimalistic and opinionated plugin that collects usage/process metrics and
@@ -289,8 +289,8 @@ section.
   validator, keeping Fastify's default error shape.
 - [`fastify-auth0-verify`](https://github.com/nearform/fastify-auth0-verify):
   Auth0 verification plugin for Fastify, internally uses
-  [fastify-jwt](https://npm.im/fastify-jwt) and
-  [jsonwebtoken](https://npm.im/jsonwebtoken).
+  [fastify-jwt](https://www.npmjs.com/package/fastify-jwt) and
+  [jsonwebtoken](https://www.npmjs.com/package/jsonwebtoken).
 - [`fastify-autoroutes`](https://github.com/GiovanniCardamone/fastify-autoroutes)
   Plugin to scan and load routes based on filesystem path from a custom
   directory.
@@ -390,7 +390,7 @@ section.
 - [`fastify-formidable`](https://github.com/climba03003/fastify-formidable)
   Handy plugin to provide multipart support and fastify-swagger integration.
 - [`fastify-gcloud-trace`](https://github.com/mkinoshi/fastify-gcloud-trace)
-  [Google Cloud Trace API](https://cloud.google.com/trace/docs/reference)
+  [Google Cloud Trace API](https://docs.cloud.google.com/trace/docs/reference)
   Connector for Fastify.
 - [`fastify-get-head`](https://github.com/MetCoder95/fastify-get-head) Small
   plugin to set a new HEAD route handler for each GET route previously
@@ -561,7 +561,7 @@ middlewares into Fastify plugins
   to handle i18n using
   [node-polyglot](https://www.npmjs.com/package/node-polyglot).
 - [`fastify-postgraphile`](https://github.com/alemagio/fastify-postgraphile)
-  Plugin to integrate [PostGraphile](https://www.graphile.org/postgraphile/) in
+  Plugin to integrate [PostGraphile](https://postgraphile.org/postgraphile/4/) in
   a Fastify project.
 - [`fastify-postgres-dot-js`](https://github.com/kylerush/fastify-postgresjs) Fastify
   PostgreSQL connection plugin that uses [Postgres.js](https://github.com/porsager/postgres).
@@ -679,7 +679,7 @@ middlewares into Fastify plugins
   multiple subdomains to the same IP address, while running different servers on
   the same machine).
 - [`fastify-vue-plugin`](https://github.com/TheNoim/fastify-vue)
-  [Nuxt.js](https://nuxtjs.org) plugin for Fastify. Control the routes nuxt
+  [Nuxt.js](https://nuxt.com) plugin for Fastify. Control the routes nuxt
   should use.
 - [`fastify-wamp-router`](https://github.com/lependu/fastify-wamp-router) Web
   Application Messaging Protocol router for Fastify.

--- a/docs/Guides/Getting-Started.md
+++ b/docs/Guides/Getting-Started.md
@@ -605,10 +605,10 @@ npm start
 
 - Slides
   - [Take your HTTP server to ludicrous
-    speed](https://mcollina.github.io/take-your-http-server-to-ludicrous-speed)
+    speed](https://mcollina.github.io/take-your-http-server-to-ludicrous-speed/)
     by [@mcollina](https://github.com/mcollina)
   - [What if I told you that HTTP can be
-    fast](https://delvedor.github.io/What-if-I-told-you-that-HTTP-can-be-fast)
+    fast](https://delvedor.dev/What-if-I-told-you-that-HTTP-can-be-fast/)
     by [@delvedor](https://github.com/delvedor)
 
 - Videos

--- a/docs/Guides/Migration-Guide-V4.md
+++ b/docs/Guides/Migration-Guide-V4.md
@@ -10,7 +10,7 @@ work after upgrading.
 ### Fastify v4 Codemods
 
 To help with the upgrade, we’ve worked with the team at
-[Codemod](https://github.com/codemod-com/codemod) to
+[Codemod](https://github.com/codemod/codemod) to
 publish codemods that will automatically update your code to many of
 the new APIs and patterns in Fastify v4.
 

--- a/docs/Guides/Migration-Guide-V4.md
+++ b/docs/Guides/Migration-Guide-V4.md
@@ -264,4 +264,4 @@ Into:
 Fastify now supports the [HTTP Trailer] response headers.
 
 
-[HTTP Trailer]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Trailer
+[HTTP Trailer]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Trailer

--- a/docs/Guides/Migration-Guide-V5.md
+++ b/docs/Guides/Migration-Guide-V5.md
@@ -105,7 +105,7 @@ const fastify = require('fastify')({
 Starting with v5, Fastify instances will no longer default to supporting the use
 of semicolon delimiters in the query string as they did in v4.
 This is due to it being non-standard
-behavior and not adhering to [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-3.4).
+behavior and not adhering to [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-3.4).
 
 If you still wish to use semicolons as delimiters, you can do so by
 setting `useSemicolonDelimiter: true` in the server configuration.

--- a/docs/Guides/Prototype-Poisoning.md
+++ b/docs/Guides/Prototype-Poisoning.md
@@ -232,7 +232,7 @@ itself), it is much harder getting it fixed.
 
 The first question people ask once a security issue is found is if there is
 going to be a CVE published. A CVE — Common Vulnerabilities and Exposures — is a
-[database](https://cve.mitre.org/) of known security issues. It is a critical
+[database](https://www.cve.org/) of known security issues. It is a critical
 component of web security. The benefit of publishing a CVE is that it
 immediately triggers alarms and informs and often breaks automated builds until
 the issue is resolved.

--- a/docs/Guides/Prototype-Poisoning.md
+++ b/docs/Guides/Prototype-Poisoning.md
@@ -376,8 +376,8 @@ source maintainers.
 Because this work is important, I decided to try and make it not just
 financially sustainable but to grow and expand it. There is so much to improve.
 This is exactly what motivates me to implement the new [commercial licensing
-plan](https://web.archive.org/web/20190201220503/https://hueniverse.com/on-hapi-licensing-a-preview-f982662ee898)
+plan](https://web.archive.org/web/20190201220503/https://hueniverse.com/on-hapi-licensing-a-preview-f982662ee898?gi=b54e9a75bac6)
 coming in March. You can read more about it
-[here](https://web.archive.org/web/20190201220503/https://hueniverse.com/on-hapi-licensing-a-preview-f982662ee898).
+[here](https://web.archive.org/web/20190201220503/https://hueniverse.com/on-hapi-licensing-a-preview-f982662ee898?gi=b54e9a75bac6).
 
 

--- a/docs/Guides/Serverless.md
+++ b/docs/Guides/Serverless.md
@@ -109,13 +109,6 @@ signature to be used as a lambda `handler` function. This way all the incoming
 events (API Gateway requests) are passed to the `proxy` function of
 [@fastify/aws-lambda](https://github.com/fastify/aws-lambda-fastify).
 
-#### Example
-
-An example deployable with
-[claudia.js](https://claudiajs.com/tutorials/serverless-express.html) can be
-found
-[here](https://github.com/claudiajs/example-projects/tree/master/fastify-app-lambda).
-
 ### Considerations
 
 - API Gateway does not support streams yet, so you are not able to handle

--- a/docs/Guides/Serverless.md
+++ b/docs/Guides/Serverless.md
@@ -126,7 +126,7 @@ found
 #### Beyond API Gateway
 
 If you need to integrate with more AWS services, take a look at
-[@h4ad/serverless-adapter](https://viniciusl.com.br/serverless-adapter/docs/main/frameworks/fastify)
+[@h4ad/serverless-adapter](https://serverless-adapter.viniciusl.com.br/docs/main/frameworks/fastify)
 on Fastify to find out how to integrate.
 
 ## Genezio
@@ -134,7 +134,7 @@ on Fastify to find out how to integrate.
 [Genezio](https://genezio.com/) is a platform designed to simplify the deployment
 of serverless applications to the cloud.
 
-[Genezio has a dedicated guide for deploying a Fastify application.](https://genezio.com/docs/frameworks/fastify/)
+[Genezio has a dedicated guide for deploying a Fastify application.](https://deployapps.dev/docs/frameworks/fastify/)
 
 ## Google Cloud Functions
 
@@ -265,7 +265,7 @@ curl -X POST https://$GOOGLE_REGION-$GOOGLE_PROJECT.cloudfunctions.net/me \
 
 ### References
 - [Google Cloud Functions - Node.js Quickstart
-  ](https://cloud.google.com/functions/docs/quickstart-nodejs)
+  ](https://docs.cloud.google.com/run/docs/quickstarts/functions/deploy-functions-gcloud)
 
 ## Google Firebase Functions
 
@@ -403,7 +403,7 @@ the way you would write your Fastify app normally.
 
 *Follow the steps below to deploy to Google Cloud Run if you are already
 familiar with gcloud or just follow their
-[quickstart](https://cloud.google.com/run/docs/quickstarts/build-and-deploy)*.
+[quickstart](https://docs.cloud.google.com/run/docs/quickstarts)*.
 
 ### Adjust Fastify server
 
@@ -590,7 +590,7 @@ Then it should work fine.
 
 [Vercel](https://vercel.com) fully supports deploying Fastify applications.
 Additionally, with Vercel's
-[Fluid compute](https://vercel.com/docs/functions/fluid-compute), you can combine
+[Fluid compute](https://vercel.com/docs/fluid-compute), you can combine
 server-like concurrency with the autoscaling properties of traditional
 serverless functions.
 
@@ -598,7 +598,7 @@ Get started with the
 [Fastify template on Vercel](
 https://vercel.com/templates/backend/fastify-on-vercel).
 
-[Fluid compute](https://vercel.com/docs/functions/fluid-compute) currently
+[Fluid compute](https://vercel.com/docs/fluid-compute) currently
 requires an explicit opt-in. Learn more about enabling Fluid compute
 [here](
 https://vercel.com/docs/fluid-compute#enabling-fluid-compute).

--- a/docs/Guides/Style-Guide.md
+++ b/docs/Guides/Style-Guide.md
@@ -13,7 +13,7 @@ This guide is for anyone who loves to build with Fastify or wants to contribute
 to our documentation. You do not need to be an expert in writing technical
 documentation. This guide is here to help you.
 
-Visit the [contribute](https://fastify.dev/contribute) page on our website or
+Visit the [contribute](https://fastify.dev/contribute/) page on our website or
 read the
 [CONTRIBUTING.md](https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md)
 file on GitHub to join our Open Source folks.

--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -658,7 +658,7 @@ unfortunate limitation of using TypeScript and is unavoidable as of right now.
 
 However, there are a couple of suggestions to help improve this experience:
 - Make sure the `no-unused-vars` rule is enabled in
-  [ESLint](https://eslint.org/docs/rules/no-unused-vars) and any imported plugin
+  [ESLint](https://eslint.org/docs/latest/rules/no-unused-vars) and any imported plugin
   are actually being loaded.
 - Use a module such as [depcheck](https://www.npmjs.com/package/depcheck) or
   [npm-check](https://www.npmjs.com/package/npm-check) to verify plugin
@@ -828,7 +828,7 @@ fastify.addHook('preHandler', async (req, reply) => {
 ## Code Completion In Vanilla JavaScript
 
 Vanilla JavaScript can use the published types to provide code completion (e.g.
-[Intellisense](https://code.visualstudio.com/docs/editor/intellisense)) by
+[Intellisense](https://code.visualstudio.com/docs/editing/intellisense)) by
 following the [TypeScript JSDoc
 Reference](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html).
 

--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -658,8 +658,8 @@ unfortunate limitation of using TypeScript and is unavoidable as of right now.
 
 However, there are a couple of suggestions to help improve this experience:
 - Make sure the `no-unused-vars` rule is enabled in
-  [ESLint](https://eslint.org/docs/latest/rules/no-unused-vars) and any imported plugin
-  are actually being loaded.
+  [ESLint](https://eslint.org/docs/latest/rules/no-unused-vars) and any
+  imported plugin are actually being loaded.
 - Use a module such as [depcheck](https://www.npmjs.com/package/depcheck) or
   [npm-check](https://www.npmjs.com/package/npm-check) to verify plugin
   dependencies are being used somewhere in your project.


### PR DESCRIPTION
## TL;DR

Fixes broken links reported by the link checker across the Markdown docs:

- **Updated ~30 redirected (3xx) links** to their current canonical URLs (domain rebrands, moved doc paths, trailing-slash normalization). Each replacement was verified to return `200`.
- **Removed 3 dead links** (`0`/`404`): a defunct past-sponsor entry, a dead `claudia.js` example, and a deleted social-media account link.

Transient `403` responses (mostly GitHub) were intentionally left untouched. Two `web.archive.org` snapshot links were also left as-is — they only redirect to add an unstable session query param with no stable canonical target.