### PR TITLE
fix: handle a null payload in the HEAD route onSend handler

### DIFF
--- a/lib/head-route.js
+++ b/lib/head-route.js
@@ -1,8 +1,15 @@
 'use strict'
 function headRouteOnSendHandler (req, reply, payload, done) {
-  // If payload is undefined
-  if (payload === undefined) {
-    reply.header('content-length', '0')
+  // An onSend hook may clear the payload by replacing it with null, so a null
+  // arrives here as well as an undefined.
+  if (payload === undefined || payload === null) {
+    // A 204, 304 or 1xx response carries no content-length, and `onSendEnd` in `lib/reply.js` sends
+    // none for the GET response either, so setting one here would make the HEAD
+    // response report a length the GET response does not.
+    const statusCode = reply.statusCode
+    if (statusCode >= 200 && statusCode !== 204 && statusCode !== 304) {
+      reply.header('content-length', '0')
+    }
     done(null, null)
     return
   }

--- a/test/route.6.test.js
+++ b/test/route.6.test.js
@@ -237,6 +237,117 @@ test('HEAD route should respect custom onSend handlers', async t => {
   t.assert.strictEqual(counter, 2)
 })
 
+test('HEAD route should handle a payload cleared by an onSend hook', async t => {
+  t.plan(6)
+
+  const fastify = Fastify({ exposeHeadRoutes: true })
+
+  // An onSend hook is allowed to clear the payload by replacing it with null.
+  fastify.addHook('onSend', (req, reply, payload, done) => {
+    done(null, null)
+  })
+
+  fastify.route({
+    method: 'GET',
+    path: '/json',
+    handler: (req, reply) => {
+      reply.send({ here: 'is Johnny' })
+    }
+  })
+
+  let res = await fastify.inject({
+    method: 'HEAD',
+    url: '/json'
+  })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.headers['content-length'], '0')
+  t.assert.strictEqual(res.body, '')
+
+  // the HEAD route reports what the GET route reports
+  res = await fastify.inject({
+    method: 'GET',
+    url: '/json'
+  })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.headers['content-length'], '0')
+  t.assert.strictEqual(res.body, '')
+})
+
+test('HEAD route sends no content-length for a status that carries none', async t => {
+  t.plan(4)
+
+  const fastify = Fastify({ exposeHeadRoutes: true })
+
+  fastify.route({
+    method: 'GET',
+    path: '/empty',
+    handler: (req, reply) => {
+      reply.code(204).send()
+    }
+  })
+
+  let res = await fastify.inject({ method: 'HEAD', url: '/empty' })
+  t.assert.strictEqual(res.statusCode, 204)
+  t.assert.strictEqual(res.headers['content-length'], undefined)
+
+  // the HEAD route reports what the GET route reports
+  res = await fastify.inject({ method: 'GET', url: '/empty' })
+  t.assert.strictEqual(res.statusCode, 204)
+  t.assert.strictEqual(res.headers['content-length'], undefined)
+})
+
+test('HEAD route should handle a conditional onSend hook that clears the payload', async t => {
+  t.plan(10)
+
+  const fastify = Fastify({ exposeHeadRoutes: true })
+
+  fastify.addHook('onSend', (req, reply, payload, done) => {
+    if (req.headers['if-none-match'] === '"v1"') {
+      reply.code(304)
+      done(null, null)
+      return
+    }
+    done(null, payload)
+  })
+
+  fastify.route({
+    method: 'GET',
+    path: '/resource',
+    handler: (req, reply) => {
+      reply.header('etag', '"v1"')
+      reply.send({ here: 'is Johnny' })
+    }
+  })
+
+  let res = await fastify.inject({
+    method: 'HEAD',
+    url: '/resource'
+  })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.headers.etag, '"v1"')
+  t.assert.strictEqual(res.body, '')
+  t.assert.strictEqual(res.headers['content-length'], '20')
+
+  res = await fastify.inject({
+    method: 'HEAD',
+    url: '/resource',
+    headers: { 'if-none-match': '"v1"' }
+  })
+  t.assert.strictEqual(res.statusCode, 304)
+  t.assert.strictEqual(res.headers.etag, '"v1"')
+  t.assert.strictEqual(res.body, '')
+  // a 304 carries no content-length, and the GET route it reports on sends none
+  t.assert.strictEqual(res.headers['content-length'], undefined)
+
+  res = await fastify.inject({
+    method: 'GET',
+    url: '/resource',
+    headers: { 'if-none-match': '"v1"' }
+  })
+  t.assert.strictEqual(res.statusCode, 304)
+  t.assert.strictEqual(res.headers['content-length'], undefined)
+})
+
 test('route onSend can be function or array of functions', async t => {
   t.plan(10)
   const counters = { single: 0, multiple: 0 }


### PR DESCRIPTION
`headRouteOnSendHandler` guarded only `payload === undefined`. An `onSend` hook may
also clear the payload with `done(null, null)`, and that `null` fell through to the
stream checks below, where `typeof payload.resume` throws.

This is documented behaviour rather than misuse — `docs/Reference/Hooks.md` shows it
under "You can also clear the payload to send a response with an empty body by
replacing the payload with `null`", and `onSendEnd` itself branches on
`payload === undefined || payload === null` (`lib/reply.js:644`).

Running that documented example verbatim against a generated HEAD route:

```js
const app = Fastify({ exposeHeadRoutes: true })

app.addHook('onSend', (request, reply, payload, done) => {
  reply.code(304)
  const newPayload = null
  done(null, newPayload)
})

app.get('/', (req, reply) => reply.send({ hello: 'world' }))
```

```
GET  /  ->  304, no content-length, empty body
HEAD /  ->  304, content-length: 103,
            body: {"statusCode":304,"error":"Not Modified",
                   "message":"Cannot read properties of null (reading 'resume')"}
```

The throw is caught and turned into an error response, which re-enters the `onSend`
chain, so the 304 ends up carrying the error page's `content-length` and body. With
no hook clearing the payload the same input answers `500 Cannot read properties of
null (reading 'resume')`.

### The fix

`null` is treated like `undefined`, and `content-length` is set only for the statuses
`onSendEnd` sets one for — `statusCode >= 200 && statusCode !== 204 && statusCode !== 304`
(`lib/reply.js:651`). Without that gate the synthesized HEAD response reports a length
the GET response does not: `test/hooks.test.js`'s "clear payload" test already asserts
that a hook doing the same thing over GET sends no `content-length` at 304.

**One behaviour change beyond the crash fix:** an `undefined` payload at 204, 304 or
1xx previously got `content-length: 0` on HEAD alone. It now gets none, matching GET.
That is covered by a new test.

### Known limitations, unchanged by this PR

- **Trailers.** `onSendEnd` also requires `reply[kReplyTrailers] === null` before
  setting the header; this handler does not mirror that, so with a trailer registered
  HEAD sends `content-length: 0` where GET sends none. That already happens on `main`
  for `undefined` payloads. Mirroring it naively is wrong: `removeTrailer` leaves the
  key present with an `undefined` value and `onSendEnd` only normalises it to `null`
  afterwards, so a naive check breaks the added-then-removed case that works today. A
  correct fix needs a shared normalisation helper and belongs in its own PR.
- **The other branches of this file are still ungated.** The stream branches and the
  final `Buffer.byteLength(payload)` branch set `content-length` at any status, so at
  1xx and 204 a non-empty payload makes HEAD report a length GET does not. Measured
  identical on `main` and on this branch.
- A `Response` payload — also a permitted replacement — still fails on a generated
  HEAD route with `ERR_INVALID_ARG_TYPE`, identically before and after this change.

### Verification

- `npx borp`: 2302 passing, 0 failing.
- With `lib/head-route.js` reverted to `main`, exactly the three new tests fail.
- `npx eslint` and `npx tstyche` clean.
- `lib/head-route.js` at 100% lines and branches, with both arms of the new condition
  exercised by the suite.
- Across a sweep of 15 statuses x {null, undefined} x {no trailers, live trailer,
  trailer added then removed}, no HEAD/GET pair disagrees that agreed on `main`, and
  every GET response is byte-identical to `main`.
