### PR TITLE
fix: use ContentType to detect `json` and `charset` in reply.send

### DIFF
--- a/lib/content-type-parser.js
+++ b/lib/content-type-parser.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { AsyncResource } = require('node:async_hooks')
-const { FifoMap: Fifo, LruMap: Lru } = require('toad-cache')
+const { FifoMap: Fifo } = require('toad-cache')
 const { parse: secureJsonParse } = require('secure-json-parse')
 const ContentType = require('./content-type')
 const {
@@ -39,15 +39,6 @@ function ContentTypeParser (bodyLimit, onProtoPoisoning, onConstructorPoisoning)
   this.parserList = ['application/json', 'text/plain']
   this.parserRegExpList = []
   this.cache = new Fifo(100)
-  this.ctCache = new Lru(100)
-}
-
-ContentTypeParser.prototype.getContentType = function (raw) {
-  let ct = this.ctCache.get(raw)
-  if (ct !== undefined) return ct
-  ct = new ContentType(raw)
-  this.ctCache.set(raw, ct)
-  return ct
 }
 
 ContentTypeParser.prototype.add = function (contentType, opts, parserFn) {
@@ -169,7 +160,6 @@ ContentTypeParser.prototype.removeAll = function () {
   this.parserRegExpList = []
   this.parserList = []
   this.cache = new Fifo(100)
-  this.ctCache = new Lru(100)
 }
 
 ContentTypeParser.prototype.remove = function (contentType) {

--- a/lib/content-type.js
+++ b/lib/content-type.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { LruMap: Lru } = require('toad-cache')
+
 /**
  * keyValuePairsReg is used to split the parameters list into associated
  * key value pairings. The leading `(?:^|;)\s*` anchor ensures the regex
@@ -36,6 +38,12 @@ const typeNameReg = /^[\w!#$%&'*+.^`|~-]+$/
 const subtypeNameReg = /^[\w!#$%&'*+.^`|~-]+\s*$/
 
 /**
+ * Content-Type internal shared cache
+ * @type {Lru<ContentType>}
+ */
+const cache = new Lru(100)
+
+/**
  * ContentType parses and represents the value of the content-type header.
  *
  * @see https://httpwg.org/specs/rfc9110.html#media.type
@@ -48,6 +56,27 @@ class ContentType {
   #subtype = ''
   #parameters = new Map()
   #string
+
+  /**
+   * The shared cache of ContentType instances. The cache is used to avoid
+   * creating multiple instances of ContentType for the same header value.
+   * @type {Lru<ContentType>}
+   */
+  static get cache () { return cache }
+
+  /**
+   * Create a ContentType instance from a header value. If the value has been
+   * previously parsed, the cached instance will be returned.
+   * @param {string} headerValue
+   * @returns {ContentType | undefined}
+   */
+  static from (headerValue) {
+    let contentType = cache.get(headerValue)
+    if (contentType !== undefined) return contentType
+    contentType = new ContentType(headerValue)
+    cache.set(headerValue, contentType)
+    return contentType
+  }
 
   constructor (headerValue) {
     if (headerValue == null || headerValue === '' || headerValue === 'undefined') {
@@ -106,7 +135,11 @@ class ContentType {
 
     let matches = keyValuePairsReg.exec(paramsList)
     while (matches) {
-      const key = matches[1]
+      // https://httpwg.org/specs/rfc9110.html#parameter
+      // Parameter names are case-insensitive.
+      const key = matches[1].toLowerCase()
+      // Parameter values might or might not be case-sensitive,
+      // depending on the semantics of the parameter name.
       const value = matches[2]
       if (value[0] === '"') {
         if (value.at(-1) !== '"') {

--- a/lib/content-type.js
+++ b/lib/content-type.js
@@ -178,7 +178,7 @@ class ContentType {
     if (this.#string) return this.#string
     const parameters = []
     for (const [key, value] of this.#parameters.entries()) {
-      parameters.push(`${key}=${value}`)
+      parameters.push(`${key}="${value}"`)
     }
     const result = [this.#type, '/', this.#subtype]
     if (parameters.length > 0) {

--- a/lib/content-type.js
+++ b/lib/content-type.js
@@ -178,7 +178,7 @@ class ContentType {
     if (this.#string) return this.#string
     const parameters = []
     for (const [key, value] of this.#parameters.entries()) {
-      parameters.push(`${key}="${value}"`)
+      parameters.push(`${key}=${value}`)
     }
     const result = [this.#type, '/', this.#subtype]
     if (parameters.length > 0) {

--- a/lib/handle-request.js
+++ b/lib/handle-request.js
@@ -14,6 +14,7 @@ const {
   kRequestContentType,
   kDiagnosticsStore
 } = require('./symbols')
+const ContentType = require('./content-type')
 
 const channels = diagnostics.tracingChannel('fastify.request.handler')
 
@@ -55,7 +56,7 @@ function handleRequest (err, request, reply) {
     // Conditional assignment to avoid creating a new ContentType instance
     // It can be assigned when accessing the .mediaType in hooks
     if (!request[kRequestContentType]) {
-      request[kRequestContentType] = request[kRouteContext].contentTypeParser.getContentType(ctHeader)
+      request[kRequestContentType] = ContentType.from(ctHeader)
     }
     if (request[kRequestContentType].isValid === false) {
       reply[kReplyIsError] = true

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -58,6 +58,7 @@ const {
   FST_ERR_DEC_UNDECLARED
 } = require('./errors')
 const decorators = require('./decorate')
+const ContentType = require('./content-type.js')
 
 const toString = Object.prototype.toString
 const HTTP2_WRITE_CHUNK_SIZE = 64 * 1024
@@ -167,8 +168,8 @@ Reply.prototype.send = function (payload) {
     return this
   }
 
-  const contentType = this.getHeader('content-type')
-  const hasContentType = contentType !== undefined
+  const contentType = ContentType.from(this.getHeader('content-type'))
+  const hasContentType = contentType.isEmpty === false
 
   if (payload !== null) {
     if (
@@ -209,14 +210,14 @@ Reply.prototype.send = function (payload) {
     payload = this[kReplySerializer](payload)
 
     // The indexOf below also matches custom json mimetypes such as 'application/hal+json' or 'application/ld+json'
-  } else if (!hasContentType || contentType.indexOf('json') !== -1) {
+  } else if (!hasContentType || contentType.mediaType.indexOf('json') !== -1) {
     if (!hasContentType) {
       this[kReplyHeaders]['content-type'] = CONTENT_TYPE.JSON
-    } else if (contentType.toLowerCase().indexOf('charset') === -1) {
+    } else if (contentType.parameters.has('charset') === false) {
       // The lookup is case-insensitive because HTTP parameter names are
       // case-insensitive (RFC 9110 section 5.6.6).
       // If user doesn't set charset, we will set charset to utf-8
-      const customContentType = contentType.trim()
+      const customContentType = contentType.toString()
       if (customContentType.endsWith(';')) {
         // custom content-type is ended with ';'
         this[kReplyHeaders]['content-type'] = `${customContentType} charset=utf-8`

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -218,12 +218,9 @@ Reply.prototype.send = function (payload) {
       // case-insensitive (RFC 9110 section 5.6.6).
       // If user doesn't set charset, we will set charset to utf-8
       const customContentType = contentType.toString()
-      if (customContentType.endsWith(';')) {
-        // custom content-type is ended with ';'
-        this[kReplyHeaders]['content-type'] = `${customContentType} charset=utf-8`
-      } else {
-        this[kReplyHeaders]['content-type'] = `${customContentType}; charset=utf-8`
-      }
+      // ContentType.toString already handle the trailing ;
+      // We can safely append the charset parameter to the end of the string
+      this[kReplyHeaders]['content-type'] = `${customContentType}; charset=utf-8`
     }
 
     if (typeof payload !== 'string') {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -212,7 +212,9 @@ Reply.prototype.send = function (payload) {
   } else if (!hasContentType || contentType.indexOf('json') !== -1) {
     if (!hasContentType) {
       this[kReplyHeaders]['content-type'] = CONTENT_TYPE.JSON
-    } else if (contentType.indexOf('charset') === -1) {
+    } else if (contentType.toLowerCase().indexOf('charset') === -1) {
+      // The lookup is case-insensitive because HTTP parameter names are
+      // case-insensitive (RFC 9110 section 5.6.6).
       // If user doesn't set charset, we will set charset to utf-8
       const customContentType = contentType.trim()
       if (customContentType.endsWith(';')) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -18,6 +18,7 @@ const {
 } = require('./symbols')
 const { FST_ERR_REQ_INVALID_VALIDATION_INVOCATION, FST_ERR_DEC_UNDECLARED } = require('./errors')
 const decorators = require('./decorate')
+const ContentType = require('./content-type')
 
 const HTTP_PART_SYMBOL_MAP = {
   body: kSchemaBody,
@@ -287,7 +288,7 @@ Object.defineProperties(Request.prototype, {
   mediaType: {
     get () {
       if (!this[kRequestContentType] && this.headers['content-type'] !== undefined) {
-        this[kRequestContentType] = this[kRouteContext].contentTypeParser.getContentType(this.headers['content-type'])
+        this[kRequestContentType] = ContentType.from(this.headers['content-type'])
       }
       return this[kRequestContentType]?.mediaType
     }

--- a/test/content-type.test.js
+++ b/test/content-type.test.js
@@ -181,6 +181,12 @@ describe('ContentType class', () => {
 })
 
 describe('ContentType class cache', () => {
+  test('allow access cache', (t) => {
+    const contentType1 = ContentType.from('application/json')
+    const contentType2 = ContentType.cache.get('application/json')
+    t.assert.equal(contentType1, contentType2)
+  })
+
   test('returns same instance for the same content type string', (t) => {
     const contentType1 = ContentType.from('application/json')
     const contentType2 = ContentType.from('application/json')

--- a/test/content-type.test.js
+++ b/test/content-type.test.js
@@ -179,3 +179,17 @@ describe('ContentType class', () => {
     )
   })
 })
+
+describe('ContentType class cache', () => {
+  test('returns same instance for the same content type string', (t) => {
+    const contentType1 = ContentType.from('application/json')
+    const contentType2 = ContentType.from('application/json')
+    t.assert.equal(contentType1, contentType2)
+  })
+
+  test('returns different instances for different content type strings', (t) => {
+    const contentType1 = ContentType.from('application/json')
+    const contentType2 = ContentType.from('text/plain')
+    t.assert.notEqual(contentType1, contentType2)
+  })
+})

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -1149,7 +1149,7 @@ test('reply.hasHeader computes raw and fastify headers', async t => {
 })
 
 test('Reply should handle JSON content type with a charset', async t => {
-  t.plan(9)
+  t.plan(10)
 
   const fastify = require('../../')()
 
@@ -1205,6 +1205,12 @@ test('Reply should handle JSON content type with a charset', async t => {
       .send({ hello: 'world' })
   })
 
+  fastify.get('/random-case', function (req, reply) {
+    reply
+      .header('content-type', 'ApPlIcAtIoN/JsOn; ChArSeT=utf-8')
+      .send({ hello: 'world' })
+  })
+
   {
     const res = await fastify.inject('/default')
     t.assert.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
@@ -1242,6 +1248,11 @@ test('Reply should handle JSON content type with a charset', async t => {
   {
     const res = await fastify.inject('/upper-charset')
     t.assert.strictEqual(res.headers['content-type'], 'application/json; CHARSET=utf-8')
+  }
+
+  {
+    const res = await fastify.inject('/random-case')
+    t.assert.strictEqual(res.headers['content-type'], 'ApPlIcAtIoN/JsOn; ChArSeT=utf-8')
   }
 
   {

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -764,7 +764,7 @@ test('non-string with custom json\'s content-type SHOULD be serialized as json',
 
   const result = await fetch(fastifyServer)
   t.assert.ok(result.ok)
-  t.assert.strictEqual(result.headers.get('content-type'), 'application/json; version=2; charset=utf-8')
+  t.assert.strictEqual(result.headers.get('content-type'), 'application/json; version="2"; charset=utf-8')
   t.assert.deepStrictEqual(await result.text(), JSON.stringify({ key: 'hello world!' }))
 })
 

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -1149,7 +1149,7 @@ test('reply.hasHeader computes raw and fastify headers', async t => {
 })
 
 test('Reply should handle JSON content type with a charset', async t => {
-  t.plan(8)
+  t.plan(9)
 
   const fastify = require('../../')()
 
@@ -1199,6 +1199,12 @@ test('Reply should handle JSON content type with a charset', async t => {
       .send({ hello: 'world' })
   })
 
+  fastify.get('/upper-charset', function (req, reply) {
+    reply
+      .header('content-type', 'application/json; CHARSET=utf-8')
+      .send({ hello: 'world' })
+  })
+
   {
     const res = await fastify.inject('/default')
     t.assert.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
@@ -1231,6 +1237,11 @@ test('Reply should handle JSON content type with a charset', async t => {
   {
     const res = await fastify.inject('/type-utf32')
     t.assert.strictEqual(res.headers['content-type'], 'application/json; charset=utf-32')
+  }
+
+  {
+    const res = await fastify.inject('/upper-charset')
+    t.assert.strictEqual(res.headers['content-type'], 'application/json; CHARSET=utf-8')
   }
 
   {


### PR DESCRIPTION
1. Move shared cache of `ContentType` from `ContentTypeParser` to itself

It makes more sense to have centralized cache instead one per parser. The parser will be recreate when the context is difference which means we have same cached key-value pairs across the application.

2. Detech `json` and `charset` in `reply.send`.

See #6828 
Closes #6828 

I have cherry-pick the work in #6828 and modify the others.
It should credit the original author for the finding and fix.


cc @aquie00t I believe it wouldn't slow down the performance boost, the cache still using.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
