### PR TITLE
fix: reset lastIndex before testing global/sticky content-type RegExp parsers

### DIFF
--- a/lib/content-type-parser.js
+++ b/lib/content-type-parser.js
@@ -145,6 +145,10 @@ ContentTypeParser.prototype.getParser = function (contentType) {
 
   for (let j = 0; j !== this.parserRegExpList.length; ++j) {
     const parserRegExp = this.parserRegExpList[j]
+    // A parser registered with a `g`/`y` flagged RegExp keeps a mutable
+    // lastIndex between calls, so a plain `.test()` would skip part of the
+    // next content type and match inconsistently. Reset it before testing.
+    parserRegExp.lastIndex = 0
     if (parserRegExp.test(ct)) {
       parser = this.customParsers.get(parserRegExp.toString())
       this.cache.set(ct, parser)

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -578,6 +578,38 @@ test('content-type match parameters - regexp', async t => {
   })
 })
 
+test('content-type match - RegExp with global flag', async t => {
+  t.plan(4)
+
+  const fastify = Fastify()
+  fastify.addContentTypeParser(/^application\/.+\+xml$/g, { parseAs: 'string' }, function (request, body, done) {
+    done(null, body)
+  })
+
+  fastify.post('/', async (request) => request.body)
+
+  // Two distinct content types that both match the parser. A RegExp with the
+  // `g` flag keeps a mutable lastIndex between test() calls, so the second
+  // content type must still match rather than fall through to 415.
+  const first = await fastify.inject({
+    method: 'POST',
+    path: '/',
+    headers: { 'content-type': 'application/vnd.a+xml' },
+    body: '<a/>'
+  })
+  const second = await fastify.inject({
+    method: 'POST',
+    path: '/',
+    headers: { 'content-type': 'application/vnd.b+xml' },
+    body: '<b/>'
+  })
+
+  t.assert.strictEqual(first.statusCode, 200)
+  t.assert.strictEqual(first.payload, '<a/>')
+  t.assert.strictEqual(second.statusCode, 200)
+  t.assert.strictEqual(second.payload, '<b/>')
+})
+
 test('content-type fail when parameters not match - string 1', async t => {
   t.plan(1)
 


### PR DESCRIPTION
## Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Developer's Certification of Origin](https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/fastify/blob/main/CODE_OF_CONDUCT.md)

## What this does

`ContentTypeParser.getParser` walks `parserRegExpList` and calls `parserRegExp.test(ct)` to find a matching custom parser. When a parser is registered with a RegExp that carries the `g` or `y` flag, `RegExp.prototype.test` is stateful: it advances `lastIndex` on a match and resumes from there on the next call. So the same parser RegExp can match one request and then miss (or partially match) a later one for the same content type, depending on where `lastIndex` was left.

The fix resets `parserRegExp.lastIndex = 0` before each `test()`, which makes matching independent of previous calls. Parsers registered with non-global RegExps (the common case) are unaffected, since `lastIndex` is not used there.

Added a regression test that registers a global-flagged content-type RegExp and sends two matching requests; it fails before this change (the second request misses the parser) and passes after.
