### PR TITLE
test: fail when an agent file is gitignored but not npmignored

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -16,8 +16,14 @@ EXPENSE_POLICY.md
 *.log
 
 # AI files
+# Keep in sync with the "Agents files" section of .gitignore: .npmignore
+# replaces .gitignore for packing, so these have to be repeated here.
 .claude/
 CLAUDE.md
+AGENTS.md
+.agents/
+.agent
+.pi/
 
 # test certification
 test/https/fastify.cert

--- a/test/build/npmignore.test.js
+++ b/test/build/npmignore.test.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const fs = require('node:fs')
+const path = require('node:path')
+const { test } = require('node:test')
+
+const root = path.join(__dirname, '..', '..')
+
+// npm ignores .gitignore entirely once a .npmignore exists, so anything listed
+// only in .gitignore ends up published. Agent scratch directories are the ones
+// that keep getting added to .gitignore alone.
+function readSection (file, header) {
+  const lines = fs.readFileSync(path.join(root, file), 'utf8').split(/\r?\n/)
+  const start = lines.indexOf(header)
+
+  if (start === -1) {
+    throw new Error(`${file} no longer has a "${header}" section`)
+  }
+
+  const patterns = []
+
+  for (const line of lines.slice(start + 1)) {
+    const entry = line.trim()
+
+    if (entry === '') {
+      break
+    }
+
+    if (!entry.startsWith('#')) {
+      patterns.push(entry.replace(/\/$/, ''))
+    }
+  }
+
+  return patterns
+}
+
+test('.npmignore ignores every agent file .gitignore ignores', t => {
+  const gitignored = readSection('.gitignore', '# Agents files')
+  const npmignored = new Set(readSection('.npmignore', '# AI files'))
+
+  t.plan(gitignored.length)
+
+  for (const pattern of gitignored) {
+    t.assert.ok(
+      npmignored.has(pattern),
+      `"${pattern}" is in .gitignore but not in the "# AI files" section of .npmignore, so it would be published`
+    )
+  }
+})

--- a/test/build/npmignore.test.js
+++ b/test/build/npmignore.test.js
@@ -4,46 +4,25 @@ const fs = require('node:fs')
 const path = require('node:path')
 const { test } = require('node:test')
 
-const root = path.join(__dirname, '..', '..')
-
-// npm ignores .gitignore entirely once a .npmignore exists, so anything listed
-// only in .gitignore ends up published. Agent scratch directories are the ones
-// that keep getting added to .gitignore alone.
-function readSection (file, header) {
-  const lines = fs.readFileSync(path.join(root, file), 'utf8').split(/\r?\n/)
-  const start = lines.indexOf(header)
-
-  if (start === -1) {
-    throw new Error(`${file} no longer has a "${header}" section`)
-  }
-
-  const patterns = []
-
-  for (const line of lines.slice(start + 1)) {
-    const entry = line.trim()
-
-    if (entry === '') {
-      break
-    }
-
-    if (!entry.startsWith('#')) {
-      patterns.push(entry.replace(/\/$/, ''))
-    }
-  }
-
-  return patterns
+// npm ignores .gitignore entirely once a .npmignore exists, so a pattern added
+// only to .gitignore is still published — that is how `.pi` shipped in 5.12.1.
+function patterns (file) {
+  return fs.readFileSync(path.join(__dirname, '..', '..', file), 'utf8')
+    .split('\n')
+    .map((line) => line.trim().replace(/\/$/, ''))
 }
 
-test('.npmignore ignores every agent file .gitignore ignores', t => {
-  const gitignored = readSection('.gitignore', '# Agents files')
-  const npmignored = new Set(readSection('.npmignore', '# AI files'))
+test('.npmignore ignores every agent file .gitignore ignores', (t) => {
+  const gitignore = patterns('.gitignore')
+  const start = gitignore.indexOf('# Agents files')
+  t.assert.notStrictEqual(start, -1, '.gitignore no longer has an "# Agents files" section')
 
-  t.plan(gitignored.length)
+  const agentFiles = gitignore.slice(start + 1).filter((line) => line && !line.startsWith('#'))
+  const npmignored = new Set(patterns('.npmignore'))
 
-  for (const pattern of gitignored) {
-    t.assert.ok(
-      npmignored.has(pattern),
-      `"${pattern}" is in .gitignore but not in the "# AI files" section of .npmignore, so it would be published`
-    )
-  }
+  t.assert.deepStrictEqual(
+    agentFiles.filter((pattern) => !npmignored.has(pattern)),
+    [],
+    'listed in the "# Agents files" section of .gitignore but not in .npmignore, so npm would publish them'
+  )
 })


### PR DESCRIPTION
Fixes #6995.

### The bug

`npm pack fastify@5.12.1` ships `.pi/self-learning-memory/` — seven files of agent notes (`core/CORE.md`, `core/index.json`, `long-term-memory.md`, `README.md`, and four `daily/*.md`):

```console
$ npm pack fastify@5.12.1 && tar -tzf fastify-5.12.1.tgz | grep '\.pi/'
package/.pi/self-learning-memory/core/index.json
package/.pi/self-learning-memory/daily/2026-07-06.md
package/.pi/self-learning-memory/daily/2026-07-29.md
package/.pi/self-learning-memory/daily/2026-08-04.md
package/.pi/self-learning-memory/daily/2026-08-18.md
package/.pi/self-learning-memory/core/CORE.md
package/.pi/self-learning-memory/long-term-memory.md
package/.pi/self-learning-memory/README.md
```

### Cause

npm ignores `.gitignore` entirely once a `.npmignore` exists. The `# Agents files` section was added to `.gitignore` only:

```
# Agents files
CLAUDE.md
AGENTS.md
.agents/
.agent
.claude
.pi
```

while `.npmignore` has just `.claude/` and `CLAUDE.md`. So `.pi`, `AGENTS.md`, `.agent` and `.agents/` are untracked in git but published to npm. The published tarball also already contains `AGENTS.md`, from a working tree where the file existed at publish time.

### Change

Mirror the `.gitignore` agent entries into `.npmignore`, plus a test in `test/build/` that parses the `# Agents files` section of `.gitignore` and the `# AI files` section of `.npmignore` and fails when a pattern is in the first but not the second — so the next agent tool added to `.gitignore` can't silently leak again.

### Verification

Locally, with all the agent paths recreated in the working tree:

| | `.pi`, `AGENTS.md`, `.agent`, `.agents/` in `npm pack --dry-run` | new test |
|---|---|---|
| before | present | fails: `"AGENTS.md" is in .gitignore but not in the "# AI files" section of .npmignore, so it would be published` |
| after | absent | passes |

360 files still packed, so nothing legitimate was dropped. `npm run lint` is clean and `test/build/` passes (3 pass, 1 skip — the skip is the existing `PREPUBLISH`-gated serializer check).

The fix only affects future publishes; the already-published 5.12.1 tarball keeps its `.pi/` directory.
