### PR TITLE
fix: parse MIME types with WHATWG

### DIFF
--- a/lib/content-type.js
+++ b/lib/content-type.js
@@ -1,63 +1,7 @@
 'use strict'
 
 const { LruMap: Lru } = require('toad-cache')
-
-/**
- * keyValuePairsReg matches a single `parameter-name "=" parameter-value`
- * at a parameter boundary, following RFC 9110 §5.6.6 grammar:
- *
- *   parameter       = parameter-name "=" parameter-value
- *   parameter-name  = token
- *   parameter-value = ( token / quoted-string )
- *   quoted-string   = DQUOTE *( qdtext / quoted-pair ) DQUOTE
- *   qdtext          = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
- *   quoted-pair     = "\" ( HTAB / SP / VCHAR / obs-text )
- *   obs-text        = %x80-FF
- *
- * The value alternative accepts either a bare token or a full quoted-string
- * whose content matches the qdtext / quoted-pair character ranges. Because
- * the quoted-string branch is aware of `\"` as an escape, embedded `"` and
- * `;` characters inside a quoted value do not terminate the value.
- *
- * @see https://httpwg.org/specs/rfc9110.html#parameter
- * @type {RegExp}
- */
-const keyValuePairsReg = /(?:^|;)\s*([\w!#$%&'*+.^`|~-]+)=("(?:[\t\u0020\u0021\u0023-\u005b\u005d-\u007e\u0080-\u00ff]|\\[\t\u0020-\u00ff])*"|[\w!#$%&'*+.^`|~-]+)/gu
-
-/**
- * quotedPairReg matches a quoted-pair (a backslash followed by a single
- * quoted-pair-allowed octet) inside a quoted-string value. Per RFC 9110
- * §5.6.4, recipients that process the value of a quoted-string MUST handle
- * a quoted-pair as if it were replaced by the octet following the backslash.
- *
- * @see https://httpwg.org/specs/rfc9110.html#quoted.string
- * @type {RegExp}
- */
-const quotedPairReg = /\\([\t\u0020-\u00ff])/gu
-
-/**
- * typeNameReg is used to validate that the first part of the media-type
- * does not use disallowed characters. Types must consist solely of
- * characters that match the specified character class. It must terminate
- * with a matching character.
- *
- * @see https://httpwg.org/specs/rfc9110.html#rule.token.separators
- * @type {RegExp}
- */
-const typeNameReg = /^[\w!#$%&'*+.^`|~-]+$/
-
-/**
- * subtypeNameReg is used to validate that the second part of the media-type
- * does not use disallowed characters. Subtypes must consist solely of
- * characters that match the specified character class, and optionally
- * terminated with any amount of whitespace characters. Without the terminating
- * anchor (`$`), the regular expression will match the leading portion of a
- * string instead of the whole string.
- *
- * @see https://httpwg.org/specs/rfc9110.html#rule.token.separators
- * @type {RegExp}
- */
-const subtypeNameReg = /^[\w!#$%&'*+.^`|~-]+\s*$/
+const parseMimeType = require('./mime-type-parser')
 
 /**
  * Content-Type internal shared cache
@@ -68,8 +12,7 @@ const cache = new Lru(100)
 /**
  * ContentType parses and represents the value of the content-type header.
  *
- * @see https://httpwg.org/specs/rfc9110.html#media.type
- * @see https://httpwg.org/specs/rfc9110.html#parameter
+ * @see https://mimesniff.spec.whatwg.org/#parse-a-mime-type
  */
 class ContentType {
   #valid = false
@@ -105,76 +48,14 @@ class ContentType {
       return
     }
 
-    let sepIdx = headerValue.indexOf(';')
-    if (sepIdx === -1) {
-      // The value is the simplest `type/subtype` variant.
-      sepIdx = headerValue.indexOf('/')
-      if (sepIdx === -1) {
-        // Got a string without the correct `type/subtype` format.
-        return
-      }
+    const parsed = parseMimeType(headerValue, this.#parameters)
+    if (parsed === undefined) return
 
-      const type = headerValue.slice(0, sepIdx).trimStart().toLowerCase()
-      const subtype = headerValue.slice(sepIdx + 1).trimEnd().toLowerCase()
-
-      if (
-        typeNameReg.test(type) === true &&
-        subtypeNameReg.test(subtype) === true
-      ) {
-        this.#valid = true
-        this.#empty = false
-        this.#type = type
-        this.#subtype = subtype
-      }
-
-      return
-    }
-
-    // We have a `type/subtype; params=list...` header value.
-    const mediaType = headerValue.slice(0, sepIdx).toLowerCase()
-    const paramsList = headerValue.slice(sepIdx + 1).trim()
-
-    sepIdx = mediaType.indexOf('/')
-    if (sepIdx === -1) {
-      // We got an invalid string like `something; params=list...`.
-      return
-    }
-    const type = mediaType.slice(0, sepIdx).trimStart()
-    const subtype = mediaType.slice(sepIdx + 1).trimEnd()
-
-    if (
-      typeNameReg.test(type) === false ||
-      subtypeNameReg.test(subtype) === false
-    ) {
-      // Some portion of the media-type is using invalid characters. Therefore,
-      // the content-type header is invalid.
-      return
-    }
-    this.#type = type
-    this.#subtype = subtype
+    this.#type = parsed.type
+    this.#subtype = parsed.subtype
+    this.#parameters = parsed.parameters
     this.#valid = true
     this.#empty = false
-
-    let matches = keyValuePairsReg.exec(paramsList)
-    while (matches) {
-      // https://httpwg.org/specs/rfc9110.html#parameter
-      // Parameter names are case-insensitive.
-      const key = matches[1].toLowerCase()
-      // Parameter values might or might not be case-sensitive,
-      // depending on the semantics of the parameter name.
-      let value = matches[2]
-      if (value.charCodeAt(0) === 0x22 /* " */) {
-        // Strip the surrounding DQUOTEs and unescape quoted-pairs per
-        // RFC 9110 §5.6.4. The regex guarantees the value starts and ends
-        // with `"` and only contains permitted qdtext / quoted-pair octets.
-        value = value.slice(1, -1)
-        if (value.indexOf('\\') !== -1) {
-          value = value.replace(quotedPairReg, '$1')
-        }
-      }
-      this.#parameters.set(key, value)
-      matches = keyValuePairsReg.exec(paramsList)
-    }
   }
 
   get [Symbol.toStringTag] () { return 'ContentType' }

--- a/lib/mime-type-parser.js
+++ b/lib/mime-type-parser.js
@@ -1,0 +1,231 @@
+'use strict'
+
+const httpTokenReg = /^[!#$%&'*+.^_`|~A-Za-z0-9-]+$/u
+const httpQuotedStringTokenReg = /^[\u0009\u0020-\u007e\u0080-\u00ff]*$/u // eslint-disable-line no-control-regex
+
+/**
+ * @see https://mimesniff.spec.whatwg.org/#parse-a-mime-type
+ * @param {string} headerValue
+ * @param {Map<string, string>} parameters
+ * @returns {{ type: string, subtype: string, parameters: Map<string, string> } | undefined}
+ */
+function parseMimeType (headerValue, parameters) {
+  // 1. Remove leading and trailing HTTP whitespace.
+  const input = trimHttpWhitespace(headerValue)
+
+  // 2–3. Start at the beginning and collect the type up to "/".
+  const slashIndex = input.indexOf('/')
+  if (slashIndex === -1) return undefined
+
+  const type = input.slice(0, slashIndex)
+
+  // 4–6. Reject an invalid type, then advance past "/".
+  if (!httpTokenReg.test(type)) return undefined
+
+  // 7. Collect the subtype up to ";" or the end of input.
+  const parameterIndex = input.indexOf(';', slashIndex + 1)
+  const subtypeEnd = parameterIndex === -1 ? input.length : parameterIndex
+
+  // 8. Remove trailing HTTP whitespace from the subtype.
+  const subtype = trimHttpWhitespace(
+    input.slice(slashIndex + 1, subtypeEnd),
+    false,
+    true
+  )
+
+  // 9. Reject an empty or non-token subtype.
+  if (!httpTokenReg.test(subtype)) return undefined
+
+  // 10–12. Create the MIME type record, parse its parameters, and return it.
+  return {
+    type: type.toLowerCase(),
+    subtype: subtype.toLowerCase(),
+    parameters: parameterIndex === -1
+      ? parameters
+      : parseParameters(input, parameterIndex, parameters)
+  }
+}
+
+function isHttpWhitespace (characterCode) {
+  return (
+    characterCode === 0x09 ||
+    characterCode === 0x0a ||
+    characterCode === 0x0d ||
+    characterCode === 0x20
+  )
+}
+
+function trimHttpWhitespace (value, trimStart = true, trimEnd = true) {
+  let start = 0
+  let end = value.length
+
+  if (trimStart) {
+    while (start < end && isHttpWhitespace(value.charCodeAt(start))) {
+      start++
+    }
+  }
+
+  if (trimEnd) {
+    while (end > start && isHttpWhitespace(value.charCodeAt(end - 1))) {
+      end--
+    }
+  }
+
+  return value.slice(start, end)
+}
+
+/**
+ * @see https://fetch.spec.whatwg.org/#collect-an-http-quoted-string
+ */
+function collectHttpQuotedString (input, position) {
+  let valueParts
+  let valueEnd
+
+  // 4. Advance past the opening quote.
+  position++
+  const valueStart = position
+
+  while (true) {
+    // 5.1. Collect until the next quote or backslash.
+    const partStart = position
+    while (
+      position < input.length &&
+      input.charCodeAt(position) !== 0x22 &&
+      input.charCodeAt(position) !== 0x5c
+    ) {
+      position++
+    }
+
+    if (valueParts !== undefined) {
+      valueParts.push(input.slice(partStart, position))
+    }
+
+    // 5.2. Stop at the end of input.
+    if (position === input.length) {
+      break
+    }
+
+    // 5.3–5.4. Read and advance past the quote or backslash.
+    const quoteOrBackslash = input.charCodeAt(position)
+    const quoteOrBackslashPosition = position
+    position++
+
+    // 5.6. A quote terminates the value.
+    if (quoteOrBackslash === 0x22) {
+      valueEnd = quoteOrBackslashPosition
+      break
+    }
+
+    if (valueParts === undefined) {
+      valueParts = [input.slice(valueStart, position - 1)]
+    }
+
+    // 5.5.1. Preserve a trailing backslash.
+    if (position === input.length) {
+      valueParts.push('\\')
+      break
+    }
+
+    // 5.5.2–5.5.3. Append the escaped code point and advance.
+    valueParts.push(input[position])
+    position++
+  }
+
+  // 6. Return the extracted value and updated position.
+  return {
+    position,
+    value: valueParts === undefined
+      ? input.slice(valueStart, valueEnd)
+      : valueParts.join('')
+  }
+}
+
+function parseParameters (input, position, parameters) {
+  while (position < input.length) {
+    // 11.1. Advance past the parameter delimiter ";".
+    position++
+
+    // 11.2. Skip HTTP whitespace.
+    while (
+      position < input.length &&
+      isHttpWhitespace(input.charCodeAt(position))
+    ) {
+      position++
+    }
+
+    // 11.3. Collect the name up to ";" or "=".
+    const nameStart = position
+    while (
+      position < input.length &&
+      input.charCodeAt(position) !== 0x3b &&
+      input.charCodeAt(position) !== 0x3d
+    ) {
+      position++
+    }
+    const name = input.slice(nameStart, position)
+
+    // 11.5. Skip malformed names at ";" or advance past "=".
+    if (position < input.length) {
+      if (input.charCodeAt(position) === 0x3b) {
+        continue
+      }
+      position++
+    }
+
+    // 11.6. Stop if there is no parameter value.
+    if (position === input.length) {
+      break
+    }
+
+    // 11.7. Collect either a quoted or unquoted value.
+    let value
+    if (input.charCodeAt(position) === 0x22) {
+      // 11.8. Collect a quoted string, then discard through the next ";".
+      const quotedString = collectHttpQuotedString(input, position)
+      position = quotedString.position
+      value = quotedString.value
+
+      while (
+        position < input.length &&
+        input.charCodeAt(position) !== 0x3b
+      ) {
+        position++
+      }
+    } else {
+      // 11.9. Collect through ";" and trim trailing HTTP whitespace.
+      const valueStart = position
+      while (
+        position < input.length &&
+        input.charCodeAt(position) !== 0x3b
+      ) {
+        position++
+      }
+      value = trimHttpWhitespace(
+        input.slice(valueStart, position),
+        false,
+        true
+      )
+      if (value === '') {
+        continue
+      }
+    }
+
+    // 11.4 and 11.10. Lowercase valid names and keep their first valid value.
+    if (
+      name !== '' &&
+      httpTokenReg.test(name) &&
+      httpQuotedStringTokenReg.test(value)
+    ) {
+      // Token validation guarantees ASCII, so native lowercasing is equivalent
+      // to the specification's ASCII lowercase operation.
+      const normalizedName = name.toLowerCase()
+      if (!parameters.has(normalizedName)) {
+        parameters.set(normalizedName, value)
+      }
+    }
+  }
+
+  return parameters
+}
+
+module.exports = parseMimeType

--- a/test/content-type.test.js
+++ b/test/content-type.test.js
@@ -96,6 +96,89 @@ describe('ContentType class', () => {
     t.assert.equal(found.isValid, false)
   })
 
+  test('recovers invalid parameter syntax', (t) => {
+    const recoveredContentTypes = [
+      {
+        input: 'application/json; charset=utf-8,application/json',
+        mediaType: 'application/json',
+        parameters: [['charset', 'utf-8,application/json']],
+        serialized: 'application/json; charset="utf-8,application/json"'
+      },
+      {
+        input: 'application/json; charset=utf-8,text/plain',
+        mediaType: 'application/json',
+        parameters: [['charset', 'utf-8,text/plain']],
+        serialized: 'application/json; charset="utf-8,text/plain"'
+      },
+      {
+        input: 'text/plain; charset=utf-8,application/json',
+        mediaType: 'text/plain',
+        parameters: [['charset', 'utf-8,application/json']],
+        serialized: 'text/plain; charset="utf-8,application/json"'
+      },
+      {
+        input: 'application/json; charset=utf-8,evil',
+        mediaType: 'application/json',
+        parameters: [['charset', 'utf-8,evil']],
+        serialized: 'application/json; charset="utf-8,evil"'
+      },
+      {
+        input: 'application/json; charset=utf-8 garbage',
+        mediaType: 'application/json',
+        parameters: [['charset', 'utf-8 garbage']],
+        serialized: 'application/json; charset="utf-8 garbage"'
+      },
+      {
+        input: 'application/json; @@@',
+        mediaType: 'application/json',
+        parameters: [],
+        serialized: 'application/json'
+      },
+      {
+        input: 'application/json; foo=@@@',
+        mediaType: 'application/json',
+        parameters: [['foo', '@@@']],
+        serialized: 'application/json; foo="@@@"'
+      },
+      {
+        input: 'application/json; foo',
+        mediaType: 'application/json',
+        parameters: [],
+        serialized: 'application/json'
+      },
+      {
+        input: 'application/json; =bar',
+        mediaType: 'application/json',
+        parameters: [],
+        serialized: 'application/json'
+      },
+      {
+        input: 'application/json; foo=bar baz',
+        mediaType: 'application/json',
+        parameters: [['foo', 'bar baz']],
+        serialized: 'application/json; foo="bar baz"'
+      },
+      {
+        input: 'application/json; foo=bar; @@@',
+        mediaType: 'application/json',
+        parameters: [['foo', 'bar']],
+        serialized: 'application/json; foo="bar"'
+      }
+    ]
+
+    for (const expected of recoveredContentTypes) {
+      const found = new ContentType(expected.input)
+      t.assert.equal(found.isValid, true, expected.input)
+      t.assert.equal(found.mediaType, expected.mediaType, expected.input)
+      t.assert.deepStrictEqual(
+        Array.from(found.parameters.entries()),
+        expected.parameters,
+        expected.input
+      )
+      t.assert.equal(found.toString(), expected.serialized, expected.input)
+    }
+  })
+
   test('subtype with multiple fields validates as incorrect', (t) => {
     let found = new ContentType('application/json whatever')
     t.assert.equal(found.isValid, false)
@@ -132,7 +215,7 @@ describe('ContentType class', () => {
   })
 
   test('returns a media type instance with parameters', (t) => {
-    const found = new ContentType('Application/JSON ; charset=utf-8; foo=BaR;baz=" 42"')
+    const found = new ContentType('Application/JSON ; CHARSET=utf-8; foo=BaR;baz=" 42"')
     t.assert.equal(found.isEmpty, false)
     t.assert.equal(found.mediaType, 'application/json')
     t.assert.equal(found.type, 'application')
@@ -155,17 +238,19 @@ describe('ContentType class', () => {
     )
   })
 
-  test('skips invalid quoted string parameters', (t) => {
+  test('recovers unterminated quoted string parameters', (t) => {
     const found = new ContentType('Application/JSON ; charset=utf-8; foo=BaR;baz=" 42')
+    t.assert.equal(found.isValid, true)
     t.assert.equal(found.isEmpty, false)
     t.assert.equal(found.mediaType, 'application/json')
     t.assert.equal(found.type, 'application')
     t.assert.equal(found.subtype, 'json')
-    t.assert.equal(found.parameters.size, 2)
+    t.assert.equal(found.parameters.size, 3)
 
     const expected = [
       ['charset', 'utf-8'],
-      ['foo', 'BaR']
+      ['foo', 'BaR'],
+      ['baz', ' 42']
     ]
     t.assert.deepStrictEqual(
       Array.from(found.parameters.entries()),
@@ -174,7 +259,7 @@ describe('ContentType class', () => {
 
     t.assert.equal(
       found.toString(),
-      'application/json; charset="utf-8"; foo="BaR"'
+      'application/json; charset="utf-8"; foo="BaR"; baz=" 42"'
     )
   })
 


### PR DESCRIPTION
Follow-up to https://github.com/fastify/fastify/pull/6414.

I'm trying to find an approach that makes sense here:

- Keep `addContentTypeParser` as the place for application-specific handling, including exact string overrides for valid values and explicitly registered `RegExp` parsers for invalid-header recovery, rather than forcing recovery into an `onRequest` hook (restored by https://github.com/fastify/fastify/pull/6918).
- Use a parsing and validation algorithm that is strict and standards-based while still providing established recovery behavior for common malformed inputs.

I suggest that Fastify parse `Content-Type` values using the [WHATWG MIME type parsing algorithm](https://mimesniff.spec.whatwg.org/#parse-a-mime-type).

This:

- recovers usable MIME types from malformed parameter syntax as specified by WHATWG
- continues to reject malformed type/subtype values
- preserves parsed parameters for content-type parser matching and reply charset handling
- moves MIME parsing into a dedicated cursor-based parser
- avoids regular-expression backtracking over parameter lists
- improves microbenchmark performance for parameterized and recovery cases
- uses a well-known algorithm maintained in a WHATWG standard

Fastify currently parses MIME parameters using a collection of regular expressions. That differs from the WHATWG recovery algorithm and can produce inconsistent results for malformed parameter syntax.

The observed webhook input appears to begin with `Content-Type` being set more than once somewhere in the request path. An HTTP implementation or intermediary then combines those field lines with commas before Fastify receives them:

```text
Content-Type: application/json; charset=utf-8
Content-Type: application/json
```

becomes:

```text
application/json; charset=utf-8,application/json
```

The sender, intermediary, or server layer responsible for introducing the duplicate is not necessarily known. Fastify receives only the combined value.

Adopting the WHATWG algorithm also resolves other parsing ambiguities, such as duplicate parameters:

```text
text/html; charset=windows-1252; charset=utf-8
```

The current Fastify parser lets the last parameter win:

```js
{
  type: 'text',
  subtype: 'html',
  parameters: new Map([
    ['charset', 'utf-8']
  ])
}
```

WHATWG keeps the first parameter value:

```js
{
  type: 'text',
  subtype: 'html',
  parameters: new Map([
    ['charset', 'windows-1252']
  ])
}
```

This follows the algorithm's directive to set a parameter only when that name does not already exist, preventing a later duplicate from changing the interpretation.

If the second `Content-Type` field conflicts with the first, the current parser silently discards it:

```text
application/json; charset=utf-8,text/plain
```

The current Fastify parser matches the valid parameter prefix and parses this as:

```js
{
  type: 'application',
  subtype: 'json',
  parameters: new Map([
    ['charset', 'utf-8']
  ])
}
```

The trailing `,text/plain` is discarded.

WHATWG preserves the complete parameter value:

```js
{
  type: 'application',
  subtype: 'json',
  parameters: new Map([
    ['charset', 'utf-8,text/plain']
  ])
}
```

The MIME type remains `application/json`, but the malformed charset value is no longer silently sanitized. This is nonsensical but more representative of reliantly, so in my opinion, preferable. 

This does not make comma-separated media types generally valid:

```text
application/json,application/json
```

The comma is part of the subtype in that case, so the value remains invalid. String parsers cannot register invalid MIME types, but applications can explicitly recover known invalid values using a `RegExp` content-type parser.

By contrast, comma-containing parameter values remain valid under WHATWG and use the parser registered for their media type. Applications that need custom behavior for a specific valid value can register an exact string parser.

For example:

```js
fastify.addContentTypeParser(
  'application/json; charset=utf-8,text/plain',
  { parseAs: 'string' },
  customParser
)
```

Fastify normalizes the registered value and the incoming header to the same MIME type representation, so this exact string parser takes precedence over the generic `application/json` parser.

The parser follows:

- https://mimesniff.spec.whatwg.org/#parse-a-mime-type
- https://fetch.spec.whatwg.org/#collect-an-http-quoted-string

The implementation uses numeric cursor positions and lazy string slices, but preserves the specified parsing behavior.

Parameter names are validated as HTTP tokens before using native `String.prototype.toLowerCase()`. Since valid HTTP tokens are ASCII, this is equivalent to the specification's ASCII-lowercase operation while avoiding Unicode case-folding surprises.

## Performance

Compared with `origin/main` at `a2f59056` using Node.js 24.18.0.

Each result is the paired median of 12 rounds with 500,000 constructions per round.

Benchmark code, run from the repository root:

```js
'use strict'

const Module = require('node:module')
const { execFileSync } = require('node:child_process')
const { performance } = require('node:perf_hooks')

const repo = process.cwd()
const baseRef = process.env.BASE_REF || 'origin/main'

function compile (code, filename) {
  const compiledModule = new Module(filename, module.parent)
  compiledModule.filename = filename
  compiledModule.paths = Module._nodeModulePaths(`${repo}/lib`)
  compiledModule._compile(code, filename)
  return compiledModule.exports
}

const oldSource = execFileSync(
  'git',
  ['show', `${baseRef}:lib/content-type.js`],
  { cwd: repo, encoding: 'utf8' }
)
const implementations = {
  old: compile(oldSource, `${repo}/lib/content-type-old.js`),
  current: require(`${repo}/lib/content-type.js`)
}
const cases = [
  'application/json',
  'Application/JSON',
  'application/json; charset=utf-8',
  'application/json; charset=utf-8; boundary=abc',
  'application/json; name="foo;bar"; charset=utf-8',
  'application/json; charset=utf-8,evil'
]
const iterations = 500_000
const rounds = 12
let checksum = 0

function run (ContentType, input, count) {
  const start = performance.now()
  for (let index = 0; index < count; index++) {
    checksum += new ContentType(input).isValid
  }
  return count / (performance.now() - start) * 1000
}

function median (values) {
  const sorted = values.toSorted((left, right) => left - right)
  return (sorted[5] + sorted[6]) / 2
}

for (const input of cases) {
  const samples = { old: [], current: [] }
  run(implementations.old, input, 300_000)
  run(implementations.current, input, 300_000)

  for (let round = 0; round < rounds; round++) {
    const order = round % 2 === 0 ? ['old', 'current'] : ['current', 'old']
    for (const name of order) {
      samples[name].push(run(implementations[name], input, iterations))
    }
  }

  const oldResult = median(samples.old)
  const currentResult = median(samples.current)
  const change = (currentResult / oldResult - 1) * 100
  console.log(`${input}\n  old ${oldResult.toFixed(0)} ops/s  new ${currentResult.toFixed(0)} ops/s  ${change >= 0 ? '+' : ''}${change.toFixed(1)}%`)
}

console.log(`checksum ${checksum}`)
```

| Input | Change |
|---|---:|
| `application/json` | -0.7% |
| `Application/JSON` | -0.8% |
| One parameter | +15.9% |
| Two parameters | +6.0% |
| Quoted parameter | +12.0% |
| Malformed parameter recovery | +8.1% |

Plain MIME types are within benchmark noise of the previous implementation. Parameterized and recovery cases are faster.

## Validation

- `npm run lint`
- `npm run unit`

Result: 2,310 tests passed, 4 skipped, 0 failed.

<!--
Thank you for your pull request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

* (b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

* (c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

* (d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with the project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
