### PR TITLE
chore: npm ignore remaining agent files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,6 +18,10 @@ EXPENSE_POLICY.md
 # AI files
 .claude/
 CLAUDE.md
+AGENTS.md
+.agent
+.agents/
+.pi/
 
 # test certification
 test/https/fastify.cert


### PR DESCRIPTION
The published tarball for fastify 5.12.1 ships a `.pi/self-learning-memory/` directory of local agent notes. `.gitignore` already lists the agent files under "Agents files", but `.npmignore` only covers `.claude/` and `CLAUDE.md`, and npm stops reading `.gitignore` once an `.npmignore` exists.

This adds the remaining entries so `AGENTS.md`, `.agent`, `.agents/` and `.pi/` stay out of the package. None of them are tracked in the repo, so `npm pack --dry-run` on a clean checkout shows no change. With the files present in the working tree, which is how they ended up in the 5.12.1 tarball, they are listed before the change and gone after it, and nothing else drops out of the file list.

`5.x` has the same gap, so this probably wants a `backport 5.x` label on merge.

Closes #6995

#### Checklist

- [x] commit message and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
