### PR TITLE
fix: uncatchable throws in writeHead when using async hook

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -306,7 +306,11 @@ function onSendHookRunner (functions, request, reply, payload, cb) {
   }
 
   function handleResolve (newPayload) {
-    next(null, newPayload)
+    try {
+      next(null, newPayload)
+    } catch (err) {
+      cb(err, request, reply, payload)
+    }
   }
 
   function handleReject (err) {

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -813,3 +813,38 @@ test('pipe stream inside error handler should not cause error', (t, testDone) =>
     testDone()
   })
 })
+
+test('should catch error when setting invalid header on async preSerializeation hook', async (t) => {
+  t.plan(2)
+
+  const app = Fastify()
+  app.addHook('preSerialization', async (_, reply) => {
+    reply.header('X-Invalid', '\n')
+  })
+  app.addHook('onError', function (request, reply, err, done) {
+    // onError will run twice, since it execute preSerialization hook twice
+    // requires to fallback to root error handler
+    t.assert.ok(err)
+    done()
+  })
+  app.get('/', async () => ({ ok: true }))
+  await app.inject({ method: 'GET', path: '/' })
+})
+
+test('should catch error when setting invalid header on async onSend hook', async (t) => {
+  t.plan(2)
+
+  const app = Fastify()
+  app.addHook('onSend', async (_, reply, payload) => {
+    reply.header('X-Invalid', '\n')
+    return payload
+  })
+  app.addHook('onError', function (request, reply, err, done) {
+    // onError will run twice, since it execute onSend hook twice
+    // requires to fallback to root error handler
+    t.assert.ok(err)
+    done()
+  })
+  app.get('/', async () => ({ ok: true }))
+  await app.inject({ method: 'GET', path: '/' })
+})


### PR DESCRIPTION
Catch the errors throw by `writeHead` when using async `onSend` and `preSerialization` hooks.

Credit @matiasinsaurralde - Thanks for the finding.

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
