### PR TITLE
fix(content-type): drop invalid quoted parameters instead of recording a placeholder

### DIFF
--- a/lib/content-type.js
+++ b/lib/content-type.js
@@ -143,7 +143,10 @@ class ContentType {
       const value = matches[2]
       if (value[0] === '"') {
         if (value.at(-1) !== '"') {
-          this.#parameters.set(key, 'invalid quoted string')
+          // An unterminated quoted string is not a valid parameter value, so
+          // the parameter is skipped. Recording a placeholder instead would
+          // let that placeholder be serialized back out by `toString()`, e.g.
+          // into a response `content-type` header.
           matches = keyValuePairsReg.exec(paramsList)
           continue
         }

--- a/test/content-type.test.js
+++ b/test/content-type.test.js
@@ -161,12 +161,11 @@ describe('ContentType class', () => {
     t.assert.equal(found.mediaType, 'application/json')
     t.assert.equal(found.type, 'application')
     t.assert.equal(found.subtype, 'json')
-    t.assert.equal(found.parameters.size, 3)
+    t.assert.equal(found.parameters.size, 2)
 
     const expected = [
       ['charset', 'utf-8'],
-      ['foo', 'BaR'],
-      ['baz', 'invalid quoted string']
+      ['foo', 'BaR']
     ]
     t.assert.deepStrictEqual(
       Array.from(found.parameters.entries()),
@@ -175,7 +174,7 @@ describe('ContentType class', () => {
 
     t.assert.equal(
       found.toString(),
-      'application/json; charset="utf-8"; foo="BaR"; baz="invalid quoted string"'
+      'application/json; charset="utf-8"; foo="BaR"'
     )
   })
 })

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -652,6 +652,23 @@ test('plain string with content type should be sent unmodified', async t => {
   t.assert.deepStrictEqual(await result.text(), 'hello world!')
 })
 
+test('content type with an unterminated quoted parameter does not leak a placeholder', async t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  fastify.get('/', function (req, reply) {
+    // The parameter value is missing its closing quote, so it is not a valid
+    // parameter and is dropped rather than serialized back out.
+    reply.header('content-type', 'application/json; foo="bar').send({ hello: 'world' })
+  })
+
+  const res = await fastify.inject({ method: 'GET', url: '/' })
+
+  t.assert.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+  t.assert.deepStrictEqual(res.json(), { hello: 'world' })
+})
+
 test('plain string with content type and custom serializer should be serialized', async t => {
   t.plan(3)
 


### PR DESCRIPTION
## Problem

When a `Content-Type` parameter value opens with a quote but never closes it, `ContentType` records the literal string `'invalid quoted string'` as that parameter's value:

https://github.com/fastify/fastify/blob/main/lib/content-type.js#L143-L149

`toString()` serializes every stored parameter back out, and `Reply` calls `toString()` when it appends the default charset. So that internal placeholder is emitted in the response header:

```js
fastify.get('/', (req, reply) => {
  reply.header('content-type', 'application/json; foo="bar').send({ hello: 'world' })
})
```

```
content-type: application/json; foo="invalid quoted string"; charset=utf-8
```

The value the client receives is fabricated — it is neither what the application set nor a valid media type parameter.

## Change

An unterminated quoted string is not a valid parameter, so the parameter is skipped rather than stored with a placeholder. After this change the same route responds with:

```
content-type: application/json; charset=utf-8
```

Note the existing unit test is already named **"skips invalid quoted string parameters"**, but asserted `parameters.size === 3` including the placeholder. Its assertions now match the name — that is the one behavioural assertion this PR changes, and I have kept the change to exactly that:

```diff
-    t.assert.equal(found.parameters.size, 3)
+    t.assert.equal(found.parameters.size, 2)
```

Nothing reads the placeholder: `'invalid quoted string'` appeared only at the assignment in `lib/content-type.js` and in that one test.

If you would rather preserve the raw text the caller supplied (so the parameter survives round-tripping) instead of dropping it, that is a small change from here — I went with dropping because an unterminated quoted string cannot be re-serialized into a valid parameter.

## Tests

* Added `content type with an unterminated quoted parameter does not leak a placeholder` to `test/internals/reply.test.js`, which is where the symptom is observable.
* Updated the two assertions in the existing `skips invalid quoted string parameters` unit test.

```console
$ npx borp
tests 2299
pass 2294
fail 0
skipped 5
```

Reverting only `lib/content-type.js` and keeping the tests fails 4 assertions, led by the new one:

```
✖ content type with an unterminated quoted parameter does not leak a placeholder
```

`npx eslint lib/content-type.js test/content-type.test.js test/internals/reply.test.js` is clean.

## Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added — not needed; no documented behaviour changes, the placeholder was internal
- [x] commit message follows commit guidelines
