### PR TITLE
fix: standardize application hook parameters

### DIFF
--- a/docs/Guides/Plugins-Guide.md
+++ b/docs/Guides/Plugins-Guide.md
@@ -322,7 +322,7 @@ fastify.register((instance, opts, done) => {
     done()
   }
 
-  instance.addHook('onRoute', (routeOptions) => {
+  instance.addHook('onRoute', (instance, routeOptions) => {
     if (routeOptions.config && routeOptions.config.useUtil === true) {
       // set or add our handler to the route preHandler hook
       if (!routeOptions.preHandler) {

--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -416,20 +416,21 @@ You can hook into the application-lifecycle as well.
 Triggered before the server starts listening for requests and when `.ready()` is
 invoked. It cannot change the routes or add new hooks. Registered hook functions
 are executed serially. Only after all `onReady` hook functions have completed
-will the server start listening for requests. Hook functions accept one
-argument: a callback, `done`, to be invoked after the hook function is complete.
+will the server start listening for requests. Hook functions accept two
+arguments: the Fastify `instance` the hook was registered on, and a callback,
+`done`, to be invoked after the hook function is complete.
 Hook functions are invoked with `this` bound to the associated Fastify instance.
 
 ```js
 // callback style
-fastify.addHook('onReady', function (done) {
+fastify.addHook('onReady', function (instance, done) {
   // Some code
   const err = null;
   done(err)
 })
 
 // or async/await style
-fastify.addHook('onReady', async function () {
+fastify.addHook('onReady', async function (instance) {
   // Some async code
   await loadCacheFromDatabase()
 })
@@ -439,23 +440,23 @@ fastify.addHook('onReady', async function () {
 
 Triggered when the server starts listening for requests. The hooks run one
 after another. If a hook function causes an error, it is logged and
-ignored, allowing the queue of hooks to continue. Hook functions accept one
-argument: a callback, `done`, to be invoked after the hook function is
-complete. Hook functions are invoked with `this` bound to the associated
-Fastify instance.
+ignored, allowing the queue of hooks to continue. Hook functions accept two
+arguments: the Fastify `instance` the hook was registered on, and a callback,
+`done`, to be invoked after the hook function is complete. Hook functions are
+invoked with `this` bound to the associated Fastify instance.
 
 This is an alternative to `fastify.server.on('listening', () => {})`.
 
 ```js
 // callback style
-fastify.addHook('onListen', function (done) {
+fastify.addHook('onListen', function (instance, done) {
   // Some code
   const err = null;
   done(err)
 })
 
 // or async/await style
-fastify.addHook('onListen', async function () {
+fastify.addHook('onListen', async function (instance) {
   // Some async code
 })
 ```
@@ -530,13 +531,13 @@ use the [`onClose`](#onclose) for the most common case.
 
 ```js
 // callback style
-fastify.addHook('preClose', (done) => {
+fastify.addHook('preClose', (instance, done) => {
   // Some code
   done()
 })
 
 // or async/await style
-fastify.addHook('preClose', async () => {
+fastify.addHook('preClose', async (instance) => {
   // Some async code
   await removeSomeServerState()
 })
@@ -545,7 +546,7 @@ fastify.addHook('preClose', async () => {
 For example, closing WebSocket connections during shutdown:
 
 ```js
-fastify.addHook('preClose', async () => {
+fastify.addHook('preClose', async (instance) => {
   // Close all WebSocket connections so that server.close() can complete.
   // Without this, open connections would keep the server alive.
   for (const ws of activeWebSockets) {
@@ -557,12 +558,14 @@ fastify.addHook('preClose', async () => {
 ### onRoute
 <a id="on-route"></a>
 
-Triggered when a new route is registered. Listeners are passed a [`routeOptions`](./Routes.md#routes-options)
-object as the sole parameter. The interface is synchronous, and, as such, the
-listeners are not passed a callback. This hook is encapsulated.
+Triggered when a new route is registered. Listeners are passed the Fastify
+`instance` the route is being registered on and the
+[`routeOptions`](./Routes.md#routes-options) object. The interface is
+synchronous, and, as such, the listeners are not passed a callback. This hook is
+encapsulated.
 
 ```js
-fastify.addHook('onRoute', (routeOptions) => {
+fastify.addHook('onRoute', (instance, routeOptions) => {
   //Some code
   routeOptions.method
   routeOptions.schema
@@ -580,7 +583,7 @@ If you are authoring a plugin and you need to customize application routes, like
 modifying the options or adding new route hooks, this is the right place.
 
 ```js
-fastify.addHook('onRoute', (routeOptions) => {
+fastify.addHook('onRoute', (instance, routeOptions) => {
   function onPreSerialization(request, reply, payload, done) {
     // Your code
     done(null, payload)
@@ -597,7 +600,7 @@ not tagged. The recommended approach is shown below.
 ```js
 const kRouteAlreadyProcessed = Symbol('route-already-processed')
 
-fastify.addHook('onRoute', function (routeOptions) {
+fastify.addHook('onRoute', function (instance, routeOptions) {
   const { url, method } = routeOptions
 
   const isAlreadyProcessed = (routeOptions.custom && routeOptions.custom[kRouteAlreadyProcessed]) || false
@@ -647,15 +650,18 @@ fastify.register(async (instance, opts) => {
   console.log(instance.data) // []
 }, { prefix: '/hello' })
 
-fastify.addHook('onRegister', (instance, opts) => {
+fastify.addHook('onRegister', (instance, newInstance, options) => {
+  // `instance` is the instance the plugin is being registered on,
+  // `newInstance` is the encapsulated instance created for the plugin
+
   // Create a new array from the old one
   // but without keeping the reference
   // allowing the user to have encapsulated
   // instances of the `data` property
-  instance.data = instance.data.slice()
+  newInstance.data = newInstance.data.slice()
 
   // the options of the new registered instance
-  console.log(opts.prefix)
+  console.log(options.prefix)
 })
 ```
 

--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -1618,7 +1618,7 @@ This hook will be executed before the customErrorHandler.
 Notice: unlike the other hooks, pass an error to the done function is not
 supported.
 
-##### fastify.onRouteHookHandler< [RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>(opts: [RouteOptions][RouteOptions] & \{ path: string; prefix: string }): Promise\<unknown\> | void
+##### fastify.onRouteHookHandler< [RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [RequestGeneric][FastifyRequestGenericInterface], [ContextConfig][ContextConfigGeneric]>(instance: [FastifyInstance][FastifyInstance], opts: [RouteOptions][RouteOptions] & \{ path: string; prefix: string }): Promise\<unknown\> | void
 
 [src](https://github.com/fastify/fastify/blob/main/types/hooks.d.ts#L174)
 
@@ -1626,7 +1626,7 @@ Triggered when a new route is registered. Listeners are passed a routeOptions
 object as the sole parameter. The interface is synchronous, and, as such, the
 listener does not get passed a callback
 
-##### fastify.onRegisterHookHandler< [RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [Logger][LoggerGeneric]>(instance: [FastifyInstance][FastifyInstance], done: (err?: [FastifyError][FastifyError]) => void): Promise\<unknown\> | void
+##### fastify.onRegisterHookHandler< [RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [Logger][LoggerGeneric]>(instance: [FastifyInstance][FastifyInstance], newInstance: [FastifyInstance][FastifyInstance], options: [FastifyRegisterOptions][FastifyRegisterOptions]): Promise\<unknown\> | void
 
 [src](https://github.com/fastify/fastify/blob/main/types/hooks.d.ts#L191)
 

--- a/docs/Reference/TypeScript.md
+++ b/docs/Reference/TypeScript.md
@@ -1622,16 +1622,20 @@ supported.
 
 [src](https://github.com/fastify/fastify/blob/main/types/hooks.d.ts#L174)
 
-Triggered when a new route is registered. Listeners are passed a routeOptions
-object as the sole parameter. The interface is synchronous, and, as such, the
-listener does not get passed a callback
+Triggered when a new route is registered. Listeners are passed the encapsulated
+Fastify instance the route is being registered on as the first parameter, and a
+routeOptions object as the second one. The interface is synchronous, and, as
+such, the listener does not get passed a callback
 
 ##### fastify.onRegisterHookHandler< [RawServer][RawServerGeneric], [RawRequest][RawRequestGeneric], [RawReply][RawReplyGeneric], [Logger][LoggerGeneric]>(instance: [FastifyInstance][FastifyInstance], newInstance: [FastifyInstance][FastifyInstance], options: [FastifyRegisterOptions][FastifyRegisterOptions]): Promise\<unknown\> | void
 
 [src](https://github.com/fastify/fastify/blob/main/types/hooks.d.ts#L191)
 
 Triggered when a new plugin is registered and a new encapsulation context is
-created. The hook will be executed before the registered code.
+created. The hook will be executed before the registered code. Listeners are
+passed the instance the plugin is being registered on as the first parameter,
+the newly created encapsulated instance as the second one, and the registration
+options as the third one.
 
 This hook can be useful if you are developing a plugin that needs to know when a
 plugin context is formed, and you want to operate in that specific context.

--- a/examples/hooks.js
+++ b/examples/hooks.js
@@ -65,8 +65,8 @@ fastify
     console.log('onResponse')
     done()
   })
-  .addHook('onRoute', function (routeOptions) {
-    console.log('onRoute')
+  .addHook('onRoute', function (instance, routeOptions) {
+    console.log('onRoute', routeOptions.method, routeOptions.url)
   })
   .addHook('onListen', async function () {
     console.log('onListen')

--- a/fastify.js
+++ b/fastify.js
@@ -588,6 +588,10 @@ function fastify (serverOptions) {
       if (fn.constructor.name === 'AsyncFunction' && fn.length > 1) {
         throw new errorCodes.FST_ERR_HOOK_INVALID_ASYNC_HANDLER()
       }
+    } else if (name === 'onRegister') {
+      if (fn.constructor.name === 'AsyncFunction' && fn.length > 3) {
+        throw new errorCodes.FST_ERR_HOOK_INVALID_ASYNC_HANDLER()
+      }
     } else if (name === 'onRequestAbort') {
       if (fn.constructor.name === 'AsyncFunction' && fn.length !== 1) {
         throw new errorCodes.FST_ERR_HOOK_INVALID_ASYNC_HANDLER()

--- a/fastify.js
+++ b/fastify.js
@@ -584,8 +584,8 @@ function fastify (serverOptions) {
       if (fn.constructor.name === 'AsyncFunction' && fn.length === 4) {
         throw new errorCodes.FST_ERR_HOOK_INVALID_ASYNC_HANDLER()
       }
-    } else if (name === 'onReady' || name === 'onListen') {
-      if (fn.constructor.name === 'AsyncFunction' && fn.length !== 0) {
+    } else if (name === 'onReady' || name === 'onListen' || name === 'preClose') {
+      if (fn.constructor.name === 'AsyncFunction' && fn.length > 1) {
         throw new errorCodes.FST_ERR_HOOK_INVALID_ASYNC_HANDLER()
       }
     } else if (name === 'onRequestAbort') {

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -150,15 +150,16 @@ function hookRunnerApplication (hookName, boot, server, cb) {
   }
 
   function wrap (fn, server) {
+    // Application hooks receive the fastify instance as first argument.
     return function (err, done) {
       if (err) {
         done(err)
         return
       }
 
-      if (fn.length === 1) {
+      if (fn.length === 2) {
         try {
-          fn.call(server, done)
+          fn.call(server, server, done)
         } catch (error) {
           done(error)
         }
@@ -166,7 +167,7 @@ function hookRunnerApplication (hookName, boot, server, cb) {
       }
 
       try {
-        const ret = fn.call(server)
+        const ret = fn.call(server, server)
         if (ret && typeof ret.then === 'function') {
           ret.then(done, done)
           return
@@ -206,16 +207,16 @@ function onListenHookRunner (server) {
   }
 
   async function wrap (fn, server, done) {
-    if (fn.length === 1) {
+    if (fn.length === 2) {
       try {
-        fn.call(server, done)
+        fn.call(server, server, done)
       } catch (e) {
         done(e)
       }
       return
     }
     try {
-      const ret = fn.call(server)
+      const ret = fn.call(server, server)
       if (ret && typeof ret.then === 'function') {
         ret.then(done, done)
         return

--- a/lib/plugin-override.js
+++ b/lib/plugin-override.js
@@ -68,7 +68,9 @@ module.exports = function override (old, fn, opts) {
     instance[kFourOhFour].arrange404(instance)
   }
 
-  for (const hook of instance[kHooks].onRegister) hook.call(old, instance, opts)
+  // `old` is the instance the plugin is being registered on, `instance` is the
+  // new encapsulated instance created for it.
+  for (const hook of instance[kHooks].onRegister) hook.call(old, old, instance, opts)
 
   return instance
 }

--- a/lib/route.js
+++ b/lib/route.js
@@ -293,7 +293,7 @@ function buildRouting (options) {
       if (prefixing === false) {
         // run 'onRoute' hooks
         for (const hook of this[kHooks].onRoute) {
-          hook.call(this, opts)
+          hook.call(this, this, opts)
         }
       }
 

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -628,7 +628,7 @@ test('preClose callback', (t, done) => {
   }
   fastify.addHook('preClose', preClose)
 
-  function preClose (done) {
+  function preClose (instance, done) {
     t.assert.ok(typeof this === typeof fastify)
     preCloseCalled = true
     done()
@@ -709,7 +709,7 @@ test('preClose execution order', (t, done) => {
     done()
   }
 
-  fastify.addHook('preClose', (done) => {
+  fastify.addHook('preClose', (instance, done) => {
     setTimeout(function () {
       order.push(1)
       done()
@@ -721,7 +721,7 @@ test('preClose execution order', (t, done) => {
     order.push(2)
   })
 
-  fastify.addHook('preClose', (done) => {
+  fastify.addHook('preClose', (instance, done) => {
     setTimeout(function () {
       order.push(3)
       done()

--- a/test/hooks-async.test.js
+++ b/test/hooks-async.test.js
@@ -813,6 +813,29 @@ describe('Should log a warning if is an async function with `done`', () => {
   })
 })
 
+describe('onRegister async arity', () => {
+  test('accepts an async handler with the three hook arguments', t => {
+    const fastify = Fastify()
+
+    t.assert.doesNotThrow(() => {
+      fastify.addHook('onRegister', async (instance, newInstance, options) => {})
+    })
+  })
+
+  test('rejects an async handler with a fourth argument', t => {
+    const fastify = Fastify()
+
+    try {
+      fastify.addHook('onRegister', async (instance, newInstance, options, done) => {
+        t.assert.fail('should have not be called')
+      })
+    } catch (e) {
+      t.assert.strictEqual(e.code, 'FST_ERR_HOOK_INVALID_ASYNC_HANDLER')
+      t.assert.strictEqual(e.message, 'Async function has too many arguments. Async hooks should not use the \'done\' argument.')
+    }
+  })
+})
+
 test('early termination, onRequest async', async t => {
   const app = Fastify()
 

--- a/test/hooks.on-listen.test.js
+++ b/test/hooks.on-listen.test.js
@@ -20,7 +20,7 @@ test('onListen should not be processed when .ready() is called', (t, testDone) =
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.fail()
     done()
   })
@@ -37,12 +37,12 @@ test('localhost onListen should be called in order', (t, testDone) => {
   t.after(() => fastify.close())
   let order = 0
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 1, '1st called in root')
     done()
   })
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 2, '2nd called in root')
     done()
   })
@@ -94,19 +94,19 @@ test('localhost onListen sync should log errors as warnings and continue /1', as
     }
   })
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 1, '1st call')
     t.assert.ok('called in root')
     done()
   })
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 2, '2nd call')
     t.assert.ok('called onListen error')
     throw new Error('FAIL ON LISTEN')
   })
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 3, '3rd call')
     t.assert.ok('onListen hooks continue after error')
     done()
@@ -138,19 +138,19 @@ test('localhost onListen sync should log errors as warnings and continue /2', (t
     }
   })
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 1, '1st call')
     t.assert.ok('called in root')
     done()
   })
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 2, '2nd call')
     t.assert.ok('called onListen error')
     done(new Error('FAIL ON LISTEN'))
   })
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 3, '3rd call')
     t.assert.ok('onListen hooks continue after error')
     done()
@@ -205,7 +205,7 @@ test('localhost Register onListen hook after a plugin inside a plugin', (t, test
   t.after(() => fastify.close())
 
   fastify.register(fp(function (instance, opts, done) {
-    instance.addHook('onListen', function (done) {
+    instance.addHook('onListen', function (instance, done) {
       t.assert.ok('called')
       done()
     })
@@ -213,12 +213,12 @@ test('localhost Register onListen hook after a plugin inside a plugin', (t, test
   }))
 
   fastify.register(fp(function (instance, opts, done) {
-    instance.addHook('onListen', function (done) {
+    instance.addHook('onListen', function (instance, done) {
       t.assert.ok('called')
       done()
     })
 
-    instance.addHook('onListen', function (done) {
+    instance.addHook('onListen', function (instance, done) {
       t.assert.ok('called')
       done()
     })
@@ -285,14 +285,14 @@ test('localhost onListen encapsulation should be called in order', async t => {
 
   let order = 0
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 1, 'called in root')
     t.assert.strictEqual(this.pluginName, fastify.pluginName, 'the this binding is the right instance')
     done()
   })
 
   await fastify.register(async (childOne, o) => {
-    childOne.addHook('onListen', function (done) {
+    childOne.addHook('onListen', function (instance, done) {
       t.assert.strictEqual(++order, 2, 'called in childOne')
       t.assert.strictEqual(this.pluginName, childOne.pluginName, 'the this binding is the right instance')
       done()
@@ -325,7 +325,7 @@ test('localhost onListen encapsulation with only nested hook', async t => {
 
   await fastify.register(async (child) => {
     await child.register(async (child2) => {
-      child2.addHook('onListen', function (done) {
+      child2.addHook('onListen', function (instance, done) {
         t.assert.ok()
         done()
       })
@@ -345,14 +345,14 @@ test('localhost onListen peer encapsulations with only nested hooks', async t =>
 
   await fastify.register(async (child) => {
     await child.register(async (child2) => {
-      child2.addHook('onListen', function (done) {
+      child2.addHook('onListen', function (instance, done) {
         t.assert.ok()
         done()
       })
     })
 
     await child.register(async (child2) => {
-      child2.addHook('onListen', function (done) {
+      child2.addHook('onListen', function (instance, done) {
         t.assert.ok()
         done()
       })
@@ -385,14 +385,14 @@ test('localhost onListen encapsulation should be called in order and should log 
 
   let order = 0
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 1, 'called in root')
     t.assert.strictEqual(this.pluginName, fastify.pluginName, 'the this binding is the right instance')
     done()
   })
 
   fastify.register(async (childOne, o) => {
-    childOne.addHook('onListen', function (done) {
+    childOne.addHook('onListen', function (instance, done) {
       t.assert.strictEqual(++order, 2, 'called in childOne')
       t.assert.strictEqual(this.pluginName, childOne.pluginName, 'the this binding is the right instance')
       done()
@@ -419,12 +419,12 @@ test('non-localhost onListen should be called in order', { skip: isIPv6Missing }
 
   let order = 0
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 1, '1st called in root')
     done()
   })
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 2, '2nd called in root')
     done()
   })
@@ -473,7 +473,7 @@ test('non-localhost sync onListen should log errors as warnings and continue', {
   })
   let order = 0
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 1)
     done()
   })
@@ -483,7 +483,7 @@ test('non-localhost sync onListen should log errors as warnings and continue', {
     throw new Error('FAIL ON LISTEN')
   })
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 3, 'should still run')
     done()
   })
@@ -541,7 +541,7 @@ test('non-localhost Register onListen hook after a plugin inside a plugin', { sk
   t.after(() => fastify.close())
 
   fastify.register(fp(function (instance, opts, done) {
-    instance.addHook('onListen', function (done) {
+    instance.addHook('onListen', function (instance, done) {
       t.assert.ok('called')
       done()
     })
@@ -549,12 +549,12 @@ test('non-localhost Register onListen hook after a plugin inside a plugin', { sk
   }))
 
   fastify.register(fp(function (instance, opts, done) {
-    instance.addHook('onListen', function (done) {
+    instance.addHook('onListen', function (instance, done) {
       t.assert.ok('called')
       done()
     })
 
-    instance.addHook('onListen', function (done) {
+    instance.addHook('onListen', function (instance, done) {
       t.assert.ok('called')
       done()
     })
@@ -621,14 +621,14 @@ test('non-localhost onListen encapsulation should be called in order', { skip: i
 
   let order = 0
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 1, 'called in root')
     t.assert.strictEqual(this.pluginName, fastify.pluginName, 'the this binding is the right instance')
     done()
   })
 
   fastify.register(async (childOne, o) => {
-    childOne.addHook('onListen', function (done) {
+    childOne.addHook('onListen', function (instance, done) {
       t.assert.strictEqual(++order, 2, 'called in childOne')
       t.assert.strictEqual(this.pluginName, childOne.pluginName, 'the this binding is the right instance')
       done()
@@ -666,7 +666,7 @@ test('non-localhost onListen encapsulation should be called in order and should 
 
   let order = 0
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 1, 'called in root')
 
     t.assert.strictEqual(this.pluginName, fastify.pluginName, 'the this binding is the right instance')
@@ -674,7 +674,7 @@ test('non-localhost onListen encapsulation should be called in order and should 
   })
 
   fastify.register(async (childOne, o) => {
-    childOne.addHook('onListen', function (done) {
+    childOne.addHook('onListen', function (instance, done) {
       t.assert.strictEqual(++order, 2, 'called in childOne')
       t.assert.strictEqual(this.pluginName, childOne.pluginName, 'the this binding is the right instance')
       done()
@@ -699,12 +699,12 @@ test('onListen localhost should work in order with callback', (t, testDone) => {
   t.after(() => fastify.close())
   let order = 0
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 1, '1st called in root')
     done()
   })
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 2, '2nd called in root')
     done()
   })
@@ -757,7 +757,7 @@ test('onListen localhost sync with callback should log errors as warnings and co
 
   let order = 0
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 1, '1st called in root')
     done()
   })
@@ -767,7 +767,7 @@ test('onListen localhost sync with callback should log errors as warnings and co
     throw new Error('FAIL ON LISTEN')
   })
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 3, '1st called in root')
     done()
   })
@@ -825,7 +825,7 @@ test('Register onListen hook localhost with callback after a plugin inside a plu
   t.after(() => fastify.close())
 
   fastify.register(fp(function (instance, opts, done) {
-    instance.addHook('onListen', function (done) {
+    instance.addHook('onListen', function (instance, done) {
       t.assert.ok('called')
       done()
     })
@@ -833,12 +833,12 @@ test('Register onListen hook localhost with callback after a plugin inside a plu
   }))
 
   fastify.register(fp(function (instance, opts, done) {
-    instance.addHook('onListen', function (done) {
+    instance.addHook('onListen', function (instance, done) {
       t.assert.ok('called')
       done()
     })
 
-    instance.addHook('onListen', function (done) {
+    instance.addHook('onListen', function (instance, done) {
       t.assert.ok('called')
       done()
     })
@@ -860,14 +860,14 @@ test('onListen localhost with callback encapsulation should be called in order',
 
   let order = 0
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 1, 'called in root')
     t.assert.strictEqual(this.pluginName, fastify.pluginName, 'the this binding is the right instance')
     done()
   })
 
   fastify.register(async (childOne, o) => {
-    childOne.addHook('onListen', function (done) {
+    childOne.addHook('onListen', function (instance, done) {
       t.assert.strictEqual(++order, 2, 'called in childOne')
       t.assert.strictEqual(this.pluginName, childOne.pluginName, 'the this binding is the right instance')
       done()
@@ -892,12 +892,12 @@ test('onListen non-localhost should work in order with callback in sync', { skip
   t.after(() => fastify.close())
   let order = 0
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 1, '1st called in root')
     done()
   })
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 2, '2nd called in root')
     done()
   })
@@ -951,7 +951,7 @@ test('onListen non-localhost sync with callback should log errors as warnings an
 
   let order = 0
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 1)
     t.assert.ok('1st called in root')
     done()
@@ -962,7 +962,7 @@ test('onListen non-localhost sync with callback should log errors as warnings an
     throw new Error('FAIL ON LISTEN')
   })
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 3)
     t.assert.ok('3rd called in root')
     done()
@@ -1024,7 +1024,7 @@ test('Register onListen hook non-localhost with callback after a plugin inside a
   t.after(() => fastify.close())
 
   fastify.register(fp(function (instance, opts, done) {
-    instance.addHook('onListen', function (done) {
+    instance.addHook('onListen', function (instance, done) {
       t.assert.ok('called')
       done()
     })
@@ -1032,12 +1032,12 @@ test('Register onListen hook non-localhost with callback after a plugin inside a
   }))
 
   fastify.register(fp(function (instance, opts, done) {
-    instance.addHook('onListen', function (done) {
+    instance.addHook('onListen', function (instance, done) {
       t.assert.ok('called')
       done()
     })
 
-    instance.addHook('onListen', function (done) {
+    instance.addHook('onListen', function (instance, done) {
       t.assert.ok('called')
       done()
     })
@@ -1059,14 +1059,14 @@ test('onListen non-localhost with callback encapsulation should be called in ord
 
   let order = 0
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(++order, 1, 'called in root')
     t.assert.strictEqual(this.pluginName, fastify.pluginName, 'the this binding is the right instance')
     done()
   })
 
   fastify.register(async (childOne, o) => {
-    childOne.addHook('onListen', function (done) {
+    childOne.addHook('onListen', function (instance, done) {
       t.assert.strictEqual(++order, 2, 'called in childOne')
       t.assert.strictEqual(this.pluginName, childOne.pluginName, 'the this binding is the right instance')
       done()
@@ -1131,7 +1131,7 @@ test('onListen hooks do not block /1', (t, testDone) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  fastify.addHook('onListen', function (done) {
+  fastify.addHook('onListen', function (instance, done) {
     t.assert.strictEqual(fastify[kState].listening, true)
     done()
   })

--- a/test/hooks.on-ready.test.js
+++ b/test/hooks.on-ready.test.js
@@ -10,14 +10,14 @@ test('onReady should be called in order', (t, done) => {
 
   let order = 0
 
-  fastify.addHook('onReady', function (done) {
+  fastify.addHook('onReady', function (instance, done) {
     t.assert.strictEqual(order++, 0, 'called in root')
     t.assert.strictEqual(this.pluginName, fastify.pluginName, 'the this binding is the right instance')
     done()
   })
 
   fastify.register(async (childOne, o) => {
-    childOne.addHook('onReady', function (done) {
+    childOne.addHook('onReady', function (instance, done) {
       t.assert.strictEqual(order++, 1, 'called in childOne')
       t.assert.strictEqual(this.pluginName, childOne.pluginName, 'the this binding is the right instance')
       done()
@@ -184,13 +184,13 @@ test('onReady should manage error in sync', (t, done) => {
   t.plan(4)
   const fastify = Fastify()
 
-  fastify.addHook('onReady', function (done) {
+  fastify.addHook('onReady', function (instance, done) {
     t.assert.ok('called in root')
     done()
   })
 
   fastify.register(async (childOne, o) => {
-    childOne.addHook('onReady', function (done) {
+    childOne.addHook('onReady', function (instance, done) {
       t.assert.ok('called in childOne')
       done(new Error('FAIL ON READY'))
     })
@@ -213,7 +213,7 @@ test('onReady should manage error in async', (t, done) => {
   t.plan(4)
   const fastify = Fastify()
 
-  fastify.addHook('onReady', function (done) {
+  fastify.addHook('onReady', function (instance, done) {
     t.assert.ok('called in root')
     done()
   })
@@ -242,13 +242,13 @@ test('onReady should manage sync error', (t, done) => {
   t.plan(4)
   const fastify = Fastify()
 
-  fastify.addHook('onReady', function (done) {
+  fastify.addHook('onReady', function (instance, done) {
     t.assert.ok('called in root')
     done()
   })
 
   fastify.register(async (childOne, o) => {
-    childOne.addHook('onReady', function (done) {
+    childOne.addHook('onReady', function (instance, done) {
       t.assert.ok('called in childOne')
       throw new Error('FAIL UNWANTED SYNC EXCEPTION')
     })
@@ -271,7 +271,7 @@ test('onReady can not add decorators or application hooks', (t, done) => {
   t.plan(3)
   const fastify = Fastify()
 
-  fastify.addHook('onReady', function (done) {
+  fastify.addHook('onReady', function (instance, done) {
     t.assert.ok('called in root')
     fastify.decorate('test', () => {})
 
@@ -281,7 +281,7 @@ test('onReady can not add decorators or application hooks', (t, done) => {
     done()
   })
 
-  fastify.addHook('onReady', function (done) {
+  fastify.addHook('onReady', function (instance, done) {
     t.assert.ok(this.hasDecorator('test'))
     done()
   })
@@ -296,7 +296,7 @@ test('onReady cannot add lifecycle hooks', (t, done) => {
   t.plan(5)
   const fastify = Fastify()
 
-  fastify.addHook('onReady', function (done) {
+  fastify.addHook('onReady', function (instance, done) {
     t.assert.ok('called in root')
     try {
       fastify.addHook('onRequest', (request, reply, done) => {})
@@ -323,7 +323,7 @@ test('onReady throw loading error', t => {
   const fastify = Fastify()
 
   try {
-    fastify.addHook('onReady', async function (done) {})
+    fastify.addHook('onReady', async function (instance, done) {})
   } catch (e) {
     t.assert.strictEqual(e.code, 'FST_ERR_HOOK_INVALID_ASYNC_HANDLER')
     t.assert.ok(e.message === 'Async function has too many arguments. Async hooks should not use the \'done\' argument.')
@@ -334,7 +334,7 @@ test('onReady does not call done', (t, done) => {
   t.plan(6)
   const fastify = Fastify({ pluginTimeout: 500 })
 
-  fastify.addHook('onReady', function someHookName (done) {
+  fastify.addHook('onReady', function someHookName (instance, done) {
     t.assert.ok('called in root')
     // done() // don't call done to test timeout
   })

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -355,13 +355,13 @@ test('onRoute hook should be called / 2', (t, testDone) => {
   let firstHandler = 0
   let secondHandler = 0
   const fastify = Fastify({ exposeHeadRoutes: false })
-  fastify.addHook('onRoute', (route) => {
+  fastify.addHook('onRoute', (instance, route) => {
     t.assert.ok('should pass')
     firstHandler++
   })
 
   fastify.register((instance, opts, done) => {
-    instance.addHook('onRoute', (route) => {
+    instance.addHook('onRoute', (instance, route) => {
       t.assert.ok('should pass')
       secondHandler++
     })
@@ -389,12 +389,12 @@ test('onRoute hook should be called / 3', (t, testDone) => {
     reply.send()
   }
 
-  fastify.addHook('onRoute', (route) => {
+  fastify.addHook('onRoute', (instance, route) => {
     t.assert.ok('should pass')
   })
 
   fastify.register((instance, opts, done) => {
-    instance.addHook('onRoute', (route) => {
+    instance.addHook('onRoute', (instance, route) => {
       t.assert.ok('should pass')
     })
     instance.get('/a', handler)
@@ -489,16 +489,17 @@ test('onRoute hook should be called (encapsulation support) / 6', (t, testDone) 
 })
 
 test('onRoute should keep the context', (t, testDone) => {
-  t.plan(4)
+  t.plan(5)
   const fastify = Fastify({ exposeHeadRoutes: false })
   fastify.register((instance, opts, done) => {
     instance.decorate('test', true)
     instance.addHook('onRoute', onRoute)
     t.assert.ok(instance.prototype === fastify.prototype)
 
-    function onRoute (route) {
+    function onRoute (hookInstance, route) {
       t.assert.ok(this.test)
       t.assert.strictEqual(this, instance)
+      t.assert.strictEqual(hookInstance, instance)
     }
 
     instance.get('/', opts, function (req, reply) {
@@ -517,7 +518,7 @@ test('onRoute should keep the context', (t, testDone) => {
 test('onRoute hook should pass correct route', (t, testDone) => {
   t.plan(9)
   const fastify = Fastify({ exposeHeadRoutes: false })
-  fastify.addHook('onRoute', (route) => {
+  fastify.addHook('onRoute', (instance, route) => {
     t.assert.strictEqual(route.method, 'GET')
     t.assert.strictEqual(route.url, '/')
     t.assert.strictEqual(route.path, '/')
@@ -525,7 +526,7 @@ test('onRoute hook should pass correct route', (t, testDone) => {
   })
 
   fastify.register((instance, opts, done) => {
-    instance.addHook('onRoute', (route) => {
+    instance.addHook('onRoute', (instance, route) => {
       t.assert.strictEqual(route.method, 'GET')
       t.assert.strictEqual(route.url, '/')
       t.assert.strictEqual(route.path, '/')
@@ -546,7 +547,7 @@ test('onRoute hook should pass correct route', (t, testDone) => {
 test('onRoute hook should pass correct route with custom prefix', (t, testDone) => {
   t.plan(11)
   const fastify = Fastify({ exposeHeadRoutes: false })
-  fastify.addHook('onRoute', function (route) {
+  fastify.addHook('onRoute', function (instance, route) {
     t.assert.strictEqual(route.method, 'GET')
     t.assert.strictEqual(route.url, '/v1/foo')
     t.assert.strictEqual(route.path, '/v1/foo')
@@ -555,7 +556,7 @@ test('onRoute hook should pass correct route with custom prefix', (t, testDone) 
   })
 
   fastify.register((instance, opts, done) => {
-    instance.addHook('onRoute', function (route) {
+    instance.addHook('onRoute', function (instance, route) {
       t.assert.strictEqual(route.method, 'GET')
       t.assert.strictEqual(route.url, '/v1/foo')
       t.assert.strictEqual(route.path, '/v1/foo')
@@ -578,7 +579,7 @@ test('onRoute hook should pass correct route with custom options', (t, testDone)
   t.plan(6)
   const fastify = Fastify({ exposeHeadRoutes: false })
   fastify.register((instance, opts, done) => {
-    instance.addHook('onRoute', function (route) {
+    instance.addHook('onRoute', function (instance, route) {
       t.assert.strictEqual(route.method, 'GET')
       t.assert.strictEqual(route.url, '/foo')
       t.assert.strictEqual(route.logLevel, 'info')
@@ -607,7 +608,7 @@ test('onRoute hook should receive any route option', (t, testDone) => {
   t.plan(5)
   const fastify = Fastify({ exposeHeadRoutes: false })
   fastify.register((instance, opts, done) => {
-    instance.addHook('onRoute', function (route) {
+    instance.addHook('onRoute', function (instance, route) {
       t.assert.strictEqual(route.method, 'GET')
       t.assert.strictEqual(route.url, '/foo')
       t.assert.strictEqual(route.routePath, '/foo')
@@ -629,7 +630,7 @@ test('onRoute hook should preserve system route configuration', (t, testDone) =>
   t.plan(5)
   const fastify = Fastify({ exposeHeadRoutes: false })
   fastify.register((instance, opts, done) => {
-    instance.addHook('onRoute', function (route) {
+    instance.addHook('onRoute', function (instance, route) {
       t.assert.strictEqual(route.method, 'GET')
       t.assert.strictEqual(route.url, '/foo')
       t.assert.strictEqual(route.routePath, '/foo')
@@ -654,7 +655,7 @@ test('onRoute hook should preserve handler function in options of shorthand rout
 
   const fastify = Fastify({ exposeHeadRoutes: false })
   fastify.register((instance, opts, done) => {
-    instance.addHook('onRoute', function (route) {
+    instance.addHook('onRoute', function (instance, route) {
       t.assert.strictEqual(route.handler, handler)
     })
     instance.get('/foo', { handler })
@@ -687,7 +688,7 @@ test('onRoute hook should be called once when prefixTrailingSlash', (t, testDone
       routePatched++
     }
 
-    instance.addHook('onRoute', function (routeOptions) {
+    instance.addHook('onRoute', function (instance, routeOptions) {
       onRouteCalled++
       patchTheRoute(routeOptions)
     })
@@ -723,7 +724,7 @@ test('onRoute hook should able to change the route url', async t => {
   t.after(() => { fastify.close() })
 
   fastify.register((instance, opts, done) => {
-    instance.addHook('onRoute', (route) => {
+    instance.addHook('onRoute', (instance, route) => {
       t.assert.strictEqual(route.url, '/foo')
       route.url = encodeURI(route.url)
     })
@@ -779,7 +780,7 @@ test('onRoute hook with many prefix', (t, testDone) => {
   ]
 
   fastify.register((instance, opts, done) => {
-    instance.addHook('onRoute', ({ routePath, prefix, url }) => {
+    instance.addHook('onRoute', (instance, { routePath, prefix, url }) => {
       t.assert.deepStrictEqual({ routePath, prefix, url }, onRouteChecks.pop())
     })
     instance.route({ method: 'GET', url: '/aPath', handler })
@@ -3017,11 +3018,11 @@ test('onRegister hook should be called / 1', (t, testDone) => {
   t.plan(5)
   const fastify = Fastify()
 
-  fastify.addHook('onRegister', function (instance, opts, done) {
+  fastify.addHook('onRegister', function (instance, newInstance, options) {
     t.assert.ok(this.addHook)
-    t.assert.ok(instance.addHook)
-    t.assert.deepStrictEqual(opts, pluginOpts)
-    t.assert.ok(!done)
+    t.assert.strictEqual(instance, fastify)
+    t.assert.ok(newInstance.addHook)
+    t.assert.deepStrictEqual(options, pluginOpts)
   })
 
   const pluginOpts = { prefix: 'hello', custom: 'world' }
@@ -3039,9 +3040,9 @@ test('onRegister hook should be called / 2', (t, testDone) => {
   t.plan(7)
   const fastify = Fastify()
 
-  fastify.addHook('onRegister', function (instance) {
+  fastify.addHook('onRegister', function (instance, newInstance) {
     t.assert.ok(this.addHook)
-    t.assert.ok(instance.addHook)
+    t.assert.ok(newInstance.addHook)
   })
 
   fastify.register((instance, opts, done) => {
@@ -3067,8 +3068,8 @@ test('onRegister hook should be called / 3', (t, testDone) => {
 
   fastify.decorate('data', [])
 
-  fastify.addHook('onRegister', instance => {
-    instance.data = instance.data.slice()
+  fastify.addHook('onRegister', (instance, newInstance) => {
+    newInstance.data = newInstance.data.slice()
   })
 
   fastify.register((instance, opts, done) => {
@@ -3102,7 +3103,7 @@ test('onRegister hook should be called (encapsulation)', (t, testDone) => {
   }
   plugin[Symbol.for('skip-override')] = true
 
-  fastify.addHook('onRegister', (instance, opts) => {
+  fastify.addHook('onRegister', (instance, newInstance, options) => {
     t.assert.fail('This should not be called')
   })
 
@@ -3344,7 +3345,7 @@ test('registering invalid hooks should throw an error', async t => {
   })
 
   t.assert.throws(() => {
-    fastify.addHook('onRoute', (routeOptions) => {
+    fastify.addHook('onRoute', (instance, routeOptions) => {
       routeOptions.onSend = [undefined]
     })
 

--- a/test/route-prefix.test.js
+++ b/test/route-prefix.test.js
@@ -579,7 +579,7 @@ test('reports the canonical route url for hidden prefix trailing slash route', a
 
   const onRouteUrls = []
 
-  fastify.addHook('onRoute', routeOptions => {
+  fastify.addHook('onRoute', (instance, routeOptions) => {
     onRouteUrls.push(routeOptions.url)
   })
 

--- a/test/route.2.test.js
+++ b/test/route.2.test.js
@@ -15,13 +15,13 @@ test('same route definition object on multiple prefixes', async t => {
   const fastify = Fastify({ exposeHeadRoutes: false })
 
   fastify.register(async function (f) {
-    f.addHook('onRoute', (routeOptions) => {
+    f.addHook('onRoute', (instance, routeOptions) => {
       t.assert.strictEqual(routeOptions.url, '/v1/simple')
     })
     f.route(routeObject)
   }, { prefix: '/v1' })
   fastify.register(async function (f) {
-    f.addHook('onRoute', (routeOptions) => {
+    f.addHook('onRoute', (instance, routeOptions) => {
       t.assert.strictEqual(routeOptions.url, '/v2/simple')
     })
     f.route(routeObject)

--- a/test/route.6.test.js
+++ b/test/route.6.test.js
@@ -13,7 +13,7 @@ test('Creates a HEAD route for a GET one with prefixTrailingSlash', async (t) =>
 
   const arr = []
   fastify.register((instance, opts, next) => {
-    instance.addHook('onRoute', (routeOptions) => {
+    instance.addHook('onRoute', (instance, routeOptions) => {
       arr.push(`${routeOptions.method} ${routeOptions.url}`)
     })
 

--- a/test/route.8.test.js
+++ b/test/route.8.test.js
@@ -100,7 +100,7 @@ test('exposeHeadRoute should not reuse the same route option', async t => {
   // we update the onRequest hook in onRoute hook
   // if we reuse the same route option
   // that means we will append another function inside the array
-  fastify.addHook('onRoute', function (routeOption) {
+  fastify.addHook('onRoute', function (instance, routeOption) {
     if (Array.isArray(routeOption.onRequest)) {
       routeOption.onRequest.push(() => {})
     } else {
@@ -108,7 +108,7 @@ test('exposeHeadRoute should not reuse the same route option', async t => {
     }
   })
 
-  fastify.addHook('onRoute', function (routeOption) {
+  fastify.addHook('onRoute', function (instance, routeOption) {
     t.assert.strictEqual(routeOption.onRequest.length, 1)
   })
 

--- a/test/schema-feature.test.js
+++ b/test/schema-feature.test.js
@@ -1343,7 +1343,7 @@ test('onReady hook has the compilers ready', (t, testDone) => {
     }
   })
 
-  fastify.addHook('onReady', function (done) {
+  fastify.addHook('onReady', function (instance, done) {
     t.assert.ok(this.validatorCompiler)
     t.assert.ok(this.serializerCompiler)
     done()
@@ -1351,7 +1351,7 @@ test('onReady hook has the compilers ready', (t, testDone) => {
 
   let hookCallCounter = 0
   fastify.register(async (i, o) => {
-    i.addHook('onReady', function (done) {
+    i.addHook('onReady', function (instance, done) {
       t.assert.ok(this.validatorCompiler)
       t.assert.ok(this.serializerCompiler)
       done()
@@ -1359,7 +1359,7 @@ test('onReady hook has the compilers ready', (t, testDone) => {
 
     i.register(async (i, o) => { })
 
-    i.addHook('onReady', function (done) {
+    i.addHook('onReady', function (instance, done) {
       hookCallCounter++
       done()
     })
@@ -1552,21 +1552,21 @@ test('Schema controller bucket', (t, testDone) => {
 
   fastify.register(async (instance) => {
     instance.addSchema({ $id: 'b', type: 'string' })
-    instance.addHook('onReady', function (done) {
+    instance.addHook('onReady', function (instance, done) {
       t.assert.strictEqual(instance.getSchemas().size, 2)
       done()
     })
     instance.register(async (subinstance) => {
       subinstance.addSchema({ $id: 'c', type: 'string' })
-      subinstance.addHook('onReady', function (done) {
-        t.assert.strictEqual(subinstance.getSchemas().size, 3)
+      subinstance.addHook('onReady', function (instance, done) {
+        t.assert.strictEqual(instance.getSchemas().size, 3)
         done()
       })
     })
   })
 
   fastify.register(async (instance) => {
-    instance.addHook('onReady', function (done) {
+    instance.addHook('onReady', function (instance, done) {
       t.assert.strictEqual(instance.getSchemas().size, 1)
       done()
     })
@@ -1624,7 +1624,7 @@ test('setSchemaController per instance', (t, testDone) => {
 
     instance2.addSchema(bSchema)
 
-    instance2.addHook('onReady', function (done) {
+    instance2.addHook('onReady', function (instance, done) {
       instance2.getSchemas()
       t.assert.deepStrictEqual(instance2.getSchema('b'), bSchema, 'the schema are loaded')
       done()

--- a/test/types/hooks.tst.ts
+++ b/test/types/hooks.tst.ts
@@ -125,26 +125,30 @@ server.addHook('onRequestAbort', function (request, done) {
   expect(done(new Error())).type.toBe<void>()
 })
 
-server.addHook('onRoute', function (opts) {
+server.addHook('onRoute', function (instance, opts) {
   expect(this).type.toBe<FastifyInstance>()
+  expect(instance).type.toBe<FastifyInstance>()
   expect(opts).type.toBe<RouteOptions & { routePath: string; path: string; prefix: string }>()
 })
 
-server.addHook('onRegister', function (instance, opts) {
+server.addHook('onRegister', function (instance, newInstance, options) {
   expect(this).type.toBe<FastifyInstance>()
   expect(instance).type.toBe<FastifyInstance>()
-  expect(opts).type.toBe<RegisterOptions & FastifyPluginOptions>()
+  expect(newInstance).type.toBe<FastifyInstance>()
+  expect(options).type.toBe<RegisterOptions & FastifyPluginOptions>()
 })
 
-server.addHook('onReady', function (done) {
+server.addHook('onReady', function (instance, done) {
   expect(this).type.toBe<FastifyInstance>()
+  expect(instance).type.toBe<FastifyInstance>()
   expect(done).type.toBeAssignableTo<(err?: FastifyError) => void>()
   expect(done).type.toBeAssignableTo<(err?: NodeJS.ErrnoException) => void>()
   expect(done(new Error())).type.toBe<void>()
 })
 
-server.addHook('onListen', function (done) {
+server.addHook('onListen', function (instance, done) {
   expect(this).type.toBe<FastifyInstance>()
+  expect(instance).type.toBe<FastifyInstance>()
   expect(done).type.toBeAssignableTo<(err?: FastifyError) => void>()
   expect(done).type.toBeAssignableTo<(err?: NodeJS.ErrnoException) => void>()
 })
@@ -222,17 +226,20 @@ server.addHook('onRequestAbort', async function (request) {
   expect(request).type.toBe<FastifyRequest>()
 })
 
-server.addHook('onRegister', async (instance, opts) => {
+server.addHook('onRegister', async (instance, newInstance, options) => {
   expect(instance).type.toBe<FastifyInstance>()
-  expect(opts).type.toBe<RegisterOptions & FastifyPluginOptions>()
+  expect(newInstance).type.toBe<FastifyInstance>()
+  expect(options).type.toBe<RegisterOptions & FastifyPluginOptions>()
 })
 
-server.addHook('onReady', async function () {
+server.addHook('onReady', async function (instance) {
   expect(this).type.toBe<FastifyInstance>()
+  expect(instance).type.toBe<FastifyInstance>()
 })
 
-server.addHook('onListen', async function () {
+server.addHook('onListen', async function (instance) {
   expect(this).type.toBe<FastifyInstance>()
+  expect(instance).type.toBe<FastifyInstance>()
 })
 
 server.addHook('onClose', async function (instance) {
@@ -528,25 +535,29 @@ server.get('/', {
 // server.get('/', { onTimeout: async (request, reply, done) => {} }, async (request, reply) => {})
 // server.get('/', { onError: async (request, reply, error, done) => {} }, async (request, reply) => {})
 
-server.addHook('preClose', function (done) {
+server.addHook('preClose', function (instance, done) {
   expect(this).type.toBe<FastifyInstance>()
+  expect(instance).type.toBe<FastifyInstance>()
   expect(done).type.toBeAssignableTo<(err?: FastifyError) => void>()
   expect(done).type.toBeAssignableTo<(err?: NodeJS.ErrnoException) => void>()
   expect(done(new Error())).type.toBe<void>()
 })
 
-const preCloseHandler: preCloseHookHandler = function (done) {
+const preCloseHandler: preCloseHookHandler = function (instance, done) {
   expect(this).type.toBe<FastifyInstance>()
+  expect(instance).type.toBe<FastifyInstance>()
   expect(done).type.toBe<HookHandlerDoneFunction>()
 }
 server.addHook('preClose', preCloseHandler)
 
-server.addHook('preClose', async function () {
+server.addHook('preClose', async function (instance) {
   expect(this).type.toBe<FastifyInstance>()
+  expect(instance).type.toBe<FastifyInstance>()
 })
 
-const preCloseAsyncHandler: preCloseAsyncHookHandler = async function () {
+const preCloseAsyncHandler: preCloseAsyncHookHandler = async function (instance) {
   expect(this).type.toBe<FastifyInstance>()
+  expect(instance).type.toBe<FastifyInstance>()
 }
 server.addHook('preClose', preCloseAsyncHandler)
 
@@ -555,9 +566,9 @@ server.addHook('onClose', async function (instance, done) {})
 // @ts-expect-error  No overload matches this call.
 server.addHook('onError', async function (request, reply, error, done) {})
 // @ts-expect-error  No overload matches this call.
-server.addHook('onReady', async function (done) {})
+server.addHook('onReady', async function (instance, done) {})
 // @ts-expect-error  No overload matches this call.
-server.addHook('onListen', async function (done) {})
+server.addHook('onListen', async function (instance, done) {})
 // @ts-expect-error  No overload matches this call.
 server.addHook('onRequest', async function (request, reply, done) {})
 // @ts-expect-error  No overload matches this call.
@@ -569,7 +580,7 @@ server.addHook('onSend', async function (request, reply, payload, done) {})
 // @ts-expect-error  No overload matches this call.
 server.addHook('onTimeout', async function (request, reply, done) {})
 // @ts-expect-error  No overload matches this call.
-server.addHook('preClose', async function (done) {})
+server.addHook('preClose', async function (instance, done) {})
 // @ts-expect-error  No overload matches this call.
 server.addHook('preHandler', async function (request, reply, done) {})
 // @ts-expect-error  No overload matches this call.

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -752,6 +752,7 @@ export interface onRouteHookHandler<
 > {
   (
     this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
+    instance: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
     opts: RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler,
       TypeProvider> & { routePath: string; path: string; prefix: string }
   ): Promise<unknown> | void;
@@ -773,7 +774,8 @@ export interface onRegisterHookHandler<
   (
     this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
     instance: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
-    opts: RegisterOptions & Options
+    newInstance: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
+    options: RegisterOptions & Options
   ): Promise<unknown> | void;
 }
 
@@ -789,6 +791,7 @@ export interface onReadyHookHandler<
 > {
   (
     this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
+    instance: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
     done: HookHandlerDoneFunction
   ): void;
 }
@@ -802,6 +805,7 @@ export interface onReadyAsyncHookHandler<
 > {
   (
     this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
+    instance: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
   ): Promise<unknown>;
 }
 
@@ -817,6 +821,7 @@ export interface onListenHookHandler<
 > {
   (
     this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
+    instance: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
     done: HookHandlerDoneFunction
   ): void;
 }
@@ -830,6 +835,7 @@ export interface onListenAsyncHookHandler<
 > {
   (
     this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
+    instance: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
   ): Promise<unknown>;
 }
 /**
@@ -874,6 +880,7 @@ export interface preCloseHookHandler<
 > {
   (
     this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
+    instance: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
     done: HookHandlerDoneFunction
   ): void;
 }
@@ -887,6 +894,7 @@ export interface preCloseAsyncHookHandler<
 > {
   (
     this: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
+    instance: FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>,
   ): Promise<unknown>;
 }
 


### PR DESCRIPTION
fix: standardize application hook parameters

All six application hooks now receive `instance` as the first
parameter, consistent with `this` binding from #5675.
onRegister receives `newInstance` as second parameter for
parent/child disambiguation.

Closes #4967

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
