### PR TITLE
ci(dependabot): temporarily ignore typescript updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,7 @@ updates:
       - dependency-name: "eslint"
       - dependency-name: "neostandard"
       - dependency-name: "@stylistic/*"
+      - dependency-name: "typescript"  
     open-pull-requests-limit: 10
     groups:
       # Production dependencies with breaking changes


### PR DESCRIPTION
Proposal:

- Temporarily adds `typescript` to the `ignore` list in `.github/dependabot.yml`, alongside `eslint`, `neostandard` and `@stylistic/*`. Because `TypeScript v7.x` needs to be updated in coordination with eslint/neostandard, which are currently pinned pending `ESLint v10.x` support (see TODO in the file). Updating TypeScript on its own risks introducing incompatibilities with the rest of the linting toolchain ( see error CI here:  https://github.com/fastify/fastify/actions/runs/30015623246/job/89234728715?pr=6868#step:5:18 )
- see PR of reference: https://github.com/fastify/busboy/pull/221

Notes:

- Should be removed along with the other ignores once `neostandard` supports `ESLint v10.x` and `Typescript v7.x`.
- I also blocked the update in the following repositories temporarily:
   - https://github.com/fastify/busboy/pull/221   
   - https://github.com/fastify/sse/pull/50
   - https://github.com/fastify/fastify-compress/pull/415
   - https://github.com/fastify/fastify-type-provider-json-schema-to-ts/pull/148
   - https://github.com/fastify/fastify-http-proxy/pull/478
   - https://github.com/fastify/fastify-type-provider-typebox/pull/291
   - https://github.com/fastify/fastify-cors/pull/415
   - https://github.com/fastify/avvio/pull/355
   - https://github.com/fastify/fast-json-stringify/pull/859
   - https://github.com/fastify/fastify-postgres/pull/229
   - https://github.com/fastify/fastify-autoload/pull/525
   - https://github.com/fastify/fastify-flash/pull/162
   - https://github.com/fastify/fastify-passport/pull/1431
   - https://github.com/fastify/fastify-cli/pull/904
   - https://github.com/fastify/fastify-type-provider-zod/pull/22

---

cc @fastify/leads @fastify/core 