### PR TITLE
fix(types): allow explicit http2: false in server options

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -69,6 +69,7 @@ declare namespace fastify {
     Logger extends FastifyBaseLogger = FastifyBaseLogger
   > = FastifyServerOptions<Server, Logger> & {
     https: https.ServerOptions | null
+    http2?: false
   }
 
   export type FastifyHttpOptions<
@@ -76,6 +77,7 @@ declare namespace fastify {
     Logger extends FastifyBaseLogger = FastifyBaseLogger
   > = FastifyServerOptions<Server, Logger> & {
     http?: http.ServerOptions | null
+    http2?: false
   }
 
   type FindMyWayVersion<RawServer extends RawServerBase> = RawServer extends http.Server

--- a/test/types/fastify.tst.ts
+++ b/test/types/fastify.tst.ts
@@ -68,6 +68,17 @@ expect(fastify({ schemaController: {} })).type.toBe<
   FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse> &
   SafePromiseLike<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>>
 >()
+
+expect(fastify({ http2: false })).type.toBe<
+  FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse> &
+  SafePromiseLike<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>>
+>()
+
+expect(fastify({ https: {}, http2: false })).type.toBe<
+  FastifyInstance<https.Server, http.IncomingMessage, http.ServerResponse> &
+  SafePromiseLike<FastifyInstance<https.Server, http.IncomingMessage, http.ServerResponse>>
+>()
+
 expect(
   fastify({
     schemaController: {


### PR DESCRIPTION
Proposal:

- Adds an optional `http2?: false` property to `FastifyHttpOptions` and`FastifyHttpsOptions` so that explicitly passing `http2: false` no longer triggers a TypeScript error, matching the runtime behavior in lib/server.js which already falls back to http.createServer/https correctly when http2 is false.

- Adds type tests verifying that `fastify({ http2: false })` resolves to an http1 instance and `fastify({ https: {}, http2: false })` resolves to an https instance, updated to the tstyche syntax used by the current test suite.

Closes #5682 and replaces this PR: https://github.com/fastify/fastify/pull/6585, which is no longer up to date since it still uses `tsd` for type testing