### PR TITLE
fix(reply): cache compiled serializers by metadata and default optional metadata to undefined

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -364,19 +364,26 @@ Reply.prototype.getSerializationFunction = function (schemaOrStatus, contentType
       serialize = this[kRouteContext][kSchemaResponse]?.[schemaOrStatus]
     }
   } else if (typeof schemaOrStatus === 'object') {
-    serialize = this[kRouteContext][kReplyCacheSerializeFns]?.get(schemaOrStatus)
+    const schemaCache = this[kRouteContext][kReplyCacheSerializeFns]?.get(schemaOrStatus)
+    if (schemaCache) {
+      const cacheKey = `${undefined}__${contentType ?? ''}`
+      serialize = schemaCache.get(cacheKey) || schemaCache.get(`${undefined}__${undefined}`) || schemaCache.values().next().value
+    }
   }
 
   return serialize
 }
 
-Reply.prototype.compileSerializationSchema = function (schema, httpStatus = null, contentType = null) {
+Reply.prototype.compileSerializationSchema = function (schema, httpStatus = undefined, contentType = undefined) {
   const { request } = this
   const { method, url } = request
 
+  const cacheKey = `${httpStatus ?? ''}__${contentType ?? ''}`
+  let schemaCache = this[kRouteContext][kReplyCacheSerializeFns]?.get(schema)
+
   // Check if serialize function already compiled
-  if (this[kRouteContext][kReplyCacheSerializeFns]?.has(schema)) {
-    return this[kRouteContext][kReplyCacheSerializeFns].get(schema)
+  if (schemaCache?.has(cacheKey)) {
+    return schemaCache.get(cacheKey)
   }
 
   const serializerCompiler = this[kRouteContext].serializerCompiler ||
@@ -405,7 +412,13 @@ Reply.prototype.compileSerializationSchema = function (schema, httpStatus = null
     this[kRouteContext][kReplyCacheSerializeFns] = new WeakMap()
   }
 
-  this[kRouteContext][kReplyCacheSerializeFns].set(schema, serializeFn)
+  schemaCache = this[kRouteContext][kReplyCacheSerializeFns].get(schema)
+  if (!schemaCache) {
+    schemaCache = new Map()
+    this[kRouteContext][kReplyCacheSerializeFns].set(schema, schemaCache)
+  }
+
+  schemaCache.set(cacheKey, serializeFn)
 
   return serializeFn
 }
@@ -434,8 +447,10 @@ Reply.prototype.serializeInput = function (input, schema, httpStatus, contentTyp
     }
   } else {
     // Check if serialize function already compiled
-    if (this[kRouteContext][kReplyCacheSerializeFns]?.has(schema)) {
-      serialize = this[kRouteContext][kReplyCacheSerializeFns].get(schema)
+    const cacheKey = `${httpStatus ?? ''}__${contentType ?? ''}`
+    const schemaCache = this[kRouteContext][kReplyCacheSerializeFns]?.get(schema)
+    if (schemaCache?.has(cacheKey)) {
+      serialize = schemaCache.get(cacheKey)
     } else {
       serialize = this.compileSerializationSchema(schema, httpStatus, contentType)
     }

--- a/test/internals/reply-serialize.test.js
+++ b/test/internals/reply-serialize.test.js
@@ -63,7 +63,7 @@ function getResponseSchema () {
 }
 
 test('Reply#compileSerializationSchema', async t => {
-  t.plan(4)
+  t.plan(6)
 
   await t.test('Should return a serialization function', async t => {
     const fastify = Fastify()
@@ -223,6 +223,64 @@ test('Reply#compileSerializationSchema', async t => {
       method: 'GET'
     })
   })
+
+  await t.test('Should pass undefined for omitted optional httpStatus and contentType',
+    async t => {
+      const fastify = Fastify()
+      t.plan(3)
+
+      const schemaObj = getDefaultSchema()
+
+      fastify.get('/', {
+        serializerCompiler: ({ schema, httpStatus, contentType }) => {
+          t.assert.strictEqual(schema, schemaObj)
+          t.assert.strictEqual(httpStatus, undefined)
+          t.assert.strictEqual(contentType, undefined)
+          return JSON.stringify
+        }
+      }, (req, reply) => {
+        reply.compileSerializationSchema(schemaObj)
+        reply.send({ hello: 'world' })
+      })
+
+      await fastify.inject('/')
+    }
+  )
+
+  await t.test('Should recompile and cache serializers when httpStatus or contentType changes for the same schema',
+    async t => {
+      const fastify = Fastify()
+      t.plan(7)
+
+      const schemaObj = getDefaultSchema()
+      const calls = []
+
+      fastify.get('/', {
+        serializerCompiler: ({ httpStatus, contentType }) => {
+          calls.push({ httpStatus, contentType })
+          return (input) => JSON.stringify({ httpStatus, contentType, ...input })
+        }
+      }, (req, reply) => {
+        const first = reply.compileSerializationSchema(schemaObj, '200', 'application/json')
+        const firstCached = reply.compileSerializationSchema(schemaObj, '200', 'application/json')
+        const second = reply.compileSerializationSchema(schemaObj, '201', 'application/vnd.example+json')
+        const third = reply.compileSerializationSchema(schemaObj)
+
+        t.assert.strictEqual(first, firstCached)
+        t.assert.notStrictEqual(first, second)
+        t.assert.notStrictEqual(first, third)
+        t.assert.strictEqual(calls.length, 3)
+
+        t.assert.deepStrictEqual(JSON.parse(first({ a: 1 })), { httpStatus: '200', contentType: 'application/json', a: 1 })
+        t.assert.deepStrictEqual(JSON.parse(second({ a: 2 })), { httpStatus: '201', contentType: 'application/vnd.example+json', a: 2 })
+        t.assert.deepStrictEqual(JSON.parse(third({ a: 3 })), { a: 3 })
+
+        reply.send({ ok: true })
+      })
+
+      await fastify.inject('/')
+    }
+  )
 })
 
 test('Reply#getSerializationFunction', async t => {


### PR DESCRIPTION
## Problem

1. `reply.compileSerializationSchema(schema, httpStatus, contentType)` keyed its compiled serializer cache solely on `schema` object identity. Calling it multiple times for the same schema with different `httpStatus` or `contentType` metadata returned the serializer compiled on the first invocation.
2. `httpStatus` and `contentType` parameters defaulted to `null`, passing `null` rather than `undefined` to custom serializer compilers when omitted.

## Solution

- Updated `compileSerializationSchema` cache to key by both `schema` and metadata (`httpStatus` and `contentType`) tuple in a nested map.
- Defaulted `httpStatus` and `contentType` parameters to `undefined` to align with TypeScript definitions and documentation.
- Updated `serializeInput` and `getSerializationFunction` to resolve cached serializers with the compound metadata cache key.

## Testing

- Added regression tests in `test/internals/reply-serialize.test.js` validating that:
  - Omitted `httpStatus` and `contentType` pass `undefined` to serializer compilers.
  - Recompiling the same schema with differing metadata returns distinct, properly scoped serializers and caches each appropriately.
- Verified all reply serialization tests pass cleanly.