### PR TITLE
fix: add path alias to RouteOptions type

### DIFF
--- a/test/route.4.test.js
+++ b/test/route.4.test.js
@@ -62,6 +62,45 @@ test('throws when route with empty url', async t => {
   }
 })
 
+test('supports path alias for url in route declaration', async t => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  fastify.route({
+    method: 'GET',
+    path: '/alias',
+    handler: (req, res) => {
+      res.send('hi!')
+    }
+  })
+
+  const res = await fastify.inject({
+    method: 'GET',
+    url: '/alias'
+  })
+  t.assert.strictEqual(res.statusCode, 200)
+})
+
+test('url takes precedence over path in route declaration', async t => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  fastify.route({
+    method: 'GET',
+    url: '/url',
+    path: '/path',
+    handler: (req, res) => {
+      res.send('hi!')
+    }
+  })
+
+  const res = await fastify.inject({
+    method: 'GET',
+    url: '/url'
+  })
+  t.assert.strictEqual(res.statusCode, 200)
+})
+
 test('throws when route with empty url in shorthand declaration', async t => {
   t.plan(1)
 

--- a/test/types/route.tst.ts
+++ b/test/types/route.tst.ts
@@ -436,6 +436,21 @@ expect(fastify().route({
   handler: routeHandler
 })).type.toBe<FastifyInstance>()
 
+// `path` is an alias for `url` (#6012)
+expect(fastify().route({
+  path: '/',
+  method: 'GET',
+  handler: routeHandler
+})).type.toBe<FastifyInstance>()
+
+// both `url` and `path` can be provided, `url` wins at runtime
+expect(fastify().route({
+  url: '/',
+  path: '/ignored',
+  method: 'GET',
+  handler: routeHandler
+})).type.toBe<FastifyInstance>()
+
 expect(fastify().route({
   url: '/',
   method: ['GET', 'POST', 'OPTION'], // OPTION is a typo for OPTIONS

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -215,13 +215,13 @@ export interface FastifyInstance<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
     ContextConfig = ContextConfigDefault,
     SchemaCompiler extends FastifySchema = FastifySchema
-  >(opts: Pick<RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>, 'method' | 'url' | 'constraints'>): boolean;
+  >(opts: Pick<RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>, 'method' | 'url' | 'constraints'> & { url: string }): boolean;
 
   findRoute<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
     ContextConfig = ContextConfigDefault,
     SchemaCompiler extends FastifySchema = FastifySchema
-  >(opts: Pick<RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>, 'method' | 'url' | 'constraints'>): Omit<FindMyWayFindResult<RawServer>, 'store'>;
+  >(opts: Pick<RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>, 'method' | 'url' | 'constraints'> & { url: string }): Omit<FindMyWayFindResult<RawServer>, 'store'>;
 
   // addHook: overloads
 

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -207,7 +207,16 @@ export interface RouteOptions<
 > extends RouteShorthandOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler,
   TypeProvider, Logger> {
   method: HTTPMethods | HTTPMethods[];
-  url: string;
+  /**
+   * Route path. Aliased by {@link RouteOptions.path}. Provide either `url` or
+   * `path`, at least one of them must be defined.
+   */
+  url?: string;
+  /**
+   * Route path. Alias for {@link RouteOptions.url}. Provide either `url` or
+   * `path`, at least one of them must be defined.
+   */
+  path?: string;
   handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler,
     TypeProvider, Logger>;
 }


### PR DESCRIPTION
## Problem

Closes #6012

`RouteOptions` only accepts `url` to declare a route, but the runtime resolves the path from `opts.url || opts.path`, the docs already document `path` as an alias of `url`, and plugins like `@fastify/static` rely on `path`. TypeScript users cannot pass `path` today without casting.

## Solution

- `RouteOptions.url` is now optional and `RouteOptions.path` is added as an optional alias. At least one of the two must be provided (enforced at runtime by `FST_ERR_ROUTE_MISSING_HANDLER` / "The path could not be empty").
- `hasRoute` / `findRoute` keep `url` as required: their runtime implementation only reads `options.url`, so a `& { url: string }` intersection preserves the existing contract.

No runtime changes: the behavior was already implemented, this only aligns the types with it.

## Tests

- `test/types/route.tst.ts`: `route({ path })` alone and `route({ url, path })` together now type-check.
- `test/route.4.test.js`: `path` registers a reachable route, and `url` takes precedence when both are set.

`npm run lint`, `npx tstyche` (1281 assertions) pass. The unit suite passes except for pre-existing IPv6/network failures unrelated to this change (confirmed identical on clean `main`).
