### PR TITLE
fix: omit response body for HEAD requests in inject

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -675,7 +675,9 @@ function onSendEnd (reply, payload) {
   // node:stream
   if (typeof payload.pipe === 'function') {
     if (req.method === 'HEAD') {
-      payload.on('error', noop)
+      payload.on('error', (err) => {
+        reply.log.error({ err }, 'Error on Stream found for HEAD route')
+      })
       payload.resume()
       safeWriteHead(reply, statusCode)
       sendTrailer(null, res, reply)
@@ -688,7 +690,9 @@ function onSendEnd (reply, payload) {
   // node:stream/web
   if (typeof payload.getReader === 'function') {
     if (req.method === 'HEAD') {
-      payload.cancel().catch(noop)
+      payload.cancel('Stream cancelled by HEAD route').catch((err) => {
+        reply.log.error({ err }, 'Error on Stream found for HEAD route')
+      })
       safeWriteHead(reply, statusCode)
       sendTrailer(null, res, reply)
       return

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -674,12 +674,25 @@ function onSendEnd (reply, payload) {
 
   // node:stream
   if (typeof payload.pipe === 'function') {
+    if (req.method === 'HEAD') {
+      payload.on('error', noop)
+      payload.resume()
+      safeWriteHead(reply, statusCode)
+      sendTrailer(null, res, reply)
+      return
+    }
     sendStream(payload, res, reply)
     return
   }
 
   // node:stream/web
   if (typeof payload.getReader === 'function') {
+    if (req.method === 'HEAD') {
+      payload.cancel().catch(noop)
+      safeWriteHead(reply, statusCode)
+      sendTrailer(null, res, reply)
+      return
+    }
     sendWebStream(payload, res, reply)
     return
   }
@@ -700,6 +713,10 @@ function onSendEnd (reply, payload) {
   }
 
   safeWriteHead(reply, statusCode)
+  if (req.method === 'HEAD') {
+    sendTrailer(null, res, reply)
+    return
+  }
   // write payload first
   writePayload(payload, res, reply)
 }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -690,6 +690,9 @@ function onSendEnd (reply, payload) {
   // node:stream/web
   if (typeof payload.getReader === 'function') {
     if (req.method === 'HEAD') {
+      if (payload.locked) {
+        throw new FST_ERR_REP_READABLE_STREAM_LOCKED()
+      }
       payload.cancel('Stream cancelled by HEAD route').catch((err) => {
         reply.log.error({ err }, 'Error on Stream found for HEAD route')
       })

--- a/test/constrained-routes.test.js
+++ b/test/constrained-routes.test.js
@@ -607,7 +607,7 @@ test('Should allow registering constrained routes in a prefixed plugin', (t, don
 })
 
 test('Should allow registering a constrained GET route after a constrained HEAD route', (t, done) => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
 
   fastify.route({
@@ -637,7 +637,8 @@ test('Should allow registering a constrained GET route after a constrained HEAD 
     }
   }, (err, res) => {
     t.assert.ifError(err)
-    t.assert.deepStrictEqual(res.payload, 'custom HEAD response')
+    t.assert.strictEqual(res.payload, '')
+    t.assert.strictEqual(res.headers['content-length'], String(Buffer.byteLength('custom HEAD response')))
     t.assert.strictEqual(res.statusCode, 200)
     done()
   })

--- a/test/internals/all.test.js
+++ b/test/internals/all.test.js
@@ -33,6 +33,10 @@ test('fastify.all should add all the methods to the same url', async t => {
     }
 
     const res = await fastify.inject(options)
+    if (method === 'HEAD') {
+      t.assert.strictEqual(res.payload, '')
+      return
+    }
     const payload = JSON.parse(res.payload)
     t.assert.deepStrictEqual(payload, { method })
   }

--- a/test/reply-web-stream-locked.test.js
+++ b/test/reply-web-stream-locked.test.js
@@ -35,3 +35,34 @@ test('reply.send(web ReadableStream) throws if locked', async t => {
     }
   )
 })
+
+test('explicit HEAD reply.send(web ReadableStream) throws if locked', async t => {
+  t.plan(4)
+
+  const app = Fastify()
+  after(() => app.close())
+
+  let errorCode
+  app.setErrorHandler((err, req, reply) => {
+    errorCode = err.code
+    reply.send(err)
+  })
+
+  app.route({
+    method: 'HEAD',
+    url: '/',
+    handler: (req, reply) => {
+      const rs = new ReadableStream({
+        start (controller) { controller.enqueue(new TextEncoder().encode('hi')); controller.close() }
+      })
+      rs.getReader()
+      t.assert.strictEqual(rs.locked, true, 'stream is locked')
+      reply.send(rs)
+    }
+  })
+
+  const res = await app.inject({ method: 'HEAD', url: '/' })
+  t.assert.strictEqual(res.statusCode, 500)
+  t.assert.strictEqual(errorCode, 'FST_ERR_REP_READABLE_STREAM_LOCKED')
+  t.assert.strictEqual(res.body, '')
+})

--- a/test/route.7.test.js
+++ b/test/route.7.test.js
@@ -136,6 +136,47 @@ test('HEAD route should be exposed by default', async t => {
   t.assert.strictEqual(res.body, '')
 })
 
+test('explicit HEAD route should not include a body in inject', async t => {
+  t.plan(4)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.route({
+    method: 'HEAD',
+    url: '/explicit-head',
+    handler: (req, reply) => {
+      reply.send({ secret: 'must-not-leak' })
+    }
+  })
+
+  const res = await fastify.inject({
+    method: 'HEAD',
+    url: '/explicit-head'
+  })
+
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.body, '')
+  t.assert.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+  t.assert.ok(Number(res.headers['content-length']) > 0)
+})
+
+test('HEAD on unknown route should not include a body in inject', async t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+  await fastify.ready()
+
+  const res = await fastify.inject({
+    method: 'HEAD',
+    url: '/this-route-does-not-exist'
+  })
+
+  t.assert.strictEqual(res.statusCode, 404)
+  t.assert.strictEqual(res.body, '')
+})
+
 test('HEAD route should be exposed if route exposeHeadRoute is set', async t => {
   t.plan(5)
 


### PR DESCRIPTION
## Summary

- HEAD responses must not include a message body ([RFC 9110 §8.6](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6)).
- Real HTTP (`listen` + fetch) already omitted the body for HEAD, but `fastify.inject()` still wrote the payload for explicit HEAD routes, streams, custom 404 handlers, and default 404 responses.
- Fix: in `onSendEnd`, skip writing the payload when `req.method === 'HEAD'` while preserving status, `content-type`, and `content-length` headers (same semantics as auto GET→HEAD routes already covered in `route.7.test.js`).

## Scope / related work

- Does **not** overlap with [#6978](https://github.com/fastify/fastify/pull/6978) (auto GET→HEAD + `onSend(null, null)` crash). That PR only touches the auto-HEAD handler path.
- This change is in `lib/reply.js` and applies to all HEAD requests regardless of how the route was registered.

## Test plan

- [x] `node --test test/route.7.test.js`
- [x] `node --test test/http-methods/head.test.js test/http2/head.test.js test/constrained-routes.test.js test/internals/reply.test.js test/internals/all.test.js`
- [x] New cases: explicit HEAD route + HEAD on unknown route (`test/route.7.test.js`)
- [x] Updated expectations in `test/constrained-routes.test.js` and `test/internals/all.test.js`
