### PR TITLE
fix(types): allow pre-serialized reply payloads

### DIFF
--- a/test/types/instance.tst.ts
+++ b/test/types/instance.tst.ts
@@ -19,6 +19,7 @@ import { Bindings, ChildLoggerOptions } from '../../types/logger.js'
 import { FastifyReply } from '../../types/reply.js'
 import { FastifyRequest } from '../../types/request.js'
 import { FastifySchemaCompiler, FastifySchemaControllerOptions, FastifySerializerCompiler } from '../../types/schema.js'
+import { FastifyReplyPreSerializedPayload } from '../../types/type-provider.js'
 
 const server = fastify()
 
@@ -88,12 +89,12 @@ interface ReplyPayload {
 // typed sync error handler
 server.setErrorHandler<CustomError, ReplyPayload>((error, request, reply) => {
   expect(error).type.toBe<CustomError>()
-  expect(reply.send).type.toBe<((...args: [payload: ReplyPayload['Reply']]) => FastifyReply<ReplyPayload, RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>>)>()
+  expect(reply.send).type.toBe<((...args: [payload: ReplyPayload['Reply'] | FastifyReplyPreSerializedPayload]) => FastifyReply<ReplyPayload, RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>>)>()
 })
 // typed async error handler send
 server.setErrorHandler<CustomError, ReplyPayload>(async (error, request, reply) => {
   expect(error).type.toBe<CustomError>()
-  expect(reply.send).type.toBe<((...args: [payload: ReplyPayload['Reply']]) => FastifyReply<ReplyPayload, RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>>)>()
+  expect(reply.send).type.toBe<((...args: [payload: ReplyPayload['Reply'] | FastifyReplyPreSerializedPayload]) => FastifyReply<ReplyPayload, RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>>)>()
 })
 // typed async error handler return
 server.setErrorHandler<CustomError, ReplyPayload>(async (error, request, reply) => {

--- a/test/types/reply.tst.ts
+++ b/test/types/reply.tst.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'node:buffer'
+import { Readable } from 'node:stream'
 import { expect } from 'tstyche'
 import fastify, {
   FastifyContextConfig,
@@ -14,6 +15,7 @@ import { FastifyInstance } from '../../types/instance.js'
 import { FastifyBaseLogger } from '../../types/logger.js'
 import { ResolveReplyTypeWithRouteGeneric } from '../../types/reply.js'
 import { FastifyRouteConfig, RouteGenericInterface } from '../../types/route.js'
+import { FastifyReplyPreSerializedPayload } from '../../types/type-provider.js'
 import { ContextConfigDefault, RawReplyDefaultExpression, RawServerDefault } from '../../types/utils.js'
 
 type DefaultSerializationFunction = (payload: { [key: string]: unknown }) => string
@@ -88,6 +90,10 @@ interface ReplyArrayPayload {
   Reply: string[]
 }
 
+interface ReplyString {
+  Reply: string
+}
+
 interface ReplyUnion {
   Reply: {
     success: boolean;
@@ -134,8 +140,8 @@ interface ReplyHttpCodesWithNoContent {
 
 const typedHandler: RouteHandler<ReplyPayload> = async (request, reply) => {
   // When Reply type is specified, send() requires a payload argument
-  expect(reply.send).type.toBe<((...args: [payload: ReplyPayload['Reply']]) => FastifyReply<ReplyPayload, RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>>)>()
-  expect(reply.code(100).send).type.toBe<((...args: [payload: ReplyPayload['Reply']]) => FastifyReply<ReplyPayload, RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>>)>()
+  expect(reply.send).type.toBe<((...args: [payload: ReplyPayload['Reply'] | FastifyReplyPreSerializedPayload]) => FastifyReply<ReplyPayload, RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>>)>()
+  expect(reply.code(100).send).type.toBe<((...args: [payload: ReplyPayload['Reply'] | FastifyReplyPreSerializedPayload]) => FastifyReply<ReplyPayload, RawServerDefault, RawRequestDefaultExpression<RawServerDefault>, RawReplyDefaultExpression<RawServerDefault>>)>()
 }
 
 const server = fastify()
@@ -143,6 +149,14 @@ server.get('/get', getHandler)
 server.get('/typed', typedHandler)
 server.get<ReplyPayload>('/get-generic-send', async function handler (request, reply) {
   reply.send({ test: true })
+})
+server.get<ReplyString>('/get-generic-pre-serialized-send', async function handler (request, reply) {
+  reply.send(Buffer.from('payload'))
+  reply.send(new Uint16Array([1, 2, 3]))
+  reply.send(new Readable())
+  reply.send(new ReadableStream())
+  expect(reply.send).type.not.toBeCallableWith(42)
+  expect(reply.send).type.not.toBeCallableWith({ pipe: 'not a function' })
 })
 // When Reply type is specified, send() requires a payload - calling without arguments should error
 server.get<ReplyPayload>('/get-generic-send-missing-payload', async function handler (request, reply) {
@@ -155,7 +169,7 @@ server.get<ReplyPayload>('/get-generic-return', async function handler (request,
 })
 server.get<ReplyPayload>('/get-generic-send-error', async function handler (request, reply) {
   reply.send({
-    // @ts-expect-error  'foo' does not exist in type '{ test: boolean; }'.
+    // @ts-expect-error  'foo' does not exist in type '{ test: boolean; } | FastifyReplyPreSerializedPayload'.
     foo: 'bar'
   })
 })
@@ -179,7 +193,7 @@ server.get<ReplyUnion>('/get-generic-union-return', async function handler (requ
 })
 server.get<ReplyUnion>('/get-generic-union-send-error-1', async function handler (request, reply) {
   reply.send({
-    // @ts-expect-error  'successes' does not exist in type '{ success: boolean; } | { error: string; }'.
+    // @ts-expect-error  'successes' does not exist in type '{ success: boolean; } | { error: string; } | FastifyReplyPreSerializedPayload'.
     successes: true
   })
 })
@@ -205,12 +219,12 @@ server.get<ReplyHttpCodes>('/get-generic-http-codes-send', async function handle
 })
 server.get<ReplyHttpCodes>('/get-generic-http-codes-send-error-1', async function handler (request, reply) {
   reply.code(200)
-  // @ts-expect-error  Argument of type '"def"' is not assignable to parameter of type '"abc"'.
+  // @ts-expect-error  Argument of type '"def"' is not assignable to parameter of type '"abc" | FastifyReplyPreSerializedPayload'.
     .send('def')
 })
 server.get<ReplyHttpCodes>('/get-generic-http-codes-send-error-2', async function handler (request, reply) {
   reply.code(201)
-  // @ts-expect-error  Argument of type 'number' is not assignable to parameter of type 'boolean'.
+  // @ts-expect-error  Argument of type '0' is not assignable to parameter of type 'boolean | FastifyReplyPreSerializedPayload'.
     .send(0)
 })
 server.get<ReplyHttpCodes>('/get-generic-http-codes-send-error-3', async function handler (request, reply) {
@@ -221,7 +235,7 @@ server.get<ReplyHttpCodes>('/get-generic-http-codes-send-error-3', async functio
 })
 server.get<ReplyHttpCodes>('/get-generic-http-codes-send-error-4', async function handler (request, reply) {
   reply.code(100)
-  // @ts-expect-error  Argument of type 'string' is not assignable to parameter of type 'number'.
+  // @ts-expect-error  Argument of type 'string' is not assignable to parameter of type 'number | FastifyReplyPreSerializedPayload'.
     .send('asdasd')
 })
 server.get<ReplyHttpCodes>('/get-generic-http-codes-send-error-5', async function handler (request, reply) {
@@ -237,7 +251,7 @@ server.get<ReplyArrayPayload>('/get-generic-array-send', async function handler 
 })
 server.get<InvalidReplyHttpCodes>('get-invalid-http-codes-reply-error', async function handler (request, reply) {
   reply.code(200)
-  // @ts-expect-error  Argument of type 'string' is not assignable to parameter of type '{ '1xx': number; 200: string; 999: boolean; }'.
+  // @ts-expect-error  Argument of type 'string' is not assignable to parameter of type '{ '1xx': number; 200: string; 999: boolean; } | FastifyReplyPreSerializedPayload'.
     .send('')
 })
 server.get<InvalidReplyHttpCodes>('get-invalid-http-codes-reply-error', async function handler (request, reply) {

--- a/test/types/type-provider.tst.ts
+++ b/test/types/type-provider.tst.ts
@@ -1,4 +1,6 @@
+import { Buffer } from 'node:buffer'
 import { IncomingHttpHeaders } from 'node:http'
+import { Readable } from 'node:stream'
 import { FromSchema, JSONSchema } from 'json-schema-to-ts'
 import { Type, TSchema, Static } from 'typebox'
 import { expect } from 'tstyche'
@@ -11,6 +13,7 @@ import fastify, {
   FastifyError,
   SafePromiseLike
 } from '../../fastify.js'
+import { FastifyReplyPreSerializedPayload } from '../../types/type-provider.js'
 
 const server = fastify()
 
@@ -479,9 +482,17 @@ server.withTypeProvider<TypeBoxProvider>().get(
     res.send('hello')
     res.send(42)
     res.send({ error: 'error' })
-    expect(res.code(200).send).type.toBe<((...args: [payload: string]) => typeof res)>()
-    expect(res.code(400).send).type.toBe<((...args: [payload: number]) => typeof res)>()
-    expect(res.code(500).send).type.toBe<((...args: [payload: { error: string }]) => typeof res)>()
+    expect(res.code(200).send).type.toBe<
+      ((...args: [payload: string | FastifyReplyPreSerializedPayload]) => typeof res)
+    >()
+    expect(res.code(400).send).type.toBe<
+      ((...args: [payload: number | FastifyReplyPreSerializedPayload]) => typeof res)
+    >()
+    expect(res.code(500).send).type.toBe<
+      ((...args: [
+        payload: { error: string } | FastifyReplyPreSerializedPayload
+      ]) => typeof res)
+    >()
   }
 )
 
@@ -712,10 +723,22 @@ server.withTypeProvider<JsonSchemaToTsProvider>().get(
     res.send('hello')
     res.send(42)
     res.send({ error: 'error' })
-    expect(res.code(200).send).type.toBe<((...args: [payload: string]) => typeof res)>()
-    expect(res.code(400).send).type.toBe<((...args: [payload: number]) => typeof res)>()
+    res.code(200).send(Buffer.from('payload'))
+    res.code(200).send(new Uint16Array([1, 2, 3]))
+    res.code(200).send(new Readable())
+    res.code(200).send(new ReadableStream())
+    expect(res.code(200).send).type.not.toBeCallableWith(42)
+    expect(res.code(200).send).type.not.toBeCallableWith({ getReader: 'not a function' })
+    expect(res.code(200).send).type.toBe<
+      ((...args: [payload: string | FastifyReplyPreSerializedPayload]) => typeof res)
+    >()
+    expect(res.code(400).send).type.toBe<
+      ((...args: [payload: number | FastifyReplyPreSerializedPayload]) => typeof res)
+    >()
     expect(res.code(500).send).type.toBe<
-      ((...args: [payload: { [x: string]: unknown; error?: string }]) => typeof res)
+      ((...args: [
+        payload: { [x: string]: unknown; error?: string } | FastifyReplyPreSerializedPayload
+      ]) => typeof res)
     >()
   }
 )

--- a/types/type-provider.d.ts
+++ b/types/type-provider.d.ts
@@ -138,14 +138,19 @@ export type SafePromiseLike<T> = PromiseLike<T> & { __linterBrands: 'SafePromise
 // SendArgs
 // -----------------------------------------------------------------------------------------------
 
+export type FastifyReplyPreSerializedPayload =
+  | ArrayBufferView
+  | { pipe: (...args: any[]) => unknown }
+  | { getReader: (...args: any[]) => unknown }
+
 /**
  * Determines whether the send() payload parameter should be required or optional.
  * - When ReplyType is unknown (default/unspecified), payload is optional
  * - When ReplyType is undefined or void, payload is optional (returning undefined is valid)
- * - Otherwise, payload is required
+ * - Otherwise, payload is required and also accepts pre-serialized payloads
  */
 export type SendArgs<ReplyType> = unknown extends ReplyType
   ? [payload?: ReplyType]
   : [ReplyType] extends [undefined | void]
       ? [payload?: ReplyType]
-      : [payload: ReplyType]
+      : [payload: ReplyType | FastifyReplyPreSerializedPayload]


### PR DESCRIPTION
## Summary

- allow `reply.send()` to accept pre-serialized buffers, typed arrays, Node streams, and Web streams when a concrete reply type is configured
- preserve required payloads for concrete reply types and optional payloads for `unknown`, `void`, and `undefined`
- add coverage for explicit reply generics and `json-schema-to-ts` inferred response schemas

`Response` is intentionally excluded because it would introduce an ambient Web API type dependency that is not available in every supported TypeScript setup, while Fastify's runtime identifies responses through a non-structural brand check.

## Tests

- `npm run test:types`
- `npm run lint`
- `node --test test/internals/reply.test.js`
- `node --test test/web-api.test.js`

Closes #7009
