### PR TITLE
refactor(types)!: remove deprecated ValidationResult type alias

### DIFF
--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -1548,9 +1548,9 @@ FastifyError is a custom error object that includes status code and validation
 results.
 
 It extends the Node.js `Error` type, and adds two additional, optional
-properties: `statusCode: number` and `validation: ValidationResult[]`.
+properties: `statusCode: number` and `validation: FastifySchemaValidationError[]`.
 
-##### fastify.ValidationResult
+##### fastify.FastifySchemaValidationError
 
 [src](https://github.com/fastify/fastify/blob/main/fastify.d.ts#L184)
 

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -211,11 +211,6 @@ declare namespace fastify {
     routerOptions?: FastifyRouterOptions<RawServer>,
   }
 
-  /**
-   * @deprecated use {@link FastifySchemaValidationError}
-   */
-  export type ValidationResult = FastifySchemaValidationError
-
   /* Export additional types */
   export type {
     LightMyRequestChain, InjectOptions, LightMyRequestResponse, LightMyRequestCallback, // 'light-my-request'


### PR DESCRIPTION
Proposal:

- Removes the deprecated `ValidationResult` type alias, superseded by `FastifySchemaValidationError`.

Breaking change:

-  Yes, anyone importing `ValidationResult` will need to switch to `FastifySchemaValidationError`.

Note:

- To be merged from the “next” branch
- For the next major release of Fastify ( v6 )
- Documentation updated accordingly (`TypeScript.md`)
