### PR TITLE
fix(deps)!: upgrade @sinonjs/fake-timers to v15 and adapt pluginTimeout test

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
   ],
   "devDependencies": {
     "@jsumners/line-reporter": "^1.0.1",
-    "@sinonjs/fake-timers": "^11.2.2",
+    "@sinonjs/fake-timers": "^15.0.0",
     "@stylistic/eslint-plugin": "^5.1.0",
     "@stylistic/eslint-plugin-js": "^4.1.0",
     "@types/node": "^26.0.1",

--- a/test/plugin.4.test.js
+++ b/test/plugin.4.test.js
@@ -46,7 +46,10 @@ test('pluginTimeout - named function', (t, testDone) => {
 
 test('pluginTimeout default', (t, testDone) => {
   t.plan(5)
-  const clock = fakeTimer.install({ shouldClearNativeTimers: true })
+  const clock = fakeTimer.install({
+    shouldClearNativeTimers: true,
+    toFake: ['setTimeout', 'clearTimeout', 'Date']
+  })
 
   const fastify = Fastify()
   fastify.register(function (app, opts, done) {


### PR DESCRIPTION
Proposal

- Upgrade `@sinonjs/fake-timers` from `^11.0.0` to `^15.0.0`.
- The `pluginTimeout default` test in `test/plugin.4.test.js` failed when updating `@sinonjs/fake-timers` from `^11.0.0` to `^15.0.0`.Starting with v13.0.0, `@sinonjs/fake-timers` simulates *all* supported timers by default (including `process.nextTick` and `setImmediate`), not just `Date`/`setTimeout`/`setInterval`.The test uses `clock.tick(10000)` to simulate the expiration of `pluginTimeout` within a plugin that never calls `done`. Startup (the Fastify startup engine) internally uses `process.nextTick`/`setImmediate` internally to advance the plugin queue: with these timers now simulated by default, the startup flow no longer proceeds as expected, and the test fails. I explicitly limit which timers are simulated by passing `toFake: [‘setTimeout’, ‘clearTimeout’, ‘Date’]` to `fakeTimer.install()`, leaving `process.nextTick` and `setImmediate` real so that the startup queue continues to function correctly. No changes to the logic or assertions of the test.
