### PR TITLE
fix: recognize constructor-assigned built-in properties as decorator …

### DIFF
--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -121,7 +121,7 @@ function checkDependencies (instance, name, deps) {
   }
 
   for (let i = 0; i !== deps.length; ++i) {
-    if (!checkExistence(instance, deps[i])) {
+    if (!checkExistence(instance, deps[i]) && !hasInstanceProperty(instance, deps[i])) {
       throw new FST_ERR_DEC_MISSING_DEPENDENCY(deps[i])
     }
   }

--- a/test/decorator-instance-properties.test.js
+++ b/test/decorator-instance-properties.test.js
@@ -61,3 +61,52 @@ test('decorateRequest still works for non-built-in names', (t, done) => {
     done()
   })
 })
+
+test('decorateRequest accepts built-in request properties as dependencies', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  for (const name of ['id', 'params', 'raw', 'query', 'log', 'body']) {
+    t.assert.doesNotThrow(() => fastify.decorateRequest(`uses_${name}`, null, [name]))
+  }
+})
+
+test('decorateReply accepts built-in reply properties as dependencies', t => {
+  t.plan(3)
+  const fastify = Fastify()
+  for (const name of ['raw', 'request', 'log']) {
+    t.assert.doesNotThrow(() => fastify.decorateReply(`uses_${name}`, null, [name]))
+  }
+})
+
+test('decorateRequest accepts built-in properties as dependencies inside a plugin', (t, done) => {
+  t.plan(2)
+  const fastify = Fastify()
+  fastify.register(async (instance) => {
+    instance.decorateRequest('scopedExtra', null, ['body'])
+    t.assert.equal(instance.hasRequestDecorator('scopedExtra'), true)
+  })
+  fastify.ready((err) => {
+    t.assert.ifError(err)
+    done()
+  })
+})
+
+test('decorateRequest accepts built-in properties mixed with user decorators as dependencies', t => {
+  t.plan(1)
+  const fastify = Fastify()
+  fastify.decorateRequest('userProp', null)
+  t.assert.doesNotThrow(() => fastify.decorateRequest('mixed', null, ['userProp', 'body']))
+})
+
+test('decorateRequest still throws FST_ERR_DEC_MISSING_DEPENDENCY for unknown dependencies', t => {
+  t.plan(2)
+  const fastify = Fastify()
+  t.assert.throws(
+    () => fastify.decorateRequest('withUnknown', null, ['nonExistent']),
+    (err) => err.code === 'FST_ERR_DEC_MISSING_DEPENDENCY'
+  )
+  t.assert.throws(
+    () => fastify.decorateReply('withUnknown', null, ['body']),
+    (err) => err.code === 'FST_ERR_DEC_MISSING_DEPENDENCY'
+  )
+})


### PR DESCRIPTION
## Summary

`decorate*`'s `dependencies` option rejects the built-in `Request`/`Reply`
properties that are assigned in the constructor, even though every other
decorator API treats them as present. Fastify currently gives two different
answers for the same name:

```js
const fastify = Fastify()

fastify.hasRequestDecorator('body')          // true
fastify.decorateRequest('body', fn)          // FST_ERR_DEC_ALREADY_PRESENT
fastify.decorateRequest('x', fn, ['body'])   // FST_ERR_DEC_MISSING_DEPENDENCY
```

A decorator cannot declare `body`, `id`, `params`, `query`, `log` or `raw` as
a dependency, while at the same time it cannot decorate over them and
`hasRequestDecorator` reports them as present. The same applies to `raw`,
`request` and `log` on `Reply`.

## Root cause

Follow-up to #6753.

#6753 introduced `hasInstanceProperty` to make Fastify aware of properties
assigned in the `Request`/`Reply` constructors rather than defined on the
prototype. It was wired into three call sites: the
`FST_ERR_DEC_ALREADY_PRESENT` guard in `decorateConstructor`,
`checkRequestExistence` and `checkReplyExistence`.

The dependency check was not updated. It still resolves names through
`checkExistence` alone, which only looks at the instance, its prototype and
`props`, so constructor-assigned properties fall through and are reported as
missing.

## Solution

`checkDependencies` now falls back to `hasInstanceProperty` when
`checkExistence` does not find a dependency.

The instance path is unaffected: `decorate()` passes a plain Fastify
instance, which has no `instanceProperties`, so the lookup returns `false`
immediately. The order also keeps the common case unchanged — for ordinary
decorator dependencies `checkExistence` succeeds and the second lookup is
never reached.

## Tests

Added to `test/decorator-instance-properties.test.js`:

- the full built-in sets for both `Request` and `Reply` accepted as
  dependencies
- an encapsulated plugin, to exercise the `parent` chain
- a dependency array mixing built-ins with user decorators
- a regression test asserting that unknown dependencies still throw
  `FST_ERR_DEC_MISSING_DEPENDENCY`, and that a `Reply` decorator depending on
  a `Request`-only property still throws

All four new cases fail on the base commit and pass with the change. Full
suite, lint and type tests are green.

## Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the
      [Developer's Certification of Origin](https://github.com/fastify/fastify#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/fastify/blob/main/CODE_OF_CONDUCT.md)