### PR TITLE
test: remove @sinonjs/fake-timers

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,6 @@
   ],
   "devDependencies": {
     "@jsumners/line-reporter": "^1.0.1",
-    "@sinonjs/fake-timers": "^11.2.2",
     "@stylistic/eslint-plugin": "^5.1.0",
     "@stylistic/eslint-plugin-js": "^4.1.0",
     "@types/node": "^26.0.1",

--- a/test/plugin.4.test.js
+++ b/test/plugin.4.test.js
@@ -3,7 +3,6 @@
 const { test, describe } = require('node:test')
 const Fastify = require('../fastify')
 const fp = require('fastify-plugin')
-const fakeTimer = require('@sinonjs/fake-timers')
 const { FST_ERR_PLUGIN_INVALID_ASYNC_HANDLER } = require('../lib/errors')
 
 test('pluginTimeout', (t, testDone) => {
@@ -46,12 +45,14 @@ test('pluginTimeout - named function', (t, testDone) => {
 
 test('pluginTimeout default', (t, testDone) => {
   t.plan(5)
-  const clock = fakeTimer.install({ shouldClearNativeTimers: true })
+  t.mock.timers.enable({
+    apis: ['setTimeout', 'Date']
+  })
 
   const fastify = Fastify()
   fastify.register(function (app, opts, done) {
     // default time elapsed without calling done
-    clock.tick(10000)
+    t.mock.timers.tick(10000)
   })
 
   fastify.ready((err) => {
@@ -64,7 +65,7 @@ test('pluginTimeout default', (t, testDone) => {
     testDone()
   })
 
-  t.after(clock.uninstall)
+  t.after(() => t.mock.timers.reset())
 })
 
 test('plugin metadata - version', (t, testDone) => {


### PR DESCRIPTION
Closes #6933 

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
