### PR TITLE
refactor(types)!: remove deprecated FastifyPlugin type

### DIFF
--- a/docs/Guides/Getting-Started.md
+++ b/docs/Guides/Getting-Started.md
@@ -616,5 +616,5 @@ npm start
     speed](https://www.youtube.com/watch?v=5z46jJZNe8k) by
     [@mcollina](https://github.com/mcollina)
   - [What if I told you that HTTP can be
-    fast](https://www.webexpo.net/prague2017/talk/what-if-i-told-you-that-http-can-be-fast/)
+    fast](https://web.archive.org/web/20251006142253/https://www.webexpo.net/prague2017/talk/what-if-i-told-you-that-http-can-be-fast/)
     by [@delvedor](https://github.com/delvedor)

--- a/docs/Guides/Getting-Started.md
+++ b/docs/Guides/Getting-Started.md
@@ -303,7 +303,7 @@ export default fastifyPlugin(dbConnector)
 ```js
 // CommonJs
 /**
- * @type {import('fastify-plugin').FastifyPlugin}
+ * @type {import('fastify-plugin').FastifyPluginAsync}
  */
 const fastifyPlugin = require('fastify-plugin')
 

--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -1334,14 +1334,6 @@ Interface method definition used within the
 Interface method definition used within the
 [`fastify.register()`][FastifyRegister] method.
 
-##### fastify.FastifyPlugin< [Options][FastifyPluginOptions]>
-[src](https://github.com/fastify/fastify/blob/main/types/plugin.d.ts#L29)
-
-Interface method definition used within the
-[`fastify.register()`][FastifyRegister] method. Document deprecated in favor of
-`FastifyPluginCallback` and `FastifyPluginAsync` since general `FastifyPlugin`
-doesn't properly infer types for async functions.
-
 ##### fastify.FastifyPluginOptions
 [src](https://github.com/fastify/fastify/blob/main/types/plugin.d.ts#L31)
 
@@ -1358,8 +1350,6 @@ extends FastifyPluginOptions`) so they can be passed to the register method.
 [src](https://github.com/fastify/fastify/blob/main/types/register.d.ts#L9)
 ##### fastify.FastifyRegister(plugin: [FastifyPluginAsync][FastifyPluginAsync], opts: [FastifyRegisterOptions][FastifyRegisterOptions])
 [src](https://github.com/fastify/fastify/blob/main/types/register.d.ts#L9)
-##### fastify.FastifyRegister(plugin: [FastifyPlugin][FastifyPlugin], opts: [FastifyRegisterOptions][FastifyRegisterOptions])
-[src](https://github.com/fastify/fastify/blob/main/types/register.d.ts#L9)
 
 This type interface specifies the type for the
 [`fastify.register()`](./Server.md#register) method. The type interface returns
@@ -1368,8 +1358,7 @@ a function signature with an underlying generic `Options` which is defaulted to
 FastifyPlugin parameter when calling this function so there is no need to
 specify the underlying generic. The options parameter is the intersection of the
 plugin's options and two additional optional properties: `prefix: string` and
-`logLevel`: [LogLevel][LogLevel]. `FastifyPlugin` is deprecated use
-`FastifyPluginCallback` and `FastifyPluginAsync` instead.
+`logLevel`: [LogLevel][LogLevel].
 
 Below is an example of the options inference in action:
 
@@ -1713,8 +1702,6 @@ database.
 [FastifyInstance]: #fastifyfastifyinstance
 [FastifyLoggerOptions]: #fastifyfastifyloggeroptions
 [ContextConfigGeneric]: #ContextConfigGeneric
-[FastifyPlugin]:
-    #fastifyfastifypluginoptions-rawserver-rawrequest-requestgeneric
 [FastifyPluginCallback]: #fastifyfastifyplugincallbackoptions
 [FastifyPluginAsync]: #fastifyfastifypluginasyncoptions
 [FastifyPluginOptions]: #fastifyfastifypluginoptions

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -876,14 +876,25 @@ with the following payload:
 
 To handle errors inside the route, specify the `attachValidation` option. If
 there is a validation error, the `validationError` property of the request will
-contain the `Error` object with the raw validation result as shown below:
+contain the same `Error` object Fastify would have sent on its own, so no
+message has to be rebuilt from the raw validation result:
+
+- `message` is the formatted message, identical to the one in the response
+  payload above (for example `body must have required property 'name'`). It is
+  produced by [`schemaErrorFormatter`](#schemaerrorformatter), so a custom
+  formatter is reflected here too.
+- `validation` is the raw validation result, as returned by the validator.
+- `validationContext` is the part of the request that failed validation
+  (`body`, `params`, `querystring` or `headers`).
+- `code` is `FST_ERR_VALIDATION` and `statusCode` is `400`.
 
 ```js
 const fastify = Fastify()
 
 fastify.post('/', { schema, attachValidation: true }, function (req, reply) {
   if (req.validationError) {
-    // `req.validationError.validation` contains the raw validation error
+    // `req.validationError.message` is the formatted message
+    // `req.validationError.validation` contains the raw validation result
     reply.code(400).send(req.validationError)
   }
 })

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -69,6 +69,7 @@ declare namespace fastify {
     Logger extends FastifyBaseLogger = FastifyBaseLogger
   > = FastifyServerOptions<Server, Logger> & {
     https: https.ServerOptions | null
+    http2?: false
   }
 
   export type FastifyHttpOptions<
@@ -76,6 +77,7 @@ declare namespace fastify {
     Logger extends FastifyBaseLogger = FastifyBaseLogger
   > = FastifyServerOptions<Server, Logger> & {
     http?: http.ServerOptions | null
+    http2?: false
   }
 
   type FindMyWayVersion<RawServer extends RawServerBase> = RawServer extends http.Server

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -24,7 +24,7 @@ import {
   LogLevel,
   PinoLoggerOptions
 } from './types/logger'
-import { FastifyPlugin, FastifyPluginAsync, FastifyPluginCallback, FastifyPluginOptions } from './types/plugin'
+import { FastifyPluginAsync, FastifyPluginCallback, FastifyPluginOptions } from './types/plugin'
 import { FastifyRegister, FastifyRegisterOptions, RegisterOptions } from './types/register'
 import { FastifyReply } from './types/reply'
 import { FastifyRequest, RequestGenericInterface } from './types/request'
@@ -222,7 +222,7 @@ declare namespace fastify {
     LightMyRequestChain, InjectOptions, LightMyRequestResponse, LightMyRequestCallback, // 'light-my-request'
     FastifyRequest, RequestGenericInterface, // './types/request'
     FastifyReply, // './types/reply'
-    FastifyPluginCallback, FastifyPluginAsync, FastifyPluginOptions, FastifyPlugin, // './types/plugin'
+    FastifyPluginCallback, FastifyPluginAsync, FastifyPluginOptions, // './types/plugin'
     FastifyListenOptions, FastifyInstance, PrintRoutesOptions, // './types/instance'
     FastifyLoggerOptions, FastifyBaseLogger, FastifyLoggerInstance, FastifyLogFn, LogLevel, // './types/logger'
     FastifyRequestContext, FastifyContextConfig, FastifyReplyContext, // './types/context'

--- a/test/types/fastify.tst.ts
+++ b/test/types/fastify.tst.ts
@@ -68,6 +68,17 @@ expect(fastify({ schemaController: {} })).type.toBe<
   FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse> &
   SafePromiseLike<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>>
 >()
+
+expect(fastify({ http2: false })).type.toBe<
+  FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse> &
+  SafePromiseLike<FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>>
+>()
+
+expect(fastify({ https: {}, http2: false })).type.toBe<
+  FastifyInstance<https.Server, http.IncomingMessage, http.ServerResponse> &
+  SafePromiseLike<FastifyInstance<https.Server, http.IncomingMessage, http.ServerResponse>>
+>()
+
 expect(
   fastify({
     schemaController: {

--- a/test/types/fastify.tst.ts
+++ b/test/types/fastify.tst.ts
@@ -10,7 +10,6 @@ import fastify, {
   FastifyError,
   FastifyErrorCodes,
   FastifyInstance,
-  FastifyPlugin,
   FastifyPluginAsync,
   FastifyPluginCallback,
   InjectOptions,
@@ -322,7 +321,6 @@ fastify().then(fastifyInstance => expect(fastifyInstance).type.toBeAssignableTo<
 
 expect<FastifyPluginAsync>().type.toBeAssignableFrom(async () => { })
 expect<FastifyPluginCallback>().type.toBeAssignableFrom(() => { })
-expect<FastifyPlugin>().type.toBeAssignableFrom(() => { })
 
 const ajvErrorObject: AjvErrorObject = {
   keyword: '',

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -218,6 +218,40 @@ test('should be able to attach validation to request', async (t) => {
   t.assert.strictEqual(response.statusCode, 400)
 })
 
+test('attached validationError exposes the same message sent by the default handler', async (t) => {
+  t.plan(4)
+
+  const fastify = Fastify()
+
+  fastify.post('/attached', { schema, attachValidation: true }, function (req, reply) {
+    reply.code(400).send({
+      message: req.validationError.message,
+      code: req.validationError.code,
+      statusCode: req.validationError.statusCode,
+      validationContext: req.validationError.validationContext
+    })
+  })
+
+  fastify.post('/default', { schema }, echoBody)
+
+  const payload = { hello: 'michelangelo' }
+  const attached = await fastify.inject({ method: 'POST', payload, url: '/attached' })
+  const notAttached = await fastify.inject({ method: 'POST', payload, url: '/default' })
+
+  const attachedBody = attached.json()
+
+  t.assert.deepStrictEqual(attachedBody, {
+    message: "body must have required property 'name'",
+    code: 'FST_ERR_VALIDATION',
+    statusCode: 400,
+    validationContext: 'body'
+  })
+
+  t.assert.strictEqual(attachedBody.message, notAttached.json().message)
+  t.assert.strictEqual(attached.statusCode, 400)
+  t.assert.strictEqual(notAttached.statusCode, 400)
+})
+
 test('should respect when attachValidation is explicitly set to false', async (t) => {
   t.plan(2)
 

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -37,12 +37,3 @@ export type FastifyPluginAsync<
     TypeProvider>,
   opts: Options
 ) => Promise<void>
-
-/**
- * Generic plugin type.
- * @deprecated union type doesn't work well with type inference in TS and is therefore deprecated in favor of explicit types. Use `FastifyPluginCallback` or `FastifyPluginAsync` instead. To activate
- * plugins use `FastifyRegister`. https://fastify.dev/docs/latest/Reference/TypeScript/#register
- */
-export type FastifyPlugin<
-  Options extends FastifyPluginOptions = Record<never, never>
-> = FastifyPluginCallback<Options> | FastifyPluginAsync<Options>


### PR DESCRIPTION
Proposal:

- This PR removes the deprecated `FastifyPlugin` TypeScript definition and its related type assertions. `FastifyPlugin` was previously marked as `@deprecated`, the users should explicitly use `FastifyPluginCallback` or `FastifyPluginAsync` instead. ( see screenshot )

Changes:
-  **Core Types**: Removed `FastifyPlugin` type definition from `types/plugin.d.ts` and its exports/imports from `fastify.d.ts`.
* **Documentation**:  Cleaned up references to `FastifyPlugin` in `docs/Reference/TypeScript.md` and `docs/Reference/Getting-Started.md`.

- Cleaned up type tests in `test/types/fastify.tst.ts`.

---

Screenshot:

<img width="1107" height="319" alt="deprecated" src="https://github.com/user-attachments/assets/338dea36-8bbb-44da-b9fe-f0d87cddf319" />
