### PR TITLE
fix(content-type): return `undefined` for invalid media types

### DIFF
--- a/lib/content-type.js
+++ b/lib/content-type.js
@@ -183,7 +183,10 @@ class ContentType {
 
   get isValid () { return this.#valid }
 
-  get mediaType () { return `${this.#type}/${this.#subtype}` }
+  get mediaType () {
+    if (this.#valid === false) return undefined
+    return `${this.#type}/${this.#subtype}`
+  }
 
   get type () { return this.#type }
 

--- a/test/content-type.test.js
+++ b/test/content-type.test.js
@@ -46,18 +46,22 @@ describe('ContentType class', () => {
   test('returns empty instance for empty value', (t) => {
     let found = new ContentType('')
     t.assert.equal(found.isEmpty, true)
+    t.assert.equal(found.mediaType, undefined)
 
     found = new ContentType('undefined')
     t.assert.equal(found.isEmpty, true)
+    t.assert.equal(found.mediaType, undefined)
 
     found = new ContentType()
     t.assert.equal(found.isEmpty, true)
+    t.assert.equal(found.mediaType, undefined)
   })
 
   test('indicates media type is not correct format', (t) => {
     let found = new ContentType('foo')
     t.assert.equal(found.isEmpty, true)
     t.assert.equal(found.isValid, false)
+    t.assert.equal(found.mediaType, undefined)
 
     found = new ContentType('foo /bar')
     t.assert.equal(found.isEmpty, true)


### PR DESCRIPTION
While reviewing https://github.com/fastify/fastify/pull/6932, I noticed there was no test for `onRequest`. I then realized that it returns `/`. Even when accessed later in the request lifecycle, the same thing happens if we remove the header with `reply.removeHeader('content-type')`.