### PR TITLE
chore: add FSTWRN003 and FSTWRN004 to warning registry comment

### DIFF
--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -3,13 +3,6 @@
 const { createWarning } = require('process-warning')
 
 /**
- * Deprecation codes:
- *   - FSTWRN001
- *   - FSTSEC001
- *   - FSTDEP022
- *   - FSTDEP023
- *   - FSTDEP024
- *
  * Deprecation Codes FSTDEP001 - FSTDEP021 were used by v4 and MUST NOT be reused.
  *                             - FSTDEP022 is used by v5 and MUST NOT be reused.
  * Warning Codes FSTWRN001 - FSTWRN002 were used by v4 and MUST NOT be reused.


### PR DESCRIPTION
The comment block at the top of `lib/warnings.js` serves as a registry of used warning and deprecation codes to prevent future duplicate code usage.

Currently, it only lists `FSTWRN001`, `FSTSEC001`, and `FSTDEP022`. The warning codes `FSTWRN003` and `FSTWRN004` (which are defined later in the file) were missing from this list.

This PR adds `FSTWRN003` and `FSTWRN004` to the registry block at the top of the file so contributors don't accidentally reuse these code values.

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
