### PR TITLE
fix: honor quoted-string in `Content-Type` parameter values

### DIFF
--- a/lib/content-type.js
+++ b/lib/content-type.js
@@ -3,15 +3,37 @@
 const { LruMap: Lru } = require('toad-cache')
 
 /**
- * keyValuePairsReg is used to split the parameters list into associated
- * key value pairings. The leading `(?:^|;)\s*` anchor ensures the regex
- * only attempts matches at parameter boundaries, preventing quadratic
- * backtracking on malformed input.
+ * keyValuePairsReg matches a single `parameter-name "=" parameter-value`
+ * at a parameter boundary, following RFC 9110 §5.6.6 grammar:
+ *
+ *   parameter       = parameter-name "=" parameter-value
+ *   parameter-name  = token
+ *   parameter-value = ( token / quoted-string )
+ *   quoted-string   = DQUOTE *( qdtext / quoted-pair ) DQUOTE
+ *   qdtext          = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
+ *   quoted-pair     = "\" ( HTAB / SP / VCHAR / obs-text )
+ *   obs-text        = %x80-FF
+ *
+ * The value alternative accepts either a bare token or a full quoted-string
+ * whose content matches the qdtext / quoted-pair character ranges. Because
+ * the quoted-string branch is aware of `\"` as an escape, embedded `"` and
+ * `;` characters inside a quoted value do not terminate the value.
  *
  * @see https://httpwg.org/specs/rfc9110.html#parameter
  * @type {RegExp}
  */
-const keyValuePairsReg = /(?:^|;)\s*([\w!#$%&'*+.^`|~-]+)=([^;]*)/gm
+const keyValuePairsReg = /(?:^|;)\s*([\w!#$%&'*+.^`|~-]+)=("(?:[\t\u0020\u0021\u0023-\u005b\u005d-\u007e\u0080-\u00ff]|\\[\t\u0020-\u00ff])*"|[\w!#$%&'*+.^`|~-]+)/gu
+
+/**
+ * quotedPairReg matches a quoted-pair (a backslash followed by a single
+ * quoted-pair-allowed octet) inside a quoted-string value. Per RFC 9110
+ * §5.6.4, recipients that process the value of a quoted-string MUST handle
+ * a quoted-pair as if it were replaced by the octet following the backslash.
+ *
+ * @see https://httpwg.org/specs/rfc9110.html#quoted.string
+ * @type {RegExp}
+ */
+const quotedPairReg = /\\([\t\u0020-\u00ff])/gu
 
 /**
  * typeNameReg is used to validate that the first part of the media-type
@@ -140,21 +162,17 @@ class ContentType {
       const key = matches[1].toLowerCase()
       // Parameter values might or might not be case-sensitive,
       // depending on the semantics of the parameter name.
-      const value = matches[2]
-      if (value[0] === '"') {
-        if (value.at(-1) !== '"') {
-          this.#parameters.set(key, 'invalid quoted string')
-          matches = keyValuePairsReg.exec(paramsList)
-          continue
+      let value = matches[2]
+      if (value.charCodeAt(0) === 0x22 /* " */) {
+        // Strip the surrounding DQUOTEs and unescape quoted-pairs per
+        // RFC 9110 §5.6.4. The regex guarantees the value starts and ends
+        // with `"` and only contains permitted qdtext / quoted-pair octets.
+        value = value.slice(1, -1)
+        if (value.indexOf('\\') !== -1) {
+          value = value.replace(quotedPairReg, '$1')
         }
-        // We should probably verify the value matches a quoted string
-        // (https://httpwg.org/specs/rfc9110.html#rule.quoted-string) value.
-        // But we are not really doing much with the parameter values, so we
-        // are omitting that at this time.
-        this.#parameters.set(key, value.slice(1, value.length - 1))
-      } else {
-        this.#parameters.set(key, value)
       }
+      this.#parameters.set(key, value)
       matches = keyValuePairsReg.exec(paramsList)
     }
   }

--- a/test/content-type.test.js
+++ b/test/content-type.test.js
@@ -161,12 +161,11 @@ describe('ContentType class', () => {
     t.assert.equal(found.mediaType, 'application/json')
     t.assert.equal(found.type, 'application')
     t.assert.equal(found.subtype, 'json')
-    t.assert.equal(found.parameters.size, 3)
+    t.assert.equal(found.parameters.size, 2)
 
     const expected = [
       ['charset', 'utf-8'],
-      ['foo', 'BaR'],
-      ['baz', 'invalid quoted string']
+      ['foo', 'BaR']
     ]
     t.assert.deepStrictEqual(
       Array.from(found.parameters.entries()),
@@ -175,8 +174,36 @@ describe('ContentType class', () => {
 
     t.assert.equal(
       found.toString(),
-      'application/json; charset="utf-8"; foo="BaR"; baz="invalid quoted string"'
+      'application/json; charset="utf-8"; foo="BaR"'
     )
+  })
+
+  test('preserves a semicolon inside a quoted parameter value', (t) => {
+    // RFC 9110 §5.6.6: ';' is a literal qdtext octet inside a quoted-string
+    // and does not terminate the parameter value.
+    const found = new ContentType('application/json; name="foo;bar"; charset=utf-8')
+    t.assert.equal(found.isValid, true)
+    t.assert.equal(found.mediaType, 'application/json')
+    t.assert.equal(found.parameters.get('name'), 'foo;bar')
+    t.assert.equal(found.parameters.get('charset'), 'utf-8')
+  })
+
+  test('does not leak a fake parameter out of a quoted value', (t) => {
+    // A `key=value;` sequence inside a quoted-string is opaque content of the
+    // enclosing value, not a subsequent parameter.
+    const found = new ContentType('application/json; name="a=b;charset=fake"; boundary=xyz')
+    t.assert.equal(found.isValid, true)
+    t.assert.equal(found.parameters.get('name'), 'a=b;charset=fake')
+    t.assert.equal(found.parameters.get('boundary'), 'xyz')
+    t.assert.equal(found.parameters.has('charset'), false)
+  })
+
+  test('unescapes a quoted-pair inside a quoted-string', (t) => {
+    // RFC 9110 §5.6.4: a quoted-pair MUST be handled as if replaced by
+    // the octet following the backslash.
+    const found = new ContentType('application/json; name="he said \\"hi\\""')
+    t.assert.equal(found.isValid, true)
+    t.assert.equal(found.parameters.get('name'), 'he said "hi"')
   })
 })
 

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -1949,3 +1949,25 @@ test('Uint8Array view of ArrayBuffer returns correct byteLength', (t, done) => {
     })
   })
 })
