### PR TITLE
fix: return 415 when request content type does not match body schema content map

### DIFF
--- a/docs/Reference/ContentTypeParser.md
+++ b/docs/Reference/ContentTypeParser.md
@@ -22,7 +22,8 @@ request](./Request.md) object, accessible via `request.body`.
 > property to validate per content type, only content types listed in the schema
 > will be validated. If you add a custom content type parser but do not include
 > its content type in the body schema's `content` property, the incoming data
-> will be parsed but **not validated**.
+> will be parsed but then rejected with a
+> `415 Unsupported Media Type` error.
 
 Note that for `GET` and `HEAD` requests, the payload is never parsed. For
 `OPTIONS` and `DELETE` requests, the payload is parsed only if a valid

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -250,7 +250,7 @@ fastify.post('/the/url', {
         'text/plain': {
           schema: { type: 'string' }
         }
-        // Other content types will not be validated
+        // Other content types are rejected with a 415 Unsupported Media Type
       }
     }
   }
@@ -258,16 +258,19 @@ fastify.post('/the/url', {
 ```
 
 > ⚠ Warning:
-> When using [custom content type parsers](./ContentTypeParser.md), the parsed
-> body is validated **only** when the request content type matches a key in the
-> schema `content` map.
+> When the request `Content-Type` does not match any key in the schema
+> `content` map, Fastify rejects the request with a
+> `415 Unsupported Media Type` error (`FST_ERR_CTP_INVALID_MEDIA_TYPE`).
+> This also applies when using [custom content type parsers](./ContentTypeParser.md):
+> the parsed body is validated **only** when the request content type matches a
+> key in the schema `content` map.
 >
 > Schema selection uses an exact match on the request's
 > [essence MIME type](https://mimesniff.spec.whatwg.org/#mime-type-miscellaneous)
 > (for example, `application/json`). If a parser is registered with a regular
 > expression (for example, `/^application\/.*json$/`), the parser can accept
 > more content types than the `content` map covers. Requests in that gap are
-> parsed but **not validated**.
+> parsed but then **rejected with 415**.
 >
 > Ensure every content type accepted by the parser has a corresponding key in
 > the `content` map, or use a catch-all body schema without `content` when
@@ -286,7 +289,7 @@ fastify.post('/the/url', {
 >         'application/json': {
 >           schema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] }
 >         },
->         // Without this entry, application/yaml requests will NOT be validated
+>         // Without this entry, application/yaml requests are rejected with 415
 >         'application/yaml': {
 >           schema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] }
 >         }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -10,7 +10,8 @@ const {
 const scChecker = /^[1-5](?:\d{2}|xx)$|^default$/
 
 const {
-  FST_ERR_SCH_RESPONSE_SCHEMA_NOT_NESTED_2XX
+  FST_ERR_SCH_RESPONSE_SCHEMA_NOT_NESTED_2XX,
+  FST_ERR_CTP_INVALID_MEDIA_TYPE
 } = require('./errors')
 
 const { FSTWRN001 } = require('./warnings')
@@ -174,6 +175,11 @@ function validate (context, request, execution) {
       const contentSchema = context[bodySchema][request.mediaType]
       if (contentSchema) {
         validatorFunction = contentSchema
+      } else {
+        // The route declares content-type-specific body schemas but the
+        // request content type does not match any of them. Reject with 415
+        // instead of silently skipping validation.
+        return new FST_ERR_CTP_INVALID_MEDIA_TYPE()
       }
     }
     const body = validateParam(validatorFunction, request, 'body')

--- a/test/schema-validation.test.js
+++ b/test/schema-validation.test.js
@@ -190,7 +190,51 @@ test('Different schema per content type', (t, testDone) => {
   completion.patience.then(testDone)
 })
 
-test('Skip validation if no schema for content type', (t, testDone) => {
+test('415 when multiple content types are declared and request does not match', (t, testDone) => {
+  t.plan(3)
+
+  const fastify = Fastify()
+  fastify.addContentTypeParser('application/octet-stream', {
+    parseAs: 'buffer'
+  }, async function (_, payload) {
+    return payload
+  })
+  fastify.post('/', {
+    schema: {
+      body: {
+        content: {
+          'application/json': {
+            schema: schemaArtist
+          },
+          'application/octet-stream': {
+            schema: {}
+          }
+          // No schema for 'text/plain'
+        }
+      }
+    }
+  }, async function (req, reply) {
+    return reply.send(req.body)
+  })
+  fastify.inject({
+    url: '/',
+    method: 'POST',
+    headers: { 'Content-Type': 'text/plain' },
+    body: 'AAAAAAAA'
+  }, (err, res) => {
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 415)
+    t.assert.deepStrictEqual(res.json(), {
+      statusCode: 415,
+      code: 'FST_ERR_CTP_INVALID_MEDIA_TYPE',
+      error: 'Unsupported Media Type',
+      message: 'Unsupported Media Type'
+    })
+    testDone()
+  })
+})
+
+test('Reject if no schema for content type', (t, testDone) => {
   t.plan(3)
 
   const fastify = Fastify()
@@ -215,13 +259,18 @@ test('Skip validation if no schema for content type', (t, testDone) => {
     body: 'AAAAAAAA'
   }, (err, res) => {
     t.assert.ifError(err)
-    t.assert.deepStrictEqual(res.payload, 'AAAAAAAA')
-    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.statusCode, 415)
+    t.assert.deepStrictEqual(res.json(), {
+      statusCode: 415,
+      code: 'FST_ERR_CTP_INVALID_MEDIA_TYPE',
+      error: 'Unsupported Media Type',
+      message: 'Unsupported Media Type'
+    })
     testDone()
   })
 })
 
-test('Skip validation if no content type schemas', (t, testDone) => {
+test('Reject if no content type schemas', (t, testDone) => {
   t.plan(3)
 
   const fastify = Fastify()
@@ -243,8 +292,13 @@ test('Skip validation if no content type schemas', (t, testDone) => {
     body: 'AAAAAAAA'
   }, (err, res) => {
     t.assert.ifError(err)
-    t.assert.deepStrictEqual(res.payload, 'AAAAAAAA')
-    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.statusCode, 415)
+    t.assert.deepStrictEqual(res.json(), {
+      statusCode: 415,
+      code: 'FST_ERR_CTP_INVALID_MEDIA_TYPE',
+      error: 'Unsupported Media Type',
+      message: 'Unsupported Media Type'
+    })
     testDone()
   })
 })
@@ -1351,7 +1405,7 @@ test('Custom validator builder override by custom validator compiler in child in
   t.assert.strictEqual(two.statusCode, 200)
 })
 
-test('Schema validation when no content type is provided', async t => {
+test('415 when no content type is provided', async t => {
   // this case should not be happened in normal use-case,
   // it is added for the completeness of code branch
   const fastify = Fastify()
@@ -1389,7 +1443,8 @@ test('Schema validation when no content type is provided', async t => {
     },
     body: { invalid: 'string' }
   })
-  t.assert.strictEqual(invalid.statusCode, 200)
+  t.assert.strictEqual(invalid.statusCode, 415)
+  t.assert.strictEqual(invalid.json().code, 'FST_ERR_CTP_INVALID_MEDIA_TYPE')
 })
 
 test('Schema validation will not be bypass by different content type', async t => {


### PR DESCRIPTION
When a route's body schema uses the `content` property to declare content-type-specific validation schemas, a request whose `Content-Type` does not match any key in that map was silently skipped during validation — letting the body pass unvalidated. This is a footgun.

Now such requests are rejected with a `415 Unsupported Media Type` error (`FST_ERR_CTP_INVALID_MEDIA_TYPE`), the same error the content-type parser already emits for unsupported media types.

Updated the tests and docs that previously documented the "not validated" skip behavior.
