### PR TITLE
feat: support disposable objects in onClose hook

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -600,7 +600,17 @@ function fastify (serverOptions) {
     }
 
     if (name === 'onClose') {
-      this.onClose(fn.bind(this))
+      if (typeof fn !== 'function') {
+        if (typeof fn[Symbol.asyncDispose] === 'function') {
+          this.onClose(() => fn[Symbol.asyncDispose]())
+        } else if (typeof fn[Symbol.dispose] === 'function') {
+          this.onClose(() => fn[Symbol.dispose]())
+        } else {
+          throw new errorCodes.FST_ERR_HOOK_INVALID_HANDLER(name, Object.prototype.toString.call(fn))
+        }
+      } else {
+        this.onClose(fn.bind(this))
+      }
     } else if (name === 'onReady' || name === 'onListen' || name === 'onRoute') {
       this[kHooks].add(name, fn)
     } else {

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -743,3 +743,85 @@ test('does not destroy connections with in-flight requests (default options)', a
   t.assert.strictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(await response.body.json(), { hello: 'world' })
 })
+
+test('addHook onClose with Symbol.asyncDispose', { skip: !('asyncDispose' in Symbol) }, async t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  let disposed = false
+  const resource = {
+    [Symbol.asyncDispose]: async () => { disposed = true }
+  }
+
+  fastify.addHook('onClose', resource)
+
+  await fastify.listen({ port: 0 })
+  await fastify.close()
+
+  t.assert.strictEqual(disposed, true)
+})
+
+test('addHook onClose with Symbol.dispose', { skip: !('dispose' in Symbol) }, async t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  let disposed = false
+  const resource = {
+    [Symbol.dispose]: () => { disposed = true }
+  }
+
+  fastify.addHook('onClose', resource)
+
+  await fastify.listen({ port: 0 })
+  await fastify.close()
+
+  t.assert.strictEqual(disposed, true)
+})
+
+test('addHook onClose with Symbol.asyncDispose preferred over Symbol.dispose', { skip: !('asyncDispose' in Symbol) }, async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  let asyncDisposed = false
+  let syncDisposed = false
+  const resource = {
+    [Symbol.asyncDispose]: async () => { asyncDisposed = true },
+    [Symbol.dispose]: () => { syncDisposed = true }
+  }
+
+  fastify.addHook('onClose', resource)
+
+  await fastify.listen({ port: 0 })
+  await fastify.close()
+
+  t.assert.strictEqual(asyncDisposed, true)
+  t.assert.strictEqual(syncDisposed, false)
+})
+
+test('addHook onClose with non-disposable object throws', async t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  t.assert.throws(() => {
+    fastify.addHook('onClose', { foo: 'bar' })
+  }, (err) => err.code === 'FST_ERR_HOOK_INVALID_HANDLER')
+})
+
+test('addHook onClose with disposable inside register', { skip: !('asyncDispose' in Symbol) }, async t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  let disposed = false
+  fastify.register(function (instance, opts, done) {
+    const resource = {
+      [Symbol.asyncDispose]: async () => { disposed = true }
+    }
+    instance.addHook('onClose', resource)
+    done()
+  })
+
+  await fastify.listen({ port: 0 })
+  await fastify.close()
+
+  t.assert.strictEqual(disposed, true)
+})

--- a/test/types/hooks.tst.ts
+++ b/test/types/hooks.tst.ts
@@ -240,6 +240,17 @@ server.addHook('onClose', async function (instance) {
   expect(instance).type.toBe<FastifyInstance>()
 })
 
+// Support disposable objects as onClose hooks
+const asyncDisposableResource: AsyncDisposable = {
+  [Symbol.asyncDispose]: async () => {}
+}
+expect(server.addHook('onClose', asyncDisposableResource)).type.toBe<FastifyInstance>()
+
+const disposableResource: Disposable = {
+  [Symbol.dispose]: () => {}
+}
+expect(server.addHook('onClose', disposableResource)).type.toBe<FastifyInstance>()
+
 // Use case to monitor any regression on issue #3620
 // ref.: https://github.com/fastify/fastify/issues/3620
 const customTypedHook: preHandlerAsyncHookHandler<

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -493,6 +493,14 @@ export interface FastifyInstance<
   ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
 
   /**
+  * Triggered when fastify.close() is invoked to stop the server. Accepts a disposable object with Symbol.asyncDispose or Symbol.dispose.
+  */
+  addHook(
+    name: 'onClose',
+    hook: AsyncDisposable | Disposable,
+  ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
+
+  /**
   * Triggered when fastify.close() is invoked to stop the server. It is useful when plugins need to cancel some state to allow the server to close successfully.
   */
   addHook<


### PR DESCRIPTION
## Summary

> **Note:** This is based on #5669 which was opened ~2 years ago. @mcollina suggested supporting disposables in `addHook('onClose', ...)` but no one picked it up. If this is no longer desired, happy to close — just let me know!

- Allow passing objects with `Symbol.asyncDispose` or `Symbol.dispose` to `addHook('onClose', disposable)` instead of requiring a wrapper function
- When both symbols are present, `asyncDispose` takes priority
- Invalid non-function, non-disposable values still throw `FST_ERR_HOOK_INVALID_HANDLER`

### Before

```js
const db = await connectToDatabase()

fastify.addHook('onClose', async () => {
  await db[Symbol.asyncDispose]()
})
```

### After

```js
const db = await connectToDatabase()

fastify.addHook('onClose', db)
```

## Changes

- `fastify.js`: Detect disposable objects in the `onClose` branch of `addHook` and wrap them into closures
- `types/instance.d.ts`: Add overload accepting `AsyncDisposable | Disposable`
- `test/close.test.js`: 5 new tests covering asyncDispose, dispose, priority, error case, and encapsulation
- `test/types/hooks.tst.ts`: 2 new type assertions

## Test plan

- [x] `npm run unit` — 2348 passed, 0 failed
- [x] `npm run test:types` — 1288 assertions passed (1286 + 2 new)
- [x] `npm run lint` — clean

Ref: #5669