### PR TITLE
docs(errors): document what the default error handler sends

### DIFF
--- a/docs/Reference/Errors.md
+++ b/docs/Reference/Errors.md
@@ -11,6 +11,7 @@
   - [Errors In Fastify](#errors-in-fastify)
     - [Errors In Input Data](#errors-in-input-data)
     - [Catching Uncaught Errors In Fastify](#catching-uncaught-errors-in-fastify)
+    - [What The Default Error Handler Sends](#what-the-default-error-handler-sends)
   - [Errors In Fastify Lifecycle Hooks And A Custom Error Handler](#errors-in-fastify-lifecycle-hooks-and-a-custom-error-handler)
   - [Fastify Error Codes](#fastify-error-codes)
     - [FST_ERR_NOT_FOUND](#fst_err_not_found)
@@ -142,10 +143,76 @@ performance. This includes:
    })`
 
 In both cases, the error will be caught safely and routed to Fastify's default
-error handler, resulting in a generic `500 Internal Server Error` response.
+error handler, resulting in a `500 Internal Server Error` response.
 
-To customize this behavior, use
-[`setErrorHandler`](./Server.md#seterrorhandler).
+#### What The Default Error Handler Sends
+The default error handler serializes the error into a JSON body with the
+`statusCode`, `error`, and `message` properties, plus `code` when the error
+carries one:
+
+```js
+app.get('/', async () => { throw new Error('kaboom') })
+```
+
+```json
+{
+  "statusCode": 500,
+  "error": "Internal Server Error",
+  "message": "kaboom"
+}
+```
+
+The `error` property is the generic HTTP status text, but **`message` is
+`error.message` verbatim**. This applies to every status code, including `500`.
+The stack trace is never included.
+
+> Security:
+> Because `message` and `code` are forwarded as-is, errors thrown by libraries
+> deeper in your application are exposed to the client. A database driver
+> error, for example, can leak schema details and query text:
+>
+> ```json
+> {
+>   "statusCode": 500,
+>   "code": "ER_BAD_FIELD_ERROR",
+>   "error": "Internal Server Error",
+>   "message": "Unknown column 'username' in 'field list'"
+> }
+> ```
+>
+> Fastify does not distinguish between development and production here. If
+> unexpected errors must not reach the client, handle this explicitly.
+
+Register a [`setErrorHandler`](./Server.md#seterrorhandler) to replace the
+message for errors you did not raise deliberately, while letting the ones you
+did pass through:
+
+```js
+app.setErrorHandler(function (error, request, reply) {
+  // Errors with a statusCode below 500 are deliberate and safe to expose,
+  // as are validation errors.
+  if (error.validation || (error.statusCode && error.statusCode < 500)) {
+    return reply.send(error)
+  }
+
+  // Anything else is unexpected: log it, but do not describe it to the client.
+  this.log.error({ err: error }, 'unhandled error')
+  reply.status(500).send({
+    statusCode: 500,
+    error: 'Internal Server Error',
+    message: 'Internal Server Error'
+  })
+})
+```
+
+The handler above is registered on the root instance, so it applies to every
+route. Error handlers are encapsulated; for how they resolve across plugin
+contexts, see
+[the next section](#errors-in-fastify-lifecycle-hooks-and-a-custom-error-handler).
+
+Note that a route-level response schema is still applied to whatever the error
+handler sends, and will reshape the payload accordingly. See
+[Serialization](./Validation-and-Serialization.md#serialization).
 
 ### Errors In Fastify Lifecycle Hooks And A Custom Error Handler
 

--- a/docs/Reference/Errors.md
+++ b/docs/Reference/Errors.md
@@ -164,7 +164,10 @@ app.get('/', async () => { throw new Error('kaboom') })
 
 The `error` property is the generic HTTP status text, but **`message` is
 `error.message` verbatim**. This applies to every status code, including `500`.
-The stack trace is never included.
+Fastify's built-in error serializer emits only these four properties, so the
+stack trace is not part of the default payload — but a route-level response
+schema replaces that serializer, and one that declares a `stack` property will
+serialize it.
 
 > Security:
 > Because `message` and `code` are forwarded as-is, errors thrown by libraries
@@ -189,8 +192,10 @@ did pass through:
 
 ```js
 app.setErrorHandler(function (error, request, reply) {
-  // Errors with a statusCode below 500 are deliberate and safe to expose,
-  // as are validation errors.
+  // Errors with a statusCode below 500 were raised deliberately by this
+  // application, as were validation errors. A status code below 500 is not on
+  // its own a guarantee that the message is safe to expose — narrow this
+  // condition if any of yours are not.
   if (error.validation || (error.statusCode && error.statusCode < 500)) {
     return reply.send(error)
   }
@@ -211,7 +216,8 @@ contexts, see
 [the next section](#errors-in-fastify-lifecycle-hooks-and-a-custom-error-handler).
 
 Note that a route-level response schema is still applied to whatever the error
-handler sends, and will reshape the payload accordingly. See
+handler sends, and will reshape the payload accordingly — including properties
+the built-in error serializer would have omitted, such as `stack`. See
 [Serialization](./Validation-and-Serialization.md#serialization).
 
 ### Errors In Fastify Lifecycle Hooks And A Custom Error Handler


### PR DESCRIPTION
Documents what the default error handler actually sends to the client, and how
to mask unexpected errors. Docs only — no behaviour change.

Refs #4513.

### Why

`docs/Reference/Errors.md` currently says an uncaught error results in "a
generic `500 Internal Server Error` response". The status text is generic; the
`message` is not. Running this against `main`:

```js
'use strict'

const app = require('fastify')()

app.get('/', async () => {
  const e = new Error("Unknown column 'username' in 'field list'")
  e.code = 'ER_BAD_FIELD_ERROR'
  throw e
})

app.inject({ method: 'GET', url: '/' }).then(res => console.log(res.body))
```

```json
{
  "statusCode": 500,
  "code": "ER_BAD_FIELD_ERROR",
  "error": "Internal Server Error",
  "message": "Unknown column 'username' in 'field list'"
}
```

The driver's message and vendor code reach the client verbatim. The stack trace
does not — the generated error serializer only emits `statusCode`, `code`,
`error` and `message` (see `build/build-error-serializer.js`), so that half of
the original 2023 report no longer applies. @Bluzzi noticed this while reading
the issue and asked whether it was still valid; nobody answered:
https://github.com/fastify/fastify/issues/4513#issuecomment-3518988684

The behaviour is intended and overridable, but it is not written down anywhere,
and it surprises people in production:
https://github.com/fastify/fastify/issues/4513#issuecomment-2481148663

### Scope

Docs only, deliberately. Changing the default was rejected in the thread —
"I don't think so. The user can always override this."
(https://github.com/fastify/fastify/issues/4513#issuecomment-1382013802) — so
this takes the documentation path instead, which @mcollina invited here:
https://github.com/fastify/fastify/issues/4513#issuecomment-2778983849

### What changed

A new `#### What The Default Error Handler Sends` subsection under *Errors In
Fastify*, plus its table-of-contents entry:

- the exact response shape, and that `message` is `error.message` verbatim for
  every status code including `500`
- a `> Security:` callout showing the leak, and noting that Fastify does not
  consult `NODE_ENV` here
- a `setErrorHandler` example that masks unexpected errors while letting
  deliberate 4xx and validation errors through
- a pointer to response-schema serialization, which still applies to whatever
  the error handler sends

I also dropped the word "generic" from the existing sentence above it, since
that is the wording that creates the wrong impression.

### Verification

Every JSON payload in the new section is real `fastify.inject()` output from
this branch, not illustrative. The documented error handler was run against
three cases:

```
GET  /leaky      -> 500 {"statusCode":500,"error":"Internal Server Error","message":"Internal Server Error"}
GET  /deliberate -> 403 {"statusCode":403,"error":"Forbidden","message":"nope"}
POST /validated  -> 400 {"statusCode":400,"code":"FST_ERR_VALIDATION","error":"Bad Request","message":"body must have required property 'a'"}
```

`npm run lint:markdown` passes on the changed file.

No test is included, as this documents existing behaviour rather than
introducing any. Happy to add a regression test pinning the default response
shape if you would prefer it locked down.
