### PR TITLE
docs: clarify reply.redirect encoding does not prevent open redirects

### DIFF
--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -325,6 +325,23 @@ to `302` (if status code is not already set by calling `code`).
 > [`encodeurl`](https://www.npmjs.com/package/encodeurl). Invalid URLs will
 > result in a 500 `TypeError` response.
 
+> ⚠️ Security:
+> Encoding alone does **not** prevent open redirects. Neither `encodeURI`
+> nor `encodeurl` escapes `/`, so a caller-supplied target such as
+> `//evil.com` or `/\evil.com` survives encoding and is resolved by the
+> browser as a new host (a protocol-relative, authority-opening
+> reference). When `dest` can be influenced by request input
+> (`req.query`, `req.body`, `req.params`, cookies, or headers), validate
+> that the resolved target is same-origin or on an explicit allowlist
+> instead of relying on encoding:
+>
+> ```js
+> const target = new URL(dest, 'https://your-site.example')
+> if (target.origin !== 'https://your-site.example') {
+>   return reply.code(400).send()
+> }
+> ```
+
 Example (no `reply.code()` call) sets status code to `302` and redirects to
 `/home`
 ```js


### PR DESCRIPTION
Clarify that `reply.redirect()` never encodes its target, and that encoding the target with `encodeURI` or `encodeurl` does not prevent open redirects: neither function escapes `/`, so caller-supplied targets like `//evil.com` or `/\evil.com` survive encoding and resolve to a new origin in the browser. Directs callers to validate same-origin / allowlist targets when `dest` is influenced by request input, matching the guidance already present in `docs/Reference/Request.md` and `docs/Reference/Routes.md`.
