### PR TITLE
fix: run onSend hooks from setNotFoundHandler regardless of dispatch path

### DIFF
--- a/docs/Reference/Reply.md
+++ b/docs/Reference/Reply.md
@@ -364,8 +364,11 @@ reply.code(303).redirect('/home', 302)
 ### .callNotFound()
 <a id="call-not-found"></a>
 
-Invokes the custom not found handler. Note that it will only call `preHandler`
-hook specified in [`setNotFoundHandler`](./Server.md#set-not-found-handler).
+Invokes the custom not found handler. Note that of the hooks specified in
+[`setNotFoundHandler`](./Server.md#set-not-found-handler), only `preHandler`
+is run explicitly; `preValidation` is skipped. `onSend` still runs as part of
+the normal response pipeline, alongside any `onSend` hooks already registered
+on the calling route's own scope.
 
 ```js
 reply.callNotFound()

--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -1860,14 +1860,19 @@ lifecycle](./Lifecycle.md#lifecycle) for unexisting URLs.
 Badly formatted URLs are sent to the [`onBadUrl`](#onbadurl)
 handler instead.
 
-You can also register [`preValidation`](./Hooks.md#route-hooks) and
-[`preHandler`](./Hooks.md#route-hooks) hooks for the 404 handler.
+You can also register [`preValidation`](./Hooks.md#route-hooks),
+[`preHandler`](./Hooks.md#route-hooks), and [`onSend`](./Hooks.md#route-hooks)
+hooks for the 404 handler.
 
 > ℹ️ Note:
 > The `preValidation` hook registered using this method will run for a
 > route that Fastify does not recognize and **not** when a route handler manually
 > calls [`reply.callNotFound`](./Reply.md#call-not-found). In which case, only
-> preHandler will be run.
+> `preHandler` is run explicitly. Hooks that are part of the normal response
+> pipeline (`preSerialization`, `onSend`, `onError`, `onResponse`) still run
+> either way; an `onSend` hook registered here runs together with, not
+> instead of, any `onSend` hooks already registered on the calling route's
+> own scope.
 
 
 ```js

--- a/lib/four-oh-four.js
+++ b/lib/four-oh-four.js
@@ -80,11 +80,8 @@ function fourOhFour (options) {
     // populated during preReady (potentially after this snapshot is taken when
     // the route is registered first), and prototype lookup keeps the
     // route-specific 404 context linked to the live one so hooks like
-    // preHandler are not lost. The route's own onSend is preserved as an own
-    // property.
-    const _404Context = Object.create(instance[kFourOhFourContext])
-    _404Context.onSend = context.onSend
-    context[kFourOhFourContext] = _404Context
+    // preHandler and onSend are not lost regardless of registration order.
+    context[kFourOhFourContext] = Object.create(instance[kFourOhFourContext])
   }
 
   function setNotFoundHandler (opts, handler, avvio, routeHandler) {

--- a/lib/four-oh-four.js
+++ b/lib/four-oh-four.js
@@ -80,8 +80,23 @@ function fourOhFour (options) {
     // populated during preReady (potentially after this snapshot is taken when
     // the route is registered first), and prototype lookup keeps the
     // route-specific 404 context linked to the live one so hooks like
-    // preHandler and onSend are not lost regardless of registration order.
-    context[kFourOhFourContext] = Object.create(instance[kFourOhFourContext])
+    // preHandler are not lost regardless of registration order.
+    const _404Context = Object.create(instance[kFourOhFourContext])
+
+    // onSend is the exception: the calling route's own onSend chain is kept
+    // as an own property (rather than falling through to the not-found
+    // context's) so that scope-wide response behavior tied to the caller's
+    // encapsulation (e.g. compression, common headers) still applies to a
+    // callNotFound() dispatch. The onSend option passed directly to
+    // setNotFoundHandler() is never part of that ambient chain -- it is
+    // tracked separately on the live context -- so it's safe to append
+    // without risking running an inherited hook twice.
+    const notFoundOnSend = instance[kFourOhFourContext].notFoundOnSendOption
+    if (context.onSend || notFoundOnSend) {
+      _404Context.onSend = (context.onSend || []).concat(notFoundOnSend || [])
+    }
+
+    context[kFourOhFourContext] = _404Context
   }
 
   function setNotFoundHandler (opts, handler, avvio, routeHandler) {
@@ -116,6 +131,10 @@ function fourOhFour (options) {
           opts.preValidation = opts.preValidation.bind(_fastify)
         }
       }
+
+      if (opts.onSend) {
+        opts.onSend = (Array.isArray(opts.onSend) ? opts.onSend : [opts.onSend]).map(hook => hook.bind(_fastify))
+      }
     }
 
     if (typeof opts === 'function') {
@@ -148,6 +167,12 @@ function fourOhFour (options) {
       config: opts.config || {},
       server: this
     })
+    // Tracked separately (and set synchronously, unlike the other hooks
+    // below) so that setContext() can append it to a calling route's own
+    // onSend chain regardless of whether the route or this not-found
+    // handler was registered first: this.after() callbacks -- this one
+    // included -- always finish before any route's preReady callback runs.
+    context.notFoundOnSendOption = opts.onSend || null
 
     avvio.once('preReady', () => {
       const context = this[kFourOhFourContext]

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -1655,6 +1655,43 @@ test('onSend option for setNotFoundHandler should be called when callNotFound an
   })
 })
 
+test('onSend option for setNotFoundHandler runs alongside the calling route\'s own onSend hooks when callNotFound', (t, done) => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.setNotFoundHandler({
+    onSend: (req, reply, payload, done) => {
+      const body = JSON.parse(payload)
+      body.option = true
+      done(null, JSON.stringify(body))
+    }
+  }, function (req, reply) {
+    reply.code(404).send({})
+  })
+
+  fastify.register(function (instance, opts, done) {
+    instance.addHook('onSend', (req, reply, payload, done) => {
+      const body = JSON.parse(payload)
+      body.caller = true
+      done(null, JSON.stringify(body))
+    })
+
+    instance.get('/', function (req, reply) {
+      t.assert.strictEqual(reply.callNotFound(), reply)
+    })
+
+    done()
+  })
+
+  fastify.inject('/', (err, res) => {
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 404)
+    const payload = JSON.parse(res.payload)
+    t.assert.deepStrictEqual(payload, { option: true, caller: true })
+    done()
+  })
+})
+
 test('reply.notFound invoked the notFound handler', (t, done) => {
   t.plan(3)
 

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -1628,9 +1628,8 @@ test('onSend option for setNotFoundHandler should be called when callNotFound an
   t.plan(4)
   const fastify = Fastify()
 
-  // Register the route before the not-found handler so that the route's
-  // preReady callback snapshots the not-found context before its lifecycle
-  // hooks are populated.
+  // Register the route before the not-found handler so its 404 context is
+  // linked before the not-found lifecycle hooks are populated during preReady.
   fastify.post('/', function (req, reply) {
     t.assert.strictEqual(reply.callNotFound(), reply)
   })

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -1594,6 +1594,68 @@ test('preHandler option for setNotFoundHandler', async t => {
   })
 })
 
+test('onSend option for setNotFoundHandler should be called when callNotFound', (t, done) => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  fastify.setNotFoundHandler({
+    onSend: (req, reply, payload, done) => {
+      t.assert.ok(true, 'onSend option called')
+      done(null, payload)
+    }
+  }, function (req, reply) {
+    reply.code(404).send(req.body)
+  })
+
+  fastify.post('/', function (req, reply) {
+    t.assert.strictEqual(reply.callNotFound(), reply)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: { hello: 'world' }
+  }, (err, res) => {
+    t.assert.ifError(err)
+    const payload = JSON.parse(res.payload)
+    t.assert.deepStrictEqual(payload, { hello: 'world' })
+    done()
+  })
+})
+
+// https://github.com/fastify/fastify/security/advisories/GHSA-gm8r-x7h4-fm5r
+test('onSend option for setNotFoundHandler should be called when callNotFound and the route is registered first', (t, done) => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  // Register the route before the not-found handler so that the route's
+  // preReady callback snapshots the not-found context before its lifecycle
+  // hooks are populated.
+  fastify.post('/', function (req, reply) {
+    t.assert.strictEqual(reply.callNotFound(), reply)
+  })
+
+  fastify.setNotFoundHandler({
+    onSend: (req, reply, payload, done) => {
+      t.assert.ok(true, 'onSend option called')
+      done(null, payload)
+    }
+  }, function (req, reply) {
+    reply.code(404).send(req.body)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: { hello: 'world' }
+  }, (err, res) => {
+    t.assert.ifError(err)
+    const payload = JSON.parse(res.payload)
+    t.assert.deepStrictEqual(payload, { hello: 'world' })
+    done()
+  })
+})
+
 test('reply.notFound invoked the notFound handler', (t, done) => {
   t.plan(3)
 

--- a/test/types/instance.tst.ts
+++ b/test/types/instance.tst.ts
@@ -13,7 +13,7 @@ import fastify, {
   RawServerDefault,
   RouteGenericInterface
 } from '../../fastify.js'
-import { HookHandlerDoneFunction } from '../../types/hooks.js'
+import { DoneFuncWithErrOrRes, HookHandlerDoneFunction } from '../../types/hooks.js'
 import { FindMyWayVersion } from '../../types/instance.js'
 import { Bindings, ChildLoggerOptions } from '../../types/logger.js'
 import { FastifyReply } from '../../types/reply.js'
@@ -143,14 +143,32 @@ async function notFoundpreValidationAsyncHandler (
   request: FastifyRequest,
   reply: FastifyReply
 ) { }
+function notFoundOnSendHandler (
+  request: FastifyRequest,
+  reply: FastifyReply,
+  payload: unknown,
+  done: DoneFuncWithErrOrRes
+) { done(null, payload) }
+async function notFoundOnSendAsyncHandler (
+  request: FastifyRequest,
+  reply: FastifyReply,
+  payload: unknown
+) { }
 
 server.setNotFoundHandler(notFoundHandler)
 server.setNotFoundHandler({ preHandler: notFoundpreHandlerHandler }, notFoundHandler)
 server.setNotFoundHandler({ preHandler: notFoundpreHandlerAsyncHandler }, notFoundHandler)
 server.setNotFoundHandler({ preValidation: notFoundpreValidationHandler }, notFoundHandler)
 server.setNotFoundHandler({ preValidation: notFoundpreValidationAsyncHandler }, notFoundHandler)
+server.setNotFoundHandler({ onSend: notFoundOnSendHandler }, notFoundHandler)
+server.setNotFoundHandler({ onSend: notFoundOnSendAsyncHandler }, notFoundHandler)
+server.setNotFoundHandler({ onSend: [notFoundOnSendHandler, notFoundOnSendAsyncHandler] }, notFoundHandler)
 server.setNotFoundHandler(
-  { preHandler: notFoundpreHandlerHandler, preValidation: notFoundpreValidationHandler },
+  {
+    preHandler: notFoundpreHandlerHandler,
+    preValidation: notFoundpreValidationHandler,
+    onSend: notFoundOnSendHandler
+  },
   notFoundHandler
 )
 
@@ -159,8 +177,14 @@ server.setNotFoundHandler({ preHandler: notFoundpreHandlerHandler }, notFoundAsy
 server.setNotFoundHandler({ preHandler: notFoundpreHandlerAsyncHandler }, notFoundAsyncHandler)
 server.setNotFoundHandler({ preValidation: notFoundpreValidationHandler }, notFoundAsyncHandler)
 server.setNotFoundHandler({ preValidation: notFoundpreValidationAsyncHandler }, notFoundAsyncHandler)
+server.setNotFoundHandler({ onSend: notFoundOnSendHandler }, notFoundAsyncHandler)
+server.setNotFoundHandler({ onSend: notFoundOnSendAsyncHandler }, notFoundAsyncHandler)
 server.setNotFoundHandler(
-  { preHandler: notFoundpreHandlerHandler, preValidation: notFoundpreValidationHandler },
+  {
+    preHandler: notFoundpreHandlerHandler,
+    preValidation: notFoundpreValidationHandler,
+    onSend: notFoundOnSendHandler
+  },
   notFoundAsyncHandler
 )
 

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -540,6 +540,11 @@ export interface FastifyInstance<
         SchemaCompiler, TypeProvider> | preHandlerHookHandler<RawServer, RawRequest, RawReply, RouteGeneric,
         ContextConfig, SchemaCompiler, TypeProvider>[] | preHandlerAsyncHookHandler<RawServer, RawRequest, RawReply,
         RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>[];
+      onSend?: onSendHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler,
+        TypeProvider> | onSendAsyncHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig,
+        SchemaCompiler, TypeProvider> | onSendHookHandler<unknown, RawServer, RawRequest, RawReply, RouteGeneric,
+        ContextConfig, SchemaCompiler, TypeProvider>[] | onSendAsyncHookHandler<unknown, RawServer, RawRequest,
+        RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider>[];
     },
     handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler,
       TypeProvider, Logger>


### PR DESCRIPTION
## Summary
- `setContext()` in `lib/four-oh-four.js` took a detached snapshot of the selected not-found context and unconditionally overrode its `onSend` with the calling route's own `onSend`. Every other lifecycle hook (`preHandler`, `preValidation`, `onError`, ...) instead falls through to the live not-found context via the prototype chain established in #6965.
- As a consequence, an `onSend` hook passed as an option to `setNotFoundHandler({ onSend }, handler)` silently never ran when the not-found handler was reached through `reply.callNotFound()` (it did run on a direct 404 hit), regardless of registration order — the same underlying class of bug #6965 already fixed for `preHandler`.
- Drops the `onSend` override so it is inherited the same way as the other hooks.

## Verification
- Reproduced live with `fastify.inject()`: `onSend` option ran on a direct 404 but not via `reply.callNotFound()` before the fix; runs consistently in both cases after.
- Confirmed order-independence (route registered before/after `setNotFoundHandler`).
- Added two regression tests to `test/404s.test.js` mirroring the existing `preHandler` regression tests, including the registration-order case from GHSA-gm8r-x7h4-fm5r. Verified both new tests fail without the fix and pass with it.
- `node --test test/404s.test.js` — 85/85 pass.
- `node --test test/hooks.test.js test/hooks-async.test.js` — 129/129 pass.
- `npx borp` (full suite) — 2303 pass, 0 fail.
- `npx eslint lib/four-oh-four.js test/404s.test.js` — clean.

## Test plan
- [x] New regression tests added and verified to catch the regression
- [x] Full unit test suite passes
- [x] Lint passes