### PR TITLE
Bump find-my-way version from: 9.6.0 to: 9.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
     "abstract-logging": "^2.0.1",
     "avvio": "^9.0.0",
     "fast-json-stringify": "^7.0.0",
-    "find-my-way": "^9.6.0",
+    "find-my-way": "^9.7.0",
     "light-my-request": "^6.0.0",
     "pino": "^9.14.0 || ^10.1.0",
     "process-warning": "^5.0.0",


### PR DESCRIPTION
High severity

https://github.com/advisories/GHSA-c96f-x56v-gq3h