### PR TITLE
docs(ecosystem): add @stitchapi/fastify to Community plugins

### DIFF
--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -232,6 +232,9 @@ section.
   Plugin to generate routes automatically with valid json content
 - [`@scalar/fastify-api-reference`](https://github.com/scalar/scalar/tree/main/integrations/fastify)
   Beautiful OpenAPI/Swagger API references for Fastify
+- [`@stitchapi/fastify`](https://github.com/rejifald/StitchAPI/tree/main/packages/fastify)
+  Decorate the app/request with a StitchAPI seam — request-scoped principal, SSE
+  streaming, error mapping, and a Pino-logger bridge.
 - [`@thecodepace/fastify-http-query`](https://github.com/TheCodePace/fastify-http-query)
   Fastify plugin enabling the HTTP `QUERY` method (a safe, idempotent, cacheable
   method with a body).


### PR DESCRIPTION
## Summary

- Adds `@stitchapi/fastify` to the [Community plugins list](https://fastify.dev/ecosystem/) in `docs/Guides/Ecosystem.md`.
- `@stitchapi/fastify` is a Fastify plugin for StitchAPI: it decorates the app/request with a `seam`, adds a request-scoped principal (`AsyncLocalStorage`), SSE streaming of a stitch's output, error mapping, and a Pino-logger bridge.
- Plugin: https://github.com/rejifald/StitchAPI/tree/main/packages/fastify · npm: https://www.npmjs.com/package/@stitchapi/fastify · License: Apache-2.0

## Test plan

- [x] Entry placed alphabetically in the `[Community]` section, between `@scalar/fastify-api-reference` and `@thecodepace/fastify-http-query`, so the `Lint Ecosystem Order` check is satisfied.
- [x] Verified the package link points to `packages/fastify` and renders correctly in the Ecosystem guide.
