### PR TITLE
docs: document percent-decoded route params as untrusted input

### DIFF
--- a/docs/Reference/Request.md
+++ b/docs/Reference/Request.md
@@ -9,7 +9,11 @@ Request is a core Fastify object containing the following fields:
 - `body` - The request payload, see [Content-Type Parser](./ContentTypeParser.md)
   for details on what request payloads Fastify natively parses and how to support
   other content types.
-- `params` - The params matching the URL.
+- `params` - The params matching the URL. Values are percent-decoded
+  (for example `%20` becomes a space, and `%2f` becomes `/`). Decoded
+  values may contain `.`, `..`, `/`, or other characters; treat them as
+  untrusted input. See the security note below and
+  [Routes - Url building](./Routes.md#url-building).
 - [`headers`](#headers) - The headers getter and setter.
 - `raw` - The incoming HTTP request from Node core.
 - `server` - The Fastify server instance, scoped to the current
@@ -35,13 +39,21 @@ Request is a core Fastify object containing the following fields:
   [`trustProxy`](./Server.md#factory-trust-proxy) is enabled).
 
 > ⚠️ Security:
+> `request.params`, `request.query`, `request.headers`, and `request.body`
+> are untrusted network input. Route parameter values are percent-decoded
+> before your handler runs, so a segment like `..%2ffile` becomes `../file`
+> in `request.params`. Do not use parameter values as filesystem paths,
+> template names, or redirect targets without validating or containing
+> them. Prefer [`@fastify/static`](https://github.com/fastify/fastify-static)
+> (or `reply.sendFile`) when serving files from a root directory.
+>
 > `request.ip`, `request.ips`, `request.host`, `request.hostname`,
 > `request.port`, and `request.protocol` come from request metadata
-> (socket and/or forwarding headers) and should be treated as untrusted input.
-> Fastify does not perform security validation for business logic.
-> If these values are used in security-sensitive decisions, they must 
-> be validated explicitly (for example: trusted proxy configuration,
-> allow-lists, strict parsing, and normalization).
+> (socket and/or forwarding headers) and should also be treated as
+> untrusted input. Fastify does not perform security validation for
+> business logic. If these values are used in security-sensitive decisions,
+> they must be validated explicitly (for example: trusted proxy
+> configuration, allow-lists, strict parsing, and normalization).
 
 - `method` - The method of the incoming request.
 - `url` - The URL of the incoming request.

--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -328,6 +328,19 @@ Prefer a single parameter approach, especially on routes that are on the hot
 path of your application. For more details, see
 [find-my-way](https://github.com/delvedor/find-my-way).
 
+> ⚠️ Security:
+> Fastify (via find-my-way) percent-decodes route parameters and wildcards
+> before they reach your handler. Encoded separators in a segment are
+> decoded in the parameter value: for a route `/download/:file`, a request
+> to `/download/..%2fsecret.txt` yields
+> `request.params.file === '../secret.txt'`. Parameters are untrusted
+> input. Do not pass them to `path.join`, `fs` APIs, template engines, or
+> redirects without validation or path containment. To serve files from a
+> directory root, use
+> [`@fastify/static`](https://github.com/fastify/fastify-static) instead of
+> joining `request.params` into a filesystem path yourself. See also
+> [Request](./Request.md).
+
 To include a colon in a path without declaring a parameter, use a double colon.
 For example:
 ```js


### PR DESCRIPTION
Document that route parameters are percent-decoded before handlers run and remain untrusted network input. A segment such as `..%2ffile` becomes `../file` in `request.params`, so applications must not pass params into filesystem, template, or redirect sinks without validation or containment. Prefer `@fastify/static` / `reply.sendFile` when serving files from a root directory.
