### PR TITLE
fix: align prefixed route alias url (continuation of #6784)

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -273,6 +273,7 @@ function buildRouting (options) {
 
     function addNewRoute ({ path, prefixing = false, isFastify = false }) {
       const url = prefix + path
+      const configUrl = prefixing === true ? prefix : url
 
       opts.url = url
       opts.path = url
@@ -327,7 +328,7 @@ function buildRouting (options) {
       const constraints = opts.constraints || {}
       const config = {
         ...opts.config,
-        url,
+        url: configUrl,
         method: opts.method
       }
 

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -964,3 +964,38 @@ test('calls onRoute only once when prefixing', async t => {
 
   t.assert.deepStrictEqual(onRouteCalled, 1)
 })
+
+test('keeps routeOptions url consistent for prefixed / route aliases', async t => {
+  t.plan(3)
+  const fastify = Fastify({
+    ignoreTrailingSlash: false,
+    exposeHeadRoutes: false
+  })
+
+  const onRouteUrls = []
+  fastify.register(function (fastify, opts, next) {
+    fastify.addHook('onRoute', routeOptions => {
+      onRouteUrls.push(routeOptions.url)
+    })
+
+    fastify.route({
+      method: 'GET',
+      url: '/',
+      prefixTrailingSlash: 'both',
+      handler: (req, reply) => {
+        reply.send({ routeUrl: req.routeOptions.url })
+      }
+    })
+
+    next()
+  }, { prefix: '/prefix' })
+
+  await fastify.ready()
+
+  const withoutSlash = await fastify.inject('/prefix')
+  const withSlash = await fastify.inject('/prefix/')
+
+  t.assert.deepStrictEqual(onRouteUrls, ['/prefix'])
+  t.assert.deepStrictEqual(JSON.parse(withoutSlash.payload), { routeUrl: '/prefix' })
+  t.assert.deepStrictEqual(JSON.parse(withSlash.payload), { routeUrl: '/prefix' })
+})


### PR DESCRIPTION
## Problem

Fixes #4424.

When a plugin registers a root route (`url: '/'`) with `prefixTrailingSlash: 'both'` under a prefix, Fastify registers an internal trailing-slash alias without running `onRoute` for it. `request.routeOptions.url` (and the `onRoute` hook payload) must stay aligned with the single user-visible route.

## Solution

The internal alias registration passes `prefixing: true` to `addNewRoute`. When that is set, store the canonical prefixed URL (`prefix`) instead of the alias URL (`prefix + path`) in the route config, keeping the router registration unchanged for matching `/prefix/`.

## Changes

- `lib/route.js`: add `configUrl` that resolves to `prefix` for internal alias registrations.
- `test/route-prefix.test.js`: regression test asserting `onRoute` fires once with `/prefix` and `req.routeOptions.url` is `/prefix` for both `/prefix` and `/prefix/`.

## Credits

This is a continuation of #6784 by @pupuking723, which was approved by @metcoder95 but had fallen 110 commits behind `main`. Rebased onto latest `main` and pushed here so it can be merged. Original commit `d042c909` retained.

## Checks

- `test/route-prefix.test.js`: 28/28 pass
- Full unit suite passes except pre-existing IPv6/network failures also present on clean `main` (verified).
- lint clean.
