### PR TITLE
chore(sponsor): add cloudways

### DIFF
--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -10,6 +10,7 @@ or [GitHub Sponsors](https://github.com/sponsors/fastify)!
 ## Tier 4
 
 - [SerpApi](https://serpapi.com/?utm_source=fastify)
+- [Cloudways](https://www.cloudways.com/en/velocity.php?id=1258368&data1=fastify)
 
 ## Tier 3
 


### PR DESCRIPTION
Adds Cloudways to the top sponsorship tier (Tier 4) in `SPONSORS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCEJC5tvmrhwzgPsFT1PTX