### PR TITLE
fix(server): normalize listen options to match Node.js priority

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1346,6 +1346,10 @@ fastify.listen({ port: 3000, host: '0.0.0.0' }, (err, address) => {
 })
 ```
 
+Like Node.js core, `handle` takes precedence over `port`, which takes precedence
+over `path`; the options that lose out are ignored. `host` is only used when
+listening on a `port`.
+
 If the `port` is omitted (or is set to zero), a random available port is
 automatically chosen (available via `fastify.server.address().port`).
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -31,6 +31,9 @@ function createServer (options, httpHandler) {
     listenOptions = { port: 0, host: 'localhost' },
     cb = undefined
   ) {
+    // The options object belongs to the caller, so work on a copy: normalizing
+    // it below would otherwise strip keys from what was passed in.
+    listenOptions = { ...listenOptions }
     if (typeof cb === 'function') {
       if (cb.constructor.name === 'AsyncFunction') {
         FSTWRN003('listen method')
@@ -56,20 +59,25 @@ function createServer (options, httpHandler) {
         listenOptions.signal.addEventListener('abort', onAborted, { once: true })
       }
     }
-
-    // If we have a path specified, don't default host to 'localhost' so we don't end up listening
-    // on both path and host
+    // Node.js prioritizes `handle` over `port` over `path`, and only uses `host`
+    // when listening on a port. Normalize the options down to a single one of
+    // those so that we never end up listening on more than one endpoint.
     // See https://github.com/fastify/fastify/issues/4007
-    let host
-    if (listenOptions.path == null) {
-      host = listenOptions.host ?? 'localhost'
+    if (listenOptions.handle != null) {
+      delete listenOptions.host
+      delete listenOptions.port
+      delete listenOptions.path
+    } else if (listenOptions.port != null) {
+      delete listenOptions.path
+      listenOptions.host ??= 'localhost'
+    } else if (listenOptions.path != null) {
+      delete listenOptions.host
     } else {
-      host = listenOptions.host
+      listenOptions.host ??= 'localhost'
+      listenOptions.port = 0
     }
-    if (!Object.hasOwn(listenOptions, 'host') ||
-      listenOptions.host == null) {
-      listenOptions.host = host
-    }
+
+    const host = listenOptions.host
     if (host === 'localhost') {
       listenOptions.cb = (err, address) => {
         if (err) {

--- a/test/listen.1.test.js
+++ b/test/listen.1.test.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const os = require('node:os')
+const path = require('node:path')
+const { EventEmitter } = require('node:events')
 const { networkInterfaces } = require('node:os')
 const { test, before } = require('node:test')
 const Fastify = require('..')
@@ -116,4 +119,88 @@ test('listen works with null host', async t => {
   t.assert.strictEqual(address.address, localhost)
   t.assert.ok(address.port > 0)
   await fastify.close()
+})
+
+function getSocketPath () {
+  const id = (Math.random().toString(16) + '0000000').slice(2, 10)
+  return os.platform() !== 'win32'
+    ? path.join(os.tmpdir(), `${id}-server.sock`)
+    : `\\\\.\\pipe\\${id}-server-sock`
+}
+
+test('listen options follow the Node.js priority of handle, port and path', async t => {
+  const handle = new EventEmitter()
+  const cases = [
+    { name: '{ handle }', actual: { handle }, expect: { handle } },
+    { name: '{ handle, path }', actual: { handle, path: '/tmp/a.sock' }, expect: { handle } },
+    { name: '{ handle, host }', actual: { handle, host: '127.0.0.1' }, expect: { handle } },
+    { name: '{ handle, host, port }', actual: { handle, host: '127.0.0.1', port: 1 }, expect: { handle } },
+    { name: '{ path }', actual: { path: '/tmp/a.sock' }, expect: { path: '/tmp/a.sock' } },
+    { name: '{ path, host }', actual: { path: '/tmp/a.sock', host: '127.0.0.1' }, expect: { path: '/tmp/a.sock' } },
+    { name: '{ path, port }', actual: { path: '/tmp/a.sock', port: 1 }, expect: { host: 'localhost', port: 1 } },
+    { name: '{ path, host, port }', actual: { path: '/tmp/a.sock', host: '127.0.0.1', port: 1 }, expect: { host: '127.0.0.1', port: 1 } },
+    { name: '{ port }', actual: { port: 1 }, expect: { host: 'localhost', port: 1 } },
+    { name: '{ host }', actual: { host: '127.0.0.1' }, expect: { host: '127.0.0.1', port: 0 } },
+    { name: '{ host, port }', actual: { host: '127.0.0.1', port: 1 }, expect: { host: '127.0.0.1', port: 1 } }
+  ]
+  t.plan(cases.length)
+
+  for (const { name, actual, expect } of cases) {
+    let listenOptions
+
+    const fastify = Fastify({
+      serverFactory () {
+        const server = new EventEmitter()
+        server.address = () => '/it-never-really-listens'
+        server.close = (done) => { done() }
+        server.listen = (options) => {
+          // only the options of the first server are of interest here, any
+          // further one is a secondary binding built from them
+          if (listenOptions === undefined) {
+            listenOptions = { ...options }
+            delete listenOptions.cb
+          }
+          process.nextTick(() => server.emit('listening'))
+        }
+        return server
+      }
+    })
+
+    await fastify.listen({ ...actual })
+    await fastify.close()
+
+    t.assert.deepStrictEqual(listenOptions, expect, name)
+  }
+})
+
+test('listen on a path and a port listens on the port', async t => {
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  await fastify.listen({ path: getSocketPath(), port: 0 })
+
+  const address = fastify.server.address()
+  t.assert.strictEqual(address.address, localhost)
+  t.assert.ok(address.port > 0)
+})
+
+test('listen works with a host and no port', async t => {
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  await fastify.listen({ host: localhost })
+
+  const address = fastify.server.address()
+  t.assert.strictEqual(address.address, localhost)
+  t.assert.ok(address.port > 0)
+})
+
+test('listen does not modify the options it is given', async t => {
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  const listenOptions = Object.freeze({ path: getSocketPath(), port: 0, host: localhost })
+  await fastify.listen(listenOptions)
+
+  t.assert.deepStrictEqual(Object.keys(listenOptions), ['path', 'port', 'host'])
 })

--- a/test/listen.3.test.js
+++ b/test/listen.3.test.js
@@ -43,6 +43,50 @@ if (os.platform() !== 'win32') {
   })
 }
 
+test('listen on a path with a host does not create additional bindings', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  const sockFile = os.platform() !== 'win32'
+    ? path.join(os.tmpdir(), `${(Math.random().toString(16) + '0000000').slice(2, 10)}-server.sock`)
+    : `\\\\.\\pipe\\${(Math.random().toString(16) + '0000000').slice(2, 10)}-server-sock`
+
+  if (os.platform() !== 'win32') {
+    try {
+      fs.unlinkSync(sockFile)
+    } catch (e) { }
+  }
+
+  await fastify.listen({ path: sockFile, host: 'localhost' })
+
+  t.assert.strictEqual(fastify.server.address(), sockFile)
+  t.assert.deepStrictEqual(fastify.addresses(), [sockFile])
+})
+
+test('listen on a path with a host does not create additional bindings - callback', (t, done) => {
+  t.plan(3)
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  const sockFile = os.platform() !== 'win32'
+    ? path.join(os.tmpdir(), `${(Math.random().toString(16) + '0000000').slice(2, 10)}-server.sock`)
+    : `\\\\.\\pipe\\${(Math.random().toString(16) + '0000000').slice(2, 10)}-server-sock`
+
+  if (os.platform() !== 'win32') {
+    try {
+      fs.unlinkSync(sockFile)
+    } catch (e) { }
+  }
+
+  fastify.listen({ path: sockFile, host: 'localhost' }, (err) => {
+    t.assert.ifError(err)
+    t.assert.strictEqual(fastify.server.address(), sockFile)
+    t.assert.deepStrictEqual(fastify.addresses(), [sockFile])
+    done()
+  })
+})
+
 test('listen without callback with (address)', async t => {
   t.plan(1)
   const fastify = Fastify()

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -40,7 +40,7 @@ export interface FastifyListenOptions {
    */
   port?: number;
   /**
-   * Default to `localhost`.
+   * Default to `localhost`. Only used when listening on a `port`.
    */
   host?: string;
   /**


### PR DESCRIPTION
## Summary

When `listen()` is given both a `path` and a `host` that resolves to `localhost`,
Fastify binds extra TCP listeners on arbitrary ports in addition to the IPC
endpoint:

```js
await app.listen({ path: sockFile, host: 'localhost' })

