### PR TITLE
feat: add `Reply.prototype.mediaType`

### DIFF
--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -6,6 +6,7 @@
   - [.code(statusCode)](#codestatuscode)
   - [.elapsedTime](#elapsedtime)
   - [.statusCode](#statuscode)
+  - [.mediaType](#mediatype)
   - [.server](#server)
   - [.header(key, value)](#headerkey-value)
   - [.headers(object)](#headersobject)
@@ -51,6 +52,7 @@ object that exposes the following functions and properties:
 - `.statusCode` - Read and set the HTTP status code.
 - `.elapsedTime` - Returns the amount of time passed
 since the request was received by Fastify.
+- `.mediaType` - The media type extracted from `Content-Type` header.
 - `.server` - A reference to the fastify instance object.
 - `.header(name, value)` - Sets a response header.
 - `.headers(object)` - Sets all the keys of the object as response headers.
@@ -127,6 +129,18 @@ This property reads and sets the HTTP status code. It is an alias for
 ```js
 if (reply.statusCode >= 299) {
   reply.statusCode = 500
+}
+```
+### .mediaType
+<a id="mediatype"></a>
+
+Returns the media type extracted from `Content-Type` header. When `Content-Type`
+header is missing, it will return `undefined`.
+
+```js
+if (reply.mediaType === 'image/gif') {
+  const versionBuffer = new Uint8Array(reply.payload, 3, 3)
+  reply.header('x-gif-version', new TextDecoder().decode(versionBuffer))
 }
 ```
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -93,6 +93,12 @@ Object.defineProperties(Reply.prototype, {
       return (this[kReplyEndTime] || now()) - this[kReplyStartTime]
     }
   },
+  mediaType: {
+    get () {
+      const contentTypeHeader = this[kReplyHeaders]['content-type']
+      return ContentType.from(contentTypeHeader).mediaType
+    }
+  },
   server: {
     get () {
       return this.request[kRouteContext].server

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -34,7 +34,7 @@ const doGet = async function (url) {
 }
 
 test('Once called, Reply should return an object with methods', t => {
-  t.plan(15)
+  t.plan(16)
   const response = { res: 'res' }
   const context = {
     config: { onSend: [] },
@@ -49,6 +49,7 @@ test('Once called, Reply should return an object with methods', t => {
   t.assert.strictEqual(typeof reply[kReplyErrorHandlerCalled], 'boolean')
   t.assert.strictEqual(typeof reply.send, 'function')
   t.assert.strictEqual(typeof reply.code, 'function')
+  t.assert.strictEqual(typeof reply.mediaType, 'string')
   t.assert.strictEqual(typeof reply.status, 'function')
   t.assert.strictEqual(typeof reply.header, 'function')
   t.assert.strictEqual(typeof reply.serialize, 'function')

--- a/test/reply-media-type.test.js
+++ b/test/reply-media-type.test.js
@@ -109,3 +109,23 @@ test('reply.mediaType supported in hooks', async (t) => {
   const body = await response.json()
   t.assert.strictEqual(body.mediaType, 'application/json')
 })
+
+test('reply.mediaType should reflect the last type set', async (t) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  fastify.get('/', (request, reply) => {
+    reply.type('application/json')
+    reply.type('text/plain')
+    t.assert.strictEqual(reply.mediaType, 'text/plain')
+    reply.send(`mediaType = ${reply.mediaType}`)
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/'
+  })
+  const body = response.body
+  t.assert.strictEqual(body, 'mediaType = text/plain')
+})

--- a/test/reply-media-type.test.js
+++ b/test/reply-media-type.test.js
@@ -1,0 +1,111 @@
+'use strict'
+
+const { test } = require('node:test')
+const Fastify = require('..')
+
+test('reply.mediaType should match the content-type header', async (t) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  fastify.get('/', (request, reply) => {
+    reply.type('application/json')
+    t.assert.strictEqual(reply.mediaType, 'application/json')
+    reply.send({ mediaType: reply.mediaType })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/'
+  })
+  const body = await response.json()
+  t.assert.strictEqual(body.mediaType, 'application/json')
+})
+
+test('reply.mediaType should strip the charset parameter', async (t) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  fastify.get('/', (request, reply) => {
+    reply.header('content-type', 'application/json; charset=utf-8')
+    t.assert.strictEqual(reply.mediaType, 'application/json')
+    reply.send({ mediaType: reply.mediaType })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/'
+  })
+  const body = await response.json()
+  t.assert.strictEqual(body.mediaType, 'application/json')
+})
+
+test('reply.mediaType should strip the space', async (t) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  fastify.get('/', (request, reply) => {
+    reply.header('content-type', ' application/json ; charset=utf-8')
+    t.assert.strictEqual(reply.mediaType, 'application/json')
+    reply.send({ mediaType: reply.mediaType })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/'
+  })
+  const body = await response.json()
+  t.assert.strictEqual(body.mediaType, 'application/json')
+})
+
+test('reply.mediaType is undefined when content-type is not set', async (t) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  fastify.get('/', (request, reply) => {
+    t.assert.strictEqual(reply.mediaType, undefined)
+    reply.send({ mediaType: reply.mediaType })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/'
+  })
+  const body = await response.json()
+  t.assert.strictEqual(body.mediaType, undefined)
+})
+
+test('reply.mediaType supported in hooks', async (t) => {
+  t.plan(5)
+
+  const fastify = Fastify()
+
+  fastify.get('/', {
+    preHandler: (request, reply, done) => {
+      reply.type('application/json')
+      t.assert.strictEqual(reply.mediaType, 'application/json')
+      done()
+    },
+    preSerialization: (request, reply, payload, done) => {
+      t.assert.strictEqual(reply.mediaType, 'application/json')
+      done(null, payload)
+    },
+    onSend: (request, reply, payload, done) => {
+      t.assert.strictEqual(reply.mediaType, 'application/json')
+      done(null, payload)
+    }
+  }, (request, reply) => {
+    t.assert.strictEqual(reply.mediaType, 'application/json')
+    reply.send({ mediaType: reply.mediaType })
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/'
+  })
+  const body = await response.json()
+  t.assert.strictEqual(body.mediaType, 'application/json')
+})


### PR DESCRIPTION
`Request.prototype.mediaType` is a surprisingly useful getter, since it eliminates the urge to use ad hoc `Content-Type` parsing.

I wonder if we can have it on `reply`, too.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
