### PR TITLE
docs: specify ajv-errors version compatible with Ajv v8

### DIFF
--- a/docs/Reference/Validation-and-Serialization.md
+++ b/docs/Reference/Validation-and-Serialization.md
@@ -953,7 +953,7 @@ For custom error responses in the schema, see
 [example](https://github.com/fastify/example/blob/HEAD/validation-messages/custom-errors-messages.js)
 usage.
 
-> Fastify v5 uses AJV v8 and requires a compatible `ajv-errors` version.
+> Fastify v5 uses AJV v8 and requires a compatible `ajv-errors` version -- use `ajv-errors@^3`, which supports AJV v8.
 > Fastify v3 requires `ajv-errors@1.0.1`, which supports AJV v6.
 > See the [AJV compiler versions table](https://github.com/fastify/ajv-compiler/#versions)
 > for the AJV version used by each Fastify release.


### PR DESCRIPTION
The docs said Fastify v5 "requires a compatible ajv-errors version" without naming one. This adds the specific version: ajv-errors@^3 supports Ajv v8 (used by Fastify v4/v5), confirmed in the ajv-errors README and consistent with @fastify/ajv-compiler's versions table.

Fixes fastify/help#1113

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
