### PR TITLE
fix: removeContentTypeParser('*') and hasContentTypeParser('*') ignore the catch-all parser

### DIFF
--- a/lib/content-type-parser.js
+++ b/lib/content-type-parser.js
@@ -171,7 +171,9 @@ ContentTypeParser.prototype.remove = function (contentType) {
   let parsers
 
   if (typeof contentType === 'string') {
-    contentType = new ContentType(contentType).toString()
+    // add() stores the catch-all alias under the empty key rather than a
+    // normalized media type, so remove() has to look for it the same way.
+    contentType = contentType === '*' ? '' : new ContentType(contentType).toString()
     parsers = this.parserList
   } else {
     if (!(contentType instanceof RegExp)) throw new FST_ERR_CTP_INVALID_TYPE()

--- a/test/custom-parser.4.test.js
+++ b/test/custom-parser.4.test.js
@@ -256,3 +256,29 @@ test('removeAllContentTypeParsers should support encapsulation', async (t) => {
   t.assert.strictEqual(result2.status, 200)
   t.assert.equal(JSON.parse(await result2.text()).test, 1)
 })
+
+test('removeContentTypeParser removes the catch-all parser added as "*"', async t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.addContentTypeParser('*', function (req, payload, done) {
+    payload.on('data', () => {})
+    payload.on('end', () => { done(null, 'catch-all') })
+  })
+
+  fastify.removeContentTypeParser('*')
+
+  fastify.post('/', (req, reply) => reply.send(req.body))
+
+  const res = await fastify.inject({
+    method: 'POST',
+    url: '/',
+    headers: { 'content-type': 'application/octet-stream' },
+    payload: 'anything'
+  })
+
+  t.assert.strictEqual(res.statusCode, 415)
+  t.assert.strictEqual(JSON.parse(res.body).code, 'FST_ERR_CTP_INVALID_MEDIA_TYPE')
+})


### PR DESCRIPTION
`add()` stores the `'*'` catch-all parser under the empty key (`this.customParsers.set('', parser)`), which is where `getParser()` falls back to. `remove()` and `hasParser()` run every string through `new ContentType(...).toString()` instead, so they never look at that key:

```js
fastify.addContentTypeParser('*', function (req, payload, done) {
  payload.on('data', () => {})
  payload.on('end', () => { done(null, 'catch-all') })
})

fastify.hasContentTypeParser('*')    // false
fastify.removeContentTypeParser('*') // does nothing

fastify.post('/', (req, reply) => reply.send(req.body))
// POST / with content-type: application/octet-stream -> still 200 "catch-all"
```

The fix adds a small `toParserKey()` helper, used by both `hasParser()` and `remove()`, that maps `'*'` to `''`. `existingParser()` keeps returning false for `'*'`, so calling `addContentTypeParser('*')` a second time still replaces the parser instead of throwing `FST_ERR_CTP_ALREADY_PRESENT`.

Tests:
- `custom-parser.4.test.js`: removing the catch-all gives 415 / `FST_ERR_CTP_INVALID_MEDIA_TYPE`
- `content-parser.test.js`: `hasContentTypeParser('*')` is true after adding one
- The existing `existingParser returns always false for "*"` test still passes
- Both new tests fail against `main`. `node --test test/content-parser.test.js test/custom-parser*.test.js` passes and eslint is clean.