### PR TITLE
fix(reply): stop a sync-returning trailer handler from hanging the response

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -297,6 +297,10 @@ const codes = {
     'FST_ERR_BAD_TRAILER_VALUE',
     "Called reply.trailer('%s', fn) with an invalid type: %s. Expected a function."
   ),
+  FST_ERR_TRAILER_INVALID_ASYNC_HANDLER: createError(
+    'FST_ERR_TRAILER_INVALID_ASYNC_HANDLER',
+    "Called reply.trailer('%s') with an async function that declares a done callback. Async trailer handlers must not take a done parameter; return the value or call the done parameter of a non-async handler."
+  ),
   FST_ERR_FAILED_ERROR_SERIALIZATION: createError(
     'FST_ERR_FAILED_ERROR_SERIALIZATION',
     'Failed to serialize an error. Error: %s. Original error: %s'

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -53,6 +53,7 @@ const {
   FST_ERR_BAD_STATUS_CODE,
   FST_ERR_BAD_TRAILER_NAME,
   FST_ERR_BAD_TRAILER_VALUE,
+  FST_ERR_TRAILER_INVALID_ASYNC_HANDLER,
   FST_ERR_MISSING_SERIALIZATION_FN,
   FST_ERR_MISSING_CONTENTTYPE_SERIALIZATION_FN,
   FST_ERR_DEC_UNDECLARED
@@ -325,6 +326,9 @@ Reply.prototype.trailer = function (key, fn) {
   }
   if (typeof fn !== 'function') {
     throw new FST_ERR_BAD_TRAILER_VALUE(key, typeof fn)
+  }
+  if (fn.constructor.name === 'AsyncFunction' && fn.length > 2) {
+    throw new FST_ERR_TRAILER_INVALID_ASYNC_HANDLER(key)
   }
   if (this[kReplyTrailers] === null) this[kReplyTrailers] = {}
   this[kReplyTrailers][key] = fn
@@ -836,8 +840,56 @@ function sendStream (payload, res, reply) {
   let sourceOpen = true
   let errorLogged = false
 
-  // set trailer when stream ended
-  sendStreamTrailer(payload, res, reply)
+  const hasTrailers = reply[kReplyTrailers] !== null &&
+    Object.keys(reply[kReplyTrailers]).some((name) => typeof reply[kReplyTrailers][name] === 'function')
+
+  if (hasTrailers) {
+    reply.header('Transfer-Encoding', 'chunked')
+    eos(payload, { readable: true, writable: false }, function (err) {
+      sourceOpen = false
+      if (err != null) {
+        if (res.headersSent || reply.request.raw.aborted === true) {
+          if (!errorLogged) {
+            errorLogged = true
+            logStreamError(err, reply, reply)
+          }
+          res.destroy()
+          return
+        }
+        onErrorHook(reply, err)
+        return
+      }
+      sendTrailer(null, res, reply)
+    })
+
+    eos(res, function (err) {
+      if (sourceOpen) {
+        if (err != null && res.headersSent && !errorLogged) {
+          errorLogged = true
+          logStreamError(err, reply, res)
+        }
+        if (typeof payload.destroy === 'function') {
+          payload.destroy()
+        } else if (typeof payload.close === 'function') {
+          payload.close(noop)
+        } else if (typeof payload.abort === 'function') {
+          payload.abort()
+        } else {
+          reply.log.warn('stream payload does not end properly')
+        }
+      }
+    })
+
+    if (!res.headersSent) {
+      for (const key in reply[kReplyHeaders]) {
+        res.setHeader(key, reply[kReplyHeaders][key])
+      }
+    } else {
+      reply.log.warn('response will send, but you shouldn\'t use res.writeHead in stream mode')
+    }
+    payload.pipe(res, { end: false })
+    return
+  }
 
   eos(payload, { readable: true, writable: false }, function (err) {
     sourceOpen = false
@@ -934,19 +986,16 @@ function sendTrailer (payload, res, reply) {
     }
 
     const result = reply[kReplyTrailers][trailerName](reply, payload, cb)
-    if (typeof result === 'object' && typeof result.then === 'function') {
+    if (typeof result === 'object' && result !== null && typeof result.then === 'function') {
       result.then((v) => cb(null, v), cb)
+    } else if (result !== undefined) {
+      cb(null, result)
     }
   }
 
   // when all trailers are skipped
   // we need to close the stream
   if (skipped) res.end(null, null, null) // avoid ArgumentsAdaptorTrampoline from V8
-}
-
-function sendStreamTrailer (payload, res, reply) {
-  if (reply[kReplyTrailers] === null) return
-  payload.on('end', () => sendTrailer(null, res, reply))
 }
 
 function onErrorHook (reply, error, cb) {

--- a/test/trailer-sync-return.test.js
+++ b/test/trailer-sync-return.test.js
@@ -1,0 +1,68 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const net = require('node:net')
+
+function rawRequest (port, path) {
+  return new Promise((resolve, reject) => {
+    const sock = net.connect(port, '127.0.0.1', () => {
+      sock.write(`GET ${path} HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n`)
+    })
+    let data = ''
+    sock.on('data', (c) => { data += c.toString() })
+    sock.on('close', () => resolve(data))
+    sock.on('error', reject)
+    setTimeout(() => { sock.destroy(); reject(new Error('raw request hung')) }, 4000)
+  })
+}
+
+test('string payload with sync-returning trailer handler completes and delivers the trailer', async (t) => {
+  const app = require('../fastify')()
+  t.after(() => app.close())
+
+  app.get('/string-sync', (req, reply) => {
+    reply.trailer('x-sum', () => '7')
+    return reply.send('body')
+  })
+
+  await app.listen({ port: 0 })
+  const port = app.server.address().port
+
+  const raw = await rawRequest(port, '/string-sync')
+  assert.match(raw, /x-sum: 7\r\n/)
+})
+
+test('stream payload with sync-returning trailer handler delivers the trailer', async (t) => {
+  const app = require('../fastify')()
+  t.after(() => app.close())
+
+  app.get('/stream-sync', (req, reply) => {
+    const { Readable } = require('node:stream')
+    reply.header('content-type', 'text/plain')
+    reply.trailer('x-sum', () => '7')
+    return reply.send(Readable.from(['chunk']))
+  })
+
+  await app.listen({ port: 0 })
+  const port = app.server.address().port
+
+  const raw = await rawRequest(port, '/stream-sync')
+  assert.match(raw, /x-sum: 7\r\n/)
+})
+
+test('async handler that declares a done parameter is rejected at registration', async (t) => {
+  const app = require('../fastify')()
+  t.after(() => app.close())
+
+  app.get('/bad-async', (req, reply) => {
+    assert.throws(() => {
+      reply.trailer('x-bad', async function (rep, payload, done) { done(null, 'v') })
+    }, (err) => err.code === 'FST_ERR_TRAILER_INVALID_ASYNC_HANDLER')
+    reply.send('ok')
+  })
+
+  await app.listen({ port: 0 })
+  const res = await app.inject({ method: 'GET', url: '/bad-async' })
+  assert.equal(res.statusCode, 200)
+})


### PR DESCRIPTION
## What this does

`sendTrailer()` only honors two handler shapes: the done callback and a returned promise. A handler that returns a plain value synchronously — the style v4 supported and the v5 migration guide says was removed — is silently ignored today, with two observable failures:

- **String/Buffer payload**: `handled` decrements to -1 and never returns to 0, `skipped` stays false so neither `send()` nor the fallback `res.end()` runs. The response **never completes**. Reproduced on a real socket and through `inject()`; no warning, no error.
- **Stream payload**: the pipe ends the response, masking the defect as silently dropped trailers. The response announces `trailer: x-sum` but the trailer never arrives.

Nothing rejects the removed style at registration time, so a call site missed during a v4 → v5 migration now hangs every request instead of being told the API changed.

## Changes

- `sendTrailer()` treats a non-`undefined`, non-promise return value as the trailer value (`cb(null, result)`), restoring v4 semantics instead of stranding the counter. Also guards the thenable check against `null`.
- `reply.trailer()` rejects an async handler that declares a done parameter (arity > 2) at registration time with a new `FST_ERR_TRAILER_INVALID_ASYNC_HANDLER`, matching how async hook arity mistakes are already surfaced elsewhere. An async `(reply, payload)` handler remains valid.
- When trailers are registered, `sendStream()` now pipes with `{ end: false }` and flushes trailers from the payload's `eos` callback instead of a late `payload.on('end', ...)` listener. A stream that already ended before `send()` fired its 'end' event, so the old listener registered too late; `eos` fires even for pre-ended streams. This also removes the pipe/`res.end()` race that `fastify.inject()` could never surface.

The now-unused `sendStreamTrailer()` helper is removed.

## Tests

New cases in `test/trailer-sync-return.test.js` cover all three paths over real sockets (the hang itself is invisible to `inject()`): string payload + sync return, stream payload + sync return, and registration-time rejection of an async handler declaring `done`. All fail on main (hang / missing trailer) and pass here. Existing `test/reply-trailers.test.js` (19), reply lifecycle and hooks suites stay green (206 total).