### PR TITLE
docs: clarify what attachValidation exposes on request.validationError

### DIFF
--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -876,14 +876,25 @@ with the following payload:
 
 To handle errors inside the route, specify the `attachValidation` option. If
 there is a validation error, the `validationError` property of the request will
-contain the `Error` object with the raw validation result as shown below:
+contain the same `Error` object Fastify would have sent on its own, so no
+message has to be rebuilt from the raw validation result:
+
+- `message` is the formatted message, identical to the one in the response
+  payload above (for example `body must have required property 'name'`). It is
+  produced by [`schemaErrorFormatter`](#schemaerrorformatter), so a custom
+  formatter is reflected here too.
+- `validation` is the raw validation result, as returned by the validator.
+- `validationContext` is the part of the request that failed validation
+  (`body`, `params`, `querystring` or `headers`).
+- `code` is `FST_ERR_VALIDATION` and `statusCode` is `400`.
 
 ```js
 const fastify = Fastify()
 
 fastify.post('/', { schema, attachValidation: true }, function (req, reply) {
   if (req.validationError) {
-    // `req.validationError.validation` contains the raw validation error
+    // `req.validationError.message` is the formatted message
+    // `req.validationError.validation` contains the raw validation result
     reply.code(400).send(req.validationError)
   }
 })

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -238,14 +238,16 @@ test('attached validationError exposes the same message sent by the default hand
   const attached = await fastify.inject({ method: 'POST', payload, url: '/attached' })
   const notAttached = await fastify.inject({ method: 'POST', payload, url: '/default' })
 
-  t.assert.deepStrictEqual(attached.json(), {
+  const attachedBody = attached.json()
+
+  t.assert.deepStrictEqual(attachedBody, {
     message: "body must have required property 'name'",
     code: 'FST_ERR_VALIDATION',
     statusCode: 400,
     validationContext: 'body'
   })
 
-  t.assert.strictEqual(attached.json().message, notAttached.json().message)
+  t.assert.strictEqual(attachedBody.message, notAttached.json().message)
   t.assert.strictEqual(attached.statusCode, 400)
   t.assert.strictEqual(notAttached.statusCode, 400)
 })

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -218,6 +218,38 @@ test('should be able to attach validation to request', async (t) => {
   t.assert.strictEqual(response.statusCode, 400)
 })
 
+test('attached validationError exposes the same message sent by the default handler', async (t) => {
+  t.plan(4)
+
+  const fastify = Fastify()
+
+  fastify.post('/attached', { schema, attachValidation: true }, function (req, reply) {
+    reply.code(400).send({
+      message: req.validationError.message,
+      code: req.validationError.code,
+      statusCode: req.validationError.statusCode,
+      validationContext: req.validationError.validationContext
+    })
+  })
+
+  fastify.post('/default', { schema }, echoBody)
+
+  const payload = { hello: 'michelangelo' }
+  const attached = await fastify.inject({ method: 'POST', payload, url: '/attached' })
+  const notAttached = await fastify.inject({ method: 'POST', payload, url: '/default' })
+
+  t.assert.deepStrictEqual(attached.json(), {
+    message: "body must have required property 'name'",
+    code: 'FST_ERR_VALIDATION',
+    statusCode: 400,
+    validationContext: 'body'
+  })
+
+  t.assert.strictEqual(attached.json().message, notAttached.json().message)
+  t.assert.strictEqual(attached.statusCode, 400)
+  t.assert.strictEqual(notAttached.statusCode, 400)
+})
+
 test('should respect when attachValidation is explicitly set to false', async (t) => {
   t.plan(2)
 


### PR DESCRIPTION
## Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Developer's Certificate of Origin](https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of Conduct](https://github.com/fastify/fastify/blob/main/CODE_OF_CONDUCT.md)

## Description of change

#5235 asks for a descriptive message to be attached alongside the raw Ajv result when `attachValidation: true` is used. That message is already there.

`wrapValidationError` in `lib/validation.js` runs `schemaErrorFormatter` and returns an `Error` with the formatted `message`, and `validationCompleted` in `lib/handle-request.js` assigns that same error to `request.validationError`. There is no separate raw-only path, so `request.validationError.message` is the string Fastify would have sent by itself.

Given the body schema from the docs and a `{}` payload:

```js
// attachValidation: false (default), response payload
{"statusCode":400,"code":"FST_ERR_VALIDATION","error":"Bad Request","message":"body must have required property 'obj1'"}

// attachValidation: true
req.validationError.message // "body must have required property 'obj1'"
```


What sent the reporter down the wrong path, I think, is the documentation. It describes `validationError` as the Error object with the raw validation result, and the example only comments on `.validation`. Read on its own, that does suggest you get the Ajv output and nothing else, and that rebuilding a message is on you.

The doc change here lists what the error actually carries (`message`, `validation`, `validationContext`, `code`, `statusCode`) and notes that `message` comes from `schemaErrorFormatter`, so a custom formatter shows up there too.

### About the test

The test pins the part that matters: the attached message and the default response message are the same string.

To confirm it fails for the right reason, I temporarily changed `validationCompleted` to assign `validationErr.validation` instead of `validationErr`, that is, I made the code behave the way #5235 describes. Against that patched build three tests fail:

- the new one
- `should be able to attach validation to request`
- `Attached validation error should take precedence over setErrorHandler`

So the behaviour was not completely uncovered before, but nothing asserted the equivalence directly, which is the thing #5235 is really about.

That patch was local and is not part of this PR: `lib/handle-request.js` is unchanged and the suite is green on this branch.

If this reads right, #5235 can be closed.