### PR TITLE
feat: expose error metadata via well-known symbols instead of mutating error objects

### DIFF
--- a/docs/Reference/Errors.md
+++ b/docs/Reference/Errors.md
@@ -197,7 +197,7 @@ app.setErrorHandler(function (error, request, reply) {
   // application, as were validation errors. A status code below 500 is not on
   // its own a guarantee that the message is safe to expose — narrow this
   // condition if any of yours are not.
-  if (error.validation || (error.statusCode && error.statusCode < 500)) {
+  if (error[Symbol.for('fastify.validation')] || (error.statusCode && error.statusCode < 500)) {
     return reply.send(error)
   }
 

--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -655,13 +655,15 @@ To circumvent this issue, there are two main options:
    returns errors in the same structure and format as `ajv`.
 2. Use a custom `errorHandler` to intercept and format custom validation errors.
 
-Fastify adds two properties to all validation errors to help write a custom
-`errorHandler`:
+Fastify adds two well-known properties to all validation errors to help write a
+custom `errorHandler`. They are stored under global symbols so they can never
+clash with user-defined properties on the error object:
 
-* `validation`: the content of the `error` property of the object returned by
-  the validation function (returned by the custom `schemaCompiler`)
-* `validationContext`: the context (body, params, query, headers) where the
-  validation error occurred
+* `Symbol.for('fastify.validation')`: the content of the `error` property of
+  the object returned by the validation function (returned by the custom
+  `schemaCompiler`)
+* `Symbol.for('fastify.validationContext')`: the context (body, params, query,
+  headers) where the validation error occurred
 
 A contrived example of such a custom `errorHandler` handling validation errors
 is shown below:
@@ -671,7 +673,8 @@ const errorHandler = (error, request, reply) => {
   const statusCode = error.statusCode
   let response
 
-  const { validation, validationContext } = error
+  const validation = error[Symbol.for('fastify.validation')]
+  const validationContext = error[Symbol.for('fastify.validationContext')]
 
   // check if we have a validation error
   if (validation) {
@@ -883,9 +886,11 @@ message has to be rebuilt from the raw validation result:
   payload above (for example `body must have required property 'name'`). It is
   produced by [`schemaErrorFormatter`](#schemaerrorformatter), so a custom
   formatter is reflected here too.
-- `validation` is the raw validation result, as returned by the validator.
+- `validation` is the raw validation result, as returned by the validator,
+  available as `error[Symbol.for('fastify.validation')]`.
 - `validationContext` is the part of the request that failed validation
-  (`body`, `params`, `querystring` or `headers`).
+  (`body`, `params`, `querystring` or `headers`), available as
+  `error[Symbol.for('fastify.validationContext')]`.
 - `code` is `FST_ERR_VALIDATION` and `statusCode` is `400`.
 
 ```js

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -33,17 +33,13 @@ import { FastifyServerFactory, FastifyServerFactoryHandler } from './types/serve
 import { FastifyTypeProvider, FastifyTypeProviderDefault, SafePromiseLike } from './types/type-provider'
 import { ContextConfigDefault, HTTPMethods, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerBase, RawServerDefault, RequestBodyDefault, RequestHeadersDefault, RequestParamsDefault, RequestQuerystringDefault } from './types/utils'
 
-declare module '@fastify/error' {
-  interface FastifyError {
-    validationContext?: SchemaErrorDataVar;
-    validation?: FastifySchemaValidationError[];
-  }
-}
-
 type Fastify = typeof fastify
 
 declare namespace fastify {
   export const errorCodes: FastifyErrorCodes
+  export const kErrorValidation: unique symbol
+  export const kErrorValidationContext: unique symbol
+  export const kErrorSerialization: unique symbol
   export { LogControllerClass as LogController }
 
   export type FastifyHttp2SecureOptions<
@@ -242,6 +238,14 @@ declare namespace fastify {
   // default export
   // import plugin from 'plugin'
   export { fastify as default }
+}
+
+declare module '@fastify/error' {
+  interface FastifyError {
+    [fastify.kErrorValidation]?: FastifySchemaValidationError[];
+    [fastify.kErrorValidationContext]?: SchemaErrorDataVar;
+    [fastify.kErrorSerialization]?: unknown;
+  }
 }
 
 /**

--- a/fastify.js
+++ b/fastify.js
@@ -34,7 +34,10 @@ const {
   kGenReqId,
   kErrorHandlerAlreadySet,
   kHandlerTimeout,
-  kLogController
+  kLogController,
+  kErrorValidation,
+  kErrorValidationContext,
+  kErrorSerialization
 } = require('./lib/symbols.js')
 
 const { createServer } = require('./lib/server')
@@ -1004,6 +1007,9 @@ function validateSchemaErrorFormatter (schemaErrorFormatter) {
  */
 module.exports = fastify
 module.exports.errorCodes = errorCodes
+module.exports.kErrorValidation = kErrorValidation
+module.exports.kErrorValidationContext = kErrorValidationContext
+module.exports.kErrorSerialization = kErrorSerialization
 module.exports.LogController = LogController
 module.exports.fastify = fastify
 module.exports.default = fastify

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -24,7 +24,8 @@ const {
   kTimeoutTimer,
   kOnAbort,
   kRequestSignal,
-  kLogController
+  kLogController,
+  kErrorSerialization
 } = require('./symbols.js')
 const {
   onSendHookRunner,
@@ -555,7 +556,7 @@ function preSerializationHookEnd (err, _request, reply, payload) {
 }
 
 function wrapSerializationError (error, reply) {
-  error.serialization = reply[kRouteContext].config
+  error[kErrorSerialization] = reply[kRouteContext].config
 }
 
 function onSendHook (reply, payload) {

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -67,7 +67,11 @@ const keys = {
   kKeepAliveConnections: Symbol('fastify.keepAliveConnections'),
   kRouteByFastify: Symbol('fastify.routeByFastify'),
   kLogController: Symbol('fastify.logController'),
-  kDiagnosticsStore: Symbol('fastify.diagnosticsStore')
+  kDiagnosticsStore: Symbol('fastify.diagnosticsStore'),
+  // Errors
+  kErrorValidation: Symbol.for('fastify.validation'),
+  kErrorValidationContext: Symbol.for('fastify.validationContext'),
+  kErrorSerialization: Symbol.for('fastify.serialization')
 }
 
 module.exports = keys

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const {
+  kErrorValidation,
+  kErrorValidationContext,
   kSchemaHeaders: headersSchema,
   kSchemaParams: paramsSchema,
   kSchemaQuerystring: querystringSchema,
@@ -266,15 +268,15 @@ function wrapValidationError (result, dataVar, schemaErrorFormatter) {
   if (result instanceof Error) {
     result.statusCode = result.statusCode || 400
     result.code = result.code || 'FST_ERR_VALIDATION'
-    result.validationContext = result.validationContext || dataVar
+    result[kErrorValidationContext] = result[kErrorValidationContext] ?? result.validationContext ?? dataVar
     return result
   }
 
   const error = schemaErrorFormatter(result, dataVar)
   error.statusCode = error.statusCode || 400
   error.code = error.code || 'FST_ERR_VALIDATION'
-  error.validation = result
-  error.validationContext = dataVar
+  error[kErrorValidation] = result
+  error[kErrorValidationContext] = dataVar
   return error
 }
 

--- a/test/reply-error.test.js
+++ b/test/reply-error.test.js
@@ -3,6 +3,7 @@
 const { test, describe } = require('node:test')
 const net = require('node:net')
 const Fastify = require('..')
+const { kErrorValidation } = Fastify
 const statusCodes = require('node:http').STATUS_CODES
 const split = require('split2')
 const fs = require('node:fs')
@@ -339,7 +340,7 @@ test('invalid schema - ajv', (t, testDone) => {
   })
 
   fastify.setErrorHandler((err, request, reply) => {
-    t.assert.ok(Array.isArray(err.validation))
+    t.assert.ok(Array.isArray(err[kErrorValidation]))
     reply.code(400).send('error')
   })
 

--- a/test/schema-examples.test.js
+++ b/test/schema-examples.test.js
@@ -3,6 +3,7 @@
 const { test } = require('node:test')
 const localize = require('ajv-i18n')
 const Fastify = require('..')
+const { kErrorValidation } = Fastify
 
 test('Example - URI $id', (t, done) => {
   t.plan(1)
@@ -628,9 +629,9 @@ test('should return localized error messages with ajv-i18n', (t, done) => {
   })
 
   fastify.setErrorHandler(function (error, request, reply) {
-    if (error.validation) {
-      localize.ru(error.validation)
-      reply.status(400).send(error.validation)
+    if (error[kErrorValidation]) {
+      localize.ru(error[kErrorValidation])
+      reply.status(400).send(error[kErrorValidation])
       return
     }
     reply.send(error)

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -4,6 +4,7 @@ const { test } = require('node:test')
 const fp = require('fastify-plugin')
 const { spyWarning } = require('process-warning')
 const Fastify = require('..')
+const { kErrorValidation, kErrorValidationContext } = Fastify
 const deepClone = require('rfdc')({ circles: true, proto: false })
 const Ajv = require('ajv')
 const { kSchemaController } = require('../lib/symbols.js')
@@ -1144,8 +1145,8 @@ test('Validation context in validation result', (t, testDone) => {
   // custom error handler to expose validation context in response, so we can test it later
   fastify.setErrorHandler((err, request, reply) => {
     t.assert.strictEqual(err instanceof Error, true)
-    t.assert.ok(err.validation, 'detailed errors')
-    t.assert.strictEqual(err.validationContext, 'body')
+    t.assert.ok(err[kErrorValidation], 'detailed errors')
+    t.assert.strictEqual(err[kErrorValidationContext], 'body')
     reply.code(400).send()
   })
   fastify.post('/', {

--- a/test/schema-serialization.test.js
+++ b/test/schema-serialization.test.js
@@ -5,6 +5,8 @@ const Fastify = require('..')
 const ContentType = require('../lib/content-type')
 const { waitForCb } = require('./helper')
 
+const { kErrorSerialization } = Fastify
+
 const echoBody = (req, reply) => { reply.send(req.body) }
 
 test('basic test', (t, testDone) => {
@@ -1141,7 +1143,7 @@ test('Errors in serializer send to errorHandler', async t => {
     message: '"name" is required!'
   })
   t.assert.ok(savedError, 'error presents')
-  t.assert.ok(savedError.serialization, 'Serialization sign presents')
+  t.assert.ok(savedError[kErrorSerialization], 'Serialization sign presents')
 })
 
 test('capital X', (t, testDone) => {

--- a/test/types/fastify.tst.ts
+++ b/test/types/fastify.tst.ts
@@ -13,6 +13,8 @@ import fastify, {
   FastifyPluginAsync,
   FastifyPluginCallback,
   InjectOptions,
+  kErrorValidation,
+  kErrorValidationContext,
   LightMyRequestCallback,
   LightMyRequestChain,
   LightMyRequestResponse,
@@ -337,11 +339,11 @@ expect<AjvErrorObject>().type.not.toBeAssignableFrom({
   message: ''
 })
 
-expect<FastifyError['validation']>().type.toBeAssignableFrom([ajvErrorObject])
-expect<FastifyError['validationContext']>().type.toBeAssignableFrom('body')
-expect<FastifyError['validationContext']>().type.toBeAssignableFrom('headers')
-expect<FastifyError['validationContext']>().type.toBeAssignableFrom('params')
-expect<FastifyError['validationContext']>().type.toBeAssignableFrom('querystring')
+expect<FastifyError[typeof kErrorValidation]>().type.toBeAssignableFrom([ajvErrorObject])
+expect<FastifyError[typeof kErrorValidationContext]>().type.toBeAssignableFrom('body')
+expect<FastifyError[typeof kErrorValidationContext]>().type.toBeAssignableFrom('headers')
+expect<FastifyError[typeof kErrorValidationContext]>().type.toBeAssignableFrom('params')
+expect<FastifyError[typeof kErrorValidationContext]>().type.toBeAssignableFrom('querystring')
 
 expect<RouteGenericInterface['Body']>().type.toBe<unknown>()
 expect<RouteGenericInterface['Headers']>().type.toBe<unknown>()

--- a/test/types/request.tst.ts
+++ b/test/types/request.tst.ts
@@ -2,6 +2,7 @@ import { expect } from 'tstyche'
 import fastify, {
   ContextConfigDefault,
   FastifyContextConfig,
+  FastifyError,
   FastifyLogFn,
   FastifySchema,
   FastifyTypeProviderDefault,
@@ -88,7 +89,7 @@ const getHandler: RouteHandler = function (request, _reply) {
   expect(request.log).type.toBe<FastifyBaseLogger>()
   expect(request.socket).type.toBe<RawRequestDefaultExpression['socket']>()
   expect(request.signal).type.toBe<AbortSignal>()
-  expect(request.validationError).type.toBe<Error & { validation: any; validationContext: string } | undefined>()
+  expect(request.validationError).type.toBe<FastifyError | undefined>()
   expect(request.server).type.toBe<FastifyInstance>()
   expect(request.getValidationFunction).type.toBeAssignableTo<
     (httpPart: HTTPRequestPart) => ExpectedGetValidationFunction | undefined

--- a/test/validation-error-handling.test.js
+++ b/test/validation-error-handling.test.js
@@ -4,6 +4,8 @@ const { describe, test } = require('node:test')
 const Joi = require('joi')
 const Fastify = require('..')
 
+const { kErrorValidation, kErrorValidationContext } = Fastify
+
 const schema = {
   body: {
     type: 'object',
@@ -73,7 +75,7 @@ test('should be able to use setErrorHandler specify custom validation error', as
   })
 
   fastify.setErrorHandler(function (error, request, reply) {
-    if (error.validation) {
+    if (error[kErrorValidation]) {
       reply.status(422).send(new Error('validation failed'))
     }
   })
@@ -143,7 +145,7 @@ test('error inside custom error handler should have validationContext', async (t
   })
 
   fastify.setErrorHandler(function (error, request, reply) {
-    t.assert.strictEqual(error.validationContext, 'body')
+    t.assert.strictEqual(error[kErrorValidationContext], 'body')
     reply.status(500).send(error)
   })
 
@@ -177,7 +179,7 @@ test('error inside custom error handler should have validationContext if specifi
   })
 
   fastify.setErrorHandler(function (error, request, reply) {
-    t.assert.strictEqual(error.validationContext, 'customContext')
+    t.assert.strictEqual(error[kErrorValidationContext], 'customContext')
     reply.status(500).send(error)
   })
 
@@ -197,7 +199,7 @@ test('should be able to attach validation to request', async (t) => {
   const fastify = Fastify()
 
   fastify.post('/', { schema, attachValidation: true }, function (req, reply) {
-    reply.code(400).send(req.validationError.validation)
+    reply.code(400).send(req.validationError[kErrorValidation])
   })
 
   const response = await fastify.inject({
@@ -228,7 +230,7 @@ test('attached validationError exposes the same message sent by the default hand
       message: req.validationError.message,
       code: req.validationError.code,
       statusCode: req.validationError.statusCode,
-      validationContext: req.validationError.validationContext
+      validationContext: req.validationError[kErrorValidationContext]
     })
   })
 
@@ -259,7 +261,7 @@ test('should respect when attachValidation is explicitly set to false', async (t
 
   fastify.post('/', { schema, attachValidation: false }, function (req, reply) {
     t.assert.fail('should not be here')
-    reply.code(200).send(req.validationError.validation)
+    reply.code(200).send(req.validationError[kErrorValidation])
   })
 
   const response = await fastify.inject({
@@ -290,7 +292,7 @@ test('Attached validation error should take precedence over setErrorHandler', as
 
   fastify.setErrorHandler(function (error, request, reply) {
     t.assert.fail('should not be here')
-    if (error.validation) {
+    if (error[kErrorValidation]) {
       reply.status(422).send(new Error('validation failed'))
     }
   })
@@ -931,4 +933,38 @@ describe('sync and async must work in the same way', () => {
     t.assert.strictEqual(response.statusCode, 500)
     t.assert.deepStrictEqual(response.json(), { error: 'Custom validation failed' })
   })
+})
+
+test('validation errors expose details via symbols without polluting the error object', async (t) => {
+  t.plan(6)
+
+  const fastify = Fastify()
+
+  fastify.post('/', { schema }, function (req, reply) {
+    t.assert.fail('should not be here')
+    reply.code(200).send(req.body.name)
+  })
+
+  fastify.setErrorHandler(function (error, request, reply) {
+    t.assert.strictEqual(error[kErrorValidationContext], 'body')
+    t.assert.deepStrictEqual(error[kErrorValidation], [{
+      keyword: 'required',
+      instancePath: '',
+      schemaPath: '#/required',
+      params: { missingProperty: 'name' },
+      message: "must have required property 'name'"
+    }])
+    t.assert.strictEqual('validation' in error, false)
+    t.assert.strictEqual('validationContext' in error, false)
+    t.assert.strictEqual('serialization' in error, false)
+    reply.status(400).send(error)
+  })
+
+  const response = await fastify.inject({
+    method: 'POST',
+    payload: { hello: 'michelangelo' },
+    url: '/'
+  })
+
+  t.assert.strictEqual(response.statusCode, 400)
 })

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -1,4 +1,5 @@
 import { ErrorObject } from '@fastify/ajv-compiler'
+import { FastifyError } from '@fastify/error'
 import { FastifyContextConfig } from './context'
 import { FastifyInstance } from './instance'
 import { FastifyBaseLogger } from './logger'
@@ -65,7 +66,7 @@ export interface FastifyRequest<RouteGeneric extends RouteGenericInterface = Rou
   body: RequestType['body'];
 
   /** in order for this to be used the user should ensure they have set the attachValidation option. */
-  validationError?: Error & { validation: any; validationContext: string };
+  validationError?: FastifyError;
 
   /**
    * Derived from request socket metadata or forwarding headers.


### PR DESCRIPTION
#### Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have written a descriptive PR title
- [x] I have written a descriptive PR description
- [x] I have run the test suite and confirmed it passes

#### Checklist

- [x] I have read the [Fastify style guide](https://fastify.dev/docs/latest/Guides/Style-Guide/)
- [x] My code follows the style guide of this project
- [x] My changes do not introduce any new warnings or errors
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have added necessary documentation updates

#### What kind of change does this PR introduce?

This PR replaces the mutation of user-owned error objects with collision-prone public properties (`validation`, `validationContext`, `serialization`) in favor of well-known global symbols, as proposed in the discussion of #2622 and tracked by #2624.

Fastify starts from the premise that errors thrown or returned by user code (custom validators, `schemaErrorFormatter` output, serializers, content-type parsers) are user-owned objects. Attaching plain properties like `validation`, `validationContext` or `serialization` to them can silently collide with user-defined properties.

#### Audit: all the cases where Fastify mutates error objects

| Site | Property written | Object mutated |
| --- | --- | --- |
| `lib/validation.js` `validateParam` catch | `statusCode = 500` | error thrown by a validator |
| `lib/validation.js` `wrapValidationError` (Error branch) | `statusCode`, `code`, `validationContext` | error returned/thrown by a validator |
| `lib/validation.js` `wrapValidationError` (formatter branch) | `statusCode`, `code`, `validation`, `validationContext` | output of a user `schemaErrorFormatter` |
| `lib/reply.js` `wrapSerializationError` | `serialization` (route config) | error raised by a serializer |
| `lib/content-type-parser.js` `onEnd` | `statusCode = 400` | error raised by a content-type parser |
| `lib/initial-config-validation.js` | `errors` | Fastify's own `FST_ERR_INIT_OPTS_INVALID` (no user object involved, left as-is) |

`statusCode`, `code` and `headers` are kept as plain properties: they are the de-facto Node.js/Express error conventions that every error handler, logger and tool in the ecosystem already reads, and moving them would create churn without any collision benefit.

#### Changes

- `lib/symbols.js`: new well-known symbols `Symbol.for('fastify.validation')`, `Symbol.for('fastify.validationContext')`, `Symbol.for('fastify.serialization')`
- `lib/validation.js`, `lib/reply.js`: write error metadata through the symbols above instead of plain properties
- `fastify.js`: export the three symbols, so they are available as e.g. `import { kErrorValidation } from 'fastify'`
- `fastify.d.ts`, `types/request.d.ts`: the symbols are typed (`unique symbol`) and the `@fastify/error` `FastifyError` augmentation now exposes them, in place of the legacy `validation`/`validationContext` members; `FastifyRequest#validationError` is now typed as `FastifyError`
- Docs updated in `docs/Reference/Errors.md` and `docs/Reference/Validation-and-Serialization.md` to use the symbol accessors
- Tests updated to read the symbols; new test verifying user error objects are no longer polluted with public properties

#### Migration

This is a breaking change for the `validation` / `validationContext` properties on validation errors. Consumers should switch to the exported symbols:

```js
const { kErrorValidation, kErrorValidationContext } = require('fastify')

app.setErrorHandler((error, request, reply) => {
  if (error[kErrorValidation]) { /* ... */ }
})
```

or use the well-known strings directly: `error[Symbol.for('fastify.validation')]`.

Props `statusCode`, `code`, `message`, `headers` are unchanged.

Closes #2624