### PR TITLE
docs: document fastify.query() shorthand for RFC 10008

### DIFF
--- a/docs/Reference/Routes.md
+++ b/docs/Reference/Routes.md
@@ -32,7 +32,7 @@ fastify.route(options)
 <a id="options"></a>
 
 * `method`: currently it supports `GET`, `HEAD`, `TRACE`, `DELETE`,
-  `OPTIONS`, `PATCH`, `PUT` and `POST`. To accept more methods,
+  `OPTIONS`, `PATCH`, `PUT`, `POST` and `QUERY`. To accept more methods,
   the [`addHttpMethod`](./Server.md#addHttpMethod) must be used.
   It could also be an array of methods.
 * `url`: the path of the URL to match this route (alias: `path`).
@@ -41,7 +41,7 @@ fastify.route(options)
   [here](./Validation-and-Serialization.md) for more info.
 
   * `body`: validates the body of the request if it is a POST, PUT, PATCH,
-    TRACE, SEARCH, PROPFIND, PROPPATCH or LOCK method.
+    TRACE, SEARCH, PROPFIND, PROPPATCH, LOCK or QUERY method.
   * `querystring` or `query`: validates the querystring. This can be a complete
     JSON Schema object, with the property `type` of `object` and `properties`
     object of parameters, or simply the values of what would be contained in the
@@ -197,6 +197,10 @@ The above route declaration is more *Hapi*-like, but if you prefer an
 `fastify.options(path, [options], handler)`
 
 `fastify.patch(path, [options], handler)`
+
+`fastify.query(path, [options], handler)`
+
+> The `QUERY` method (RFC 10008) requires a `Content-Type` header.
 
 Example:
 ```js


### PR DESCRIPTION
## Why

PR [#6832](https://github.com/fastify/fastify/pull/6832) introduced the QUERY HTTP method (RFC 10008) and the `fastify.query()` route shorthand. `docs/Reference/Server.md` and `docs/Reference/Errors.md` were updated as part of that PR, but `docs/Reference/Routes.md` was not — leaving users without a doc entry for the new shorthand and a stale list of supported methods.

## What

Four edits to `docs/Reference/Routes.md`:

1. Add `QUERY` to the methods listed for the `method` route option.
2. Add `QUERY` to the methods for which the `body` schema is validated.
3. Add the `fastify.query(path, [options], handler)` shorthand entry after `fastify.patch`.
4. Note that QUERY (RFC 10008) requires a `Content-Type` header

## Verification

`npx markdownlint-cli2 docs/Reference/Routes.md` — no errors.
