### PR TITLE
Allow custom parsers to recover content types

### DIFF
--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -45,6 +45,11 @@ parsed.
 > by the regex has a corresponding entry in the schema's `content` map. See
 > [Validation and Serialization](./Validation-and-Serialization.md) for details.
 
+Invalid `Content-Type` values are rejected unless they match a registered
+`RegExp` parser. This allows an application to recover known malformed values
+without weakening Fastify's default validation. String and catch-all parsers
+do not recover invalid values.
+
 ### Usage
 ```js
 fastify.addContentTypeParser('application/jsoff', function (request, payload, done) {

--- a/lib/content-type-parser.js
+++ b/lib/content-type-parser.js
@@ -117,12 +117,30 @@ ContentTypeParser.prototype.existingParser = function (contentType) {
 }
 
 ContentTypeParser.prototype.getParser = function (contentType) {
+  let rawContentType
   if (typeof contentType === 'string') {
     const cached = this.cache.get(contentType)
     if (cached !== undefined) return cached
-    contentType = new ContentType(contentType)
+    rawContentType = contentType
+    contentType = ContentType.from(contentType)
   }
   const ct = contentType.toString()
+
+  if (
+    contentType.isValid === false &&
+    typeof rawContentType === 'string' &&
+    rawContentType !== ''
+  ) {
+    for (let j = 0; j !== this.parserRegExpList.length; ++j) {
+      const parserRegExp = this.parserRegExpList[j]
+      if (parserRegExp.test(rawContentType)) {
+        const parser = this.customParsers.get(parserRegExp.toString())
+        this.cache.set(rawContentType, parser)
+        return parser
+      }
+    }
+    return undefined
+  }
 
   let parser = this.cache.get(ct)
   if (parser !== undefined) return parser
@@ -188,7 +206,11 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
   const parser = this.getParser(contentType)
 
   if (parser === undefined) {
-    if (request.is404 === true) {
+    const hasInvalidContentType = typeof contentType === 'string' &&
+      contentType !== '' &&
+      ContentType.from(contentType).isValid === false
+
+    if (request.is404 === true && hasInvalidContentType === false) {
       handler(request, reply)
       return
     }

--- a/lib/handle-request.js
+++ b/lib/handle-request.js
@@ -5,7 +5,6 @@ const wrapThenable = require('./wrap-thenable')
 const { validate: validateSchema } = require('./validation')
 const { preValidationHookRunner, preHandlerHookRunner } = require('./hooks')
 const {
-  FST_ERR_CTP_INVALID_MEDIA_TYPE,
   FST_ERR_ROUTE_MISSING_CONTENT_TYPE,
   FST_ERR_ROUTE_MISSING_CONTENT
 } = require('./errors')
@@ -15,10 +14,8 @@ const {
   kRouteContext,
   kFourOhFourContext,
   kSupportedHTTPMethods,
-  kRequestContentType,
   kDiagnosticsStore
 } = require('./symbols')
-const ContentType = require('./content-type')
 
 const channels = diagnostics.tracingChannel('fastify.request.handler')
 
@@ -74,17 +71,7 @@ function handleRequest (err, request, reply) {
       return
     }
 
-    // Conditional assignment to avoid creating a new ContentType instance
-    // It can be assigned when accessing the .mediaType in hooks
-    if (!request[kRequestContentType]) {
-      request[kRequestContentType] = ContentType.from(ctHeader)
-    }
-    if (request[kRequestContentType].isValid === false) {
-      reply[kReplyIsError] = true
-      reply.status(415).send(new FST_ERR_CTP_INVALID_MEDIA_TYPE())
-      return
-    }
-    request[kRouteContext].contentTypeParser.run(request[kRequestContentType].toString(), handler, request, reply)
+    request[kRouteContext].contentTypeParser.run(ctHeader, handler, request, reply)
     return
   }
 

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -723,6 +723,125 @@ test('invalid content-type error message should not contain format placeholder',
   })
 })
 
+test('RegExp parser can recover an invalid content-type', async t => {
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.addContentTypeParser(
+    /^application\/json,application\/json$/,
+    { parseAs: 'string' },
+    fastify.getDefaultJsonParser('error', 'error')
+  )
+  fastify.post('/', request => request.body)
+
+  const response = await fastify.inject({
+    method: 'POST',
+    url: '/',
+    headers: {
+      'content-type': 'application/json,application/json'
+    },
+    payload: JSON.stringify({ recovered: true })
+  })
+
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(response.json(), { recovered: true })
+})
+
+test('invalid content-type recovery is encapsulated', async t => {
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.register((instance, _options, done) => {
+    instance.addContentTypeParser(
+      /^application\/json,application\/json$/,
+      { parseAs: 'string' },
+      instance.getDefaultJsonParser('error', 'error')
+    )
+    instance.post('/recover', request => request.body)
+    done()
+  })
+  fastify.post('/strict', request => request.body)
+
+  const requestOptions = {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json,application/json'
+    },
+    payload: JSON.stringify({ recovered: true })
+  }
+  const recoveredResponse = await fastify.inject({
+    ...requestOptions,
+    url: '/recover'
+  })
+  const strictResponse = await fastify.inject({
+    ...requestOptions,
+    url: '/strict'
+  })
+
+  t.assert.strictEqual(recoveredResponse.statusCode, 200)
+  t.assert.deepStrictEqual(recoveredResponse.json(), { recovered: true })
+  t.assert.strictEqual(strictResponse.statusCode, 415)
+  t.assert.strictEqual(
+    strictResponse.json().code,
+    'FST_ERR_CTP_INVALID_MEDIA_TYPE'
+  )
+})
+
+test('catch-all parser does not recover an invalid content-type', async t => {
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.addContentTypeParser('*', { parseAs: 'string' }, (_request, body, done) => {
+    done(null, body)
+  })
+  fastify.post('/', request => request.body)
+
+  const response = await fastify.inject({
+    method: 'POST',
+    url: '/',
+    headers: {
+      'content-type': 'application/json,application/json'
+    },
+    payload: JSON.stringify({ recovered: false })
+  })
+
+  t.assert.strictEqual(response.statusCode, 415)
+  t.assert.strictEqual(response.json().code, 'FST_ERR_CTP_INVALID_MEDIA_TYPE')
+})
+
+test('invalid content-type on a missing route remains unsupported', async t => {
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  const response = await fastify.inject({
+    method: 'POST',
+    url: '/missing',
+    headers: {
+      'content-type': 'application/json,application/json'
+    },
+    payload: '{}'
+  })
+
+  t.assert.strictEqual(response.statusCode, 415)
+  t.assert.strictEqual(response.json().code, 'FST_ERR_CTP_INVALID_MEDIA_TYPE')
+})
+
+test('valid unsupported content-type on a missing route remains not found', async t => {
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  const response = await fastify.inject({
+    method: 'POST',
+    url: '/missing',
+    headers: {
+      'content-type': 'application/unsupported'
+    },
+    payload: 'body'
+  })
+
+  t.assert.strictEqual(response.statusCode, 404)
+})
+
 test('content-type fail when not a valid type', async t => {
   t.plan(1)
 


### PR DESCRIPTION
Keep malformed content types rejected by default while allowing an explicitly registered RegExp parser to recover known external values. Keep request handling independent of media type parsing so validation, normalization, and recovery remain encapsulated in the content type parser. Preserve existing catch-all and missing-route behavior.

Followup to https://github.com/fastify/fastify/pull/6414

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
