### PR TITLE
fix(types): restore this context in route shorthand hooks

### DIFF
--- a/test/types/route.tst.ts
+++ b/test/types/route.tst.ts
@@ -58,6 +58,15 @@ const asyncPreHandler = async (request: FastifyRequest) => {
 
 fastify().get('/', { preHandler: asyncPreHandler }, async () => 'this is an example')
 
+fastify().route({
+  method: 'GET',
+  url: '/',
+  onRequest: async function () {
+    expect(this).type.toBe<FastifyInstance>()
+  },
+  handler: async () => 'ok'
+})
+
 fastify().get(
   '/',
   { config: { foo: 'bar', bar: 100, includeMessage: true } },

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -46,7 +46,9 @@ export interface RouteConstraint {
 /**
  * Route shorthand options for the various shorthand methods
  */
-type RouteShorthandHook<T extends (...args: any) => any> = (...args: Parameters<T>) => void | Promise<unknown>
+type RouteShorthandHook<T extends (this: any, ...args: any) => any> = T extends (this: infer C, ...args: infer A) => any
+  ? (this: C, ...args: A) => void | Promise<unknown>
+  : never
 
 export interface RouteShorthandOptions<
   RawServer extends RawServerBase = RawServerDefault,


### PR DESCRIPTION
PR #6514 wrapped route shorthand hooks in a `RouteShorthandHook<T>` helper to widen their return type, but the helper only forwarded `Parameters<T>` and dropped the `this` parameter, so `this` inside `onRequest`, `preHandler`, and the other shorthand hooks resolved as the route options object instead of `FastifyInstance`. This makes the helper infer and reattach the hook's own `this` type instead of discarding it.

Closes #6974