### PR TITLE
types: add missing property typings in RouteShorthandOptions and RouteOptions

### DIFF
--- a/test/types/route.tst.ts
+++ b/test/types/route.tst.ts
@@ -551,6 +551,24 @@ expect(fastify().route({
   handler: routeHandlerWithReturnValue
 })).type.toBe<FastifyInstance>()
 
+expect(fastify().get('/', {
+  logSerializers: {
+    foo: (value: any) => JSON.stringify(value),
+  },
+  return503OnClosing: true,
+}, async () => 'test')).type.toBe<FastifyInstance>()
+
+expect(fastify().route({
+  method: 'GET',
+  url: '/route-options',
+  path: '/route-options',
+  logSerializers: {
+    bar: (value: any) => String(value),
+  },
+  return503OnClosing: false,
+  handler: async () => 'test',
+})).type.toBe<FastifyInstance>()
+
 expect(fastify().route({
   url: '/',
   method: ['put', 'patch'],

--- a/types/route.d.ts
+++ b/types/route.d.ts
@@ -80,6 +80,8 @@ export interface RouteShorthandOptions<
   ) => void;
   childLoggerFactory?: FastifyChildLoggerFactory<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
   schemaErrorFormatter?: SchemaErrorFormatter;
+  logSerializers?: Record<string, (value: any) => string>;
+  return503OnClosing?: boolean;
 
   // hooks
   onRequest?: RouteShorthandHook<onRequestHookHandler<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig,
@@ -207,7 +209,8 @@ export interface RouteOptions<
 > extends RouteShorthandOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler,
   TypeProvider, Logger> {
   method: HTTPMethods | HTTPMethods[];
-  url: string;
+  url?: string;
+  path?: string;
   handler: RouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler,
     TypeProvider, Logger>;
 }


### PR DESCRIPTION
## Problem

While Fastify routes natively support options like `logSerializers`, `return503OnClosing`, and alias `path` on routes at runtime, these properties were missing from `RouteShorthandOptions` and `RouteOptions` in `types/route.d.ts`, causing TypeScript compilation errors when passing them.

## Cause

- `RouteShorthandOptions` did not declare `logSerializers?: Record<string, (value: any) => string>` or `return503OnClosing?: boolean`.
- `RouteOptions` required `url: string` and did not permit `path?: string` or optional `url?: string` when `path` is specified.

## Fix

- Added `logSerializers?: Record<string, (value: any) => string>` and `return503OnClosing?: boolean` to `RouteShorthandOptions`.
- Added `path?: string` and made `url?: string` in `RouteOptions`.

## Testing

- Added type assertions in `test/types/route.tst.ts` verifying `logSerializers`, `return503OnClosing`, and `path` options across shorthand and `fastify.route(...)` declarations.
- Verified all 16 type test suites with 1286 assertions pass cleanly with `tstyche`.