### PR TITLE
docs: remove deprecated-API notices ahead of v6 cleanup

### DIFF
--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -167,10 +167,6 @@ fastify.addContentTypeParser('text/xml', function (request, payload, done) {
 })
 ```
 
-> ℹ️ Note:
-> `function(req, done)` and `async function(req)` are
-> still supported but deprecated.
-
 #### Body Parser
 The request body can be parsed in two ways. First, add a custom content type
 parser and handle the request stream. Or second, use the `parseAs` option in the

--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -624,9 +624,6 @@ invocation of `reply.send()` once the handler promise resolve should be skipped.
 By calling `reply.hijack()`, an application claims full responsibility for the
 low-level request and response. Moreover, hooks will not be invoked.
 
-*Modifying the `.sent` property directly is deprecated. Please use the
-aforementioned `.hijack()` method to achieve the same effect.*
-
 ### .hijack()
 <a name="hijack"></a>
 

--- a/docs/Reference/Request.md
+++ b/docs/Reference/Request.md
@@ -72,10 +72,6 @@ Request is a core Fastify object containing the following fields:
   for cooperative cancellation. On timeout, `signal.reason` is the
   `FST_ERR_HANDLER_TIMEOUT` error; on client disconnect it is a generic
   `AbortError`. Check `signal.reason.code` to distinguish the two cases.
-- `context` - Deprecated, use `request.routeOptions.config` instead. A Fastify
-  internal object. Do not use or modify it directly. It is useful to access one
-  special key:
-  - `context.config` - The route [`config`](./Routes.md#routes-config) object.
 - `routeOptions` - The route [`option`](./Routes.md#routes-options) object.
   - `bodyLimit` - Either server limit or route limit.
   - `handlerTimeout` - The handler timeout configured for this route.


### PR DESCRIPTION
Proposal:

Removed three deprecation notes from the documentation, in preparation for the Fastify v6 cleanup:

1. **`Request.md`** — Removed the `context` entry (deprecated in favor of `request.routeOptions.config`).
2. **`Reply.md`** — Removed the note about `.sent` as a deprecated setter (`Modifying the .sent property directly is deprecated...`), as direct assignment has already been removed/no longer relevant.
3. **`ContentTypeParser.md`** — Removed the note about `function(req, done)` / `async function(req)` as deprecated signatures for `addContentTypeParser`.

These elements have been deprecated for some time (v4/v5), and the related documentation no longer makes sense for v6, where they will be removed/no longer supported.

Notes:

- To be merged from the `"next"` branch
- For the next major release of Fastify ( v6 )
