### PR TITLE
fix: trim trailing slash from routeOptions.url for auto-registered prefix routes

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -327,7 +327,11 @@ function buildRouting (options) {
       const constraints = opts.constraints || {}
       const config = {
         ...opts.config,
-        url,
+        // When the route is the trailing-slash variant auto-registered via
+        // prefixTrailingSlash, expose the canonical (trimmed) url through
+        // routeOptions so consumers (e.g. metrics plugins) see the same
+        // route for both /prefix and /prefix/.
+        url: prefixing && path === '/' && url.length > 1 ? url.slice(0, -1) : url,
         method: opts.method
       }
 

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -964,3 +964,53 @@ test('calls onRoute only once when prefixing', async t => {
 
   t.assert.deepStrictEqual(onRouteCalled, 1)
 })
+
+test('routeOptions.url should not have a trailing slash for the auto-registered prefix route (#4424)', (t, testDone) => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.register(function (fastify, opts, done) {
+    fastify.get('/', (req, reply) => {
+      reply.send({ route: req.routeOptions.url })
+    })
+
+    done()
+  }, { prefix: '/foo' })
+
+  const completion = waitForCb({ steps: 2 })
+  fastify.inject({
+    method: 'GET',
+    url: '/foo'
+  }, (err, res) => {
+    t.assert.ifError(err)
+    t.assert.deepStrictEqual(JSON.parse(res.payload), { route: '/foo' })
+    completion.stepIn()
+  })
+  fastify.inject({
+    method: 'GET',
+    url: '/foo/'
+  }, (err, res) => {
+    t.assert.ifError(err)
+    t.assert.deepStrictEqual(JSON.parse(res.payload), { route: '/foo' })
+    completion.stepIn()
+  })
+  completion.patience.then(testDone)
+})
+
+test('routeOptions.url keeps the trailing slash for an explicitly registered trailing-slash route', (t, testDone) => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.get('/foo/', (req, reply) => {
+    reply.send({ route: req.routeOptions.url })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/foo/'
+  }, (err, res) => {
+    t.assert.ifError(err)
+    t.assert.deepStrictEqual(JSON.parse(res.payload), { route: '/foo/' })
+    testDone()
+  })
+})


### PR DESCRIPTION
Fixes #4424.

## Problem

With `prefixTrailingSlash: 'both'` (the default), registering `get('/')` under `prefix: '/foo'` registers two internal routes (`/foo` and `/foo/`), but the `onRoute` hook fires only once — so from the user's perspective there is one route. However, `request.routeOptions.url` (formerly `routerPath`) returned `/foo/` for the trailing-slash variant, which is a route the user never registered. Metrics plugins (e.g. fastify-metrics) keyed on this value then fail to record metrics for trailing-slash requests.

## Solution

When fastify auto-registers the trailing-slash variant via `prefixTrailingSlash`, the route's `config.url` (the source of `routeOptions.url`) now uses the canonical trimmed form. Explicitly registered trailing-slash routes are unchanged, and router matching is untouched (the real url is still passed to `router.on`).

## Tests

Added two tests in `test/route-prefix.test.js`:

- `/foo` and `/foo/` requests both report `routeOptions.url === '/foo'` under `prefix: '/foo'`
- an explicitly registered `/foo/` route keeps `'/foo/'`

`route-prefix` suite 29/29, related suites (hooks/route/has-route/find-route) 109/109, eslint clean.