### PR TITLE
fix: interrupt request lifecycle when reply.send() is not awaited in a hook

### DIFF
--- a/lib/handle-request.js
+++ b/lib/handle-request.js
@@ -12,6 +12,7 @@ const {
 const { setErrorStatusCode } = require('./error-status')
 const {
   kReplyIsError,
+  kReplySending,
   kRouteContext,
   kFourOhFourContext,
   kSupportedHTTPMethods,
@@ -23,7 +24,7 @@ const ContentType = require('./content-type')
 const channels = diagnostics.tracingChannel('fastify.request.handler')
 
 function handleRequest (err, request, reply) {
-  if (reply.sent === true) return
+  if (reply.sent === true || reply[kReplySending] === true) return
   if (err != null) {
     reply[kReplyIsError] = true
     reply.send(err)
@@ -117,7 +118,7 @@ function isEmptyBody (headers) {
 }
 
 function preValidationCallback (err, request, reply) {
-  if (reply.sent === true) return
+  if (reply.sent === true || reply[kReplySending] === true) return
 
   if (err != null) {
     reply[kReplyIsError] = true
@@ -160,7 +161,7 @@ function validationCompleted (request, reply, validationErr) {
 }
 
 function preHandlerCallback (err, request, reply) {
-  if (reply.sent) return
+  if (reply.sent || reply[kReplySending]) return
 
   const context = request[kRouteContext]
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -34,7 +34,8 @@ const {
 const {
   kChildren,
   kHooks,
-  kRequestPayloadStream
+  kRequestPayloadStream,
+  kReplySending
 } = require('./symbols')
 
 function Hooks () {
@@ -330,7 +331,7 @@ function preParsingHookRunner (functions, request, reply, cb) {
   let i = 0
 
   function next (err, newPayload) {
-    if (reply.sent) {
+    if (reply.sent || reply[kReplySending]) {
       return
     }
 
@@ -408,7 +409,7 @@ function onRequestAbortHookRunner (functions, request, cb) {
 }
 
 function hookIterator (fn, request, reply, next) {
-  if (reply.sent === true) return undefined
+  if (reply.sent === true || reply[kReplySending] === true) return undefined
   return fn(request, reply, next)
 }
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -6,6 +6,7 @@ const {
   kFourOhFourContext,
   kReplyErrorHandlerCalled,
   kReplyHijacked,
+  kReplySending,
   kReplyStartTime,
   kReplyEndTime,
   kReplySerializer,
@@ -156,6 +157,13 @@ Reply.prototype.send = function (payload) {
     this.log.warn({ err: new FST_ERR_REP_ALREADY_SENT(this.request.url, this.request.method) })
     return this
   }
+
+  // Mark the reply as being in the middle of a `send()` call so that the
+  // request lifecycle (preParsing, preValidation, preHandler, the handler
+  // itself) does not keep running while the payload is being produced.
+  // This covers `reply.send()` called from an async hook without being
+  // awaited or returned (see fastify/fastify#4374).
+  this[kReplySending] = true
 
   if (this[kReplyIsError] || payload instanceof Error) {
     this[kReplyIsError] = false

--- a/lib/route.js
+++ b/lib/route.js
@@ -43,6 +43,7 @@ const {
   kOptions,
   kReplySerializerDefault,
   kReplyIsError,
+  kReplySending,
   kRequestPayloadStream,
   kSchemaErrorFormatter,
   kErrorHandler,
@@ -641,7 +642,7 @@ function validateLogLevelOption (logLevel, method, path, logger) {
 }
 
 function runPreParsing (err, request, reply) {
-  if (reply.sent === true) return
+  if (reply.sent === true || reply[kReplySending] === true) return
   if (err != null) {
     reply[kReplyIsError] = true
     reply.send(err)

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -51,6 +51,7 @@ const keys = {
   kReplyTrailers: Symbol('fastify.reply.trailers'),
   kReplyHasStatusCode: Symbol('fastify.reply.hasStatusCode'),
   kReplyHijacked: Symbol('fastify.reply.hijacked'),
+  kReplySending: Symbol('fastify.reply.sending'),
   kReplyStartTime: Symbol('fastify.reply.startTime'),
   kReplyNextErrorHandler: Symbol('fastify.reply.nextErrorHandler'),
   kReplyEndTime: Symbol('fastify.reply.endTime'),

--- a/test/reply-send-in-onrequest-hook.test.js
+++ b/test/reply-send-in-onrequest-hook.test.js
@@ -1,0 +1,79 @@
+'use strict'
+
+const { test } = require('node:test')
+const Fastify = require('..')
+
+process.removeAllListeners('warning')
+
+test('lifecycle hooks should not run when reply.send() is called without await in an async onRequest hook', async (t) => {
+  const fastify = Fastify()
+  const called = []
+
+  fastify.addHook('onRequest', async (request, reply) => {
+    // not awaited / not returned on purpose, see fastify/fastify#4374
+    reply.code(200).send('hello')
+  })
+
+  // keep reply.send() in-flight so the lifecycle would otherwise continue
+  // while the payload is being produced
+  fastify.addHook('onSend', async (request, reply, payload) => {
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    return payload
+  })
+
+  fastify.addHook('preParsing', async (request, reply, payload) => {
+    called.push('preParsing')
+    return payload
+  })
+
+  fastify.addHook('preValidation', async (request, reply) => {
+    called.push('preValidation')
+  })
+
+  fastify.addHook('preHandler', async (request, reply) => {
+    called.push('preHandler')
+  })
+
+  fastify.get('/', async (request, reply) => {
+    called.push('handler')
+    return 'should not be used'
+  })
+
+  const res = await fastify.inject({ method: 'GET', url: '/' })
+
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.payload, 'hello')
+  t.assert.deepStrictEqual(called, [])
+})
+
+test('lifecycle should not continue while an unawaited reply.send() is serializing in an async onRequest hook', async (t) => {
+  const fastify = Fastify()
+  const called = []
+
+  fastify.addHook('onRequest', async (request, reply) => {
+    // not awaited / not returned on purpose, see fastify/fastify#4374
+    reply.code(200).send({ hello: 'world' })
+  })
+
+  // keep reply.send() in-flight through the (async) preSerialization step
+  fastify.addHook('preSerialization', async (request, reply, payload) => {
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    return payload
+  })
+
+  fastify.addHook('preParsing', async (request, reply, payload) => {
+    called.push('preParsing')
+    return payload
+  })
+
+  fastify.get('/', async (request, reply) => {
+    called.push('handler')
+    return { shouldNotBeUsed: true }
+  })
+
+  const res = await fastify.inject({ method: 'GET', url: '/' })
+
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.payload), { hello: 'world' })
+  t.assert.deepStrictEqual(called, [])
+})


### PR DESCRIPTION
## Problem

When `reply.send()` is called from an async `onRequest` (or other lifecycle) hook without being `await`ed or `return`ed, Fastify keeps running the rest of the request lifecycle. With an async `onSend`/`preSerialization` hook (or any slow payload), the response is still being produced while `preParsing`, `preValidation`, `preHandler` and the route handler itself continue to execute — running hooks that should never run and potentially sending a second, conflicting response (see #4374).

## Root cause

`reply.sent` is only `true` once the underlying response has actually ended (`raw.writableEnded`). While an async `onSend`/`preSerialization` hook is producing the payload the response has not ended yet, so the existing `reply.sent` guards in `lib/hooks.js`, `lib/route.js` and `lib/handle-request.js` do not fire and the lifecycle proceeds as if nothing had been sent.

## Fix

Track that a `send()` has started. Add a `kReplySending` symbol, set it at the top of `Reply.prototype.send`, and extend the existing "already sent" guards to also bail out while the reply is mid-send:

- `lib/hooks.js` — `preParsingHookRunner` and `hookIterator`
- `lib/route.js` — `runPreParsing`
- `lib/handle-request.js` — `handleRequest`, `preValidationCallback`, `preHandlerCallback`

This makes an unawaited `reply.send()` in a hook completely interrupt the request lifecycle (the expected behavior from the issue) even when the payload is produced asynchronously. `onSend`, `preSerialization` and `onResponse` are part of the send path itself and are unaffected.

## Test

New `test/reply-send-in-onrequest-hook.test.js`:

- asserts that `preParsing`, `preValidation`, `preHandler` and the handler are NOT invoked when `reply.send()` is called (without `await`) in an async `onRequest` hook while an async `onSend` hook keeps the send in flight;
- same scenario with an async `preSerialization` hook.

Fixes #4374

## Maintainer-reported secondary crash (aquie00t)

Beyond the lifecycle-interruption fix, the same root cause (the "already sent" guard not firing while the send is in flight) also turns a *second* `send()` during an async `onSend` into an uncaught `cb is not a function` from `fallbackErrorHandler`, killing the process. With `kReplySending` set at the top of `Reply.prototype.send`, the second `send()` is short-circuited by the extended guard before it can reach the error handler, so the response completes cleanly.
