### PR TITLE
fix: clear trailer state when removing all trailers

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -595,9 +595,13 @@ function onSendEnd (reply, payload) {
       header += ' '
       header += trailerName
     }
-    // it must be chunked for trailer to work
-    reply.header('Transfer-Encoding', 'chunked')
-    reply.header('Trailer', header.trim())
+    if (header !== '') {
+      // it must be chunked for trailer to work
+      reply.header('Transfer-Encoding', 'chunked')
+      reply.header('Trailer', header.trim())
+    } else {
+      reply[kReplyTrailers] = null
+    }
   }
 
   // since Response contain status code, headers and body,

--- a/test/reply-trailers.test.js
+++ b/test/reply-trailers.test.js
@@ -142,6 +142,37 @@ test('send trailers when payload is stream', (t, testDone) => {
   })
 })
 
+test('remove trailer while stream is being consumed', (t, testDone) => {
+  t.plan(5)
+
+  const fastify = Fastify()
+
+  fastify.get('/', function (request, reply) {
+    const stream = Readable.from((function * () {
+      reply.removeTrailer('ETag')
+      yield 'hello'
+    })())
+
+    reply.trailer('ETag', function () {
+      t.assert.fail('removed trailer should not be called')
+    })
+
+    reply.send(stream)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (error, res) => {
+    t.assert.ifError(error)
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.payload, 'hello')
+    t.assert.strictEqual(res.headers.trailer, 'etag')
+    t.assert.strictEqual(res.trailers.etag, undefined)
+    testDone()
+  })
+})
+
 test('send trailers when using async-await', (t, testDone) => {
   t.plan(5)
 
@@ -395,10 +426,37 @@ test('remove all trailers', (t, testDone) => {
   }, (error, res) => {
     t.assert.ifError(error)
     t.assert.strictEqual(res.statusCode, 200)
-    t.assert.ok(!res.headers.trailer)
-    t.assert.ok(!res.trailers.etag)
-    t.assert.ok(!res.trailers['should-not-call'])
-    t.assert.ok(!res.headers['content-length'])
+    t.assert.strictEqual(res.headers.trailer, undefined)
+    t.assert.strictEqual(res.trailers.etag, undefined)
+    t.assert.strictEqual(res.trailers['should-not-call'], undefined)
+    t.assert.strictEqual(res.headers['content-length'], '0')
+    testDone()
+  })
+})
+
+test('remove all trailers should behave like no trailers were registered', (t, testDone) => {
+  t.plan(6)
+
+  const fastify = Fastify()
+
+  fastify.get('/', function (request, reply) {
+    reply.trailer('ETag', function () {
+      t.assert.fail('removed trailer should not be called')
+    })
+    reply.removeTrailer('ETag')
+    reply.send('hello')
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (error, res) => {
+    t.assert.ifError(error)
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.headers.trailer, undefined)
+    t.assert.strictEqual(res.headers['transfer-encoding'], undefined)
+    t.assert.strictEqual(res.headers['content-length'], '5')
+    t.assert.strictEqual(res.trailers.etag, undefined)
     testDone()
   })
 })

--- a/test/reply-trailers.test.js
+++ b/test/reply-trailers.test.js
@@ -434,6 +434,36 @@ test('remove all trailers', (t, testDone) => {
   })
 })
 
+test('remove some trailers should keep trailer mode for the remaining ones', (t, testDone) => {
+  t.plan(6)
+
+  const fastify = Fastify()
+
+  fastify.get('/', function (request, reply) {
+    reply.trailer('ETag', function () {
+      t.assert.fail('removed trailer should not be called')
+    })
+    reply.removeTrailer('ETag')
+    reply.trailer('Content-MD5', function (reply, payload, done) {
+      done(null, 'custom-md5')
+    })
+    reply.send('hello')
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (error, res) => {
+    t.assert.ifError(error)
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.headers.trailer, 'content-md5')
+    t.assert.strictEqual(res.headers['transfer-encoding'], 'chunked')
+    t.assert.strictEqual(res.headers['content-length'], undefined)
+    t.assert.strictEqual(res.trailers['content-md5'], 'custom-md5')
+    testDone()
+  })
+})
+
 test('remove all trailers should behave like no trailers were registered', (t, testDone) => {
   t.plan(6)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

### Description

`reply.removeTrailer()` marked removed trailers as `undefined`, but it did not clear the internal trailer state when all active trailer callbacks were removed.

Because the send path checks whether trailer state is non-null, a response could still enter trailer mode after all trailers were removed. That could produce chunked framing, an empty `Trailer` header, and no `Content-Length` even though no trailers remained.

This change clears the trailer state when no active trailer callbacks remain, so removing all trailers behaves the same as not registering trailers.

The send-trailer path now keeps a stable reference to the trailer state while callbacks are running. This keeps trailer iteration safe if a trailer callback removes other trailers during execution.

### Changes proposed

- Clear trailer state when the last active trailer callback is removed
- Preserve trailer mode when other active trailers remain
- Keep trailer callback iteration safe when trailers are removed during callback execution
- Add regression coverage for remove-all and callback-time removal cases

### Verification

- Ran `node --test test/reply-trailers.test.js`
- Ran `npm run coverage:ci-check-coverage`
- Ran `npm test`
- Ran `npm run benchmark --if-present`

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
