### PR TITLE
docs: document that response schemas serialize error handler payloads

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -2029,12 +2029,11 @@ if (statusCode >= 500) {
 > Avoid calling setErrorHandler multiple times in the same scope.
 > See [`allowErrorHandlerOverride`](#allowerrorhandleroverride).
 
-> Note:
+> ℹ️ Note:
 > When the error handler sends a JSON object or array, the route's
-> `schema.response` serializes it just like a route handler's payload —
-> there is no separate schema for error responses. Serialization is not
-> validation, so the schema may rewrite values and drop properties the handler
-> emitted. See
+> `schema.response` serializes it just like a route handler's payload. There is
+> no separate schema for error responses, and serialization is not validation,
+> so the schema may rewrite values and drop properties the handler emitted. See
 > [Response schemas and error replies](./Validation-and-Serialization.md#error-handler-serialization).
 
 ##### Custom error handler for stream replies

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -2029,6 +2029,14 @@ if (statusCode >= 500) {
 > Avoid calling setErrorHandler multiple times in the same scope.
 > See [`allowErrorHandlerOverride`](#allowerrorhandleroverride).
 
+> Note:
+> When the error handler sends a JSON object or array, the route's
+> `schema.response` serializes it just like a route handler's payload —
+> there is no separate schema for error responses. Serialization is not
+> validation, so the schema may rewrite values and drop properties the handler
+> emitted. See
+> [Response schemas and error replies](./Validation-and-Serialization.md#error-handler-serialization).
+
 ##### Custom error handler for stream replies
 <a id="set-error-handler-stream-replies"></a>
 

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -840,6 +840,77 @@ fastify.get('/user', {
 *To set a custom serializer in a specific part of the code, use
 [`reply.serializer(...)`](./Reply.md#serializerfunc).*
 
+#### Response schemas and error replies
+<a id="error-handler-serialization"></a>
+
+A response schema is selected by status code, with no distinction between
+success and error replies. A payload sent from a handler registered with
+[`setErrorHandler`](./Server.md#seterrorhandler), or from the default error
+handler, is therefore serialized by the route's `response[400]`,
+`response['4xx']` or `response.default` schema, exactly like a payload sent
+from the route handler.
+
+Because serialization is not validation, the schema reshapes the payload to fit
+instead of rejecting it. Here the `code` the error handler chose never reaches
+the client:
+
+```js
+const appErrorSchema = {
+  type: 'object',
+  required: ['code', 'message'],
+  properties: {
+    code: { type: 'string', const: 'APP_ERROR' },
+    message: { type: 'string' }
+  }
+}
+
+fastify.post('/', {
+  schema: {
+    body: { type: 'object', required: ['a'], properties: { a: { type: 'string' } } },
+    response: { 400: appErrorSchema }
+  }
+}, handler)
+
+fastify.setErrorHandler(function (error, request, reply) {
+  reply.code(400).send({ code: 'CUSTOM_ERROR', message: 'Unknown custom error' })
+})
+```
+
+A request with an invalid body responds `400` with
+`{"code":"APP_ERROR","message":"Unknown custom error"}`: the `const` keyword
+replaced `CUSTOM_ERROR`. Properties the schema does not list are dropped in the
+same silent way, unless it allows additional properties.
+
+When the payload cannot be serialized at all — a `required` property is missing,
+or a value cannot be converted to the declared type — serialization throws and
+the reply re-enters the error path, which may answer `500` with the code
+`FST_ERR_FAILED_ERROR_SERIALIZATION`.
+
+> ⚠ Warning:
+> An error handler that never sets a status code leaves the reply at `200`, so
+> the route's *success* schema serializes the error payload. Always set the
+> status code explicitly in an error handler.
+
+To send exactly what the error handler produced, bypass the schema with
+[`reply.serializer()`](./Reply.md#serializerfunc), or send an already-serialized
+string, which is never passed to a response schema. Set the content type in
+both cases: `reply.serializer()` leaves it unset, and a string payload defaults
+to `text/plain`.
+
+```js
+fastify.setErrorHandler(function (error, request, reply) {
+  reply
+    .code(400)
+    .type('application/json')
+    .serializer(JSON.stringify)
+    .send({ code: 'CUSTOM_ERROR', message: 'Unknown custom error' })
+})
+```
+
+[`setReplySerializer`](./Server.md#setreplyserializer) does the same for every
+reply in a scope and takes precedence over the response schema. Declaring no
+schema for a status code also leaves that status's payload untouched.
+
 ### Error Handling
 When schema validation fails for a request, Fastify will automatically return a
 status 400 response including the result from the validator in the payload. For

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -843,16 +843,15 @@ fastify.get('/user', {
 #### Response schemas and error replies
 <a id="error-handler-serialization"></a>
 
-A response schema is selected by status code, with no distinction between
-success and error replies. A payload sent from a handler registered with
-[`setErrorHandler`](./Server.md#seterrorhandler), or from the default error
-handler, is therefore serialized by the route's `response[400]`,
-`response['4xx']` or `response.default` schema, exactly like a payload sent
-from the route handler.
+There is no separate schema for error responses. A payload sent from a
+[`setErrorHandler`](./Server.md#seterrorhandler) handler, or from the default
+error handler, is serialized by the route's response schema for its status code
+(`response[400]`, `response['4xx']` or `response.default`), just like a route
+handler's payload.
 
-Because serialization is not validation, the schema reshapes the payload to fit
-instead of rejecting it. Here the `code` the error handler chose never reaches
-the client:
+Serialization is not validation, so the schema reshapes the payload to fit
+rather than rejecting it. Here the error handler's `code` never reaches the
+client:
 
 ```js
 const appErrorSchema = {
@@ -876,27 +875,25 @@ fastify.setErrorHandler(function (error, request, reply) {
 })
 ```
 
-A request with an invalid body responds `400` with
-`{"code":"APP_ERROR","message":"Unknown custom error"}`: the `const` keyword
-replaced `CUSTOM_ERROR`, and `details` was dropped because the schema does not
-list it. Properties absent from the schema are removed in this same silent way,
-unless it allows additional properties.
+The request responds `400` with
+`{"code":"APP_ERROR","message":"Unknown custom error"}`: `const` replaced
+`CUSTOM_ERROR`, and `details` was dropped as an unlisted property. Unless the
+schema allows additional properties, any property it omits is dropped this way.
 
-When the payload cannot be serialized at all — a `required` property is missing,
-or a value cannot be converted to the declared type — serialization throws and
-the reply re-enters the error path, which may answer `500` with the code
-`FST_ERR_FAILED_ERROR_SERIALIZATION`.
+If the payload cannot be serialized, for example when a `required` property is
+missing, serialization throws and the reply re-enters the error path, which may
+answer `500` with `FST_ERR_FAILED_ERROR_SERIALIZATION`.
 
 > ⚠ Warning:
 > An error handler that never sets a status code leaves the reply at `200`, so
-> the route's *success* schema serializes the error payload. Always set the
-> status code explicitly in an error handler.
+> the route's success schema serializes the error payload. Always set the
+> status code explicitly.
 
-To send exactly what the error handler produced, bypass the schema with
-[`reply.serializer()`](./Reply.md#serializerfunc), or send an already-serialized
-string, which is never passed to a response schema. Set the content type in
-both cases: `reply.serializer()` leaves it unset, and a string payload defaults
-to `text/plain`.
+To send the payload untouched, bypass the schema with
+[`reply.serializer()`](./Reply.md#serializerfunc) or send an already-serialized
+string, which no response schema is applied to. Set the content type in both
+cases: `reply.serializer()` leaves it unset, and a string defaults to
+`text/plain`.
 
 ```js
 fastify.setErrorHandler(function (error, request, reply) {
@@ -909,8 +906,8 @@ fastify.setErrorHandler(function (error, request, reply) {
 ```
 
 [`setReplySerializer`](./Server.md#set-reply-serializer) does the same for every
-reply in a scope and takes precedence over the response schema. Declaring no
-schema for a status code also leaves that status's payload untouched.
+reply in its scope and takes precedence over the response schema. A status code
+with no declared schema is left untouched.
 
 ### Error Handling
 When schema validation fails for a request, Fastify will automatically return a

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -872,14 +872,15 @@ fastify.post('/', {
 }, handler)
 
 fastify.setErrorHandler(function (error, request, reply) {
-  reply.code(400).send({ code: 'CUSTOM_ERROR', message: 'Unknown custom error' })
+  reply.code(400).send({ code: 'CUSTOM_ERROR', message: 'Unknown custom error', details: 'invalid body' })
 })
 ```
 
 A request with an invalid body responds `400` with
 `{"code":"APP_ERROR","message":"Unknown custom error"}`: the `const` keyword
-replaced `CUSTOM_ERROR`. Properties the schema does not list are dropped in the
-same silent way, unless it allows additional properties.
+replaced `CUSTOM_ERROR`, and `details` was dropped because the schema does not
+list it. Properties absent from the schema are removed in this same silent way,
+unless it allows additional properties.
 
 When the payload cannot be serialized at all — a `required` property is missing,
 or a value cannot be converted to the declared type — serialization throws and
@@ -907,7 +908,7 @@ fastify.setErrorHandler(function (error, request, reply) {
 })
 ```
 
-[`setReplySerializer`](./Server.md#setreplyserializer) does the same for every
+[`setReplySerializer`](./Server.md#set-reply-serializer) does the same for every
 reply in a scope and takes precedence over the response schema. Declaring no
 schema for a status code also leaves that status's payload untouched.
 

--- a/test/schema-serialization.test.js
+++ b/test/schema-serialization.test.js
@@ -995,6 +995,203 @@ test('The schema changes the default error handler output', async t => {
   t.assert.deepStrictEqual(res.json(), { error: 'Internal Server Error', message: '500 message', customId: 42 })
 })
 
+// The response serializer is selected by status code, with no error-vs-success
+// distinction, so a route's `schema.response` also serializes what a custom
+// error handler emits
+// see https://github.com/fastify/fastify/issues/4881 for discussion
+test('The route response schema also serializes a custom error handler payload (#4881)', async t => {
+  t.plan(4)
+
+  const bodySchema = {
+    type: 'object',
+    required: ['a'],
+    properties: { a: { type: 'string' } }
+  }
+
+  const appErrorSchema = {
+    type: 'object',
+    required: ['code', 'message'],
+    properties: {
+      code: { type: 'string', const: 'APP_ERROR' },
+      message: { type: 'string' }
+    }
+  }
+
+  // every payload carries an unlisted `details` property, so a reply that still
+  // contains it proves the response schema did not run
+  const post = (fastify, url) => fastify.inject({ method: 'POST', url, payload: {} })
+
+  await t.test('the schema rewrites and prunes what the error handler sent', async t => {
+    t.plan(8)
+
+    const fastify = Fastify()
+    t.after(() => { fastify.close() })
+
+    for (const url of ['/sent', '/returned']) {
+      fastify.post(url, { schema: { body: bodySchema, response: { 400: appErrorSchema } } }, echoBody)
+    }
+
+    // a wildcard key matches an error status code just as an exact one does
+    fastify.post('/4xx', { schema: { body: bodySchema, response: { '4xx': appErrorSchema } } }, echoBody)
+
+    fastify.setErrorHandler(function (_error, request, reply) {
+      reply.code(400)
+      // the returned payload carries a marker the sent one cannot produce, so
+      // this pins the return path rather than falling through to `reply.send`
+      if (request.url === '/returned') {
+        return { code: 'CUSTOM_ERROR', message: 'via return', details: { field: 'a' } }
+      }
+      reply.send({ code: 'CUSTOM_ERROR', message: request.url, details: { field: 'a' } })
+    })
+
+    // `const` rewrites the code the handler chose and `details` is dropped
+    let res = await post(fastify, '/sent')
+    t.assert.strictEqual(res.statusCode, 400)
+    t.assert.deepStrictEqual(res.json(), { code: 'APP_ERROR', message: '/sent' })
+
+    // returning the payload instead of sending it takes the same path
+    res = await post(fastify, '/returned')
+    t.assert.strictEqual(res.statusCode, 400)
+    t.assert.deepStrictEqual(res.json(), { code: 'APP_ERROR', message: 'via return' })
+
+    res = await post(fastify, '/4xx')
+    t.assert.strictEqual(res.statusCode, 400)
+    t.assert.deepStrictEqual(res.json(), { code: 'APP_ERROR', message: '/4xx' })
+
+    // an async handler resolves through a different branch, same outcome
+    const asyncFastify = Fastify()
+    t.after(() => { asyncFastify.close() })
+
+    asyncFastify.post('/', { schema: { body: bodySchema, response: { 400: appErrorSchema } } }, echoBody)
+    asyncFastify.setErrorHandler(async function (_error, request, reply) {
+      reply.code(400)
+      return { code: 'CUSTOM_ERROR', message: 'from async', details: { field: 'a' } }
+    })
+
+    res = await post(asyncFastify, '/')
+    t.assert.strictEqual(res.statusCode, 400)
+    t.assert.deepStrictEqual(res.json(), { code: 'APP_ERROR', message: 'from async' })
+  })
+
+  await t.test('a payload the schema cannot serialize fails the reply', async t => {
+    t.plan(4)
+
+    const fastify = Fastify()
+    t.after(() => { fastify.close() })
+
+    // the retry serializes Fastify's own error object, which has no `code`
+    // either, so serialization fails a second time
+    fastify.post('/twice', { schema: { body: bodySchema, response: { 400: appErrorSchema } } }, echoBody)
+
+    // here the retry succeeds, because the error object does carry `message`
+    fastify.post('/once', {
+      schema: {
+        body: bodySchema,
+        response: {
+          400: { type: 'object', required: ['message'], properties: { message: { type: 'string' } } }
+        }
+      }
+    }, echoBody)
+
+    fastify.setErrorHandler(function (_error, request, reply) {
+      reply.code(400).send(request.url === '/twice' ? { code: 'CUSTOM_ERROR' } : {})
+    })
+
+    let res = await post(fastify, '/twice')
+    t.assert.strictEqual(res.statusCode, 500)
+    t.assert.strictEqual(res.json().code, 'FST_ERR_FAILED_ERROR_SERIALIZATION')
+
+    res = await post(fastify, '/once')
+    t.assert.strictEqual(res.statusCode, 400)
+    t.assert.match(res.json().message, /required/)
+  })
+
+  await t.test('an error handler that never sets a status code replies 200', async t => {
+    t.plan(4)
+
+    const fastify = Fastify()
+    t.after(() => { fastify.close() })
+
+    fastify.post('/bare', { schema: { body: bodySchema } }, echoBody)
+
+    // the success schema, not an error schema, serializes the error payload
+    fastify.post('/success-schema', {
+      schema: {
+        body: bodySchema,
+        response: {
+          200: { type: 'object', properties: { code: { type: 'string', const: 'OK_SHAPE' } } }
+        }
+      }
+    }, echoBody)
+
+    fastify.setErrorHandler(function (_error, request, reply) {
+      reply.send({ code: 'CUSTOM_ERROR', message: request.url, details: { field: 'a' } })
+    })
+
+    let res = await post(fastify, '/bare')
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.json(), { code: 'CUSTOM_ERROR', message: '/bare', details: { field: 'a' } })
+
+    res = await post(fastify, '/success-schema')
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.json(), { code: 'OK_SHAPE' })
+  })
+
+  await t.test('bypassing the schema preserves the payload', async t => {
+    t.plan(8)
+
+    const errorPayload = { code: 'CUSTOM_ERROR', message: 'Unknown custom error', details: { field: 'a' } }
+
+    const fastify = Fastify()
+    t.after(() => { fastify.close() })
+
+    for (const url of ['/serializer', '/string', '/control']) {
+      fastify.post(url, { schema: { body: bodySchema, response: { 400: appErrorSchema } } }, echoBody)
+    }
+
+    fastify.setErrorHandler(function (_error, request, reply) {
+      reply.code(400).type('application/json')
+      if (request.url === '/serializer') {
+        reply.serializer(JSON.stringify).send(errorPayload)
+        return
+      }
+      if (request.url === '/control') {
+        reply.send(errorPayload)
+        return
+      }
+      reply.send(JSON.stringify(errorPayload))
+    })
+
+    // the control proves the same schema does reshape this payload when it runs
+    let res = await post(fastify, '/control')
+    t.assert.strictEqual(res.statusCode, 400)
+    t.assert.deepStrictEqual(res.json(), { code: 'APP_ERROR', message: 'Unknown custom error' })
+
+    res = await post(fastify, '/serializer')
+    t.assert.strictEqual(res.statusCode, 400)
+    t.assert.deepStrictEqual(res.json(), errorPayload)
+
+    // a string is never handed to a response schema
+    res = await post(fastify, '/string')
+    t.assert.strictEqual(res.statusCode, 400)
+    t.assert.deepStrictEqual(res.json(), errorPayload)
+
+    // a scope-wide reply serializer takes precedence over the response schema
+    const wrapped = Fastify()
+    t.after(() => { wrapped.close() })
+
+    wrapped.setReplySerializer(payload => JSON.stringify(payload))
+    wrapped.post('/', { schema: { body: bodySchema, response: { 400: appErrorSchema } } }, echoBody)
+    wrapped.setErrorHandler(function (_error, request, reply) {
+      reply.code(400).send(errorPayload)
+    })
+
+    res = await post(wrapped, '/')
+    t.assert.strictEqual(res.statusCode, 400)
+    t.assert.deepStrictEqual(res.json(), errorPayload)
+  })
+})
+
 test('do not crash if status code serializer errors', async t => {
   const fastify = Fastify()
 

--- a/test/schema-serialization.test.js
+++ b/test/schema-serialization.test.js
@@ -995,9 +995,6 @@ test('The schema changes the default error handler output', async t => {
   t.assert.deepStrictEqual(res.json(), { error: 'Internal Server Error', message: '500 message', customId: 42 })
 })
 
-// The response serializer is selected by status code, with no error-vs-success
-// distinction, so a route's `schema.response` also serializes what a custom
-// error handler emits
 // see https://github.com/fastify/fastify/issues/4881 for discussion
 test('The route response schema also serializes a custom error handler payload (#4881)', async t => {
   t.plan(4)
@@ -1017,8 +1014,6 @@ test('The route response schema also serializes a custom error handler payload (
     }
   }
 
-  // every payload carries an unlisted `details` property, so a reply that still
-  // contains it proves the response schema did not run
   const post = (fastify, url) => fastify.inject({ method: 'POST', url, payload: {} })
 
   await t.test('the schema rewrites and prunes what the error handler sent', async t => {
@@ -1031,25 +1026,20 @@ test('The route response schema also serializes a custom error handler payload (
       fastify.post(url, { schema: { body: bodySchema, response: { 400: appErrorSchema } } }, echoBody)
     }
 
-    // a wildcard key matches an error status code just as an exact one does
     fastify.post('/4xx', { schema: { body: bodySchema, response: { '4xx': appErrorSchema } } }, echoBody)
 
     fastify.setErrorHandler(function (_error, request, reply) {
       reply.code(400)
-      // the returned payload carries a marker the sent one cannot produce, so
-      // this pins the return path rather than falling through to `reply.send`
       if (request.url === '/returned') {
         return { code: 'CUSTOM_ERROR', message: 'via return', details: { field: 'a' } }
       }
       reply.send({ code: 'CUSTOM_ERROR', message: request.url, details: { field: 'a' } })
     })
 
-    // `const` rewrites the code the handler chose and `details` is dropped
     let res = await post(fastify, '/sent')
     t.assert.strictEqual(res.statusCode, 400)
     t.assert.deepStrictEqual(res.json(), { code: 'APP_ERROR', message: '/sent' })
 
-    // returning the payload instead of sending it takes the same path
     res = await post(fastify, '/returned')
     t.assert.strictEqual(res.statusCode, 400)
     t.assert.deepStrictEqual(res.json(), { code: 'APP_ERROR', message: 'via return' })
@@ -1058,7 +1048,6 @@ test('The route response schema also serializes a custom error handler payload (
     t.assert.strictEqual(res.statusCode, 400)
     t.assert.deepStrictEqual(res.json(), { code: 'APP_ERROR', message: '/4xx' })
 
-    // an async handler resolves through a different branch, same outcome
     const asyncFastify = Fastify()
     t.after(() => { asyncFastify.close() })
 
@@ -1079,11 +1068,8 @@ test('The route response schema also serializes a custom error handler payload (
     const fastify = Fastify()
     t.after(() => { fastify.close() })
 
-    // the retry serializes Fastify's own error object, which has no `code`
-    // either, so serialization fails a second time
     fastify.post('/twice', { schema: { body: bodySchema, response: { 400: appErrorSchema } } }, echoBody)
 
-    // here the retry succeeds, because the error object does carry `message`
     fastify.post('/once', {
       schema: {
         body: bodySchema,
@@ -1114,7 +1100,6 @@ test('The route response schema also serializes a custom error handler payload (
 
     fastify.post('/bare', { schema: { body: bodySchema } }, echoBody)
 
-    // the success schema, not an error schema, serializes the error payload
     fastify.post('/success-schema', {
       schema: {
         body: bodySchema,
@@ -1162,7 +1147,6 @@ test('The route response schema also serializes a custom error handler payload (
       reply.send(JSON.stringify(errorPayload))
     })
 
-    // the control proves the same schema does reshape this payload when it runs
     let res = await post(fastify, '/control')
     t.assert.strictEqual(res.statusCode, 400)
     t.assert.deepStrictEqual(res.json(), { code: 'APP_ERROR', message: 'Unknown custom error' })
@@ -1171,12 +1155,10 @@ test('The route response schema also serializes a custom error handler payload (
     t.assert.strictEqual(res.statusCode, 400)
     t.assert.deepStrictEqual(res.json(), errorPayload)
 
-    // a string is never handed to a response schema
     res = await post(fastify, '/string')
     t.assert.strictEqual(res.statusCode, 400)
     t.assert.deepStrictEqual(res.json(), errorPayload)
 
-    // a scope-wide reply serializer takes precedence over the response schema
     const wrapped = Fastify()
     t.after(() => { wrapped.close() })
 


### PR DESCRIPTION
Documents that a route's `schema.response` also serializes payloads sent from
`setErrorHandler`, and pins the behavior with a regression test.

Refs #4881. Docs-only — no runtime change.

## Why

A response schema is selected by status code, with no distinction between
success and error replies: `serialize()` in `lib/reply.js` resolves the
serializer via `getSchemaSerializer()` in `lib/schemas.js` from the reply's
status code, and nothing marks the reply as an error. So an error handler that
replies `400` gets the route's `response[400]` serializer, and because
`fast-json-stringify` is a serializer rather than a validator it reshapes the
payload instead of rejecting it — `const` rewrites values, unlisted properties
disappear.

That is exactly what #4881 reported, and it was never written down anywhere, so
it reads as Fastify corrupting the error response rather than as a consequence
of serialization not being validation. @climba03003 made this same point on the
thread ("it is a serializer not a validator").

## What is documented

A new `#### Response schemas and error replies` section at the end of
`### Serialization` in `docs/Reference/Validation-and-Serialization.md`, plus a
short note under `#### setErrorHandler` in `docs/Reference/Server.md` for
readers arriving from that side.

Beyond the reported case, two things that are easy to hit and were documented
nowhere:

- **An error handler that never calls `reply.code()` leaves the reply at
  `200`**, so the route's *success* schema serializes the error payload. The
  client gets `HTTP 200` with an error body — or a `500` if that schema has
  unmet `required` properties.
- **A payload the schema cannot serialize throws**, and the reply re-enters the
  error path, which may answer `500 FST_ERR_FAILED_ERROR_SERIALIZATION`. The
  outcome depends on whether the retry finds a matching schema, so the wording
  is hedged deliberately.

The section also documents `reply.serializer()`, sending an already-serialized
string, and `setReplySerializer` (which takes precedence over the response
schema) as the ways to send the payload untouched.

## What is deliberately not here

The `setErrorHandler({ schema }, handler)` API proposed on the thread. @Eomm
objected ("it could become very hard to manage this stuff... the route's schema
always has the priority") and the design was never resolved, so this PR follows
@metcoder95's closing suggestion — "Maybe we can start easy and extend the
documentation?" — and stays docs-only.

The section is also deliberately **not** an exhaustive `fast-json-stringify`
reshaping reference. It states the core behavior and one worked example; the
per-keyword details (`enum` is not honored, `default` fills omitted
properties, coercion, `additionalProperties`, `anyOf` pruning) are all verified
but left out to keep a reference section short and accurate. Happy to add any
of them if you would rather have them here.

## Tests

`test/schema-serialization.test.js` gains one test with four subtests, sitting
next to the existing `'The schema changes the default error handler output'`
which already covers the default handler:

1. `const` rewrite and unlisted-property drop, across `reply.send()`, a sync
   `return`, an `async` return (a different branch in `lib/error-handler.js`),
   and a `'4xx'` key.
2. Both retry outcomes of an unserializable payload.
3. The `reply.code()` omission trap.
4. Each bypass path, with a control route proving the same schema would
   otherwise reshape the payload.

Every payload carries an unlisted `details` property so a reply that still
contains it proves the schema did not run, and the returned payload carries a
marker `reply.send` cannot produce. Assertions use error `code`s rather than
`fast-json-stringify` or Ajv message text.

## Checklist

- `npm test` passes (lint, unit, types); full suite green.
- `npm run lint:markdown` clean for both changed docs.
- No `lib/`, `types/`, `fastify.js` or `package.json` changes; no version bump.
- Behavior unchanged — every documented claim was verified against `main` first.

Should this close #4881, or would you rather keep it open for the
`setErrorHandler({ schema })` discussion?
