### PR TITLE
docs(server): fix contradictory requestIdHeader default

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -567,7 +567,7 @@ enhance the server instance inside the `serverFactory` function before the
 ### `requestIdHeader`
 <a id="factory-request-id-header"></a>
 
-+ Default: `'request-id'`
++ Default: `false`
 
 The header name used to set the request-id. See [the
 request-id](./Logging.md#logging-request-id) section.
@@ -578,8 +578,6 @@ the specified string as the `requestIdHeader`.
 By default `requestIdHeader` is set to `false` and will immediately use [genReqId](#genreqid).
 Setting `requestIdHeader` to an empty String (`""`) will set the
 requestIdHeader to `false`.
-
-+ Default: `false`
 
 ```js
 const fastify = require('fastify')({


### PR DESCRIPTION
The `requestIdHeader` section of `docs/Reference/Server.md` carries two `+ Default:` lines with opposite values, and the wrong one is the one readers hit first:

```
570: + Default: `'request-id'`
...
578: By default `requestIdHeader` is set to `false` and will immediately use genReqId
...
582: + Default: `false`
```

`false` is the correct one:

- `require('fastify')().initialConfig.requestIdHeader` is `false` on 5.x
- `build/build-validation.js:42` → `requestIdHeader: false`
- `lib/config-validator.js:60-61` → `if (data.requestIdHeader === undefined) { data.requestIdHeader = false }`
- `fastify.js:875` → the header name is only used when `requestIdHeader === true` or a non-empty string

Origin, in case it's useful: `7381195d` (#4194, "Change request id header default value to false") corrected the single `+ Default:` line at the bottom of the section on the v5 `next` branch, while `bf01ba44` (#4904, docs restructure) independently moved a copy of the old line up under the heading on v4 `main`. The merge `aceab549` kept both.

This fixes the line under the heading and drops the duplicate lower down, matching the 28-of-31 convention in this file of putting `+ Default:` directly under the option heading.

Separately, `### genReqId` just below still documents its default as "value of 'request-id' header if provided…", which reads stale for the same reason — happy to follow up on that in its own PR if you want it changed.
