### PR TITLE
fix: pass undefined for omitted compileSerializationSchema metadata

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -370,7 +370,7 @@ Reply.prototype.getSerializationFunction = function (schemaOrStatus, contentType
   return serialize
 }
 
-Reply.prototype.compileSerializationSchema = function (schema, httpStatus = null, contentType = null) {
+Reply.prototype.compileSerializationSchema = function (schema, httpStatus, contentType) {
   const { request } = this
   const { method, url } = request
 

--- a/test/internals/reply-serialize.test.js
+++ b/test/internals/reply-serialize.test.js
@@ -63,7 +63,7 @@ function getResponseSchema () {
 }
 
 test('Reply#compileSerializationSchema', async t => {
-  t.plan(4)
+  t.plan(5)
 
   await t.test('Should return a serialization function', async t => {
     const fastify = Fastify()
@@ -214,6 +214,29 @@ test('Reply#compileSerializationSchema', async t => {
       t.assert.strictEqual(reply.compileSerializationSchema(getDefaultSchema())(input), JSON.stringify(input))
       t.assert.ok(reply[kRouteContext][kReplyCacheSerializeFns] instanceof WeakMap)
       t.assert.strictEqual(reply.compileSerializationSchema(getDefaultSchema())(input), JSON.stringify(input))
+
+      reply.send({ hello: 'world' })
+    })
+
+    await fastify.inject({
+      path: '/',
+      method: 'GET'
+    })
+  })
+
+  await t.test('Should pass undefined metadata when it is not provided', async t => {
+    const fastify = Fastify()
+    const serializerCompiler = ({ httpStatus, contentType }) => {
+      t.assert.strictEqual(httpStatus, undefined)
+      t.assert.strictEqual(contentType, undefined)
+
+      return JSON.stringify
+    }
+
+    t.plan(2)
+
+    fastify.get('/', { serializerCompiler }, (req, reply) => {
+      reply.compileSerializationSchema(getDefaultSchema())
 
       reply.send({ hello: 'world' })
     })


### PR DESCRIPTION
`reply.compileSerializationSchema()` defaulted `httpStatus` and `contentType` to `null`, so a custom `serializerCompiler` received `null` for metadata the caller never passed. The public `FastifyRouteSchemaDef` type declares both as optional strings and the reference docs say they default to `undefined`.

Dropping the `= null` defaults lets both stay `undefined`, which is also what the route-level compile path in `lib/validation.js` already does when there is no content type.

Fixes #6988
