### PR TITLE
docs: add fastify-arktype to ecosystem

### DIFF
--- a/docs/Guides/Ecosystem.md
+++ b/docs/Guides/Ecosystem.md
@@ -282,6 +282,8 @@ section.
   plugin to authenticate HTTP requests based on API key and signature
 - [`fastify-appwrite`](https://github.com/maniecodes/fastify-appwrite) Fastify
   Plugin for interacting with Appwrite server.
+- [`fastify-arktype`](https://github.com/BlairCurrey/fastify-arktype) ArkType
+  type provider with validation and @fastify/swagger OpenAPI generation.
 - [`fastify-asyncforge`](https://github.com/mcollina/fastify-asyncforge) Plugin
   to access Fastify instance, logger, request and reply from Node.js [Async
   Local Storage](https://nodejs.org/api/async_context.html#class-asynclocalstorage).


### PR DESCRIPTION
Adds [fastify-arktype](https://github.com/blaircurrey/fastify-arktype) to the Community section. It is an [ArkType](https://arktype.io/) type provider mirroring `fastify-type-provider-zod`'s API. It has validator/serializer compilers and a `@fastify/swagger` transformer.

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
