### PR TITLE
fix: run preClose hook exactly once per declaring instance

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -600,7 +600,7 @@ function fastify (serverOptions) {
 
     if (name === 'onClose') {
       this.onClose(fn.bind(this))
-    } else if (name === 'onReady' || name === 'onListen' || name === 'onRoute') {
+    } else if (name === 'onReady' || name === 'onListen' || name === 'onRoute' || name === 'preClose') {
       this[kHooks].add(name, fn)
     } else {
       this.after((err, done) => {

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -665,6 +665,40 @@ test('preClose async', async t => {
   await fastify.close()
 })
 
+test('preClose runs exactly once with a child plugin', async t => {
+  t.plan(1)
+  const fastify = Fastify()
+  let count = 0
+
+  fastify.register(async (child) => {
+    child.get('/x', async () => 'ok')
+  })
+  fastify.addHook('preClose', async () => { count++ })
+
+  await fastify.ready()
+  await fastify.close()
+
+  t.assert.strictEqual(count, 1)
+})
+
+test('preClose runs exactly once with nested child plugins', async t => {
+  t.plan(1)
+  const fastify = Fastify()
+  let count = 0
+
+  fastify.register(async (child) => {
+    child.register(async (grandchild) => {
+      grandchild.get('/y', async () => 'ok')
+    })
+  })
+  fastify.addHook('preClose', async () => { count++ })
+
+  await fastify.ready()
+  await fastify.close()
+
+  t.assert.strictEqual(count, 1)
+})
+
 test('preClose execution order', (t, done) => {
   t.plan(4)
   const fastify = Fastify()


### PR DESCRIPTION
## What

A single `preClose` hook added to a Fastify instance is executed once for **every** instance in the encapsulation subtree (the declaring instance plus each descendant plugin) instead of exactly once.

### Reproduction

```js
const fastify = Fastify()
let count = 0

fastify.register(async (child) => {
  child.get('/x', async () => 'ok')
})
fastify.addHook('preClose', async () => { count++ })

await fastify.ready()
await fastify.close()

console.log(count) // 2, expected 1
```

With two levels of nested plugins the same hook runs 3 times. An equivalent `onReady` hook in the identical setup correctly runs once.

### Root cause

In `addHook`, the hooks `onReady`, `onListen`, and `onRoute` are special-cased to be stored only on the declaring instance via `this[kHooks].add`. `preClose` was omitted from that list, so it falls into the `else` branch and goes through `_addHook`, which copies the hook into every child via `this[kChildren].forEach`. At close time, `hookRunnerApplication('preClose')` already walks the entire child tree, so each propagated copy fires again.

That `preClose` is not meant to be inherited is already established elsewhere in the codebase: `buildHooks` in `lib/hooks.js` resets `onReady`, `onListen`, and `preClose` to empty arrays for children. `preClose` was simply left off the special-case list in `addHook`.

### Fix

Add `preClose` to the same special-case branch as `onReady`/`onListen`/`onRoute` so it is stored only on the declaring instance and not propagated into children. Since `hookRunnerApplication` already recurses the child tree and `buildHooks` already excludes `preClose` from inheritance, each declared hook now fires exactly once.

### Tests

Added two regression tests in `test/close.test.js` (a single child plugin and nested child plugins) asserting the hook runs exactly once. Both fail on `main` (count 2 and 3) and pass with this change. The full `test/close.test.js` suite (26 tests) stays green.

### Checklist
- [x] run `npm run test` and the linter
- [x] tests are included
- [x] commit is signed off (DCO)
