### PR TITLE
fix: normalize method in findRoute

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -179,7 +179,7 @@ function buildRouting (options) {
 
   function findRoute (options) {
     const route = router.find(
-      options.method,
+      options.method?.toUpperCase() ?? '',
       options.url || '',
       options.constraints
     )

--- a/test/find-route.test.js
+++ b/test/find-route.test.js
@@ -66,6 +66,22 @@ test('findRoute should return null when when url is not passed', t => {
   }), null)
 })
 
+test('findRoute should return null when method is not passed', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  fastify.get('/artists/:artistId', {
+    schema: {
+      params: { artistId: { type: 'integer' } }
+    },
+    handler: (req, reply) => reply.send(typeof req.params.artistId)
+  })
+
+  t.assert.strictEqual(fastify.findRoute({
+    url: '/artists/:artistId'
+  }), null)
+})
+
 test('findRoute should return null when route cannot be found due to a different path', t => {
   t.plan(1)
   const fastify = Fastify()
@@ -100,6 +116,25 @@ test('findRoute should return the route when found', t => {
     method: 'GET',
     url: '/artists/:artistId'
   })
+  t.assert.strictEqual(route.params.artistId, ':artistId')
+})
+
+test('findRoute should find a route even if method is not uppercased', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.get('/artists/:artistId', {
+    schema: {
+      params: { artistId: { type: 'integer' } }
+    },
+    handler: (req, reply) => reply.send(typeof req.params.artistId)
+  })
+
+  const route = fastify.findRoute({
+    method: 'get',
+    url: '/artists/:artistId'
+  })
+  t.assert.notStrictEqual(route, null)
   t.assert.strictEqual(route.params.artistId, ':artistId')
 })
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

### Description

`findRoute()` was passing the provided method directly to the router lookup. Because registered route methods are normalized, a lookup like `findRoute({ method: 'get', ... })` returned `null` even when the matching `GET` route existed.

This change normalizes the method in `findRoute()`, matching the existing behavior in `hasRoute()`.

### Changes proposed:

- Updated `lib/route.js` to normalize the method before calling `router.find()`
- Added a regression test in `test/find-route.test.js` for lowercase method lookup

### Verification

1. Ran `node --test test/find-route.test.js`
2. Ran `node --test test/has-route.test.js`
3. Ran `npm test`

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
