### PR TITLE
docs: link documentation style guide in contributing guidelines

### DIFF
--- a/docs/Guides/Contributing.md
+++ b/docs/Guides/Contributing.md
@@ -74,10 +74,10 @@ guide, do one of the following:
 ## Setting Up Your Environment
 <a id="contributing-environment"></a>
 
-Please adhere to the project's code and [documentation](./Style-Guide.md) style. Some popular tools
-that automatically "correct" code and documentation do not follow a style that
-conforms to this project's styles. Notably, this project uses
-[StandardJS](https://standardjs.com) for code formatting.
+Please adhere to the project's code and [documentation](./Style-Guide.md)
+style. Some popular tools that automatically "correct" code and documentation
+do not follow a style that conforms to this project's styles. Notably, this
+project uses [StandardJS](https://standardjs.com) for code formatting.
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/fastify/fastify)
 

--- a/docs/Guides/Contributing.md
+++ b/docs/Guides/Contributing.md
@@ -70,15 +70,11 @@ guide, do one of the following:
   issue first. That way, other people can weigh in on the discussion before you
   do any work.
 
-<!--
-TODO: add link to a style guide, when we have one, here as in
-https://github.com/github/opensource.guide/blob/2868efbf0c14aec821909c19e210c3603a4a7805/CONTRIBUTING.md#style-guide
--->
 
 ## Setting Up Your Environment
 <a id="contributing-environment"></a>
 
-Please adhere to the project's code and documentation style. Some popular tools
+Please adhere to the project's code and documentation style. For writing documentation, please refer to the [Style Guide](./Style-Guide.md). Some popular tools
 that automatically "correct" code and documentation do not follow a style that
 conforms to this project's styles. Notably, this project uses
 [StandardJS](https://standardjs.com) for code formatting.

--- a/docs/Guides/Contributing.md
+++ b/docs/Guides/Contributing.md
@@ -74,7 +74,7 @@ guide, do one of the following:
 ## Setting Up Your Environment
 <a id="contributing-environment"></a>
 
-Please adhere to the project's code and documentation style. For writing documentation, please refer to the [Style Guide](./Style-Guide.md). Some popular tools
+Please adhere to the project's code and [documentation](./Style-Guide.md) style. Some popular tools
 that automatically "correct" code and documentation do not follow a style that
 conforms to this project's styles. Notably, this project uses
 [StandardJS](https://standardjs.com) for code formatting.


### PR DESCRIPTION
### Description
This pull request resolves an outdated `TODO` comment in the informal contributing guide (`docs/Guides/Contributing.md`) by linking the existing `Style-Guide.md` file.

### Changes
* Removed the obsolete `TODO` comment block that was referencing an external GitHub Open Source Guide link as an example.
* Added a direct relative link to the internal `[Style Guide](./Style-Guide.md)` within the **Setting Up Your Environment** section of the contributing guidelines.

### Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md) guidelines.
- [x] The commit message follows the project guidelines (`docs: ...`).
- [x] No code changes or test updates are required as this is purely a documentation improvement.