### PR TITLE
ci(links-check): pin linkinator server root to the workspace

### DIFF
--- a/.github/workflows/links-check.yml
+++ b/.github/workflows/links-check.yml
@@ -57,6 +57,7 @@ jobs:
         uses: JustinBeckwith/linkinator-action@7b6b0bc671f6264e1a8daa4488a5bd91ce61dcd4 # 2.4.2
         with:
           paths: ${{ steps.changed-md.outputs.files }}
+          serverRoot: ${{ github.workspace }}
           retry: true
           redirects: error
           verbosity: error


### PR DESCRIPTION
When a pull request changes a single markdown file, the `External Link Checker` step reports 404s for relative links that traverse upward.

A live example from #6876 :

```
Scanning docs/Reference/Server.md
Error: [404] docs/Reference/Guides/Prototype-Poisoning.md - HTTP 404
Error: [404] docs/Reference/Guides/Testing.md - HTTP 404
Scanned total of 40 links!
Error: Detected 2 broken links.
```

Both targets exist, and they are linked from `docs/Reference/Server.md` as `../Guides/...`.

The cause is how linkinator picks its static server root when none is configured:

```js
if (options.path.length > 1) {
  options.serverRoot = process.cwd();
} else {
  ...
  options.serverRoot = pathParts.slice(0, -1).join(sep) || ".";
}
```

Given a single local file it serves that file's own directory, so `docs/Reference/Server.md` is served from `docs/Reference/` and `../Guides/...` resolves above the server root, ending up as `docs/Reference/Guides/...`. Given more than one path it uses the working directory and the same links resolve correctly.

Since #6421 the step runs only on changed markdown files, so a pull request touching exactly one markdown file takes the single-path branch. 16 files under `docs/` contain upward-traversing links and are affected: 5 under `docs/Reference/` and 11 under `docs/Guides/`. Scanned alone, `docs/Guides/Getting-Started.md` reports 10 false 404s.

Setting `serverRoot` to the workspace pins the server to the repository root, mirroring what #6535 did for lychee with `--root-dir "$(pwd)"`. All 16 files then report zero 404s, and multi-file invocations are unaffected since they already resolve against the working directory.

The paths collected by the previous step are repository-relative, which is what linkinator expects when `serverRoot` is set:

```js
let fullPath = options.serverRoot ? path.join(options.serverRoot, filePath) : filePath;
```

A relative value such as `.` does not work: the contraction step slices as many leading segments as `serverRoot` has, so `.` would strip `docs/`.

The `lychee` step already validates these same links correctly, which is why they are not reported there.

Note: this pull request changes no markdown files, so the `External Link Checker` step is skipped here and cannot demonstrate the fix on itself.

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)