### PR TITLE
fix(types): add logSerializers to RouteShorthandOptions

### DIFF
--- a/test/types/route.tst.ts
+++ b/test/types/route.tst.ts
@@ -574,3 +574,17 @@ expect(fastify().route({
     expect(req.routeOptions.method).type.toBeAssignableTo<string | Array<string>>()
   }
 })).type.toBe<FastifyInstance>()
+
+// RouteShorthandOptions: logSerializers is a supported per-route option (#6818)
+expect(fastify().route({
+  url: '/',
+  method: 'get',
+  logSerializers: { key: (value: any) => `${value}` },
+  handler: routeHandlerWithReturnValue
+})).type.toBe<FastifyInstance>()
+
+expect(fastify().get('/log-serializers', {
+  logSerializers: {
+    reqId: (value: any) => String(value)
+  }
+}, routeHandlerWithReturnValue)).type.toBe<FastifyInstance>()

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -67,6 +67,7 @@ export interface RouteShorthandOptions<
   bodyLimit?: number;
   handlerTimeout?: number;
   logLevel?: LogLevel;
+  logSerializers?: Record<string, (value: any) => string>;
   config?: FastifyContextConfig & ContextConfig;
   constraints?: RouteConstraint,
   prefixTrailingSlash?: 'slash' | 'no-slash' | 'both';


### PR DESCRIPTION
Fixes #6818.

## Problem

`logSerializers` is a documented per-route option (docs/Reference/Routes.md: "set serializers to log for this route") and is consumed at runtime (`lib/route.js` merges `opts.logSerializers` into the route context, `lib/context.js` stores it), but it is missing from the `RouteShorthandOptions` type. Passing it to `fastify.route()` or the shorthand methods fails TypeScript checking even though it works at runtime.

## Solution

Add `logSerializers?: Record<string, (value: any) => string>` to `RouteShorthandOptions`, matching the existing type used in `RegisterOptions`.

## Tests

Added type-level assertions in `test/types/route.tst.ts` covering `fastify.route()` and `fastify.get(path, opts, handler)` with `logSerializers`. Full type test suite passes (1281 assertions).