app.addresses()
// [ { address: '::1',       family: 'IPv6', port: 50704 },
//   { address: '127.0.0.1', family: 'IPv4', port: 50705 },
//   '\\.\pipe\25703a78-server-sock' ]
```

Each extra listener serves the full application, so an application that
deliberately listens on an IPC endpoint ends up reachable over TCP as well. The
two ports differ from each other because every secondary server binds an
arbitrary port of its own rather than reusing the primary one.

This is the same problem reported in #4007; the fix for that issue only covered
the case where `host` is defaulted, so passing `host` explicitly still reached
the secondary binding logic.

## Root cause

`listen()` decided what kind of endpoint was being opened from the listen
options, while Node.js decides it from its own precedence rules, and the two
disagreed. For an IPC endpoint `server.address()` returns a string, so
`primaryAddress.address` and `primaryAddress.port` both read as `undefined`.
Every resolved address then compared as different, and the secondary options
carried a `port` key holding `undefined` — which Node normalises to an
unspecified TCP port before it ever looks at `path`
([`lib/net.js`](https://github.com/nodejs/node/blob/main/lib/net.js)):

```js
if (args.length === 0 || typeof args[0] === 'function' ||
    (options.port === undefined && 'port' in options) ||
    options.port === null) {
  options.port = 0;
}
```

## Fix

The listen options are normalized to Node's own precedence — `handle` over
`port` over `path`, with `host` used only when listening on a port — so that a
single endpoint is ever requested:

| given | passed to `listen()` |
| --- | --- |
| `{ handle }` | `{ handle }` |
| `{ handle, path }` | `{ handle }` |
| `{ handle, host }` | `{ handle }` |
| `{ handle, host, port }` | `{ handle }` |
| `{ path }` | `{ path }` |
| `{ path, host }` | `{ path }` |
| `{ path, port }` | `{ host: 'localhost', port }` |
| `{ path, host, port }` | `{ host, port }` |
| `{ port }` | `{ host: 'localhost', port }` |
| `{ host }` | `{ host, port: 0 }` |
| `{ host, port }` | `{ host, port }` |

Deciding this up front means `multipleBindings()` is no longer reached at all
for an IPC endpoint, so it needs no guard of its own.

`listenOptions` is shallow-copied at the top of `listen()` so that normalizing
never strips keys from the caller's object. That also removes the `TypeError`
thrown today when a frozen options object is passed.

## Behaviour changes

Two of these are worth calling out for the 5.x backport:

- `{ path, port }` now binds `localhost` instead of `0.0.0.0`, so adding a
  `path` to a TCP listen no longer silently widens it to every interface.
- `{ host }` on its own now binds a random port instead of throwing
  `ERR_INVALID_ARG_VALUE`. This matches what the docs already state about an
  omitted `port`.

## Tests

`test/listen.1.test.js` covers the table above, plus `{ path, port }`,
`{ host }` on its own, and the caller's options object being left untouched.
`test/listen.3.test.js` covers the original report through both the promise and
the callback form. All six fail on `main`.
#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
