### PR TITLE
refactor(types)!: remove deprecated FastifyLoggerInstance in favor of FastifyBaseLogger

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -19,7 +19,6 @@ import {
   FastifyChildLoggerFactory,
   LogController as LogControllerClass,
   FastifyLogFn,
-  FastifyLoggerInstance,
   FastifyLoggerOptions,
   LogLevel,
   PinoLoggerOptions
@@ -224,7 +223,7 @@ declare namespace fastify {
     FastifyReply, // './types/reply'
     FastifyPluginCallback, FastifyPluginAsync, FastifyPluginOptions, // './types/plugin'
     FastifyListenOptions, FastifyInstance, PrintRoutesOptions, // './types/instance'
-    FastifyLoggerOptions, FastifyBaseLogger, FastifyLoggerInstance, FastifyLogFn, LogLevel, // './types/logger'
+    FastifyLoggerOptions, FastifyBaseLogger, FastifyLogFn, LogLevel, // './types/logger'
     FastifyRequestContext, FastifyContextConfig, FastifyReplyContext, // './types/context'
     RouteHandler, RouteHandlerMethod, RouteOptions, RouteShorthandMethod, RouteShorthandOptions,
     RouteShorthandOptionsWithHandler, RouteGenericInterface, // './types/route'

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -28,12 +28,6 @@ export interface FastifyBaseLogger extends Pick<BaseLogger, 'level' | 'info' | '
   child(bindings: Bindings, options?: ChildLoggerOptions): FastifyBaseLogger
 }
 
-// TODO delete FastifyLoggerInstance in the next major release. It seems that it is enough to have only FastifyBaseLogger.
-/**
- * @deprecated Use FastifyBaseLogger instead
- */
-export type FastifyLoggerInstance = FastifyBaseLogger
-
 export interface FastifyLoggerStreamDestination {
   write(msg: string): void;
 }


### PR DESCRIPTION
Proposal:

- Removes the deprecated `FastifyLoggerInstance` type from `fastify.d.ts` and `types/logger.d.ts`. `FastifyLoggerInstance` was already marked `@deprecated` in favor of `FastifyBaseLogger`, with a TODO noting it should be removed in the next major release. Since this is part of the v6 cleanup, we're removing it now.

Breaking change:

- Yes, anyone importing `FastifyLoggerInstance` needs to migrate to `FastifyBaseLogger`, which exposes the same API.

Note:
- To be merged from the “next” branch
- For the next major release of Fastify ( v6 )