### PR TITLE
docs: remove marko from @fastify/view engines (support dropped)

### DIFF
--- a/docs/Guides/Plugins-Guide.md
+++ b/docs/Guides/Plugins-Guide.md
@@ -507,7 +507,7 @@ section of our documentation!
 
 If you want to see some real-world examples, check out:
 - [`@fastify/view`](https://github.com/fastify/point-of-view) Templates
-  rendering (*ejs, pug, handlebars, marko*) plugin support for Fastify.
+  rendering (*ejs, pug, handlebars*) plugin support for Fastify.
 - [`@fastify/mongodb`](https://github.com/fastify/fastify-mongodb) Fastify
   MongoDB connection plugin, with this you can share the same MongoDB connection
   pool in every part of your server.


### PR DESCRIPTION
`@fastify/view` dropped marko support; the engine list should no longer mention it.