### PR TITLE
feat: support cloneRouteConfig option in findRoute

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1421,19 +1421,23 @@ if (routeExists === false) {
 
 Method to retrieve a route already registered to the internal router. It
 expects an object as the payload. `url` and `method` are mandatory fields. It
-is possible to also specify `constraints`.
+is possible to also specify `constraints` and `cloneRouteConfig`.
 The method returns a route object or `null` if the route cannot be found.
+
+When `cloneRouteConfig: true` is passed, the returned route object includes a deeply cloned `config` object of the route.
 
 ```js
 const route = fastify.findRoute({
   url: '/artists/:artistId',
   method: 'GET',
-  constraints: { version: '1.0.0' } // optional
+  constraints: { version: '1.0.0' }, // optional
+  cloneRouteConfig: true // optional
 })
 
 if (route !== null) {
   // perform some route checks
   console.log(route.params)   // `{artistId: ':artistId'}`
+  console.log(route.config)   // `{custom: 'value', url: '/artists/:artistId', method: 'GET'}`
 }
 ```
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const FindMyWay = require('find-my-way')
+const clone = require('rfdc')({ circles: false, proto: false })
 const Context = require('./context')
 const handleRequest = require('./handle-request.js')
 const { onRequestAbortHookRunner, lifecycleHooks, preParsingHookRunner, onTimeoutHookRunner, onRequestHookRunner } = require('./hooks')
@@ -186,11 +187,15 @@ function buildRouting (options) {
       // we must reduce the expose surface, otherwise
       // we provide the ability for the user to modify
       // all the route and server information in runtime
-      return {
+      const result = {
         handler: route.handler,
         params: route.params,
         searchParams: route.searchParams
       }
+      if (options.cloneRouteConfig) {
+        result.config = clone(route.store?.config)
+      }
+      return result
     } else {
       return null
     }

--- a/test/find-route.test.js
+++ b/test/find-route.test.js
@@ -185,3 +185,39 @@ test('findRoute should not expose store', t => {
   })
   t.assert.strictEqual(route.store, undefined)
 })
+
+test('findRoute with cloneRouteConfig should return cloned route config', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.get('/artists/:artistId', {
+    config: {
+      custom: 'value',
+      nested: { foo: 'bar' }
+    },
+    handler: (req, reply) => reply.send('ok')
+  })
+
+  const routeWithoutConfig = fastify.findRoute({
+    method: 'GET',
+    url: '/artists/:artistId'
+  })
+  t.assert.strictEqual(routeWithoutConfig.config, undefined)
+
+  const routeWithConfig = fastify.findRoute({
+    method: 'GET',
+    url: '/artists/:artistId',
+    cloneRouteConfig: true
+  })
+  t.assert.deepStrictEqual(routeWithConfig.config.custom, 'value')
+  t.assert.deepStrictEqual(routeWithConfig.config.nested, { foo: 'bar' })
+
+  // Ensure modifying cloned config does not mutate original route context
+  routeWithConfig.config.custom = 'mutated'
+  const secondFind = fastify.findRoute({
+    method: 'GET',
+    url: '/artists/:artistId',
+    cloneRouteConfig: true
+  })
+  t.assert.deepStrictEqual(secondFind.config.custom, 'value')
+})

--- a/test/types/route.tst.ts
+++ b/test/types/route.tst.ts
@@ -1,10 +1,10 @@
 import { FastifyError } from '@fastify/error'
 import * as http from 'node:http'
 import { expect } from 'tstyche'
-import fastify, { FastifyInstance, FastifyReply, FastifyRequest, RouteHandlerMethod } from '../../fastify.js'
+import fastify, { FastifyContextConfig, FastifyInstance, FastifyReply, FastifyRequest, RouteHandlerMethod } from '../../fastify.js'
 import { RequestPayload } from '../../types/hooks.js'
 import { FindMyWayFindResult } from '../../types/instance.js'
-import { HTTPMethods, RawServerDefault } from '../../types/utils.js'
+import { ContextConfigDefault, HTTPMethods, RawServerDefault } from '../../types/utils.js'
 
 /*
  * Testing Fastify HTTP Routes and Route Shorthands.
@@ -537,7 +537,23 @@ expect(
     url: '/',
     method: 'get'
   })
-).type.toBe<Omit<FindMyWayFindResult<RawServerDefault>, 'store'>>()
+).type.toBe<Omit<FindMyWayFindResult<RawServerDefault>, 'store'> & { config?: ContextConfigDefault }>()
+
+expect(
+  fastify().findRoute({
+    url: '/',
+    method: 'get',
+    cloneRouteConfig: true
+  })
+).type.toBe<Omit<FindMyWayFindResult<RawServerDefault>, 'store'> & { config?: ContextConfigDefault }>()
+
+expect(
+  fastify().findRoute<FastifyContextConfig>({
+    url: '/',
+    method: 'get',
+    cloneRouteConfig: true
+  })
+).type.toBe<Omit<FindMyWayFindResult<RawServerDefault>, 'store'> & { config?: FastifyContextConfig }>()
 
 // we should not expose store
 expect(fastify().findRoute({

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -218,10 +218,10 @@ export interface FastifyInstance<
   >(opts: Pick<RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>, 'method' | 'url' | 'constraints'>): boolean;
 
   findRoute<
-    RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
     ContextConfig = ContextConfigDefault,
+    RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
     SchemaCompiler extends FastifySchema = FastifySchema
-  >(opts: Pick<RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>, 'method' | 'url' | 'constraints'>): Omit<FindMyWayFindResult<RawServer>, 'store'>;
+  >(opts: Pick<RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfigDefault, SchemaCompiler, TypeProvider>, 'method' | 'url' | 'constraints'> & { cloneRouteConfig?: boolean }): Omit<FindMyWayFindResult<RawServer>, 'store'> & { config?: ContextConfig };
 
   // addHook: overloads
 


### PR DESCRIPTION
## Problem

`fastify.findRoute` purposefully restricts exposed route properties to `{ handler, params, searchParams }` to avoid exposing the internal `store` or allowing accidental runtime mutations of route configuration. However, plugins and handlers (such as `@fastify/cors` resolving target route configuration during OPTIONS preflight requests) need a safe, immutable way to inspect the target route's custom configuration.

## Solution

- Added `cloneRouteConfig` boolean option to `fastify.findRoute`.
- When `cloneRouteConfig: true` is passed, `findRoute` clones the route's `config` using `rfdc` and includes it in the returned result as `config`.
- Updated TypeScript definitions in `types/instance.d.ts` and `test/types/route.tst.ts`.
- Updated `docs/Reference/Server.md`.

## Testing

- Added unit tests in `test/find-route.test.js` verifying cloned config retrieval and ensuring mutations on the returned config do not affect the internal route store.
- Verified TypeScript type tests and eslint pass cleanly.