### PR TITLE
fix: do not force close in-flight connections when forceCloseConnections is 'idle'

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -392,7 +392,7 @@ function fastify (serverOptions) {
           if (forceCloseConnections === 'idle' && options.serverFactory) {
             instance.server.closeIdleConnections()
             /* istanbul ignore next: Cannot test this without Node.js core support */
-          } else if (serverHasCloseAllConnections && forceCloseConnections) {
+          } else if (serverHasCloseAllConnections && forceCloseConnections === true) {
             instance.server.closeAllConnections()
           } else if (forceCloseConnections === true) {
             for (const conn of fastify[kKeepAliveConnections]) {

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -704,3 +704,42 @@ test('preClose execution order', (t, done) => {
     })
   })
 })
+
+test('does not destroy connections with in-flight requests (forceCloseConnections - idle)', { skip: noSupport }, async t => {
+  const fastify = Fastify({ forceCloseConnections: 'idle' })
+
+  fastify.get('/', async () => {
+    // the server starts closing while this request is still being served
+    fastify.close()
+    await sleep(200)
+    return { hello: 'world' }
+  })
+
+  await fastify.listen({ port: 0 })
+
+  const client = new Client('http://localhost:' + fastify.server.address().port)
+  t.after(() => client.close())
+
+  const response = await client.request({ path: '/', method: 'GET' })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(await response.body.json(), { hello: 'world' })
+})
+
+test('does not destroy connections with in-flight requests (default options)', async t => {
+  const fastify = Fastify()
+
+  fastify.get('/', async () => {
+    fastify.close()
+    await sleep(200)
+    return { hello: 'world' }
+  })
+
+  await fastify.listen({ port: 0 })
+
+  const client = new Client('http://localhost:' + fastify.server.address().port)
+  t.after(() => client.close())
+
+  const response = await client.request({ path: '/', method: 'GET' })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(await response.body.json(), { hello: 'world' })
+})


### PR DESCRIPTION
### Summary

`fastify.close()` destroys connections that are still serving a request when
`forceCloseConnections` is `'idle'`. Since `'idle'` is the default whenever the
server supports `closeIdleConnections()`, this affects the default
configuration.

```
fastify 5.8.5  (before #6669) → 200 OK
fastify 5.10.0 (after #6669)  → ECONNRESET
```

Reproduced with a handler that sleeps 400ms while `close()` is called after
100ms.

### Root cause

Regression from #6669. That PR correctly avoided the redundant
`closeIdleConnections()` call on native servers by narrowing the first branch
to `serverFactory`, but the next branch was left with a loose truthiness check
dating back to #3925:

```js
if (forceCloseConnections === 'idle' && options.serverFactory) {
  instance.server.closeIdleConnections()
} else if (serverHasCloseAllConnections && forceCloseConnections) {
  instance.server.closeAllConnections()
}
```

The loose check was safe while the first branch caught `'idle'`
unconditionally — it could only ever see `true`. After #6669 the string
`'idle'` falls through to it, and being truthy it takes the
`closeAllConnections()` path.

### Fix

Tighten the check to `=== true`, matching the branch below it. Native servers
with `'idle'` now call neither method and rely on `server.close()`, which has
closed idle connections since Node.js v19 — the premise of #6669. All
supported Node.js versions (20, 22, 24, 26) have this behaviour.

The `serverFactory` path, `forceCloseConnections: true`, and the
`kKeepAliveConnections` reap loop for servers without `closeAllConnections()`
are unchanged.

### Tests

Two tests added to `test/close.test.js`, both failing on `main` with
`UND_ERR_SOCKET: other side closed`.

The existing `'idle'` coverage (`shutsdown while keep-alive connections are
active (non-async, idle, native)`) calls `close()` from the response callback,
so the socket is already idle by then. The only behavioural difference between
`'idle'` and `true` is what happens to an active request, and nothing
exercised it.

### Notes

No documentation change: this restores the behaviour already described in
`Server.md`, both in the option reference and in the shutdown lifecycle
section ("`\"idle\"` — idle keep-alive connections are closed; in-flight
requests continue").

/cc @trivikr

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
