### PR TITLE
docs: fix duplicate fastify declaration in Getting-Started examples

### DIFF
--- a/docs/Guides/Getting-Started.md
+++ b/docs/Guides/Getting-Started.md
@@ -28,14 +28,29 @@ yarn add fastify
 
 Let's write our first server:
 ```js
-// Require the framework and instantiate it
-
 // ESM
 import Fastify from 'fastify'
 
 const fastify = Fastify({
   logger: true
 })
+
+// Declare a route
+fastify.get('/', function (request, reply) {
+  reply.send({ hello: 'world' })
+})
+
+// Run the server!
+fastify.listen({ port: 3000 }, function (err, address) {
+  if (err) {
+    fastify.log.error(err)
+    process.exit(1)
+  }
+  // Server is now listening on ${address}
+})
+```
+
+```js
 // CommonJs
 const fastify = require('fastify')({
   logger: true
@@ -73,6 +88,26 @@ import Fastify from 'fastify'
 const fastify = Fastify({
   logger: true
 })
+
+fastify.get('/', async (request, reply) => {
+  return { hello: 'world' }
+})
+
+/**
+ * Run the server!
+ */
+const start = async () => {
+  try {
+    await fastify.listen({ port: 3000 })
+  } catch (err) {
+    fastify.log.error(err)
+    process.exit(1)
+  }
+}
+start()
+```
+
+```js
 // CommonJs
 const fastify = require('fastify')({
   logger: true


### PR DESCRIPTION
## Summary
Splits the combined ESM/CommonJS code blocks in `docs/Guides/Getting-Started.md`'s "Your first server" section (both the callback and async/await variants) into separate, standalone blocks — matching the pattern already used correctly later in the same file under "Your first plugin".

## Problem
Both variants of "Your first server" put ESM and CommonJS code in one fenced block, each declaring `const fastify`. Copied verbatim into a `.js` file, Node auto-detects ES module syntax from the `import` line and throws at parse/link time:
```
SyntaxError: Identifier 'fastify' has already been declared
```
This is a new user's very first copy-paste from the docs.

## Root Cause
Documentation authoring — two alternative snippets were concatenated into a single code fence instead of two, with only a comment (not real separation) between them.

## Solution
Split each of the two affected blocks into two independent, fully runnable fenced blocks (one ESM, one CommonJS), each including its own route declaration and server-start call — the same self-contained style the doc already uses under "Your first plugin".

## Testing
- `npm run lint:markdown`: PASS
- `npm run lint`: PASS (unaffected, but re-run to confirm no regression)
- Manual: extracted all four new/changed code blocks verbatim into standalone files, resolved `fastify` via a `node_modules` symlink to the local checkout, ran each with `node`, and confirmed each boots and returns `{"hello":"world"}` from `GET /`
- Not run: `npm run unit` / `npm run test:types` — not applicable, no runtime code changed

## Before
Copy-pasting the "Your first server" example (either variant) throws `SyntaxError: Identifier 'fastify' has already been declared`.

## After
Each example (ESM and CommonJS, sync and async/await) is copy-paste runnable on its own and boots a working server.

## Risk
None to runtime behavior — documentation-only change, no files under `lib/`, `fastify.js`, or `test/` touched.

## Related Issue
None filed — self-identified and reproduced during repo onboarding.