### PR TITLE
fix: omit absent compileSerializationSchema metadata instead of passing null

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -370,7 +370,7 @@ Reply.prototype.getSerializationFunction = function (schemaOrStatus, contentType
   return serialize
 }
 
-Reply.prototype.compileSerializationSchema = function (schema, httpStatus = null, contentType = null) {
+Reply.prototype.compileSerializationSchema = function (schema, httpStatus, contentType) {
   const { request } = this
   const { method, url } = request
 

--- a/test/internals/reply-serialize.test.js
+++ b/test/internals/reply-serialize.test.js
@@ -712,3 +712,23 @@ test('Reply#serializeInput', async t => {
     })
   })
 })
+
+test('Reply#compileSerializationSchema omits absent metadata instead of passing null', async t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  fastify.setSerializerCompiler(({ httpStatus, contentType }) => {
+    t.assert.strictEqual(httpStatus, undefined)
+    t.assert.strictEqual(contentType, undefined)
+
+    return input => JSON.stringify(input)
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.compileSerializationSchema(getDefaultSchema())
+    reply.send({ hello: 'world' })
+  })
+
+  await fastify.inject({ path: '/', method: 'GET' })
+})


### PR DESCRIPTION
Closes #6988.

`compileSerializationSchema` defaulted both optional parameters to `null`:

```js
function (schema, httpStatus = null, contentType = null)
```

so a custom serializer compiler called through `reply.compileSerializationSchema(schema)` received `null` for both. `FastifyRouteSchemaDef` declares them as optional strings and the reference docs describe the default as `undefined`, so the implementation was the odd one out. `serializeInput` already declares the same two parameters without defaults and forwards `undefined`, so this also makes the two paths agree.

Dropping the defaults is the whole change. Existing tests that touch this assert `!httpStatus` rather than a specific value, so they hold either way, and I could not find anywhere in `lib`, `test` or `types` that compares this to `null`.

Added one test asserting both values arrive as `undefined` when the metadata is not supplied. It fails without the change.

Verified locally: `node --test test/internals/*.test.js` gives 395 passed / 0 failed, `npm run test:types` passes all 16 files and 1282 assertions, and eslint is clean on both touched files.

I left a separate note on #6987 about the cache-keying half, since fixing that one has a public API consequence for `getSerializationFunction` and I would rather agree the approach first.
