### PR TITLE
perf: avoid redundant request-part reads during validation

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -284,19 +284,21 @@ function compileSchemasForValidation (context, compile, isCustom) {
 }
 
 function validateParam (validatorFunction, request, paramName) {
-  const isUndefined = request[paramName] === undefined
+  // The headers getter may allocate a new object, so only read it when needed.
+  if (validatorFunction == null) return false
+  const value = request[paramName]
   let ret
 
   try {
-    const data = isUndefined ? null : request[paramName]
+    const data = value === undefined ? null : value
     // Ajv can only mutate a root value when its parent is provided.
-    if (validatorFunction?.schemaEnv) {
+    if (validatorFunction.schemaEnv) {
       ret = validatorFunction(data, {
         parentData: request,
         parentDataProperty: paramName
       })
     } else {
-      ret = validatorFunction?.(data)
+      ret = validatorFunction(data)
     }
   } catch (err) {
     // If validator throws synchronously, ensure it propagates as an internal error

--- a/test/internals/validation.test.js
+++ b/test/internals/validation.test.js
@@ -10,6 +10,72 @@ const { normalizeSchema } = require('../../lib/schemas')
 const symbols = require('../../lib/validation').symbols
 const { kSchemaVisited } = require('../../lib/symbols')
 
+for (const [part, symbol] of [
+  ['params', symbols.paramsSchema],
+  ['body', symbols.bodySchema],
+  ['query', symbols.querystringSchema],
+  ['headers', symbols.headersSchema]
+]) {
+  for (const async of [false, true]) {
+    test(`validate reads only the validated ${part} once (${async ? 'async' : 'sync'})`, async t => {
+      const request = {}
+      const value = { hello: 'world' }
+      let reads = 0
+      let calls = 0
+
+      for (const name of ['params', 'body', 'query', 'headers']) {
+        Object.defineProperty(request, name, {
+          get () {
+            t.assert.strictEqual(name, part, 'unvalidated request parts must not be read')
+            reads++
+            return value
+          }
+        })
+      }
+
+      const context = {
+        [symbol]: data => {
+          calls++
+          t.assert.strictEqual(data, value)
+          return async ? Promise.resolve(data) : true
+        }
+      }
+
+      t.assert.strictEqual(await validation.validate(context, request), false)
+      t.assert.strictEqual(reads, 1)
+      t.assert.strictEqual(calls, 1)
+    })
+  }
+}
+
+test('validate skips a body without a matching content-type schema', t => {
+  const context = { [symbols.bodySchema]: { 'application/json': () => true } }
+  const request = {
+    mediaType: 'text/plain',
+    get body () {
+      t.assert.fail('an unvalidated body must not be read')
+    }
+  }
+
+  t.assert.strictEqual(validation.validate(context, request), false)
+})
+
+test('validate passes null for an undefined request part and preserves other values', t => {
+  for (const value of [undefined, null, false, 0, '']) {
+    let calls = 0
+    const context = {
+      [symbols.bodySchema]: data => {
+        calls++
+        t.assert.strictEqual(data, value === undefined ? null : value)
+        return true
+      }
+    }
+
+    t.assert.strictEqual(validation.validate(context, { body: value }), false)
+    t.assert.strictEqual(calls, 1)
+  }
+})
+
 test('Symbols', t => {
   t.plan(5)
   t.assert.strictEqual(typeof symbols.responseSchema, 'symbol')


### PR DESCRIPTION
Before the patch, validation could read headers twice despite having no header validator. If application code had previously assigned `request.headers = {...}`, those reads copied the merged headers twice in this path. You can see why we copied in the headers getter here:

https://github.com/fastify/fastify/blob/af079bd4c60c3cbebedc7640517d7288468fb5eb/lib/request.js#L277-L286

The patch checks for a validator before reading the request part and reads validated parts once. Query-only validation therefore reduces header copies from two to zero; header validation reduces them from two to one.

Header assignment may occur in onRequest, preParsing, a content-type parser, or preValidation, including encapsulated hooks.

```text
   Scenario                                                  Before            After    Change
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━  ━━━━━━━━
   Query validation + enriched headers                 51,456 req/s     94,349 req/s      +83%
  ─────────────────────────────────────────────────  ───────────────  ───────────────  ────────
   Query + header validation with enriched headers     51,059 req/s     64,957 req/s      +27%
  ─────────────────────────────────────────────────  ───────────────  ───────────────  ────────
   Query validation only                              147,968 req/s    147,024 req/s    −0.64% (flat)
```