### PR TITLE
fix(content-type): escape quoted-pairs when serializing parameters

### DIFF
--- a/lib/content-type.js
+++ b/lib/content-type.js
@@ -36,6 +36,17 @@ const keyValuePairsReg = /(?:^|;)\s*([\w!#$%&'*+.^`|~-]+)=("(?:[\t\u0020\u0021\u
 const quotedPairReg = /\\([\t\u0020-\u00ff])/gu
 
 /**
+ * quotedStringEscapeReg matches the two octets a sender must express as a
+ * quoted-pair when generating a quoted-string: DQUOTE and backslash. Per
+ * RFC 9110 §5.6.4 they cannot appear literally inside the string, so they
+ * are each preceded with a backslash on the way out.
+ *
+ * @see https://httpwg.org/specs/rfc9110.html#quoted.string
+ * @type {RegExp}
+ */
+const quotedStringEscapeReg = /["\\]/gu
+
+/**
  * typeNameReg is used to validate that the first part of the media-type
  * does not use disallowed characters. Types must consist solely of
  * characters that match the specified character class. It must terminate
@@ -199,7 +210,10 @@ class ContentType {
     if (this.#string) return this.#string
     const parameters = []
     for (const [key, value] of this.#parameters.entries()) {
-      parameters.push(`${key}="${value}"`)
+      // The constructor unescapes quoted-pairs, so the stored value can hold
+      // octets that are not legal inside a quoted-string. Escape them again,
+      // otherwise the serialization does not parse back to the same value.
+      parameters.push(`${key}="${value.replace(quotedStringEscapeReg, '\\$&')}"`)
     }
     const result = [this.#type, '/', this.#subtype]
     if (parameters.length > 0) {

--- a/test/content-type.test.js
+++ b/test/content-type.test.js
@@ -211,6 +211,77 @@ describe('ContentType class', () => {
   })
 })
 
+describe('ContentType class serialization', () => {
+  test('escapes a DQUOTE so the value survives a round trip', (t) => {
+    // RFC 9110 §5.6.4: DQUOTE cannot appear literally inside a quoted-string,
+    // so a sender must express it as a quoted-pair.
+    const found = new ContentType('application/json; name="he said \\"hi\\""')
+    t.assert.equal(found.parameters.get('name'), 'he said "hi"')
+    t.assert.equal(
+      found.toString(),
+      'application/json; name="he said \\"hi\\""'
+    )
+    t.assert.equal(
+      new ContentType(found.toString()).parameters.get('name'),
+      'he said "hi"'
+    )
+  })
+
+  test('escapes a backslash so the value survives a round trip', (t) => {
+    const found = new ContentType('application/json; name="a\\\\b"')
+    t.assert.equal(found.parameters.get('name'), 'a\\b')
+    t.assert.equal(found.toString(), 'application/json; name="a\\\\b"')
+    t.assert.equal(
+      new ContentType(found.toString()).parameters.get('name'),
+      'a\\b'
+    )
+  })
+
+  test('does not let a quoted value forge additional parameters', (t) => {
+    // `p` holds a single value that happens to contain `"; q="`. Serializing
+    // it without escaping would produce `p="a"; q="b"`, which is a different
+    // content type carrying two parameters.
+    const one = new ContentType('application/json; p="a\\"; q=\\"b"')
+    const two = new ContentType('application/json; p="a"; q="b"')
+
+    t.assert.equal(one.parameters.size, 1)
+    t.assert.equal(one.parameters.get('p'), 'a"; q="b')
+    t.assert.equal(two.parameters.size, 2)
+
+    t.assert.notEqual(one.toString(), two.toString())
+  })
+
+  test('leaves a value with no quoted-pair octets untouched', (t) => {
+    const found = new ContentType('application/json; charset=utf-8; foo=BaR')
+    t.assert.equal(found.toString(), 'application/json; charset="utf-8"; foo="BaR"')
+  })
+})
+
+describe('ContentType serialization and parser lookup', () => {
+  test('does not run a parser registered for a different content type', async (t) => {
+    t.plan(2)
+
+    const fastify = Fastify()
+    // The registered type has one parameter whose value contains `"; q="`.
+    fastify.addContentTypeParser('text/plain; p="a\\"; q=\\"b"', function (request, payload, done) {
+      done(null, 'parsed by the registered parser')
+    })
+    fastify.post('/', (request, reply) => { reply.send(request.body) })
+
+    // A different content type: two parameters, p=a and q=b. It must not
+    // reach the parser above.
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/',
+      headers: { 'content-type': 'text/plain; p="a"; q="b"' },
+      payload: 'body'
+    })
+
+    t.assert.equal(response.statusCode, 200)
+    t.assert.notEqual(response.body, 'parsed by the registered parser')
+  })
+})
+
 describe('ContentType class cache', () => {
   test('allow access cache', (t) => {
     const contentType1 = ContentType.from('application/json')


### PR DESCRIPTION
## Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added — N/A, no public API change
- [x] commit message and code follow the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

No open issue — found by auditing `lib/content-type.js`.

## The bug

The constructor unescapes quoted-pairs, as RFC 9110 §5.6.4 requires of a recipient:

```js
if (value.indexOf('\\') !== -1) {
  value = value.replace(quotedPairReg, '$1')
}
```

So a stored parameter value can contain a DQUOTE or a backslash. `toString()` then wrapped it in DQUOTEs verbatim:

```js
parameters.push(`${key}="${value}"`)
```

which produces a header that no longer parses back to the same value:

| input | parsed | `toString()` | re-parsed |
|---|---|---|---|
| `p="a\"b"` | `a"b` | `p="a"b"` | **`a`** |
| `p="a\\b"` | `a\b` | `p="a\b"` | **`ab`** |

## Why it is not only cosmetic

`toString()` is the normalized key that custom parsers are registered and looked up under — `ContentTypeParser.prototype.add` stores `ct.toString()`, and `getParser` looks up `contentType.toString()` for the incoming request. Because the escaping is dropped, two different content types collapse onto one key:

```js
new ContentType('text/plain; p="a\\"; q=\\"b"')  // 1 parameter: p === 'a"; q="b'
new ContentType('text/plain; p="a"; q="b"')      // 2 parameters: p === 'a', q === 'b'
// both serialize to:  text/plain; p="a"; q="b"
```

A parser registered for the first therefore runs for requests carrying the second. There is a test for exactly this through `inject`.

## The fix

Precede each DQUOTE and backslash with a backslash when serializing, which is what RFC 9110 §5.6.4 requires of a sender. A value containing neither octet is unchanged, so the existing `toString()` assertions in `test/content-type.test.js` are untouched.

I deliberately did **not** also stop quoting values that are bare tokens (`charset=utf-8` still serializes as `charset="utf-8"`). That round-trips correctly today, and changing it would alter every existing parser key — a separate question from this bug.

## Verification

- 4 new tests fail before the change, pass after
- `npm run unit`: **2345 tests, 0 failures**
- `npm run lint` clean, `npm run test:types` clean (1282 assertions)
