### PR TITLE
refactor(types)!: remove deprecated req in request.d.ts

### DIFF
--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -68,10 +68,6 @@ export interface FastifyRequest<RouteGeneric extends RouteGenericInterface = Rou
   validationError?: Error & { validation: any; validationContext: string };
 
   /**
-   * @deprecated Use `raw` property
-   */
-  readonly req: RawRequest & RouteGeneric['Headers']; // this enables the developer to extend the existing http(s|2) headers list
-  /**
    * Derived from request socket metadata or forwarding headers.
    * Treat as untrusted input and validate before security-sensitive use.
    */


### PR DESCRIPTION
Proposal:

- Removes the deprecated `req` property from `types/request.d.ts` in favor of `raw` property

Notes:

- To be merged from the “next” branch
- For the next major release of Fastify ( v6 )