### PR TITLE
refactor(types)!: remove deprecated FastifyRequestContext and FastifyReplyContext types

### DIFF
--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -1416,39 +1416,6 @@ Union type of: `'info' | 'error' | 'debug' | 'fatal' | 'warn' | 'trace'`
 
 ---
 
-#### Context
-
-The context type definition is similar to the other highly dynamic pieces of the
-type system. Route context is available in the route handler method.
-
-##### fastify.FastifyRequestContext
-
-[src](https://github.com/fastify/fastify/blob/main/types/context.d.ts#L11)
-
-An interface with a single required property `config` that is set by default to
-`unknown`. Can be specified either using a generic or an overload.
-
-This type definition is potentially incomplete. If you are using it and can
-provide more details on how to improve the definition, we strongly encourage you
-to open an issue in the main
-[fastify/fastify](https://github.com/fastify/fastify) repository. Thank you in
-advanced!
-
-##### fastify.FastifyReplyContext
-
-[src](https://github.com/fastify/fastify/blob/main/types/context.d.ts#L11)
-
-An interface with a single required property `config` that is set by default to
-`unknown`. Can be specified either using a generic or an overload.
-
-This type definition is potentially incomplete. If you are using it and can
-provide more details on how to improve the definition, we strongly encourage you
-to open an issue in the main
-[fastify/fastify](https://github.com/fastify/fastify) repository. Thank you in
-advanced!
-
----
-
 #### Routing
 
 One of the core principles in Fastify is its routing capabilities. Most of the

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -10,7 +10,7 @@ import { ConstraintStrategy, Config as FindMyWayConfig, HTTPVersion } from 'find
 import { InjectOptions, CallbackFunc as LightMyRequestCallback, Chain as LightMyRequestChain, Response as LightMyRequestResponse } from 'light-my-request'
 
 import { AddContentTypeParser, ConstructorAction, FastifyBodyParser, FastifyContentTypeParser, getDefaultJsonParser, hasContentTypeParser, ProtoAction } from './types/content-type-parser'
-import { FastifyContextConfig, FastifyReplyContext, FastifyRequestContext } from './types/context'
+import { FastifyContextConfig } from './types/context'
 import { FastifyErrorCodes } from './types/errors'
 import { DoneFuncWithErrOrRes, HookHandlerDoneFunction, onCloseAsyncHookHandler, onCloseHookHandler, onErrorAsyncHookHandler, onErrorHookHandler, onListenAsyncHookHandler, onListenHookHandler, onReadyAsyncHookHandler, onReadyHookHandler, onRegisterHookHandler, onRequestAbortAsyncHookHandler, onRequestAbortHookHandler, onRequestAsyncHookHandler, onRequestHookHandler, onResponseAsyncHookHandler, onResponseHookHandler, onRouteHookHandler, onSendAsyncHookHandler, onSendHookHandler, onTimeoutAsyncHookHandler, onTimeoutHookHandler, preCloseAsyncHookHandler, preCloseHookHandler, preHandlerAsyncHookHandler, preHandlerHookHandler, preParsingAsyncHookHandler, preParsingHookHandler, preSerializationAsyncHookHandler, preSerializationHookHandler, preValidationAsyncHookHandler, preValidationHookHandler, RequestPayload } from './types/hooks'
 import { FastifyInstance, FastifyListenOptions, PrintRoutesOptions } from './types/instance'
@@ -224,7 +224,7 @@ declare namespace fastify {
     FastifyPluginCallback, FastifyPluginAsync, FastifyPluginOptions, // './types/plugin'
     FastifyListenOptions, FastifyInstance, PrintRoutesOptions, // './types/instance'
     FastifyLoggerOptions, FastifyBaseLogger, FastifyLogFn, LogLevel, // './types/logger'
-    FastifyRequestContext, FastifyContextConfig, FastifyReplyContext, // './types/context'
+    FastifyContextConfig, // './types/context'
     RouteHandler, RouteHandlerMethod, RouteOptions, RouteShorthandMethod, RouteShorthandOptions,
     RouteShorthandOptionsWithHandler, RouteGenericInterface, // './types/route'
     FastifyRegister, FastifyRegisterOptions, RegisterOptions, // './types/register'

--- a/types/context.d.ts
+++ b/types/context.d.ts
@@ -1,22 +1,2 @@
-import { FastifyRouteConfig } from './route'
-import { ContextConfigDefault } from './utils'
-
 export interface FastifyContextConfig {
-}
-
-/**
- * Route context object. Properties defined here will be available in the route's handler
- */
-export interface FastifyRequestContext<ContextConfig = ContextConfigDefault> {
-  /**
-   * @deprecated Use Request#routeOptions#config or Request#routeOptions#schema instead
-   */
-  config: FastifyContextConfig & FastifyRouteConfig & ContextConfig;
-}
-
-export interface FastifyReplyContext<ContextConfig = ContextConfigDefault> {
-  /**
-   * @deprecated Use Reply#routeOptions#config or Reply#routeOptions#schema instead
-   */
-  config: FastifyContextConfig & FastifyRouteConfig & ContextConfig;
 }


### PR DESCRIPTION
Proposal:

- Removes the deprecated `FastifyRequestContext` and `FastifyReplyContext` type interfaces from `types/context.d.ts`, along with their re-exports in `fastify.d.ts` and the corresponding docs section in `docs/Reference/TypeScript.md`.
- Both interfaces were marked `@deprecated` in favor of `Request#routeOptions#config` / `Reply#routeOptions#config`, and a full grep across the codebase (`types/`, `test/`, `docs/`, `build/`) shows they are not referenced anywhere except:
    - their own declaration in `types/context.d.ts`
    - the public re-export in `fastify.d.ts`
    - their documentation entry `FastifyContextConfig` is untouched and remains fully in use in `route.d.ts` and `request.d.ts`.
- `types/context.d.ts`: removed `FastifyRequestContext` and `FastifyReplyContext`; removed now-unused imports
  (`FastifyRouteConfig`, `ContextConfigDefault`); kept  `FastifyContextConfig`
- `fastify.d.ts`: updated import and public `export type` block
- `docs/Reference/TypeScript.md`: removed the "Context" section

Breaking change:

- Yes,  anyone importing `FastifyRequestContext` or `FastifyReplyContext` directly from `fastify` will need to remove that import. There is no drop-in replacement since these types were not wired to any runtimeproperty.

Note: 
- To be merged from the “next” branch
- For the next major release of Fastify ( v6 )
- Documentation updated accordingly (TypeScript.md)