### PR TITLE
fix: exclude .pi/ from the published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,6 +18,7 @@ EXPENSE_POLICY.md
 # AI files
 .claude/
 CLAUDE.md
+.pi/
 
 # test certification
 test/https/fastify.cert


### PR DESCRIPTION
Closes #6995.

`.pi/` is not tracked in git and is not listed in `.npmignore`, and npm includes untracked files in the tarball unless they are ignored, so the directory ends up in the published package. I confirmed it is still there in 5.12.1, which is the current latest: 8 files under `package/.pi/self-learning-memory/`.

`.npmignore` already has an "AI files" section covering `.claude/` and `CLAUDE.md` for the same reason, so this just adds `.pi/` alongside them.

To check it, I created a placeholder file at that path locally and ran `npm pack --dry-run`. Before the change the entry appears in the file list, after it the count is zero, and the rest of the package contents are unchanged.

Worth noting this only affects future publishes. The files are already on the registry in 5.12.1 and earlier, so if any of them should not be public that needs handling separately from this change.