+
+test('reply.send should not treat charset= inside a quoted parameter value as an already-declared charset', async t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.get('/', function (req, reply) {
+    // A quoted parameter value that happens to contain the substring
+    // `charset=` is opaque content of that value, not a real charset
+    // parameter, so reply.send must still append `; charset=utf-8`.
+    reply.header('content-type', 'application/json; name="a=b;charset=fake"')
+    reply.send({ hello: 'world' })
+  })
+
+  const res = await fastify.inject({ method: 'GET', url: '/' })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(
+    res.headers['content-type'],
+    'application/json; name="a=b;charset=fake"; charset=utf-8'
+  )
+})


### PR DESCRIPTION
### Summary

`lib/content-type.js` parses parameters with a single regex whose value alternative is `[^;]*`, which is not aware of quoted-strings. Three consequences follow, all reproducible on `main`:

- A `;` inside a quoted parameter value terminates the value early. `name="foo;bar"` is parsed as if `name` were unterminated.
- Any `key=value;` text inside a quoted value surfaces as an extra parameter of its own. `name="a=b;charset=fake"` produces a phantom `charset` entry that never appeared on the wire.
- Backslash escapes inside a quoted-string are left untouched instead of being unescaped as required by RFC 9110 §5.6.4.

The second one has an observable effect on responses. `reply.send()` decides whether to append the default `charset=utf-8` via `contentType.parameters.has('charset')` (introduced in #6830). A leaked `charset` from inside a quoted parameter value passes that check and suppresses the correct charset on the response — the added integration test in this PR fails on `main` and passes with the fix.

### Description

This aligns the parameter parser with the grammar defined in [RFC 9110 §5.6.6](https://httpwg.org/specs/rfc9110.html#parameter) (`parameter-value = ( token / quoted-string )`) and the quoted-pair rule in [§5.6.4](https://httpwg.org/specs/rfc9110.html#quoted.string). The behavior matches [`fast-content-type-parse`](https://github.com/fastify/fast-content-type-parse), which the ecosystem already treats as the reference implementation of this grammar.

I kept the fix in-tree rather than introducing `fast-content-type-parse` as a dependency for two reasons: `lib/content-type.js` was only just added in #6830 and exposes a class-based API (`.mediaType`, `.parameters.has()`, `.toString()`, shared LRU cache) that the reference package does not provide, and the change here is a bug fix on a fresh piece of code rather than a rewrite.

One small behavior change worth calling out: previously, an unterminated quoted value (e.g. `foo=" 42`) was stored under a synthetic `'invalid quoted string'` sentinel string. That sentinel was indistinguishable from a real value to `parameters.has()` / `parameters.get()`, which is what enabled the leaked-`charset` case in the first place. With this change an unterminated quoted parameter is dropped instead.

### Changes

- `lib/content-type.js` — extend the parameter regex so the value alternative matches either a token or a full quoted-string whose content follows the qdtext / quoted-pair character ranges; strip the enclosing DQUOTEs and unescape any quoted-pairs when the matched value is a quoted-string.
- `test/content-type.test.js` — add three unit tests covering the three broken cases, and update `skips invalid quoted string parameters` to reflect that an unterminated quoted value is now dropped rather than kept under a sentinel string.
- `test/internals/reply.test.js` — add an integration test asserting that `reply.send()` still appends `charset=utf-8` when a quoted parameter value happens to contain the substring `charset=`.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
