### PR TITLE
docs: add per-route logging for Google Cloud Functions

### DIFF
--- a/docs/Guides/Serverless.md
+++ b/docs/Guides/Serverless.md
@@ -256,6 +256,32 @@ curl -X POST https://$GOOGLE_REGION-$GOOGLE_PROJECT.cloudfunctions.net/me \
 {"message":"Hello Fastify!"}
 ```
 
+#### Per-route logging
+
+Google Cloud Functions exposes one entry point for your Fastify instance, so
+the dashboard may show all HTTP traffic under that function. Instead of
+deploying one function per endpoint, keep the single Fastify instance and emit
+a structured log line after each request with the matched route:
+
+```js
+fastify.addHook('onResponse', async (request, reply) => {
+  request.log.info({
+    route: request.routeOptions.url,
+    method: request.method,
+    statusCode: reply.statusCode,
+    responseTime: reply.elapsedTime
+  }, 'request completed')
+})
+```
+
+`request.routeOptions.url` is the route pattern, so `/users/123` and
+`/users/456` are grouped under `/users/:id`. With Fastify's logger enabled, the
+fields are emitted as structured log fields. In Cloud Logging, create a
+log-based metric or filter on `jsonPayload.route` to get per-route request
+counts, latency, and error rates.
+
+The same hook works when deploying through Firebase Functions with `onRequest`.
+
 ### References
 - [Google Cloud Functions - Node.js Quickstart
   ](https://docs.cloud.google.com/run/docs/quickstarts/functions/deploy-functions-gcloud)

--- a/docs/Guides/Serverless.md
+++ b/docs/Guides/Serverless.md
@@ -276,15 +276,21 @@ fastify.addHook('onResponse', async (request, reply) => {
 
 `request.routeOptions.url` is the route pattern, so `/users/123` and
 `/users/456` are grouped under `/users/:id`. With Fastify's logger enabled, the
-fields are emitted as structured log fields. In Cloud Logging, create a
-log-based metric or filter on `jsonPayload.route` to get per-route request
-counts, latency, and error rates.
+fields are emitted as structured log fields, as described in the [Cloud
+Logging structured logging documentation](https://cloud.google.com/logging/docs/structured-logging)
+and the [Cloud Functions logging guide](https://cloud.google.com/functions/docs/monitoring/logging).
+In Cloud Logging, create a [log-based
+metric](https://cloud.google.com/logging/docs/logs-based-metrics) or filter on
+`jsonPayload.route` to get per-route request counts, latency, and error rates.
 
 The same hook works when deploying through Firebase Functions with `onRequest`.
 
 ### References
 - [Google Cloud Functions - Node.js Quickstart
   ](https://docs.cloud.google.com/run/docs/quickstarts/functions/deploy-functions-gcloud)
+- [Cloud Logging - Structured Logging](https://cloud.google.com/logging/docs/structured-logging)
+- [Cloud Logging - Log-based Metrics](https://cloud.google.com/logging/docs/logs-based-metrics)
+- [Cloud Functions - Logging](https://cloud.google.com/functions/docs/monitoring/logging)
 
 ## Google Firebase Functions
 

--- a/docs/Guides/Serverless.md
+++ b/docs/Guides/Serverless.md
@@ -287,7 +287,7 @@ The same hook works when deploying through Firebase Functions with `onRequest`.
 
 ### References
 - [Google Cloud Functions - Node.js Quickstart
-  ](https://docs.cloud.google.com/run/docs/quickstarts/functions/deploy-functions-gcloud)
+  ](https://cloud.google.com/run/docs/quickstarts/functions/deploy-functions-gcloud)
 - [Cloud Logging - Structured Logging](https://cloud.google.com/logging/docs/structured-logging)
 - [Cloud Logging - Log-based Metrics](https://cloud.google.com/logging/docs/logs-based-metrics)
 - [Cloud Functions - Logging](https://cloud.google.com/functions/docs/monitoring/logging)


### PR DESCRIPTION
Closes #4670.

Adds a per-route logging section to the Google Cloud Functions part of the serverless guide.

The section shows how to keep a single Fastify function while getting per-route visibility in Cloud Logging:

- emit a structured `onResponse` log with the matched route pattern
- use `request.routeOptions.url` so `/users/123` and `/users/456` group under `/users/:id`
- build log-based metrics from `jsonPayload.route`

The same hook applies to Firebase Functions with `onRequest`.

Validated with `markdownlint-cli2`.
