### PR TITLE
feat: add lazySchemaCompilation option to defer validator and serializer compilation to the first request

### DIFF
--- a/build/build-validation.js
+++ b/build/build-validation.js
@@ -37,6 +37,7 @@ const defaultInitOptions = {
   http2SessionTimeout: 72000, // 72 seconds
   exposeHeadRoutes: true,
   allowErrorHandlerOverride: false,
+  lazySchemaCompilation: false,
   routerOptions: {
     allowUnsafeRegex: false,
     caseSensitive: true,
@@ -96,6 +97,7 @@ const schema = {
     requestIdHeader: { anyOf: [{ type: 'boolean' }, { type: 'string' }], default: defaultInitOptions.requestIdHeader },
     http2SessionTimeout: { type: 'integer', default: defaultInitOptions.http2SessionTimeout },
     exposeHeadRoutes: { type: 'boolean', default: defaultInitOptions.exposeHeadRoutes },
+    lazySchemaCompilation: { type: 'boolean', default: defaultInitOptions.lazySchemaCompilation },
     routerOptions: {
       type: 'object',
       additionalProperties: false,

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -29,6 +29,7 @@ describes the properties available in that options object.
   - [`trustProxy`](#trustproxy)
   - [`pluginTimeout`](#plugintimeout)
   - [`exposeHeadRoutes`](#exposeheadroutes)
+  - [`lazySchemaCompilation`](#lazyschemacompilation)
   - [`return503OnClosing`](#return503onclosing)
   - [`ajv`](#ajv)
   - [`serializerOpts`](#serializeropts)
@@ -659,6 +660,55 @@ const fastify = require('fastify')({
 Automatically creates a sibling `HEAD` route for each `GET` route defined. If
 you want a custom `HEAD` handler without disabling this option, make sure to
 define it before the `GET` route.
+
+### `lazySchemaCompilation`
+<a id="lazySchemaCompilation"></a>
+
++ Default: `false`
+
+By default Fastify compiles the validation functions (`body`, `querystring`,
+`params`, `headers`) and the response serializers of every route with a
+`schema` while the route is registered, so all the compilation work happens
+before [`ready`](#ready) resolves. The generated functions are kept for the
+whole life of the process, whether the route is ever hit or not.
+
+When set to `true`, the compilation of each route is deferred to the first
+request that reaches that route: validators and serializers are compiled right
+before the validation step of that request (or earlier, if a hook calls
+[`request.getValidationFunction`](./Request.md) or
+[`reply.getSerializationFunction`](./Reply.md#getserializationfunction) before
+it). Once compiled, the functions are cached on the route exactly as in the
+default mode, so only the first request of each route pays the compilation
+cost. Routes that are never hit are never compiled.
+
+This lowers startup time and memory for applications that register many routes
+with schemas and use only a subset of them per process (for example generated
+CRUD APIs, or API gateways that proxy a large OpenAPI document). The trade-off
+is that a schema which cannot be compiled is no longer reported by `ready()`:
+the error (`FST_ERR_SCH_VALIDATION_BUILD` or `FST_ERR_SCH_SERIALIZATION_BUILD`)
+is raised by the first request of that route, which then fails with a 500.
+Keep the default in development or in test suites, where failing fast on a
+broken schema is more valuable than the startup time.
+
+```js
+const fastify = Fastify({ lazySchemaCompilation: true })
+
+fastify.get('/items/:id', {
+  schema: {
+    params: { type: 'object', properties: { id: { type: 'integer' } } },
+    response: { 200: { type: 'object', properties: { id: { type: 'integer' } } } }
+  }
+}, async (request) => ({ id: request.params.id }))
+
+await fastify.ready() // no validator or serializer compiled yet
+await fastify.inject('/items/1') // compiles validators and serializers of this route, then caches them
+```
+
+The option applies to the default compilers and to compilers set with
+[`setValidatorCompiler`](#setvalidatorcompiler),
+[`setSerializerCompiler`](#setserializercompiler) or the route level
+`validatorCompiler` / `serializerCompiler` options alike: the compiler is
+simply invoked later.
 
 ### `return503OnClosing`
 <a id="factory-return-503-on-closing"></a>

--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -200,6 +200,11 @@ declare namespace fastify {
     clientErrorHandler?: (error: ConnectionError, socket: Socket) => void,
     childLoggerFactory?: FastifyChildLoggerFactory,
     allowErrorHandlerOverride?: boolean
+    /**
+     * Defer the compilation of route validators and serializers to the first request that needs them.
+     * Reduces startup time and memory for applications with many routes; schema errors surface at first request.
+     */
+    lazySchemaCompilation?: boolean
     routerOptions?: FastifyRouterOptions<RawServer>,
   }
 

--- a/fastify.js
+++ b/fastify.js
@@ -905,6 +905,7 @@ function processOptions (options, defaultRoute, onBadUrl, onMaxParamLength) {
   options.ajv = ajvOptions
   options.clientErrorHandler = options.clientErrorHandler || defaultClientErrorHandler
   options.allowErrorHandlerOverride = options.allowErrorHandlerOverride ?? defaultInitOptions.allowErrorHandlerOverride
+  options.lazySchemaCompilation = options.lazySchemaCompilation ?? defaultInitOptions.lazySchemaCompilation
 
   options.routerOptions = buildRouterOptions(options, {
     buildPrettyMeta: defaultBuildPrettyMeta,

--- a/fastify.js
+++ b/fastify.js
@@ -918,6 +918,9 @@ function processOptions (options, defaultRoute, onBadUrl, onMaxParamLength) {
 
   // exposeHeadRoutes have its default set from the validator
   options.exposeHeadRoutes = initialConfig.exposeHeadRoutes
+  // lazySchemaCompilation is read from the validated config so that coercible
+  // values ('true', 1) behave like the boolean they were validated into
+  options.lazySchemaCompilation = initialConfig.lazySchemaCompilation
 
   // we need to set this before calling createServer
   options.http2SessionTimeout = initialConfig.http2SessionTimeout

--- a/lib/config-validator.js
+++ b/lib/config-validator.js
@@ -3,7 +3,7 @@
 "use strict";
 module.exports = validate10;
 module.exports.default = validate10;
-const schema11 = {"type":"object","additionalProperties":false,"properties":{"connectionTimeout":{"type":"integer","default":0},"keepAliveTimeout":{"type":"integer","default":72000},"forceCloseConnections":{"oneOf":[{"type":"string","pattern":"idle"},{"type":"boolean"}]},"maxRequestsPerSocket":{"type":"integer","default":0,"nullable":true},"requestTimeout":{"type":"integer","default":0},"handlerTimeout":{"type":"integer","default":0},"bodyLimit":{"type":"integer","default":1048576},"http2":{"type":"boolean"},"https":{"if":{"not":{"oneOf":[{"type":"boolean"},{"type":"null"},{"type":"object","additionalProperties":false,"required":["allowHTTP1"],"properties":{"allowHTTP1":{"type":"boolean"}}}]}},"then":{"setDefaultValue":true}},"ignoreTrailingSlash":{"type":"boolean"},"ignoreDuplicateSlashes":{"type":"boolean"},"onProtoPoisoning":{"type":"string","default":"error"},"onConstructorPoisoning":{"type":"string","default":"error"},"pluginTimeout":{"type":"integer","default":10000},"requestIdHeader":{"anyOf":[{"type":"boolean"},{"type":"string"}],"default":false},"http2SessionTimeout":{"type":"integer","default":72000},"exposeHeadRoutes":{"type":"boolean","default":true},"routerOptions":{"type":"object","additionalProperties":false,"properties":{"allowUnsafeRegex":{"type":"boolean","default":false},"caseSensitive":{"type":"boolean","default":true},"constraints":{"type":"object","additionalProperties":{"type":"object","required":["name","storage","validate","deriveConstraint"],"additionalProperties":true,"properties":{"name":{"type":"string"},"storage":{},"validate":{},"deriveConstraint":{}}}},"ignoreTrailingSlash":{"type":"boolean","default":false},"ignoreDuplicateSlashes":{"type":"boolean","default":false},"maxParamLength":{"type":"integer","default":100},"useSemicolonDelimiter":{"type":"boolean","default":false}}}}};
+const schema11 = {"type":"object","additionalProperties":false,"properties":{"connectionTimeout":{"type":"integer","default":0},"keepAliveTimeout":{"type":"integer","default":72000},"forceCloseConnections":{"oneOf":[{"type":"string","pattern":"idle"},{"type":"boolean"}]},"maxRequestsPerSocket":{"type":"integer","default":0,"nullable":true},"requestTimeout":{"type":"integer","default":0},"handlerTimeout":{"type":"integer","default":0},"bodyLimit":{"type":"integer","default":1048576},"http2":{"type":"boolean"},"https":{"if":{"not":{"oneOf":[{"type":"boolean"},{"type":"null"},{"type":"object","additionalProperties":false,"required":["allowHTTP1"],"properties":{"allowHTTP1":{"type":"boolean"}}}]}},"then":{"setDefaultValue":true}},"ignoreTrailingSlash":{"type":"boolean"},"ignoreDuplicateSlashes":{"type":"boolean"},"onProtoPoisoning":{"type":"string","default":"error"},"onConstructorPoisoning":{"type":"string","default":"error"},"pluginTimeout":{"type":"integer","default":10000},"requestIdHeader":{"anyOf":[{"type":"boolean"},{"type":"string"}],"default":false},"http2SessionTimeout":{"type":"integer","default":72000},"exposeHeadRoutes":{"type":"boolean","default":true},"lazySchemaCompilation":{"type":"boolean","default":false},"routerOptions":{"type":"object","additionalProperties":false,"properties":{"allowUnsafeRegex":{"type":"boolean","default":false},"caseSensitive":{"type":"boolean","default":true},"constraints":{"type":"object","additionalProperties":{"type":"object","required":["name","storage","validate","deriveConstraint"],"additionalProperties":true,"properties":{"name":{"type":"string"},"storage":{},"validate":{},"deriveConstraint":{}}}},"ignoreTrailingSlash":{"type":"boolean","default":false},"ignoreDuplicateSlashes":{"type":"boolean","default":false},"maxParamLength":{"type":"integer","default":100},"useSemicolonDelimiter":{"type":"boolean","default":false}}}}};
 const func2 = Object.prototype.hasOwnProperty;
 const pattern0 = new RegExp("idle", "u");
 
@@ -47,6 +47,9 @@ data.http2SessionTimeout = 72000;
 }
 if(data.exposeHeadRoutes === undefined){
 data.exposeHeadRoutes = true;
+}
+if(data.lazySchemaCompilation === undefined){
+data.lazySchemaCompilation = false;
 }
 const _errs1 = errors;
 for(const key0 in data){
@@ -865,62 +868,62 @@ data["exposeHeadRoutes"] = coerced20;
 }
 var valid0 = _errs57 === errors;
 if(valid0){
-if(data.routerOptions !== undefined){
-let data18 = data.routerOptions;
+let data18 = data.lazySchemaCompilation;
 const _errs59 = errors;
-if(errors === _errs59){
-if(data18 && typeof data18 == "object" && !Array.isArray(data18)){
-if(data18.allowUnsafeRegex === undefined){
-data18.allowUnsafeRegex = false;
-}
-if(data18.caseSensitive === undefined){
-data18.caseSensitive = true;
-}
-if(data18.ignoreTrailingSlash === undefined){
-data18.ignoreTrailingSlash = false;
-}
-if(data18.ignoreDuplicateSlashes === undefined){
-data18.ignoreDuplicateSlashes = false;
-}
-if(data18.maxParamLength === undefined){
-data18.maxParamLength = 100;
-}
-if(data18.useSemicolonDelimiter === undefined){
-data18.useSemicolonDelimiter = false;
-}
-const _errs61 = errors;
-for(const key2 in data18){
-if(!(((((((key2 === "allowUnsafeRegex") || (key2 === "caseSensitive")) || (key2 === "constraints")) || (key2 === "ignoreTrailingSlash")) || (key2 === "ignoreDuplicateSlashes")) || (key2 === "maxParamLength")) || (key2 === "useSemicolonDelimiter"))){
-delete data18[key2];
-}
-}
-if(_errs61 === errors){
-let data19 = data18.allowUnsafeRegex;
-const _errs62 = errors;
-if(typeof data19 !== "boolean"){
+if(typeof data18 !== "boolean"){
 let coerced21 = undefined;
 if(!(coerced21 !== undefined)){
-if(data19 === "false" || data19 === 0 || data19 === null){
+if(data18 === "false" || data18 === 0 || data18 === null){
 coerced21 = false;
 }
-else if(data19 === "true" || data19 === 1){
+else if(data18 === "true" || data18 === 1){
 coerced21 = true;
 }
 else {
-validate10.errors = [{instancePath:instancePath+"/routerOptions/allowUnsafeRegex",schemaPath:"#/properties/routerOptions/properties/allowUnsafeRegex/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
+validate10.errors = [{instancePath:instancePath+"/lazySchemaCompilation",schemaPath:"#/properties/lazySchemaCompilation/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
 return false;
 }
 }
 if(coerced21 !== undefined){
-data19 = coerced21;
-if(data18 !== undefined){
-data18["allowUnsafeRegex"] = coerced21;
+data18 = coerced21;
+if(data !== undefined){
+data["lazySchemaCompilation"] = coerced21;
 }
 }
 }
-var valid7 = _errs62 === errors;
-if(valid7){
-let data20 = data18.caseSensitive;
+var valid0 = _errs59 === errors;
+if(valid0){
+if(data.routerOptions !== undefined){
+let data19 = data.routerOptions;
+const _errs61 = errors;
+if(errors === _errs61){
+if(data19 && typeof data19 == "object" && !Array.isArray(data19)){
+if(data19.allowUnsafeRegex === undefined){
+data19.allowUnsafeRegex = false;
+}
+if(data19.caseSensitive === undefined){
+data19.caseSensitive = true;
+}
+if(data19.ignoreTrailingSlash === undefined){
+data19.ignoreTrailingSlash = false;
+}
+if(data19.ignoreDuplicateSlashes === undefined){
+data19.ignoreDuplicateSlashes = false;
+}
+if(data19.maxParamLength === undefined){
+data19.maxParamLength = 100;
+}
+if(data19.useSemicolonDelimiter === undefined){
+data19.useSemicolonDelimiter = false;
+}
+const _errs63 = errors;
+for(const key2 in data19){
+if(!(((((((key2 === "allowUnsafeRegex") || (key2 === "caseSensitive")) || (key2 === "constraints")) || (key2 === "ignoreTrailingSlash")) || (key2 === "ignoreDuplicateSlashes")) || (key2 === "maxParamLength")) || (key2 === "useSemicolonDelimiter"))){
+delete data19[key2];
+}
+}
+if(_errs63 === errors){
+let data20 = data19.allowUnsafeRegex;
 const _errs64 = errors;
 if(typeof data20 !== "boolean"){
 let coerced22 = undefined;
@@ -932,56 +935,81 @@ else if(data20 === "true" || data20 === 1){
 coerced22 = true;
 }
 else {
-validate10.errors = [{instancePath:instancePath+"/routerOptions/caseSensitive",schemaPath:"#/properties/routerOptions/properties/caseSensitive/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
+validate10.errors = [{instancePath:instancePath+"/routerOptions/allowUnsafeRegex",schemaPath:"#/properties/routerOptions/properties/allowUnsafeRegex/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
 return false;
 }
 }
 if(coerced22 !== undefined){
 data20 = coerced22;
-if(data18 !== undefined){
-data18["caseSensitive"] = coerced22;
+if(data19 !== undefined){
+data19["allowUnsafeRegex"] = coerced22;
 }
 }
 }
 var valid7 = _errs64 === errors;
 if(valid7){
-if(data18.constraints !== undefined){
-let data21 = data18.constraints;
+let data21 = data19.caseSensitive;
 const _errs66 = errors;
-if(errors === _errs66){
-if(data21 && typeof data21 == "object" && !Array.isArray(data21)){
-for(const key3 in data21){
-let data22 = data21[key3];
-const _errs69 = errors;
-if(errors === _errs69){
+if(typeof data21 !== "boolean"){
+let coerced23 = undefined;
+if(!(coerced23 !== undefined)){
+if(data21 === "false" || data21 === 0 || data21 === null){
+coerced23 = false;
+}
+else if(data21 === "true" || data21 === 1){
+coerced23 = true;
+}
+else {
+validate10.errors = [{instancePath:instancePath+"/routerOptions/caseSensitive",schemaPath:"#/properties/routerOptions/properties/caseSensitive/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
+return false;
+}
+}
+if(coerced23 !== undefined){
+data21 = coerced23;
+if(data19 !== undefined){
+data19["caseSensitive"] = coerced23;
+}
+}
+}
+var valid7 = _errs66 === errors;
+if(valid7){
+if(data19.constraints !== undefined){
+let data22 = data19.constraints;
+const _errs68 = errors;
+if(errors === _errs68){
 if(data22 && typeof data22 == "object" && !Array.isArray(data22)){
+for(const key3 in data22){
+let data23 = data22[key3];
+const _errs71 = errors;
+if(errors === _errs71){
+if(data23 && typeof data23 == "object" && !Array.isArray(data23)){
 let missing1;
-if(((((data22.name === undefined) && (missing1 = "name")) || ((data22.storage === undefined) && (missing1 = "storage"))) || ((data22.validate === undefined) && (missing1 = "validate"))) || ((data22.deriveConstraint === undefined) && (missing1 = "deriveConstraint"))){
+if(((((data23.name === undefined) && (missing1 = "name")) || ((data23.storage === undefined) && (missing1 = "storage"))) || ((data23.validate === undefined) && (missing1 = "validate"))) || ((data23.deriveConstraint === undefined) && (missing1 = "deriveConstraint"))){
 validate10.errors = [{instancePath:instancePath+"/routerOptions/constraints/" + key3.replace(/~/g, "~0").replace(/\//g, "~1"),schemaPath:"#/properties/routerOptions/properties/constraints/additionalProperties/required",keyword:"required",params:{missingProperty: missing1},message:"must have required property '"+missing1+"'"}];
 return false;
 }
 else {
-if(data22.name !== undefined){
-let data23 = data22.name;
-if(typeof data23 !== "string"){
-let dataType23 = typeof data23;
-let coerced23 = undefined;
-if(!(coerced23 !== undefined)){
-if(dataType23 == "number" || dataType23 == "boolean"){
-coerced23 = "" + data23;
+if(data23.name !== undefined){
+let data24 = data23.name;
+if(typeof data24 !== "string"){
+let dataType24 = typeof data24;
+let coerced24 = undefined;
+if(!(coerced24 !== undefined)){
+if(dataType24 == "number" || dataType24 == "boolean"){
+coerced24 = "" + data24;
 }
-else if(data23 === null){
-coerced23 = "";
+else if(data24 === null){
+coerced24 = "";
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/routerOptions/constraints/" + key3.replace(/~/g, "~0").replace(/\//g, "~1")+"/name",schemaPath:"#/properties/routerOptions/properties/constraints/additionalProperties/properties/name/type",keyword:"type",params:{type: "string"},message:"must be string"}];
 return false;
 }
 }
-if(coerced23 !== undefined){
-data23 = coerced23;
-if(data22 !== undefined){
-data22["name"] = coerced23;
+if(coerced24 !== undefined){
+data24 = coerced24;
+if(data23 !== undefined){
+data23["name"] = coerced24;
 }
 }
 }
@@ -993,7 +1021,7 @@ validate10.errors = [{instancePath:instancePath+"/routerOptions/constraints/" + 
 return false;
 }
 }
-var valid8 = _errs69 === errors;
+var valid8 = _errs71 === errors;
 if(!valid8){
 break;
 }
@@ -1004,38 +1032,13 @@ validate10.errors = [{instancePath:instancePath+"/routerOptions/constraints",sch
 return false;
 }
 }
-var valid7 = _errs66 === errors;
+var valid7 = _errs68 === errors;
 }
 else {
 var valid7 = true;
 }
 if(valid7){
-let data24 = data18.ignoreTrailingSlash;
-const _errs74 = errors;
-if(typeof data24 !== "boolean"){
-let coerced24 = undefined;
-if(!(coerced24 !== undefined)){
-if(data24 === "false" || data24 === 0 || data24 === null){
-coerced24 = false;
-}
-else if(data24 === "true" || data24 === 1){
-coerced24 = true;
-}
-else {
-validate10.errors = [{instancePath:instancePath+"/routerOptions/ignoreTrailingSlash",schemaPath:"#/properties/routerOptions/properties/ignoreTrailingSlash/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
-return false;
-}
-}
-if(coerced24 !== undefined){
-data24 = coerced24;
-if(data18 !== undefined){
-data18["ignoreTrailingSlash"] = coerced24;
-}
-}
-}
-var valid7 = _errs74 === errors;
-if(valid7){
-let data25 = data18.ignoreDuplicateSlashes;
+let data25 = data19.ignoreTrailingSlash;
 const _errs76 = errors;
 if(typeof data25 !== "boolean"){
 let coerced25 = undefined;
@@ -1047,67 +1050,92 @@ else if(data25 === "true" || data25 === 1){
 coerced25 = true;
 }
 else {
-validate10.errors = [{instancePath:instancePath+"/routerOptions/ignoreDuplicateSlashes",schemaPath:"#/properties/routerOptions/properties/ignoreDuplicateSlashes/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
+validate10.errors = [{instancePath:instancePath+"/routerOptions/ignoreTrailingSlash",schemaPath:"#/properties/routerOptions/properties/ignoreTrailingSlash/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
 return false;
 }
 }
 if(coerced25 !== undefined){
 data25 = coerced25;
-if(data18 !== undefined){
-data18["ignoreDuplicateSlashes"] = coerced25;
+if(data19 !== undefined){
+data19["ignoreTrailingSlash"] = coerced25;
 }
 }
 }
 var valid7 = _errs76 === errors;
 if(valid7){
-let data26 = data18.maxParamLength;
+let data26 = data19.ignoreDuplicateSlashes;
 const _errs78 = errors;
-if(!(((typeof data26 == "number") && (!(data26 % 1) && !isNaN(data26))) && (isFinite(data26)))){
-let dataType26 = typeof data26;
+if(typeof data26 !== "boolean"){
 let coerced26 = undefined;
 if(!(coerced26 !== undefined)){
-if(dataType26 === "boolean" || data26 === null
-              || (dataType26 === "string" && data26 && data26 == +data26 && !(data26 % 1))){
-coerced26 = +data26;
+if(data26 === "false" || data26 === 0 || data26 === null){
+coerced26 = false;
+}
+else if(data26 === "true" || data26 === 1){
+coerced26 = true;
+}
+else {
+validate10.errors = [{instancePath:instancePath+"/routerOptions/ignoreDuplicateSlashes",schemaPath:"#/properties/routerOptions/properties/ignoreDuplicateSlashes/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
+return false;
+}
+}
+if(coerced26 !== undefined){
+data26 = coerced26;
+if(data19 !== undefined){
+data19["ignoreDuplicateSlashes"] = coerced26;
+}
+}
+}
+var valid7 = _errs78 === errors;
+if(valid7){
+let data27 = data19.maxParamLength;
+const _errs80 = errors;
+if(!(((typeof data27 == "number") && (!(data27 % 1) && !isNaN(data27))) && (isFinite(data27)))){
+let dataType27 = typeof data27;
+let coerced27 = undefined;
+if(!(coerced27 !== undefined)){
+if(dataType27 === "boolean" || data27 === null
+              || (dataType27 === "string" && data27 && data27 == +data27 && !(data27 % 1))){
+coerced27 = +data27;
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/routerOptions/maxParamLength",schemaPath:"#/properties/routerOptions/properties/maxParamLength/type",keyword:"type",params:{type: "integer"},message:"must be integer"}];
 return false;
 }
 }
-if(coerced26 !== undefined){
-data26 = coerced26;
-if(data18 !== undefined){
-data18["maxParamLength"] = coerced26;
+if(coerced27 !== undefined){
+data27 = coerced27;
+if(data19 !== undefined){
+data19["maxParamLength"] = coerced27;
 }
 }
 }
-var valid7 = _errs78 === errors;
+var valid7 = _errs80 === errors;
 if(valid7){
-let data27 = data18.useSemicolonDelimiter;
-const _errs80 = errors;
-if(typeof data27 !== "boolean"){
-let coerced27 = undefined;
-if(!(coerced27 !== undefined)){
-if(data27 === "false" || data27 === 0 || data27 === null){
-coerced27 = false;
+let data28 = data19.useSemicolonDelimiter;
+const _errs82 = errors;
+if(typeof data28 !== "boolean"){
+let coerced28 = undefined;
+if(!(coerced28 !== undefined)){
+if(data28 === "false" || data28 === 0 || data28 === null){
+coerced28 = false;
 }
-else if(data27 === "true" || data27 === 1){
-coerced27 = true;
+else if(data28 === "true" || data28 === 1){
+coerced28 = true;
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/routerOptions/useSemicolonDelimiter",schemaPath:"#/properties/routerOptions/properties/useSemicolonDelimiter/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
 return false;
 }
 }
-if(coerced27 !== undefined){
-data27 = coerced27;
-if(data18 !== undefined){
-data18["useSemicolonDelimiter"] = coerced27;
+if(coerced28 !== undefined){
+data28 = coerced28;
+if(data19 !== undefined){
+data19["useSemicolonDelimiter"] = coerced28;
 }
 }
 }
-var valid7 = _errs80 === errors;
+var valid7 = _errs82 === errors;
 }
 }
 }
@@ -1121,10 +1149,11 @@ validate10.errors = [{instancePath:instancePath+"/routerOptions",schemaPath:"#/p
 return false;
 }
 }
-var valid0 = _errs59 === errors;
+var valid0 = _errs61 === errors;
 }
 else {
 var valid0 = true;
+}
 }
 }
 }
@@ -1155,5 +1184,5 @@ return errors === 0;
 }
 
 
-module.exports.defaultInitOptions = {"connectionTimeout":0,"keepAliveTimeout":72000,"maxRequestsPerSocket":0,"requestTimeout":0,"handlerTimeout":0,"bodyLimit":1048576,"onProtoPoisoning":"error","onConstructorPoisoning":"error","pluginTimeout":10000,"requestIdHeader":false,"http2SessionTimeout":72000,"exposeHeadRoutes":true,"allowErrorHandlerOverride":false,"routerOptions":{"allowUnsafeRegex":false,"caseSensitive":true,"ignoreTrailingSlash":false,"ignoreDuplicateSlashes":false,"maxParamLength":100,"useSemicolonDelimiter":false}}
+module.exports.defaultInitOptions = {"connectionTimeout":0,"keepAliveTimeout":72000,"maxRequestsPerSocket":0,"requestTimeout":0,"handlerTimeout":0,"bodyLimit":1048576,"onProtoPoisoning":"error","onConstructorPoisoning":"error","pluginTimeout":10000,"requestIdHeader":false,"http2SessionTimeout":72000,"exposeHeadRoutes":true,"allowErrorHandlerOverride":false,"lazySchemaCompilation":false,"routerOptions":{"allowUnsafeRegex":false,"caseSensitive":true,"ignoreTrailingSlash":false,"ignoreDuplicateSlashes":false,"maxParamLength":100,"useSemicolonDelimiter":false}}
 /* c8 ignore stop */

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -9,7 +9,8 @@ const {
   kReplyIsRunningOnErrorHook,
   kRouteContext,
   kLogController,
-  kDiagnosticsStore
+  kDiagnosticsStore,
+  kSchemaBuildError
 } = require('./symbols.js')
 
 const {
@@ -109,7 +110,13 @@ function fallbackErrorHandler (error, reply, cb) {
     reply.server[kLogController].serializerError(err, reply.request, reply, { statusCode: res.statusCode })
 
     reply.code(500)
-    payload = serializeError(new FST_ERR_FAILED_ERROR_SERIALIZATION(err.message, error.message))
+    if (err[kSchemaBuildError] === true) {
+      // A response schema that could not be compiled on demand (`lazySchemaCompilation`)
+      // is reported with the same payload every request of the route gets.
+      payload = serializeError({ error: statusCodes['500'], code: err.code, message: err.message, statusCode: 500 })
+    } else {
+      payload = serializeError(new FST_ERR_FAILED_ERROR_SERIALIZATION(err.message, error.message))
+    }
   }
 
   if (typeof payload !== 'string' && !Buffer.isBuffer(payload)) {

--- a/lib/handle-request.js
+++ b/lib/handle-request.js
@@ -16,7 +16,8 @@ const {
   kFourOhFourContext,
   kSupportedHTTPMethods,
   kRequestContentType,
-  kDiagnosticsStore
+  kDiagnosticsStore,
+  kSchemaBuildError
 } = require('./symbols')
 const ContentType = require('./content-type')
 
@@ -138,7 +139,9 @@ function preValidationCallback (err, request, reply) {
 
 function validationCompleted (request, reply, validationErr) {
   if (validationErr) {
-    if (reply[kRouteContext].attachValidation === false) {
+    // A schema that could not be compiled (`lazySchemaCompilation`) is not a
+    // validation error of the request: it always fails the request.
+    if (reply[kRouteContext].attachValidation === false || validationErr[kSchemaBuildError] === true) {
       reply.send(validationErr)
       return
     }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -26,6 +26,7 @@ const {
   kRequestSignal,
   kLogController
 } = require('./symbols.js')
+const { resolveLazySerialization } = require('./validation')
 const {
   onSendHookRunner,
   onResponseHookRunner,
@@ -356,6 +357,7 @@ Reply.prototype.status = Reply.prototype.code
 
 Reply.prototype.getSerializationFunction = function (schemaOrStatus, contentType) {
   let serialize
+  resolveLazySerialization(this[kRouteContext])
 
   if (typeof schemaOrStatus === 'string' || typeof schemaOrStatus === 'number') {
     if (typeof contentType === 'string') {
@@ -422,6 +424,7 @@ Reply.prototype.serializeInput = function (input, schema, httpStatus, contentTyp
     : contentType
 
   if (httpStatus != null) {
+    resolveLazySerialization(this[kRouteContext])
     if (contentType != null) {
       serialize = this[kRouteContext][kSchemaResponse]?.[httpStatus]?.[contentType]
     } else {

--- a/lib/request.js
+++ b/lib/request.js
@@ -16,6 +16,7 @@ const {
   kRequestSignal,
   kOnAbort
 } = require('./symbols')
+const { resolveLazyValidation } = require('./validation')
 const { FST_ERR_REQ_INVALID_VALIDATION_INVOCATION, FST_ERR_DEC_UNDECLARED } = require('./errors')
 const decorators = require('./decorate')
 const ContentType = require('./content-type')
@@ -296,6 +297,7 @@ Object.defineProperties(Request.prototype, {
   getValidationFunction: {
     value: function (httpPartOrSchema) {
       if (typeof httpPartOrSchema === 'string') {
+        resolveLazyValidation(this[kRouteContext])
         const symbol = HTTP_PART_SYMBOL_MAP[httpPartOrSchema]
         return this[kRouteContext][symbol]
       } else if (typeof httpPartOrSchema === 'object') {
@@ -350,6 +352,7 @@ Object.defineProperties(Request.prototype, {
 
       if (symbol) {
         // Validate using the HTTP Request Part schema
+        resolveLazyValidation(this[kRouteContext])
         validate = this[kRouteContext][symbol]
       }
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -426,7 +426,8 @@ function buildRouting (options) {
               compileSchemasForValidation(
                 context,
                 opts.validatorCompiler || schemaController.validatorCompiler,
-                isCustom
+                isCustom,
+                this[kOptions].lazySchemaCompilation
               )
             } catch (error) {
               throw new FST_ERR_SCH_VALIDATION_BUILD(opts.method, url, error.message)
@@ -436,7 +437,11 @@ function buildRouting (options) {
               schemaController.setupSerializer(this[kOptions])
             }
             try {
-              compileSchemasForSerialization(context, opts.serializerCompiler || schemaController.serializerCompiler)
+              compileSchemasForSerialization(
+                context,
+                opts.serializerCompiler || schemaController.serializerCompiler,
+                this[kOptions].lazySchemaCompilation
+              )
             } catch (error) {
               throw new FST_ERR_SCH_SERIALIZATION_BUILD(opts.method, url, error.message)
             }

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -2,6 +2,7 @@
 
 const fastClone = require('rfdc')({ circles: false, proto: true })
 const { kSchemaVisited, kSchemaResponse } = require('./symbols')
+const { resolveLazySerialization } = require('./validation')
 const kFluentSchema = Symbol.for('fluent-schema-object')
 
 const {
@@ -146,6 +147,7 @@ function generateFluentSchema (schema) {
  * the reply or false if it is not set
  */
 function getSchemaSerializer (context, statusCode, contentType) {
+  resolveLazySerialization(context)
   const responseSchemaDef = context[kSchemaResponse]
   if (!responseSchemaDef) {
     return false

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -24,6 +24,8 @@ const keys = {
   kSchemaQuerystring: Symbol('querystring-schema'),
   kSchemaBody: Symbol('body-schema'),
   kSchemaResponse: Symbol('response-schema'),
+  kSchemaLazy: Symbol('fastify.schemaLazy'),
+  kSchemaBuildError: Symbol('fastify.schemaBuildError'),
   kSchemaErrorFormatter: Symbol('fastify.schemaErrorFormatter'),
   kSchemaVisited: Symbol('fastify.schemas.visited'),
   // Request

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -512,7 +512,9 @@ function lazySlot (context) {
 
 function runLazyBuild (context, key, ErrorClass) {
   const lazy = context[lazySchema]
-  if (lazy === undefined || lazy[key] === undefined) return
+  if (lazy === undefined) return
+  if (lazy.error !== undefined) throw lazy.error
+  if (lazy[key] === undefined) return
   const build = lazy[key]
   lazy[key] = undefined
   try {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -5,18 +5,27 @@ const {
   kSchemaParams: paramsSchema,
   kSchemaQuerystring: querystringSchema,
   kSchemaBody: bodySchema,
-  kSchemaResponse: responseSchema
+  kSchemaResponse: responseSchema,
+  kSchemaLazy: lazySchema,
+  kSchemaBuildError: buildErrorFlag
 } = require('./symbols')
 const scChecker = /^[1-5](?:\d{2}|xx)$|^default$/
 
 const {
-  FST_ERR_SCH_RESPONSE_SCHEMA_NOT_NESTED_2XX
+  FST_ERR_SCH_RESPONSE_SCHEMA_NOT_NESTED_2XX,
+  FST_ERR_SCH_VALIDATION_BUILD,
+  FST_ERR_SCH_SERIALIZATION_BUILD
 } = require('./errors')
 
 const { FSTWRN001, FSTSEC002 } = require('./warnings')
 
-function compileSchemasForSerialization (context, compile) {
+function compileSchemasForSerialization (context, compile, lazy) {
   if (!context.schema || !context.schema.response) {
+    return
+  }
+  if (lazy === true) {
+    // Defer the code generation to the first request of this route.
+    lazySlot(context).serialization = () => compileSchemasForSerialization(context, compile)
     return
   }
   const { method, url } = context.config || {}
@@ -217,12 +226,21 @@ function findExternalHeaderRef (schema) {
   return undefined
 }
 
-function compileSchemasForValidation (context, compile, isCustom) {
+// A plain-object header schema is case-normalized before compilation. Custom
+// validators (e.g. Joi, TypeBox), boolean schemas (true/false) and invalid
+// values are compiled as they are.
+function isNormalizableHeadersSchema (headers, isCustom) {
+  return !isCustom &&
+    typeof headers === 'object' &&
+    headers !== null &&
+    Object.getPrototypeOf(headers) === Object.prototype
+}
+
+function compileSchemasForValidation (context, compile, isCustom, lazy) {
   const { schema } = context
   if (!schema) {
     return
   }
-
   const { method, url } = context.config || {}
 
   // JSON Schema Draft 7 defines the boolean `false` (and `true`) as a valid
@@ -230,26 +248,49 @@ function compileSchemasForValidation (context, compile, isCustom) {
   // every request-part schema is selected by an explicit `undefined` check
   // rather than truthiness. FSTWRN001 is preserved only for schemas that are
   // explicitly set to `undefined`.
+  for (const part of ['headers', 'body', 'querystring', 'params']) {
+    if (schema[part] === undefined && Object.hasOwn(schema, part)) {
+      FSTWRN001(part, method, url)
+    }
+  }
+
+  if (isNormalizableHeadersSchema(schema.headers, isCustom)) {
+    const externalRef = findExternalHeaderRef(schema.headers)
+    if (externalRef !== undefined) {
+      FSTSEC002(method, url, externalRef)
+    }
+  }
+
+  if (lazy === true) {
+    // The static checks above stay at registration; only the code generation
+    // is deferred to the first request of this route.
+    if (schema.body !== undefined ||
+      schema.headers !== undefined ||
+      schema.querystring !== undefined ||
+      schema.params !== undefined) {
+      lazySlot(context).validation = () => buildValidationFunctions(context, compile, isCustom)
+    }
+    return
+  }
+
+  buildValidationFunctions(context, compile, isCustom)
+}
+
+function buildValidationFunctions (context, compile, isCustom) {
+  const { schema } = context
+  const { method, url } = context.config || {}
 
   const headers = schema.headers
-  // the or part is used for backward compatibility
   if (headers !== undefined) {
-    if (isCustom || typeof headers !== 'object' || headers === null || Object.getPrototypeOf(headers) !== Object.prototype) {
+    if (isNormalizableHeadersSchema(headers, isCustom)) {
+      // The header keys are case insensitive
+      //  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2
+      context[headersSchema] = compile({ schema: lowerCaseHeadersSchema(headers), method, url, httpPart: 'headers' })
+    } else {
       // do not mess with schema when custom validator applied, e.g. Joi, Typebox
       // boolean schemas (true/false) and invalid values are compiled directly
       context[headersSchema] = compile({ schema: headers, method, url, httpPart: 'headers' })
-    } else {
-      // The header keys are case insensitive
-      //  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2
-      const headersSchemaLowerCase = lowerCaseHeadersSchema(headers)
-      const externalRef = findExternalHeaderRef(headers)
-      if (externalRef !== undefined) {
-        FSTSEC002(method, url, externalRef)
-      }
-      context[headersSchema] = compile({ schema: headersSchemaLowerCase, method, url, httpPart: 'headers' })
     }
-  } else if (Object.hasOwn(schema, 'headers')) {
-    FSTWRN001('headers', method, url)
   }
 
   if (schema.body !== undefined) {
@@ -266,20 +307,14 @@ function compileSchemasForValidation (context, compile, isCustom) {
     } else {
       context[bodySchema] = compile({ schema: schema.body, method, url, httpPart: 'body' })
     }
-  } else if (Object.hasOwn(schema, 'body')) {
-    FSTWRN001('body', method, url)
   }
 
   if (schema.querystring !== undefined) {
     context[querystringSchema] = compile({ schema: schema.querystring, method, url, httpPart: 'querystring' })
-  } else if (Object.hasOwn(schema, 'querystring')) {
-    FSTWRN001('querystring', method, url)
   }
 
   if (schema.params !== undefined) {
     context[paramsSchema] = compile({ schema: schema.params, method, url, httpPart: 'params' })
-  } else if (Object.hasOwn(schema, 'params')) {
-    FSTWRN001('params', method, url)
   }
 }
 
@@ -327,6 +362,13 @@ function validateParam (validatorFunction, request, paramName) {
 
 function validate (context, request, execution) {
   const runExecution = execution === undefined
+
+  if (context[lazySchema] !== undefined) {
+    const buildError = resolveLazySchemas(context)
+    if (buildError !== undefined) {
+      return buildError
+    }
+  }
 
   if (runExecution &&
     context[paramsSchema] === undefined &&
@@ -451,7 +493,82 @@ function wrapValidationError (result, dataVar, schemaErrorFormatter) {
   return error
 }
 
+/**
+ * Deferred compilation (`lazySchemaCompilation` option).
+ *
+ * Routes registered with the option carry a slot with the pending build
+ * functions. The slot is removed once both builds succeeded, so a compiled
+ * route only pays an `undefined` property check in the validation step and
+ * in the serializer lookup. A failed build is terminal for the route and is
+ * remembered in the slot: every request keeps failing with the same error,
+ * just like `ready()` would have failed in the default mode.
+ */
+function lazySlot (context) {
+  if (context[lazySchema] === undefined) {
+    context[lazySchema] = { validation: undefined, serialization: undefined, error: undefined }
+  }
+  return context[lazySchema]
+}
+
+function runLazyBuild (context, key, ErrorClass) {
+  const lazy = context[lazySchema]
+  if (lazy === undefined || lazy[key] === undefined) return
+  const build = lazy[key]
+  lazy[key] = undefined
+  try {
+    build()
+  } catch (error) {
+    // The first failure is terminal for the route: drop any other pending
+    // build so that every request reports this same error.
+    lazy.validation = undefined
+    lazy.serialization = undefined
+    const { method, url } = context.config
+    lazy.error = new ErrorClass(method, url, error.message)
+    lazy.error[buildErrorFlag] = true
+    throw lazy.error
+  }
+}
+
+/**
+ * Compile the validation schemas of a route whose compilation was deferred.
+ * No-op when nothing is pending.
+ * @param {object} context the route context
+ */
+function resolveLazyValidation (context) {
+  runLazyBuild(context, 'validation', FST_ERR_SCH_VALIDATION_BUILD)
+}
+
+/**
+ * Compile the response schemas of a route whose compilation was deferred.
+ * No-op when nothing is pending.
+ * @param {object} context the route context
+ */
+function resolveLazySerialization (context) {
+  runLazyBuild(context, 'serialization', FST_ERR_SCH_SERIALIZATION_BUILD)
+}
+
+/**
+ * Resolve every pending build of the route, at the validation step of a request.
+ * @param {object} context the route context
+ * @returns {Error|undefined} the build error, if any
+ */
+function resolveLazySchemas (context) {
+  const lazy = context[lazySchema]
+  if (lazy.error !== undefined) {
+    return lazy.error
+  }
+  try {
+    resolveLazyValidation(context)
+    resolveLazySerialization(context)
+  } catch (error) {
+    return error
+  }
+  context[lazySchema] = undefined
+}
+
 module.exports = {
+  resolveLazyValidation,
+  resolveLazySerialization,
   symbols: { bodySchema, querystringSchema, responseSchema, paramsSchema, headersSchema },
   compileSchemasForValidation,
   compileSchemasForSerialization,

--- a/test/internals/initial-config.test.js
+++ b/test/internals/initial-config.test.js
@@ -42,6 +42,7 @@ test('without options passed to Fastify, initialConfig should expose default val
     requestIdHeader: false,
     http2SessionTimeout: 72000,
     exposeHeadRoutes: true,
+    lazySchemaCompilation: false,
     routerOptions: {
       allowUnsafeRegex: false,
       caseSensitive: true,
@@ -299,6 +300,7 @@ test('Should not have issues when passing stream options to Pino.js', (t, done) 
       requestIdHeader: false,
       http2SessionTimeout: 72000,
       exposeHeadRoutes: true,
+      lazySchemaCompilation: false,
       routerOptions: {
         allowUnsafeRegex: false,
         caseSensitive: true,

--- a/test/schema-lazy-compilation.test.js
+++ b/test/schema-lazy-compilation.test.js
@@ -1,0 +1,275 @@
+'use strict'
+
+const { test } = require('node:test')
+const Fastify = require('..')
+const { spyWarning } = require('process-warning')
+const { FSTWRN001 } = require('../lib/warnings')
+const { AjvCompiler } = require('@fastify/ajv-compiler')
+const { SerializerSelector } = require('@fastify/fast-json-stringify-compiler')
+
+const schema = {
+  params: { type: 'object', properties: { id: { type: 'integer' } } },
+  body: { type: 'object', required: ['name'], properties: { name: { type: 'string' } } },
+  querystring: { type: 'object', properties: { verbose: { type: 'boolean' } } },
+  headers: { type: 'object', properties: { 'x-trace': { type: 'string' } } },
+  response: {
+    200: { type: 'object', properties: { id: { type: 'integer' }, name: { type: 'string' } } }
+  }
+}
+
+function build (options, compilerSpies) {
+  const calls = { validator: 0, serializer: 0 }
+  if (compilerSpies) {
+    options = {
+      ...options,
+      schemaController: {
+        compilersFactory: {
+          buildValidator (externalSchemas, ajvOptions) {
+            const compile = AjvCompiler()(externalSchemas, ajvOptions)
+            return function (opts) { calls.validator++; return compile(opts) }
+          },
+          buildSerializer (externalSchemas, serializerOptions) {
+            const compile = SerializerSelector()(externalSchemas, serializerOptions)
+            return function (opts) { calls.serializer++; return compile(opts) }
+          }
+        }
+      }
+    }
+  }
+  const fastify = Fastify(options)
+  fastify.post('/items/:id', { schema }, async (request) => ({
+    id: request.params.id,
+    name: request.body.name,
+    leaked: true
+  }))
+  fastify.get('/plain', async () => ({ plain: true }))
+  return { fastify, calls }
+}
+
+test('lazySchemaCompilation defaults to false and is exposed in initialConfig', t => {
+  t.plan(2)
+  t.assert.strictEqual(Fastify().initialConfig.lazySchemaCompilation, false)
+  t.assert.strictEqual(Fastify({ lazySchemaCompilation: true }).initialConfig.lazySchemaCompilation, true)
+})
+
+test('default mode compiles validators and serializers at route registration', async t => {
+  t.plan(2)
+  const { fastify, calls } = build({}, true)
+  await fastify.ready()
+  t.assert.strictEqual(calls.validator, 4)
+  t.assert.strictEqual(calls.serializer, 1)
+})
+
+test('lazy mode compiles nothing before the first request, then once per route', async t => {
+  t.plan(8)
+  const { fastify, calls } = build({ lazySchemaCompilation: true }, true)
+  await fastify.ready()
+  t.assert.strictEqual(calls.validator, 0)
+  t.assert.strictEqual(calls.serializer, 0)
+
+  const res = await fastify.inject({ method: 'POST', url: '/items/1', payload: { name: 'a' } })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(calls.validator, 4)
+  t.assert.strictEqual(calls.serializer, 1)
+
+  await fastify.inject({ method: 'POST', url: '/items/2', payload: { name: 'b' } })
+  await fastify.inject('/plain')
+  t.assert.strictEqual(calls.validator, 4)
+  t.assert.strictEqual(calls.serializer, 1)
+  t.assert.strictEqual(res.json().leaked, undefined)
+})
+
+test('lazy mode produces the same responses as the default mode', async t => {
+  const requests = [
+    { method: 'POST', url: '/items/1', payload: { name: 'a' } },
+    { method: 'POST', url: '/items/1', payload: {} },
+    { method: 'POST', url: '/items/abc', payload: { name: 'a' } },
+    { method: 'POST', url: '/items/1?verbose=maybe', payload: { name: 'a' } },
+    { method: 'POST', url: '/items/1', payload: 'not json', headers: { 'content-type': 'application/json' } },
+    { method: 'GET', url: '/plain' }
+  ]
+  t.plan(requests.length * 2)
+  const eager = build({}).fastify
+  const lazy = build({ lazySchemaCompilation: true }).fastify
+  await eager.ready()
+  await lazy.ready()
+  for (const request of requests) {
+    const a = await eager.inject(request)
+    const b = await lazy.inject(request)
+    t.assert.strictEqual(b.statusCode, a.statusCode, `${request.method} ${request.url}`)
+    t.assert.deepStrictEqual(b.json(), a.json(), `${request.method} ${request.url}`)
+  }
+})
+
+test('lazy mode applies to route level compilers too', async t => {
+  t.plan(4)
+  const fastify = Fastify({ lazySchemaCompilation: true })
+  let validator = 0
+  let serializer = 0
+  fastify.get('/custom', {
+    schema: { querystring: { type: 'object' }, response: { 200: { type: 'object' } } },
+    validatorCompiler: () => { validator++; return () => true },
+    serializerCompiler: () => { serializer++; return (data) => JSON.stringify({ wrapped: data }) }
+  }, async () => ({ ok: true }))
+  await fastify.ready()
+  t.assert.strictEqual(validator + serializer, 0)
+  const res = await fastify.inject('/custom')
+  t.assert.strictEqual(validator, 1)
+  t.assert.strictEqual(serializer, 1)
+  t.assert.deepStrictEqual(res.json(), { wrapped: { ok: true } })
+})
+
+test('lazy mode: request.getValidationFunction and reply.getSerializationFunction compile on demand', async t => {
+  t.plan(3)
+  const fastify = Fastify({ lazySchemaCompilation: true })
+  fastify.post('/fns', { schema }, async (request, reply) => {
+    const validate = request.getValidationFunction('body')
+    const serialize = reply.getSerializationFunction(200)
+    return { id: 1, name: String(typeof validate === 'function' && typeof serialize === 'function') }
+  })
+  await fastify.ready()
+  const res = await fastify.inject({ method: 'POST', url: '/fns', payload: { name: 'x' } })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.json().name, 'true')
+  t.assert.strictEqual(res.json().leaked, undefined)
+})
+
+test('lazy mode: a validation schema that cannot be compiled fails at the first request, not at ready', async t => {
+  t.plan(5)
+  const broken = { body: { type: 'object', properties: { a: { type: 'not-a-type' } } } }
+
+  const eager = Fastify()
+  eager.post('/broken', { schema: broken }, async () => ({}))
+  await t.assert.rejects(eager.ready(), { code: 'FST_ERR_SCH_VALIDATION_BUILD' })
+
+  const lazy = Fastify({ lazySchemaCompilation: true })
+  lazy.post('/broken', { schema: broken }, async () => ({}))
+  await lazy.ready()
+  const res = await lazy.inject({ method: 'POST', url: '/broken', payload: {} })
+  t.assert.strictEqual(res.statusCode, 500)
+  t.assert.strictEqual(res.json().code, 'FST_ERR_SCH_VALIDATION_BUILD')
+  // the failure is not cached as a compiled function: the route keeps failing the same way
+  const again = await lazy.inject({ method: 'POST', url: '/broken', payload: {} })
+  t.assert.strictEqual(again.statusCode, 500)
+  t.assert.strictEqual(again.json().code, 'FST_ERR_SCH_VALIDATION_BUILD')
+})
+
+test('lazy mode: a response schema that cannot be compiled fails at the first reply, not at ready', async t => {
+  t.plan(5)
+  const broken = { response: { 200: { type: 'object', properties: { a: { type: 'not-a-type' } } } } }
+
+  const eager = Fastify()
+  eager.get('/broken', { schema: broken }, async () => ({}))
+  await t.assert.rejects(eager.ready(), { code: 'FST_ERR_SCH_SERIALIZATION_BUILD' })
+
+  const lazy = Fastify({ lazySchemaCompilation: true })
+  lazy.get('/broken', { schema: broken }, async () => ({}))
+  await lazy.ready()
+  const res = await lazy.inject('/broken')
+  t.assert.strictEqual(res.statusCode, 500)
+  t.assert.strictEqual(res.json().code, 'FST_ERR_SCH_SERIALIZATION_BUILD')
+  const again = await lazy.inject('/broken')
+  t.assert.strictEqual(again.statusCode, 500)
+  t.assert.strictEqual(again.json().code, 'FST_ERR_SCH_SERIALIZATION_BUILD')
+})
+
+test('lazy mode: a build error always fails the request, even with attachValidation', async t => {
+  t.plan(8)
+  const brokenValidation = { body: { type: 'object', properties: { a: { type: 'not-a-type' } } } }
+  const brokenSerialization = { response: { 200: { type: 'object', properties: { a: { type: 'not-a-type' } } } } }
+  const fastify = Fastify({ lazySchemaCompilation: true })
+  fastify.post('/validation', { schema: brokenValidation, attachValidation: true }, async () => ({ handler: 'ran' }))
+  fastify.post('/serialization', { schema: brokenSerialization, attachValidation: true }, async () => ({ handler: 'ran' }))
+  await fastify.ready()
+  for (const [url, code] of [['/validation', 'FST_ERR_SCH_VALIDATION_BUILD'], ['/serialization', 'FST_ERR_SCH_SERIALIZATION_BUILD']]) {
+    for (let i = 0; i < 2; i++) {
+      const res = await fastify.inject({ method: 'POST', url, payload: {} })
+      t.assert.strictEqual(res.statusCode, 500, `${url} request ${i}`)
+      t.assert.strictEqual(res.json().code, code, `${url} request ${i}`)
+    }
+  }
+})
+
+test('lazy mode: attachValidation still attaches ordinary validation errors', async t => {
+  t.plan(2)
+  const fastify = Fastify({ lazySchemaCompilation: true })
+  const { response, ...withoutResponse } = schema
+  fastify.post('/attach', { schema: withoutResponse, attachValidation: true }, async (request) => ({ attached: request.validationError !== undefined }))
+  await fastify.ready()
+  const res = await fastify.inject({ method: 'POST', url: '/attach', payload: {} })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.json().attached, true)
+})
+
+test('lazy mode: the first build failure is terminal, a second broken schema does not replace it', async t => {
+  t.plan(4)
+  const broken = {
+    body: { type: 'object', properties: { a: { type: 'not-a-type' } } },
+    response: { 200: { type: 'object', properties: { a: { type: 'not-a-type' } } } }
+  }
+  const fastify = Fastify({ lazySchemaCompilation: true })
+  fastify.post('/both', { schema: broken }, async () => ({}))
+  await fastify.ready()
+  for (let i = 0; i < 2; i++) {
+    const res = await fastify.inject({ method: 'POST', url: '/both', payload: {} })
+    t.assert.strictEqual(res.statusCode, 500)
+    t.assert.strictEqual(res.json().code, 'FST_ERR_SCH_VALIDATION_BUILD')
+  }
+})
+
+test('lazy mode: request.validateInput works on a route that has not been compiled yet', async t => {
+  t.plan(4)
+  const results = {}
+  for (const lazySchemaCompilation of [false, true]) {
+    const fastify = Fastify({ lazySchemaCompilation })
+    fastify.post('/input', {
+      schema,
+      // runs before the validation step, so on a lazy route nothing is compiled yet
+      preValidation: async (request) => {
+        request.results = [
+          request.validateInput({ name: 'x' }, 'body'),
+          request.validateInput({}, 'body'),
+          // an explicit schema does not replace the schema of the route part
+          request.validateInput({}, { type: 'object' }, 'body')
+        ].join(',')
+      }
+    }, async (request) => ({ id: 1, name: request.results }))
+    await fastify.ready()
+    const res = await fastify.inject({ method: 'POST', url: '/input', payload: { name: 'y' } })
+    t.assert.strictEqual(res.statusCode, 200, `lazy=${lazySchemaCompilation}`)
+    results[lazySchemaCompilation] = res.json().name
+  }
+  t.assert.strictEqual(results.true, results.false)
+  t.assert.strictEqual(results.true, 'true,false,false')
+})
+
+test('lazy mode: FSTWRN001 for an undefined schema part is still emitted at registration', async t => {
+  t.plan(3)
+  const spyData = spyWarning(FSTWRN001)
+  t.after(spyData.restore)
+  const fastify = Fastify({ lazySchemaCompilation: true })
+  fastify.post('/warn', { schema: { body: schema.body, headers: undefined } }, async () => ({}))
+  await fastify.ready()
+  t.assert.deepStrictEqual(spyData.calls, [{ arguments: ['headers', 'POST', '/warn'], result: true }])
+  const res = await fastify.inject({ method: 'POST', url: '/warn', payload: { name: 'x' } })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(spyData.callCount(), 1)
+})
+
+test('lazy mode: a request failing before validation still reports the broken response schema consistently', async t => {
+  t.plan(6)
+  const broken = { response: { 200: { type: 'object', properties: { a: { type: 'not-a-type' } } } } }
+  const fastify = Fastify({ lazySchemaCompilation: true })
+  fastify.post('/broken', { schema: broken }, async () => ({}))
+  await fastify.ready()
+  // malformed JSON: the request fails before the validation step, the error reply
+  // is the first thing that needs a serializer of this route
+  const first = await fastify.inject({ method: 'POST', url: '/broken', payload: '{not json', headers: { 'content-type': 'application/json' } })
+  t.assert.strictEqual(first.statusCode, 500)
+  t.assert.strictEqual(first.json().code, 'FST_ERR_SCH_SERIALIZATION_BUILD')
+  const second = await fastify.inject({ method: 'POST', url: '/broken', payload: {} })
+  t.assert.strictEqual(second.statusCode, 500)
+  t.assert.strictEqual(second.json().code, 'FST_ERR_SCH_SERIALIZATION_BUILD')
+  t.assert.deepStrictEqual(first.json(), second.json())
+  t.assert.strictEqual(first.json().error, 'Internal Server Error')
+})

--- a/test/schema-lazy-compilation.test.js
+++ b/test/schema-lazy-compilation.test.js
@@ -273,3 +273,44 @@ test('lazy mode: a request failing before validation still reports the broken re
   t.assert.deepStrictEqual(first.json(), second.json())
   t.assert.strictEqual(first.json().error, 'Internal Server Error')
 })
+
+test('lazy mode: a cached build failure is reported by every later lookup, even on a request that never reaches validation', async t => {
+  t.plan(8)
+  const broken = { response: { 200: { type: 'object', properties: { a: { type: 'not-a-type' } } } } }
+  const fastify = Fastify({ lazySchemaCompilation: true })
+  fastify.post('/broken', { schema: broken }, async () => ({}))
+  // the public lookup helpers, called before the validation step, must report the
+  // build error on the request that triggers it and on every request after it
+  fastify.post('/lookup', {
+    schema: broken,
+    onRequest: async (request, reply) => {
+      t.assert.throws(() => reply.getSerializationFunction(200), { code: 'FST_ERR_SCH_SERIALIZATION_BUILD' })
+    }
+  }, async () => ({}))
+  await fastify.ready()
+  const malformed = { method: 'POST', url: '/broken', payload: '{not json', headers: { 'content-type': 'application/json' } }
+  const first = await fastify.inject(malformed)
+  t.assert.strictEqual(first.statusCode, 500)
+  t.assert.strictEqual(first.json().code, 'FST_ERR_SCH_SERIALIZATION_BUILD')
+  // the second malformed request also fails before validation: the serializer
+  // lookup in the error reply must surface the cached build error, not the parse error
+  const second = await fastify.inject(malformed)
+  t.assert.strictEqual(second.statusCode, 500)
+  t.assert.strictEqual(second.json().code, 'FST_ERR_SCH_SERIALIZATION_BUILD')
+  t.assert.deepStrictEqual(first.json(), second.json())
+  await fastify.inject({ method: 'POST', url: '/lookup', payload: {} })
+  const lookup = await fastify.inject({ method: 'POST', url: '/lookup', payload: {} })
+  t.assert.strictEqual(lookup.json().code, 'FST_ERR_SCH_SERIALIZATION_BUILD')
+})
+
+test('lazySchemaCompilation accepts the coercible values the config validator accepts', async t => {
+  t.plan(4)
+  for (const value of ['true', 1]) {
+    const fastify = Fastify({ lazySchemaCompilation: value })
+    const broken = { body: { type: 'object', properties: { a: { type: 'not-a-type' } } } }
+    fastify.post('/broken', { schema: broken }, async () => ({}))
+    t.assert.strictEqual(fastify.initialConfig.lazySchemaCompilation, true)
+    // eager compilation would reject ready(): the coerced value must reach the route code
+    await t.assert.doesNotReject(fastify.ready())
+  }
+})

--- a/test/schema-lazy-compilation.test.js
+++ b/test/schema-lazy-compilation.test.js
@@ -3,7 +3,7 @@
 const { test } = require('node:test')
 const Fastify = require('..')
 const { spyWarning } = require('process-warning')
-const { FSTWRN001 } = require('../lib/warnings')
+const { FSTWRN001, FSTSEC002 } = require('../lib/warnings')
 const { AjvCompiler } = require('@fastify/ajv-compiler')
 const { SerializerSelector } = require('@fastify/fast-json-stringify-compiler')
 
@@ -313,4 +313,68 @@ test('lazySchemaCompilation accepts the coercible values the config validator ac
     // eager compilation would reject ready(): the coerced value must reach the route code
     await t.assert.doesNotReject(fastify.ready())
   }
+})
+
+test('lazy mode: boolean false request schemas are compiled at the first request and reject it', async t => {
+  t.plan(6)
+  const spyData = spyWarning(FSTWRN001)
+  t.after(spyData.restore)
+  let validator = 0
+  const fastify = Fastify({
+    lazySchemaCompilation: true,
+    exposeHeadRoutes: false,
+    schemaController: {
+      compilersFactory: {
+        buildValidator (externalSchemas, ajvOptions) {
+          const compile = AjvCompiler()(externalSchemas, ajvOptions)
+          return function (opts) { validator++; return compile(opts) }
+        }
+      }
+    }
+  })
+  let executed = false
+  fastify.post('/body', { schema: { body: false } }, async () => { executed = true; return {} })
+  fastify.get('/headers', { schema: { headers: false } }, async () => { executed = true; return {} })
+  await fastify.ready()
+  // a boolean is a schema: no FSTWRN001, and nothing is compiled before the first request
+  t.assert.strictEqual(spyData.callCount(), 0)
+  t.assert.strictEqual(validator, 0)
+  const body = await fastify.inject({ method: 'POST', url: '/body', payload: {} })
+  t.assert.strictEqual(body.statusCode, 400)
+  const headers = await fastify.inject('/headers')
+  t.assert.strictEqual(headers.statusCode, 400)
+  t.assert.strictEqual(validator, 2)
+  t.assert.strictEqual(executed, false)
+})
+
+test('lazy mode: header names are case-normalized when the route is compiled', async t => {
+  t.plan(2)
+  const fastify = Fastify({ lazySchemaCompilation: true })
+  fastify.get('/trace', {
+    schema: { headers: { type: 'object', required: ['X-Trace'], properties: { 'X-Trace': { type: 'string' } } } }
+  }, async () => ({}))
+  await fastify.ready()
+  const missing = await fastify.inject('/trace')
+  t.assert.strictEqual(missing.statusCode, 400)
+  const present = await fastify.inject({ url: '/trace', headers: { 'x-trace': '1' } })
+  t.assert.strictEqual(present.statusCode, 200)
+})
+
+test('lazy mode: FSTSEC002 for an external header $ref is still emitted at registration', async t => {
+  t.plan(3)
+  const spyData = spyWarning(FSTSEC002)
+  t.after(spyData.restore)
+  const fastify = Fastify({ lazySchemaCompilation: true })
+  fastify.addSchema({
+    $id: 'http://example.com/lazy-headers',
+    type: 'object',
+    properties: { 'X-Admin': { type: 'string' } }
+  })
+  fastify.post('/warn', { schema: { headers: { $ref: 'http://example.com/lazy-headers#' } } }, async () => ({}))
+  await fastify.ready()
+  t.assert.deepStrictEqual(spyData.calls, [{ arguments: ['POST', '/warn', 'http://example.com/lazy-headers#'], result: true }])
+  const res = await fastify.inject({ method: 'POST', url: '/warn', payload: {} })
+  t.assert.strictEqual(res.statusCode, 200)
+  // compiling the route at the first request does not warn a second time
+  t.assert.strictEqual(spyData.callCount(), 1)
 })

--- a/test/types/fastify.tst.ts
+++ b/test/types/fastify.tst.ts
@@ -358,3 +358,5 @@ expect(fastify).type.not.toBeCallableWith({ routerOptions: { allowUnsafeRegex: '
 
 expect(fastify({ allowErrorHandlerOverride: true })).type.toBeAssignableTo<FastifyInstance>()
 expect(fastify({ allowErrorHandlerOverride: false })).type.toBeAssignableTo<FastifyInstance>()
+expect(fastify({ lazySchemaCompilation: true })).type.toBeAssignableTo<FastifyInstance>()
+expect(fastify({ lazySchemaCompilation: false })).type.toBeAssignableTo<FastifyInstance>()


### PR DESCRIPTION
## Summary

Adds an opt-in server option, `lazySchemaCompilation` (default `false`), that defers the compilation of a route's validators (`body`, `querystring`, `params`, `headers`) and response serializers from route registration to the first request that reaches the route. Routes that are never hit are never compiled. Once compiled, the functions are cached on the route context exactly as today, so only the first request of each route pays the cost.

The default behavior is unchanged: without the option the same functions are compiled at the same time as today (the validation step and the serializer lookup gain one property check each), and the existing suite passes unchanged.

## Motivation

Today `ready()` compiles an ajv validator per validation part and a fast-json-stringify serializer per response code for every route with a schema. Both are `new Function` code generation, and V8 keeps the generated source alive for the life of the process. On applications with many routes this is a large share of boot time and of the idle heap, even when most routes are never hit by a given process. Two real cases that led here:

- generated CRUD APIs (Platformatic DB style): hundreds of routes per service, a handful actually used per process; measured on a real service with 161 routes, the retained validator and serializer sources are 7.5 MB of an 88 MB heap after `ready()`
- API gateways that proxy a large composed OpenAPI document: about 2000 routes with full schemas, 100 MB of a 177 MB heap in compiled sources, 7 s of the boot spent compiling

The framework-level fix is to compile on first use. A plugin can only wrap the compilers with a stub that compiles on its first call, which loses the `schemaEnv` detection in `validateParam` (the stub has no `schemaEnv` until it is compiled, so root-level coercion silently changes on the first request) and cannot make a broken schema fail the request consistently. Doing it in core keeps the compiled functions and the error reporting identical to the default mode, which is why it is proposed as a core option.

## Numbers

Plain fastify (this branch), N routes cloned from a real 161-operation OpenAPI document (mix of params, querystring, body and 2 to 4 response schemas per route), handler returns `{}`. `heapUsed` after two forced GCs, Node 24.15, Apple silicon. "10 % hit" injects two requests to every tenth route; "first request" is the average latency of the first request of the hit routes (validators and serializers of that route compile inside it).

| N routes | mode | boot | heap after `ready()` | heap after 10 % of routes hit | first request (hit routes) | second request |
|---|---|---|---|---|---|---|
| 200 | default | 764 ms | 14.8 MB | 16.3 MB | 1.39 ms | 0.14 ms |
| 200 | lazy | 42 ms | 3.3 MB | 7.5 MB | 8.90 ms | 0.33 ms |
| 1000 | default | 958 ms | 31.0 MB | 34.0 MB | 0.63 ms | 0.08 ms |
| 1000 | lazy | 79 ms | 7.1 MB | 17.6 MB | 5.34 ms | 0.16 ms |
| 2000 | default | 1240 ms | 49.6 MB | 53.5 MB | 0.48 ms | 0.08 ms |
| 2000 | lazy | 147 ms | 11.5 MB | 27.0 MB | 4.15 ms | 0.13 ms |

Boot is 8 to 18 times faster and the schema-related heap drops by roughly 75 % at `ready()`; the cost is 4 to 9 ms once per route on its first request. The bench script is small and can be added to `benchmarks/` if wanted.

## Design

- `compileSchemasForValidation` and `compileSchemasForSerialization` take a `lazy` flag. When set, instead of compiling they store a build function in one slot on the route context (`kSchemaLazy`) and return.
- `validate()` (the validation step of every request) checks that slot. When present it runs both builds, then removes the slot, so a compiled route only pays an `undefined` property check in the validation step and in the serializer lookup. The first build failure is terminal for the route: the other pending build is dropped, the error is remembered in the slot and every request of that route fails with it (`FST_ERR_SCH_VALIDATION_BUILD` / `FST_ERR_SCH_SERIALIZATION_BUILD`, status 500), also when the route sets `attachValidation: true`, mirroring what `ready()` would have thrown in the default mode. The error reply itself serializes normally because the failed build is not retried; when the first thing that needs a serializer of the route is an error reply (for example a malformed JSON body, which fails before the validation step), the fallback error handler reports the build error as is instead of wrapping it in `FST_ERR_FAILED_ERROR_SERIALIZATION`.
- `request.getValidationFunction`, `request.validateInput`, `reply.getSerializationFunction`, `reply.serializeInput` and `getSchemaSerializer` resolve the pending build first, so a hook or handler that asks for the functions before or after the validation step gets the real, compiled ones. Custom compilers (`setValidatorCompiler`, `setSerializerCompiler`, `schemaController.compilersFactory`, route-level `validatorCompiler` / `serializerCompiler`) are supported unchanged: the compiler factories still run at registration (`setupValidator` / `setupSerializer`), only the calls to the compiler function they return are deferred.
- Schema normalization (`normalizeSchema`), the registration of shared schemas in the schema controller, the compiler setup (`setupValidator` / `setupSerializer`) and the `FSTWRN001` warning for `undefined` schema parts still happen at registration. The actual resolution of `$ref`s happens inside the compilers, so it is deferred with the code generation: a missing `$ref` is reported by the first request of the route, like any other build error.

Trade-off, documented in `docs/Reference/Server.md`: with the option on, a schema that cannot be compiled is reported by the first request of that route instead of by `ready()`. The recommendation in the docs is to keep the default in development and test suites.

## Checklist

- [x] tests: `test/schema-lazy-compilation.test.js` (default vs lazy compile counts through `compilersFactory`, identical responses for valid and invalid requests in both modes, route-level compilers, `getValidationFunction` / `getSerializationFunction` / `validateInput` from a `preValidation` hook on a cold route, validation and serialization build failures surfacing at the first request and staying failed, also with `attachValidation: true` and with both schemas broken, `FSTWRN001` still emitted at registration, malformed request first with a broken response schema)
- [x] `npm run unit`: 2319 tests, 2315 passed, 0 failed, 4 skipped
- [x] `npm run coverage:ci-check-coverage` (100 % lines)
- [x] `npm run lint`, `npm run test:types` (`test/types/fastify.tst.ts` extended)
- [x] `npm run build:validation` regenerated `lib/config-validator.js`; `fastify.d.ts` and `docs/Reference/Server.md` updated
