### PR TITLE
docs(contenttypeparser): new strict content-type validation

### DIFF
--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -45,6 +45,37 @@ parsed.
 > by the regex has a corresponding entry in the schema's `content` map. See
 > [Validation and Serialization](./Validation-and-Serialization.md) for details.
 
+### Invalid content types
+
+Fastify validates the request's `Content-Type` header before selecting a body
+parser. A syntactically invalid value produces a `415` response with the
+`FST_ERR_CTP_INVALID_MEDIA_TYPE` error code. Parsers registered with a string,
+a `RegExp`, or the [catch-all](#catch-all) value are not considered when the
+header is invalid.
+
+If a client you cannot control sends a known malformed value, an `onRequest`
+hook can replace that exact value with an unambiguous valid media type before
+Fastify validates it:
+
+```js
+fastify.addHook('onRequest', async function repairContentType (request) {
+  const contentType = request.headers['content-type']
+
+  if (contentType === 'application/json,application/json') {
+    request.headers['content-type'] = 'application/json'
+  }
+})
+```
+
+Keep recovery rules narrow. Broad recovery can select the wrong body parser or
+undermine the guarantees of per-content-type validation with
+`schema.body.content`. Reject malformed values that the application cannot
+repair unambiguously.
+
+The `request.mediaType` property parses and caches the current header value.
+Therefore, repair `request.headers['content-type']` before accessing
+`request.mediaType` in an `onRequest` hook.
+
 ### Usage
 ```js
 fastify.addContentTypeParser('application/jsoff', function (request, payload, done) {

--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -5,7 +5,8 @@ Fastify natively supports `'application/json'` and `'text/plain'` content types
 with a default charset of `utf-8`. These default parsers can be changed or
 removed.
 
-Unsupported or syntactically invalid content types will throw an
+Unsupported or syntactically invalid content types result in a `415 Unsupported
+Media Type` response with an
 [`FST_ERR_CTP_INVALID_MEDIA_TYPE`](./Errors.md#fst_err_ctp_invalid_media_type)
 error.
 

--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -48,35 +48,24 @@ parsed.
 > by the regex has a corresponding entry in the schema's `content` map. See
 > [Validation and Serialization](./Validation-and-Serialization.md) for details.
 
-### Invalid content types
-
-Fastify validates the request's `Content-Type` header before selecting a body
-parser ([implementation](https://github.com/fastify/fastify/blob/main/lib/handle-request.js#L77-L87)).
-Therefore, parsers registered with a string, a `RegExp`, or the
-[catch-all](#catch-all) value are not considered when the header is invalid.
-
-If a client you cannot control sends a known malformed value, an `onRequest`
-hook can replace that exact value with an unambiguous valid media type before
-Fastify validates it:
-
-```js
-fastify.addHook('onRequest', async function repairContentType (request) {
-  const contentType = request.headers['content-type']
-
-  if (contentType === 'application/json,application/json') {
-    request.headers['content-type'] = 'application/json'
-  }
-})
-```
-
-Keep recovery rules narrow. Replacing a malformed value with the wrong media
-type can select a different body parser and, when using `schema.body.content`,
-route the request body through a different validation schema. Reject malformed
-values that the application cannot repair unambiguously.
-
-The `request.mediaType` property parses and caches the current header value.
-Therefore, repair `request.headers['content-type']` before accessing
-`request.mediaType` in an `onRequest` hook.
+> ℹ️ Note:
+> Fastify validates the request's `Content-Type` header before selecting a body
+> parser. String, `RegExp`, and [catch-all](#catch-all) parsers therefore cannot
+> handle an invalid header. An `onRequest` hook can repair an exact malformed
+> value from a client outside the application's control:
+>
+> ```js
+> fastify.addHook('onRequest', async function repairContentType (request) {
+>   if (request.headers['content-type'] === 'application/json,application/json') {
+>     request.headers['content-type'] = 'application/json'
+>   }
+> })
+> ```
+>
+> Apply only unambiguous repairs and reject other malformed values. A wrong
+> media type can select a different body parser or `schema.body.content`
+> validation schema. Repair the header before accessing `request.mediaType`,
+> which parses and caches the current value.
 
 ### Usage
 ```js

--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -50,8 +50,8 @@ parsed.
 
 > ℹ️ Note:
 > Fastify validates the request's `Content-Type` header before selecting a body
-> parser. String, `RegExp`, and [catch-all](#catch-all) parsers therefore cannot
-> handle an invalid header. An `onRequest` hook can rewrite a malformed
+> parser. String, `RegExp`, and [catch-all](#catch-all) parsers therefore will
+> never handle an invalid header. An `onRequest` hook can rewrite a malformed
 > header prior to validation:
 >
 > ```js

--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -55,16 +55,16 @@ parsed.
 > header prior to validation:
 >
 > ```js
-> fastify.addHook('onRequest', async function repairContentType (request) {
+> fastify.addHook('onRequest', async function rewriteContentType (request) {
 >   if (request.headers['content-type'] === 'application/json,application/json') {
 >     request.headers['content-type'] = 'application/json'
 >   }
 > })
 > ```
 >
-> Apply only unambiguous repairs and reject other malformed values. A wrong
+> Apply only unambiguous rewrites and reject other malformed values. An invalid
 > media type can select a different body parser or `schema.body.content`
-> validation schema. Repair the header before accessing `request.mediaType`,
+> validation schema. Rewrite the header before accessing `request.mediaType`,
 > which parses and caches the current value.
 
 ### Usage

--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -69,10 +69,10 @@ fastify.addHook('onRequest', async function repairContentType (request) {
 })
 ```
 
-Keep recovery rules narrow. Broad recovery can select the wrong body parser or
-undermine the guarantees of per-content-type validation with
-`schema.body.content`. Reject malformed values that the application cannot
-repair unambiguously.
+Keep recovery rules narrow. Replacing a malformed value with the wrong media
+type can select a different body parser and, when using `schema.body.content`,
+route the request body through a different validation schema. Reject malformed
+values that the application cannot repair unambiguously.
 
 The `request.mediaType` property parses and caches the current header value.
 Therefore, repair `request.headers['content-type']` before accessing

--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -51,8 +51,8 @@ parsed.
 > ℹ️ Note:
 > Fastify validates the request's `Content-Type` header before selecting a body
 > parser. String, `RegExp`, and [catch-all](#catch-all) parsers therefore cannot
-> handle an invalid header. An `onRequest` hook can repair an exact malformed
-> value from a client outside the application's control:
+> handle an invalid header. An `onRequest` hook can rewrite a malformed
+> header prior to validation:
 >
 > ```js
 > fastify.addHook('onRequest', async function repairContentType (request) {

--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -5,7 +5,9 @@ Fastify natively supports `'application/json'` and `'text/plain'` content types
 with a default charset of `utf-8`. These default parsers can be changed or
 removed.
 
-Unsupported content types will throw an `FST_ERR_CTP_INVALID_MEDIA_TYPE` error.
+Unsupported or syntactically invalid content types will throw an
+[`FST_ERR_CTP_INVALID_MEDIA_TYPE`](./Errors.md#fst_err_ctp_invalid_media_type)
+error.
 
 To support other content types, use the `addContentTypeParser` API or an
 existing [plugin](https://fastify.dev/ecosystem/).
@@ -48,10 +50,9 @@ parsed.
 ### Invalid content types
 
 Fastify validates the request's `Content-Type` header before selecting a body
-parser. A syntactically invalid value produces a `415` response with the
-`FST_ERR_CTP_INVALID_MEDIA_TYPE` error code. Parsers registered with a string,
-a `RegExp`, or the [catch-all](#catch-all) value are not considered when the
-header is invalid.
+parser ([implementation](https://github.com/fastify/fastify/blob/main/lib/handle-request.js#L77-L87)).
+Therefore, parsers registered with a string, a `RegExp`, or the
+[catch-all](#catch-all) value are not considered when the header is invalid.
 
 If a client you cannot control sends a known malformed value, an `onRequest`
 hook can replace that exact value with an unambiguous valid media type before

--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -5,8 +5,8 @@ Fastify natively supports `'application/json'` and `'text/plain'` content types
 with a default charset of `utf-8`. These default parsers can be changed or
 removed.
 
-Unsupported or syntactically invalid content types result in a `415 Unsupported
-Media Type` response with an
+Unsupported or [syntactically invalid](https://httpwg.org/specs/rfc9110.html#media.type)
+content types result in a `415 Unsupported Media Type` response with an
 [`FST_ERR_CTP_INVALID_MEDIA_TYPE`](./Errors.md#fst_err_ctp_invalid_media_type)
 error.
 


### PR DESCRIPTION
Document the request lifecycle boundary introduced by fastify/fastify#6414:

- malformed `Content-Type` values are rejected before body parser selection
- string, RegExp, and catch-all parsers cannot recover invalid values
- an `onRequest` hook can narrowly canonicalize known external input
- repair must happen before `request.mediaType` is accessed and cached
- broad recovery can undermine parser selection and `schema.body.content` guarantees

The example intentionally handles one exact malformed value and leaves every unrelated value under Fastify strict validation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
