### PR TITLE
docs: clarify Fastify instance access in Application Hooks

### DIFF
--- a/docs/Reference/Hooks.md
+++ b/docs/Reference/Hooks.md
@@ -412,6 +412,25 @@ You can hook into the application-lifecycle as well.
 - [onRoute](#onroute)
 - [onRegister](#onregister)
 
+### Fastify instance reference in Application Hooks
+
+Each application hook exposes the Fastify instance differently. The table below
+summarises how to access it in each hook:
+
+| Hook | Callback style | `async` style |
+|------|---------------|---------------|
+| `onReady` | `this` (use `function`, not arrow) | `this` (use `function`, not arrow) |
+| `onListen` | `this` (use `function`, not arrow) | `this` (use `function`, not arrow) |
+| `onClose` | first argument (`instance`) | first argument (`instance`) |
+| `preClose` | not passed — use the outer `fastify` reference | not passed — use the outer `fastify` reference |
+| `onRoute` | `this` (use `function`, not arrow) | N/A — synchronous only |
+| `onRegister` | first argument (`instance`) | first argument (`instance`) |
+
+> ⚠️ **Arrow functions do not bind `this`.** For hooks that expose the instance
+> via `this` (`onReady`, `onListen`, `onRoute`), always use a regular
+> `function` declaration, not an arrow function, otherwise `this` will be
+> `undefined` or the outer scope's context.
+
 ### onReady
 Triggered before the server starts listening for requests and when `.ready()` is
 invoked. It cannot change the routes or add new hooks. Registered hook functions


### PR DESCRIPTION
## Summary

Each application hook exposes the Fastify instance differently, but this was never documented in one place, making it easy to write a hook that silently does nothing because the instance reference is wrong.

| Hook | How to access the instance |
|------|---------------------------|
| \onReady\ | \	his\ (regular function only) |
| \onListen\ | \	his\ (regular function only) |
| \onClose\ | first argument (\instance\) |
| \preClose\ | not passed — use outer \astify\ reference |
| \onRoute\ | \	his\ (regular function only) |
| \onRegister\ | first argument (\instance\) |

## Changes

Added a summary table + arrow-function warning at the top of the **Application Hooks** section in \docs/Reference/Hooks.md\.

Closes #4967