### PR TITLE
docs: fix requestTimeout link to point at the correct Node.js anchor

### DIFF
--- a/docs/Reference/Server.md
+++ b/docs/Reference/Server.md
@@ -213,7 +213,7 @@ ignored.
 
 Defines the maximum number of milliseconds for receiving the entire request from
 the client. See [`server.requestTimeout`
-property](https://nodejs.org/dist/latest/docs/api/http.html#servertimeout)
+property](https://nodejs.org/dist/latest/docs/api/http.html#serverrequesttimeout)
 to understand the effect of this option.
 
 When `serverFactory` option is specified, this option is ignored.


### PR DESCRIPTION
## Summary

The `requestTimeout` server option's documentation links to Node's `http.html#servertimeout` anchor (the `server.timeout` property) instead of `#serverrequesttimeout` (the `server.requestTimeout` property the section is actually describing). These are two distinct Node.js `http.Server` properties with different semantics, so the link currently sends readers to the wrong reference.

## Change

In `docs/Reference/Server.md`, the `requestTimeout` section's link now points to `https://nodejs.org/dist/latest/docs/api/http.html#serverrequesttimeout`.

The neighboring `connectionTimeout` section's link to `#servertimeout` is correct as-is (it documents `server.timeout`) and was left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
