### PR TITLE
fix(types): preserve `this` binding in RouteShorthandHook

### DIFF
--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -46,7 +46,8 @@ export interface RouteConstraint {
 /**
  * Route shorthand options for the various shorthand methods
  */
-type RouteShorthandHook<T extends (...args: any) => any> = (...args: Parameters<T>) => void | Promise<unknown>
+type RouteShorthandHook<T extends (...args: any) => any> =
+  (this: ThisParameterType<T>, ...args: Parameters<T>) => void | Promise<unknown>
 
 export interface RouteShorthandOptions<
   RawServer extends RawServerBase = RawServerDefault,


### PR DESCRIPTION
## Summary
- Fixes #6974. `RouteShorthandHook<T>` rebuilds the hook function type as `(...args: Parameters<T>) => void | Promise<unknown>`, which drops the original handler's `this` parameter. As a result, `this` inside a route-level hook (e.g. `onRequest` passed to `fastify.route({...})`) is inferred as the surrounding options object instead of `FastifyInstance`, causing spurious `strict` mode type errors such as `Property 'log' does not exist on type 'RouteOptions<...>'`.
- Replaces the rebuilt signature with `(this: ThisParameterType<T>, ...args: Parameters<T>) => void | Promise<unknown>`, which carries the original `this` type over without needing `infer` in the type parameter constraint (an alternative fix using `infer` was tried first but broke the `onRequestAbort` field's own constraint check inside `route.d.ts`).

## Test plan
- [x] Reproduced the reported error with the repo's own `tsc` against a minimal repro matching the issue.
- [x] Confirmed the fix resolves it.
- [x] `npm run test:types` (tstyche) — 16/16 type test files pass, 1282/1282 assertions.
- [x] `npx eslint types/route.d.ts` — clean.