### PR TITLE
docs: use async trailer handlers in Reply examples

### DIFF
--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -271,7 +271,7 @@ as soon as possible.
 > in the error, you can turn on `debug` level logging.
 
 ```js
-reply.trailer('server-timing', function() {
+reply.trailer('server-timing', async function () {
   return 'db;dur=53, app;dur=47.2'
 })
 
@@ -304,7 +304,7 @@ Returns a boolean indicating if the specified trailer has been set.
 
 Remove the value of a previously set trailer.
 ```js
-reply.trailer('server-timing', function() {
+reply.trailer('server-timing', async function () {
   return 'db;dur=53, app;dur=47.2'
 })
 reply.removeTrailer('server-timing')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

### Description

The Reply reference still used synchronous direct-return trailer handlers in two examples. Direct trailer returns were removed in Fastify v5, so the examples no longer match the supported API.

This updates both examples to use async handlers, consistent with the v5 migration guide, runtime behavior, and TypeScript definitions.

### Verification

- Ran `npm run lint:markdown`

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
