### PR TITLE
fix: add http method override warning

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1729,9 +1729,7 @@ fastify.mkcol('/', (req, reply) => {
 })
 ```
 
-Calling `addHttpMethod` for an existing method overrides its body behavior. In
-Fastify v5, the override still occurs, but Fastify emits `FSTWRN005` unless
-`overrideExisting` is `true`:
+Calling `addHttpMethod` for an existing method overrides its body behavior.
 
 ```js
 fastify.addHttpMethod('GET', {
@@ -1740,8 +1738,8 @@ fastify.addHttpMethod('GET', {
 })
 ```
 
-In Fastify v6, overriding an existing method without `overrideExisting: true`
-will throw an error.
+In Fastify v5, omitting `overrideExisting: true` emits `FSTWRN005`; in Fastify
+v6, it will throw an error.
 
 #### addSchema
 <a id="add-schema"></a>

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1704,6 +1704,13 @@ Fastify supports the `GET`, `HEAD`, `TRACE`, `DELETE`, `OPTIONS`,
 The `addHttpMethod` method allows to add any non standard HTTP
 methods to the server that are [supported by Node.js](https://nodejs.org/api/http.html#httpmethods).
 
+The method accepts an optional configuration object:
+
+| Property | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| `hasBody` | `boolean` | `false` | Whether the method accepts a request body. |
+| `overrideExisting` | `boolean` | `false` | Whether to explicitly override an existing method. |
+
 ```js
 // Add a new HTTP method called 'MKCOL' that supports a request body
 fastify.addHttpMethod('MKCOL', { hasBody: true,  })
@@ -1722,8 +1729,19 @@ fastify.mkcol('/', (req, reply) => {
 })
 ```
 
-> ⚠ Warning:
-> `addHttpMethod` overrides existing methods.
+Calling `addHttpMethod` for an existing method overrides its body behavior. In
+Fastify v5, the override still occurs, but Fastify emits `FSTWRN005` unless
+`overrideExisting` is `true`:
+
+```js
+fastify.addHttpMethod('GET', {
+  hasBody: true,
+  overrideExisting: true
+})
+```
+
+In Fastify v6, overriding an existing method without `overrideExisting: true`
+will throw an error.
 
 #### addSchema
 <a id="add-schema"></a>

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1738,7 +1738,7 @@ fastify.addHttpMethod('GET', {
 })
 ```
 
-In Fastify v5, omitting `overrideExisting: true` emits `FSTWRN005`; in Fastify
+In Fastify v5, omitting `overrideExisting: true` emits `FSTDEP025`; in Fastify
 v6, it will throw an error.
 
 #### addSchema

--- a/docs/Reference/Warnings.md
+++ b/docs/Reference/Warnings.md
@@ -46,6 +46,7 @@ Disabling warnings is not recommended and may cause unexpected behavior.
 | <a id="FSTWRN001">FSTWRN001</a> | The specified schema for a route is missing. This may indicate the schema is not well specified. | Check the schema for the route. | [#4647](https://github.com/fastify/fastify/pull/4647) |
 | <a id="FSTWRN003">FSTWRN003</a> | The `%s` plugin mixes async and callback styles, which may lead to unhandled rejections. | Do not mix async and callback style. | [#6011](https://github.com/fastify/fastify/pull/6011) |
 | <a id="FSTWRN004">FSTWRN004</a> | An `errorHandler` is being overridden in the same scope, which can lead to subtle bugs. | Avoid calling `setErrorHandler` more than once in the same scope. For more information, see [Server documentation](https://fastify.dev/docs/latest/Reference/Server/#allowerrorhandleroverride). | [#6104](https://github.com/fastify/fastify/pull/6104) |
+| <a id="FSTWRN005">FSTWRN005</a> | `addHttpMethod` was called for an existing HTTP method. | Pass `{ overrideExisting: true }` to make the override explicit. | [#6608](https://github.com/fastify/fastify/pull/6608) |
 
 
 ### Fastify Deprecation Codes

--- a/docs/Reference/Warnings.md
+++ b/docs/Reference/Warnings.md
@@ -12,6 +12,7 @@
     - [FSTDEP022](#FSTDEP022)
     - [FSTDEP023](#FSTDEP023)
     - [FSTDEP024](#FSTDEP024)
+    - [FSTDEP025](#FSTDEP025)
 
 ## Warnings
 
@@ -46,9 +47,6 @@ Disabling warnings is not recommended and may cause unexpected behavior.
 | <a id="FSTWRN001">FSTWRN001</a> | The specified schema for a route is missing. This may indicate the schema is not well specified. | Check the schema for the route. | [#4647](https://github.com/fastify/fastify/pull/4647) |
 | <a id="FSTWRN003">FSTWRN003</a> | The `%s` plugin mixes async and callback styles, which may lead to unhandled rejections. | Do not mix async and callback style. | [#6011](https://github.com/fastify/fastify/pull/6011) |
 | <a id="FSTWRN004">FSTWRN004</a> | An `errorHandler` is being overridden in the same scope, which can lead to subtle bugs. | Avoid calling `setErrorHandler` more than once in the same scope. For more information, see [Server documentation](https://fastify.dev/docs/latest/Reference/Server/#allowerrorhandleroverride). | [#6104](https://github.com/fastify/fastify/pull/6104) |
-| <a id="FSTWRN005">FSTWRN005</a> | `addHttpMethod` was called for an existing HTTP method. | Pass `{ overrideExisting: true }` to make the override explicit. | [#6608](https://github.com/fastify/fastify/pull/6608) |
-
-
 ### Fastify Deprecation Codes
 
 Deprecation codes are supported by the Node.js CLI options:
@@ -63,3 +61,4 @@ Deprecation codes are supported by the Node.js CLI options:
 | <a id="FSTDEP022">FSTDEP022</a> | You are trying to access the deprecated router options on top option properties. | Use `options.routerOptions`. | [#5985](https://github.com/fastify/fastify/pull/5985)
 | <a id="FSTDEP023">FSTDEP023</a> | `disableRequestLogging` top-level option is deprecated. | Pass a `LogController` instance via the `logController` option with `disableRequestLogging` in its constructor instead. |
 | <a id="FSTDEP024">FSTDEP024</a> | `requestIdLogLabel` top-level option is deprecated. | Pass a `LogController` instance via the `logController` option with `requestIdLogLabel` in its constructor instead. |
+| <a id="FSTDEP025">FSTDEP025</a> | Calling `addHttpMethod` for an existing HTTP method without `{ overrideExisting: true }` is deprecated. | Pass `{ overrideExisting: true }` to make the override explicit. | [#6879](https://github.com/fastify/fastify/pull/6879) |

--- a/fastify.js
+++ b/fastify.js
@@ -80,7 +80,7 @@ const {
 } = errorCodes
 
 const { buildErrorHandler } = require('./lib/error-handler.js')
-const { FSTWRN004, FSTDEP023, FSTDEP024 } = require('./lib/warnings.js')
+const { FSTWRN004, FSTWRN005, FSTDEP023, FSTDEP024 } = require('./lib/warnings.js')
 
 const initChannel = diagnostics.channel('fastify.initialization')
 
@@ -823,9 +823,16 @@ function fastify (serverOptions) {
     return this
   }
 
-  function addHttpMethod (method, { hasBody = false } = {}) {
+  function addHttpMethod (method, { hasBody = false, overrideExisting = false } = {}) {
     if (typeof method !== 'string' || http.METHODS.indexOf(method) === -1) {
       throw new FST_ERR_ROUTE_METHOD_INVALID()
+    }
+
+    const alreadyExists = this[kSupportedHTTPMethods].bodyless.has(method) ||
+      this[kSupportedHTTPMethods].bodywith.has(method)
+
+    if (alreadyExists && !overrideExisting) {
+      FSTWRN005(method)
     }
 
     if (hasBody === true) {

--- a/fastify.js
+++ b/fastify.js
@@ -80,7 +80,7 @@ const {
 } = errorCodes
 
 const { buildErrorHandler } = require('./lib/error-handler.js')
-const { FSTWRN004, FSTWRN005, FSTDEP023, FSTDEP024 } = require('./lib/warnings.js')
+const { FSTWRN004, FSTDEP023, FSTDEP024, FSTDEP025 } = require('./lib/warnings.js')
 
 const initChannel = diagnostics.channel('fastify.initialization')
 
@@ -832,7 +832,7 @@ function fastify (serverOptions) {
       this[kSupportedHTTPMethods].bodywith.has(method)
 
     if (alreadyExists && !overrideExisting) {
-      FSTWRN005(method)
+      FSTDEP025(method)
     }
 
     if (hasBody === true) {

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -13,6 +13,7 @@ const { createWarning } = require('process-warning')
  * Deprecation Codes FSTDEP001 - FSTDEP021 were used by v4 and MUST NOT be reused.
  *                             - FSTDEP022 is used by v5 and MUST NOT be reused.
  * Warning Codes FSTWRN001 - FSTWRN002 were used by v4 and MUST NOT be reused.
+ *               FSTWRN003 - FSTWRN005 are used by v5 and MUST NOT be reused.
  */
 
 const FSTWRN001 = createWarning({
@@ -33,6 +34,13 @@ const FSTWRN004 = createWarning({
   name: 'FastifyWarning',
   code: 'FSTWRN004',
   message: 'It seems that you are overriding an errorHandler in the same scope, which can lead to subtle bugs. To disable this behavior, set \'allowErrorHandlerOverride\' to false. For more information, visit: https://fastify.dev/docs/latest/Reference/Server/#allowerrorhandleroverride',
+  unlimited: true
+})
+
+const FSTWRN005 = createWarning({
+  name: 'FastifyWarning',
+  code: 'FSTWRN005',
+  message: 'addHttpMethod was called for method "%s", which already exists. Pass { overrideExisting: true } to suppress this warning. In Fastify v6, calling addHttpMethod on an existing method without this option will throw an error.',
   unlimited: true
 })
 
@@ -68,6 +76,7 @@ module.exports = {
   FSTWRN001,
   FSTWRN003,
   FSTWRN004,
+  FSTWRN005,
   FSTSEC001,
   FSTDEP022,
   FSTDEP023,

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -9,11 +9,11 @@ const { createWarning } = require('process-warning')
  *   - FSTDEP022
  *   - FSTDEP023
  *   - FSTDEP024
+ *   - FSTDEP025
  *
  * Deprecation Codes FSTDEP001 - FSTDEP021 were used by v4 and MUST NOT be reused.
- *                             - FSTDEP022 is used by v5 and MUST NOT be reused.
+ *                             - FSTDEP022 - FSTDEP025 are used by v5 and MUST NOT be reused.
  * Warning Codes FSTWRN001 - FSTWRN002 were used by v4 and MUST NOT be reused.
- *               FSTWRN003 - FSTWRN005 are used by v5 and MUST NOT be reused.
  */
 
 const FSTWRN001 = createWarning({
@@ -34,13 +34,6 @@ const FSTWRN004 = createWarning({
   name: 'FastifyWarning',
   code: 'FSTWRN004',
   message: 'It seems that you are overriding an errorHandler in the same scope, which can lead to subtle bugs. To disable this behavior, set \'allowErrorHandlerOverride\' to false. For more information, visit: https://fastify.dev/docs/latest/Reference/Server/#allowerrorhandleroverride',
-  unlimited: true
-})
-
-const FSTWRN005 = createWarning({
-  name: 'FastifyWarning',
-  code: 'FSTWRN005',
-  message: 'addHttpMethod was called for method "%s", which already exists. Pass { overrideExisting: true } to suppress this warning. In Fastify v6, calling addHttpMethod on an existing method without this option will throw an error.',
   unlimited: true
 })
 
@@ -72,13 +65,20 @@ const FSTDEP024 = createWarning({
   unlimited: true
 })
 
+const FSTDEP025 = createWarning({
+  name: 'FastifyDeprecation',
+  code: 'FSTDEP025',
+  message: 'Calling addHttpMethod for existing method "%s" without { overrideExisting: true } is deprecated. In Fastify v6, this will throw an error.',
+  unlimited: true
+})
+
 module.exports = {
   FSTWRN001,
   FSTWRN003,
   FSTWRN004,
-  FSTWRN005,
   FSTSEC001,
   FSTDEP022,
   FSTDEP023,
-  FSTDEP024
+  FSTDEP024,
+  FSTDEP025
 }

--- a/test/http-methods/custom-http-methods.test.js
+++ b/test/http-methods/custom-http-methods.test.js
@@ -116,8 +116,8 @@ test('addHttpMethod rejects fake http method', t => {
 test('addHttpMethod warns when overriding an existing method', (t, done) => {
   const fastify = Fastify()
   const onWarning = warning => {
-    t.assert.strictEqual(warning.name, 'FastifyWarning')
-    t.assert.strictEqual(warning.code, 'FSTWRN005')
+    t.assert.strictEqual(warning.name, 'FastifyDeprecation')
+    t.assert.strictEqual(warning.code, 'FSTDEP025')
     done()
   }
   process.once('warning', onWarning)

--- a/test/http-methods/custom-http-methods.test.js
+++ b/test/http-methods/custom-http-methods.test.js
@@ -1,7 +1,9 @@
 'use strict'
 
 const http = require('node:http')
+const { once } = require('node:events')
 const { test } = require('node:test')
+const { setImmediate: setImmediateAsync } = require('node:timers/promises')
 const Fastify = require('../../fastify')
 
 function addEcho (fastify, method) {
@@ -111,4 +113,62 @@ test('addHttpMethod rejects fake http method', t => {
   t.plan(1)
   const fastify = Fastify()
   t.assert.throws(() => { fastify.addHttpMethod('FOOO') }, /Provided method is invalid!/)
+})
+
+test('addHttpMethod warns when overriding an existing method', async t => {
+  const warningPromise = once(process, 'warning')
+  const fastify = Fastify()
+
+  fastify.addHttpMethod('GET', { hasBody: true })
+
+  const [warning] = await warningPromise
+  t.assert.strictEqual(warning.name, 'FastifyWarning')
+  t.assert.strictEqual(warning.code, 'FSTWRN005')
+})
+
+test('addHttpMethod does not warn when overriding an existing method explicitly', async t => {
+  let warning
+  function onWarning (emittedWarning) {
+    if (emittedWarning.code === 'FSTWRN005') {
+      warning = emittedWarning
+    }
+  }
+
+  process.on('warning', onWarning)
+  t.after(() => process.off('warning', onWarning))
+
+  const fastify = Fastify()
+  fastify.addHttpMethod('POST', { overrideExisting: true })
+  await setImmediateAsync()
+
+  t.assert.strictEqual(warning, undefined)
+})
+
+test('addHttpMethod can change an existing method body behavior', async t => {
+  const fastify = Fastify()
+
+  fastify.addHttpMethod('GET', {
+    hasBody: true,
+    overrideExisting: true
+  })
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    exposeHeadRoute: false,
+    schema: {
+      body: {
+        type: 'object'
+      }
+    },
+    handler: async request => request.body
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/',
+    payload: { hello: 'world' }
+  })
+
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(response.json(), { hello: 'world' })
 })

--- a/test/http-methods/custom-http-methods.test.js
+++ b/test/http-methods/custom-http-methods.test.js
@@ -1,9 +1,7 @@
 'use strict'
 
 const http = require('node:http')
-const { once } = require('node:events')
 const { test } = require('node:test')
-const { setImmediate: setImmediateAsync } = require('node:timers/promises')
 const Fastify = require('../../fastify')
 
 function addEcho (fastify, method) {
@@ -115,33 +113,36 @@ test('addHttpMethod rejects fake http method', t => {
   t.assert.throws(() => { fastify.addHttpMethod('FOOO') }, /Provided method is invalid!/)
 })
 
-test('addHttpMethod warns when overriding an existing method', async t => {
-  const warningPromise = once(process, 'warning')
+test('addHttpMethod warns when overriding an existing method', (t, done) => {
   const fastify = Fastify()
+  const onWarning = warning => {
+    t.assert.strictEqual(warning.name, 'FastifyWarning')
+    t.assert.strictEqual(warning.code, 'FSTWRN005')
+    done()
+  }
+  process.once('warning', onWarning)
+
+  t.after(() => {
+    fastify.close()
+    process.removeListener('warning', onWarning)
+  })
 
   fastify.addHttpMethod('GET', { hasBody: true })
-
-  const [warning] = await warningPromise
-  t.assert.strictEqual(warning.name, 'FastifyWarning')
-  t.assert.strictEqual(warning.code, 'FSTWRN005')
 })
 
-test('addHttpMethod does not warn when overriding an existing method explicitly', async t => {
-  let warning
-  function onWarning (emittedWarning) {
-    if (emittedWarning.code === 'FSTWRN005') {
-      warning = emittedWarning
-    }
+test('addHttpMethod does not warn when overriding an existing method explicitly', t => {
+  const doNotWarn = () => {
+    t.assert.fail('should not warn')
   }
-
-  process.on('warning', onWarning)
-  t.after(() => process.off('warning', onWarning))
+  process.on('warning', doNotWarn)
 
   const fastify = Fastify()
-  fastify.addHttpMethod('POST', { overrideExisting: true })
-  await setImmediateAsync()
+  t.after(() => {
+    fastify.close()
+    process.removeListener('warning', doNotWarn)
+  })
 
-  t.assert.strictEqual(warning, undefined)
+  fastify.addHttpMethod('POST', { overrideExisting: true })
 })
 
 test('addHttpMethod can change an existing method body behavior', async t => {

--- a/test/types/instance.tst.ts
+++ b/test/types/instance.tst.ts
@@ -215,6 +215,8 @@ function invalidSchemaErrorFormatter (err: Error) {
 server.setSchemaErrorFormatter(invalidSchemaErrorFormatter)
 
 expect(server.addHttpMethod('SEARCH', { hasBody: true })).type.toBe<FastifyInstance>()
+expect(server.addHttpMethod('GET', { overrideExisting: true })).type.toBe<FastifyInstance>()
+expect(server.addHttpMethod('POST', { hasBody: true, overrideExisting: true })).type.toBe<FastifyInstance>()
 
 // test listen opts objects
 const options: FastifyListenOptions = {}

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -663,7 +663,10 @@ export interface FastifyInstance<
    * Methods defined by default include `GET`, `HEAD`, `TRACE`, `DELETE`,
    * `OPTIONS`, `PATCH`, `PUT` and `POST`
    */
-  addHttpMethod(method: string, methodOptions?: { hasBody: boolean }): FastifyInstance<RawServer, RawRequest, RawReply,
+  addHttpMethod(method: string, methodOptions?: {
+    hasBody?: boolean;
+    overrideExisting?: boolean;
+  }): FastifyInstance<RawServer, RawRequest, RawReply,
     Logger, TypeProvider>;
   /**
    * Fastify default JSON parser


### PR DESCRIPTION
Fixes #6284.

This supersedes #6608 because the original contributor has not responded to the latest review feedback.
I would like to publish this deprecation at least a few weeks before the Fastify v6 release.

This change:

- Emits `FSTDEP025` when `addHttpMethod` overrides an existing method implicitly.
- Adds `overrideExisting: true` to make the override explicit and suppress the warning.
- Documents that implicit overrides will throw in v6.