### PR TITLE
perf: reduce content-type parser overhead

### DIFF
--- a/lib/content-type-parser.js
+++ b/lib/content-type-parser.js
@@ -140,6 +140,7 @@ ContentTypeParser.prototype.getParser = function (contentType) {
   // with that type.
   parser = this.customParsers.get(contentType.mediaType)
   if (parser !== undefined) {
+    this.cache.set(ct, parser)
     return parser
   }
 
@@ -203,7 +204,12 @@ ContentTypeParser.prototype.run = function (contentType, handler, request, reply
   }
 
   const resource = new AsyncResource('content-type-parser:run', request)
-  const done = resource.bind(onDone)
+
+  // Preserve the request's async context without the per-request function
+  // properties and wrappers created by AsyncResource.bind().
+  function done (error, body) {
+    resource.runInAsyncScope(onDone, undefined, error, body)
+  }
 
   if (parser.asString === true || parser.asBuffer === true) {
     rawBody(

--- a/test/content-type-parser-async-context.test.js
+++ b/test/content-type-parser-async-context.test.js
@@ -1,0 +1,76 @@
+'use strict'
+
+const { AsyncLocalStorage, AsyncResource, createHook, executionAsyncId } = require('node:async_hooks')
+const { setImmediate: immediate } = require('node:timers/promises')
+const { test } = require('node:test')
+const Fastify = require('..')
+
+test('content type parser callbacks restore request context and destroy their resources', async t => {
+  const storage = new AsyncLocalStorage()
+  const external = new AsyncResource('external-parser')
+  const resources = new Set()
+  const destroyed = new Set()
+  const hook = createHook({
+    init (id, type) {
+      if (type === 'content-type-parser:run') resources.add(id)
+    },
+    destroy (id) {
+      if (resources.has(id)) destroyed.add(id)
+    }
+  }).enable()
+  const app = Fastify()
+  t.after(async () => {
+    hook.disable()
+    external.emitDestroy()
+    storage.disable()
+    await app.close()
+  })
+
+  app.addHook('onRequest', (request, reply, done) => {
+    storage.run({ id: request.headers['x-request-id'] }, done)
+  })
+
+  app.addContentTypeParser('application/custom', { parseAs: 'string' }, (request, body, done) => {
+    external.runInAsyncScope(() => {
+      t.assert.strictEqual(storage.getStore(), undefined)
+      setImmediate(() => {
+        if (body === 'error') {
+          done(new Error('parser failed'))
+        } else {
+          done(null, body)
+        }
+      })
+    })
+  })
+
+  function assertContext (request) {
+    t.assert.deepStrictEqual(storage.getStore(), { id: request.headers['x-request-id'] })
+    t.assert.ok(resources.has(executionAsyncId()))
+  }
+
+  app.setErrorHandler((error, request, reply) => {
+    assertContext(request)
+    reply.code(400).send({ error: error.message, id: storage.getStore().id })
+  })
+  app.post('/', (request, reply) => {
+    assertContext(request)
+    return { body: request.body, id: storage.getStore().id }
+  })
+
+  const responses = await Promise.all(['first', 'second', 'error'].map(id => app.inject({
+    method: 'POST',
+    url: '/',
+    headers: { 'content-type': 'application/custom', 'x-request-id': id },
+    payload: id
+  })))
+
+  t.assert.deepStrictEqual(responses.map(response => response.statusCode), [200, 200, 400])
+  t.assert.deepStrictEqual(responses.map(response => response.json()), [
+    { body: 'first', id: 'first' },
+    { body: 'second', id: 'second' },
+    { error: 'parser failed', id: 'error' }
+  ])
+  await immediate()
+  t.assert.strictEqual(resources.size, 3)
+  t.assert.deepStrictEqual(destroyed, resources)
+})

--- a/test/custom-parser.4.test.js
+++ b/test/custom-parser.4.test.js
@@ -6,6 +6,46 @@ const jsonParser = require('fast-json-body')
 
 process.removeAllListeners('warning')
 
+test('parameterized parser matches preserve precedence and encapsulation on repeated requests', async t => {
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.addContentTypeParser('application/custom', { parseAs: 'string' }, (request, body, done) => {
+    done(null, 'parent')
+  })
+  fastify.addContentTypeParser('application/custom; version=2', { parseAs: 'string' }, (request, body, done) => {
+    done(null, 'version 2')
+  })
+  fastify.post('/', request => request.body)
+
+  fastify.register(async child => {
+    child.removeContentTypeParser('application/custom')
+    child.addContentTypeParser('application/custom', { parseAs: 'string' }, (request, body, done) => {
+      done(null, 'child')
+    })
+    child.post('/child', request => request.body)
+  })
+
+  for (let i = 0; i < 3; i++) {
+    for (const [url, contentType, expected] of [
+      ['/', 'application/custom; charset=utf-8', 'parent'],
+      ['/child', 'application/custom; charset=utf-8', 'child'],
+      ['/', 'application/custom; version=2', 'version 2'],
+      ['/child', 'application/custom; version=2', 'version 2'],
+      ['/', 'Application/Custom ; Charset="utf-8"', 'parent']
+    ]) {
+      const response = await fastify.inject({
+        method: 'POST',
+        url,
+        headers: { 'content-type': contentType },
+        payload: 'body'
+      })
+      t.assert.strictEqual(response.statusCode, 200)
+      t.assert.strictEqual(response.body, expected)
+    }
+  }
+})
+
 test('should prefer string content types over RegExp ones', async (t) => {
   t.plan(6)
   const fastify = Fastify()


### PR DESCRIPTION
This PR does 2 things:

* Replace AsyncResource.bind() with a callback that still preserves async scope (this is an optimization I've seen in Node.js, I believe by @mcollina)
* Cache parameterized content-type parser matches

```sh
   Existing command                   Before            After    Change
  ━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━  ━━━━━━━━
   npm run benchmark:parser    123,106 req/s    161,468 req/s    +31.2%
  ──────────────────────────  ───────────────  ───────────────  ────────
   npm run benchmark           201,041 req/s    201,310 req/s    +0.13%
```