### PR TITLE
fix: detect an existing charset case-insensitively when sending JSON

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -208,8 +208,10 @@ Reply.prototype.send = function (payload) {
     }
     payload = this[kReplySerializer](payload)
 
-    // The indexOf below also matches custom json mimetypes such as 'application/hal+json' or 'application/ld+json'
-  } else if (!hasContentType || contentType.indexOf('json') !== -1) {
+    // The indexOf below also matches custom json mimetypes such as 'application/hal+json' or 'application/ld+json'.
+    // The media type is matched case-insensitively because media types are
+    // case-insensitive (RFC 9110 section 8.3.1).
+  } else if (!hasContentType || contentType.toLowerCase().indexOf('json') !== -1) {
     if (!hasContentType) {
       this[kReplyHeaders]['content-type'] = CONTENT_TYPE.JSON
     } else if (contentType.toLowerCase().indexOf('charset') === -1) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -212,7 +212,9 @@ Reply.prototype.send = function (payload) {
   } else if (!hasContentType || contentType.indexOf('json') !== -1) {
     if (!hasContentType) {
       this[kReplyHeaders]['content-type'] = CONTENT_TYPE.JSON
-    } else if (contentType.indexOf('charset') === -1) {
+    } else if (contentType.toLowerCase().indexOf('charset') === -1) {
+      // The lookup is case-insensitive because HTTP parameter names are
+      // case-insensitive (RFC 9110 section 5.6.6).
       // If user doesn't set charset, we will set charset to utf-8
       const customContentType = contentType.trim()
       if (customContentType.endsWith(';')) {

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -1149,7 +1149,7 @@ test('reply.hasHeader computes raw and fastify headers', async t => {
 })
 
 test('Reply should handle JSON content type with a charset', async t => {
-  t.plan(9)
+  t.plan(10)
 
   const fastify = require('../../')()
 
@@ -1205,6 +1205,12 @@ test('Reply should handle JSON content type with a charset', async t => {
       .send({ hello: 'world' })
   })
 
+  fastify.get('/upper-mediatype', function (req, reply) {
+    reply
+      .header('content-type', 'application/JsOn')
+      .send({ hello: 'world' })
+  })
+
   {
     const res = await fastify.inject('/default')
     t.assert.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
@@ -1242,6 +1248,11 @@ test('Reply should handle JSON content type with a charset', async t => {
   {
     const res = await fastify.inject('/upper-charset')
     t.assert.strictEqual(res.headers['content-type'], 'application/json; CHARSET=utf-8')
+  }
+
+  {
+    const res = await fastify.inject('/upper-mediatype')
+    t.assert.strictEqual(res.headers['content-type'], 'application/JsOn; charset=utf-8')
   }
 
   {

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -1149,7 +1149,7 @@ test('reply.hasHeader computes raw and fastify headers', async t => {
 })
 
 test('Reply should handle JSON content type with a charset', async t => {
-  t.plan(8)
+  t.plan(9)
 
   const fastify = require('../../')()
 
@@ -1199,6 +1199,12 @@ test('Reply should handle JSON content type with a charset', async t => {
       .send({ hello: 'world' })
   })
 
+  fastify.get('/upper-charset', function (req, reply) {
+    reply
+      .header('content-type', 'application/json; CHARSET=utf-8')
+      .send({ hello: 'world' })
+  })
+
   {
     const res = await fastify.inject('/default')
     t.assert.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
@@ -1231,6 +1237,11 @@ test('Reply should handle JSON content type with a charset', async t => {
   {
     const res = await fastify.inject('/type-utf32')
     t.assert.strictEqual(res.headers['content-type'], 'application/json; charset=utf-32')
+  }
+
+  {
+    const res = await fastify.inject('/upper-charset')
+    t.assert.strictEqual(res.headers['content-type'], 'application/json; CHARSET=utf-8')
   }
 
   {


### PR DESCRIPTION
When a route sets a JSON content type with an uppercase or mixed case charset,
Fastify appends a second `charset=utf-8`, producing a malformed header.

In `lib/reply.js`, `Reply.prototype.send` decides whether the content type
already has a charset with a case-sensitive `contentType.indexOf('charset')`. A
value such as `application/json; CHARSET=utf-8` does not match, so Fastify treats
it as missing a charset and appends its own:

    application/json; CHARSET=utf-8  ->  application/json; CHARSET=utf-8; charset=utf-8

HTTP parameter names are case-insensitive (RFC 9110 section 5.6.6), so the
existing charset should be detected regardless of case. The fix lowercases the
value before the lookup. A route that sets a lowercase charset is unchanged.

Added an assertion for an uppercase `CHARSET` to the existing charset test.
