### PR TITLE
fix: remove raw response headers

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -254,9 +254,13 @@ Reply.prototype.hasHeader = function (key) {
 }
 
 Reply.prototype.removeHeader = function (key) {
+  key = key.toLowerCase()
   // Node.js does not like headers with keys set to undefined,
   // so we have to delete the key.
-  delete this[kReplyHeaders][key.toLowerCase()]
+  delete this[kReplyHeaders][key]
+  if (!this.raw.headersSent) {
+    this.raw.removeHeader(key)
+  }
   return this
 }
 

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -1114,6 +1114,80 @@ test('reply.removeHeader can remove the value', async t => {
   await fetch(`${fastifyServer}/headers`)
 })
 
+test('reply.removeHeader removes raw headers', async t => {
+  t.plan(9)
+
+  const fastify = require('../../')()
+
+  t.after(() => fastify.close())
+
+  fastify.get('/headers', function (req, reply) {
+    reply.raw.setHeader('X-Foo', 'raw')
+    t.assert.strictEqual(reply.getHeader('x-foo'), 'raw')
+    t.assert.strictEqual(reply.getHeaders()['x-foo'], 'raw')
+    t.assert.strictEqual(reply.hasHeader('x-foo'), true)
+
+    t.assert.strictEqual(reply.removeHeader('x-FoO'), reply)
+    t.assert.strictEqual(reply.getHeader('x-foo'), undefined)
+    t.assert.strictEqual(Object.hasOwn(reply.getHeaders(), 'x-foo'), false)
+    t.assert.strictEqual(reply.hasHeader('x-foo'), false)
+    t.assert.strictEqual(reply.removeHeader('X-FOO'), reply)
+
+    reply.send()
+  })
+
+  const fastifyServer = await fastify.listen({ port: 0 })
+  const response = await fetch(`${fastifyServer}/headers`)
+  t.assert.strictEqual(response.headers.get('x-foo'), null)
+})
+
+test('reply.removeHeader removes layered headers', async t => {
+  t.plan(7)
+
+  const fastify = require('../../')()
+
+  t.after(() => fastify.close())
+
+  fastify.get('/headers', function (req, reply) {
+    reply.raw.setHeader('x-foo', 'raw')
+    reply.header('x-foo', 'fastify')
+    t.assert.strictEqual(reply.getHeader('x-foo'), 'fastify')
+    t.assert.strictEqual(reply.getHeaders()['x-foo'], 'fastify')
+
+    t.assert.strictEqual(reply.removeHeader('x-foo'), reply)
+    t.assert.strictEqual(reply.getHeader('x-foo'), undefined)
+    t.assert.strictEqual(Object.hasOwn(reply.getHeaders(), 'x-foo'), false)
+    t.assert.strictEqual(reply.hasHeader('x-foo'), false)
+
+    reply.send()
+  })
+
+  const fastifyServer = await fastify.listen({ port: 0 })
+  const response = await fetch(`${fastifyServer}/headers`)
+  t.assert.strictEqual(response.headers.get('x-foo'), null)
+})
+
+test('reply.removeHeader does not throw after headers are sent', async t => {
+  t.plan(3)
+
+  const fastify = require('../../')()
+
+  t.after(() => fastify.close())
+
+  fastify.get('/headers', function (req, reply) {
+    reply.hijack()
+    reply.raw.setHeader('x-foo', 'raw')
+    reply.raw.flushHeaders()
+    t.assert.strictEqual(reply.raw.headersSent, true)
+    t.assert.doesNotThrow(() => reply.removeHeader('x-foo'))
+    reply.raw.end()
+  })
+
+  const fastifyServer = await fastify.listen({ port: 0 })
+  const response = await fetch(`${fastifyServer}/headers`)
+  t.assert.strictEqual(response.headers.get('x-foo'), 'raw')
+})
+
 test('reply.header can reset the value', async t => {
   t.plan(1)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

### Description

`reply.removeHeader()` removed only headers stored in Fastify's internal header map.

Headers set through `reply.raw.setHeader()` remained visible through `getHeader()`, `getHeaders()`, and `hasHeader()`, and were still sent to the client after calling `removeHeader()`.

This change removes the header from both Fastify's internal header map and the raw response before the headers have been sent. The `headersSent` check preserves the existing non-throwing behavior after transmission.

This also means that when both a raw and Fastify-managed value exist for the same header, `removeHeader()` removes the complete effective header rather than revealing the underlying raw value.

### Tests

Added regression coverage for:

- raw-only headers
- layered raw and Fastify-managed headers
- mixed-case header names
- repeated removal and chainability
- behavior after headers have already been sent
- client-visible response headers

### Verification

- `node --test test/internals/reply.test.js`
- `npm test`
- `npm run coverage:ci-check-coverage`

All tests passed and coverage remains at 100%.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
