### PR TITLE
docs: fix logController migration example and links

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -390,8 +390,8 @@ Pino interface by having the following methods: `info`, `error`, `debug`,
 ### `disableRequestLogging`
 <a id="factory-disable-request-logging"></a>
 
-> **Deprecated:** Use the [`logController`](#log-controller) option with
-> `disableRequestLogging` or `isLogDisabled` override instead.
+> **Deprecated:** Use the [`logController`](#factory-log-controller)
+> option with `disableRequestLogging` or `isLogDisabled` override instead.
 > This top-level option will be removed in `fastify@6`.
 
 + Default: `false`
@@ -407,6 +407,8 @@ and returns a boolean. This allows for conditional request logging based on the
 request properties (e.g., URL, headers, decorations).
 
 ```js
+const { LogController } = require('fastify')
+
 // Deprecated
 const fastify = require('fastify')({
   logger: true,
@@ -418,11 +420,11 @@ const fastify = require('fastify')({
 // Recommended: use logController instead
 const fastify = require('fastify')({
   logger: true,
-  logController: {
+  logController: new LogController({
     disableRequestLogging: (request) => {
       return request.url === '/health' || request.url === '/ready'
     }
-  }
+  })
 })
 ```
 
@@ -594,8 +596,9 @@ const fastify = require('fastify')({
 ### `requestIdLogLabel`
 <a id="factory-request-id-log-label"></a>
 
-> **Deprecated:** Use the [`logController`](#log-controller) option with
-> `requestIdLogLabel` instead. This top-level option will be removed in `fastify@6`.
+> **Deprecated:** Use the [`logController`](#factory-log-controller)
+> option with `requestIdLogLabel` instead. This top-level option will be
+> removed in `fastify@6`.
 
 + Default: `'reqId'`
 


### PR DESCRIPTION
The `disableRequestLogging` deprecation notice recommends passing a plain object to `logController`, but that throws at server construction on 5.10.0:

```js
require('fastify')({
  logger: true,
  logController: {
    disableRequestLogging: (request) => request.url === '/health'
  }
})
```

```
FST_ERR_LOG_INVALID_LOG_CONTROLLER: logController option must be an instance of LogController, got 'object'.
```

`createLogController` requires an instance, and `fastify.d.ts` types the option as `LogControllerClass`, so the plain-object form does not typecheck either. The `logController` section's own example already uses `new MyLogController()`.

Both deprecation notices also link to `#log-controller`, while the section anchor is `factory-log-controller`.

Since these top-level options are removed in `fastify@6`, users following the documented migration path hit this today.

Introduced in #6580.

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
