### PR TITLE
types: restrict route lookup methods

### DIFF
--- a/test/types/route.tst.ts
+++ b/test/types/route.tst.ts
@@ -495,6 +495,12 @@ expect(fastify().hasRoute({
   method: 'GET'
 })).type.toBe<boolean>()
 
+fastify().hasRoute({
+  url: '/',
+  // @ts-expect-error  Type 'string[]' is not assignable to type 'HTTPMethods'.
+  method: ['GET', 'POST']
+})
+
 expect(fastify().hasRoute({
   url: '/',
   method: 'GET',
@@ -538,6 +544,12 @@ expect(
     method: 'get'
   })
 ).type.toBe<Omit<FindMyWayFindResult<RawServerDefault>, 'store'>>()
+
+fastify().findRoute({
+  url: '/',
+  // @ts-expect-error  Type 'string[]' is not assignable to type 'HTTPMethods'.
+  method: ['GET', 'POST']
+})
 
 // we should not expose store
 expect(fastify().findRoute({

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -215,13 +215,13 @@ export interface FastifyInstance<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
     ContextConfig = ContextConfigDefault,
     SchemaCompiler extends FastifySchema = FastifySchema
-  >(opts: Pick<RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>, 'method' | 'url' | 'constraints'>): boolean;
+  >(opts: Pick<RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>, 'url' | 'constraints'> & { method: HTTPMethods }): boolean;
 
   findRoute<
     RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
     ContextConfig = ContextConfigDefault,
     SchemaCompiler extends FastifySchema = FastifySchema
-  >(opts: Pick<RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>, 'method' | 'url' | 'constraints'>): Omit<FindMyWayFindResult<RawServer>, 'store'>;
+  >(opts: Pick<RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>, 'url' | 'constraints'> & { method: HTTPMethods }): Omit<FindMyWayFindResult<RawServer>, 'store'>;
 
   // addHook: overloads
 


### PR DESCRIPTION
#### Description

`hasRoute` and `findRoute` look up a route for a single HTTP method, but their TypeScript definitions reused `RouteOptions.method`, which also allows method arrays for route registration.

Both APIs forward one method to the router after normalizing it with `toUpperCase()`. Arrays are only meaningful during route registration; for a lookup they have no defined result semantics and currently cause a runtime `TypeError`.

This narrows the `method` option for both lookup APIs to `HTTPMethods` and adds type tests to reject method arrays.
#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certificate of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)