### PR TITLE
fix(content-type): escape quoted-pairs when serializing parameter values

### DIFF
--- a/lib/content-type.js
+++ b/lib/content-type.js
@@ -36,6 +36,18 @@ const keyValuePairsReg = /(?:^|;)\s*([\w!#$%&'*+.^`|~-]+)=("(?:[\t\u0020\u0021\u
 const quotedPairReg = /\\([\t\u0020-\u00ff])/gu
 
 /**
+ * quotedStringEscapeReg matches the octets that may not appear literally
+ * inside a quoted-string: DQUOTE, which would end the string, and the
+ * backslash, which would start a quoted-pair. Per RFC 9110 §5.6.4 a sender
+ * that emits either of them within a quoted-string has to escape it as a
+ * quoted-pair.
+ *
+ * @see https://httpwg.org/specs/rfc9110.html#quoted.string
+ * @type {RegExp}
+ */
+const quotedStringEscapeReg = /["\\]/gu
+
+/**
  * typeNameReg is used to validate that the first part of the media-type
  * does not use disallowed characters. Types must consist solely of
  * characters that match the specified character class. It must terminate
@@ -196,7 +208,14 @@ class ContentType {
     if (this.#string) return this.#string
     const parameters = []
     for (const [key, value] of this.#parameters.entries()) {
-      parameters.push(`${key}="${value}"`)
+      // Values are stored with their quoted-pairs already resolved, so any
+      // DQUOTE or backslash has to be escaped again on the way out. Without
+      // it the emitted quoted-string ends early and everything after it is
+      // read as additional parameters.
+      const quoted = value.indexOf('"') === -1 && value.indexOf('\\') === -1
+        ? value
+        : value.replace(quotedStringEscapeReg, '\\$&')
+      parameters.push(`${key}="${quoted}"`)
     }
     const result = [this.#type, '/', this.#subtype]
     if (parameters.length > 0) {

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -769,3 +769,31 @@ test('content-type fail when not a valid type', async t => {
     t.assert.equal(error.message, 'The content type should be a string or a RegExp')
   }
 })
+
+test('contentTypeParser should match a content type registered with a quoted-pair', async t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  // `\"` is a quoted-pair, so the `boundary` parameter value is `a"b`.
+  const contentType = 'application/x-custom; boundary="a\\"b"'
+
+  fastify.addContentTypeParser(contentType, { parseAs: 'string' }, function (request, body, done) {
+    done(null, body.toUpperCase())
+  })
+
+  fastify.post('/', (request, reply) => {
+    reply.send(request.body)
+  })
+
+  const res = await fastify.inject({
+    method: 'POST',
+    url: '/',
+    headers: { 'content-type': contentType },
+    payload: 'hello'
+  })
+
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.body, 'HELLO')
+})

--- a/test/content-type.test.js
+++ b/test/content-type.test.js
@@ -205,6 +205,47 @@ describe('ContentType class', () => {
     t.assert.equal(found.isValid, true)
     t.assert.equal(found.parameters.get('name'), 'he said "hi"')
   })
+
+  test('re-escapes a DQUOTE when serializing a parameter value', (t) => {
+    // The value is stored unescaped, so serializing it back into a
+    // quoted-string has to restore the quoted-pair. Otherwise the emitted
+    // header terminates the value early and grows extra parameters.
+    const found = new ContentType('application/json; name="he said \\"hi\\""')
+    t.assert.equal(found.parameters.get('name'), 'he said "hi"')
+    t.assert.equal(
+      found.toString(),
+      'application/json; name="he said \\"hi\\""'
+    )
+
+    const reparsed = new ContentType(found.toString())
+    t.assert.equal(reparsed.parameters.size, 1)
+    t.assert.equal(reparsed.parameters.get('name'), 'he said "hi"')
+  })
+
+  test('re-escapes a backslash when serializing a parameter value', (t) => {
+    const found = new ContentType('application/json; name="a\\\\b"')
+    t.assert.equal(found.parameters.get('name'), 'a\\b')
+    t.assert.equal(
+      found.toString(),
+      'application/json; name="a\\\\b"'
+    )
+
+    const reparsed = new ContentType(found.toString())
+    t.assert.equal(reparsed.parameters.get('name'), 'a\\b')
+  })
+
+  test('does not smuggle parameters out of a quoted value when serializing', (t) => {
+    // A quoted-pair lets a single parameter value carry `"` and `;` octets.
+    // Serializing without escaping them would turn one parameter into three.
+    const found = new ContentType('application/json; foo="a\\"; charset=iso-8859-1; x=\\"b"')
+    t.assert.equal(found.parameters.size, 1)
+    t.assert.equal(found.parameters.get('foo'), 'a"; charset=iso-8859-1; x="b')
+
+    const reparsed = new ContentType(found.toString())
+    t.assert.equal(reparsed.parameters.size, 1)
+    t.assert.equal(reparsed.parameters.has('charset'), false)
+    t.assert.equal(reparsed.parameters.get('foo'), 'a"; charset=iso-8859-1; x="b')
+  })
 })
 
 describe('ContentType class cache', () => {

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -2045,3 +2045,25 @@ test('reply.send should not treat charset= inside a quoted parameter value as an
     'application/json; name="a=b;charset=fake"; charset=utf-8'
   )
 })
+
+test('reply.send should keep a quoted-pair escaped when it appends the default charset', async t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.get('/', function (req, reply) {
+    // The quoted-pairs make `"` part of the parameter value. They must survive
+    // the round trip through the content-type serializer, otherwise the
+    // response carries a malformed header the application never set.
+    reply.header('content-type', 'application/json; foo="a\\"; charset=iso-8859-1; x=\\"b"')
+    reply.send({ hello: 'world' })
+  })
+
+  const res = await fastify.inject({ method: 'GET', url: '/' })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(
+    res.headers['content-type'],
+    'application/json; foo="a\\"; charset=iso-8859-1; x=\\"b"; charset=utf-8'
+  )
+})


### PR DESCRIPTION
`ContentType` resolves quoted-pairs while parsing, but `toString()` writes the resolved value straight back out inside DQUOTEs without re-escaping it. A parameter value that legitimately contains `"` or `\` therefore serializes into a quoted-string that terminates early, and everything after it is re-read as further parameters.

This is the mirror image of #6865, which added the unescape step on the parse side (`lib/content-type.js` L166-174) and left the serializer at L199 untouched. The existing test `unescapes a quoted-pair inside a quoted-string` asserts the parsed value and stops short of asserting `toString()`, which is where the gap slipped through.

### Reproduction

All output below is from the published `fastify@5.11.3`.

```js
const app = require('fastify')()

app.get('/echo', (req, reply) => {
  reply.header('content-type', req.headers['content-type']).send({ hello: 'world' })
})

app.addContentTypeParser('application/x-weird; foo="a\\"b"', { parseAs: 'string' },
  (req, body, done) => done(null, { matched: true, body }))
app.post('/parser', (req, reply) => reply.send(req.body))
```

**1. `reply.send()` emits a header the application never set.** `reply.send()` calls `toString()` when it appends the default charset to a JSON content type (`lib/reply.js` L220-223), so the lossy output goes on the wire. Sending `/echo` a single parameter whose value contains quoted-pairs:

```
request  content-type: application/json; foo="a\"; charset=iso-8859-1; x=\"b"
response content-type: application/json; foo="a"; charset=iso-8859-1; x="b"; charset=utf-8
```

One parameter went in; three came out, including a `charset` that precedes Fastify's own. Re-parsing the response header confirms `[['foo','a'], ['charset','utf-8'], ['x','b']]`.

**2. A registered content-type parser is never selected.** This is the sharper consequence. `addContentTypeParser()` stores the parser under `toString()` (`lib/content-type-parser.js` L83-85) and dispatch looks it up with `toString()` of an *already normalized* value (`lib/handle-request.js` L87, re-parsed at `content-type-parser.js` L123). Because normalizing is not stable under repetition, the second pass is lossy and the two keys no longer match:

```
new ContentType(h).toString()                      -> 'application/x-weird; foo="a"b"'
new ContentType(that).toString()                   -> 'application/x-weird; foo="a"'      // lost
```

So `POST /parser` with exactly the registered content type responds:

```
415 {"statusCode":415,"code":"FST_ERR_CTP_INVALID_MEDIA_TYPE","error":"Unsupported Media Type"}
```

### Change

Escape DQUOTE and backslash as quoted-pairs when serializing, per [RFC 9110 §5.6.4](https://httpwg.org/specs/rfc9110.html#quoted.string), behind an `indexOf` fast path so the regex never runs for values containing neither character. A value containing either octet now survives a parse/serialize round trip, and values containing neither serialize byte-identically to before.

After the change, the same two cases give:

```
response content-type: application/json; foo="a\"; charset=iso-8859-1; x=\"b"; charset=utf-8
                       (reparsed: [['foo','a"; charset=iso-8859-1; x="b'], ['charset','utf-8']])
POST /parser        -> 200 {"matched":true,"body":"hi"}
```

I deliberately kept this to escaping rather than switching to token-vs-quoted-string emission (what `content-type` and `fast-content-type-parse` do). That would also drop the quotes Fastify currently adds around e.g. `charset="utf-8"`, but it changes observable output for nearly every parameterized content type and rewrites parser-registry keys — a normalization-policy change rather than a bug fix, and one that overlaps #6941. Happy to do it separately if you want it.

This change does not touch the strict-validation policy under discussion in #6941 / #6925 / #6926 / #6927. It does not alter which headers are accepted or rejected, only how an already-accepted value is written back out.

### Files

- `lib/content-type.js` — add `quotedStringEscapeReg`; escape `"` and `\` in `toString()`.
- `test/content-type.test.js` — three unit tests: DQUOTE re-escaping, backslash re-escaping, and no parameter smuggling on round trip.
- `test/content-parser.test.js` — a parser registered under a content type containing a quoted-pair is selected (415 on `main`, 200 here).
- `test/internals/reply.test.js` — `reply.send()` keeps the quoted-pair escaped when it appends the default charset.

All five test additions fail on `main` and pass with the fix. The suite goes from 2294 tests / 2290 pass / 0 fail to 2299 / 2295 / 0.

### Notes

- **One octet is still not round-tripped, and I left it alone on purpose.** Sweeping all 256 octets reachable through a quoted-pair (parse → `toString()` → re-parse) shows `main` breaks on three of them — `0x22`, `0x5C`, `0x7F` — and this change fixes the first two. `0x7F` (DEL) remains: `keyValuePairsReg`'s quoted-pair branch `\\[\t -ÿ]` accepts `\<DEL>`, but its qdtext class excludes `0x7F`, so a DEL in a value is emitted literally and the parameter is dropped on re-parse. The serializer cannot fix that one, because RFC 9110 excludes DEL from `qdtext` *and* from `quoted-pair` (`VCHAR` is `%x21-7E`) — there is no conformant way to write it inside a quoted-string. The conformant fix is to stop accepting `\<DEL>` at parse time, which is a strictness decision belonging to #6941, not to this PR.
- `5.x` is affected identically — the reproduction above is against the published 5.11.3, and `origin/5.x` carries the same #6865 commit. A `backport` label looks appropriate.
- Concurrent work in this file: #6942 also edits `lib/content-type.js` (the `mediaType` getter) and `test/content-type.test.js`; this commit cherry-picks onto it cleanly. #6927 touches `lib/content-type.js` too, and the only overlap is an append-at-EOF conflict in `test/content-parser.test.js` where both branches add a test at the tail — `lib/content-type.js` itself does not conflict.
- No CR or LF can reach the output either before or after this change: the qdtext and quoted-pair character classes in `keyValuePairsReg` exclude `0x0A` and `0x0D`, so both octets are rejected in raw and quoted-pair form and the parameter is dropped. I checked this on both builds. The pre-existing defect could splice extra *parameters* into a Content-Type, never a new header line.
- The added regex is a single character class with no alternation or quantifier, so no backtracking. Measured on the serialization path with headers built from N quoted-pair parameters, cost is linear — each doubling of the input doubles the time (1000 params / 12.9 KB: 402 µs/op; 2000 / 26.9 KB: 763 µs; 4000 / 54.9 KB: 1481 µs; 8000 / 110.9 KB: 3010 µs; 16000 / 228.9 KB: 6223 µs). Over 20k parse+serialize cycles the common `application/json; charset=utf-8` is unchanged (7.0 ms before, 6.7 ms after — the `indexOf` fast path means the regex never runs), and the adversarial case costs about 1.5× (9.3 s → 13.9 s) because the output string grows, which is the unavoidable cost of correct escaping. `toString()` memoizes, request-side instances come from the 100-entry LRU in `ContentType.from()`, and `--max-http-header-size` caps the input at 16 KB by default.

### What I have not verified

Verification was macOS + Node v26.7.0 only. I did not exercise the Windows/Linux, alternative-runtime, or citgm CI jobs, nor `npm run bench` (branchcmp) — the default benchmark route sends JSON with no explicit content-type, so it never reaches `toString()` and cannot measure this path; the microbenchmarks above are what cover it. I traced every `toString()` consumer in `lib/` and the full suite is green, but I did not audit third-party plugins: one that hand-built a normalized registry key containing a literal unescaped `"` would now miss, though it would have been relying on malformed output to do so.

*Disclosure: this change was AI-assisted. I reviewed the diff and the evidence above myself before opening the PR.*

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
