### PR TITLE
fix(reply): send stream trailers after the stream actually finishes

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -836,9 +836,6 @@ function sendStream (payload, res, reply) {
   let sourceOpen = true
   let errorLogged = false
 
-  // set trailer when stream ended
-  sendStreamTrailer(payload, res, reply)
-
   eos(payload, { readable: true, writable: false }, function (err) {
     sourceOpen = false
     if (err != null) {
@@ -851,8 +848,15 @@ function sendStream (payload, res, reply) {
       } else {
         onErrorHook(reply, err)
       }
+      return
     }
-    // there is nothing to do if there is not an error
+    // stream finished without error: flush trailers, if any, and close
+    // the response. eos fires even for a stream whose 'end' already
+    // passed before this listener was attached, so a pre-drained
+    // stream still gets its trailers sent and the response closed.
+    if (reply[kReplyTrailers] !== null) {
+      sendTrailer(null, res, reply)
+    }
   })
 
   eos(res, function (err) {
@@ -884,7 +888,14 @@ function sendStream (payload, res, reply) {
   } else {
     reply.log.warn('response will send, but you shouldn\'t use res.writeHead in stream mode')
   }
-  payload.pipe(res)
+  // when trailers are set, the eos(payload, ...) listener above takes
+  // over ending the response once the trailers are resolved, so pipe
+  // must not end res on its own or it races with the deferred flush
+  if (reply[kReplyTrailers] !== null) {
+    payload.pipe(res, { end: false })
+  } else {
+    payload.pipe(res)
+  }
 }
 
 function sendTrailer (payload, res, reply) {
@@ -942,11 +953,6 @@ function sendTrailer (payload, res, reply) {
   // when all trailers are skipped
   // we need to close the stream
   if (skipped) res.end(null, null, null) // avoid ArgumentsAdaptorTrampoline from V8
-}
-
-function sendStreamTrailer (payload, res, reply) {
-  if (reply[kReplyTrailers] === null) return
-  payload.on('end', () => sendTrailer(null, res, reply))
 }
 
 function onErrorHook (reply, error, cb) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -850,10 +850,7 @@ function sendStream (payload, res, reply) {
       }
       return
     }
-    // stream finished without error: flush trailers, if any, and close
-    // the response. eos fires even for a stream whose 'end' already
-    // passed before this listener was attached, so a pre-drained
-    // stream still gets its trailers sent and the response closed.
+    // eos fires even for a stream that already ended
     if (reply[kReplyTrailers] !== null) {
       sendTrailer(null, res, reply)
     }
@@ -888,9 +885,7 @@ function sendStream (payload, res, reply) {
   } else {
     reply.log.warn('response will send, but you shouldn\'t use res.writeHead in stream mode')
   }
-  // when trailers are set, the eos(payload, ...) listener above takes
-  // over ending the response once the trailers are resolved, so pipe
-  // must not end res on its own or it races with the deferred flush
+  // trailers set: the eos listener above ends the response, not pipe
   if (reply[kReplyTrailers] !== null) {
     payload.pipe(res, { end: false })
   } else {

--- a/test/reply-trailers.test.js
+++ b/test/reply-trailers.test.js
@@ -4,7 +4,28 @@ const { test, describe } = require('node:test')
 const Fastify = require('..')
 const { Readable } = require('node:stream')
 const { createHash } = require('node:crypto')
-const { sleep } = require('./helper')
+const { sleep, getServerUrl } = require('./helper')
+const http = require('node:http')
+
+function getWithTrailers (url) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(url, (res) => {
+      const chunks = []
+      res.on('data', (chunk) => chunks.push(chunk))
+      res.on('end', () => {
+        resolve({
+          statusCode: res.statusCode,
+          headers: res.headers,
+          trailers: res.trailers,
+          body: Buffer.concat(chunks).toString()
+        })
+      })
+      res.on('error', reject)
+    })
+    req.on('error', reject)
+    req.end()
+  })
+}
 
 test('send trailers when payload is empty string', (t, testDone) => {
   t.plan(5)
@@ -139,6 +160,143 @@ test('send trailers when payload is stream', (t, testDone) => {
     t.assert.strictEqual(res.trailers.etag, 'custom-etag')
     t.assert.ok(!res.headers['content-length'])
     testDone()
+  })
+})
+
+// fastify.inject() never touches a real socket, so it cannot observe
+// the res.end() race between Readable#pipe() and the trailer flush.
+describe('trailers over a real socket', () => {
+  test('send trailers when payload is a Readable stream', async (t) => {
+    const fastify = Fastify()
+
+    fastify.get('/', function (request, reply) {
+      reply.trailer('ETag', function (reply, payload, done) {
+        done(null, 'custom-etag')
+      })
+      const stream = Readable.from([JSON.stringify({ hello: 'world' })])
+      reply.send(stream)
+    })
+
+    await fastify.listen({ port: 0 })
+    t.after(() => fastify.close())
+
+    const res = await getWithTrailers(getServerUrl(fastify))
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.headers['transfer-encoding'], 'chunked')
+    t.assert.strictEqual(res.headers.trailer, 'etag')
+    t.assert.strictEqual(res.trailers.etag, 'custom-etag')
+    t.assert.strictEqual(res.body, JSON.stringify({ hello: 'world' }))
+  })
+
+  test('send trailers when payload is a web ReadableStream', async (t) => {
+    const fastify = Fastify()
+
+    fastify.get('/', function (request, reply) {
+      reply.trailer('ETag', function (reply, payload, done) {
+        done(null, 'custom-etag')
+      })
+      const webStream = new ReadableStream({
+        start (controller) {
+          controller.enqueue(Buffer.from(JSON.stringify({ hello: 'world' })))
+          controller.close()
+        }
+      })
+      reply.send(webStream)
+    })
+
+    await fastify.listen({ port: 0 })
+    t.after(() => fastify.close())
+
+    const res = await getWithTrailers(getServerUrl(fastify))
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.headers.trailer, 'etag')
+    t.assert.strictEqual(res.trailers.etag, 'custom-etag')
+    t.assert.strictEqual(res.body, JSON.stringify({ hello: 'world' }))
+  })
+
+  test('send trailers when payload is a pre-ended Readable stream', async (t) => {
+    const fastify = Fastify()
+
+    // drain the stream and let 'end' pass before it is ever handed to
+    // send(), so sendStream() attaches its listeners after the stream
+    // is already done. the route handler stays synchronous so fastify's
+    // async "did the handler forget to send" rescue in wrap-thenable
+    // never gets a chance to paper over a stuck response.
+    const stream = Readable.from([JSON.stringify({ hello: 'world' })])
+    stream.resume()
+    await new Promise((resolve) => stream.on('end', resolve))
+
+    fastify.get('/', function (request, reply) {
+      reply.trailer('ETag', function (reply, payload, done) {
+        done(null, 'custom-etag')
+      })
+      reply.send(stream)
+    })
+
+    await fastify.listen({ port: 0 })
+    t.after(() => fastify.close())
+
+    const res = await Promise.race([
+      getWithTrailers(getServerUrl(fastify)),
+      new Promise((resolve, reject) => {
+        const hangTimer = setTimeout(() => reject(new Error('response hung')), 2000)
+        t.after(() => clearTimeout(hangTimer))
+      })
+    ])
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.headers.trailer, 'etag')
+    t.assert.strictEqual(res.trailers.etag, 'custom-etag')
+    t.assert.strictEqual(res.body, '')
+  })
+
+  test('stream response with no trailers registered ends normally', async (t) => {
+    const fastify = Fastify()
+
+    fastify.get('/', function (request, reply) {
+      const stream = Readable.from(['no-trailer-payload'])
+      reply.send(stream)
+    })
+
+    await fastify.listen({ port: 0 })
+    t.after(() => fastify.close())
+
+    const res = await getWithTrailers(getServerUrl(fastify))
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.trailers, {})
+    t.assert.strictEqual(res.body, 'no-trailer-payload')
+  })
+
+  test('stream error before end does not hang the response', async (t) => {
+    const fastify = Fastify({ logger: false })
+
+    fastify.get('/', function (request, reply) {
+      reply.trailer('ETag', function (reply, payload, done) {
+        done(null, 'custom-etag')
+      })
+      const stream = new Readable({
+        read () {
+          this.push('partial-data')
+          process.nextTick(() => this.destroy(new Error('boom')))
+        }
+      })
+      reply.send(stream)
+    })
+
+    await fastify.listen({ port: 0 })
+    t.after(() => fastify.close())
+
+    await new Promise((resolve, reject) => {
+      const req = http.request(getServerUrl(fastify), (res) => {
+        res.on('data', () => {})
+        res.on('error', () => resolve())
+        res.on('close', () => resolve())
+        res.on('end', () => resolve())
+      })
+      req.on('error', () => resolve())
+      req.end()
+      const hangTimer = setTimeout(() => reject(new Error('response hung')), 2000)
+      t.after(() => clearTimeout(hangTimer))
+    })
   })
 })
 


### PR DESCRIPTION
## Checklist

- [x] run `npm run test`
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/fastify/blob/main/CODE_OF_CONDUCT.md)

## What this does

When trailers are registered, `sendStream()` pipes with `{ end: false }` so `sendTrailer()` can own `res.end()` once the trailers resolve, since the default pipe behavior would end the response on its own and race the trailer flush (`fastify.inject()` never touches a real socket, so this race never showed up in the existing tests).

The trailer flush itself was wired through a plain `payload.on('end', ...)` listener. If the stream had already ended before `reply.send()` was called, that `end` event had already fired and the listener was registered too late, so the trailers never got sent, and since nothing else was calling `res.end()` either, the response hung.

This moves the trailer flush into the `eos` (`stream.finished`) listener already present in `sendStream()`. It fires exactly once when the stream is done, error or not, and it fires even for a stream that finished before the listener was attached, so the pre-ended case is handled the same way as the normal one.

## Tests

Added real-socket coverage in `test/reply-trailers.test.js`, since `inject()` can't see the pipe/`res.end()` race: trailers on a Readable stream, trailers on a web ReadableStream, a stream with no trailers registered, a stream that errors before ending, and a stream that has already ended before being handed to `send()`.
